### PR TITLE
8324236: compiler/ciReplay/TestInliningProtectionDomain.java failed with RuntimeException: should only dump inline information for ... expected true, was false

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -61,7 +61,7 @@ public class TestInliningProtectionDomain extends InliningBase {
         boolean inlineFails = testClass == ProtectionDomainTestNoOtherCompilationPrivate.class;
         int inlineeCount = inlineFails ? 1 : 5;
 
-        List<InlineEntry> inlineesNormal = parseLogFile(LOG_FILE_NORMAL, entryString, "compile_id='" + getCompileIdFromFile(getReplayFileName()), inlineeCount);
+        List<InlineEntry> inlineesNormal = parseLogFile(LOG_FILE_NORMAL, entryString, "compile_id='" + getCompileIdFromFile(getReplayFileName()) + "'", inlineeCount);
         List<InlineEntry> inlineesReplay = parseLogFile(LOG_FILE_REPLAY, entryString, "test ()V", inlineeCount);
         verifyLists(inlineesNormal, inlineesReplay, inlineeCount);
 


### PR DESCRIPTION
The test failed when trying to match the compile id of the interesting method by looking for "`<nmethod compile_id='2`" in this line:
```
<nmethod compile_id='2' compiler='c2' entry='0x000000010e293f40' size='680' address='0x000000010e293d90' relocation_offset='360' insts_offset='432' stub_offset='568' scopes_data_offset='616' scopes_pcs_offset='624' dependencies_offset='672' oops_offset='600' metadata_offset='608' method='compiler.ciReplay.ProtectionDomainTestNoOtherCompilationPrivateString test ()V' bytes='5' count='6784' iicount='6784' stamp='0.307'/>
```
But it first found the earlier line:
```
<nmethod compile_id='20' compile_kind='c2n' compiler='' entry='0x000000010e28b6c0' size='544' address='0x000000010e28b510' relocation_offset='360' insts_offset='432' method='java.lang.invoke.MethodHandle linkToStatic (ILjava/lang/invoke/MemberName;)Ljava/lang/Object;' bytes='0' count='0' iicount='0' stamp='0.213'/>
```
 which unfortunately also matched "`<nmethod compile_id='2`". I suggest to make the check stronger by adding a closing `'` which should then only match "`<nmethod compile_id='2'`"

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324236](https://bugs.openjdk.org/browse/JDK-8324236): compiler/ciReplay/TestInliningProtectionDomain.java failed with RuntimeException: should only dump inline information for ... expected true, was false (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17598/head:pull/17598` \
`$ git checkout pull/17598`

Update a local copy of the PR: \
`$ git checkout pull/17598` \
`$ git pull https://git.openjdk.org/jdk.git pull/17598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17598`

View PR using the GUI difftool: \
`$ git pr show -t 17598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17598.diff">https://git.openjdk.org/jdk/pull/17598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17598#issuecomment-1912739270)