### PR TITLE
8324678: Replace NULL with nullptr in HotSpot gtests

### DIFF
--- a/test/hotspot/gtest/compiler/test_directivesParser.cpp
+++ b/test/hotspot/gtest/compiler/test_directivesParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ class DirectivesParserTest : public ::testing::Test{
   ResourceMark rm;
   stringStream stream;
   // These tests require the "C" locale to correctly parse decimal values
-  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, NULL)) {
+  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, nullptr)) {
     setlocale(LC_NUMERIC, "C");
   }
   ~DirectivesParserTest() {

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ TEST_VM(FreeRegionList, length) {
 
   // Create a fake heap. It does not need to be valid, as the HeapRegion constructor
   // does not access it.
-  MemRegion heap(NULL, num_regions_in_test * HeapRegion::GrainWords);
+  MemRegion heap(nullptr, num_regions_in_test * HeapRegion::GrainWords);
 
   // Allocate a fake BOT because the HeapRegion constructor initializes
   // the BOT.

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
+++ b/test/hotspot/gtest/gc/g1/test_g1CardSet.cpp
@@ -50,7 +50,7 @@ class G1CardSetTest : public ::testing::Test {
   static uint _max_workers;
 
   static WorkerThreads* workers() {
-    if (_workers == NULL) {
+    if (_workers == nullptr) {
       _max_workers = os::processor_count();
       _workers = new WorkerThreads("G1CardSetTest Workers", _max_workers);
       _workers->initialize_workers();
@@ -87,7 +87,7 @@ public:
   static void iterate_cards(G1CardSet* card_set, G1CardSet::CardClosure* cl);
 };
 
-WorkerThreads* G1CardSetTest::_workers = NULL;
+WorkerThreads* G1CardSetTest::_workers = nullptr;
 uint G1CardSetTest::_max_workers = 0;
 
 void G1CardSetTest::add_cards(G1CardSet* card_set, uint cards_per_region, uint* cards, uint num_cards, G1AddCardResult* results) {
@@ -97,7 +97,7 @@ void G1CardSetTest::add_cards(G1CardSet* card_set, uint cards_per_region, uint* 
     uint card_idx = cards[i] % cards_per_region;
 
     G1AddCardResult res = card_set->add_card(region_idx, card_idx);
-    if (results != NULL) {
+    if (results != nullptr) {
       ASSERT_TRUE(res == results[i]);
     }
   }
@@ -269,7 +269,7 @@ void G1CardSetTest::cardset_basic_test() {
     translate_cards(CardsPerRegion, 100, &cards1[0], 4);
     translate_cards(CardsPerRegion, 990, &cards1[4], 4);
 
-    add_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1), NULL);
+    add_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1), nullptr);
     contains_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1));
     ASSERT_TRUE(card_set.occupied() == ARRAY_SIZE(cards1));
 
@@ -291,7 +291,7 @@ void G1CardSetTest::cardset_basic_test() {
       cards1[i] = i + 3;
       translate_cards(CardsPerRegion, i, &cards1[i], 1);
     }
-    add_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1), NULL);
+    add_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1), nullptr);
     contains_cards(&card_set, CardsPerRegion, cards1, ARRAY_SIZE(cards1));
 
     ASSERT_TRUE(card_set.num_containers() == ARRAY_SIZE(cards1));

