### PR TITLE
8324786: validate-source fails after JDK-8042981

### DIFF
--- a/test/langtools/tools/javac/processing/model/util/types/TestAnnotationStripping.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestAnnotationStripping.java
@@ -8,7 +8,7 @@
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *


### PR DESCRIPTION
A trivial fix for validate-source.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324786](https://bugs.openjdk.org/browse/JDK-8324786): validate-source fails after JDK-8042981 (**Bug** - P1)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17599/head:pull/17599` \
`$ git checkout pull/17599`

Update a local copy of the PR: \
`$ git checkout pull/17599` \
`$ git pull https://git.openjdk.org/jdk.git pull/17599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17599`

View PR using the GUI difftool: \
`$ git pr show -t 17599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17599.diff">https://git.openjdk.org/jdk/pull/17599.diff</a>

</details>
