### PR TITLE
8324817: Parallel GC does not pre-touch all heap pages when AlwaysPreTouch enabled and large page disabled

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -120,11 +120,12 @@ void MutableSpace::initialize(MemRegion mr,
     }
 
     if (AlwaysPreTouch) {
+      size_t pretouch_page_size = UseLargePages ? page_size : os::vm_page_size();
       PretouchTask::pretouch("ParallelGC PreTouch head", (char*)head.start(), (char*)head.end(),
-                             page_size, pretouch_workers);
+                             pretouch_page_size, pretouch_workers);
 
       PretouchTask::pretouch("ParallelGC PreTouch tail", (char*)tail.start(), (char*)tail.end(),
-                             page_size, pretouch_workers);
+                             pretouch_page_size, pretouch_workers);
     }
 
     // Remember where we stopped so that we can continue later.

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -27,6 +27,7 @@ package gc.parallel;
  * @test TestAlwaysPreTouchBehavior
  * @summary Tests AlwaysPreTouch Bahavior, pages of java heap should be pretouched with AlwaysPreTouch enabled. This test reads RSS of test process, which should be bigger than heap size(1g) with AlwaysPreTouch enabled.
  * @requires vm.gc.Parallel
+ * @requires vm.debug != true
  * @requires os.family == "linux" & os.maxMemory > 2G
  * @library /test/lib
  * @run main/othervm -Xmx1g -Xms1g -XX:+UseParallelGC -XX:+AlwaysPreTouch gc.parallel.TestAlwaysPreTouchBehavior
