### PR TITLE
JDK-8324753: [AIX] adjust os_posix after JDK-8318696

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -753,11 +753,11 @@ void os::dll_unload(void *lib) {
 }
 
 jlong os::lseek(int fd, jlong offset, int whence) {
-  return (jlong) ::lseek(fd, offset, whence);
+  return (jlong) AIX_ONLY(::lseek64) NOT_AIX(::lseek)(fd, offset, whence);
 }
 
 int os::ftruncate(int fd, jlong length) {
-   return ::ftruncate(fd, length);
+   return AIX_ONLY(::ftruncate64) NOT_AIX(::ftruncate)(fd, length);
 }
 
 const char* os::get_current_directory(char *buf, size_t buflen) {


### PR DESCRIPTION
[JDK-8318696](https://bugs.openjdk.org/browse/JDK-8318696) changed not only Linux related os coding, but also os_posix.
Unfortunately, this touches AIX as well, we use there now the non-large-file functions (e.g. lseek) which could be problematic.
See also https://www.ibm.com/docs/en/aix/7.1?topic=volumes-writing-programs-that-access-large-files .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324753](https://bugs.openjdk.org/browse/JDK-8324753): [AIX] adjust os_posix after JDK-8318696 (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Author)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17587/head:pull/17587` \
`$ git checkout pull/17587`

Update a local copy of the PR: \
`$ git checkout pull/17587` \
`$ git pull https://git.openjdk.org/jdk.git pull/17587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17587`

View PR using the GUI difftool: \
`$ git pr show -t 17587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17587.diff">https://git.openjdk.org/jdk/pull/17587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17587#issuecomment-1912077259)