### PR TITLE
8327786: Add fluent setAccessible()

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Field.java
+++ b/src/java.base/share/classes/java/lang/reflect/Field.java
@@ -178,6 +178,16 @@ class Field extends AccessibleObject implements Member {
         setAccessible0(flag);
     }
 
+    /**
+     * @throws InaccessibleObjectException {@inheritDoc}
+     * @throws SecurityException {@inheritDoc}
+     */
+    @CallerSensitive
+    public Field setAccessible() {
+        setAccessible(true);
+        return this;
+    }
+
     @Override
     void checkCanSetAccessible(Class<?> caller) {
         checkCanSetAccessible(caller, clazz);


### PR DESCRIPTION
The feature allows to extract a private field value in a single expression, like so:
```java
object.getClass().getDeclaredField().setAccessible().get(object)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8327786](https://bugs.openjdk.org/browse/JDK-8327786)

### Issue
 * [JDK-8327786](https://bugs.openjdk.org/browse/JDK-8327786): Fluent setAccessible() for the Field class (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17578/head:pull/17578` \
`$ git checkout pull/17578`

Update a local copy of the PR: \
`$ git checkout pull/17578` \
`$ git pull https://git.openjdk.org/jdk.git pull/17578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17578`

View PR using the GUI difftool: \
`$ git pr show -t 17578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17578.diff">https://git.openjdk.org/jdk/pull/17578.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17578#issuecomment-1989611180)