### PR TITLE
JDK-8324287: Record total and free swap space in JFR

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -273,6 +273,23 @@ julong os::Aix::available_memory() {
   }
 }
 
+jlong os::total_swap_space() {
+  perfstat_memory_total_t memory_info;
+  if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
+    return -1;
+  }
+  return (jlong)(memory_info.pgsp_total * 4L * 1024L);
+}
+
+jlong os::free_swap_space() {
+  perfstat_memory_total_t memory_info;
+  if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
+    return -1;
+  }
+  return (jlong)(memory_info.pgsp_free * 4L * 1024L);
+}
+
+
 julong os::physical_memory() {
   return Aix::physical_memory();
 }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -278,7 +278,7 @@ jlong os::total_swap_space() {
   if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
     return -1;
   }
-  return (jlong)(memory_info.pgsp_total * 4L * 1024L);
+  return (jlong)(memory_info.pgsp_total * 4 * K);
 }
 
 jlong os::free_swap_space() {
@@ -286,7 +286,7 @@ jlong os::free_swap_space() {
   if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
     return -1;
   }
-  return (jlong)(memory_info.pgsp_free * 4L * 1024L);
+  return (jlong)(memory_info.pgsp_free * 4 * K);
 }
 
 julong os::physical_memory() {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -289,7 +289,6 @@ jlong os::free_swap_space() {
   return (jlong)(memory_info.pgsp_free * 4L * 1024L);
 }
 
-
 julong os::physical_memory() {
   return Aix::physical_memory();
 }

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,6 +180,33 @@ void os::Bsd::print_uptime_info(outputStream* st) {
     os::print_dhm(st, "OS uptime:", (long) difftime(currsec, bootsec));
   }
 }
+
+jlong os::total_swap_space() {
+#if defined(__APPLE__)
+    struct xsw_usage vmusage;
+    size_t size = sizeof(vmusage);
+    if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
+      return -1;
+    }
+    return (jlong)vmusage.xsu_total;
+#else
+    return -1;
+#endif
+}
+
+jlong os::free_swap_space() {
+#if defined(__APPLE__)
+    struct xsw_usage vmusage;
+    size_t size = sizeof(vmusage);
+    if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
+      return -1;
+    }
+  return (jlong)vmusage.xsu_avail;
+#else
+  return -1;
+#endif
+}
+
 
 julong os::physical_memory() {
   return Bsd::physical_memory();

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -183,30 +183,29 @@ void os::Bsd::print_uptime_info(outputStream* st) {
 
 jlong os::total_swap_space() {
 #if defined(__APPLE__)
-    struct xsw_usage vmusage;
-    size_t size = sizeof(vmusage);
-    if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
-      return -1;
-    }
-    return (jlong)vmusage.xsu_total;
-#else
+  struct xsw_usage vmusage;
+  size_t size = sizeof(vmusage);
+  if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
     return -1;
-#endif
-}
-
-jlong os::free_swap_space() {
-#if defined(__APPLE__)
-    struct xsw_usage vmusage;
-    size_t size = sizeof(vmusage);
-    if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
-      return -1;
-    }
-  return (jlong)vmusage.xsu_avail;
+  }
+  return (jlong)vmusage.xsu_total;
 #else
   return -1;
 #endif
 }
 
