### PR TITLE
8316813: NMT: Using WhiteBox API, virtual memory tracking should also be stressed in JMH tests

### DIFF
--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
@@ -54,10 +54,10 @@ public abstract class NMTBenchmark_wb {
     @Param({"2", "4", "8", "16"})
     public int THREADS;
 
-    @Param({"16", "32", "64"})
+    @Param({"25", "50", "100", "200", "400"})
     public int REGIONS;
 
-    @Param({"4", "8", "16", "32", "64"})
+    @Param({"25", "50", "100"})
     public int SUB_REGIONS;
 
     private static final int PAGE_SIZE = 1024 * 4;
@@ -97,12 +97,12 @@ public abstract class NMTBenchmark_wb {
 
         for (int r = 0; r < reserved_regions_count; r++) {
           long base = base_array[r];
-          for (int i = 0; i < region_count; i += 4) commit  (base, i    );
-          for (int i = 1; i < region_count; i += 4) commit  (base, i    ); // causes merge from right
-          for (int i = 4; i < region_count; i += 4) commit  (base, i - 1); // causes merge from left
-          for (int i = 4; i < region_count; i += 4) uncommit(base, i - 1); // causes split from left
-          for (int i = 1; i < region_count; i += 4) uncommit(base, i    ); // causes split from right
-          for (int i = 0; i < region_count; i += 4) uncommit(base, i    ); // remove the regions
+          for (int i = 0; i < committed_regions_count; i += 4) commit  (base, i    );
+          for (int i = 1; i < committed_regions_count; i += 4) commit  (base, i    ); // causes merge from right
+          for (int i = 4; i < committed_regions_count; i += 4) commit  (base, i - 1); // causes merge from left
+          for (int i = 4; i < committed_regions_count; i += 4) uncommit(base, i - 1); // causes split from left
+          for (int i = 1; i < committed_regions_count; i += 4) uncommit(base, i    ); // causes split from right
+          for (int i = 0; i < committed_regions_count; i += 4) uncommit(base, i    ); // remove the regions
         }
 
         for (int i = 0; i < reserved_regions_count; i++)
@@ -143,7 +143,7 @@ public abstract class NMTBenchmark_wb {
     @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=summary"})
     public static class NMTSummary extends NMTBenchmark_wb { }
 
-    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=detail"})
-    public static class NMTDetail extends NMTBenchmark_wb { }
+    // @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=detail"})
+    // public static class NMTDetail extends NMTBenchmark_wb { }
 
 }

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.runtime;
+
+import org.openjdk.bench.vm.lang.Throw;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.lang.*;
+import java.util.*;
+
+import jdk.internal.misc.Unsafe;
+import jdk.test.whitebox.WhiteBox;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Warmup(iterations = 1, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+public abstract class NMTBenchmark_wb {
+
+    @Param({"2", "4", "8", "16"})
+    public int THREADS;
+
+    @Param({"16", "32", "64"})
+    public int REGIONS;
+
+    @Param({"4", "8", "16", "32", "64"})
+    public int SUB_REGIONS;
+
+    private static final int P = 1024 * 4;
+
+    // Need to wrap WhiteBox in a holder class so that it doesn't get initialized on the host VM (which won't
+    // have WB enabled.
+    private static class WhiteBoxHolder {
+
+        private static final WhiteBox WB;
+
+        static {
+            System.out.println("Current user dir: " + System.getProperty("user.dir"));
+            WhiteBox wb = null;
+            try {
+                wb = WhiteBox.getWhiteBox();
+            } catch (Throwable t) {
+                System.out.println("WhiteBox initialization failure: " + t);
+                t.printStackTrace();
+                // Explicit exit to avoid initialization loops.
+                System.exit(17);
+            }
+            WB = wb;
+        }
+    }
+
+    private static long reserve (long size           ) { return WhiteBoxHolder.WB.NMTReserveMemory (size               ); }
+    private static void commit  (long base, int r    ) {        WhiteBoxHolder.WB.NMTCommitMemory  (base + r * P, P    ); }
+    private static void uncommit(long base, int r    ) {        WhiteBoxHolder.WB.NMTUncommitMemory(base + r * P, P    ); }
+    private static void release (long base, long size) {        WhiteBoxHolder.WB.NMTReleaseMemory (base        , size ); }
+
+    public static void doAllMemoryOps(int nR, int region_count) {
+        long region_size = region_count * P;
+        long[] base_array = new long[nR];
+        for (int i = 0; i < nR; i++)
+          base_array[i] = reserve(region_size);
+
+        for (int R = 0; R < nR; R++) {
+          long base = base_array[R];
+          for (int i = 0; i < region_count; i += 4) commit  (base, i    );
+          for (int i = 1; i < region_count; i += 4) commit  (base, i    ); // causes merge from right
+          for (int i = 4; i < region_count; i += 4) commit  (base, i - 1); // causes merge from left
+          for (int i = 4; i < region_count; i += 4) uncommit(base, i - 1); // causes split from left
+          for (int i = 1; i < region_count; i += 4) uncommit(base, i    ); // causes split from right
+          for (int i = 0; i < region_count; i += 4) uncommit(base, i    ); // remove the regions
+        }
+
+        for (int i = 0; i < nR; i++)
+          release(base_array[i], region_size);
+    }
+    public static void doTest(int nR, int nT, int nr) throws InterruptedException{
+        int RT = nR / nT;
+        Thread[] threads =  new Thread[nT];
+        for (int t = 0; t < nT; t++) {
+            threads[t] = new Thread(() -> doAllMemoryOps(RT, nr));
+            threads[t].start();
+        }
+        for (Thread t: threads) t.join();
+    }
+
+    @Benchmark
+    public void virtualMemoryTests() {
+        try { doTest(REGIONS, THREADS, SUB_REGIONS); }
+        catch (Throwable t) {
+            System.out.println(t.getMessage());
+        }
+    }
+
+    public static final String ADD_EXPORTS = "--add-exports";
+
+    public static final String MISC_PACKAGE = "java.base/jdk.internal.misc=ALL-UNNAMED"; // used for Unsafe API
+
+    public static final String WB_UNLOCK_OPTION = "-XX:+UnlockDiagnosticVMOptions";
+
+    public static final String WB_API = "-XX:+WhiteBoxAPI";
+
+    public static final String WB_JAR_APPEND = "-Xbootclasspath/a:lib-test/wb.jar";
+
+    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=off"})
+    public static class NMTOff extends NMTBenchmark_wb { }
+
+    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=summary"})
+    public static class NMTSummary extends NMTBenchmark_wb { }
+
+    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=detail"})
+    public static class NMTDetails extends NMTBenchmark_wb { }
+
+}

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
@@ -60,7 +60,7 @@ public abstract class NMTBenchmark_wb {
     @Param({"4", "8", "16", "32", "64"})
     public int SUB_REGIONS;
 
-    private static final int P = 1024 * 4;
+    private static final int PageSize = 1024 * 4;
 
     // Need to wrap WhiteBox in a holder class so that it doesn't get initialized on the host VM (which won't
     // have WB enabled.
@@ -83,13 +83,13 @@ public abstract class NMTBenchmark_wb {
         }
     }
 
-    private static long reserve (long size           ) { return WhiteBoxHolder.WB.NMTReserveMemory (size               ); }
-    private static void commit  (long base, int r    ) {        WhiteBoxHolder.WB.NMTCommitMemory  (base + r * P, P    ); }
-    private static void uncommit(long base, int r    ) {        WhiteBoxHolder.WB.NMTUncommitMemory(base + r * P, P    ); }
-    private static void release (long base, long size) {        WhiteBoxHolder.WB.NMTReleaseMemory (base        , size ); }
+    private static long reserve (long size           ) { return WhiteBoxHolder.WB.NMTReserveMemory (size                           ); }
+    private static void commit  (long base, int pno  ) {        WhiteBoxHolder.WB.NMTCommitMemory  (base + pno * PageSize, PageSize); }
+    private static void uncommit(long base, int pno  ) {        WhiteBoxHolder.WB.NMTUncommitMemory(base + pno * PageSize, PageSize); }
+    private static void release (long base, long size) {        WhiteBoxHolder.WB.NMTReleaseMemory (base                 , size    ); }
 
     public static void doAllMemoryOps(int nR, int region_count) {
-        long region_size = region_count * P;
+        long region_size = region_count * PageSize;
         long[] base_array = new long[nR];
         for (int i = 0; i < nR; i++)
           base_array[i] = reserve(region_size);


### PR DESCRIPTION
After WhiteBox (`wb.jar`) is added to the lib-test, it is possible to use it in Java benchmarks. This PR uses WhiteBox to access and call directly NMT API and measure their performance in stressed circumstances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316813](https://bugs.openjdk.org/browse/JDK-8316813): NMT: Using WhiteBox API, virtual memory tracking should also be stressed in JMH tests (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [9467a95c](https://git.openjdk.org/jdk/pull/17582/files/9467a95c23595c24c2c38eee35ba8ac2c8896ae6)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17582/head:pull/17582` \
`$ git checkout pull/17582`

Update a local copy of the PR: \
`$ git checkout pull/17582` \
`$ git pull https://git.openjdk.org/jdk.git pull/17582/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17582`

View PR using the GUI difftool: \
`$ git pr show -t 17582`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17582.diff">https://git.openjdk.org/jdk/pull/17582.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17582#issuecomment-1911880847)