### PR TITLE
8323950: Null CLD while loading shared lambda proxy class with javaagent active

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -1111,13 +1111,12 @@ InstanceKlass* SystemDictionary::load_shared_lambda_proxy_class(InstanceKlass* i
   if (loaded_ik != nullptr) {
     assert(shared_nest_host->is_same_class_package(ik),
            "lambda proxy class and its nest host must be in the same package");
+    // The lambda proxy class and its nest host have the same class loader and class loader data,
+    // as verified in SystemDictionaryShared::add_lambda_proxy_class()
+    assert(shared_nest_host->class_loader() == class_loader(), "mismatched class loader");
+    assert(shared_nest_host->class_loader_data() == class_loader_data(class_loader), "mismatched class loader data");
+    ik->set_nest_host(shared_nest_host);
   }
-
-  // The lambda proxy class and its nest host have the same class loader and class loader data,
-  // as verified in SystemDictionaryShared::add_lambda_proxy_class()
-  assert(shared_nest_host->class_loader() == class_loader(), "mismatched class loader");
-  assert(shared_nest_host->class_loader_data() == class_loader_data(class_loader), "mismatched class loader data");
-  ik->set_nest_host(shared_nest_host);
 
   return loaded_ik;
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TransformInterfaceOfLambda.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8323950
+ * @summary Transforming an interface of an archived lambda proxy class should not
+ *          crash the VM. The lambda proxy class should be regenerated during runtime.
+ * @requires vm.cds
+ * @requires vm.jvmti
+ * @requires vm.flagless
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @compile test-classes/SimpleTest.java
+ * @compile test-classes/TransformBootClass.java
+ * @run driver TransformInterfaceOfLambda
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class TransformInterfaceOfLambda {
+
+    public static String agentClasses[] = {
+        TransformBootClass.class.getName(),
+    };
+
+    public static void main(String[] args) throws Exception {
+        String mainClass = SimpleTest.class.getName();
+        String namePrefix = "transform-interface-of-lambda";
+        JarBuilder.build(namePrefix, mainClass);
+
+        String appJar = TestCommon.getTestJar(namePrefix + ".jar");
+
+        String agentJar =
+            ClassFileInstaller.writeJar("TransformBootClass.jar",
+                                        ClassFileInstaller.Manifest.fromSourceFile("test-classes/TransformBootClass.mf"),
+                                        agentClasses);
+        String useJavaAgent = "-javaagent:" + agentJar + "=java/util/function/IntFunction";
+
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-cp", appJar, "-Xlog:class+load,cds=debug",
+            "-XX:+UnlockDiagnosticVMOptions",
+            "-XX:+AllowArchivingWithJavaAgent",
+            useJavaAgent,
+            mainClass);
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        System.out.println(out.getStdout());
+        out.shouldHaveExitValue(0)
+           // the class loaded by the SimpleTest should be from the archive
+           .shouldContain("[class,load] java.text.SimpleDateFormat source: shared objects file")
+           // the IntFunction is the interface which is being transformed. The
+           // interface is a super type of the following lambda proxy class.
+           .shouldContain("Transforming class java/util/function/IntFunction")
+           // the lambda proxy class should be regenerated
+           .shouldMatch(".class.load.*sun.util.locale.provider.LocaleProviderAdapter[$][$]Lambda/0x.*source:.*sun.util.locale.provider.LocaleProviderAdapter");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/SimpleTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/SimpleTest.java
@@ -28,8 +28,8 @@
  * which will also load its interface java.util.function.IntFunction.
  * By default, all of the above classes should be in the default CDS archive.
  */
-public class SimpleTest { 
-    public static void main(String[] args) throws Exception { 
-        new java.text.SimpleDateFormat(); 
-    } 
+public class SimpleTest {
+    public static void main(String[] args) throws Exception {
+        new java.text.SimpleDateFormat();
+    }
 }

--- a/test/hotspot/jtreg/runtime/cds/appcds/test-classes/SimpleTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/test-classes/SimpleTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * Loading the java.text.SimpleDateFormat class will in turn load the
+ * sun.util.locale.provider.LocaleProviderAdapter$$Lambda/0x... lambda proxy class
+ * which will also load its interface java.util.function.IntFunction.
+ * By default, all of the above classes should be in the default CDS archive.
+ */
+public class SimpleTest { 
+    public static void main(String[] args) throws Exception { 
+        new java.text.SimpleDateFormat(); 
+    } 
+}


### PR DESCRIPTION
A simple fix for an assert failure when an archived interface of an archived lambda proxy class is being transformed using
a java agent during runtime. Please refer to the bug report for details.

Testing: passed tiers 1 - 4 (including the new test).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323950](https://bugs.openjdk.org/browse/JDK-8323950): Null CLD while loading shared lambda proxy class with javaagent active (**Bug** - P2)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17602/head:pull/17602` \
`$ git checkout pull/17602`

Update a local copy of the PR: \
`$ git checkout pull/17602` \
`$ git pull https://git.openjdk.org/jdk.git pull/17602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17602`

View PR using the GUI difftool: \
`$ git pr show -t 17602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17602.diff">https://git.openjdk.org/jdk/pull/17602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17602#issuecomment-1912898411)