+jlong os::free_swap_space() {
+#if defined(__APPLE__)
+  struct xsw_usage vmusage;
+  size_t size = sizeof(vmusage);
+  if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
+    return -1;
+  }
+  return (jlong)vmusage.xsu_avail;
+#else
+  return -1;
+#endif
+}
 
 julong os::physical_memory() {
   return Bsd::physical_memory();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -289,17 +289,21 @@ julong os::Linux::free_memory() {
   return free_mem;
 }
 
-// do we need to handle container envs separately ?
 jlong os::total_swap_space() {
-  struct sysinfo si;
-  int ret = sysinfo(&si);
-  if (ret != 0) {
-    return -1;
+  if (OSContainer::is_containerized()) {
+    return (jlong)(OSContainer::memory_and_swap_limit_in_bytes() - OSContainer::memory_limit_in_bytes());
+  } else {
+    struct sysinfo si;
+    int ret = sysinfo(&si);
+    if (ret != 0) {
+      return -1;
+    }
+    return  (jlong)(si.totalswap * si.mem_unit);
   }
-  return  (jlong)(si.totalswap * si.mem_unit);
 }
 
 jlong os::free_swap_space() {
+  // TODO support free swap space in container APIs
   struct sysinfo si;
   int ret = sysinfo(&si);
   if (ret != 0) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -289,6 +289,25 @@ julong os::Linux::free_memory() {
   return free_mem;
 }
 
+// do we need to handle container envs separately ?
+jlong os::total_swap_space() {
+  struct sysinfo si;
+  int ret = sysinfo(&si);
+  if (ret != 0) {
+    return -1;
+  }
+  return  (jlong)(si.totalswap * si.mem_unit);
+}
+
+jlong os::free_swap_space() {
+  struct sysinfo si;
+  int ret = sysinfo(&si);
+  if (ret != 0) {
+    return -1;
+  }
+  return (jlong)(si.freeswap * si.mem_unit);
+}
+
 julong os::physical_memory() {
   jlong phys_mem = 0;
   if (OSContainer::is_containerized()) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -291,25 +291,30 @@ julong os::Linux::free_memory() {
 
 jlong os::total_swap_space() {
   if (OSContainer::is_containerized()) {
-    return (jlong)(OSContainer::memory_and_swap_limit_in_bytes() - OSContainer::memory_limit_in_bytes());
+    if (OSContainer::memory_limit_in_bytes() > 0) {
+      return (jlong)(OSContainer::memory_and_swap_limit_in_bytes() - OSContainer::memory_limit_in_bytes());
+    }
+  }
+  struct sysinfo si;
+  int ret = sysinfo(&si);
+  if (ret != 0) {
+    return -1;
+  }
+  return  (jlong)(si.totalswap * si.mem_unit);
+}
+
+jlong os::free_swap_space() {
+  if (OSContainer::is_containerized()) {
+    // TODO add a good implementation
+    return -1;
   } else {
     struct sysinfo si;
     int ret = sysinfo(&si);
     if (ret != 0) {
       return -1;
     }
-    return  (jlong)(si.totalswap * si.mem_unit);
+    return (jlong)(si.freeswap * si.mem_unit);
   }
-}
-
-jlong os::free_swap_space() {
-  // TODO support free swap space in container APIs
-  struct sysinfo si;
-  int ret = sysinfo(&si);
-  if (ret != 0) {
-    return -1;
-  }
-  return (jlong)(si.freeswap * si.mem_unit);
 }
 
 julong os::physical_memory() {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -840,6 +840,20 @@ julong os::win32::available_memory() {
   return (julong)ms.ullAvailPhys;
 }
 
+jlong os::total_swap_space() {
+  MEMORYSTATUSEX ms;
+  ms.dwLength = sizeof(ms);
+  GlobalMemoryStatusEx(&ms);
+  return (jlong) ms.ullTotalPageFile;
+}
+
+jlong os::free_swap_space() {
+  MEMORYSTATUSEX ms;
+  ms.dwLength = sizeof(ms);
+  GlobalMemoryStatusEx(&ms);
+  return (jlong) ms.ullAvailPageFile;
+}
+
 julong os::physical_memory() {
   return win32::physical_memory();
 }

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -927,6 +927,11 @@
     <Field type="ulong" contentType="bytes" name="usedSize" label="Used Size" description="Total amount of physical memory in use" />
   </Event>
 
+  <Event name="SwapSpace" category="Operating System, Memory" label="Swap Space" description="OS Swap Space" period="everyChunk">
+    <Field type="long" contentType="bytes" name="totalSize" label="Total Size" description="Total swap space available to OS" />
+    <Field type="long" contentType="bytes" name="freeSize" label="Free Size" description="Free swap space" />
+  </Event>
+
   <Event name="ExecutionSample" category="Java Virtual Machine, Profiling" label="Method Profiling Sample" description="Snapshot of a threads state"
     period="everyChunk">
     <Field type="Thread" name="sampledThread" label="Thread" />

--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -928,7 +928,7 @@
   </Event>
 
   <Event name="SwapSpace" category="Operating System, Memory" label="Swap Space" description="OS Swap Space" period="everyChunk">
-    <Field type="long" contentType="bytes" name="totalSize" label="Total Size" description="Total swap space available to OS" />
+    <Field type="long" contentType="bytes" name="totalSize" label="Total Size" description="Total swap space available to the OS" />
     <Field type="long" contentType="bytes" name="freeSize" label="Free Size" description="Free swap space" />
   </Event>
 

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -527,6 +527,14 @@ TRACE_REQUEST_FUNC(PhysicalMemory) {
   event.commit();
 }
 
+TRACE_REQUEST_FUNC(SwapSpace) {
+  EventSwapSpace event;
+  // check that the type matches (long? ulong ?)
+  event.set_totalSize(os::total_swap_space());
+  event.set_freeSize(os::free_swap_space());
+  event.commit();
+}
+
 TRACE_REQUEST_FUNC(JavaThreadStatistics) {
   EventJavaThreadStatistics event;
   event.set_activeCount(ThreadService::get_live_thread_count());

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -529,7 +529,6 @@ TRACE_REQUEST_FUNC(PhysicalMemory) {
 
 TRACE_REQUEST_FUNC(SwapSpace) {
   EventSwapSpace event;
-  // check that the type matches (long? ulong ?)
   event.set_totalSize(os::total_swap_space());
   event.set_freeSize(os::free_swap_space());
   event.commit();

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -324,6 +324,9 @@ class os: AllStatic {
   static julong available_memory();
   static julong free_memory();
 
+  static jlong total_swap_space();
+  static jlong free_swap_space();
+
   static julong physical_memory();
   static bool has_allocatable_memory_limit(size_t* limit);
   static bool is_server_class_machine();

--- a/src/jdk.jfr/share/conf/jfr/default.jfc
+++ b/src/jdk.jfr/share/conf/jfr/default.jfc
@@ -678,6 +678,11 @@
       <setting name="period">everyChunk</setting>
     </event>
 
+    <event name="jdk.SwapSpace">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
     <event name="jdk.ObjectAllocationInNewTLAB">
       <setting name="enabled" control="gc-enabled-high">false</setting>
       <setting name="stackTrace">true</setting>

--- a/src/jdk.jfr/share/conf/jfr/profile.jfc
+++ b/src/jdk.jfr/share/conf/jfr/profile.jfc
@@ -678,6 +678,11 @@
       <setting name="period">everyChunk</setting>
     </event>
 
+    <event name="jdk.SwapSpace">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
     <event name="jdk.ObjectAllocationInNewTLAB">
       <setting name="enabled" control="gc-enabled-high">false</setting>
       <setting name="stackTrace">true</setting>

--- a/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
+++ b/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
@@ -50,7 +50,8 @@ public class TestSwapSpaceEvent {
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
             long totalSize = Events.assertField(event, "totalSize").atLeast(0L).getValue();
-            Events.assertField(event, "freeSize").atLeast(0L).atMost(totalSize);
+            Events.assertField(event, "freeSize").atLeast(-1L); // we still get on Linux -1 in container envs
+            Events.assertField(event, "freeSize").atMost(totalSize);
         }
     }
 }

--- a/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
+++ b/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
@@ -34,8 +34,18 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
+ * @requires (os.family != "linux")
  * @library /test/lib
  * @run main/othervm jdk.jfr.event.os.TestSwapSpaceEvent
+ */
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @requires (os.family == "linux")
+ * @library /test/lib
+ * @run main/othervm -XX:-UseContainerSupport jdk.jfr.event.os.TestSwapSpaceEvent
  */
 public class TestSwapSpaceEvent {
     private final static String EVENT_NAME = EventNames.SwapSpace;
@@ -50,7 +60,7 @@ public class TestSwapSpaceEvent {
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
             long totalSize = Events.assertField(event, "totalSize").atLeast(0L).getValue();
-            Events.assertField(event, "freeSize").atLeast(-1L); // we still get on Linux -1 in container envs
+            Events.assertField(event, "freeSize").atLeast(0L);
             Events.assertField(event, "freeSize").atMost(totalSize);
         }
     }

--- a/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
+++ b/test/jdk/jdk/jfr/event/os/TestSwapSpaceEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.jfr.event.os;
+
+import java.util.List;
+
+import jdk.jfr.Recording;
+import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.jfr.EventNames;
+import jdk.test.lib.jfr.Events;
+
+/**
+ * @test
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.event.os.TestSwapSpaceEvent
+ */
+public class TestSwapSpaceEvent {
+    private final static String EVENT_NAME = EventNames.SwapSpace;
+
+    public static void main(String[] args) throws Throwable {
+        Recording recording = new Recording();
+        recording.enable(EVENT_NAME);
+        recording.start();
+        recording.stop();
+        List<RecordedEvent> events = Events.fromRecording(recording);
+        Events.hasEvents(events);
+        for (RecordedEvent event : events) {
+            System.out.println("Event: " + event);
+            long totalSize = Events.assertField(event, "totalSize").atLeast(0L).getValue();
+            Events.assertField(event, "freeSize").atLeast(0L).atMost(totalSize);
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/jfr/EventNames.java
+++ b/test/lib/jdk/test/lib/jfr/EventNames.java
@@ -186,6 +186,7 @@ public class EventNames {
     public static final String NativeLibraryLoad = PREFIX + "NativeLibraryLoad";
     public static final String NativeLibraryUnload = PREFIX + "NativeLibraryUnload";
     public static final String PhysicalMemory = PREFIX + "PhysicalMemory";
+    public static final String SwapSpace = PREFIX + "SwapSpace";
     public static final String NetworkUtilization = PREFIX + "NetworkUtilization";
     public static final String ProcessStart = PREFIX + "ProcessStart";
     public static final String ResidentSetSize = PREFIX + "ResidentSetSize";


### PR DESCRIPTION
Total and free swap space should be recorded in JFR, because it is important to know e.g. in case of memory shortages.

Currently we only have a container related event (ContainerMemoryUsage) that provides some info but no general event.
PhysicalMemory could be enhanced or a new event added.

There is already some coding (see Java_com_sun_management_internal_OperatingSystemImpl_getTotalSwapSpaceSize0 and
Java_com_sun_management_internal_OperatingSystemImpl_getFreeSwapSpaceSize0) for the swap space info retrieval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324287](https://bugs.openjdk.org/browse/JDK-8324287): Record total and free swap space in JFR (**Enhancement** - P4)


### Reviewers
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer) ⚠️ Review applies to [824f3bc5](https://git.openjdk.org/jdk/pull/17581/files/824f3bc5e7e0dac81f10bf41e50a686077629c67)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [ca81d40a](https://git.openjdk.org/jdk/pull/17581/files/ca81d40ab7fb24c9b14415fd9be317f0e71b4363)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17581/head:pull/17581` \
`$ git checkout pull/17581`

Update a local copy of the PR: \
`$ git checkout pull/17581` \
`$ git pull https://git.openjdk.org/jdk.git pull/17581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17581`

View PR using the GUI difftool: \
`$ git pr show -t 17581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17581.diff">https://git.openjdk.org/jdk/pull/17581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17581#issuecomment-1911630424)