@@ -48,36 +49,27 @@ import java.util.stream.*;
 import java.io.*;
 
 public class TestAlwaysPreTouchBehavior {
-    static final long EXCEPTION_VALUE = -1L;
     public static long getProcessRssInKb() throws IOException {
         String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
         // Read RSS from /proc/$pid/status. Only avaiable on Linux
         String processStatusFile = "/proc/" + pid + "/status";
         BufferedReader reader = new BufferedReader(new FileReader(processStatusFile));
-        StringBuilder stringBuilder = new StringBuilder();
         String line = null;
         while ((line = reader.readLine()) != null) {
             if (line.startsWith("VmRSS:")) {
-                stringBuilder.append(line);
                 break;
             }
         }
-        stringBuilder.deleteCharAt(stringBuilder.length() - 1);
         reader.close();
-
-        String content = stringBuilder.toString();
-        return Long.valueOf(content.split("\\s+")[1].trim());
+        return Long.valueOf(line.split("\\s+")[1].trim());
     }
     public static void main(String [] args) {
     long rss = 0;
     Runtime runtime = Runtime.getRuntime();
     long committedMemory = runtime.totalMemory() / 1024; // in kb
     try {
-       rss = getProcessRssInKb();
+        rss = getProcessRssInKb();
     } catch (Exception e) {
-       rss = EXCEPTION_VALUE;
-    }
-    if (rss == EXCEPTION_VALUE) {
         System.out.println("cannot get RSS, just skip");
         return; // Did not get avaiable RSS, just ignore this test
     }

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -51,7 +51,7 @@ public class TestAlwaysPreTouchBehavior {
     public static long getProcessRssInKb() throws IOException {
         String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
         // Read RSS from /proc/$pid/status. Only avaiable on Linux
-	String processStatusFile = "/proc/" + pid + "/status";
+        String processStatusFile = "/proc/" + pid + "/status";
         try {
             BufferedReader reader = new BufferedReader(new FileReader(processStatusFile));
             StringBuilder stringBuilder = new StringBuilder();
@@ -84,12 +84,12 @@ public class TestAlwaysPreTouchBehavior {
        rss = EXCEPTION_VALUE;
     }
     if (rss == EXCEPTION_VALUE) {
-	System.out.println("cannot get RSS, just skip");
+        System.out.println("cannot get RSS, just skip");
         return; // Did not get avaiable RSS, just ignore this test
     } else if (rss < base) {
         System.out.println("RSS = " + rss + " smaller than committed heap memory");
     } else {
-	System.out.println("Passed RSS = " + rss + " base value " + base);
+        System.out.println("Passed RSS = " + rss + " base value " + base);
     }
     Asserts.assertTrue(rss >= base, "heap rss should be bigger than committed heap mem");
    }

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -78,19 +78,14 @@ public class TestAlwaysPreTouchBehavior {
     long committedMemory = (runtime.totalMemory()) / 1024; // in kb
     try {
        rss = getProcessRssInKb();
-       System.out.println("RSS = " + rss);
     } catch (Exception e) {
        rss = EXCEPTION_VALUE;
     }
     if (rss == EXCEPTION_VALUE) {
         System.out.println("cannot get RSS, just skip");
         return; // Did not get avaiable RSS, just ignore this test
-    } else if (rss < committedMemory) {
-        System.out.println("RSS = " + rss + " smaller than committed heap memory " + committedMemory);
-    } else {
-        System.out.println("Passed RSS = " + rss + " committed memory " + committedMemory);
     }
-    Asserts.assertTrue(rss >= committedMemory, "heap rss should not be smaller than committed heap mem");
+    Asserts.assertGreaterThanOrEqual(rss, committedMemory, "RSS of this process(" + rss + "kb) should be bigger than or equal to committed heap mem(" + committedMemory + "kb)");
    }
 }
 

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -28,7 +28,8 @@ package gc.parallel;
  * @summary Tests AlwaysPreTouch Bahavior, pages of java heap should be pretouched with AlwaysPreTouch enabled. This test reads RSS of test process, which should be bigger than heap size(1g) with AlwaysPreTouch enabled.
  * @requires vm.gc.Parallel
  * @requires vm.debug != true
- * @requires os.family == "linux" & os.maxMemory > 2G
+ * @requires os.family == "linux"
+ * @requires os.maxMemory > 2G
  * @library /test/lib
  * @run main/othervm -Xmx1g -Xms1g -XX:+UseParallelGC -XX:+AlwaysPreTouch gc.parallel.TestAlwaysPreTouchBehavior
  */

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -51,7 +51,7 @@ import java.io.*;
 public class TestAlwaysPreTouchBehavior {
     public static long getProcessRssInKb() throws IOException {
         String pid = ManagementFactory.getRuntimeMXBean().getName().split("@")[0];
-        // Read RSS from /proc/$pid/status. Only avaiable on Linux
+        // Read RSS from /proc/$pid/status. Only available on Linux.
         String processStatusFile = "/proc/" + pid + "/status";
         BufferedReader reader = new BufferedReader(new FileReader(processStatusFile));
         String line = null;

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -26,7 +26,7 @@ package gc.parallel;
 /**
  * @test TestAlwaysPreTouchBehavior
  * @summary Tests AlwaysPreTouch Bahavior, pages of java heap should be pretouched with AlwaysPreTouch enabled. This test reads RSS of test process, which should be bigger than heap size(1g) with AlwaysPreTouch enabled.
- * @requires os.family == "linux"
+ * @requires vm.gc.Serial & os.family == "linux" & os.maxMemory > 2G
  * @library /test/lib
  * @run main/othervm -Xmx1g -Xms1g -XX:+UseParallelGC -XX:+AlwaysPreTouch gc.parallel.TestAlwaysPreTouchBehavior
  */
@@ -76,7 +76,6 @@ public class TestAlwaysPreTouchBehavior {
     long rss = 0;
     Runtime runtime = Runtime.getRuntime();
     long committedMemory = (runtime.totalMemory()) / 1024; // in kb
-    long base = (long)(committedMemory * 0.9);
     try {
        rss = getProcessRssInKb();
        System.out.println("RSS = " + rss);
@@ -86,12 +85,12 @@ public class TestAlwaysPreTouchBehavior {
     if (rss == EXCEPTION_VALUE) {
         System.out.println("cannot get RSS, just skip");
         return; // Did not get avaiable RSS, just ignore this test
-    } else if (rss < base) {
+    } else if (rss < committedMemory) {
         System.out.println("RSS = " + rss + " smaller than committed heap memory");
     } else {
-        System.out.println("Passed RSS = " + rss + " base value " + base);
+        System.out.println("Passed RSS = " + rss + " committed memory " + committedMemory);
     }
-    Asserts.assertTrue(rss >= base, "heap rss should be bigger than committed heap mem");
+    Asserts.assertTrue(rss >= committedMemory, "heap rss should not be smaller than committed heap mem");
    }
 }
 

--- a/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
+++ b/test/hotspot/jtreg/gc/parallel/TestAlwaysPreTouchBehavior.java
@@ -86,7 +86,7 @@ public class TestAlwaysPreTouchBehavior {
         System.out.println("cannot get RSS, just skip");
         return; // Did not get avaiable RSS, just ignore this test
     } else if (rss < committedMemory) {
-        System.out.println("RSS = " + rss + " smaller than committed heap memory");
+        System.out.println("RSS = " + rss + " smaller than committed heap memory " + committedMemory);
     } else {
         System.out.println("Passed RSS = " + rss + " committed memory " + committedMemory);
     }


### PR DESCRIPTION
AlwaysPreTouch requires all freshly committed pages to be pre-touched. While currently PS GC does not pre-touch heap pages with -XX:+AlwaysPreTouch.
It is related to [JDK-8315923](https://bugs.openjdk.org/browse/JDK-8315923), which fixes the issue when huge pages are used. But the bug still stands if regular page are used. On linux we can reproduce this bug when /sys/kernel/mm/transparent_hugepage/enabled is madvise or never, but cannot reproduce when it is always.

A simple way to reproduce, please make sure large pages are NOT used.
Just run a test with the following parameters
-XX:+AlwaysPreTouch -Xms31g -Xmx31g -XX:+UseParallelGC
There is no pre-touching during heap initialing stage. After initialization, RSS of the test process is much smaller than memory committed.
On the contrary, using -XX:+UseG1GC and run the test again
-XX:+AlwaysPreTouch -Xms31g -Xmx31g -XX:+UseG1GC
it takes several seconds to pre-touch heap pages during initialization, and RSS usage after initialization is similar to memory committed. This is the expected behavior of AlwaysPreTouch

This issue related to [JDK-8283935](https://bugs.openjdk.org/browse/JDK-8283935), which uses alignment() instead of os::vm_page_size() as pre-touching step size. The value of alignment() is usually bigger than OS page size, which causes most heap pages are not pre-touched.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324817](https://bugs.openjdk.org/browse/JDK-8324817): Parallel GC does not pre-touch all heap pages when AlwaysPreTouch enabled and large page disabled (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [df96a217](https://git.openjdk.org/jdk/pull/17610/files/df96a21795f8b185ac506c17cdb8a288f43dda7d)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [6a238ac4](https://git.openjdk.org/jdk/pull/17610/files/6a238ac4954998ae8e1ffcfa3846f185c168a6ed)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17610/head:pull/17610` \
`$ git checkout pull/17610`

Update a local copy of the PR: \
`$ git checkout pull/17610` \
`$ git pull https://git.openjdk.org/jdk.git pull/17610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17610`

View PR using the GUI difftool: \
`$ git pr show -t 17610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17610.diff">https://git.openjdk.org/jdk/pull/17610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17610#issuecomment-1914226844)