### PR TITLE
8324585: JVM native memory leak in PCKS11-NSS security provider

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11PSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,6 @@ final class P11PSSSignature extends SignatureSpi {
             }
         } finally {
             p11Key.releaseKeyID();
-            mechanism.freeHandle();
             session = token.releaseSession(session);
             isActive = false;
         }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1254,6 +1254,24 @@ public final class SunPKCS11 extends AuthProvider {
                 ("Token info for token in slot " + slotID + ":");
             System.out.println(token.tokenInfo);
         }
+        Set<Long> brokenMechanisms = Set.of();
+        if (P11Util.isNSS(token)) {
+            CK_VERSION nssVersion = slotInfo.hardwareVersion;
+            if (nssVersion.major < 3 ||
+                    nssVersion.major == 3 && nssVersion.minor < 65) {
+                // RSA-PSS is broken in NSS prior to 3.65
+                brokenMechanisms = Set.of(CKM_RSA_PKCS_PSS,
+                        CKM_SHA1_RSA_PKCS_PSS,
+                        CKM_SHA224_RSA_PKCS_PSS,
+                        CKM_SHA256_RSA_PKCS_PSS,
+                        CKM_SHA384_RSA_PKCS_PSS,
+                        CKM_SHA512_RSA_PKCS_PSS,
+                        CKM_SHA3_224_RSA_PKCS_PSS,
+                        CKM_SHA3_256_RSA_PKCS_PSS,
+                        CKM_SHA3_384_RSA_PKCS_PSS,
+                        CKM_SHA3_512_RSA_PKCS_PSS);
+            }
+        }
         long[] supportedMechanisms = p11.C_GetMechanismList(slotID);
 
         // Create a map from the various Descriptors to the "most
