### PR TITLE
JDK-8324733 : [macos14] Problem list tests which fail due to macOS bug described in JDK-8322653

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -443,8 +443,8 @@ java/awt/event/KeyEvent/DeadKey/DeadKeyMacOSXInputText.java 8233568 macosx-all
 java/awt/event/KeyEvent/DeadKey/deadKeyMacOSX.java 8233568 macosx-all
 java/awt/TrayIcon/RightClickWhenBalloonDisplayed/RightClickWhenBalloonDisplayed.java 8238720 windows-all
 java/awt/PopupMenu/PopupMenuLocation.java 8259913,8315878 windows-all,macosx-aarch64
-java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720 windows-all
-java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720 windows-all
+java/awt/GridLayout/ComponentPreferredSize/ComponentPreferredSize.java 8238720,8324782 windows-all,macosx-all
+java/awt/GridLayout/ChangeGridSize/ChangeGridSize.java   8238720,8324782 windows-all,macosx-all
 java/awt/event/MouseEvent/FrameMouseEventAbsoluteCoordsTest/FrameMouseEventAbsoluteCoordsTest.java 8238720 windows-all
 
 # Several tests which fail sometimes on macos11
@@ -471,6 +471,9 @@ sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 
 # Several tests which fail on some hidpi systems/macosx12-aarch64 system
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
+
+# This test fails on macOS 14
+java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
 ############################################################################
 
@@ -684,6 +687,9 @@ sanity/client/SwingSet/src/EditorPaneDemoTest.java 8212240 linux-x64
 # jdk_swing Ubuntu 23.04 specific
 
 javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
+
+# This test fails on macOS 14
+javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
Following tests fail on macOS 14 and thus being problemlisted.