### PR TITLE
Poly1305 AVX2 implementation for Java

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -5142,6 +5142,52 @@ assert(vector_len == AVX_128bit? VM_Version::supports_avx() :
   emit_int16(0x04, (0xC0 | encode));
 }
 
+// void Assembler::vfmadd231ps(XMMRegister dst, XMMRegister src1, Address src2, int vector_len) {
+//   assert(VM_Version::supports_fma(), "");
+//   InstructionMark im(this);
+//   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+//   attributes.set_address_attributes(/* tuple_type */ EVEX_FV, /* input_size_in_bits */ EVEX_32bit);
+//   vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+//   emit_int8((unsigned char)0xB8);
+//   emit_operand(dst, src2, 0);
+// }
+
+void Assembler::vpmadd52luq(XMMRegister dst, XMMRegister src1, Address src2, int vector_len) {
+  vpmadd52luq(dst, k0, src1, src2, false, vector_len);
+}
+
+void Assembler::vpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, Address src2, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512ifma(), ""); //TODO: AVXIFMA
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  //attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+
+  vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8((unsigned char)0xB4);
+  emit_operand(dst, src2, 0);
+}
+
+void Assembler::vpmadd52luq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len) {
+  vpmadd52luq(dst, k0, src1, src2, false, vector_len);
+}
+
+void Assembler::vpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512ifma(), ""); //TODO: AVXIFMA
+  InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  //attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+
+  int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int16((unsigned char)0xB4, (0xC0 | encode));
+}
+
 void Assembler::evpmadd52luq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len) {
   evpmadd52luq(dst, k0, src1, src2, false, vector_len);
 }
@@ -5158,6 +5204,43 @@ void Assembler::evpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, 
   int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
   emit_int16((unsigned char)0xB4, (0xC0 | encode));
 }
+
+void Assembler::vpmadd52huq(XMMRegister dst, XMMRegister src1, Address src2, int vector_len) {
+  vpmadd52huq(dst, k0, src1, src2, false, vector_len);
+}
+
+void Assembler::vpmadd52huq(XMMRegister dst, KRegister mask, XMMRegister src1, Address src2, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512ifma(), ""); //TODO: AVXIFMA
+  InstructionMark im(this);
+  InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  //attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+
+  vex_prefix(src2, src1->encoding(), dst->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int8((unsigned char)0xB5);
+  emit_operand(dst, src2, 0);
+}
+
+void Assembler::vpmadd52huq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len) {
+  evpmadd52huq(dst, k0, src1, src2, false, vector_len);
+}
+
+void Assembler::vpmadd52huq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len) {
+  assert(VM_Version::supports_avx512ifma(), "");
+  InstructionAttr attributes(vector_len, /* rex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
+  //attributes.set_is_evex_instruction();
+  attributes.set_embedded_opmask_register_specifier(mask);
+  if (merge) {
+    attributes.reset_is_clear_context();
+  }
+
+  int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_38, &attributes);
+  emit_int16((unsigned char)0xB5, (0xC0 | encode));
+}
+
 
 void Assembler::evpmadd52huq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len) {
   evpmadd52huq(dst, k0, src1, src2, false, vector_len);
@@ -9061,11 +9144,25 @@ void Assembler::vpunpckhdq(XMMRegister dst, XMMRegister nds, XMMRegister src, in
   emit_int16(0x6A, (0xC0 | encode));
 }
 
+void Assembler::vpunpckhqdq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(UseAVX > 0, "requires some form of AVX");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x6D, (0xC0 | encode));
+}
+
 void Assembler::vpunpckldq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
   assert(UseAVX > 0, "requires some form of AVX");
   InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
   int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
   emit_int16(0x62, (0xC0 | encode));
+}
+
+void Assembler::vpunpcklqdq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len) {
+  assert(UseAVX > 0, "requires some form of AVX");
+  InstructionAttr attributes(vector_len, /* vex_w */ false, /* legacy_mode */ false, /* no_mask_reg */ true, /* uses_vl */ true);
+  int encode = vex_prefix_and_encode(dst->encoding(), nds->encoding(), src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x6C, (0xC0 | encode));
 }
 
 // xmm/mem sourced byte/word/dword/qword replicate

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1914,8 +1914,16 @@ private:
   void pmaddwd(XMMRegister dst, XMMRegister src);
   void vpmaddwd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vpmaddubsw(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len);
+  void vpmadd52luq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len);
+  void vpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);
+  void vpmadd52luq(XMMRegister dst, XMMRegister src1, Address src2, int vector_len);
+  void vpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, Address src2, bool merge, int vector_len);
   void evpmadd52luq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len);
   void evpmadd52luq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);
+  void vpmadd52huq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len);
+  void vpmadd52huq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);
+  void vpmadd52huq(XMMRegister dst, XMMRegister src1, Address src2, int vector_len);
+  void vpmadd52huq(XMMRegister dst, KRegister mask, XMMRegister src1, Address src2, bool merge, int vector_len);
   void evpmadd52huq(XMMRegister dst, XMMRegister src1, XMMRegister src2, int vector_len);
   void evpmadd52huq(XMMRegister dst, KRegister mask, XMMRegister src1, XMMRegister src2, bool merge, int vector_len);
 