--- a/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
+++ b/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
 class G1MapperWorkers : AllStatic {
   static WorkerThreads* _workers;
   static WorkerThreads* workers() {
-    if (_workers == NULL) {
+    if (_workers == nullptr) {
       _workers = new WorkerThreads("G1 Small Workers", MaxWorkers);
       _workers->initialize_workers();
       _workers->set_active_workers(MaxWorkers);
@@ -48,7 +48,7 @@ public:
     workers()->run_task(task);
   }
 };
-WorkerThreads* G1MapperWorkers::_workers = NULL;
+WorkerThreads* G1MapperWorkers::_workers = nullptr;
 
 class G1TestCommitUncommit : public WorkerTask {
   G1RegionToSpaceMapper* _mapper;

--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ TEST_VM(BufferNodeAllocatorTest, test) {
   for (size_t i = 0; i < node_count; ++i) {
     ASSERT_EQ(0u, allocator.free_count());
     nodes[i] = allocator.allocate();
-    ASSERT_EQ((BufferNode*)NULL, nodes[i]->next());
+    ASSERT_EQ((BufferNode*)nullptr, nodes[i]->next());
   }
 
   // Release the nodes, adding them to the allocator's free list.
@@ -102,7 +102,7 @@ public:
   }
 
   void push(BufferNode* node) {
-    assert(node != NULL, "precondition");
+    assert(node != nullptr, "precondition");
     _completed_list.push(*node);
   }
 
@@ -169,7 +169,7 @@ public:
     bool shutdown_requested = false;
     while (true) {
       BufferNode* node = _cbl->pop();
-      if (node != NULL) {
+      if (node != nullptr) {
         _allocator->release(node);
       } else if (shutdown_requested) {
         return;

--- a/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
+++ b/test/hotspot/gtest/gc/shared/test_bufferNodeAllocator.cpp
@@ -62,7 +62,7 @@ TEST_VM(BufferNodeAllocatorTest, test) {
   for (size_t i = 0; i < node_count; ++i) {
     ASSERT_EQ(0u, allocator.free_count());
     nodes[i] = allocator.allocate();
-    ASSERT_EQ((BufferNode*)nullptr, nodes[i]->next());
+    ASSERT_EQ(nullptr, nodes[i]->next());
   }
 
   // Release the nodes, adding them to the allocator's free list.

--- a/test/hotspot/gtest/gc/shared/test_collectedHeap.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectedHeap.cpp
@@ -33,7 +33,7 @@ TEST_VM(CollectedHeap, is_in) {
   uintptr_t outside_heap = (uintptr_t) &epsilon;
 
   // Test that nullptr is not in the heap.
-  ASSERT_FALSE(heap->is_in(nullptr)) << "nullptr is unexpectedly in the heap";
+  ASSERT_FALSE(heap->is_in(nullptr)) << "null is unexpectedly in the heap";
 
   // Test that a pointer to outside the heap start is reported as outside the heap.
   ASSERT_FALSE(heap->is_in((void*)outside_heap)) << "outside_heap: " << outside_heap

--- a/test/hotspot/gtest/gc/shared/test_collectedHeap.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,8 +32,8 @@ TEST_VM(CollectedHeap, is_in) {
   uintptr_t epsilon = (uintptr_t) MinObjAlignment;
   uintptr_t outside_heap = (uintptr_t) &epsilon;
 
-  // Test that NULL is not in the heap.
-  ASSERT_FALSE(heap->is_in(NULL)) << "NULL is unexpectedly in the heap";
+  // Test that nullptr is not in the heap.
+  ASSERT_FALSE(heap->is_in(nullptr)) << "nullptr is unexpectedly in the heap";
 
   // Test that a pointer to outside the heap start is reported as outside the heap.
   ASSERT_FALSE(heap->is_in((void*)outside_heap)) << "outside_heap: " << outside_heap

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,14 +73,14 @@ class TestGenCollectorPolicy {
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 
-      if (setter2 != NULL) {
+      if (setter2 != nullptr) {
         ASSERT_NO_FATAL_FAILURE(setter2->execute());
       }
 
       ASSERT_NO_FATAL_FAILURE(checker->execute());
     }
     static void test(Executor* setter, Executor* checker) {
-      test(setter, NULL, checker);
+      test(setter, nullptr, checker);
     }
   };
 

--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,13 +104,13 @@ typedef TestAccess::Block OopBlock;
 typedef TestAccess::AllocationList AllocationList;
 typedef TestAccess::ActiveArray ActiveArray;
 
-// Using EXPECT_EQ can't use NULL directly. Otherwise AIX build breaks.
-const OopBlock* const NULL_BLOCK = NULL;
+// Using EXPECT_EQ can't use nullptr directly. Otherwise AIX build breaks.
+const OopBlock* const NULL_BLOCK = nullptr;
 
 static size_t list_length(const AllocationList& list) {
   size_t result = 0;
   for (const OopBlock* block = list.chead();
-       block != NULL;
+       block != nullptr;
        block = list.next(*block)) {
     ++result;
   }
@@ -119,14 +119,14 @@ static size_t list_length(const AllocationList& list) {
 
 static void clear_list(AllocationList& list) {
   OopBlock* next;
-  for (OopBlock* block = list.head(); block != NULL; block = next) {
+  for (OopBlock* block = list.head(); block != nullptr; block = next) {
     next = list.next(*block);
     list.unlink(*block);
   }
 }
 
 static bool is_list_empty(const AllocationList& list) {
-  return list.chead() == NULL;
+  return list.chead() == nullptr;
 }
 
 static bool process_deferred_updates(OopStorage& storage) {
@@ -139,7 +139,7 @@ static bool process_deferred_updates(OopStorage& storage) {
 }
 
 static void release_entry(OopStorage& storage, oop* entry, bool process_deferred = true) {
-  *entry = NULL;
+  *entry = nullptr;
   storage.release(entry);
   if (process_deferred) {
     process_deferred_updates(storage);
@@ -150,7 +150,7 @@ static size_t empty_block_count(const OopStorage& storage) {
   const AllocationList& list = TestAccess::allocation_list(storage);
   size_t count = 0;
   for (const OopBlock* block = list.ctail();
-       (block != NULL) && block->is_empty();
+       (block != nullptr) && block->is_empty();
        ++count, block = list.prev(*block))
   {}
   return count;
@@ -164,7 +164,7 @@ static OopBlock* active_head(const OopStorage& storage) {
   ActiveArray& ba = TestAccess::active_array(storage);
   size_t count = ba.block_count();
   if (count == 0) {
-    return NULL;
+    return nullptr;
   } else {
     return ba.at(count - 1);
   }
@@ -203,7 +203,7 @@ public:
 OopStorageTestWithAllocation::OopStorageTestWithAllocation() {
   for (size_t i = 0; i < _max_entries; ++i) {
     _entries[i] = storage().allocate();
-    EXPECT_TRUE(_entries[i] != NULL);
+    EXPECT_TRUE(_entries[i] != nullptr);
     EXPECT_EQ(i + 1, storage().allocation_count());
   }
 };
@@ -215,8 +215,8 @@ static bool is_allocation_list_sorted(const OopStorage& storage) {
   // blocks are segregated to the end of the list.
   const AllocationList& list = TestAccess::allocation_list(storage);
   const OopBlock* block = list.ctail();
-  for ( ; (block != NULL) && block->is_empty(); block = list.prev(*block)) {}
-  for ( ; block != NULL; block = list.prev(*block)) {
+  for ( ; (block != nullptr) && block->is_empty(); block = list.prev(*block)) {}
+  for ( ; block != nullptr; block = list.prev(*block)) {
     if (block->is_empty()) {
       return false;
     }
@@ -239,7 +239,7 @@ TEST_VM_F(OopStorageTest, allocate_one) {
   EXPECT_TRUE(is_list_empty(TestAccess::allocation_list(storage())));
 
   oop* ptr = storage().allocate();
-  EXPECT_TRUE(ptr != NULL);
+  EXPECT_TRUE(ptr != nullptr);
   EXPECT_EQ(1u, storage().allocation_count());
 
   EXPECT_EQ(1u, active_count(storage()));
@@ -249,7 +249,7 @@ TEST_VM_F(OopStorageTest, allocate_one) {
   EXPECT_EQ(0u, empty_block_count(storage()));
 
   const OopBlock* block = TestAccess::allocation_list(storage()).chead();
-  EXPECT_NE(block, (OopBlock*)NULL);
+  EXPECT_NE(block, (OopBlock*)nullptr);
   EXPECT_EQ(block, active_head(storage()));
   EXPECT_FALSE(TestAccess::block_is_empty(*block));
   EXPECT_FALSE(TestAccess::block_is_full(*block));
@@ -326,7 +326,7 @@ TEST_VM_F(OopStorageTest, allocate_many) {
   EXPECT_EQ(0u, empty_block_count(storage()));
 
   entries[0] = storage().allocate();
-  ASSERT_TRUE(entries[0] != NULL);
+  ASSERT_TRUE(entries[0] != nullptr);
   EXPECT_EQ(1u, active_count(storage()));
   EXPECT_EQ(1u, storage().block_count());
   EXPECT_EQ(1u, list_length(allocation_list));
@@ -339,10 +339,10 @@ TEST_VM_F(OopStorageTest, allocate_many) {
   for (size_t i = 1; i < max_entries; ++i) {
     entries[i] = storage().allocate();
     EXPECT_EQ(i + 1, storage().allocation_count());
-    ASSERT_TRUE(entries[i] != NULL);
+    ASSERT_TRUE(entries[i] != nullptr);
     EXPECT_EQ(0u, empty_block_count(storage()));
 
-    if (block == NULL) {
+    if (block == nullptr) {
       ASSERT_FALSE(is_list_empty(allocation_list));
       EXPECT_EQ(1u, list_length(allocation_list));
       block = allocation_list.chead();
@@ -350,7 +350,7 @@ TEST_VM_F(OopStorageTest, allocate_many) {
       EXPECT_EQ(block, active_head(storage()));
     } else if (TestAccess::block_is_full(*block)) {
       EXPECT_TRUE(is_list_empty(allocation_list));
-      block = NULL;
+      block = nullptr;
     } else {
       EXPECT_FALSE(is_list_empty(allocation_list));
       EXPECT_EQ(block, allocation_list.chead());
@@ -358,7 +358,7 @@ TEST_VM_F(OopStorageTest, allocate_many) {
     }
   }
 
-  if (block != NULL) {
+  if (block != nullptr) {
     EXPECT_NE(0u, TestAccess::block_allocation_count(*block));
     EXPECT_FALSE(is_list_empty(allocation_list));
     EXPECT_EQ(block, allocation_list.chead());
@@ -375,7 +375,7 @@ TEST_VM_F(OopStorageTest, allocate_many) {
   EXPECT_EQ(active_count(storage()), storage().block_count());
   EXPECT_EQ(active_count(storage()), empty_block_count(storage()));
   for (const OopBlock* block = allocation_list.chead();
-       block != NULL;
+       block != nullptr;
        block = allocation_list.next(*block)) {
     EXPECT_TRUE(TestAccess::block_is_empty(*block));
   }
@@ -395,9 +395,9 @@ TEST_VM_F(OopStorageTestWithAllocation, random_release) {
   // Release all entries in "random" order.
   size_t released = 0;
   for (size_t i = 0; released < _max_entries; i = (i + step) % _max_entries) {
-    if (_entries[i] != NULL) {
+    if (_entries[i] != nullptr) {
       release_entry(storage(), _entries[i]);
-      _entries[i] = NULL;
+      _entries[i] = nullptr;
       ++released;
       EXPECT_EQ(_max_entries - released, total_allocation_count(storage()));
       EXPECT_TRUE(is_allocation_list_sorted(storage()));
@@ -427,9 +427,9 @@ TEST_VM_F(OopStorageTestWithAllocation, random_allocate_release) {
   size_t released = 0;
   size_t total_released = 0;
   for (size_t i = 0; released < _max_entries; i = (i + release_step) % _max_entries) {
-    if (_entries[i] != NULL) {
+    if (_entries[i] != nullptr) {
       release_entry(storage(), _entries[i]);
-      _entries[i] = NULL;
+      _entries[i] = nullptr;
       ++released;
       ++total_released;
       EXPECT_EQ(_max_entries - released, total_allocation_count(storage()));
@@ -458,7 +458,7 @@ public:
 
     for (size_t i = 0; i < nrelease; ++i) {
       to_release[i] = _entries[2 * i];
-      *to_release[i] = NULL;
+      *to_release[i] = nullptr;
     }
     if (sorted) {
       QuickSort::sort(to_release, nrelease, PointerCompare(), false);
@@ -509,7 +509,7 @@ TEST_VM_F(OopStorageTest, bulk_allocation) {
     EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, storage().allocation_status(entries[i]));
   }
   for (size_t i = allocated; i < max_entries; ++i) {
-    EXPECT_EQ(NULL, entries[i]);
+    EXPECT_EQ(nullptr, entries[i]);
   }
   storage().release(entries, allocated);
   EXPECT_EQ(0u, storage().allocation_count());
@@ -546,14 +546,14 @@ public:
 
   void do_oop(const oop* ptr) {
     ++_const_count;
-    if (*ptr != NULL) {
+    if (*ptr != nullptr) {
       ++_const_non_null;
     }
   }
 
   void do_oop(oop* ptr) {
     ++_non_const_count;
-    if (*ptr != NULL) {
+    if (*ptr != nullptr) {
       ++_non_const_non_null;
     }
   }
@@ -595,7 +595,7 @@ TEST_VM_F(OopStorageTest, simple_iterate) {
   for (size_t i = 0; i < max_entries; i += 10) {
     for ( ; allocated < i; ++allocated) {
       entries[allocated] = storage().allocate();
-      ASSERT_TRUE(entries[allocated] != NULL);
+      ASSERT_TRUE(entries[allocated] != nullptr);
       if ((allocated % 3) != 0) {
         *entries[allocated] = dummy_oop;
         ++entries_with_values;
@@ -872,10 +872,10 @@ private:
   static WorkerThreads* _workers;
 };
 
-WorkerThreads* OopStorageTestParIteration::_workers = NULL;
+WorkerThreads* OopStorageTestParIteration::_workers = nullptr;
 
 WorkerThreads* OopStorageTestParIteration::workers() {
-  if (_workers == NULL) {
+  if (_workers == nullptr) {
     _workers = new WorkerThreads("OopStorageTestParIteration workers", _max_workers);
     _workers->initialize_workers();
     _workers->set_active_workers(_max_workers);
@@ -1074,7 +1074,7 @@ TEST_VM_F(OopStorageTest, usage_info) {
     while (storage().block_count() == this_count) {
       ASSERT_GT(ARRAY_SIZE(entries), allocated);
       entries[allocated] = storage().allocate();
-      ASSERT_TRUE(entries[allocated] != NULL);
+      ASSERT_TRUE(entries[allocated] != nullptr);
       ++allocated;
     }
     EXPECT_NE(0u, storage().block_count());
@@ -1092,13 +1092,13 @@ TEST_VM_F(OopStorageTestWithAllocation, print_storage) {
   for (size_t i = 0; i < (_max_entries / 2); ++i) {
     // Deferred updates don't affect print output.
     release_entry(storage(), _entries[i], false);
-    _entries[i] = NULL;
+    _entries[i] = nullptr;
   }
   // Release every other remaining
   for (size_t i = _max_entries / 2; i < _max_entries; i += 2) {
     // Deferred updates don't affect print output.
     release_entry(storage(), _entries[i], false);
-    _entries[i] = NULL;
+    _entries[i] = nullptr;
   }
 
   size_t expected_entries = _max_entries / 4;

--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,10 +74,10 @@ public:
   oop* _entries[_storage_entries];
 };
 
-WorkerThreads* OopStorageParIterPerf::_workers = NULL;
+WorkerThreads* OopStorageParIterPerf::_workers = nullptr;
 
 WorkerThreads* OopStorageParIterPerf::workers() const {
-  if (_workers == NULL) {
+  if (_workers == nullptr) {
     WorkerThreads* wg = new WorkerThreads("OopStorageParIterPerf workers", _num_workers);
     wg->initialize_workers();
     wg->set_active_workers(_num_workers);
@@ -126,7 +126,7 @@ class OopStorageParIterPerf::Task : public WorkerTask {
 public:
   Task(OopStorage* storage, OopClosure* closure, uint nthreads) :
     WorkerTask("OopStorageParIterPerf::Task"),
-    _worker_times(NULL),
+    _worker_times(nullptr),
     _state(storage, nthreads),
     _closure(closure)
   {
@@ -152,7 +152,7 @@ public:
 
 class OopStorageParIterPerf::Closure : public OopClosure {
 public:
-  virtual void do_oop(oop* p) { guarantee(*p == NULL, "expected NULL"); }
+  virtual void do_oop(oop* p) { guarantee(*p == nullptr, "expected nullptr"); }
   virtual void do_oop(narrowOop* p) { ShouldNotReachHere(); }
 };
 

--- a/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
@@ -152,7 +152,7 @@ public:
 
 class OopStorageParIterPerf::Closure : public OopClosure {
 public:
-  virtual void do_oop(oop* p) { guarantee(*p == nullptr, "expected nullptr"); }
+  virtual void do_oop(oop* p) { guarantee(*p == nullptr, "expected null"); }
   virtual void do_oop(narrowOop* p) { ShouldNotReachHere(); }
 };
 

--- a/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
+++ b/test/hotspot/gtest/gc/shared/test_workerDataArray.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ class WorkerDataArrayTest : public ::testing::Test {
  protected:
   WorkerDataArrayTest() :
     title("Test array"),
-    array(NULL, title, 3),
+    array(nullptr, title, 3),
     sub_item_title("Sub item array") {
 
     array.create_thread_work_items(sub_item_title);

--- a/test/hotspot/gtest/gc/x/test_xAddress.cpp
+++ b/test/hotspot/gtest/gc/x/test_xAddress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ TEST_F(XAddressTest, is_weak_good_or_null) {
     << " is_remaped: " << XAddress::is_remapped(value)                           \
     << " is_good_or_null_or_remapped: " << XAddress::is_weak_good_or_null(value)
 
-  check_is_weak_good_or_null((uintptr_t)NULL);
+  check_is_weak_good_or_null((uintptr_t)nullptr);
   check_is_weak_good_or_null(XAddressMetadataMarked0);
   check_is_weak_good_or_null(XAddressMetadataMarked1);
   check_is_weak_good_or_null(XAddressMetadataRemapped);

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,7 @@ class JVMInitializerListener : public ::testing::EmptyTestEventListener {
   }
 
   void destroy_jvm() {
-    if (_jvm != NULL) {
+    if (_jvm != nullptr) {
       int ret = _jvm->DestroyJavaVM();
       if (ret != 0) {
         fprintf(stderr, "Warning: DestroyJavaVM error %d\n", ret);
@@ -151,7 +151,7 @@ static char* get_java_home_arg(int argc, char** argv) {
       return argv[i] + strlen("-jdk:");
     }
   }
-  return NULL;
+  return nullptr;
 }
 
 static bool get_spawn_new_main_thread_arg(int argc, char** argv) {
@@ -244,7 +244,7 @@ static void runUnitTestsInner(int argc, char** argv) {
   }
 
   char* java_home = get_java_home_arg(argc, argv);
-  if (java_home == NULL) {
+  if (java_home == nullptr) {
     fprintf(stderr, "ERROR: You must specify a JDK (-jdk <image>, --jdk=<image> or -jdk:<image>) to use for running the unit tests.\n");
     os::exit(1);
   }
@@ -270,10 +270,10 @@ static void runUnitTestsInner(int argc, char** argv) {
   argv = remove_test_runner_arguments(&argc, argv);
 
 
-  JVMInitializerListener* jvm_listener = NULL;
+  JVMInitializerListener* jvm_listener = nullptr;
 
   if (is_vmassert_test || is_othervm_test) {
-    JavaVM* jvm = NULL;
+    JavaVM* jvm = nullptr;
     // both vmassert and other vm tests require inited jvm
     // but only vmassert tests disable hs_err and core file generation
     int ret;
@@ -300,7 +300,7 @@ static void runUnitTestsInner(int argc, char** argv) {
     os::exit(2);
   }
 
-  if (jvm_listener != NULL) {
+  if (jvm_listener != nullptr) {
     jvm_listener->destroy_jvm();
   }
 }
@@ -323,8 +323,8 @@ static DWORD WINAPI thread_wrapper(void* p) {
 
 static void run_in_new_thread(const args_t* args) {
   HANDLE hdl;
-  hdl = CreateThread(NULL, STACK_SIZE, thread_wrapper, (void*)args, 0, NULL);
-  if (hdl == NULL) {
+  hdl = CreateThread(nullptr, STACK_SIZE, thread_wrapper, (void*)args, 0, nullptr);
+  if (hdl == nullptr) {
     fprintf(stderr, "Failed to create main thread\n");
     os::exit(2);
   }
@@ -351,7 +351,7 @@ static void run_in_new_thread(const args_t* args) {
     os::exit(2);
   }
 
-  if (pthread_join(tid, NULL) != 0) {
+  if (pthread_join(tid, nullptr) != 0) {
     fprintf(stderr, "Failed to join main thread\n");
     os::exit(2);
   }

--- a/test/hotspot/gtest/jfr/test_adaptiveSampler.cpp
+++ b/test/hotspot/gtest/jfr/test_adaptiveSampler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Datadog, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -200,7 +200,7 @@ class JfrGTestAdaptiveSampling : public ::testing::Test {
 };
 
 void JfrGTestAdaptiveSampling::test(JfrGTestAdaptiveSampling::incoming inc, size_t sample_points_per_window, double error_factor, const char* const description) {
-  assert(description != NULL, "invariant");
+  assert(description != nullptr, "invariant");
   char output[1024] = "Adaptive sampling: ";
   strcat(output, description);
   fprintf(stdout, "=== %s\n", output);

--- a/test/hotspot/gtest/jfr/test_networkUtilization.cpp
+++ b/test/hotspot/gtest/jfr/test_networkUtilization.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ namespace {
    public:
     MockJfrOSInterface() {}
     static int network_utilization(NetworkInterface** network_interfaces) {
-      *network_interfaces = NULL;
+      *network_interfaces = nullptr;
       for (std::list<MockNetworkInterface>::const_iterator i = _interfaces.begin();
            i != _interfaces.end();
            ++i) {

--- a/test/hotspot/gtest/jfr/test_threadCpuLoad.cpp
+++ b/test/hotspot/gtest/jfr/test_threadCpuLoad.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,14 +82,14 @@ namespace {
   class MockJfrJavaThreadIterator
   {
   public:
-    MockJavaThread* next() { return NULL; }
+    MockJavaThread* next() { return nullptr; }
     bool has_next() const { return false; }
   };
 
   class MockJfrJavaThreadIteratorAdapter
   {
   public:
-    MockJavaThread* next() { return NULL; }
+    MockJavaThread* next() { return nullptr; }
     bool has_next() const { return false; }
   };
 

--- a/test/hotspot/gtest/logging/logTestFixture.cpp
+++ b/test/hotspot/gtest/logging/logTestFixture.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 #include "unittest.hpp"
 #include "utilities/ostream.hpp"
 
-LogTestFixture::LogTestFixture() : _n_snapshots(0), _configuration_snapshot(NULL) {
+LogTestFixture::LogTestFixture() : _n_snapshots(0), _configuration_snapshot(nullptr) {
 
   // Set up TestLogFileName to include temp_dir, PID, testcase name and test name.
   const testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
@@ -98,19 +98,19 @@ void LogTestFixture::restore_config() {
     char* decorators = str;
 
     str = strchr(str, ' ');
-    if (str != NULL) {
+    if (str != nullptr) {
       // This output has options. However, UL doesn't allow the options of any
       // output to be changed, so they cannot be modified by the tests,
       // and also we cannot change them here. So just mark the end of the
       // decorators.
       *str++ = '\0';
     }
-    set_log_config(name, selection, decorators, /* options = */ NULL);
+    set_log_config(name, selection, decorators, /* options = */ nullptr);
   }
 }
 
 void LogTestFixture::clear_snapshot() {
-  if (_configuration_snapshot == NULL) {
+  if (_configuration_snapshot == nullptr) {
     return;
   }
   ASSERT_GT(_n_snapshots, size_t(0)) << "non-null array should have at least 1 element";
@@ -118,6 +118,6 @@ void LogTestFixture::clear_snapshot() {
     os::free(_configuration_snapshot[i]);
   }
   FREE_C_HEAP_ARRAY(char*, _configuration_snapshot);
-  _configuration_snapshot = NULL;
+  _configuration_snapshot = nullptr;
   _n_snapshots = 0;
 }

--- a/test/hotspot/gtest/logging/logTestUtils.inline.hpp
+++ b/test/hotspot/gtest/logging/logTestUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ static const char* invalid_selection_substr[] = {
 };
 
 static inline bool string_contains_substring(const char* haystack, const char* needle) {
-  return strstr(haystack, needle) != NULL;
+  return strstr(haystack, needle) != nullptr;
 }
 
 static inline bool file_exists(const char* filename) {
@@ -60,7 +60,7 @@ static inline void create_directory(const char* name) {
   ASSERT_FALSE(file_exists(name)) << "can't create directory: " << name << " already exists";
   bool failed;
 #ifdef _WINDOWS
-  failed = !CreateDirectory(name, NULL);
+  failed = !CreateDirectory(name, nullptr);
 #else
   failed = mkdir(name, 0777);
 #endif
@@ -115,16 +115,16 @@ static inline char* prepend_prefix_temp_dir(const char* prefix, const char* file
 }
 
 // Read a complete line from fp and return it as a resource allocated string.
-// Returns NULL on EOF.
+// Returns nullptr on EOF.
 static inline char* read_line(FILE* fp) {
-  assert(fp != NULL, "invalid fp");
+  assert(fp != nullptr, "invalid fp");
   int buflen = 512;
   char* buf = NEW_RESOURCE_ARRAY(char, buflen);
   long pos = ftell(fp);
-  if (pos < 0) return NULL;
+  if (pos < 0) return nullptr;
 
   char* ret = fgets(buf, buflen, fp);
-  while (ret != NULL && buf[strlen(buf) - 1] != '\n' && !feof(fp)) {
+  while (ret != nullptr && buf[strlen(buf) - 1] != '\n' && !feof(fp)) {
     // retry with a larger buffer
     buf = REALLOC_RESOURCE_ARRAY(char, buf, buflen, buflen * 2);
     buflen *= 2;
@@ -139,19 +139,19 @@ static inline char* read_line(FILE* fp) {
 static bool file_contains_substrings_in_order(const char* filename, const char* substrs[]) {
   AsyncLogWriter::flush();
   FILE* fp = os::fopen(filename, "r");
-  assert(fp != NULL, "error opening file %s: %s", filename, os::strerror(errno));
+  assert(fp != nullptr, "error opening file %s: %s", filename, os::strerror(errno));
 
   size_t idx = 0;
-  while (substrs[idx] != NULL) {
+  while (substrs[idx] != nullptr) {
     ResourceMark rm;
     char* line = read_line(fp);
-    if (line == NULL) {
+    if (line == nullptr) {
       break;
     }
-    for (char* match = strstr(line, substrs[idx]); match != NULL;) {
+    for (char* match = strstr(line, substrs[idx]); match != nullptr;) {
       size_t match_len = strlen(substrs[idx]);
       idx++;
-      if (substrs[idx] == NULL) {
+      if (substrs[idx] == nullptr) {
         break;
       }
       match = strstr(match + match_len, substrs[idx]);
@@ -159,10 +159,10 @@ static bool file_contains_substrings_in_order(const char* filename, const char* 
   }
 
   fclose(fp);
-  return substrs[idx] == NULL;
+  return substrs[idx] == nullptr;
 }
 
 static inline bool file_contains_substring(const char* filename, const char* substr) {
-  const char* strs[] = {substr, NULL};
+  const char* strs[] = {substr, nullptr};
   return file_contains_substrings_in_order(filename, strs);
 }

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/logging/test_asynclog.cpp
+++ b/test/hotspot/gtest/logging/test_asynclog.cpp
@@ -91,7 +91,7 @@ LOG_LEVEL_LIST
   bool write_to_file(const std::string& output) {
     FILE* f = os::fopen(TestLogFileName, "w");
 
-    if (f != NULL) {
+    if (f != nullptr) {
       size_t sz = output.size();
       size_t written = fwrite(output.c_str(), sizeof(char), output.size(), f);
       return fclose(f) == 0 && sz == written;
@@ -146,7 +146,7 @@ TEST_VM_F(AsyncLogTest, logMessage) {
   ResourceMark rm;
   LogMessageBuffer buffer;
   const char* strs[MULTI_LINES + 1];
-  strs[MULTI_LINES] = NULL;
+  strs[MULTI_LINES] = nullptr;
   for (int i = 0; i < MULTI_LINES; ++i) {
     stringStream ss;
     ss.print_cr("nonbreakable log message line-%02d", i);

--- a/test/hotspot/gtest/logging/test_gcTraceTime.cpp
+++ b/test/hotspot/gtest/logging/test_gcTraceTime.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,13 +45,13 @@ TEST_VM_F(GCTraceTimeTest, full) {
   {
     ThreadInVMfromNative tvn(JavaThread::current());
     MutexLocker lock(Heap_lock); // Needed to read heap usage
-    GCTraceTime(Debug, gc) timer("Test GC", NULL, GCCause::_allocation_failure, true);
+    GCTraceTime(Debug, gc) timer("Test GC", nullptr, GCCause::_allocation_failure, true);
   }
 
   const char* expected[] = {
     "[gc,start", "] Test GC (Allocation Failure)",
     "[gc", "] Test GC (Allocation Failure) ", "M) ", "ms",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, expected));
 }
@@ -68,13 +68,13 @@ TEST_VM_F(GCTraceTimeTest, full_multitag) {
   {
     ThreadInVMfromNative tvn(JavaThread::current());
     MutexLocker lock(Heap_lock); // Needed to read heap usage
-    GCTraceTime(Debug, gc, ref) timer("Test GC", NULL, GCCause::_allocation_failure, true);
+    GCTraceTime(Debug, gc, ref) timer("Test GC", nullptr, GCCause::_allocation_failure, true);
   }
 
   const char* expected[] = {
     "[gc,ref,start", "] Test GC (Allocation Failure)",
     "[gc,ref", "] Test GC (Allocation Failure) ", "M) ", "ms",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, expected));
 }
@@ -89,7 +89,7 @@ TEST_VM_F(GCTraceTimeTest, no_heap) {
   EXPECT_TRUE(gc_start_debug.is_enabled());
 
   {
-    GCTraceTime(Debug, gc) timer("Test GC", NULL, GCCause::_allocation_failure, false);
+    GCTraceTime(Debug, gc) timer("Test GC", nullptr, GCCause::_allocation_failure, false);
   }
 
   const char* expected[] = {
@@ -97,7 +97,7 @@ TEST_VM_F(GCTraceTimeTest, no_heap) {
     "[gc,start", "] Test GC (Allocation Failure)",
     // [2.975s][debug][gc      ] Test GC (Allocation Failure) 0.026ms
     "[gc", "] Test GC (Allocation Failure) ", "ms",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, expected));
 
@@ -120,7 +120,7 @@ TEST_VM_F(GCTraceTimeTest, no_cause) {
   {
     ThreadInVMfromNative tvn(JavaThread::current());
     MutexLocker lock(Heap_lock); // Needed to read heap usage
-    GCTraceTime(Debug, gc) timer("Test GC", NULL, GCCause::_no_gc, true);
+    GCTraceTime(Debug, gc) timer("Test GC", nullptr, GCCause::_no_gc, true);
   }
 
   const char* expected[] = {
@@ -128,7 +128,7 @@ TEST_VM_F(GCTraceTimeTest, no_cause) {
     "[gc,start", "] Test GC",
     // [2.975s][debug][gc      ] Test GC 59M->59M(502M) 0.026ms
     "[gc", "] Test GC ", "M) ", "ms",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, expected));
 }
@@ -143,7 +143,7 @@ TEST_VM_F(GCTraceTimeTest, no_heap_no_cause) {
   EXPECT_TRUE(gc_start_debug.is_enabled());
 
   {
-    GCTraceTime(Debug, gc) timer("Test GC", NULL, GCCause::_no_gc, false);
+    GCTraceTime(Debug, gc) timer("Test GC", nullptr, GCCause::_no_gc, false);
   }
 
   const char* expected[] = {
@@ -151,7 +151,7 @@ TEST_VM_F(GCTraceTimeTest, no_heap_no_cause) {
     "[gc,start", "] Test GC",
     // [2.975s][debug][gc      ] Test GC 0.026ms
     "[gc", "] Test GC ", "ms",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(TestLogFileName, expected));
 

--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -61,7 +61,7 @@ TEST_VM_F(LogTest, large_message) {
   AsyncLogWriter::flush();
   ResourceMark rm;
   FILE* fp = os::fopen(TestLogFileName, "r");
-  ASSERT_NE((void*)nullptr, fp);
+  ASSERT_NE(nullptr, fp);
   char* output = read_line(fp);
   fclose(fp);
 

--- a/test/hotspot/gtest/logging/test_log.cpp
+++ b/test/hotspot/gtest/logging/test_log.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ TEST_VM_F(LogTest, large_message) {
   AsyncLogWriter::flush();
   ResourceMark rm;
   FILE* fp = os::fopen(TestLogFileName, "r");
-  ASSERT_NE((void*)NULL, fp);
+  ASSERT_NE((void*)nullptr, fp);
   char* output = read_line(fp);
   fclose(fp);
 
@@ -91,7 +91,7 @@ TEST_VM_F(LogTest, disabled_logtarget) {
   // Try to log, but expect this to be filtered out.
   log.print(LOG_TEST_STRING_LITERAL);
 
-  // Log a dummy line so that fgets doesn't return NULL because the file is empty.
+  // Log a dummy line so that fgets doesn't return nullptr because the file is empty.
   log_info(gc)("Dummy line");
 
   EXPECT_FALSE(file_contains_substring(TestLogFileName, LOG_TEST_STRING_LITERAL));
@@ -122,7 +122,7 @@ TEST_VM_F(LogTest, disabled_loghandle) {
   // Try to log through a LogHandle.
   log_handle.debug("%d workers", 3);
 
-  // Log a dummy line so that fgets doesn't return NULL because the file is empty.
+  // Log a dummy line so that fgets doesn't return nullptr because the file is empty.
   log_info(gc)("Dummy line");
 
   EXPECT_FALSE(file_contains_substring(TestLogFileName, "3 workers"));
@@ -153,7 +153,7 @@ TEST_VM_F(LogTest, disabled_logtargethandle) {
   // Try to log through a LogHandle.
   log_handle.print("%d workers", 3);
 
-  // Log a dummy line so that fgets doesn't return NULL because the file is empty.
+  // Log a dummy line so that fgets doesn't return nullptr because the file is empty.
   log_info(gc)("Dummy line");
 
   EXPECT_FALSE(file_contains_substring(TestLogFileName, "3 workers"));

--- a/test/hotspot/gtest/logging/test_logConfiguration.cpp
+++ b/test/hotspot/gtest/logging/test_logConfiguration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ TEST_VM_F(LogConfigurationTest, update_output) {
 
     // Verify by iterating over tagsets
     LogOutput* o = LogConfiguration::StdoutLog;
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       EXPECT_TRUE(ts->has_output(o));
       EXPECT_TRUE(ts->is_level(LogLevel::Info));
       EXPECT_FALSE(ts->is_level(LogLevel::Debug));
@@ -140,7 +140,7 @@ TEST_VM_F(LogConfigurationTest, update_output) {
 
     // Now change the level and verify the change propagated
     set_log_config(test_outputs[i], "all=debug");
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       EXPECT_TRUE(ts->has_output(o));
       EXPECT_TRUE(ts->is_level(LogLevel::Debug));
       EXPECT_FALSE(ts->is_level(LogLevel::Trace));
@@ -160,7 +160,7 @@ TEST_VM_F(LogConfigurationTest, add_new_output) {
   EXPECT_TRUE(is_described("all=trace"));
 
   // Also verify by iterating over tagsets, checking levels on tagsets
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_TRUE(ts->is_level(LogLevel::Trace));
   }
 }
@@ -182,7 +182,7 @@ TEST_VM_F(LogConfigurationTest, disable_logging) {
   delete_file(other_file_name);
 
   // Verify that no tagset has logging enabled
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_FALSE(ts->has_output(LogConfiguration::StdoutLog));
     EXPECT_FALSE(ts->has_output(LogConfiguration::StderrLog));
     EXPECT_FALSE(ts->is_level(LogLevel::Error));
@@ -199,7 +199,7 @@ TEST_VM_F(LogConfigurationTest, disable_output) {
 
   // Verify by iterating over tagsets
   LogOutput* o = LogConfiguration::StdoutLog;
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_FALSE(ts->has_output(o));
     EXPECT_FALSE(ts->is_level(LogLevel::Error));
   }
@@ -212,7 +212,7 @@ TEST_VM_F(LogConfigurationTest, disable_output) {
   // Now disable it, verifying it is removed completely
   set_log_config(TestLogFileName, "all=off");
   EXPECT_FALSE(is_described(TestLogFileName));
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_FALSE(ts->is_level(LogLevel::Error));
   }
 }
@@ -337,7 +337,7 @@ TEST_VM_F(LogConfigurationTest, parse_empty_command_line_arguments) {
     const char* cmdline = empty_variations[i];
     bool ret = LogConfiguration::parse_command_line_arguments(cmdline);
     EXPECT_TRUE(ret) << "Error parsing command line arguments '" << cmdline << "'";
-    for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+    for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
       EXPECT_EQ(LogLevel::Unspecified, ts->level_for(LogConfiguration::StdoutLog));
     }
   }
@@ -427,7 +427,7 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   EXPECT_TRUE(log_is_enabled(Debug, gc));
   EXPECT_TRUE(log_is_enabled(Info, logging));
   EXPECT_FALSE(log_is_enabled(Debug, gc, heap));
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     if (ts->contains(PREFIX_LOG_TAG(gc))) {
       if (ts->ntags() == 1) {
         EXPECT_EQ(LogLevel::Debug, ts->level_for(LogConfiguration::StdoutLog));
@@ -441,7 +441,7 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   LogConfiguration::configure_stdout(LogLevel::Trace, false, LOG_TAGS(gc));
   EXPECT_TRUE(log_is_enabled(Trace, gc));
   EXPECT_TRUE(log_is_enabled(Trace, gc, heap));
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     if (ts->contains(PREFIX_LOG_TAG(gc))) {
       EXPECT_EQ(LogLevel::Trace, ts->level_for(LogConfiguration::StdoutLog));
     } else if (ts == logging_ts) {
@@ -458,7 +458,7 @@ TEST_VM_F(LogConfigurationTest, configure_stdout) {
   LogConfiguration::configure_stdout(LogLevel::Off, false, LOG_TAGS(gc));
   EXPECT_FALSE(log_is_enabled(Error, gc));
   EXPECT_FALSE(log_is_enabled(Error, gc, heap));
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_EQ(LogLevel::Off, ts->level_for(LogConfiguration::StdoutLog));
   }
 }
@@ -476,7 +476,7 @@ TEST_VM_F(LogConfigurationTest, subscribe) {
   LogConfiguration::register_update_listener(&Test_logconfiguration_subscribe_helper);
 
   LogStream ls(log.error());
-  LogConfiguration::parse_log_arguments("stdout", "logging=trace", NULL, NULL, &ls);
+  LogConfiguration::parse_log_arguments("stdout", "logging=trace", nullptr, nullptr, &ls);
   ASSERT_EQ(1, Test_logconfiguration_subscribe_triggered);
 
   LogConfiguration::configure_stdout(LogLevel::Debug, true, LOG_TAGS(gc));
@@ -492,7 +492,7 @@ TEST_VM_F(LogConfigurationTest, parse_invalid_tagset) {
   // Make sure warning is produced if one or more configured tagsets are invalid
   ResourceMark rm;
   stringStream ss;
-  bool success = LogConfiguration::parse_log_arguments("stdout", invalid_tagset, NULL, NULL, &ss);
+  bool success = LogConfiguration::parse_log_arguments("stdout", invalid_tagset, nullptr, nullptr, &ss);
   const char* msg = ss.as_string();
   EXPECT_TRUE(success) << "Should only cause a warning, not an error";
   EXPECT_THAT(msg, HasSubstr("No tag set matches selection:"));
@@ -527,7 +527,7 @@ TEST_VM_F(LogConfigurationTest, output_name_normalization) {
 
 static size_t count_occurrences(const char* haystack, const char* needle) {
   size_t count = 0;
-  for (const char* p = strstr(haystack, needle); p != NULL; p = strstr(p + 1, needle)) {
+  for (const char* p = strstr(haystack, needle); p != nullptr; p = strstr(p + 1, needle)) {
     count++;
   }
   return count;
@@ -539,7 +539,7 @@ TEST_OTHER_VM(LogConfiguration, output_reconfigured) {
 
   EXPECT_FALSE(is_described("(reconfigured)"));
 
-  bool success = LogConfiguration::parse_log_arguments("#1", "all=warning", NULL, NULL, &ss);
+  bool success = LogConfiguration::parse_log_arguments("#1", "all=warning", nullptr, nullptr, &ss);
   ASSERT_TRUE(success);
   EXPECT_EQ(0u, ss.size());
 
@@ -557,7 +557,7 @@ TEST_VM_F(LogConfigurationTest, suggest_similar_selection) {
 
   ResourceMark rm;
   stringStream ss;
-  LogConfiguration::parse_log_arguments("stdout", nonexisting_tagset, NULL, NULL, &ss);
+  LogConfiguration::parse_log_arguments("stdout", nonexisting_tagset, nullptr, nullptr, &ss);
 
   const char* suggestion = ss.as_string();
   SCOPED_TRACE(suggestion);

--- a/test/hotspot/gtest/logging/test_logDecorations.cpp
+++ b/test/hotspot/gtest/logging/test_logDecorations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ TEST_VM(LogDecorations, uptime) {
   for (int i = 0; i < 3; i++) {
     os::naked_short_sleep(10);
     LogDecorations d(LogLevel::Info, tagset, default_decorators);
-    double cur = strtod(d.decoration(LogDecorators::uptime_decorator, buf, sizeof(buf)), NULL);
+    double cur = strtod(d.decoration(LogDecorators::uptime_decorator, buf, sizeof(buf)), nullptr);
     ASSERT_LT(prev, cur);
     prev = cur;
   }
@@ -123,7 +123,7 @@ TEST_VM(LogDecorations, timestamps) {
       // at 15-16ms, so we use 20.
       os::naked_short_sleep(20);
       LogDecorations d(LogLevel::Info, tagset, decorator_selection);
-      julong val = strtoull(d.decoration(decorator, buf, sizeof(buf)), NULL, 10);
+      julong val = strtoull(d.decoration(decorator, buf, sizeof(buf)), nullptr, 10);
       tty->print_cr("Read value: " UINT64_FORMAT, val);
       ASSERT_LT(prev, val);
       prev = val;
@@ -139,7 +139,7 @@ TEST(LogDecorations, iso8601_time) {
   LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
 
   const char *timestr = decorations.decoration(LogDecorators::time_decorator, buf, sizeof(buf));
-  time_t expected_ts = time(NULL);
+  time_t expected_ts = time(nullptr);
 
   // Verify format
   int y, M, d, h, m, s, ms;
@@ -174,7 +174,7 @@ TEST(LogDecorations, iso8601_utctime) {
   LogDecorations decorations(LogLevel::Info, tagset, decorator_selection);
 
   const char *timestr = decorations.decoration(LogDecorators::utctime_decorator, buf, sizeof(buf));
-  time_t expected_ts = time(NULL);
+  time_t expected_ts = time(nullptr);
 
   // Verify format
   char trailing_character;
@@ -234,6 +234,6 @@ TEST(LogDecorations, identifiers) {
     EXPECT_EQ('\0', *str) << "Should only contain digits";
 
     // Verify value
-    EXPECT_EQ(ids[i].expected, strtol(reported, NULL, 10));
+    EXPECT_EQ(ids[i].expected, strtol(reported, nullptr, 10));
   }
 }

--- a/test/hotspot/gtest/logging/test_logMessageTest.cpp
+++ b/test/hotspot/gtest/logging/test_logMessageTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ protected:
 Log(logging) LogMessageTest::_log;
 
 const char* LogMessageTest::_level_filename[] = {
-  NULL, // LogLevel::Off
+  nullptr, // LogLevel::Off
 #define LOG_LEVEL(name, printname) "multiline-" #printname ".log",
   LOG_LEVEL_LIST
 #undef LOG_LEVEL
@@ -132,7 +132,7 @@ TEST_VM_F(LogMessageTest, line_order) {
   _log.write(msg);
 
   const char* expected[] = { "info line", "error line", "trace line",
-                             "another error", "warning line", "debug line", NULL };
+                             "another error", "warning line", "debug line", nullptr };
   EXPECT_TRUE(file_contains_substrings_in_order(_level_filename[LogLevel::Trace], expected))
     << "output missing or in incorrect order";
 }
@@ -156,7 +156,7 @@ TEST_VM_F(LogMessageTest, long_message) {
   msg.trace("%s", data); // Adds a newline, making the message exactly 10K in length.
   _log.write(msg);
 
-  const char* expected[] = { start_marker, "0123456789", end_marker, NULL };
+  const char* expected[] = { start_marker, "0123456789", end_marker, nullptr };
   EXPECT_TRUE(file_contains_substrings_in_order(_level_filename[LogLevel::Trace], expected))
     << "unable to print long line";
   FREE_C_HEAP_ARRAY(char, data);
@@ -178,7 +178,7 @@ TEST_VM_F(LogMessageTest, message_with_many_lines) {
     jio_snprintf(&expected_lines_data[i][0], line_length, "Line #" SIZE_FORMAT, i);
     expected_lines[i] = expected_lines_data[i];
   }
-  expected_lines[lines] = NULL;
+  expected_lines[lines] = nullptr;
 
   EXPECT_TRUE(file_contains_substrings_in_order(_level_filename[LogLevel::Trace], expected_lines))
     << "couldn't find all lines in multiline message";
@@ -201,7 +201,7 @@ TEST_VM_F(LogMessageTest, prefixing) {
   for (int i = 0; i < 3; i++) {
     msg.info("test %d", i);
   }
-  msg.set_prefix(NULL);
+  msg.set_prefix(nullptr);
   msg.info("test 3");
   _log.write(msg);
 
@@ -210,7 +210,7 @@ TEST_VM_F(LogMessageTest, prefixing) {
     "] some prefix: test 1",
     "] some prefix: test 2",
     "] test 3",
-    NULL
+    nullptr
   };
   EXPECT_TRUE(file_contains_substrings_in_order(_level_filename[LogLevel::Trace], expected))
     << "error in prefixed output";
@@ -238,7 +238,7 @@ TEST_VM_F(LogMessageTest, scoped_flushing) {
     EXPECT_TRUE(file_contains_substring(_level_filename[LogLevel::Info], "manual flush info"))
       << "missing output from manually flushed scoped log message";
   }
-  const char* tmp[] = {"manual flush info", "manual flush info", NULL};
+  const char* tmp[] = {"manual flush info", "manual flush info", nullptr};
   EXPECT_FALSE(file_contains_substrings_in_order(_level_filename[LogLevel::Info], tmp))
     << "log file contains duplicate lines from single scoped log message";
 }

--- a/test/hotspot/gtest/logging/test_logSelectionList.cpp
+++ b/test/hotspot/gtest/logging/test_logSelectionList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ TEST(LogSelectionList, level_for_empty) {
   LogSelectionList emptyexpr;
   ASSERT_TRUE(emptyexpr.parse(""));
   // All tagsets should be unspecified since the expression doesn't involve any tagset
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     EXPECT_EQ(LogLevel::Unspecified, emptyexpr.level_for(*ts));
   }
 }
@@ -93,7 +93,7 @@ TEST(LogSelectionList, level_for_overlap) {
   LogSelectionList overlapexpr;
   // The all=warning will be overridden with gc=info and/or logging+safepoint*=trace
   ASSERT_TRUE(overlapexpr.parse("all=warning,gc=info,logging+safepoint*=trace"));
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     if (ts->contains(PREFIX_LOG_TAG(gc)) && ts->ntags() == 1) {
       EXPECT_EQ(LogLevel::Info, overlapexpr.level_for(*ts));
     } else if (ts->contains(PREFIX_LOG_TAG(logging)) && ts->contains(PREFIX_LOG_TAG(safepoint))) {

--- a/test/hotspot/gtest/logging/test_logStream.cpp
+++ b/test/hotspot/gtest/logging/test_logStream.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ TEST_VM_F(LogStreamTest, TestLineBufferAllocation) {
 // Compare this to NonInterLeavingLogStreamTest_NonInterleavingStream
 TEST_VM_F(LogStreamTest, InterleavingStream) {
   set_log_config(TestLogFileName, "gc=info");
-  const char* message_order[] = {"1", "I am one line", "2", "but", "3", "I am not", NULL};
+  const char* message_order[] = {"1", "I am one line", "2", "but", "3", "I am not", nullptr};
   {
     LogStream foo(Log(gc)::info());
     if (foo.is_enabled()) {
@@ -116,7 +116,7 @@ TEST_VM_F(LogStreamTest, InterleavingStream) {
 // Compare this to LogStreamTest_InterleavingStream
 TEST_VM_F(LogStreamTest, NonInterleavingStream) {
   set_log_config(TestLogFileName, "gc=info");
-  const char* message_order[] = {"1", "2" , "3", "I am one line", "but", "I am not", NULL};
+  const char* message_order[] = {"1", "2" , "3", "I am one line", "but", "I am not", nullptr};
   {
     LogMessage(gc) lm ;
     NonInterleavingLogStream foo{LogLevelType::Info, lm};

--- a/test/hotspot/gtest/logging/test_logTag.cpp
+++ b/test/hotspot/gtest/logging/test_logTag.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,16 +72,16 @@ TEST(LogTag, list_tags) {
 
   bool listed_tags[LogTag::Count] = { false };
 
-  char* last_tag = NULL;
+  char* last_tag = nullptr;
   for (char* tag = buf; *tag != '\0';) {
     char* end = strpbrk(tag, ",\n");
-    ASSERT_TRUE(end != NULL) <<  "line should end with newline";
+    ASSERT_TRUE(end != nullptr) <<  "line should end with newline";
     *end = '\0';
     if (*tag == ' ') {
       tag++;
     }
 
-    EXPECT_TRUE(last_tag == NULL || strcmp(last_tag, tag) < 0) << tag << " should be listed before " << last_tag;
+    EXPECT_TRUE(last_tag == nullptr || strcmp(last_tag, tag) < 0) << tag << " should be listed before " << last_tag;
     listed_tags[LogTag::from_string(tag)] = true;
 
     last_tag = tag;

--- a/test/hotspot/gtest/logging/test_logTagSet.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
 
 // Test the default level for each tagset
 TEST_VM(LogTagSet, defaults) {
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     char buf[256];
     ts->label(buf, sizeof(buf));
     SCOPED_TRACE(buf);
@@ -49,7 +49,7 @@ TEST_VM(LogTagSet, has_output) {
   LogTagSet& ts = LogTagSetMapping<LOG_TAGS(logging)>::tagset();
   ts.set_output_level(LogConfiguration::StderrLog, LogLevel::Trace);
   EXPECT_TRUE(ts.has_output(LogConfiguration::StderrLog));
-  EXPECT_FALSE(ts.has_output(NULL));
+  EXPECT_FALSE(ts.has_output(nullptr));
   ts.set_output_level(LogConfiguration::StderrLog, LogLevel::Off);
   EXPECT_FALSE(ts.has_output(LogConfiguration::StderrLog));
 }
@@ -140,7 +140,7 @@ TEST_VM(LogTagSet, label) {
 }
 
 TEST_VM(LogTagSet, duplicates) {
-  for (LogTagSet* ts = LogTagSet::first(); ts != NULL; ts = ts->next()) {
+  for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     char ts_name[512];
     ts->label(ts_name, sizeof(ts_name), ",");
 
@@ -155,7 +155,7 @@ TEST_VM(LogTagSet, duplicates) {
     }
 
     // verify that there are no duplicate tagsets (same tags in different order)
-    for (LogTagSet* other = ts->next(); other != NULL; other = other->next()) {
+    for (LogTagSet* other = ts->next(); other != nullptr; other = other->next()) {
       if (ts->ntags() != other->ntags()) {
         continue;
       }

--- a/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
+++ b/test/hotspot/gtest/logging/test_logTagSetDescriptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 #include "utilities/ostream.hpp"
 
 TEST_VM(LogTagSetDescriptions, describe) {
-  for (LogTagSetDescription* d = tagset_descriptions; d->tagset != NULL; d++) {
+  for (LogTagSetDescription* d = tagset_descriptions; d->tagset != nullptr; d++) {
     char expected[1 * K];
     d->tagset->label(expected, sizeof(expected), "+");
     jio_snprintf(expected + strlen(expected),
@@ -51,12 +51,12 @@ TEST_VM(LogTagSetDescriptions, command_line_help) {
   ResourceMark rm;
   const char* filename = prepend_temp_dir("logtagset_descriptions");
   FILE* fp = os::fopen(filename, "w+");
-  ASSERT_NE((void*)NULL, fp);
+  ASSERT_NE((void*)nullptr, fp);
   fileStream stream(fp);
   LogConfiguration::print_command_line_help(&stream);
   fclose(fp);
 
-  for (LogTagSetDescription* d = tagset_descriptions; d->tagset != NULL; d++) {
+  for (LogTagSetDescription* d = tagset_descriptions; d->tagset != nullptr; d++) {
     char expected[1 * K];
     d->tagset->label(expected, sizeof(expected), "+");
     jio_snprintf(expected + strlen(expected),

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -94,15 +94,15 @@ TEST_VM(Arena, realloc_same_size) {
   ASSERT_RANGE_IS_MARKED(p2, 0x200);
 }
 
-// Test behavior for Afree(NULL) and Arealloc(NULL, x)
+// Test behavior for Afree(nullptr) and Arealloc(nullptr, x)
 TEST_VM(Arena, free_null) {
   Arena ar(mtTest);
-  ar.Afree(NULL, 10); // should just be ignored
+  ar.Afree(nullptr, 10); // should just be ignored
 }
 
 TEST_VM(Arena, realloc_null) {
   Arena ar(mtTest);
-  void* p = ar.Arealloc(NULL, 0, 20); // equivalent to Amalloc(20)
+  void* p = ar.Arealloc(nullptr, 0, 20); // equivalent to Amalloc(20)
   ASSERT_AMALLOC(ar, p);
 }
 
@@ -238,7 +238,7 @@ TEST_VM(Arena, random_allocs) {
   for (int i = 0; i < num_allocs; i ++) {
     size_t size = os::random() % (avg_alloc_size * 2); // Note: size==0 is okay; we want to test that too
     size_t alignment = 0;
-    void* p = NULL;
+    void* p = nullptr;
     if (os::random() % 2) { // randomly switch between Amalloc and AmallocWords
       p = ar.Amalloc(size);
       alignment = BytesPerLong;
@@ -297,7 +297,7 @@ TEST_VM(Arena, random_allocs) {
       ar.Afree(ptrs[i], sizes[i]);
       // In debug builds the freed space should be filled the space with badResourceValue
       DEBUG_ONLY(ASSERT_RANGE_IS_MARKED_WITH(ptrs[i], sizes[i], badResourceValue));
-      ptrs[i] = NULL;
+      ptrs[i] = nullptr;
     }
   }
 

--- a/test/hotspot/gtest/memory/test_arena.cpp
+++ b/test/hotspot/gtest/memory/test_arena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.

--- a/test/hotspot/gtest/memory/test_guardedMemory.cpp
+++ b/test/hotspot/gtest/memory/test_guardedMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
 #define GEN_PURPOSE_TAG ((void *) ((uintptr_t)0xf000f000))
 
 static void guarded_memory_test_check(void* p, size_t sz, void* tag) {
-  ASSERT_TRUE(p != NULL) << "NULL pointer given to check";
+  ASSERT_TRUE(p != nullptr) << "nullptr pointer given to check";
   u_char* c = (u_char*) p;
   GuardedMemory guarded(c);
   EXPECT_EQ(guarded.get_tag(), tag) << "Tag is not the same as supplied";
@@ -130,19 +130,19 @@ TEST(GuardedMemory, buffer_overrun_tail) {
 
 // Test wrap_copy/wrap_free
 TEST(GuardedMemory, wrap) {
-  EXPECT_TRUE(GuardedMemory::free_copy(NULL)) << "Expected free NULL to be OK";
+  EXPECT_TRUE(GuardedMemory::free_copy(nullptr)) << "Expected free nullptr to be OK";
 
   const char* str = "Check my bounds out";
   size_t str_sz = strlen(str) + 1;
   char* str_copy = (char*) GuardedMemory::wrap_copy(str, str_sz);
-  guarded_memory_test_check(str_copy, str_sz, NULL);
+  guarded_memory_test_check(str_copy, str_sz, nullptr);
   if (HasFatalFailure()) {
     return;
   }
   EXPECT_STREQ(str, str_copy) << "Not identical copy";
   EXPECT_TRUE(GuardedMemory::free_copy(str_copy)) << "Free copy failed to verify";
 
-  void* no_data = NULL;
+  void* no_data = nullptr;
   void* no_data_copy = GuardedMemory::wrap_copy(no_data, 0);
   EXPECT_TRUE(GuardedMemory::free_copy(no_data_copy))
           << "Expected valid guards even for no data copy";

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ namespace {
     ReservedSpace rs(size);
     MemoryReleaser releaser(&rs);
 
-    EXPECT_TRUE(rs.base() != NULL) << "rs.special: " << rs.special();
+    EXPECT_TRUE(rs.base() != nullptr) << "rs.special: " << rs.special();
     EXPECT_EQ(size, rs.size()) << "rs.special: " << rs.special();
 
     if (rs.special()) {
@@ -78,9 +78,9 @@ namespace {
   static void test_reserved_size_alignment(size_t size, size_t alignment) {
     ASSERT_PRED2(is_size_aligned, size, alignment) << "Incorrect input parameters";
     size_t page_size = UseLargePages ? os::large_page_size() : os::vm_page_size();
-    ReservedSpace rs(size, alignment, page_size, (char *) NULL);
+    ReservedSpace rs(size, alignment, page_size, (char *) nullptr);
 
-    ASSERT_TRUE(rs.base() != NULL) << "rs.special = " << rs.special();
+    ASSERT_TRUE(rs.base() != nullptr) << "rs.special = " << rs.special();
     ASSERT_EQ(size, rs.size()) << "rs.special = " << rs.special();
 
     EXPECT_PRED2(is_ptr_aligned, rs.base(), alignment)
@@ -109,7 +109,7 @@ namespace {
     ReservedSpace rs(size, alignment, page_size);
     MemoryReleaser releaser(&rs);
 
-    EXPECT_TRUE(rs.base() != NULL) << "rs.special: " << rs.special();
+    EXPECT_TRUE(rs.base() != nullptr) << "rs.special: " << rs.special();
     EXPECT_EQ(size, rs.size()) << "rs.special: " << rs.special();
 
     if (rs.special()) {
@@ -369,9 +369,9 @@ class TestReservedSpace : AllStatic {
     ReservedSpace rs(size,          // size
                      alignment,     // alignment
                      page_size, // page size
-                     (char *)NULL); // requested_address
+                     (char *)nullptr); // requested_address
 
-    EXPECT_TRUE(rs.base() != NULL);
+    EXPECT_TRUE(rs.base() != nullptr);
     EXPECT_EQ(rs.size(), size) <<  "rs.size: " << rs.size();
 
     EXPECT_TRUE(is_aligned(rs.base(), alignment)) << "aligned sizes should always give aligned addresses";
@@ -389,7 +389,7 @@ class TestReservedSpace : AllStatic {
 
     ReservedSpace rs(size);
 
-    EXPECT_TRUE(rs.base() != NULL);
+    EXPECT_TRUE(rs.base() != nullptr);
     EXPECT_EQ(rs.size(), size) <<  "rs.size: " << rs.size();
 
     if (rs.special()) {
@@ -414,7 +414,7 @@ class TestReservedSpace : AllStatic {
 
     ReservedSpace rs(size, alignment, page_size);
 
-    EXPECT_TRUE(rs.base() != NULL);
+    EXPECT_TRUE(rs.base() != nullptr);
     EXPECT_EQ(rs.size(), size) <<  "rs.size: " << rs.size();
 
     if (rs.special()) {

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.cpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.cpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.cpp
@@ -54,14 +54,14 @@ void check_marked_address(const MetaWord* p, uintx pattern) {
 // The filled range can be checked with check_range_for_pattern. One also can only check
 // a sub range of the original range.
 void fill_range_with_pattern(MetaWord* p, size_t word_size, uintx pattern) {
-  assert(word_size > 0 && p != NULL, "sanity");
+  assert(word_size > 0 && p != nullptr, "sanity");
   for (MetaWord* p2 = p; p2 < p + word_size; p2++) {
     mark_address(p2, pattern);
   }
 }
 
 void check_range_for_pattern(const MetaWord* p, size_t word_size, uintx pattern) {
-  assert(p != NULL, "sanity");
+  assert(p != nullptr, "sanity");
   const MetaWord* p2 = p;
   while (p2 < p + word_size) {
     check_marked_address(p2, pattern);
@@ -74,19 +74,19 @@ void check_range_for_pattern(const MetaWord* p, size_t word_size, uintx pattern)
 // Use check_marked_range to check the range. In contrast to check_range_for_pattern, only the original
 // range can be checked.
 void mark_range(MetaWord* p, size_t word_size, uintx pattern) {
-  assert(word_size > 0 && p != NULL, "sanity");
+  assert(word_size > 0 && p != nullptr, "sanity");
   mark_address(p, pattern);
   mark_address(p + word_size - 1, pattern);
 }
 
 void check_marked_range(const MetaWord* p, size_t word_size, uintx pattern) {
-  assert(word_size > 0 && p != NULL, "sanity");
+  assert(word_size > 0 && p != nullptr, "sanity");
   check_marked_address(p, pattern);
   check_marked_address(p + word_size - 1, pattern);
 }
 
 void mark_range(MetaWord* p, size_t word_size) {
-  assert(word_size > 0 && p != NULL, "sanity");
+  assert(word_size > 0 && p != nullptr, "sanity");
   uintx pattern = (uintx)p2i(p);
   mark_range(p, word_size, pattern);
 }

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
@@ -38,7 +38,7 @@ class TestMap {
   const size_t _len;
   char* _arr;
 public:
-  TestMap(size_t len) : _len(len), _arr(NULL) {
+  TestMap(size_t len) : _len(len), _arr(nullptr) {
     _arr = NEW_C_HEAP_ARRAY(char, len, mtInternal);
     memset(_arr, 0, _len);
   }
@@ -145,12 +145,12 @@ void mark_range(MetaWord* p, size_t word_size);
 void check_marked_range(const MetaWord* p, size_t word_size);
 
 //////////////////////////////////////////////////////////
-// Some helpers to avoid typing out those annoying casts for NULL
+// Some helpers to avoid typing out those annoying casts for nullptr
 
-#define ASSERT_NOT_NULL(ptr)      ASSERT_NE((void*)NULL, (void*)ptr)
-#define ASSERT_NULL(ptr)          ASSERT_EQ((void*)NULL, (void*)ptr)
-#define EXPECT_NOT_NULL(ptr)      EXPECT_NE((void*)NULL, (void*)ptr)
-#define EXPECT_NULL(ptr)          EXPECT_EQ((void*)NULL, (void*)ptr)
+#define ASSERT_NOT_NULL(ptr)      ASSERT_NE((void*)nullptr, (void*)ptr)
+#define ASSERT_NULL(ptr)          ASSERT_EQ((void*)nullptr, (void*)ptr)
+#define EXPECT_NOT_NULL(ptr)      EXPECT_NE((void*)nullptr, (void*)ptr)
+#define EXPECT_NULL(ptr)          EXPECT_EQ((void*)nullptr, (void*)ptr)
 
 #define ASSERT_0(v)               ASSERT_EQ((intptr_t)0, (intptr_t)v)
 #define ASSERT_NOT_0(v)           ASSERT_NE((intptr_t)0, (intptr_t)v)
@@ -188,7 +188,7 @@ class FeederBuffer {
 
 public:
 
-  FeederBuffer(size_t size) : _buf(NULL), _cap(size), _used(0) {
+  FeederBuffer(size_t size) : _buf(nullptr), _cap(size), _used(0) {
     _buf = NEW_C_HEAP_ARRAY(MetaWord, _cap, mtInternal);
   }
 
@@ -198,7 +198,7 @@ public:
 
   MetaWord* get(size_t word_size) {
     if (_used + word_size > _cap) {
-      return NULL;
+      return nullptr;
     }
     MetaWord* p = _buf + _used;
     _used += word_size;

--- a/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestCommon.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -147,10 +147,10 @@ void check_marked_range(const MetaWord* p, size_t word_size);
 //////////////////////////////////////////////////////////
 // Some helpers to avoid typing out those annoying casts for nullptr
 
-#define ASSERT_NOT_NULL(ptr)      ASSERT_NE((void*)nullptr, (void*)ptr)
-#define ASSERT_NULL(ptr)          ASSERT_EQ((void*)nullptr, (void*)ptr)
-#define EXPECT_NOT_NULL(ptr)      EXPECT_NE((void*)nullptr, (void*)ptr)
-#define EXPECT_NULL(ptr)          EXPECT_EQ((void*)nullptr, (void*)ptr)
+#define ASSERT_NOT_NULL(ptr)      ASSERT_NE(nullptr, (void*)ptr)
+#define ASSERT_NULL(ptr)          ASSERT_EQ(nullptr, (void*)ptr)
+#define EXPECT_NOT_NULL(ptr)      EXPECT_NE(nullptr, (void*)ptr)
+#define EXPECT_NULL(ptr)          EXPECT_EQ(nullptr, (void*)ptr)
 
 #define ASSERT_0(v)               ASSERT_EQ((intptr_t)0, (intptr_t)v)
 #define ASSERT_NOT_0(v)           ASSERT_NE((intptr_t)0, (intptr_t)v)

--- a/test/hotspot/gtest/metaspace/metaspaceGtestContexts.cpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestContexts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -34,11 +34,11 @@ using metaspace::Settings;
 void ChunkGtestContext::checked_alloc_chunk_0(Metachunk** p_return_value, chunklevel_t preferred_level, chunklevel_t max_level,
                                                       size_t min_committed_size) {
 
-  *p_return_value = NULL;
+  *p_return_value = nullptr;
 
   Metachunk* c = cm().get_chunk(preferred_level, max_level, min_committed_size);
 
-  if (c != NULL) {
+  if (c != nullptr) {
 
     ASSERT_LE(c->level(), max_level);
     ASSERT_GE(c->level(), preferred_level);

--- a/test/hotspot/gtest/metaspace/metaspaceGtestContexts.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestContexts.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/metaspaceGtestContexts.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestContexts.hpp
@@ -89,7 +89,7 @@ public:
 
   // Allocate a chunk but expect it to fail.
   void alloc_chunk_expect_failure(chunklevel_t preferred_level, chunklevel_t max_level, size_t min_committed_size) {
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     checked_alloc_chunk_0(&c, preferred_level, max_level, min_committed_size);
     ASSERT_NULL(c);
   }

--- a/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
+++ b/test/hotspot/gtest/metaspace/metaspaceGtestSparseArray.hpp
@@ -68,8 +68,8 @@ class SparseArray : public StackObj {
   // Helper for next_matching_slot
   bool slot_matches(int slot, condition_t c) const {
     switch(c) {
-    case cond_null:     return _slots[slot] == NULL;
-    case cond_non_null: return _slots[slot] != NULL;
+    case cond_null:     return _slots[slot] == nullptr;
+    case cond_non_null: return _slots[slot] != nullptr;
     case cond_dontcare: return true;
     }
     ShouldNotReachHere();
@@ -95,7 +95,7 @@ public:
     _index_range(num)
   {
     for (int i = 0; i < _num; i++) {
-      _slots[i] = NULL;
+      _slots[i] = nullptr;
     }
   }
 
@@ -109,7 +109,7 @@ public:
 
   int size() const         { return _num; }
 
-  bool slot_is_null(int i) const                      { check_index(i); return _slots[i] == NULL; }
+  bool slot_is_null(int i) const                      { check_index(i); return _slots[i] == nullptr; }
 
   DEBUG_ONLY(void check_slot_is_null(int i) const     { assert(slot_is_null(i), "Slot %d is not null", i); })
   DEBUG_ONLY(void check_slot_is_not_null(int i) const { assert(!slot_is_null(i), "Slot %d is null", i); })

--- a/test/hotspot/gtest/metaspace/test_binlist.cpp
+++ b/test/hotspot/gtest/metaspace/test_binlist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_binlist.cpp
+++ b/test/hotspot/gtest/metaspace/test_binlist.cpp
@@ -61,7 +61,7 @@ struct BinListBasicTest {
     // Try to get a block from an empty list.
     size_t real_size = 4711;
     MetaWord* p = bl.remove_block(innocous_size, &real_size);
-    EXPECT_EQ(p, (MetaWord*)NULL);
+    EXPECT_EQ(p, (MetaWord*)nullptr);
     EXPECT_EQ((size_t)0, real_size);
 
     // Add a block...
@@ -102,7 +102,7 @@ struct BinListBasicTest {
           CHECK_BL_CONTENT(bl, 0, 0);
           DEBUG_ONLY(bl.verify();)
         } else {
-          EXPECT_EQ(p, (MetaWord*)NULL);
+          EXPECT_EQ(p, (MetaWord*)nullptr);
           EXPECT_EQ((size_t)0, real_size);
           CHECK_BL_CONTENT(bl, 1, s1);
           DEBUG_ONLY(bl.verify();)
@@ -135,7 +135,7 @@ struct BinListBasicTest {
     for (;;) {
       size_t s = rgen.get();
       MetaWord* p = fb.get(s);
-      if (p != NULL) {
+      if (p != nullptr) {
         bl[which].add_block(p, s);
         cnt[which].add(s);
         which = which == 0 ? 1 : 0;
@@ -156,7 +156,7 @@ struct BinListBasicTest {
 
       size_t real_size = 4711;
       MetaWord* p = bl[giver].remove_block(s, &real_size);
-      if (p != NULL) {
+      if (p != nullptr) {
 
         ASSERT_TRUE(fb.is_valid_range(p, real_size));
         ASSERT_GE(real_size, s);
@@ -166,7 +166,7 @@ struct BinListBasicTest {
         cnt[taker].add(real_size);
 
       } else {
-        ASSERT_EQ(real_size, (size_t)NULL);
+        ASSERT_EQ(real_size, (size_t)nullptr);
       }
 
       CHECK_COUNTERS;
@@ -185,7 +185,7 @@ struct BinListBasicTest {
         size_t real_size = 4711;
         MetaWord* p = bl[which].remove_block(1, &real_size);
 
-        ASSERT_NE(p, (MetaWord*) NULL);
+        ASSERT_NE(p, (MetaWord*) nullptr);
         ASSERT_GE(real_size, (size_t)1);
         ASSERT_TRUE(fb.is_valid_range(p, real_size));
 

--- a/test/hotspot/gtest/metaspace/test_blocktree.cpp
+++ b/test/hotspot/gtest/metaspace/test_blocktree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_blocktree.cpp
+++ b/test/hotspot/gtest/metaspace/test_blocktree.cpp
@@ -59,7 +59,7 @@ TEST_VM(metaspace, BlockTree_basic) {
   CHECK_BT_CONTENT(bt, 0, 0);
 
   size_t real_size = 0;
-  MetaWord* p = NULL;
+  MetaWord* p = nullptr;
   MetaWord arr[10000];
 
   ASSERT_LE(BlockTree::MinWordSize, (size_t)6); // Sanity check. Adjust if Node is changed.
@@ -278,7 +278,7 @@ class BlockTreeTest {
   // Feed the whole feeder buffer to the trees, according to feeding_pattern.
   void feed_all(feeding_pattern_t feeding_pattern) {
 
-    MetaWord* p = NULL;
+    MetaWord* p = nullptr;
     unsigned added = 0;
 
     // If we feed in small graining, we cap the number of blocks to limit test duration.
@@ -306,14 +306,14 @@ class BlockTreeTest {
 
       // Get a block from the feeder buffer; feed it alternatingly to either tree.
       p = _fb.get(s);
-      if (p != NULL) {
+      if (p != nullptr) {
         int which = added % 2;
         added++;
         _bt[which].add_block(p, s);
         _cnt[which].add(s);
         CHECK_COUNTERS
       }
-    } while (p != NULL && added < max_blocks);
+    } while (p != nullptr && added < max_blocks);
 
     DEBUG_ONLY(verify_trees();)
 
@@ -335,7 +335,7 @@ class BlockTreeTest {
       size_t s =_rgen.get();
       size_t real_size = 0;
       MetaWord* p = _bt[giver].remove_block(s, &real_size);
-      if (p != NULL) {
+      if (p != nullptr) {
         ASSERT_TRUE(_fb.is_valid_range(p, real_size));
         ASSERT_GE(real_size, s);
         _bt[taker].add_block(p, real_size);

--- a/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkManager_stress.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,9 +116,9 @@ class ChunkManagerRandomChunkAllocTest {
     const chunklevel_t max_level = r.highest();
     const size_t min_committed = random_committed_words(max_level, _commit_factor);
 
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     _context.alloc_chunk(&c, r.lowest(), r.highest(), min_committed);
-    if (c == NULL) {
+    if (c == nullptr) {
       EXPECT_TRUE(could_be_reserve_error() ||
                   could_be_commit_error(min_committed));
       LOG("Alloc chunk at %d failed.", slot);
@@ -162,7 +162,7 @@ class ChunkManagerRandomChunkAllocTest {
     Metachunk* c = _chunks.at(slot);
     LOG("Returning chunk at %d: " METACHUNK_FORMAT ".", slot, METACHUNK_FORMAT_ARGS(c));
     _context.return_chunk(c);
-    _chunks.set_at(slot, NULL);
+    _chunks.set_at(slot, nullptr);
   }
 
   // return a random number of chunks (at most a quarter of the full slot range)

--- a/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
+++ b/test/hotspot/gtest/metaspace/test_chunkheaderpool.cpp
@@ -48,12 +48,12 @@ class ChunkHeaderPoolTest {
 
     LOG("attempt_free_at " SIZE_FORMAT ".", index);
 
-    if (_elems[index] == NULL) {
+    if (_elems[index] == nullptr) {
       return;
     }
 
     _pool.return_chunk_header(_elems[index]);
-    _elems[index] = NULL;
+    _elems[index] = nullptr;
 
     _num_allocated.decrement();
     DEBUG_ONLY(_num_allocated.check(_pool.used());)
@@ -66,7 +66,7 @@ class ChunkHeaderPoolTest {
 
     LOG("attempt_allocate_at " SIZE_FORMAT ".", index);
 
-    if (_elems[index] != NULL) {
+    if (_elems[index] != nullptr) {
       return;
     }
 
@@ -82,7 +82,7 @@ class ChunkHeaderPoolTest {
   }
 
   void attempt_allocate_or_free_at(size_t index) {
-    if (_elems[index] == NULL) {
+    if (_elems[index] == nullptr) {
       attempt_allocate_at(index);
     } else {
       attempt_free_at(index);

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_freeblocks.cpp
+++ b/test/hotspot/gtest/metaspace/test_freeblocks.cpp
@@ -72,7 +72,7 @@ class FreeBlocksTest {
   bool feed_some() {
     size_t word_size = _rgen_feeding.get();
     MetaWord* p = _fb.get(word_size);
-    if (p != NULL) {
+    if (p != nullptr) {
       _freeblocks.add_block(p, word_size);
       return true;
     }
@@ -82,7 +82,7 @@ class FreeBlocksTest {
   bool deallocate_top() {
 
     allocation_t* a = _allocations;
-    if (a != NULL) {
+    if (a != nullptr) {
       _allocations = a->next;
       check_marked_range(a->p, a->word_size);
       _freeblocks.add_block(a->p, a->word_size);
@@ -101,7 +101,7 @@ class FreeBlocksTest {
 
     size_t word_size = MAX2(_rgen_allocations.get(), _freeblocks.MinWordSize);
     MetaWord* p = _freeblocks.remove_block(word_size);
-    if (p != NULL) {
+    if (p != nullptr) {
       _allocated_words.increment_by(word_size);
       allocation_t* a = new allocation_t;
       a->p = p; a->word_size = word_size;
@@ -115,7 +115,7 @@ class FreeBlocksTest {
   }
 
   void test_all_marked_ranges() {
-    for (allocation_t* a = _allocations; a != NULL; a = a->next) {
+    for (allocation_t* a = _allocations; a != nullptr; a = a->next) {
       check_marked_range(a->p, a->word_size);
     }
   }
@@ -177,7 +177,7 @@ public:
     _fb(512 * K), _freeblocks(),
     _rgen_feeding(128, 4096),
     _rgen_allocations(avg_alloc_size / 4, avg_alloc_size * 2, 0.01f, avg_alloc_size / 3, avg_alloc_size * 30),
-    _allocations(NULL),
+    _allocations(nullptr),
     _num_allocs(0),
     _num_deallocs(0),
     _num_feeds(0)

--- a/test/hotspot/gtest/metaspace/test_is_metaspace_obj.cpp
+++ b/test/hotspot/gtest/metaspace/test_is_metaspace_obj.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_is_metaspace_obj.cpp
+++ b/test/hotspot/gtest/metaspace/test_is_metaspace_obj.cpp
@@ -42,7 +42,7 @@ class MetaspaceIsMetaspaceObjTest {
 
 public:
 
-  MetaspaceIsMetaspaceObjTest() : _lock(NULL), _ms(NULL) {}
+  MetaspaceIsMetaspaceObjTest() : _lock(nullptr), _ms(nullptr) {}
   ~MetaspaceIsMetaspaceObjTest() {
     delete _ms;
     delete _lock;
@@ -75,7 +75,7 @@ public:
     ASSERT_TRUE(vslist->contains((MetaWord*)((address)p) + 1));
 
     // Now for some bogus values
-    ASSERT_FALSE(MetaspaceObj::is_valid((MetaspaceObj*)NULL));
+    ASSERT_FALSE(MetaspaceObj::is_valid((MetaspaceObj*)nullptr));
 
     // Should exercise various paths in MetaspaceObj::is_valid()
     ASSERT_FALSE(MetaspaceObj::is_valid((MetaspaceObj*)1024));
@@ -93,9 +93,9 @@ public:
     ASSERT_TRUE(Metaspace::contains_non_shared(p));
 
     delete _ms;
-    _ms = NULL;
+    _ms = nullptr;
     delete _lock;
-    _lock = NULL;
+    _lock = nullptr;
   }
 
 };

--- a/test/hotspot/gtest/metaspace/test_metachunk.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunk.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ using namespace metaspace::chunklevel;
 TEST_VM(metaspace, get_chunk) {
 
   ChunkGtestContext context(8 * M);
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
 
   for (chunklevel_t pref_lvl = LOWEST_CHUNK_LEVEL; pref_lvl <= HIGHEST_CHUNK_LEVEL; pref_lvl++) {
 
@@ -70,7 +70,7 @@ TEST_VM(metaspace, get_chunk_with_commit_limit) {
        commit_limit_words < MAX_CHUNK_WORD_SIZE * 2; commit_limit_words *= 2) {
 
     ChunkGtestContext context(commit_limit_words);
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
 
     for (chunklevel_t pref_lvl = LOWEST_CHUNK_LEVEL; pref_lvl <= HIGHEST_CHUNK_LEVEL; pref_lvl++) {
 
@@ -103,7 +103,7 @@ TEST_VM(metaspace, get_chunk_with_commit_limit) {
 TEST_VM(metaspace, get_chunk_recommit) {
 
   ChunkGtestContext context;
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
   context.alloc_chunk_expect_success(&c, ROOT_CHUNK_LEVEL, ROOT_CHUNK_LEVEL, 0);
   context.uncommit_chunk_with_test(c);
 
@@ -136,7 +136,7 @@ TEST_VM(metaspace, get_chunk_with_reserve_limit) {
   //  root chunk.
 
   // Cause allocation of the firstone root chunk, should still work:
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
   context.alloc_chunk_expect_success(&c, HIGHEST_CHUNK_LEVEL);
 
   // and this should need a new root chunk and hence fail:
@@ -152,7 +152,7 @@ TEST_VM(metaspace, chunk_allocate_full) {
   ChunkGtestContext context;
 
   for (chunklevel_t lvl = LOWEST_CHUNK_LEVEL; lvl <= HIGHEST_CHUNK_LEVEL; lvl++) {
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     context.alloc_chunk_expect_success(&c, lvl);
     context.allocate_from_chunk(c, c->word_size());
     context.return_chunk(c);
@@ -167,7 +167,7 @@ TEST_VM(metaspace, chunk_allocate_random) {
 
   for (chunklevel_t lvl = LOWEST_CHUNK_LEVEL; lvl <= HIGHEST_CHUNK_LEVEL; lvl++) {
 
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     context.alloc_chunk_expect_success(&c, lvl);
     context.uncommit_chunk_with_test(c); // start out fully uncommitted
 
@@ -202,11 +202,11 @@ TEST_VM(metaspace, chunk_buddy_stuff) {
     // (Note: strictly speaking the ChunkManager does not promise any placement but
     //  we know how the placement works so these tests make sense).
 
-    Metachunk* c1 = NULL;
+    Metachunk* c1 = nullptr;
     context.alloc_chunk(&c1, CHUNK_LEVEL_1K);
     EXPECT_TRUE(c1->is_leader());
 
-    Metachunk* c2 = NULL;
+    Metachunk* c2 = nullptr;
     context.alloc_chunk(&c2, CHUNK_LEVEL_1K);
     EXPECT_FALSE(c2->is_leader());
 
@@ -234,7 +234,7 @@ TEST_VM(metaspace, chunk_allocate_with_commit_limit) {
   ChunkGtestContext context(commit_limit);
 
   // A big chunk, but uncommitted.
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
   context.alloc_chunk_expect_success(&c, ROOT_CHUNK_LEVEL, ROOT_CHUNK_LEVEL, 0);
   context.uncommit_chunk_with_test(c); // ... just to make sure.
 
@@ -310,7 +310,7 @@ TEST_VM(metaspace, chunk_split_and_merge) {
 
     // Split a fully committed chunk. The resulting chunk should be fully
     //  committed as well, and have its content preserved.
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     context.alloc_chunk_expect_success(&c, orig_lvl);
 
     // We allocate from this chunk to be able to completely paint the payload.
@@ -387,7 +387,7 @@ TEST_VM(metaspace, chunk_enlarge_in_place) {
   // Starting with the smallest chunk size, attempt to enlarge the chunk in place until we arrive
   // at root chunk size. Since the state is clean, this should work.
 
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
   context.alloc_chunk_expect_success(&c, HIGHEST_CHUNK_LEVEL);
 
   chunklevel_t l = c->level();

--- a/test/hotspot/gtest/metaspace/test_metachunklist.cpp
+++ b/test/hotspot/gtest/metaspace/test_metachunklist.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ TEST_VM(metaspace, metachunklist) {
   size_t total_size = 0;
 
   for (int i = 0; i < 10; i++) {
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     context.alloc_chunk_expect_success(&c, ChunkLevelRanges::all_chunks().random_value());
     chunks[i] = c;
     total_size += c->committed_words();
@@ -95,7 +95,7 @@ TEST_VM(metaspace, freechunklist) {
   // Make every other chunk randomly uncommitted, and later we check that committed chunks are sorted in at the front
   // of the lists.
   for (int i = 0; i < 100; i++) {
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     context.alloc_chunk_expect_success(&c, ChunkLevelRanges::all_chunks().random_value());
     bool uncommitted_chunk = i % 3;
     if (uncommitted_chunk) {
@@ -122,7 +122,7 @@ TEST_VM(metaspace, freechunklist) {
   for (chunklevel_t lvl = LOWEST_CHUNK_LEVEL; lvl <= HIGHEST_CHUNK_LEVEL; lvl++) {
     Metachunk* c = lst.remove_first(lvl);
     bool found_uncommitted = false;
-    while (c != NULL) {
+    while (c != nullptr) {
 
       LOG("<-" METACHUNK_FULL_FORMAT, METACHUNK_FULL_FORMAT_ARGS(c));
 
@@ -153,7 +153,7 @@ TEST_VM(metaspace, freechunklist_retrieval) {
 
   ChunkGtestContext context;
   FreeChunkList fcl;
-  Metachunk* c = NULL;
+  Metachunk* c = nullptr;
 
   // For a chunk level which allows us to have partially committed chunks...
   const size_t chunk_word_size = Settings::commit_granule_words() * 4;
@@ -162,19 +162,19 @@ TEST_VM(metaspace, freechunklist_retrieval) {
   // get some chunks:
 
   // ...a completely uncommitted one ...
-  Metachunk* c_0 = NULL;
+  Metachunk* c_0 = nullptr;
   context.alloc_chunk_expect_success(&c_0, lvl, lvl, 0);
 
   // ... a fully committed one ...
-  Metachunk* c_full = NULL;
+  Metachunk* c_full = nullptr;
   context.alloc_chunk_expect_success(&c_full, lvl);
 
   // ... a chunk with one commit granule committed ...
-  Metachunk* c_1g = NULL;
+  Metachunk* c_1g = nullptr;
   context.alloc_chunk_expect_success(&c_1g, lvl, lvl, Settings::commit_granule_words());
 
   // ... a chunk with two commit granules committed.
-  Metachunk* c_2g = NULL;
+  Metachunk* c_2g = nullptr;
   context.alloc_chunk_expect_success(&c_2g, lvl, lvl, Settings::commit_granule_words() * 2);
 
   LOG("c_0: " METACHUNK_FULL_FORMAT, METACHUNK_FULL_FORMAT_ARGS(c_0));

--- a/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -96,12 +96,12 @@ public:
   // in non-void returning tests.
 
   void delete_arena_with_tests() {
-    if (_arena != NULL) {
+    if (_arena != nullptr) {
       size_t used_words_before = _used_words_counter.get();
       size_t committed_words_before = limiter().committed_words();
       DEBUG_ONLY(_arena->verify());
       delete _arena;
-      _arena = NULL;
+      _arena = nullptr;
       size_t used_words_after = _used_words_counter.get();
       size_t committed_words_after = limiter().committed_words();
       ASSERT_0(used_words_after);
@@ -111,14 +111,14 @@ public:
 
   void usage_numbers_with_test(size_t* p_used, size_t* p_committed, size_t* p_capacity) const {
     _arena->usage_numbers(p_used, p_committed, p_capacity);
-    if (p_used != NULL) {
-      if (p_committed != NULL) {
+    if (p_used != nullptr) {
+      if (p_committed != nullptr) {
         ASSERT_GE(*p_committed, *p_used);
       }
       // Since we own the used words counter, it should reflect our usage number 1:1
       ASSERT_EQ(_used_words_counter.get(), *p_used);
     }
-    if (p_committed != NULL && p_capacity != NULL) {
+    if (p_committed != nullptr && p_capacity != nullptr) {
       ASSERT_GE(*p_capacity, *p_committed);
     }
   }
@@ -131,13 +131,13 @@ public:
 
   // Allocate; caller expects success but is not interested in return value
   void allocate_from_arena_with_tests_expect_success(size_t word_size) {
-    MetaWord* dummy = NULL;
+    MetaWord* dummy = nullptr;
     allocate_from_arena_with_tests_expect_success(&dummy, word_size);
   }
 
   // Allocate; caller expects failure
   void allocate_from_arena_with_tests_expect_failure(size_t word_size) {
-    MetaWord* dummy = NULL;
+    MetaWord* dummy = nullptr;
     allocate_from_arena_with_tests(&dummy, word_size);
     ASSERT_NULL(dummy);
   }
@@ -158,7 +158,7 @@ public:
     size_t used2 = 0, committed2 = 0, capacity2 = 0;
     usage_numbers_with_test(&used2, &committed2, &capacity2);
 
-    if (p == NULL) {
+    if (p == nullptr) {
       // Allocation failed.
       ASSERT_LT(possible_expansion, word_size);
       ASSERT_EQ(used, used2);
@@ -181,7 +181,7 @@ public:
 
   // Allocate; it may or may not work; but caller does not care for the result value
   void allocate_from_arena_with_tests(size_t word_size) {
-    MetaWord* dummy = NULL;
+    MetaWord* dummy = nullptr;
     allocate_from_arena_with_tests(&dummy, word_size);
   }
 
@@ -406,25 +406,25 @@ TEST_VM(metaspace, MetaspaceArena_deallocate) {
     MetaspaceGtestContext context;
     MetaspaceArenaTestHelper helper(context, Metaspace::StandardMetaspaceType, false);
 
-    MetaWord* p1 = NULL;
+    MetaWord* p1 = nullptr;
     helper.allocate_from_arena_with_tests_expect_success(&p1, s);
 
     size_t used1 = 0, capacity1 = 0;
-    helper.usage_numbers_with_test(&used1, NULL, &capacity1);
+    helper.usage_numbers_with_test(&used1, nullptr, &capacity1);
     ASSERT_EQ(used1, s);
 
     helper.deallocate_with_tests(p1, s);
 
     size_t used2 = 0, capacity2 = 0;
-    helper.usage_numbers_with_test(&used2, NULL, &capacity2);
+    helper.usage_numbers_with_test(&used2, nullptr, &capacity2);
     ASSERT_EQ(used1, used2);
     ASSERT_EQ(capacity2, capacity2);
 
-    MetaWord* p2 = NULL;
+    MetaWord* p2 = nullptr;
     helper.allocate_from_arena_with_tests_expect_success(&p2, s);
 
     size_t used3 = 0, capacity3 = 0;
-    helper.usage_numbers_with_test(&used3, NULL, &capacity3);
+    helper.usage_numbers_with_test(&used3, nullptr, &capacity3);
     ASSERT_EQ(used3, used2);
     ASSERT_EQ(capacity3, capacity2);
 
@@ -471,8 +471,8 @@ static void test_recover_from_commit_limit_hit() {
 
   // Now, allocating from helper3, creep up on the limit
   size_t allocated_from_3 = 0;
-  MetaWord* p = NULL;
-  while ( (helper3.allocate_from_arena_with_tests(&p, 1), p != NULL) &&
+  MetaWord* p = nullptr;
+  while ( (helper3.allocate_from_arena_with_tests(&p, 1), p != nullptr) &&
          ++allocated_from_3 < Settings::commit_granule_words() * 2);
 
   EXPECT_LE(allocated_from_3, Settings::commit_granule_words() * 2);
@@ -732,7 +732,7 @@ static void test_repeatedly_allocate_and_deallocate(bool is_topmost) {
   // Test various sizes, including (important) the max. possible block size = 1 root chunk
   for (size_t blocksize = Metaspace::max_allocation_word_size(); blocksize >= 1; blocksize /= 2) {
     size_t used1 = 0, used2 = 0, committed1 = 0, committed2 = 0;
-    MetaWord* p = NULL, *p2 = NULL;
+    MetaWord* p = nullptr, *p2 = nullptr;
 
     MetaspaceGtestContext context;
     MetaspaceArenaTestHelper helper(context, Metaspace::StandardMetaspaceType, false);
@@ -745,7 +745,7 @@ static void test_repeatedly_allocate_and_deallocate(bool is_topmost) {
     }
 
     // Measure
-    helper.usage_numbers_with_test(&used1, &committed1, NULL);
+    helper.usage_numbers_with_test(&used1, &committed1, nullptr);
 
     // Dealloc, alloc several times with the same size.
     for (int i = 0; i < 5; i ++) {
@@ -756,7 +756,7 @@ static void test_repeatedly_allocate_and_deallocate(bool is_topmost) {
     }
 
     // Measure again
-    helper.usage_numbers_with_test(&used2, &committed2, NULL);
+    helper.usage_numbers_with_test(&used2, &committed2, nullptr);
     EXPECT_EQ(used2, used1);
     EXPECT_EQ(committed1, committed2);
   }

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -66,13 +66,13 @@ class MetaspaceArenaTestBed : public CHeapObj<mtInternal> {
   // later check for overwriters.
   struct allocation_t {
     allocation_t* next;
-    MetaWord* p; // NULL if deallocated
+    MetaWord* p; // nullptr if deallocated
     size_t word_size;
     void mark() {
       mark_range(p, word_size);
     }
     void verify() const {
-      if (p != NULL) {
+      if (p != nullptr) {
         check_marked_range(p, word_size);
       }
     }
@@ -128,10 +128,10 @@ public:
 
   MetaspaceArenaTestBed(ChunkManager* cm, const ArenaGrowthPolicy* alloc_sequence,
                         SizeAtomicCounter* used_words_counter, SizeRange allocation_range) :
-    _arena(NULL),
+    _arena(nullptr),
     _allocation_range(allocation_range),
     _size_of_last_failed_allocation(0),
-    _allocations(NULL),
+    _allocations(nullptr),
     _alloc_count(),
     _dealloc_count()
   {
@@ -143,7 +143,7 @@ public:
     verify_arena_statistics();
 
     allocation_t* a = _allocations;
-    while (a != NULL) {
+    while (a != nullptr) {
       allocation_t* b = a->next;
       a->verify();
       FREE_C_HEAP_OBJ(a);
@@ -166,7 +166,7 @@ public:
   bool checked_random_allocate() {
     size_t word_size = 1 + _allocation_range.random_value();
     MetaWord* p = _arena->allocate(word_size);
-    if (p != NULL) {
+    if (p != nullptr) {
       EXPECT_TRUE(is_aligned(p, AllocationAlignmentByteSize));
 
       allocation_t* a = NEW_C_HEAP_OBJ(allocation_t, mtInternal);
@@ -190,14 +190,14 @@ public:
   // Deallocate a random allocation
   void checked_random_deallocate() {
     allocation_t* a = _allocations;
-    while (a && a->p != NULL && os::random() % 10 != 0) {
+    while (a && a->p != nullptr && os::random() % 10 != 0) {
       a = a->next;
     }
-    if (a != NULL && a->p != NULL) {
+    if (a != nullptr && a->p != nullptr) {
       a->verify();
       _arena->deallocate(a->p, a->word_size);
       _dealloc_count.add(a->word_size);
-      a->p = NULL; a->word_size = 0;
+      a->p = nullptr; a->word_size = 0;
       if ((_dealloc_count.count() % 20) == 0) {
         verify_arena_statistics();
         DEBUG_ONLY(_arena->verify();)
@@ -257,7 +257,7 @@ class MetaspaceArenaTest {
     DEBUG_ONLY(_testbeds.check_slot_is_not_null(slotindex));
     MetaspaceArenaTestBed* bed = _testbeds.at(slotindex);
     delete bed; // This will return all its memory to the chunk manager
-    _testbeds.set_at(slotindex, NULL);
+    _testbeds.set_at(slotindex, nullptr);
     _num_beds.decrement();
   }
 

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -91,7 +91,7 @@ class VirtualSpaceNodeTest {
     verify();
 
     const bool node_is_full = _node->used_words() == _node->word_size();
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     {
       MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       c = _node->allocate_root_chunk();
@@ -258,7 +258,7 @@ class VirtualSpaceNodeTest {
 
     //freelist->print_on(tty);
 
-    Metachunk* result = NULL;
+    Metachunk* result = nullptr;
     {
       MutexLocker fcl(Metaspace_lock, Mutex::_no_safepoint_check_flag);
       result = _node->merge(c, freelist);
@@ -293,7 +293,7 @@ public:
     _counter_reserved_words(),
     _counter_committed_words(),
     _commit_limiter(commit_limit),
-    _node(NULL),
+    _node(nullptr),
     _vs_word_size(vs_word_size),
     _commit_limit(commit_limit)
   {
@@ -327,14 +327,14 @@ public:
   }
 
   void test_exhaust_node() {
-    Metachunk* c = NULL;
+    Metachunk* c = nullptr;
     bool rc = true;
     do {
       c = alloc_root_chunk();
-      if (c != NULL) {
+      if (c != nullptr) {
         rc = commit_root_chunk(c, c->word_size());
       }
-    } while (c != NULL && rc);
+    } while (c != nullptr && rc);
   }
 
   void test_arbitrary_commits() {

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022 SAP SE. All rights reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,7 +109,7 @@ DEFINE_TEST(test_double_free, "header canary")
 ///////
 
 static void test_invalid_block_address() {
-  // very low, like the result of an overflow or of accessing a nullptr this pointer
+  // very low, like the result of an overflow or of accessing a null this pointer
   os::free((void*)0x100);
 }
 DEFINE_TEST(test_invalid_block_address, "invalid block address")

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -109,7 +109,7 @@ DEFINE_TEST(test_double_free, "header canary")
 ///////
 
 static void test_invalid_block_address() {
-  // very low, like the result of an overflow or of accessing a NULL this pointer
+  // very low, like the result of an overflow or of accessing a nullptr this pointer
   os::free((void*)0x100);
 }
 DEFINE_TEST(test_invalid_block_address, "invalid block address")

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,11 +84,11 @@ public:
     os::free(os_malloc(0));              // 0-sized allocation, should be free-able
     p2 = os_realloc(os_malloc(10), 20);  // realloc, growing
     p3 = os_realloc(os_malloc(20), 10);  // realloc, shrinking
-    p4 = os_realloc(NULL, 10);           // realloc with NULL pointer
+    p4 = os_realloc(nullptr, 10);           // realloc with nullptr pointer
     os_realloc(os_realloc(os_malloc(20), 0), 30);  // realloc to size 0 and back up again
     os::free(os_malloc(20));             // malloc, free
     os::free(os_realloc(os_malloc(20), 30));  // malloc, realloc, free
-    os::free(NULL);                      // free(null)
+    os::free(nullptr);                      // free(null)
     DEBUG_ONLY(NMTPreInit::verify();)
 
     // This should result in a fatal native oom error from NMT preinit with a clear error message.

--- a/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinit.cpp
@@ -84,7 +84,7 @@ public:
     os::free(os_malloc(0));              // 0-sized allocation, should be free-able
     p2 = os_realloc(os_malloc(10), 20);  // realloc, growing
     p3 = os_realloc(os_malloc(20), 10);  // realloc, shrinking
-    p4 = os_realloc(nullptr, 10);           // realloc with nullptr pointer
+    p4 = os_realloc(nullptr, 10);        // realloc with null pointer
     os_realloc(os_realloc(os_malloc(20), 0), 30);  // realloc to size 0 and back up again
     os::free(os_malloc(20));             // malloc, free
     os::free(os_realloc(os_malloc(20), 30));  // malloc, realloc, free

--- a/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmtpreinitmap.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ TEST_VM(NMTPreInit, stress_test_map) {
     NMTPreInitAllocation* a = table.find_and_remove(allocations[i]->payload);
     ASSERT_EQ(a, allocations[i]);
     NMTPreInitAllocation::do_free(a);
-    allocations[i] = NULL;
+    allocations[i] = nullptr;
   }
 
   print_and_check_table(table, 0);

--- a/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
+++ b/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
@@ -213,7 +213,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first nested ThreadsListHandle (tlh2) has been destroyed
 
-    // Verify the current thread's hazard ptr is nullptr:
+    // Verify the current thread's hazard ptr is null:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
         << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
@@ -397,7 +397,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Test case: after double nested ThreadsListHandle (tlh3) has been destroyed
 
-      // Verify the current thread's hazard ptr is nullptr:
+      // Verify the current thread's hazard ptr is null:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
           << "thr->_threads_hazard_ptr must be null";
       // Verify the current thread's threads list ptr refers to tlh2:
@@ -445,7 +445,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first nested ThreadsListHandle (tlh2) has been destroyed
 
-    // Verify the current thread's hazard ptr is nullptr:
+    // Verify the current thread's hazard ptr is null:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
         << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
@@ -565,7 +565,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first back-to-back nested ThreadsListHandle (tlh2a) has been destroyed
 
-    // Verify the current thread's hazard ptr is nullptr:
+    // Verify the current thread's hazard ptr is null:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
         << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
@@ -643,7 +643,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after second back-to-back nested ThreadsListHandle (tlh2b) has been destroyed
 
-    // Verify the current thread's hazard ptr is nullptr:
+    // Verify the current thread's hazard ptr is null:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
         << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:

--- a/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
+++ b/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,10 +83,10 @@ TEST_VM(ThreadsListHandle, sanity) {
   //
 
   // Verify the current thread refers to no ThreadsListHandle:
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-      << "thr->_threads_hazard_ptr must be NULL";
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) NULL)
-      << "thr->_threads_list_ptr must be NULL";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+      << "thr->_threads_hazard_ptr must be nullptr";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
+      << "thr->_threads_list_ptr must be nullptr";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -105,8 +105,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -125,10 +125,10 @@ TEST_VM(ThreadsListHandle, sanity) {
   //
 
   // Verify the current thread refers to no ThreadsListHandle:
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-      << "thr->_threads_hazard_ptr must match be NULL";
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) NULL)
-      << "thr->_threads_list_ptr must be NULL";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+      << "thr->_threads_hazard_ptr must match be nullptr";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
+      << "thr->_threads_list_ptr must be nullptr";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -147,8 +147,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -193,8 +193,8 @@ TEST_VM(ThreadsListHandle, sanity) {
           << "list_ptr2->_needs_release must be true";
 
       // Verify tlh1 has the right field values:
-      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-          << "list_ptr1->previous() must be NULL";
+      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+          << "list_ptr1->previous() must be nullptr";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -213,9 +213,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first nested ThreadsListHandle (tlh2) has been destroyed
 
-    // Verify the current thread's hazard ptr is NULL:
-    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-        << "thr->_threads_hazard_ptr must be NULL";
+    // Verify the current thread's hazard ptr is nullptr:
+    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+        << "thr->_threads_hazard_ptr must be nullptr";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -223,8 +223,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -245,10 +245,10 @@ TEST_VM(ThreadsListHandle, sanity) {
   //
 
   // Verify the current thread refers to no ThreadsListHandle:
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-      << "thr->_threads_hazard_ptr must match be NULL";
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) NULL)
-      << "thr->_threads_list_ptr must be NULL";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+      << "thr->_threads_hazard_ptr must match be nullptr";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
+      << "thr->_threads_list_ptr must be nullptr";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -267,8 +267,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -313,8 +313,8 @@ TEST_VM(ThreadsListHandle, sanity) {
           << "list_ptr2->_needs_release must be true";
 
       // Verify tlh1 has the right field values:
-      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-          << "list_ptr1->previous() must be NULL";
+      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+          << "list_ptr1->previous() must be nullptr";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -377,8 +377,8 @@ TEST_VM(ThreadsListHandle, sanity) {
             << "list_ptr2->_needs_release must be true";
 
         // Verify tlh1 has the right field values:
-        EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-            << "list_ptr1->previous() must be NULL";
+        EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+            << "list_ptr1->previous() must be nullptr";
         EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
             << "list_ptr1->_thread must match current thread";
         EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -397,9 +397,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Test case: after double nested ThreadsListHandle (tlh3) has been destroyed
 
-      // Verify the current thread's hazard ptr is NULL:
-      EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-          << "thr->_threads_hazard_ptr must be NULL";
+      // Verify the current thread's hazard ptr is nullptr:
+      EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+          << "thr->_threads_hazard_ptr must be nullptr";
       // Verify the current thread's threads list ptr refers to tlh2:
       EXPECT_EQ(tlh1.list(), tlh2.list())
           << "tlh1.list() must match tlh2.list()";
@@ -425,8 +425,8 @@ TEST_VM(ThreadsListHandle, sanity) {
           << "list_ptr2->_needs_release must be true";
 
       // Verify tlh1 has the right field values:
-      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-          << "list_ptr1->previous() must be NULL";
+      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+          << "list_ptr1->previous() must be nullptr";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -445,9 +445,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first nested ThreadsListHandle (tlh2) has been destroyed
 
-    // Verify the current thread's hazard ptr is NULL:
-    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-        << "thr->_threads_hazard_ptr must be NULL";
+    // Verify the current thread's hazard ptr is nullptr:
+    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+        << "thr->_threads_hazard_ptr must be nullptr";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -455,8 +455,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -477,10 +477,10 @@ TEST_VM(ThreadsListHandle, sanity) {
   //
 
   // Verify the current thread refers to no ThreadsListHandle:
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-      << "thr->_threads_hazard_ptr must match be NULL";
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) NULL)
-      << "thr->_threads_list_ptr must be NULL";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+      << "thr->_threads_hazard_ptr must match be nullptr";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
+      << "thr->_threads_list_ptr must be nullptr";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -499,8 +499,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -545,8 +545,8 @@ TEST_VM(ThreadsListHandle, sanity) {
           << "list_ptr2a->_needs_release must be true";
 
       // Verify tlh1 has the right field values:
-      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-          << "list_ptr1->previous() must be NULL";
+      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+          << "list_ptr1->previous() must be nullptr";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -565,9 +565,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after first back-to-back nested ThreadsListHandle (tlh2a) has been destroyed
 
-    // Verify the current thread's hazard ptr is NULL:
-    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-        << "thr->_threads_hazard_ptr must be NULL";
+    // Verify the current thread's hazard ptr is nullptr:
+    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+        << "thr->_threads_hazard_ptr must be nullptr";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -575,8 +575,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -623,8 +623,8 @@ TEST_VM(ThreadsListHandle, sanity) {
           << "list_ptr2b->_needs_release must be true";
 
       // Verify tlh1 has the right field values:
-      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-          << "list_ptr1->previous() must be NULL";
+      EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+          << "list_ptr1->previous() must be nullptr";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -643,9 +643,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Test case: after second back-to-back nested ThreadsListHandle (tlh2b) has been destroyed
 
-    // Verify the current thread's hazard ptr is NULL:
-    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-        << "thr->_threads_hazard_ptr must be NULL";
+    // Verify the current thread's hazard ptr is nullptr:
+    EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+        << "thr->_threads_hazard_ptr must be nullptr";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -653,8 +653,8 @@ TEST_VM(ThreadsListHandle, sanity) {
         << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
     // Verify tlh1 has the right field values:
-    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)NULL)
-        << "list_ptr1->previous() must be NULL";
+    EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
+        << "list_ptr1->previous() must be nullptr";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -675,10 +675,10 @@ TEST_VM(ThreadsListHandle, sanity) {
   //
 
   // Verify the current thread refers to no ThreadsListHandle:
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)NULL)
-      << "thr->_threads_hazard_ptr must match be NULL";
-  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) NULL)
-      << "thr->_threads_list_ptr must be NULL";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
+      << "thr->_threads_hazard_ptr must match be nullptr";
+  EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
+      << "thr->_threads_list_ptr must be nullptr";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 

--- a/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
+++ b/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
@@ -84,9 +84,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
   // Verify the current thread refers to no ThreadsListHandle:
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-      << "thr->_threads_hazard_ptr must be nullptr";
+      << "thr->_threads_hazard_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
-      << "thr->_threads_list_ptr must be nullptr";
+      << "thr->_threads_list_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -106,7 +106,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -126,9 +126,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
   // Verify the current thread refers to no ThreadsListHandle:
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-      << "thr->_threads_hazard_ptr must match be nullptr";
+      << "thr->_threads_hazard_ptr must match be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
-      << "thr->_threads_list_ptr must be nullptr";
+      << "thr->_threads_list_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -148,7 +148,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -194,7 +194,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify tlh1 has the right field values:
       EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-          << "list_ptr1->previous() must be nullptr";
+          << "list_ptr1->previous() must be null";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -215,7 +215,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify the current thread's hazard ptr is nullptr:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-        << "thr->_threads_hazard_ptr must be nullptr";
+        << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -224,7 +224,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -246,9 +246,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
   // Verify the current thread refers to no ThreadsListHandle:
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-      << "thr->_threads_hazard_ptr must match be nullptr";
+      << "thr->_threads_hazard_ptr must match be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
-      << "thr->_threads_list_ptr must be nullptr";
+      << "thr->_threads_list_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -268,7 +268,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -314,7 +314,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify tlh1 has the right field values:
       EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-          << "list_ptr1->previous() must be nullptr";
+          << "list_ptr1->previous() must be null";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -378,7 +378,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
         // Verify tlh1 has the right field values:
         EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-            << "list_ptr1->previous() must be nullptr";
+            << "list_ptr1->previous() must be null";
         EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
             << "list_ptr1->_thread must match current thread";
         EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -399,7 +399,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify the current thread's hazard ptr is nullptr:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-          << "thr->_threads_hazard_ptr must be nullptr";
+          << "thr->_threads_hazard_ptr must be null";
       // Verify the current thread's threads list ptr refers to tlh2:
       EXPECT_EQ(tlh1.list(), tlh2.list())
           << "tlh1.list() must match tlh2.list()";
@@ -426,7 +426,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify tlh1 has the right field values:
       EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-          << "list_ptr1->previous() must be nullptr";
+          << "list_ptr1->previous() must be null";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -447,7 +447,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify the current thread's hazard ptr is nullptr:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-        << "thr->_threads_hazard_ptr must be nullptr";
+        << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -456,7 +456,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -478,9 +478,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
   // Verify the current thread refers to no ThreadsListHandle:
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-      << "thr->_threads_hazard_ptr must match be nullptr";
+      << "thr->_threads_hazard_ptr must match be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
-      << "thr->_threads_list_ptr must be nullptr";
+      << "thr->_threads_list_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 
@@ -500,7 +500,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -546,7 +546,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify tlh1 has the right field values:
       EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-          << "list_ptr1->previous() must be nullptr";
+          << "list_ptr1->previous() must be null";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -567,7 +567,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify the current thread's hazard ptr is nullptr:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-        << "thr->_threads_hazard_ptr must be nullptr";
+        << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -576,7 +576,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -624,7 +624,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
       // Verify tlh1 has the right field values:
       EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-          << "list_ptr1->previous() must be nullptr";
+          << "list_ptr1->previous() must be null";
       EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
           << "list_ptr1->_thread must match current thread";
       EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -645,7 +645,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify the current thread's hazard ptr is nullptr:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-        << "thr->_threads_hazard_ptr must be nullptr";
+        << "thr->_threads_hazard_ptr must be null";
     // Verify the current thread's threads list ptr refers to tlh1:
     EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr1)
         << "thr->_threads_list_ptr must match list_ptr1";
@@ -654,7 +654,7 @@ TEST_VM(ThreadsListHandle, sanity) {
 
     // Verify tlh1 has the right field values:
     EXPECT_EQ(list_ptr1->previous(), (SafeThreadsListPtr*)nullptr)
-        << "list_ptr1->previous() must be nullptr";
+        << "list_ptr1->previous() must be null";
     EXPECT_EQ(ThreadsListHandleTest::get_STLP_thread(list_ptr1), thr)
         << "list_ptr1->_thread must match current thread";
     EXPECT_EQ(list_ptr1->list(), tlh1.list())
@@ -676,9 +676,9 @@ TEST_VM(ThreadsListHandle, sanity) {
 
   // Verify the current thread refers to no ThreadsListHandle:
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), (ThreadsList*)nullptr)
-      << "thr->_threads_hazard_ptr must match be nullptr";
+      << "thr->_threads_hazard_ptr must match be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), (SafeThreadsListPtr*) nullptr)
-      << "thr->_threads_list_ptr must be nullptr";
+      << "thr->_threads_list_ptr must be null";
   EXPECT_EQ(ThreadsListHandleTest::get_Thread_nested_threads_hazard_ptr_cnt(thr), (uint)0)
       << "thr->_nested_threads_hazard_ptr_cnt must be 0";
 

--- a/test/hotspot/gtest/runtime/test_arguments.cpp
+++ b/test/hotspot/gtest/runtime/test_arguments.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ static const intx no_value = 4711;
 
 inline intx ArgumentsTest::parse_xss_inner_annotated(const char* str, jint expected_err, const char* file, int line_number) {
   intx value = no_value;
-  jint err = parse_xss(NULL /* Silence error messages */, str, &value);
+  jint err = parse_xss(nullptr /* Silence error messages */, str, &value);
   EXPECT_EQ(err, expected_err) << "Failure from: " << file << ":" << line_number;
   return value;
 }
@@ -231,7 +231,7 @@ struct NumericArgument {
 static void check_invalid_numeric_string(JVMFlag* flag,  const char** invalid_strings) {
   for (uint i = 0; ; i++) {
     const char* str = invalid_strings[i];
-    if (str == NULL) {
+    if (str == nullptr) {
       return;
     }
     ASSERT_FALSE(ArgumentsTest::parse_argument(flag->name(), str))
@@ -273,7 +273,7 @@ void check_numeric_flag(JVMFlag* flag, T getvalue(JVMFlag* flag),
       "0x800000000000m", "0x800000000000000k",
       "-0x8000000t", "-0x800000000g",
       "-0x800000000000m", "-0x800000000000000k",
-      NULL,
+      nullptr,
     };
     check_invalid_numeric_string(flag, invalid_strings);
   }
@@ -283,7 +283,7 @@ void check_numeric_flag(JVMFlag* flag, T getvalue(JVMFlag* flag),
       "INF", "Inf", "Infinity", "INFINITY",
       "-INF", "-Inf", "-Infinity", "-INFINITY",
       "nan", "NAN", "NaN",
-      NULL,
+      nullptr,
     };
     check_invalid_numeric_string(flag, invalid_strings_for_double);
   } else {
@@ -293,7 +293,7 @@ void check_numeric_flag(JVMFlag* flag, T getvalue(JVMFlag* flag),
       "0x10000000000000000", "18446744073709551616",
       "-0x10000000000000000", "-18446744073709551616",
       "-0x8000000000000001", "-9223372036854775809",
-      NULL,
+      nullptr,
     };
     check_invalid_numeric_string(flag, invalid_strings_for_integers);
   }
@@ -449,7 +449,7 @@ void check_numeric_flag(JVMFlag* flag, T getvalue(JVMFlag* flag),
 template <typename T, ENABLE_IF(std::is_signed<T>::value), ENABLE_IF(sizeof(T) == 4)>
 void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
   JVMFlag* flag = JVMFlag::find_flag(f);
-  if (flag == NULL) { // not available in product builds
+  if (flag == nullptr) { // not available in product builds
     return;
   }
 
@@ -464,7 +464,7 @@ void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
 template <typename T, ENABLE_IF(!std::is_signed<T>::value), ENABLE_IF(sizeof(T) == 4)>
 void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
   JVMFlag* flag = JVMFlag::find_flag(f);
-  if (flag == NULL) { // not available in product builds
+  if (flag == nullptr) { // not available in product builds
     return;
   }
 
@@ -479,7 +479,7 @@ void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
 template <typename T, ENABLE_IF(std::is_signed<T>::value), ENABLE_IF(sizeof(T) == 8)>
 void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
   JVMFlag* flag = JVMFlag::find_flag(f);
-  if (flag == NULL) { // not available in product builds
+  if (flag == nullptr) { // not available in product builds
     return;
   }
 
@@ -495,7 +495,7 @@ void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
 template <typename T, ENABLE_IF(!std::is_signed<T>::value), ENABLE_IF(sizeof(T) == 8)>
 void check_flag(const char* f, T getvalue(JVMFlag* flag)) {
   JVMFlag* flag = JVMFlag::find_flag(f);
-  if (flag == NULL) { // not available in product builds
+  if (flag == nullptr) { // not available in product builds
     return;
   }
 
@@ -555,7 +555,7 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_size_t) {
 
 TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
   JVMFlag* flag = JVMFlag::find_flag("TestFlagFor_double");
-  if (flag == NULL) { // not available in product builds
+  if (flag == nullptr) { // not available in product builds
     return;
   }
 
@@ -597,7 +597,7 @@ TEST_VM_F(ArgumentsTest, set_numeric_flag_double) {
     char* end;
     errno = 0;
     double expected = strtod(str, &end);
-    if (errno == 0 && end != NULL && *end == '\0') {
+    if (errno == 0 && end != nullptr && *end == '\0') {
       ASSERT_TRUE(ArgumentsTest::parse_argument(flag->name(), str))
         << "Test string '" <<
         str << "' did not parse for type " << flag->type_string() << ". (Expected value = " << expected << ")";

--- a/test/hotspot/gtest/runtime/test_classLoader.cpp
+++ b/test/hotspot/gtest/runtime/test_classLoader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,16 @@
 // Tests ClassLoader::package_from_class_name()
 TEST_VM(ClassLoader, null_class_name) {
   bool bad_class_name = false;
-  TempNewSymbol retval = ClassLoader::package_from_class_name(NULL, &bad_class_name);
-  ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with NULL class name";
-  ASSERT_TRUE(retval == NULL) << "Wrong package for NULL class name pointer";
+  TempNewSymbol retval = ClassLoader::package_from_class_name(nullptr, &bad_class_name);
+  ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with nullptr class name";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for nullptr class name pointer";
 }
 
 TEST_VM(ClassLoader, empty_class_name) {
   bool bad_class_name = false;
   TempNewSymbol name = SymbolTable::new_symbol("");
   TempNewSymbol retval = ClassLoader::package_from_class_name(name, &bad_class_name);
-  ASSERT_TRUE(retval == NULL) << "Wrong package for empty string";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for empty string";
 }
 
 TEST_VM(ClassLoader, no_slash) {
@@ -47,7 +47,7 @@ TEST_VM(ClassLoader, no_slash) {
   TempNewSymbol name = SymbolTable::new_symbol("L");
   TempNewSymbol retval = ClassLoader::package_from_class_name(name, &bad_class_name);
   ASSERT_FALSE(bad_class_name) << "Function set bad_class_name with empty package";
-  ASSERT_TRUE(retval == NULL) << "Wrong package for class with no slashes";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for class with no slashes";
 }
 
 TEST_VM(ClassLoader, just_slash) {
@@ -55,7 +55,7 @@ TEST_VM(ClassLoader, just_slash) {
   TempNewSymbol name = SymbolTable::new_symbol("/");
   TempNewSymbol retval = ClassLoader::package_from_class_name(name, &bad_class_name);
   ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with package of length 0";
-  ASSERT_TRUE(retval == NULL) << "Wrong package for class with just slash";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for class with just slash";
 }
 
 TEST_VM(ClassLoader, multiple_slashes) {
@@ -103,5 +103,5 @@ TEST_VM(ClassLoader, class_object_array) {
   TempNewSymbol name = SymbolTable::new_symbol("[Lpackage/class");
   TempNewSymbol retval = ClassLoader::package_from_class_name(name, &bad_class_name);
   ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with array of class objects";
-  ASSERT_TRUE(retval == NULL) << "Wrong package for class with leading '[L'";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for class with leading '[L'";
 }

--- a/test/hotspot/gtest/runtime/test_classLoader.cpp
+++ b/test/hotspot/gtest/runtime/test_classLoader.cpp
@@ -31,8 +31,8 @@
 TEST_VM(ClassLoader, null_class_name) {
   bool bad_class_name = false;
   TempNewSymbol retval = ClassLoader::package_from_class_name(nullptr, &bad_class_name);
-  ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with nullptr class name";
-  ASSERT_TRUE(retval == nullptr) << "Wrong package for nullptr class name pointer";
+  ASSERT_TRUE(bad_class_name) << "Function did not set bad_class_name with null class name";
+  ASSERT_TRUE(retval == nullptr) << "Wrong package for null class name pointer";
 }
 
 TEST_VM(ClassLoader, empty_class_name) {

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -44,7 +44,7 @@ public:
     VirtualMemoryTracker::snapshot_thread_stacks();
 
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion(stack_end, stack_size));
-    ASSERT_TRUE(rmr != NULL);
+    ASSERT_TRUE(rmr != nullptr);
 
     ASSERT_EQ(rmr->base(), stack_end);
     ASSERT_EQ(rmr->size(), stack_size);
@@ -58,7 +58,7 @@ public:
     address stack_top = stack_end + stack_size;
     bool found_stack_top = false;
 
-    for (const CommittedMemoryRegion* region = iter.next(); region != NULL; region = iter.next()) {
+    for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
       if (region->base() + region->size() == stack_top) {
         ASSERT_TRUE(region->size() <= stack_size);
         found_stack_top = true;
@@ -95,7 +95,7 @@ public:
     char* base = os::reserve_memory(size, !ExecMem, mtThreadStack);
     bool result = os::commit_memory(base, size, !ExecMem);
     size_t index;
-    ASSERT_NE(base, (char*)NULL);
+    ASSERT_NE(base, (char*)nullptr);
     for (index = 0; index < touch_pages; index ++) {
       char* touch_addr = base + page_sz * page_num[index];
       *touch_addr = 'a';
@@ -109,14 +109,14 @@ public:
     VirtualMemoryTracker::snapshot_thread_stacks();
 
     ReservedMemoryRegion* rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion((address)base, size));
-    ASSERT_TRUE(rmr != NULL);
+    ASSERT_TRUE(rmr != nullptr);
 
     bool precise_tracking_supported = false;
     CommittedRegionIterator iter = rmr->iterate_committed_regions();
-    for (const CommittedMemoryRegion* region = iter.next(); region != NULL; region = iter.next()) {
+    for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
       if (region->size() == size) {
         // platforms that do not support precise tracking.
-        ASSERT_TRUE(iter.next() == NULL);
+        ASSERT_TRUE(iter.next() == nullptr);
         break;
       } else {
         precise_tracking_supported = true;
@@ -136,7 +136,7 @@ public:
     VirtualMemoryTracker::remove_released_region((address)base, size);
 
     rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion((address)base, size));
-    ASSERT_TRUE(rmr == NULL);
+    ASSERT_TRUE(rmr == nullptr);
   }
 
   static void test_committed_region() {
@@ -161,7 +161,7 @@ public:
     const size_t num_pages = 4;
     const size_t size = num_pages * page_sz;
     char* base = os::reserve_memory(size, !ExecMem, mtTest);
-    ASSERT_NE(base, (char*)NULL);
+    ASSERT_NE(base, (char*)nullptr);
     result = os::commit_memory(base, size, !ExecMem);
 
     ASSERT_TRUE(result);

--- a/test/hotspot/gtest/runtime/test_globals.cpp
+++ b/test/hotspot/gtest/runtime/test_globals.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,14 +94,14 @@ TEST_VM(FlagAccess, ccstr_flag) {
 
 template <typename T, int type_enum>
 static JVMFlag::Error get_flag(const char* name) {
-  JVMFlag* flag = (name == NULL) ? NULL : JVMFlag::find_flag(name);
+  JVMFlag* flag = (name == nullptr) ? nullptr : JVMFlag::find_flag(name);
 
   T val;
   return JVMFlagAccess::get<T, type_enum>(flag, &val);
 }
 
 TEST_VM(FlagAccess, wrong_format) {
-  ASSERT_EQ((get_flag<JVM_FLAG_TYPE(int)>(NULL)), JVMFlag::INVALID_FLAG);
+  ASSERT_EQ((get_flag<JVM_FLAG_TYPE(int)>(nullptr)), JVMFlag::INVALID_FLAG);
 
   // MaxRAMPercentage is a double flag
   ASSERT_EQ((get_flag<JVM_FLAG_TYPE(bool)>    ("MaxRAMPercentage")), JVMFlag::WRONG_FORMAT);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -313,8 +313,8 @@ static void test_snprintf(PrintFn pf, bool expect_count) {
   }
 
   // Special case of 0-length buffer with empty (except for terminator) output.
-  check_snprintf_result(0, 0, pf(NULL, 0, "%s", ""), expect_count);
-  check_snprintf_result(0, 0, pf(NULL, 0, ""), expect_count);
+  check_snprintf_result(0, 0, pf(nullptr, 0, "%s", ""), expect_count);
+  check_snprintf_result(0, 0, pf(nullptr, 0, ""), expect_count);
 }
 
 // This is probably equivalent to os::snprintf, but we're being
@@ -368,7 +368,7 @@ static inline bool can_reserve_executable_memory(void) {
   bool executable = true;
   size_t len = 128;
   char* p = os::reserve_memory(len, executable);
-  bool exec_supported = (p != NULL);
+  bool exec_supported = (p != nullptr);
   if (exec_supported) {
     os::release_memory(p, len);
   }
@@ -401,12 +401,12 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   const bool exec_supported = can_reserve_executable_memory();
 #endif
 
-  address p = NULL;
-  for (int tries = 0; tries < 256 && p == NULL; tries ++) {
+  address p = nullptr;
+  for (int tries = 0; tries < 256 && p == nullptr; tries ++) {
     size_t total_range_len = num_stripes * stripe_len;
     // Reserve a large contiguous area to get the address space...
     p = (address)os::reserve_memory(total_range_len);
-    EXPECT_NE(p, (address)NULL);
+    EXPECT_NE(p, (address)nullptr);
     // .. release it...
     EXPECT_TRUE(os::release_memory((char*)p, total_range_len));
     // ... re-reserve in the same spot multiple areas...
@@ -420,11 +420,11 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
       const bool executable = stripe % 2 == 0;
 #endif
       q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, executable);
-      if (q == NULL) {
+      if (q == nullptr) {
         // Someone grabbed that area concurrently. Cleanup, then retry.
         tty->print_cr("reserve_multiple: retry (%d)...", stripe);
         carefully_release_multiple(p, stripe, stripe_len);
-        p = NULL;
+        p = nullptr;
       } else {
         EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, executable));
       }
@@ -440,7 +440,7 @@ static address reserve_one_commit_multiple(int num_stripes, size_t stripe_len) {
   assert(is_aligned(stripe_len, os::vm_allocation_granularity()), "Sanity");
   size_t total_range_len = num_stripes * stripe_len;
   address p = (address)os::reserve_memory(total_range_len);
-  EXPECT_NE(p, (address)NULL);
+  EXPECT_NE(p, (address)nullptr);
   for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
     if (stripe % 2 == 0) {
@@ -491,7 +491,7 @@ TEST_VM(os, release_multi_mappings) {
 
   // reserve address space...
   address p = reserve_multiple(num_stripes, stripe_len);
-  ASSERT_NE(p, (address)NULL);
+  ASSERT_NE(p, (address)nullptr);
   PRINT_MAPPINGS("A");
 
   // .. release the middle stripes...
@@ -530,7 +530,7 @@ TEST_VM_ASSERT_MSG(os, release_bad_ranges, ".*bad release") {
 TEST_VM(os, release_bad_ranges) {
 #endif
   char* p = os::reserve_memory(4 * M);
-  ASSERT_NE(p, (char*)NULL);
+  ASSERT_NE(p, (char*)nullptr);
   // Release part of range
   ASSERT_FALSE(os::release_memory(p, M));
   // Release part of range
@@ -624,13 +624,13 @@ TEST_VM(os, find_mapping_simple) {
   os::win32::mapping_info_t mapping_info;
 
   // Some obvious negatives
-  ASSERT_FALSE(os::win32::find_mapping((address)NULL, &mapping_info));
+  ASSERT_FALSE(os::win32::find_mapping((address)nullptr, &mapping_info));
   ASSERT_FALSE(os::win32::find_mapping((address)4711, &mapping_info));
 
   // A simple allocation
   {
     address p = (address)os::reserve_memory(total_range_len);
-    ASSERT_NE(p, (address)NULL);
+    ASSERT_NE(p, (address)nullptr);
     PRINT_MAPPINGS("A");
     for (size_t offset = 0; offset < total_range_len; offset += 4711) {
       ASSERT_TRUE(os::win32::find_mapping(p + offset, &mapping_info));
@@ -659,7 +659,7 @@ TEST_VM(os, find_mapping_2) {
 
   const size_t stripe_len = total_range_len / 4;
   address p = reserve_one_commit_multiple(4, stripe_len);
-  ASSERT_NE(p, (address)NULL);
+  ASSERT_NE(p, (address)nullptr);
   PRINT_MAPPINGS("A");
   for (size_t offset = 0; offset < total_range_len; offset += 4711) {
     ASSERT_TRUE(os::win32::find_mapping(p + offset, &mapping_info));
@@ -688,7 +688,7 @@ TEST_VM(os, find_mapping_3) {
   {
     const size_t stripe_len = total_range_len / 4;
     address p = reserve_multiple(4, stripe_len);
-    ASSERT_NE(p, (address)NULL);
+    ASSERT_NE(p, (address)nullptr);
     PRINT_MAPPINGS("E");
     for (int stripe = 0; stripe < 4; stripe++) {
       ASSERT_TRUE(os::win32::find_mapping(p + (stripe * stripe_len), &mapping_info));
@@ -795,8 +795,8 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
   LOG("os::print_function_and_library_name(st, -1) expects FALSE.");
   address addr = (address)(intptr_t)-1;
   EXPECT_FALSE(os::print_function_and_library_name(&st, addr));
-  LOG("os::print_function_and_library_name(st, NULL) expects FALSE.");
-  addr = NULL;
+  LOG("os::print_function_and_library_name(st, nullptr) expects FALSE.");
+  addr = nullptr;
   EXPECT_FALSE(os::print_function_and_library_name(&st, addr));
 
   // Valid addresses
@@ -813,7 +813,7 @@ TEST_VM(os, dll_address_to_function_and_library_name) {
     addr = CAST_FROM_FN_PTR(address, Threads::create_vm);
     st.reset();
     EXPECT_TRUE(os::print_function_and_library_name(&st, addr,
-                                                    provide_scratch_buffer ? tmp : NULL,
+                                                    provide_scratch_buffer ? tmp : nullptr,
                                                     sizeof(tmp),
                                                     shorten_paths, demangle,
                                                     strip_arguments));
@@ -859,7 +859,7 @@ static bool very_simple_string_matcher(const char* pattern, const char* s) {
 TEST_VM(os, iso8601_time) {
   char buffer[os::iso8601_timestamp_size + 1]; // + space for canary
   buffer[os::iso8601_timestamp_size] = 'X'; // canary
-  const char* result = NULL;
+  const char* result = nullptr;
   // YYYY-MM-DDThh:mm:ss.mmm+zzzz
   const char* const pattern_utc = "dddd-dd-dd.dd:dd:dd.ddd.0000";
   const char* const pattern_local = "dddd-dd-dd.dd:dd:dd.ddd.dddd";

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ namespace {
     }
     HugeTlbfsMemory(char* const ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~HugeTlbfsMemory() {
-      if (_ptr != NULL) {
+      if (_ptr != nullptr) {
         os::release_memory_special(_ptr, _size);
       }
     }
@@ -81,9 +81,9 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_aligned) {
   size_t lp = os::large_page_size();
 
   for (size_t size = lp; size <= lp * 10; size += lp) {
-    char* addr = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, lp, lp, NULL, false);
+    char* addr = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, lp, lp, nullptr, false);
 
-    if (addr != NULL) {
+    if (addr != nullptr) {
       HugeTlbfsMemory mr(addr, size);
       small_page_write(addr, size);
     }
@@ -107,8 +107,8 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_without_add
   for (int i = 0; i < num_sizes; i++) {
     const size_t size = sizes[i];
     for (size_t alignment = ag; is_size_aligned(size, alignment); alignment *= 2) {
-      char* p = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, alignment, lp, NULL, false);
-      if (p != NULL) {
+      char* p = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, alignment, lp, nullptr, false);
+      if (p != nullptr) {
         HugeTlbfsMemory mr(p, size);
         EXPECT_PRED2(is_ptr_aligned, p, alignment) << " size = " << size;
         small_page_write(p, size);
@@ -135,7 +135,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_good_r
   // Pre-allocate an area as large as the largest allocation
   // and aligned to the largest alignment we will be testing.
   const size_t mapping_size = sizes[num_sizes - 1] * 2;
-  char* const mapping = (char*) ::mmap(NULL, mapping_size,
+  char* const mapping = (char*) ::mmap(nullptr, mapping_size,
       PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
       -1, 0);
   ASSERT_TRUE(mapping != MAP_FAILED) << " mmap failed, mapping_size = " << mapping_size;
@@ -148,7 +148,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_good_r
       // req_addr must be at least large page aligned.
       char* const req_addr = align_up(mapping, MAX2(alignment, lp));
       char* p = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, alignment, lp, req_addr, false);
-      if (p != NULL) {
+      if (p != nullptr) {
         HugeTlbfsMemory mr(p, size);
         ASSERT_EQ(req_addr, p) << " size = " << size << ", alignment = " << alignment;
         small_page_write(p, size);
@@ -176,7 +176,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_bad_re
   // Pre-allocate an area as large as the largest allocation
   // and aligned to the largest alignment we will be testing.
   const size_t mapping_size = sizes[num_sizes - 1] * 2;
-  char* const mapping = (char*) ::mmap(NULL, mapping_size,
+  char* const mapping = (char*) ::mmap(nullptr, mapping_size,
       PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
       -1, 0);
   ASSERT_TRUE(mapping != MAP_FAILED) << " mmap failed, mapping_size = " << mapping_size;
@@ -200,8 +200,8 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_bad_re
       char* p = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, alignment, lp, req_addr, false);
       HugeTlbfsMemory mr(p, size);
       // as the area around req_addr contains already existing mappings, the API should always
-      // return NULL (as per contract, it cannot return another address)
-      EXPECT_TRUE(p == NULL) << " size = " << size
+      // return nullptr (as per contract, it cannot return another address)
+      EXPECT_TRUE(p == nullptr) << " size = " << size
                              << ", alignment = " << alignment
                              << ", req_addr = " << req_addr
                              << ", p = " << p;
@@ -224,8 +224,8 @@ class TestReserveMemorySpecial : AllStatic {
     if (!using_static_hugepages()) {
       return;
     }
-    char* addr = os::reserve_memory_special(size, alignment, page_size, NULL, false);
-    if (addr != NULL) {
+    char* addr = os::reserve_memory_special(size, alignment, page_size, nullptr, false);
+    if (addr != nullptr) {
       small_page_write(addr, size);
       os::release_memory_special(addr, size);
     }
@@ -254,7 +254,7 @@ class TestReserveMemorySpecial : AllStatic {
     const int num_sizes = sizeof(sizes) / sizeof(size_t);
 
     // For each size/alignment combination, we test three scenarios:
-    // 1) with req_addr == NULL
+    // 1) with req_addr == nullptr
     // 2) with a non-null req_addr at which we expect to successfully allocate
     // 3) with a non-null req_addr which contains a pre-existing mapping, at which we
     //    expect the allocation to either fail or to ignore req_addr
@@ -262,12 +262,12 @@ class TestReserveMemorySpecial : AllStatic {
     // Pre-allocate two areas; they shall be as large as the largest allocation
     //  and aligned to the largest alignment we will be testing.
     const size_t mapping_size = sizes[num_sizes - 1] * 2;
-    char* const mapping1 = (char*) ::mmap(NULL, mapping_size,
+    char* const mapping1 = (char*) ::mmap(nullptr, mapping_size,
       PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
       -1, 0);
     EXPECT_NE(mapping1, MAP_FAILED);
 
-    char* const mapping2 = (char*) ::mmap(NULL, mapping_size,
+    char* const mapping2 = (char*) ::mmap(nullptr, mapping_size,
       PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE,
       -1, 0);
     EXPECT_NE(mapping2, MAP_FAILED);
@@ -281,8 +281,8 @@ class TestReserveMemorySpecial : AllStatic {
     for (int i = 0; i < num_sizes; i++) {
       const size_t size = sizes[i];
       for (size_t alignment = ag; is_aligned(size, alignment); alignment *= 2) {
-        char* p = os::reserve_memory_special(size, alignment, lp, NULL, false);
-        if (p != NULL) {
+        char* p = os::reserve_memory_special(size, alignment, lp, nullptr, false);
+        if (p != nullptr) {
           EXPECT_TRUE(is_aligned(p, alignment));
           small_page_write(p, size);
           os::release_memory_special(p, size);
@@ -297,7 +297,7 @@ class TestReserveMemorySpecial : AllStatic {
         // req_addr must be at least large page aligned.
         char* const req_addr = align_up(mapping1, MAX2(alignment, lp));
         char* p = os::reserve_memory_special(size, alignment, lp, req_addr, false);
-        if (p != NULL) {
+        if (p != nullptr) {
           EXPECT_EQ(p, req_addr);
           small_page_write(p, size);
           os::release_memory_special(p, size);
@@ -313,8 +313,8 @@ class TestReserveMemorySpecial : AllStatic {
         char* const req_addr = align_up(mapping2, MAX2(alignment, lp));
         char* p = os::reserve_memory_special(size, alignment, lp, req_addr, false);
         // as the area around req_addr contains already existing mappings, the API should always
-        // return NULL (as per contract, it cannot return another address)
-        EXPECT_TRUE(p == NULL);
+        // return nullptr (as per contract, it cannot return another address)
+        EXPECT_TRUE(p == nullptr);
       }
     }
 

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -200,7 +200,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_bad_re
       char* p = HugeTlbfsMemory::reserve_memory_special_huge_tlbfs(size, alignment, lp, req_addr, false);
       HugeTlbfsMemory mr(p, size);
       // as the area around req_addr contains already existing mappings, the API should always
-      // return nullptr (as per contract, it cannot return another address)
+      // return null (as per contract, it cannot return another address)
       EXPECT_TRUE(p == nullptr) << " size = " << size
                              << ", alignment = " << alignment
                              << ", req_addr = " << req_addr

--- a/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
@@ -63,13 +63,13 @@ TEST(cgroupTest, set_cgroupv1_subsystem_path) {
 TEST(cgroupTest, set_cgroupv2_subsystem_path) {
   TestCase at_mount_root = {
     "/sys/fs/cgroup",       // mount_path
-    nullptr,                   // root_path, ignored
+    nullptr,                // root_path, ignored
     "/",                    // cgroup_path
     "/sys/fs/cgroup"        // expected_path
   };
   TestCase sub_path = {
     "/sys/fs/cgroup",       // mount_path
-    nullptr,                   // root_path, ignored
+    nullptr,                // root_path, ignored
     "/foobar",              // cgroup_path
     "/sys/fs/cgroup/foobar" // expected_path
   };

--- a/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux_cgroups.cpp
@@ -63,13 +63,13 @@ TEST(cgroupTest, set_cgroupv1_subsystem_path) {
 TEST(cgroupTest, set_cgroupv2_subsystem_path) {
   TestCase at_mount_root = {
     "/sys/fs/cgroup",       // mount_path
-    NULL,                   // root_path, ignored
+    nullptr,                   // root_path, ignored
     "/",                    // cgroup_path
     "/sys/fs/cgroup"        // expected_path
   };
   TestCase sub_path = {
     "/sys/fs/cgroup",       // mount_path
-    NULL,                   // root_path, ignored
+    nullptr,                   // root_path, ignored
     "/foobar",              // cgroup_path
     "/sys/fs/cgroup/foobar" // expected_path
   };

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ namespace {
    public:
     MemoryReleaser(char* ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~MemoryReleaser() {
-      if (_ptr != NULL) {
+      if (_ptr != nullptr) {
         os::release_memory_special(_ptr, _size);
       }
     }
@@ -53,7 +53,7 @@ namespace {
 // This is of course only some dodgy assumption, there is no guarantee that the vicinity of
 // the previously allocated memory is available for allocation. The only actual failure
 // that is reported is when the test tries to allocate at a particular location but gets a
-// different valid one. A NULL return value at this point is not considered an error but may
+// different valid one. A nullptr return value at this point is not considered an error but may
 // be legitimate.
 void TestReserveMemorySpecial_test() {
   if (!UseLargePages) {
@@ -67,8 +67,8 @@ void TestReserveMemorySpecial_test() {
   FLAG_SET_CMDLINE(UseNUMAInterleaving, false);
 
   const size_t large_allocation_size = os::large_page_size() * 4;
-  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), NULL, false);
-  if (result == NULL) {
+  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), nullptr, false);
+  if (result == nullptr) {
       // failed to allocate memory, skipping the test
       return;
   }
@@ -78,20 +78,20 @@ void TestReserveMemorySpecial_test() {
   const size_t expected_allocation_size = os::large_page_size();
   char* expected_location = result + os::large_page_size();
   char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
-  EXPECT_TRUE(actual_location == NULL) << "Should not be allowed to reserve within present reservation";
+  EXPECT_TRUE(actual_location == nullptr) << "Should not be allowed to reserve within present reservation";
 
   // Instead try reserving after the first reservation.
   expected_location = result + large_allocation_size;
   actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
-  EXPECT_TRUE(actual_location != NULL) << "Unexpected reservation failure, can’t verify correct location";
+  EXPECT_TRUE(actual_location != nullptr) << "Unexpected reservation failure, can’t verify correct location";
   EXPECT_TRUE(actual_location == expected_location) << "Reservation must be at requested location";
   MemoryReleaser m2(actual_location, os::large_page_size());
 
   // Now try to do a reservation with a larger alignment.
   const size_t alignment = os::large_page_size() * 2;
   const size_t new_large_size = alignment * 4;
-  char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), NULL, false);
-  EXPECT_TRUE(aligned_request != NULL) << "Unexpected reservation failure, can’t verify correct alignment";
+  char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), nullptr, false);
+  EXPECT_TRUE(aligned_request != nullptr) << "Unexpected reservation failure, can’t verify correct alignment";
   EXPECT_TRUE(is_aligned(aligned_request, alignment)) << "Returned address must be aligned";
   MemoryReleaser m3(aligned_request, new_large_size);
 }
@@ -139,7 +139,7 @@ static bool file_exists_w(const wchar_t* path) {
 static void create_rel_directory_w(const wchar_t* path) {
   WITH_ABS_PATH(path);
   EXPECT_FALSE(file_exists_w(abs_path)) <<  "Can't create directory: \"" << path << "\" already exists";
-  BOOL result = CreateDirectoryW(abs_path, NULL);
+  BOOL result = CreateDirectoryW(abs_path, nullptr);
   EXPECT_TRUE(result) << "Failed to create directory \"" << path << "\" " << GetLastError();
 }
 
@@ -165,7 +165,7 @@ static void delete_empty_rel_directory_w(const wchar_t* path) {
 static void create_rel_file_w(const wchar_t* path) {
   WITH_ABS_PATH(path);
   EXPECT_FALSE(file_exists_w(abs_path)) << "Can't create file: \"" << path << "\" already exists";
-  HANDLE h = CreateFileW(abs_path, 0, 0, NULL, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+  HANDLE h = CreateFileW(abs_path, 0, 0, nullptr, CREATE_NEW, FILE_ATTRIBUTE_NORMAL, nullptr);
   EXPECT_NE(h, INVALID_HANDLE_VALUE) << "Failed to create file \"" << path << "\": " << GetLastError();
   CloseHandle(h);
 }
@@ -218,7 +218,7 @@ static bool unnormalize_path(wchar_t* result, size_t size, bool is_dir, const wc
   } else if (wcsncmp(src, L"\\\\", 2) == 0) {
     path_start = wcschr(src + 2, L'?');
 
-    if (path_start == NULL) {
+    if (path_start == nullptr) {
       path_start = wcschr(src + 2, L'\\');
     } else {
       path_start = wcschr(path_start, L'\\');
@@ -245,7 +245,7 @@ static bool unnormalize_path(wchar_t* result, size_t size, bool is_dir, const wc
           const wchar_t* replacement = sep_replacements[i];
           dest = my_wcscpy_s(dest - 1, size,  result, replacement);
         }
-      } else if (path_start != NULL) {
+      } else if (path_start != nullptr) {
         if (allow_dotdot_change && (src > path_start + 1) && ((os::random() & 7) == 7)) {
           wchar_t const* last_sep = src - 2;
 
@@ -397,7 +397,7 @@ static void bench_path(wchar_t* path) {
         size_t buf_len = strlen(buf);
         wchar_t* w_path = (wchar_t*) os::malloc(sizeof(wchar_t) * (buf_len + 1), mtInternal);
 
-        if (w_path != NULL) {
+        if (w_path != nullptr) {
           size_t converted_chars;
           if (::mbstowcs_s(&converted_chars, w_path, buf_len + 1, buf, buf_len) == ERROR_SUCCESS) {
             if (t == 1) {
@@ -417,7 +417,7 @@ static void bench_path(wchar_t* path) {
               }
               succ = false;
             }
-            HANDLE h = ::CreateFileW(w_path, 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+            HANDLE h = ::CreateFileW(w_path, 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
             if (h != INVALID_HANDLE_VALUE) {
               ::CloseHandle(h);
@@ -439,7 +439,7 @@ static void bench_path(wchar_t* path) {
     jlong ctime = os::javaTimeNanos();
 
     for (int i = 0; i < reps; ++i) {
-      HANDLE h = ::CreateFileA(buf, 0, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+      HANDLE h = ::CreateFileA(buf, 0, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
 
       if (h == INVALID_HANDLE_VALUE) {
         return;

--- a/test/hotspot/gtest/runtime/test_perfdata.cpp
+++ b/test/hotspot/gtest/runtime/test_perfdata.cpp
@@ -34,10 +34,10 @@ class PerfMemoryTest : public ::testing::Test {
 TEST_VM_F(PerfMemoryTest, destroy) {
   PerfMemory::destroy();
 
-  ASSERT_NE(PerfMemory::start(), (char*)nullptr) << "PerfMemory::_start should not be nullptr";
-  ASSERT_NE(PerfMemory::end(), (char*)nullptr) << "PerfMemory::_end should not be nullptr";
-  ASSERT_NE(PerfMemoryTest::top(), (char*)nullptr) << "PerfMemory::_top should not be nullptr";
-  ASSERT_NE(PerfMemoryTest::prologue(), (PerfDataPrologue*)nullptr) << "PerfMemory::_prologue should not be nullptr";
+  ASSERT_NE(PerfMemory::start(), (char*)nullptr) << "PerfMemory::_start should not be null";
+  ASSERT_NE(PerfMemory::end(), (char*)nullptr) << "PerfMemory::_end should not be null";
+  ASSERT_NE(PerfMemoryTest::top(), (char*)nullptr) << "PerfMemory::_top should not be null";
+  ASSERT_NE(PerfMemoryTest::prologue(), (PerfDataPrologue*)nullptr) << "PerfMemory::_prologue should not be null";
   ASSERT_NE(PerfMemory::capacity(), (size_t)0) << "PerfMemory::_capacity should not be 0";
 }
 

--- a/test/hotspot/gtest/runtime/test_perfdata.cpp
+++ b/test/hotspot/gtest/runtime/test_perfdata.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,10 +34,10 @@ class PerfMemoryTest : public ::testing::Test {
 TEST_VM_F(PerfMemoryTest, destroy) {
   PerfMemory::destroy();
 
-  ASSERT_NE(PerfMemory::start(), (char*)NULL) << "PerfMemory::_start should not be NULL";
-  ASSERT_NE(PerfMemory::end(), (char*)NULL) << "PerfMemory::_end should not be NULL";
-  ASSERT_NE(PerfMemoryTest::top(), (char*)NULL) << "PerfMemory::_top should not be NULL";
-  ASSERT_NE(PerfMemoryTest::prologue(), (PerfDataPrologue*)NULL) << "PerfMemory::_prologue should not be NULL";
+  ASSERT_NE(PerfMemory::start(), (char*)nullptr) << "PerfMemory::_start should not be nullptr";
+  ASSERT_NE(PerfMemory::end(), (char*)nullptr) << "PerfMemory::_end should not be nullptr";
+  ASSERT_NE(PerfMemoryTest::top(), (char*)nullptr) << "PerfMemory::_top should not be nullptr";
+  ASSERT_NE(PerfMemoryTest::prologue(), (PerfDataPrologue*)nullptr) << "PerfMemory::_prologue should not be nullptr";
   ASSERT_NE(PerfMemory::capacity(), (size_t)0) << "PerfMemory::_capacity should not be 0";
 }
 

--- a/test/hotspot/gtest/runtime/test_safefetch.cpp
+++ b/test/hotspot/gtest/runtime/test_safefetch.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -64,11 +64,11 @@ static void test_safefetchN_negative() {
   ASSERT_EQ(-1, a);
   a = SafeFetchN(bad_addressN, ~patternN);
   ASSERT_EQ(~patternN, a);
-  // Also test NULL, but not on AIX, where NULL is readable
+  // Also test nullptr, but not on AIX, where nullptr is readable
 #ifndef AIX
-  a = SafeFetchN(NULL, 0);
+  a = SafeFetchN(nullptr, 0);
   ASSERT_EQ(0, a);
-  a = SafeFetchN(NULL, ~patternN);
+  a = SafeFetchN(nullptr, ~patternN);
   ASSERT_EQ(~patternN, a);
 #endif
 }
@@ -80,11 +80,11 @@ static void test_safefetch32_negative() {
   ASSERT_EQ(-1, a);
   a = SafeFetch32(bad_address32, ~pattern32);
   ASSERT_EQ(~pattern32, a);
-  // Also test NULL, but not on AIX, where NULL is readable
+  // Also test nullptr, but not on AIX, where nullptr is readable
 #ifndef AIX
-  a = SafeFetch32(NULL, 0);
+  a = SafeFetch32(nullptr, 0);
   ASSERT_EQ(0, a);
-  a = SafeFetch32(NULL, ~pattern32);
+  a = SafeFetch32(nullptr, ~pattern32);
   ASSERT_EQ(~pattern32, a);
 #endif
 }
@@ -105,7 +105,7 @@ TEST_VM(os, safefetch32_negative) {
   test_safefetch32_negative();
 }
 
-// Try with Thread::current being NULL. SafeFetch should work then too.
+// Try with Thread::current being nullptr. SafeFetch should work then too.
 // See JDK-8282475
 
 class ThreadCurrentNullMark : public StackObj {

--- a/test/hotspot/gtest/runtime/test_threads.cpp
+++ b/test/hotspot/gtest/runtime/test_threads.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -185,7 +185,7 @@ TEST_VM(ThreadsTest, fast_jni_in_vm) {
   // DirectByteBuffer is an easy way to trigger GetIntField,
   // see JDK-8262896
   jlong capacity = 0x10000;
-  jobject buffer = env->NewDirectByteBuffer(NULL, (jlong)capacity);
-  ASSERT_NE((void*)NULL, buffer);
+  jobject buffer = env->NewDirectByteBuffer(nullptr, (jlong)capacity);
+  ASSERT_NE((void*)nullptr, buffer);
   ASSERT_EQ(capacity, env->GetDirectBufferCapacity(buffer));
 }

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,13 +55,13 @@ namespace {
 
 #define check_empty(rmr)                              \
   do {                                                \
-    check_inner((rmr), NULL, 0, __FILE__, __LINE__);  \
+    check_inner((rmr), nullptr, 0, __FILE__, __LINE__);  \
   } while (false)
 
 static void diagnostic_print(ReservedMemoryRegion* rmr) {
   CommittedRegionIterator iter = rmr->iterate_committed_regions();
   LOG("In reserved region " PTR_FORMAT ", size " SIZE_FORMAT_HEX ":", p2i(rmr->base()), rmr->size());
-  for (const CommittedMemoryRegion* region = iter.next(); region != NULL; region = iter.next()) {
+  for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
     LOG("   committed region: " PTR_FORMAT ", size " SIZE_FORMAT_HEX, p2i(region->base()), region->size());
   }
 }
@@ -76,7 +76,7 @@ static void check_inner(ReservedMemoryRegion* rmr, R* regions, size_t regions_si
 
 #define WHERE " from " << file << ":" << line
 
-  for (const CommittedMemoryRegion* region = iter.next(); region != NULL; region = iter.next()) {
+  for (const CommittedMemoryRegion* region = iter.next(); region != nullptr; region = iter.next()) {
     EXPECT_LT(i, regions_size) << WHERE;
     EXPECT_EQ(region->base(), regions[i]._addr) << WHERE;
     EXPECT_EQ(region->size(), regions[i]._size) << WHERE;

--- a/test/hotspot/gtest/runtime/test_vmStructs.cpp
+++ b/test/hotspot/gtest/runtime/test_vmStructs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,8 +55,8 @@ TEST(VMStructs, last_entries)  {
 
 TEST(VMStructs, VMTypes_duplicates)  {
   // Check for duplicate entries in type array
-  for (int i = 0; VMStructs::localHotSpotVMTypes[i].typeName != NULL; i++) {
-    for (int j = i + 1; VMStructs::localHotSpotVMTypes[j].typeName != NULL; j++) {
+  for (int i = 0; VMStructs::localHotSpotVMTypes[i].typeName != nullptr; i++) {
+    for (int j = i + 1; VMStructs::localHotSpotVMTypes[j].typeName != nullptr; j++) {
       EXPECT_STRNE(VMStructs::localHotSpotVMTypes[i].typeName, VMStructs::localHotSpotVMTypes[j].typeName)
               << "Duplicate entries on indexes " << i << " and " << j << " : " << VMStructs::localHotSpotVMTypes[i].typeName;
     }

--- a/test/hotspot/gtest/testutils.cpp
+++ b/test/hotspot/gtest/testutils.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,17 +35,17 @@
 // Note: these could be made more suitable for covering large ranges (e.g. just mark one byte per page).
 
 void GtestUtils::mark_range_with(void* p, size_t s, uint8_t mark) {
-  if (p != NULL && s > 0) {
+  if (p != nullptr && s > 0) {
     ::memset(p, mark, s);
   }
 }
 
 bool GtestUtils::is_range_marked(const void* p, size_t s, uint8_t expected) {
-  if (p == NULL || s == 0) {
+  if (p == nullptr || s == 0) {
     return true;
   }
 
-  const char* first_wrong = NULL;
+  const char* first_wrong = nullptr;
   char* p2 = (char*)p;
   const char* const end = p2 + s;
   while (p2 < end) {
@@ -56,7 +56,7 @@ bool GtestUtils::is_range_marked(const void* p, size_t s, uint8_t expected) {
     p2 ++;
   }
 
-  if (first_wrong != NULL) {
+  if (first_wrong != nullptr) {
     tty->print_cr("check_range [" PTR_FORMAT ".." PTR_FORMAT "), 0x%X, : wrong pattern around " PTR_FORMAT,
                   p2i(p), p2i(p) + s, expected, p2i(first_wrong));
     // Note: We deliberately print the surroundings too without bounds check. Might be interesting,
@@ -65,5 +65,5 @@ bool GtestUtils::is_range_marked(const void* p, size_t s, uint8_t expected) {
                             (address)(align_up(end, 0x10) + 0x10), 1);
   }
 
-  return first_wrong == NULL;
+  return first_wrong == nullptr;
 }

--- a/test/hotspot/gtest/testutils.hpp
+++ b/test/hotspot/gtest/testutils.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,12 @@ class GtestUtils : public AllStatic {
 public:
 
   // Fill range with a byte mark.
-  // Tolerates p == NULL or s == 0.
+  // Tolerates p == nullptr or s == 0.
   static void mark_range_with(void* p, size_t s, uint8_t mark);
 
   // Given a memory range, check that the whole range is filled with the expected byte.
   // If not, hex dump around first non-matching address and return false.
-  // If p == NULL or size == 0, returns true.
+  // If p == nullptr or size == 0, returns true.
   static bool is_range_marked(const void* p, size_t s, uint8_t expected);
 
   // Convenience method with a predefined byte mark.
@@ -53,8 +53,8 @@ public:
 #define EXPECT_RANGE_IS_MARKED(p, size)             EXPECT_TRUE(GtestUtils::is_range_marked(p, size))
 
 // Mimicking the official ASSERT_xx and EXPECT_xx counterparts of the googletest suite.
-// (ASSERT|EXPECT)_NOT_NULL: check that the given pointer is not NULL
-// (ASSERT|EXPECT)_NULL: check that the given pointer is NULL
+// (ASSERT|EXPECT)_NOT_NULL: check that the given pointer is not nullptr
+// (ASSERT|EXPECT)_NULL: check that the given pointer is nullptr
 #define ASSERT_NOT_NULL(p)  ASSERT_NE(p2i(p), 0)
 #define ASSERT_NULL(p)      ASSERT_EQ(p2i(p), 0)
 #define EXPECT_NOT_NULL(p)  EXPECT_NE(p2i(p), 0)

--- a/test/hotspot/gtest/testutils.hpp
+++ b/test/hotspot/gtest/testutils.hpp
@@ -53,8 +53,8 @@ public:
 #define EXPECT_RANGE_IS_MARKED(p, size)             EXPECT_TRUE(GtestUtils::is_range_marked(p, size))
 
 // Mimicking the official ASSERT_xx and EXPECT_xx counterparts of the googletest suite.
-// (ASSERT|EXPECT)_NOT_NULL: check that the given pointer is not nullptr
-// (ASSERT|EXPECT)_NULL: check that the given pointer is nullptr
+// (ASSERT|EXPECT)_NOT_NULL: check that the given pointer is not null
+// (ASSERT|EXPECT)_NULL: check that the given pointer is null
 #define ASSERT_NOT_NULL(p)  ASSERT_NE(p2i(p), 0)
 #define ASSERT_NULL(p)      ASSERT_EQ(p2i(p), 0)
 #define EXPECT_NOT_NULL(p)  EXPECT_NE(p2i(p), 0)

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -105,7 +105,7 @@ struct SimpleTestLookup {
   uintptr_t _val;
   SimpleTestLookup(uintptr_t val) : _val(val) {}
   uintx get_hash() {
-    return Pointer::get_hash(_val, NULL);
+    return Pointer::get_hash(_val, nullptr);
   }
   bool equals(const uintptr_t* value) {
     return _val == *value;
@@ -119,7 +119,7 @@ struct ValueGet {
   uintptr_t _return;
   ValueGet() : _return(0) {}
   void operator()(uintptr_t* value) {
-    EXPECT_NE(value, (uintptr_t*)NULL) << "expected valid value";
+    EXPECT_NE(value, (uintptr_t*)nullptr) << "expected valid value";
     _return = *value;
   }
   uintptr_t get_value() const {
@@ -562,7 +562,7 @@ struct TestLookup {
   uintptr_t _val;
   TestLookup(uintptr_t val) : _val(val) {}
   uintx get_hash() {
-    return TestInterface::get_hash(_val, NULL);
+    return TestInterface::get_hash(_val, nullptr);
   }
   bool equals(const uintptr_t* value) {
     return _val == *value;
@@ -684,7 +684,7 @@ class RunnerSimpleInserterThread : public CHTTestThread {
 public:
   Semaphore _done;
 
-  RunnerSimpleInserterThread(Semaphore* post) : CHTTestThread(0, 0, NULL, post) {
+  RunnerSimpleInserterThread(Semaphore* post) : CHTTestThread(0, 0, nullptr, post) {
     _cht = new TestTable(SIZE_32, SIZE_32);
   };
   virtual ~RunnerSimpleInserterThread(){}
@@ -768,7 +768,7 @@ class RunnerDeleteInserterThread : public CHTTestThread {
 public:
   Semaphore _done;
 
-  RunnerDeleteInserterThread(Semaphore* post) : CHTTestThread(0, 0, NULL, post) {
+  RunnerDeleteInserterThread(Semaphore* post) : CHTTestThread(0, 0, nullptr, post) {
     _cht = new TestTable(SIZE_32, SIZE_32);
   };
   virtual ~RunnerDeleteInserterThread(){}
@@ -795,7 +795,7 @@ public:
         TestLookup tl(v);
         TestGetHandle value_handle(this, _cht);
         uintptr_t* tmp = value_handle.get(tl);
-        tv = tmp != NULL ? *tmp : 0;
+        tv = tmp != nullptr ? *tmp : 0;
       }
       EXPECT_TRUE(tv == 0 || tv == v) << "Got unknown value.";
     }
@@ -894,7 +894,7 @@ public:
   uintptr_t _range;
   Semaphore _done;
 
-  RunnerGSInserterThread(Semaphore* post) : CHTTestThread(0, 0, NULL, post) {
+  RunnerGSInserterThread(Semaphore* post) : CHTTestThread(0, 0, nullptr, post) {
     _cht = new TestTable(START_SIZE, END_SIZE, 2);
   };
   virtual ~RunnerGSInserterThread(){}
@@ -1036,7 +1036,7 @@ public:
   Semaphore _done;
   uintptr_t _start;
   uintptr_t _range;
-  RunnerGI_BD_InserterThread(Semaphore* post) : CHTTestThread(0, 0, NULL, post) {
+  RunnerGI_BD_InserterThread(Semaphore* post) : CHTTestThread(0, 0, nullptr, post) {
     _cht = new TestTable(GI_BD_GI_BD_START_SIZE, GI_BD_END_SIZE, 2);
   };
   virtual ~RunnerGI_BD_InserterThread(){}

--- a/test/hotspot/gtest/utilities/test_linkedlist.cpp
+++ b/test/hotspot/gtest/utilities/test_linkedlist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ class Integer : public StackObj {
 static void check_list_values(const int* expected, const LinkedList<Integer>* list) {
   LinkedListNode<Integer>* head = list->head();
   int index = 0;
-  while (head != NULL) {
+  while (head != nullptr) {
     ASSERT_EQ(expected[index], head->peek()->value())
             << "Unexpected value at index " << index;
     head = head->next();
@@ -70,14 +70,14 @@ TEST(LinkedList, simple) {
   ASSERT_TRUE(!ll.is_empty()) << "Should not be empty";
 
   Integer* i = ll.find(six);
-  ASSERT_TRUE(i != NULL) << "Should find it";
+  ASSERT_TRUE(i != nullptr) << "Should find it";
   ASSERT_EQ(six.value(), i->value()) << "Should be 6";
 
   i = ll.find(three);
-  ASSERT_TRUE(i == NULL) << "Not in the list";
+  ASSERT_TRUE(i == nullptr) << "Not in the list";
 
   LinkedListNode<Integer>* node = ll.find_node(six);
-  ASSERT_TRUE(node != NULL) << "6 is in the list";
+  ASSERT_TRUE(node != nullptr) << "6 is in the list";
 
   ll.insert_after(three, node);
   ll.insert_before(one, node);
@@ -136,7 +136,7 @@ TEST(LinkedList, generic) {
 
   LinkedListIterator<Integer> it2(dummy.head());
   EXPECT_TRUE(it2.is_empty());
-  EXPECT_EQ(it2.next(), (Integer* )NULL);
+  EXPECT_EQ(it2.next(), (Integer* )nullptr);
 }
 
 TEST(LinkedList, algorithm) {
@@ -145,7 +145,7 @@ TEST(LinkedList, algorithm) {
   il.add(2);
   il.add(3);
   EXPECT_EQ(*il.find(1), 1);
-  EXPECT_EQ(il.find(404), (int* )NULL);
+  EXPECT_EQ(il.find(404), (int* )nullptr);
   EXPECT_TRUE(il.remove(1));
   EXPECT_FALSE(il.remove(404));
 
@@ -189,7 +189,7 @@ TEST(SortedLinkedList, simple) {
   }
 
   LinkedListNode<Integer>* node = sl.find_node(four);
-  ASSERT_TRUE(node != NULL) << "4 is in the list";
+  ASSERT_TRUE(node != nullptr) << "4 is in the list";
   sl.remove_before(node);
   sl.remove_after(node);
   int remains[] = {1, 2, 4, 6};

--- a/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
+++ b/test/hotspot/gtest/utilities/test_lockFreeStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,8 @@ LockFreeStackTestBasics::LockFreeStackTestBasics() : stack() {
 void LockFreeStackTestBasics::initialize() {
   ASSERT_TRUE(stack.empty());
   ASSERT_EQ(0u, stack.length());
-  ASSERT_TRUE(stack.pop() == NULL);
-  ASSERT_TRUE(stack.top() == NULL);
+  ASSERT_TRUE(stack.pop() == nullptr);
+  ASSERT_TRUE(stack.top() == nullptr);
 
   for (size_t id = 0; id < nelements; ++id) {
     ASSERT_EQ(id, stack.length());
@@ -101,48 +101,48 @@ TEST_F(LockFreeStackTestBasics, push_pop) {
     ASSERT_EQ(i, stack.length());
     --i;
     Element* e = stack.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
   }
   ASSERT_TRUE(stack.empty());
   ASSERT_EQ(0u, stack.length());
-  ASSERT_TRUE(stack.pop() == NULL);
+  ASSERT_TRUE(stack.pop() == nullptr);
 }
 
 TEST_F(LockFreeStackTestBasics, prepend_one) {
   TestStack other_stack;
   ASSERT_TRUE(other_stack.empty());
-  ASSERT_TRUE(other_stack.pop() == NULL);
+  ASSERT_TRUE(other_stack.pop() == nullptr);
   ASSERT_EQ(0u, other_stack.length());
-  ASSERT_TRUE(other_stack.top() == NULL);
-  ASSERT_TRUE(other_stack.pop() == NULL);
+  ASSERT_TRUE(other_stack.top() == nullptr);
+  ASSERT_TRUE(other_stack.pop() == nullptr);
 
   other_stack.prepend(*stack.pop_all());
   ASSERT_EQ(nelements, other_stack.length());
   ASSERT_TRUE(stack.empty());
   ASSERT_EQ(0u, stack.length());
-  ASSERT_TRUE(stack.pop() == NULL);
-  ASSERT_TRUE(stack.top() == NULL);
+  ASSERT_TRUE(stack.pop() == nullptr);
+  ASSERT_TRUE(stack.top() == nullptr);
 
   for (size_t i = nelements; i > 0; ) {
     ASSERT_EQ(i, other_stack.length());
     --i;
     Element* e = other_stack.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
   }
   ASSERT_EQ(0u, other_stack.length());
-  ASSERT_TRUE(other_stack.pop() == NULL);
+  ASSERT_TRUE(other_stack.pop() == nullptr);
 }
 
 TEST_F(LockFreeStackTestBasics, prepend_two) {
   TestStack other_stack;
   ASSERT_TRUE(other_stack.empty());
   ASSERT_EQ(0u, other_stack.length());
-  ASSERT_TRUE(other_stack.top() == NULL);
-  ASSERT_TRUE(other_stack.pop() == NULL);
+  ASSERT_TRUE(other_stack.top() == nullptr);
+  ASSERT_TRUE(other_stack.pop() == nullptr);
 
   Element* top = stack.pop_all();
   ASSERT_EQ(top, &elements[nelements - 1]);
@@ -152,17 +152,17 @@ TEST_F(LockFreeStackTestBasics, prepend_two) {
     ASSERT_EQ(i, other_stack.length());
     --i;
     Element* e = other_stack.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
   }
   ASSERT_EQ(0u, other_stack.length());
-  ASSERT_TRUE(other_stack.pop() == NULL);
+  ASSERT_TRUE(other_stack.pop() == nullptr);
 }
 
 TEST_F(LockFreeStackTestBasics, two_stacks) {
   TestStack1 stack1;
-  ASSERT_TRUE(stack1.pop() == NULL);
+  ASSERT_TRUE(stack1.pop() == nullptr);
 
   for (size_t id = 0; id < nelements; ++id) {
     stack1.push(elements[id]);
@@ -172,7 +172,7 @@ TEST_F(LockFreeStackTestBasics, two_stacks) {
   Element* e1 = stack1.top();
   while (true) {
     ASSERT_EQ(e0, e1);
-    if (e0 == NULL) break;
+    if (e0 == nullptr) break;
     e0 = stack.next(*e0);
     e1 = stack1.next(*e1);
   }
@@ -182,12 +182,12 @@ TEST_F(LockFreeStackTestBasics, two_stacks) {
     ASSERT_EQ(i, stack1.length());
     --i;
     Element* e = stack.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
 
     Element* e1 = stack1.pop();
-    ASSERT_TRUE(e1 != NULL);
+    ASSERT_TRUE(e1 != nullptr);
     ASSERT_EQ(&elements[i], e1);
     ASSERT_EQ(i, e1->id());
 
@@ -195,8 +195,8 @@ TEST_F(LockFreeStackTestBasics, two_stacks) {
   }
   ASSERT_EQ(0u, stack.length());
   ASSERT_EQ(0u, stack1.length());
-  ASSERT_TRUE(stack.pop() == NULL);
-  ASSERT_TRUE(stack1.pop() == NULL);
+  ASSERT_TRUE(stack.pop() == nullptr);
+  ASSERT_TRUE(stack1.pop() == nullptr);
 }
 
 class LockFreeStackTestThread : public JavaTestThread {
@@ -229,7 +229,7 @@ public:
     Atomic::release_store_fence(&_ready, true);
     while (true) {
       Element* e = _from->pop();
-      if (e != NULL) {
+      if (e != nullptr) {
         _to->push(*e);
         Atomic::inc(_processed);
         ++_local_processed;
@@ -300,7 +300,7 @@ TEST_VM(LockFreeStackTest, stress) {
   ASSERT_EQ(0u, start_stack.length());
   ASSERT_EQ(0u, middle_stack.length());
   ASSERT_EQ(nelements, final_stack.length());
-  while (final_stack.pop() != NULL) {}
+  while (final_stack.pop() != nullptr) {}
 
   FREE_C_HEAP_ARRAY(Element, elements);
 }

--- a/test/hotspot/gtest/utilities/test_metaspaceClosure.cpp
+++ b/test/hotspot/gtest/utilities/test_metaspaceClosure.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/utilities/test_metaspaceClosure.cpp
+++ b/test/hotspot/gtest/utilities/test_metaspaceClosure.cpp
@@ -35,7 +35,7 @@ public:
   MyMetaData* _a;
   MyMetaData* _b;
 
-  MyMetaData() : _a(NULL), _b(NULL) {}
+  MyMetaData() : _a(nullptr), _b(nullptr) {}
 
   MetaspaceObj::Type type() const {
     return MetaspaceObj::SymbolType; // Just lie. It doesn't matter in this test
@@ -64,7 +64,7 @@ class MyUniqueMetaspaceClosure : public MetaspaceClosure {
 public:
   MyUniqueMetaspaceClosure() {
     for (int i = 0; i < SIZE; i++) {
-      _visited[i] = NULL;
+      _visited[i] = nullptr;
     }
     _count = 0;
   }
@@ -92,7 +92,7 @@ TEST_VM(MetaspaceClosure, MSOPointerArrayRef) {
   ClassLoaderData* cld = ClassLoaderData::the_null_class_loader_data();
   Array<MyMetaData*>* array = MetadataFactory::new_array<MyMetaData*>(cld, 4, THREAD);
   for (int i = 0; i < array->length(); i++) {
-    EXPECT_TRUE(array->at(i) == NULL) << "should be initialized to null";
+    EXPECT_TRUE(array->at(i) == nullptr) << "should be initialized to null";
   }
 
   MyMetaData x;
@@ -117,8 +117,8 @@ TEST_VM(MetaspaceClosure, MSOArrayRef) {
   ClassLoaderData* cld = ClassLoaderData::the_null_class_loader_data();
   Array<MyMetaData>* array = MetadataFactory::new_array<MyMetaData>(cld, 4, THREAD);
   for (int i = 0; i < array->length(); i++) {
-    EXPECT_TRUE(array->at(i)._a == NULL) << "should be initialized to null";
-    EXPECT_TRUE(array->at(i)._b == NULL) << "should be initialized to null";
+    EXPECT_TRUE(array->at(i)._a == nullptr) << "should be initialized to null";
+    EXPECT_TRUE(array->at(i)._b == nullptr) << "should be initialized to null";
   }
 
   MyMetaData x;

--- a/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
+++ b/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
+++ b/test/hotspot/gtest/utilities/test_nonblockingQueue.cpp
@@ -64,7 +64,7 @@ static void initialize(Element* elements, size_t size, TestQueue* queue) {
   ASSERT_TRUE(queue->empty());
   ASSERT_EQ(0u, queue->length());
   ASSERT_TRUE(queue->is_end(queue->first()));
-  ASSERT_TRUE(queue->pop() == NULL);
+  ASSERT_TRUE(queue->pop() == nullptr);
 
   for (size_t id = 0; id < size; ++id) {
     ASSERT_EQ(id, queue->length());
@@ -97,13 +97,13 @@ TEST_F(NonblockingQueueTestBasics, pop) {
     ASSERT_FALSE(queue.empty());
     ASSERT_EQ(nelements - i, queue.length());
     Element* e = queue.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
   }
   ASSERT_TRUE(queue.empty());
   ASSERT_EQ(0u, queue.length());
-  ASSERT_TRUE(queue.pop() == NULL);
+  ASSERT_TRUE(queue.pop() == nullptr);
 }
 
 TEST_F(NonblockingQueueTestBasics, append) {
@@ -111,7 +111,7 @@ TEST_F(NonblockingQueueTestBasics, append) {
   ASSERT_TRUE(other_queue.empty());
   ASSERT_EQ(0u, other_queue.length());
   ASSERT_TRUE(other_queue.is_end(other_queue.first()));
-  ASSERT_TRUE(other_queue.pop() == NULL);
+  ASSERT_TRUE(other_queue.pop() == nullptr);
 
   Pair<Element*, Element*> pair = queue.take_all();
   other_queue.append(*pair.first, *pair.second);
@@ -119,22 +119,22 @@ TEST_F(NonblockingQueueTestBasics, append) {
   ASSERT_TRUE(queue.empty());
   ASSERT_EQ(0u, queue.length());
   ASSERT_TRUE(queue.is_end(queue.first()));
-  ASSERT_TRUE(queue.pop() == NULL);
+  ASSERT_TRUE(queue.pop() == nullptr);
 
   for (size_t i = 0; i < nelements; ++i) {
     ASSERT_EQ(nelements - i, other_queue.length());
     Element* e = other_queue.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
   }
   ASSERT_EQ(0u, other_queue.length());
-  ASSERT_TRUE(other_queue.pop() == NULL);
+  ASSERT_TRUE(other_queue.pop() == nullptr);
 }
 
 TEST_F(NonblockingQueueTestBasics, two_queues) {
   TestQueue1 queue1;
-  ASSERT_TRUE(queue1.pop() == NULL);
+  ASSERT_TRUE(queue1.pop() == nullptr);
 
   for (size_t id = 0; id < nelements; ++id) {
     queue1.push(elements[id]);
@@ -142,8 +142,8 @@ TEST_F(NonblockingQueueTestBasics, two_queues) {
   ASSERT_EQ(nelements, queue1.length());
   Element* e0 = queue.first();
   Element* e1 = queue1.first();
-  ASSERT_TRUE(e0 != NULL);
-  ASSERT_TRUE(e1 != NULL);
+  ASSERT_TRUE(e0 != nullptr);
+  ASSERT_TRUE(e1 != nullptr);
   ASSERT_FALSE(queue.is_end(e0));
   ASSERT_FALSE(queue1.is_end(e1));
   while (!queue.is_end(e0) && !queue1.is_end(e1)) {
@@ -159,12 +159,12 @@ TEST_F(NonblockingQueueTestBasics, two_queues) {
     ASSERT_EQ(nelements - i, queue1.length());
 
     Element* e = queue.pop();
-    ASSERT_TRUE(e != NULL);
+    ASSERT_TRUE(e != nullptr);
     ASSERT_EQ(&elements[i], e);
     ASSERT_EQ(i, e->id());
 
     Element* e1 = queue1.pop();
-    ASSERT_TRUE(e1 != NULL);
+    ASSERT_TRUE(e1 != nullptr);
     ASSERT_EQ(&elements[i], e1);
     ASSERT_EQ(i, e1->id());
 
@@ -172,8 +172,8 @@ TEST_F(NonblockingQueueTestBasics, two_queues) {
   }
   ASSERT_EQ(0u, queue.length());
   ASSERT_EQ(0u, queue1.length());
-  ASSERT_TRUE(queue.pop() == NULL);
-  ASSERT_TRUE(queue1.pop() == NULL);
+  ASSERT_TRUE(queue.pop() == nullptr);
+  ASSERT_TRUE(queue1.pop() == nullptr);
 }
 
 class NonblockingQueueTestThread : public JavaTestThread {
@@ -206,7 +206,7 @@ public:
     Atomic::release_store_fence(&_ready, true);
     while (true) {
       Element* e = _from->pop();
-      if (e != NULL) {
+      if (e != nullptr) {
         _to->push(*e);
         Atomic::inc(_processed);
         ++_local_processed;
@@ -278,7 +278,7 @@ TEST_VM(NonblockingQueueTest, stress) {
   ASSERT_EQ(0u, start_queue.length());
   ASSERT_EQ(0u, middle_queue.length());
   ASSERT_EQ(nelements, final_queue.length());
-  while (final_queue.pop() != NULL) {}
+  while (final_queue.pop() != nullptr) {}
 
   FREE_C_HEAP_ARRAY(Element, elements);
 }

--- a/test/hotspot/gtest/utilities/test_objectBitSet.cpp
+++ b/test/hotspot/gtest/utilities/test_objectBitSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/utilities/test_objectBitSet.cpp
+++ b/test/hotspot/gtest/utilities/test_objectBitSet.cpp
@@ -32,15 +32,15 @@ TEST_VM(ObjectBitSet, empty) {
   ASSERT_FALSE(obs.is_marked(&obj1));
 }
 
-// NOTE: This is a little weird. NULL is not treated any special: ObjectBitSet will happily
-// allocate a fragement for the memory range starting at 0 and mark the first bit when passing NULL.
+// NOTE: This is a little weird. nullptr is not treated any special: ObjectBitSet will happily
+// allocate a fragement for the memory range starting at 0 and mark the first bit when passing nullptr.
 // In the absense of any error handling, I am not sure what would possibly be a reasonable better
 // way to do it, though.
 TEST_VM(ObjectBitSet, null) {
   ObjectBitSet<mtTracing> obs;
-  ASSERT_FALSE(obs.is_marked((oop)NULL));
-  obs.mark_obj((oop) NULL);
-  ASSERT_TRUE(obs.is_marked((oop)NULL));
+  ASSERT_FALSE(obs.is_marked((oop)nullptr));
+  obs.mark_obj((oop) nullptr);
+  ASSERT_TRUE(obs.is_marked((oop)nullptr));
 }
 
 TEST_VM(ObjectBitSet, mark_single) {

--- a/test/hotspot/gtest/utilities/test_quicksort.cpp
+++ b/test/hotspot/gtest/utilities/test_quicksort.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,8 +81,8 @@ extern "C" {
 
 TEST(QuickSort, quicksort) {
   {
-    int* test_array = NULL;
-    int* expected_array = NULL;
+    int* test_array = nullptr;
+    int* expected_array = nullptr;
     EXPECT_TRUE(sort_and_compare(test_array, expected_array, 0, test_comparator));
   }
   {

--- a/test/hotspot/gtest/utilities/test_vmerror.cpp
+++ b/test/hotspot/gtest/utilities/test_vmerror.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/utilities/test_vmerror.cpp
+++ b/test/hotspot/gtest/utilities/test_vmerror.cpp
@@ -43,8 +43,8 @@ TEST_VM_ASSERT_MSG(vmErrorTest, resourceMark,
 const char* const str = "hello";
 const size_t      num = 500;
 
-TEST_VM_ASSERT_MSG(vmErrorTest, assert1, "assert.str == NULL. failed: expected null") {
-  vmassert(str == NULL, "expected null");
+TEST_VM_ASSERT_MSG(vmErrorTest, assert1, "assert.str == nullptr. failed: expected null") {
+  vmassert(str == nullptr, "expected null");
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, assert2, "assert.num == 1023 && .str == 'X'. failed: num=500 str=\"hello\"") {
@@ -52,8 +52,8 @@ TEST_VM_ASSERT_MSG(vmErrorTest, assert2, "assert.num == 1023 && .str == 'X'. fai
            "num=" SIZE_FORMAT " str=\"%s\"", num, str);
 }
 
-TEST_VM_ASSERT_MSG(vmErrorTest, guarantee1, "guarantee.str == NULL. failed: expected null") {
-  guarantee(str == NULL, "expected null");
+TEST_VM_ASSERT_MSG(vmErrorTest, guarantee1, "guarantee.str == nullptr. failed: expected null") {
+  guarantee(str == nullptr, "expected null");
 }
 
 TEST_VM_ASSERT_MSG(vmErrorTest, guarantee2, "guarantee.num == 1023 && .str == 'X'. failed: num=500 str=\"hello\"") {


### PR DESCRIPTION
If this is sufficient, here's the change for NULL to nullptr, adjusting some obvious strings that had NULL in them maybe not all.
Tested with gtest,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324678](https://bugs.openjdk.org/browse/JDK-8324678): Replace NULL with nullptr in HotSpot gtests (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [d8e3d92d](https://git.openjdk.org/jdk/pull/17577/files/d8e3d92d2198cb9c92d1da923f5d1b2772edbd51)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [d8e3d92d](https://git.openjdk.org/jdk/pull/17577/files/d8e3d92d2198cb9c92d1da923f5d1b2772edbd51)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17577/head:pull/17577` \
`$ git checkout pull/17577`

Update a local copy of the PR: \
`$ git checkout pull/17577` \
`$ git pull https://git.openjdk.org/jdk.git pull/17577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17577`

View PR using the GUI difftool: \
`$ git pr show -t 17577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17577.diff">https://git.openjdk.org/jdk/pull/17577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17577#issuecomment-1912634434)