### PR TITLE
8324845: management.properties text "interface name" is misleading

### DIFF
--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -255,7 +255,7 @@
 # ################ Management agent listen interface #########################
 #
 # com.sun.management.jmxremote.host=<host-name-or-address>
-#      Specifies the address on which the JMX RMI agent will bind.
+#      The local host name or IP address on which the JMX RMI agent will bind.
 #      This is useful when running on machines which have several
 #      interfaces defined. It makes it possible to listen to a specific
 #      subnet accessible through that interface.

--- a/src/jdk.management.agent/share/conf/management.properties
+++ b/src/jdk.management.agent/share/conf/management.properties
@@ -254,8 +254,8 @@
 
 # ################ Management agent listen interface #########################
 #
-# com.sun.management.jmxremote.host=<host-or-interface-name>
-#      Specifies the local interface on which the JMX RMI agent will bind.
+# com.sun.management.jmxremote.host=<host-name-or-address>
+#      Specifies the address on which the JMX RMI agent will bind.
 #      This is useful when running on machines which have several
 #      interfaces defined. It makes it possible to listen to a specific
 #      subnet accessible through that interface.


### PR DESCRIPTION
We have the text "host-or-interface-name" describing the com.sun.management.jmxremote.host property in management.properties, but interface names (like "eth0" or "lo", or "ens3"...) are not what it accepts.  It should just say it needs to be a host name or address.

This change only affects comment text in a properties file.

(We don't currently mention this property in other docs, e.g. in the M&M guide.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324845](https://bugs.openjdk.org/browse/JDK-8324845): management.properties text "interface name" is misleading (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17615/head:pull/17615` \
`$ git checkout pull/17615`

Update a local copy of the PR: \
`$ git checkout pull/17615` \
`$ git pull https://git.openjdk.org/jdk.git pull/17615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17615`

View PR using the GUI difftool: \
`$ git pr show -t 17615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17615.diff">https://git.openjdk.org/jdk/pull/17615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17615#issuecomment-1914892036)