### PR TITLE
8324668: JDWP process management needs more efficient file descriptor handling

### DIFF
--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -95,8 +95,11 @@ closeDescriptors(void)
     snprintf(aix_fd_dir, 32, "/proc/%d/fd", getpid());
 #endif
 
-    if ((dp = opendir(FD_DIR)) == NULL)
+    if ((dp = opendir(FD_DIR)) == NULL) {
+        LOG_MISC(("warning: failed to open dir %s while determining"
+                  " file descriptors to close for process %d", FD_DIR, getpid()));
         return 0; // failure
+    }
 
     while ((dirp = readdir(dp)) != NULL) {
         int fd;

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -105,11 +105,13 @@ closeDescriptors(void)
     while ((dirp = readdir(dp)) != NULL) {
         int fd;
         if (isAsciiDigit(dirp->d_name[0]) &&
-            (fd = strtol(dirp->d_name, NULL, 10)) >= from_fd)
-            close(fd);
+            (fd = strtol(dirp->d_name, NULL, 10)) >= from_fd) {
+            (void)close(fd);
+        }
+
     }
 
-    closedir(dp);
+    (void)closedir(dp);
 
     return 1; // success
 }

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -25,8 +25,8 @@
 
 #include <dirent.h>
 #include <errno.h>
-#include <limits.h>
 #include <stdlib.h>
+#include <sys/resource.h>
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -48,12 +48,6 @@ static char *skipNonWhitespace(char *p) {
     return p;
 }
 
-int
-isAsciiDigit(char c)
-{
-  return c >= '0' && c <= '9';
-}
-
 #if defined(_AIX)
   /* AIX does not understand '/proc/self' - it requires the real process ID */
   #define FD_DIR aix_fd_dir
