### PR TITLE
8324838: test_nmt_locationprinting.cpp broken in the gcc windows build

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -64,6 +64,7 @@ static void test_for_live_c_heap_block(size_t sz, ssize_t offset) {
   FREE_C_HEAP_ARRAY(char, c);
 }
 
+#ifdef LINUX
 static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
   if (!MemTracker::enabled()) {
     return;
@@ -89,6 +90,7 @@ static void test_for_dead_c_heap_block(size_t sz, ssize_t offset) {
   hdr->revive();
   FREE_C_HEAP_ARRAY(char, c);
 }
+#endif
 
 TEST_VM(NMT, location_printing_cheap_live_1) { test_for_live_c_heap_block(2 * K, 0); }              // start of payload
 TEST_VM(NMT, location_printing_cheap_live_2) { test_for_live_c_heap_block(2 * K, -7); }             // into header


### PR DESCRIPTION
test\_nmt\_locationprinting.cpp defines method test\_for\_dead\_c\_heap\_block unconditionally, but this method is only ever used on Linux. In the gcc windows build this fires an unused method warning and breaks the gtest suite. Since this is never used outside of Linux, make this method's definition only appear on Linux to avoid polluting code on other platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324838](https://bugs.openjdk.org/browse/JDK-8324838): test_nmt_locationprinting.cpp broken in the gcc windows build (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17612/head:pull/17612` \
`$ git checkout pull/17612`

Update a local copy of the PR: \
`$ git checkout pull/17612` \
`$ git pull https://git.openjdk.org/jdk.git pull/17612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17612`

View PR using the GUI difftool: \
`$ git pr show -t 17612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17612.diff">https://git.openjdk.org/jdk/pull/17612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17612#issuecomment-1914645709)