### PR TITLE
8324794: C2 SuperWord: do not ignore reductions in SuperWord::unrolling_analysis

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -189,7 +189,6 @@ void SuperWord::unrolling_analysis(int &local_loop_unroll_factor) {
   for (uint i = 0; i < lpt()->_body.size(); i++) {
     Node* n = lpt()->_body.at(i);
     if (n == cl->incr() ||
-      is_marked_reduction(n) ||
       n->is_AddP() ||
       n->is_Cmp() ||
       n->is_Bool() ||


### PR DESCRIPTION
Subtask of https://github.com/openjdk/jdk/pull/16620

Ignoring reductions in unrolling_analysis is unnecessary, and it adds unnecessary dependency of unrolling_analysis on reduction-analysis. That dependency needs to be removed for further refactoring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324794](https://bugs.openjdk.org/browse/JDK-8324794): C2 SuperWord: do not ignore reductions in SuperWord::unrolling_analysis (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17604/head:pull/17604` \
`$ git checkout pull/17604`

Update a local copy of the PR: \
`$ git checkout pull/17604` \
`$ git pull https://git.openjdk.org/jdk.git pull/17604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17604`

View PR using the GUI difftool: \
`$ git pr show -t 17604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17604.diff">https://git.openjdk.org/jdk/pull/17604.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17604#issuecomment-1913028264)