@@ -105,7 +99,7 @@ closeDescriptors(void)
 
     while ((dirp = readdir(dp)) != NULL) {
         int fd;
-        if (isAsciiDigit(dirp->d_name[0]) &&
+        if (isdigit(dirp->d_name[0]) &&
             (fd = strtol(dirp->d_name, NULL, 10)) >= from_fd) {
             (void)close(fd);
         }

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -30,6 +30,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>
+#include "log_messages.h"
 #include "sys.h"
 #include "util.h"
 
@@ -132,6 +133,9 @@ forkedChildProcess(const char *file, char *const argv[])
         JDI_ASSERT(max_fd != (rlim_t)-1);
         /* leave out standard input/output/error file descriptors */
         rlim_t i = STDERR_FILENO + 1;
+        LOG_MISC(("warning: failed to close file descriptors of"
+                  " child process optimally, falling back to closing"
+                  " %d file descriptors sequentially", (max_fd - i + 1)));
         for (; i < max_fd; i++) {
             (void)close(i);
         }

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -62,11 +62,11 @@ static char *skipNonWhitespace(char *p) {
   #define FD_DIR "/proc/self/fd"
 #endif
 
-// closes every file descriptor that is listed as a directory
-// entry in "/proc/self/fd" (or its equivalent). standard
+// Closes every file descriptor that is listed as a directory
+// entry in "/proc/self/fd" (or its equivalent). Standard
 // input/output/error file descriptors will not be closed
-// by this function. this function returns 0 on failure
-// and 1 on success
+// by this function. This function returns 0 on failure
+// and 1 on success.
 int
 closeDescriptors(void)
 {
@@ -79,9 +79,10 @@ closeDescriptors(void)
      * itself be implemented using a file descriptor, and we certainly
      * don't want to close that while it's in use.  We assume that if
      * opendir() is implemented using a file descriptor, then it uses
-     * the lowest numbered file descriptor, just like open().  So we
-     * close a couple explicitly, so that opendir() can then use
-     * these lowest numbered closed file descriptors afresh.   */
+     * the lowest numbered file descriptor, just like open().  So
+     * before calling opendir(), we close a couple explicitly, so that
+     * opendir() can then use these lowest numbered closed file
+     * descriptors afresh.   */
 
     close(from_fd);          /* for possible use by opendir() */
     close(from_fd + 1);      /* another one for good luck */
@@ -111,18 +112,18 @@ closeDescriptors(void)
     return 1; // success
 }
 
-// does necessary housekeeping of a forked child process
+// Does necessary housekeeping of a forked child process
 // (like closing copied file descriptors) before
-// execing the child process. this function never returns
+// execing the child process. This function never returns.
 void
 forkedChildProcess(const char *file, char *const argv[])
 {
-    /* close all file descriptors that have been copied over
-     * from the parent process due to fork() */
+    /* Close all file descriptors that have been copied over
+     * from the parent process due to fork(). */
     if (closeDescriptors() == 0) { /* failed,  close the old way */
-        /* find max allowed file descriptors for a process
+        /* Find max allowed file descriptors for a process
          * and assume all were opened for the parent process and
-         * copied over to this child process. we close them all */
+         * copied over to this child process. We close them all. */
         const rlim_t max_fd = sysconf(_SC_OPEN_MAX);
         JDI_ASSERT(max_fd != (rlim_t)-1);
         /* leave out standard input/output/error file descriptors */

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -97,7 +97,8 @@ closeDescriptors(void)
 
     if ((dp = opendir(FD_DIR)) == NULL) {
         ERROR_MESSAGE(("failed to open dir %s while determining"
-                  " file descriptors to close for process %d", FD_DIR, getpid()));
+                       " file descriptors to close for process %d",
+                       FD_DIR, getpid()));
         return 0; // failure
     }
 
@@ -135,8 +136,8 @@ forkedChildProcess(const char *file, char *const argv[])
         /* leave out standard input/output/error file descriptors */
         rlim_t i = STDERR_FILENO + 1;
         ERROR_MESSAGE(("failed to close file descriptors of"
-                  " child process optimally, falling back to closing"
-                  " %d file descriptors sequentially", (max_fd - i + 1)));
+                       " child process optimally, falling back to closing"
+                       " %d file descriptors sequentially", (max_fd - i + 1)));
         for (; i < max_fd; i++) {
             (void)close(i);
         }

--- a/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
+++ b/src/jdk.jdwp.agent/unix/native/libjdwp/exec_md.c
@@ -30,9 +30,9 @@
 #include <unistd.h>
 #include <string.h>
 #include <ctype.h>
-#include "log_messages.h"
 #include "sys.h"
 #include "util.h"
+#include "error_messages.h"
 
 static char *skipWhitespace(char *p) {
     while ((*p != '\0') && isspace(*p)) {
@@ -96,7 +96,7 @@ closeDescriptors(void)
 #endif
 
     if ((dp = opendir(FD_DIR)) == NULL) {
-        LOG_MISC(("warning: failed to open dir %s while determining"
+        ERROR_MESSAGE(("failed to open dir %s while determining"
                   " file descriptors to close for process %d", FD_DIR, getpid()));
         return 0; // failure
     }
@@ -134,7 +134,7 @@ forkedChildProcess(const char *file, char *const argv[])
         JDI_ASSERT(max_fd <= INT_MAX);
         /* leave out standard input/output/error file descriptors */
         rlim_t i = STDERR_FILENO + 1;
-        LOG_MISC(("warning: failed to close file descriptors of"
+        ERROR_MESSAGE(("failed to close file descriptors of"
                   " child process optimally, falling back to closing"
                   " %d file descriptors sequentially", (max_fd - i + 1)));
         for (; i < max_fd; i++) {


### PR DESCRIPTION
Can I please get a review of this change which proposes to address https://bugs.openjdk.org/browse/JDK-8324668?

This change proposes to fix the issue in jdwp where when launching a child process (for the `launch=<cmd>` option), it iterates over an extremely large number of file descriptors to close each one of those. Details about the issue and the proposed fixed are added in a subsequent comment in this PR https://github.com/openjdk/jdk/pull/17588#issuecomment-1912256075. tier1, tier2 and tier3 testing is currently in progress with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324668](https://bugs.openjdk.org/browse/JDK-8324668): JDWP process management needs more efficient file descriptor handling (**Enhancement** - P3)


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [3d323f7d](https://git.openjdk.org/jdk/pull/17588/files/3d323f7d1d08ceeac1306c7f5638ca9e71c75407)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17588/head:pull/17588` \
`$ git checkout pull/17588`

Update a local copy of the PR: \
`$ git checkout pull/17588` \
`$ git pull https://git.openjdk.org/jdk.git pull/17588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17588`

View PR using the GUI difftool: \
`$ git pr show -t 17588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17588.diff">https://git.openjdk.org/jdk/pull/17588.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17588#issuecomment-1912205857)