### PR TITLE
8324785: ProblemList two tests on linux due to JDK-8315923

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -109,6 +109,8 @@ runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
+runtime/os/TestTransparentHugePageUsage.java 8324776 linux-all
+runtime/Thread/TestAlwaysPreTouchStacks.java 8324781 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList two tests on linux due to JDK-8315923.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324785](https://bugs.openjdk.org/browse/JDK-8324785): ProblemList two tests on linux due to JDK-8315923 (**Sub-task** - P2)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17596/head:pull/17596` \
`$ git checkout pull/17596`

Update a local copy of the PR: \
`$ git checkout pull/17596` \
`$ git pull https://git.openjdk.org/jdk.git pull/17596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17596`

View PR using the GUI difftool: \
`$ git pr show -t 17596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17596.diff">https://git.openjdk.org/jdk/pull/17596.diff</a>

</details>
