### PR TITLE
8324752: C2 Superword: remove SuperWordRTDepCheck

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -339,9 +339,6 @@
   product(bool, UseSuperWord, true,                                         \
           "Transform scalar operations into superword operations")          \
                                                                             \
-  develop(bool, SuperWordRTDepCheck, false,                                 \
-          "Enable runtime dependency checks.")                              \
-                                                                            \
   product(bool, SuperWordReductions, true,                                  \
           "Enable reductions support in superword.")                        \
                                                                             \

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -57,7 +57,6 @@
 // second statement is considered the right element.
 
 class VPointer;
-class OrderedPair;
 
 // ========================= Dependence Graph =====================
 
@@ -198,33 +197,6 @@ class SWNodeInfo {
   static const SWNodeInfo initial;
 };
 
-class SuperWord;
-
-// JVMCI: OrderedPair is moved up to deal with compilation issues on Windows
-//------------------------------OrderedPair---------------------------
-// Ordered pair of Node*.
-class OrderedPair {
- protected:
-  Node* _p1;
-  Node* _p2;
- public:
-  OrderedPair() : _p1(nullptr), _p2(nullptr) {}
-  OrderedPair(Node* p1, Node* p2) {
-    if (p1->_idx < p2->_idx) {
-      _p1 = p1; _p2 = p2;
-    } else {
-      _p1 = p2; _p2 = p1;
-    }
-  }
-
-  bool operator==(const OrderedPair &rhs) {
-    return _p1 == rhs._p1 && _p2 == rhs._p2;
-  }
-  void print() { tty->print("  (%d, %d)", _p1->_idx, _p2->_idx); }
-
-  static const OrderedPair initial;
-};
-
 // -----------------------------SuperWord---------------------------------
 // Transforms scalar operations into packed (superword) operations.
 class SuperWord : public ResourceObj {
@@ -248,8 +220,6 @@ class SuperWord : public ResourceObj {
   GrowableArray<SWNodeInfo> _node_info;  // Info needed per node
   CloneMap&            _clone_map;       // map of nodes created in cloning
   MemNode const* _align_to_ref;          // Memory reference that pre-loop will align to
-
-  GrowableArray<OrderedPair> _disjoint_ptrs; // runtime disambiguated pointer pairs
 
   DepGraph _dg; // Dependence graph
 


### PR DESCRIPTION
Subtask of https://github.com/openjdk/jdk/pull/16620

SuperWordRTDepCheck is a debug-only flag, which detects if there are arrays in the same slice that have different bases, i.e. may be different arrays. This could be the basis for alias-analysis.

We should do aliasing-analysis properly in a future RFE ([JDK-8324751](https://bugs.openjdk.org/browse/JDK-8324751)). If we can prove (statically or with a runtime-check) that two arrays are different, then this removes edges from the dependency graph, and may allow vectorization that would otherwise not be possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324752](https://bugs.openjdk.org/browse/JDK-8324752): C2 Superword: remove SuperWordRTDepCheck (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17585/head:pull/17585` \
`$ git checkout pull/17585`

Update a local copy of the PR: \
`$ git checkout pull/17585` \
`$ git pull https://git.openjdk.org/jdk.git pull/17585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17585`

View PR using the GUI difftool: \
`$ git pr show -t 17585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17585.diff">https://git.openjdk.org/jdk/pull/17585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17585#issuecomment-1911806817)