@@ -1284,6 +1302,13 @@ public final class SunPKCS11 extends AuthProvider {
             if (isLegacy(mechInfo)) {
                 if (showInfo) {
                     System.out.println("DISABLED due to legacy");
+                }
+                continue;
+            }
+
+            if (brokenMechanisms.contains(longMech)) {
+                if (showInfo) {
+                    System.out.println("DISABLED due to broken provider");
                 }
                 continue;
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1308,7 +1308,7 @@ public final class SunPKCS11 extends AuthProvider {
 
             if (brokenMechanisms.contains(longMech)) {
                 if (showInfo) {
-                    System.out.println("DISABLED due to broken provider");
+                    System.out.println("DISABLED due to known issue with NSS");
                 }
                 continue;
             }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/CK_MECHANISM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -83,14 +83,6 @@ public class CK_MECHANISM {
      * </PRE>
      */
     public Object pParameter = null;
-
-    // pointer to native CK_MECHANISM structure
-    // For mechanisms which have only mechanism id, the native structure
-    // can be freed right after init and this field will not be used. However,
-    // for mechanisms which have both mechanism id and parameters, it can
-    // only be freed after operation is finished. Thus, the native pointer
-    // will be stored here and then be explicitly freed by caller.
-    private long pHandle = 0L;
 
     public CK_MECHANISM(long mechanism) {
         this.mechanism = mechanism;
@@ -180,14 +172,7 @@ public class CK_MECHANISM {
         if (this.pParameter != null && this.pParameter.equals(params)) {
             return;
         }
-        freeHandle();
         this.pParameter = params;
-    }
-
-    public void freeHandle() {
-        if (this.pHandle != 0L) {
-            this.pHandle = PKCS11.freeMechanism(pHandle);
-        }
     }
 
     private void init(long mechanism, Object pParameter) {
@@ -219,12 +204,6 @@ public class CK_MECHANISM {
         sb.append("ulParameterLen: ??");
         sb.append(Constants.NEWLINE);
         */
-        if (pHandle != 0L) {
-            sb.append(Constants.INDENT);
-            sb.append("pHandle: ");
-            sb.append(pHandle);
-            sb.append(Constants.NEWLINE);
-        }
         return sb.toString() ;
     }
 }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -99,12 +99,6 @@ public class PKCS11 {
         // portion has been loaded. actual loading happens in the
         // static initializer, hence this method is empty.
     }
-
-    /* *****************************************************************************
-     * Utility, Resource Clean up
-     ******************************************************************************/
-    // always return 0L
-    public static native long freeMechanism(long hMechanism);
 
     /**
      * The PKCS#11 module to connect to. This is the PKCS#11 driver of the token;

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_general.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -68,7 +68,6 @@ jobject ckMechanismInfoPtrToJMechanismInfo(JNIEnv *env, const CK_MECHANISM_INFO_
 jfieldID pNativeDataID;
 jfieldID mech_mechanismID;
 jfieldID mech_pParameterID;
-jfieldID mech_pHandleID;
 
 jclass jByteArrayClass;
 jclass jLongClass;
@@ -85,23 +84,6 @@ JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved) {
 /* ************************************************************************** */
 /* The native implementation of the methods of the PKCS11Implementation class */
 /* ************************************************************************** */
-
-/*
- * This method is used to do free the memory allocated for CK_MECHANISM structure.
- *
- * Class:     sun_security_pkcs11_wrapper_PKCS11
- * Method:    freeMechanism
- * Signature: (J)J
- */
-JNIEXPORT jlong JNICALL
-Java_sun_security_pkcs11_wrapper_PKCS11_freeMechanism
-(JNIEnv *env, jclass thisClass, jlong ckpMechanism) {
-    if (ckpMechanism != 0L) {
-        freeCKMechanismPtr(jlong_to_ptr(ckpMechanism));
-        TRACE1("DEBUG PKCS11_freeMechanism: free pMech = %lld\n", (long long int) ckpMechanism);
-    }
-    return 0L;
-}
 
 /*
  * This method is used to do static initialization. This method is static and
@@ -146,8 +128,6 @@ void prefetchFields(JNIEnv *env, jclass thisClass) {
     mech_pParameterID = (*env)->GetFieldID(env, tmpClass, "pParameter",
                                            "Ljava/lang/Object;");
     if (mech_pParameterID == NULL) { return; }
-    mech_pHandleID = (*env)->GetFieldID(env, tmpClass, "pHandle", "J");
-    if (mech_pHandleID == NULL) { return; }
 
     /* java classes for primitive types - byte[], long */
     jByteArrayClass = fetchClass(env, "[B");

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/p11_sign.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -87,13 +87,9 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignInit
 
     rv = (*ckpFunctions->C_SignInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK ||
-            (ckpMechanism->pParameter == NULL)) {
-        freeCKMechanismPtr(ckpMechanism);
-    } else {
-        (*env)->SetLongField(env, jMechanism, mech_pHandleID, ptr_to_jlong(ckpMechanism));
-        TRACE1("DEBUG C_SignInit: stored pMech = 0x%lX\n", ptr_to_jlong(ckpMechanism));
-    }
+    TRACE1("DEBUG C_SignInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
     TRACE0("FINISHED\n");
 }
 #endif
@@ -310,13 +306,9 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1SignRecoverIni
 
     rv = (*ckpFunctions->C_SignRecoverInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK ||
-            (ckpMechanism->pParameter == NULL)) {
-        freeCKMechanismPtr(ckpMechanism);
-    } else {
-        (*env)->SetLongField(env, jMechanism, mech_pHandleID, ptr_to_jlong(ckpMechanism));
-        TRACE1("DEBUG C_SignRecoverInit, stored pMech = 0x%lX\n", ptr_to_jlong(ckpMechanism));
-    }
+    TRACE1("DEBUG C_SignRecoverInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
     TRACE0("FINISHED\n");
 }
 #endif
@@ -420,13 +412,9 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1VerifyInit
 
     rv = (*ckpFunctions->C_VerifyInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK ||
-            (ckpMechanism->pParameter == NULL)) {
-        freeCKMechanismPtr(ckpMechanism);
-    } else {
-        (*env)->SetLongField(env, jMechanism, mech_pHandleID, ptr_to_jlong(ckpMechanism));
-        TRACE1("DEBUG C_VerifyInit: stored pMech = 0x%lX\n", ptr_to_jlong(ckpMechanism));
-    }
+    TRACE1("DEBUG C_VerifyInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
     TRACE0("FINISHED\n");
 }
 #endif
@@ -608,13 +596,9 @@ JNIEXPORT void JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_C_1VerifyRecoverI
 
     rv = (*ckpFunctions->C_VerifyRecoverInit)(ckSessionHandle, ckpMechanism, ckKeyHandle);
 
-    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK ||
-            (ckpMechanism->pParameter == NULL)) {
-        freeCKMechanismPtr(ckpMechanism);
-    } else {
-        (*env)->SetLongField(env, jMechanism, mech_pHandleID, ptr_to_jlong(ckpMechanism));
-        TRACE1("DEBUG C_VerifyRecoverInit: stored pMech = 0x%lX\n", ptr_to_jlong(ckpMechanism));
-    }
+    TRACE1("DEBUG C_VerifyRecoverInit: freed pMech = %p\n", ckpMechanism);
+    freeCKMechanismPtr(ckpMechanism);
+    if (ckAssertReturnValueOK(env, rv) != CK_ASSERT_OK) { return; }
     TRACE0("FINISHED\n");
 }
 #endif

--- a/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
+++ b/src/jdk.crypto.cryptoki/share/native/libj2pkcs11/pkcs11wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -508,7 +508,6 @@ void destroyLockObject(JNIEnv *env, jobject jLockObject);
 extern jfieldID pNativeDataID;
 extern jfieldID mech_mechanismID;
 extern jfieldID mech_pParameterID;
-extern jfieldID mech_pHandleID;
 
 extern jclass jByteArrayClass;
 extern jclass jLongClass;


### PR DESCRIPTION
Please review this patch that fixes a memory leak in P11TlsPrfGenerator, which is triggered during TLS1.2 Finished message generation and verification.

The patch changes C_SignInit JNI method to free the mechanism data immediately after use. This matches the behavior of other Init methods (like C_EncryptInit). The patch also fixes a similar issue in other signature-related methods.

The change essentially reverts part of [JDK-8080462](https://bugs.openjdk.org/browse/JDK-8080462).

All sun/security/pkcs11 tests still pass with NSS ~3.35 and~ 3.91. All tier1-3 tests still pass.

EDIT:
Some sun/security/pkcs11 tests fail with NSS 3.64 and older, see [comment](https://github.com/openjdk/jdk/pull/17584#issuecomment-1914665234)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324585](https://bugs.openjdk.org/browse/JDK-8324585): JVM native memory leak in PCKS11-NSS security provider (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [87edba10](https://git.openjdk.org/jdk/pull/17584/files/87edba103808da6bfc0de50a2eae87c48b894c54)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17584/head:pull/17584` \
`$ git checkout pull/17584`

Update a local copy of the PR: \
`$ git checkout pull/17584` \
`$ git pull https://git.openjdk.org/jdk.git pull/17584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17584`

View PR using the GUI difftool: \
`$ git pr show -t 17584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17584.diff">https://git.openjdk.org/jdk/pull/17584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17584#issuecomment-1911793890)