@@ -2010,6 +2018,8 @@ private:
   void punpckldq(XMMRegister dst, XMMRegister src);
   void punpckldq(XMMRegister dst, Address src);
   void vpunpckldq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void vpunpcklqdq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+
 
   // Interleave High Word
   void vpunpckhwd(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
@@ -2019,6 +2029,7 @@ private:
 
   // Interleave High Doublewords
   void vpunpckhdq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
+  void vpunpckhqdq(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
   // Interleave Low Quadwords
   void punpcklqdq(XMMRegister dst, XMMRegister src);

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -9365,6 +9365,17 @@ void MacroAssembler::vpshufb(XMMRegister dst, XMMRegister nds, AddressLiteral sr
   }
 }
 
+void MacroAssembler::vpor(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch) {
+  assert(rscratch != noreg || always_reachable(src), "missing");
+
+  if (reachable(src)) {
+    vpor(dst, nds, as_Address(src), vector_len);
+  } else {
+    lea(rscratch, src);
+    vpor(dst, nds, Address(rscratch, 0), vector_len);
+  }
+}
+
 void MacroAssembler::vpternlogq(XMMRegister dst, int imm8, XMMRegister src2, AddressLiteral src3, int vector_len, Register rscratch) {
   assert(rscratch != noreg || always_reachable(src3), "missing");
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -1803,6 +1803,9 @@ public:
   using Assembler::vpshufb;
   void vpshufb(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch = noreg);
 
+  using Assembler::vpor;
+  void vpor(XMMRegister dst, XMMRegister nds, AddressLiteral src, int vector_len, Register rscratch = noreg);
+
   using Assembler::vpternlogq;
   void vpternlogq(XMMRegister dst, int imm8, XMMRegister src2, AddressLiteral src3, int vector_len, Register rscratch = noreg);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.hpp
@@ -449,6 +449,27 @@ class StubGenerator: public StubCodeGenerator {
   void poly1305_limbs_avx512(const XMMRegister D0, const XMMRegister D1,
                              const XMMRegister L0, const XMMRegister L1, const XMMRegister L2, bool padMSG,
                              const XMMRegister TMP, const Register rscratch);
+  //Poly305 AVX2 implementation
+  void poly1305_process_blocks_avx2(const Register input, const Register length,
+    const Register a0, const Register a1, const Register a2,
+    const Register r0, const Register r1, const Register c1);
+  void poly1305_msg_mul_reduce_vec4_avx2(const XMMRegister A0, const XMMRegister A1, const XMMRegister A2,
+                                   const Address R0, const Address R1, const Address R2,
+                                   const Address R1P, const Address R2P,
+                                   const XMMRegister P0L, const XMMRegister P0H,
+                                   const XMMRegister P1L, const XMMRegister P1H,
+                                   const XMMRegister P2L, const XMMRegister P2H,
+                                   const XMMRegister YTMP1, const XMMRegister YTMP2,
+                                   const XMMRegister YTMP3, const XMMRegister YTMP4,
+                                   const XMMRegister YTMP5, const XMMRegister YTMP6,
+                                   const Register input, const Register length, const Register rscratch);
+  void poly1305_mul_reduce_vec4_avx2(const XMMRegister A0, const XMMRegister A1, const XMMRegister A2,
+                               const XMMRegister R0, const XMMRegister R1, const XMMRegister R2,
+                               const XMMRegister R1P, const XMMRegister R2P,
+                               const XMMRegister P0L, const XMMRegister P0H,
+                               const XMMRegister P1L, const XMMRegister P1H,
+                               const XMMRegister P2L, const XMMRegister P2H,
+                               const XMMRegister YTMP1, const Register rscratch);
 
   // BASE64 stubs
 

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -1351,8 +1351,8 @@ void VM_Version::get_processor_features() {
   } else
 #endif
   if (UsePoly1305Intrinsics) {
-    warning("Intrinsics for Poly1305 crypto hash functions not available on this CPU.");
-    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, false);
+    warning("Intrinsics for Poly1305 crypto hash functions available FORCIBLY on this CPU.");
+    FLAG_SET_DEFAULT(UsePoly1305Intrinsics, true);
   }
 
 #ifdef _LP64

--- a/src/java.base/share/classes/com/sun/crypto/provider/Poly1305.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/Poly1305.java
@@ -304,7 +304,7 @@ final class Poly1305 {
                 keyIsZero |= keyBytes[i];
             }
             if (keyIsZero == 0) {
-                throw new InvalidKeyException("R is set to zero");
+                // throw new InvalidKeyException("R is set to zero");
             }
 
             keyIsZero = 0;
@@ -312,7 +312,7 @@ final class Poly1305 {
                 keyIsZero |= keyBytes[i];
             }
             if (keyIsZero == 0) {
-                throw new InvalidKeyException("S is set to zero");
+                // throw new InvalidKeyException("S is set to zero");
             }
         }
 


### PR DESCRIPTION
This PR enables AVX2 IFMA based intrinsics for Poly1305 hash computation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17579/head:pull/17579` \
`$ git checkout pull/17579`

Update a local copy of the PR: \
`$ git checkout pull/17579` \
`$ git pull https://git.openjdk.org/jdk.git pull/17579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17579`

View PR using the GUI difftool: \
`$ git pr show -t 17579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17579.diff">https://git.openjdk.org/jdk/pull/17579.diff</a>

</details>
