### PR TITLE
8324840: windows-x64-slowdebug does not build anymore after JDK-8317572

### DIFF
--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -27,6 +27,8 @@
 
 #include "memory/allStatic.hpp"
 
+#include <string.h>
+
 class StringUtils : AllStatic {
 public:
   // Replace the substring <from> with another string <to>. <to> must be


### PR DESCRIPTION
Hi all,

  after [JDK-8317572](https://bugs.openjdk.org/browse/JDK-8317572) windows-x64-slowdebug does not build any more with teh following error:

 ```
[2024-01-29T12:19:47,671Z] Creating support/native/java.desktop/libjsound/static/jsound.lib from 17 file(s)
[2024-01-29T12:24:59,378Z] ...\open\src\hotspot\share\utilities/stringUtils.hpp(65): error C3861: 'strtok_r': identifier not found
[2024-01-29T12:24:59,378Z] ...\open\src\hotspot\share\utilities/stringUtils.hpp(73): error C3861: 'strtok_r': identifier not found
[2024-01-29T12:24:59,378Z] lib/CompileJvm.gmk:152: recipe for target '.../windows-x64-slowdebug/hotspot/variant-server/libjvm/objs/static/logLevel.obj' failed
[2024-01-29T12:24:59,378Z] make[3]: *** [.../windows-x64-slowdebug/hotspot/variant-server/libjvm/objs/static/logLevel.obj] Error 1
[2024-01-29T12:24:59,378Z] make[3]: *** Waiting for unfinished jobs....
[2024-01-29T12:25:02,568Z] make/Main.gmk:261: recipe for target 'hotspot-server-static-libs' failed
[2024-01-29T12:25:02,568Z] make[2]: *** [hotspot-server-static-libs] Error 2
[2024-01-29T12:25:02,568Z] make[2]: *** Waiting for unfinished jobs....
[2024-01-29T12:25:03,412Z] ...\open\src\hotspot\share\utilities/stringUtils.hpp(65): error C3861: 'strtok_r': identifier not found
[2024-01-29T12:25:03,412Z] ...\open\src\hotspot\share\utilities/stringUtils.hpp(73): error C3861: 'strtok_r': identifier not found
[2024-01-29T12:25:03,412Z] lib/CompileJvm.gmk:152: recipe for target '.../windows-x64-slowdebug/hotspot/variant-server/libjvm/objs/logLevel.obj' failed
[2024-01-29T12:25:03,412Z] make[3]: *** [.../windows-x64-slowdebug/hotspot/variant-server/libjvm/objs/logLevel.obj] Error 1
``` 

This change adds the necessary includes.

Still compiling the change....

Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324840](https://bugs.openjdk.org/browse/JDK-8324840): windows-x64-slowdebug does not build anymore after JDK-8317572 (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17613/head:pull/17613` \
`$ git checkout pull/17613`

Update a local copy of the PR: \
`$ git checkout pull/17613` \
`$ git pull https://git.openjdk.org/jdk.git pull/17613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17613`

View PR using the GUI difftool: \
`$ git pr show -t 17613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17613.diff">https://git.openjdk.org/jdk/pull/17613.diff</a>

</details>
