### PR TITLE
8324811: java/nio/file/Files/CopyMoveVariations.java fails run with non-root user

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyMoveVariations.java
+++ b/test/jdk/java/nio/file/Files/CopyMoveVariations.java
@@ -192,8 +192,12 @@ public class CopyMoveVariations {
                     assertThrows(FileAlreadyExistsException.class,
                                  () -> Files.move(src, dst, options));
                 } else {
-                    Files.move(source, target, options);
-                    assert Files.exists(target);
+                    try {
+                        Files.move(source, target, options);
+                        assert Files.exists(target);
+                    } catch (AccessDeniedException ade) {
+                        assertTrue(mode.charAt(0) != 'r');
+                    }
                 }
             } else if (type == PathType.DIR) {
                 if (op == OpType.COPY) {
@@ -212,7 +216,7 @@ public class CopyMoveVariations {
                         Files.move(source, target, options);
                         assert Files.exists(target);
                     } catch (AccessDeniedException ade) {
-                        assertTrue(mode.charAt(1) != 'w');
+                        assertTrue(mode.charAt(1) != 'r');
                     } catch (FileAlreadyExistsException faee) {
                         assertTrue(targetExists && !replaceExisting);
                     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324811](https://bugs.openjdk.org/browse/JDK-8324811): java/nio/file/Files/CopyMoveVariations.java fails run with non-root user (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17606/head:pull/17606` \
`$ git checkout pull/17606`

Update a local copy of the PR: \
`$ git checkout pull/17606` \
`$ git pull https://git.openjdk.org/jdk.git pull/17606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17606`

View PR using the GUI difftool: \
`$ git pr show -t 17606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17606.diff">https://git.openjdk.org/jdk/pull/17606.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17606#issuecomment-1913645243)