### PR TITLE
8324734: Relax too-strict assert(VM_Version::supports_evex()) in Assembler::locate_operand()

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1089,7 +1089,6 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     break;
 
   case 0x62: // EVEX_4bytes
-    assert(VM_Version::supports_evex(), "shouldn't have EVEX prefix");
     assert(ip == inst+1, "no prefixes allowed");
     // no EVEX collisions, all instructions that have 0x62 opcodes
     // have EVEX versions and are subopcodes of 0x66

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1089,6 +1089,7 @@ address Assembler::locate_operand(address inst, WhichOperand which) {
     break;
 
   case 0x62: // EVEX_4bytes
+    assert(VM_Version::cpu_supports_evex(), "shouldn't have EVEX prefix");
     assert(ip == inst+1, "no prefixes allowed");
     // no EVEX collisions, all instructions that have 0x62 opcodes
     // have EVEX versions and are subopcodes of 0x66

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -809,7 +809,7 @@ void VM_Version::get_processor_features() {
   _stepping = cpu_stepping();
 
   if (cpu_family() > 4) { // it supports CPUID
-    _features = feature_flags(); // It can be changed by VM flags
+    _features = feature_flags(); // These can be changed by VM settings
     _cpu_features = _features;   // Preserve features
     // Logical processors are only available on P4s and above,
     // and only if hyperthreading is available.

--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -809,7 +809,8 @@ void VM_Version::get_processor_features() {
   _stepping = cpu_stepping();
 
   if (cpu_family() > 4) { // it supports CPUID
-    _features = feature_flags();
+    _features = feature_flags(); // It can be changed by VM flags
+    _cpu_features = _features;   // Preserve features
     // Logical processors are only available on P4s and above,
     // and only if hyperthreading is available.
     _logical_processors_per_package = logical_processor_count();

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -706,7 +706,7 @@ public:
   //
   // Feature identification not affected by VM flags
   //
-  static bool cpu_supports_evex()         { return (_cpu_features & CPU_AVX512F) != 0; }
+  static bool cpu_supports_evex()     { return (_cpu_features & CPU_AVX512F) != 0; }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -640,7 +640,7 @@ public:
   }
 
   //
-  // Feature identification which can be affected by VM flags
+  // Feature identification which can be affected by VM settings
   //
   static bool supports_cpuid()        { return _features  != 0; }
   static bool supports_cmov()         { return (_features & CPU_CMOV) != 0; }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -640,7 +640,7 @@ public:
   }
 
   //
-  // Feature identification
+  // Feature identification which can be affected by VM flags
   //
   static bool supports_cpuid()        { return _features  != 0; }
   static bool supports_cmov()         { return (_features & CPU_CMOV) != 0; }
@@ -702,6 +702,11 @@ public:
   static bool supports_ospke()        { return (_features & CPU_OSPKE) != 0; }
   static bool supports_cet_ss()       { return (_features & CPU_CET_SS) != 0; }
   static bool supports_cet_ibt()      { return (_features & CPU_CET_IBT) != 0; }
+
+  //
+  // Feature identification not affected by VM flags
+  //
+  static bool cpu_supports_evex()         { return (_cpu_features & CPU_AVX512F) != 0; }
 
   // Intel features
   static bool is_intel_family_core() { return is_intel() &&

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -34,6 +34,7 @@ const char* Abstract_VM_Version::_s_internal_vm_info_string = Abstract_VM_Versio
 
 uint64_t Abstract_VM_Version::_features = 0;
 const char* Abstract_VM_Version::_features_string = "";
+uint64_t Abstract_VM_Version::_cpu_features = 0;
 
 #ifndef SUPPORTS_NATIVE_CX8
 bool Abstract_VM_Version::_supports_cx8 = false;

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -54,9 +54,12 @@ class Abstract_VM_Version: AllStatic {
   static const char*  _s_vm_release;
   static const char*  _s_internal_vm_info_string;
 
-  // CPU feature flags.
+  // CPU feature flags which can be restricted by VM flags.
   static uint64_t _features;
   static const char* _features_string;
+
+  // CPU feature flags not affected by VM flags.
+  static uint64_t _cpu_features;
 
   // These are set by machine-dependent initializations
 #ifndef SUPPORTS_NATIVE_CX8

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -58,7 +58,7 @@ class Abstract_VM_Version: AllStatic {
   static uint64_t _features;
   static const char* _features_string;
 
-  // CPU feature flags not affected by VM flags.
+  // Original CPU feature flags, not affected by VM settings.
   static uint64_t _cpu_features;
 
   // These are set by machine-dependent initializations

--- a/src/hotspot/share/runtime/abstract_vm_version.hpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.hpp
@@ -54,7 +54,7 @@ class Abstract_VM_Version: AllStatic {
   static const char*  _s_vm_release;
   static const char*  _s_internal_vm_info_string;
 
-  // CPU feature flags which can be restricted by VM flags.
+  // CPU feature flags, can be affected by VM settings.
   static uint64_t _features;
   static const char* _features_string;
 


### PR DESCRIPTION
Details see bug report. The gist is that HotSpot downgrades to UseAVX=2 on some processors, and reports supports_evex() == false, but the instruction decoder can still encounter EVEX instructions when (e.g.) hitting a SIGBUS in memset() - which does have EVEX instructions.

Testing:
 - [x] runtime/Unsafe/InternalErrorTest.java
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324734](https://bugs.openjdk.org/browse/JDK-8324734): Relax too-strict assert(VM_Version::supports_evex()) in Assembler::locate_operand() (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Contributors
 * Vladimir Kozlov `<kvn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17590/head:pull/17590` \
`$ git checkout pull/17590`

Update a local copy of the PR: \
`$ git checkout pull/17590` \
`$ git pull https://git.openjdk.org/jdk.git pull/17590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17590`

View PR using the GUI difftool: \
`$ git pr show -t 17590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17590.diff">https://git.openjdk.org/jdk/pull/17590.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17590#issuecomment-1912244126)