### PR TITLE
8324765: C2 SuperWord: remove dead code: SuperWord::insert_extracts

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2851,7 +2851,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
 
 #ifdef ASSERT
 // We check that every packset (name it p_def) only has vector uses (p_use),
-// which are properly vector uses of def.
+// which are proper vector uses of def.
 void SuperWord::verify_no_extract() {
   for (int i = 0; i < _packset.length(); i++) {
     Node_List* p_def = _packset.at(i);

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -60,7 +60,6 @@ SuperWord::SuperWord(PhaseIdealLoop* phase) :
   _dg(_arena),                                              // dependence graph
   _visited(arena()),                                        // visited node set
   _post_visited(arena()),                                   // post visited node set
-  _n_idx_list(arena(), 8),                                  // scratch list of (node,index) pairs
   _nlist(arena(), 8, 0, nullptr),                           // scratch list of nodes
   _stk(arena(), 8, 0, nullptr),                             // scratch stack of nodes
   _lpt(nullptr),                                            // loop tree node
@@ -2399,10 +2398,7 @@ bool SuperWord::output() {
 
   adjust_pre_loop_limit_to_align_main_loop_vectors();
 
-  // Insert extract (unpack) operations for scalar uses
-  for (int i = 0; i < _packset.length(); i++) {
-    insert_extracts(_packset.at(i));
-  }
+  DEBUG_ONLY(verify_no_extract());
 
   uint max_vlen_in_bytes = 0;
   uint max_vlen = 0;
@@ -2853,55 +2849,34 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
   return pk;
 }
 
-//------------------------------insert_extracts---------------------------
-// If a use of pack p is not a vector use, then replace the
-// use with an extract operation.
-void SuperWord::insert_extracts(Node_List* p) {
-  if (p->at(0)->is_Store()) return;
-  assert(_n_idx_list.is_empty(), "empty (node,index) list");
+#ifdef ASSERT
+// We check that every packset (name it p_def) only has vector uses (p_use),
+// which are properly vector uses of def.
+void SuperWord::verify_no_extract() {
+  for (int i = 0; i < _packset.length(); i++) {
+    Node_List* p_def = _packset.at(i);
 
-  // Inspect each use of each pack member.  For each use that is
-  // not a vector use, replace the use with an extract operation.
+    // A vector store has no uses
+    if (p_def->at(0)->is_Store()) { continue; }
 
-  for (uint i = 0; i < p->size(); i++) {
-    Node* def = p->at(i);
-    for (DUIterator_Fast jmax, j = def->fast_outs(jmax); j < jmax; j++) {
-      Node* use = def->fast_out(j);
-      for (uint k = 0; k < use->req(); k++) {
-        Node* n = use->in(k);
-        if (def == n) {
-          Node_List* u_pk = my_pack(use);
-          if ((u_pk == nullptr || use->is_CMove()) && !is_vector_use(use, k)) {
-              _n_idx_list.push(use, k);
+    // for every def in p_def, and every use:
+    for (uint i = 0; i < p_def->size(); i++) {
+      Node* def = p_def->at(i);
+      for (DUIterator_Fast jmax, j = def->fast_outs(jmax); j < jmax; j++) {
+        Node* use = def->fast_out(j);
+        // find every use->def edge:
+        for (uint k = 0; k < use->req(); k++) {
+          Node* maybe_def = use->in(k);
+          if (def == maybe_def) {
+            Node_List* p_use = my_pack(use);
+            assert(p_use != nullptr && is_vector_use(use, k), "all uses must be vector uses");
           }
         }
       }
     }
   }
-
-  while (_n_idx_list.is_nonempty()) {
-    Node* use = _n_idx_list.node();
-    int   idx = _n_idx_list.index();
-    _n_idx_list.pop();
-    Node* def = use->in(idx);
-
-    if (is_marked_reduction(def)) continue;
-
-    // Insert extract operation
-    _igvn.hash_delete(def);
-    int def_pos = alignment(def) / data_size(def);
-
-    ConINode* def_pos_con = _igvn.intcon(def_pos)->as_ConI();
-    Node* ex = ExtractNode::make(def, def_pos_con, velt_basic_type(def));
-    _igvn.register_new_node_with_optimizer(ex);
-    _phase->set_ctrl(ex, _phase->get_ctrl(def));
-    _igvn.replace_input_of(use, idx, ex);
-    _igvn._worklist.push(def);
-
-    bb_insert_after(ex, bb_idx(def));
-    set_velt_type(ex, velt_type(def));
-  }
 }
+#endif
 
 //------------------------------is_vector_use---------------------------
 // Is use->in(u_idx) a vector use?

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2869,6 +2869,7 @@ void SuperWord::verify_no_extract() {
           Node* maybe_def = use->in(k);
           if (def == maybe_def) {
             Node_List* p_use = my_pack(use);
+            if (is_marked_reduction(def)) { continue; }
             assert(p_use != nullptr && is_vector_use(use, k), "all uses must be vector uses");
           }
         }

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -256,7 +256,6 @@ class SuperWord : public ResourceObj {
   // Scratch pads
   VectorSet    _visited;       // Visited set
   VectorSet    _post_visited;  // Post-visited set
-  Node_Stack   _n_idx_list;    // List of (node,index) pairs
   GrowableArray<Node*> _nlist; // List of nodes
   GrowableArray<Node*> _stk;   // Stack of nodes
 
@@ -513,8 +512,8 @@ private:
   bool implemented(Node_List* p);
   // For pack p, are all operands and all uses (with in the block) vector?
   bool profitable(Node_List* p);
-  // If a use of pack p is not a vector use, then replace the use with an extract operation.
-  void insert_extracts(Node_List* p);
+  // Verify that all uses of packs are also packs, i.e. we do not need extract operations.
+  DEBUG_ONLY(void verify_no_extract();)
   // Is use->in(u_idx) a vector use?
   bool is_vector_use(Node* use, int u_idx);
   // Construct reverse postorder list of block members


### PR DESCRIPTION
Subtask of https://github.com/openjdk/jdk/pull/16620

As far as all tests and code study have showed me, SuperWord::insert_extracts is dead.

I am replacing it with verification code, that checks that no ExtractNode is required.

**Details**

All the relevant cases are marked as "unprofitable" in `SuperWord::profitable`, see:
https://github.com/openjdk/jdk/blob/dfdd2174d7af5e3e995147484db17b45b006f6d0/src/hotspot/share/opto/superword.cpp#L1912-L1915

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324765](https://bugs.openjdk.org/browse/JDK-8324765): C2 SuperWord: remove dead code: SuperWord::insert_extracts (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [8a08a4f2](https://git.openjdk.org/jdk/pull/17589/files/8a08a4f248c95842f4c2651bb542c3aebb0e2453)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [8a08a4f2](https://git.openjdk.org/jdk/pull/17589/files/8a08a4f248c95842f4c2651bb542c3aebb0e2453)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17589/head:pull/17589` \
`$ git checkout pull/17589`

Update a local copy of the PR: \
`$ git checkout pull/17589` \
`$ git pull https://git.openjdk.org/jdk.git pull/17589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17589`

View PR using the GUI difftool: \
`$ git pr show -t 17589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17589.diff">https://git.openjdk.org/jdk/pull/17589.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17589#issuecomment-1912333520)