### PR TITLE
8324861: Exceptions::wrap_dynamic_exception() doesn't have ResourceMark

### DIFF
--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -433,6 +433,7 @@ void Exceptions::wrap_dynamic_exception(bool is_indy, JavaThread* THREAD) {
       // Pass through an Error, including BootstrapMethodError, any other form
       // of linkage error, or say OutOfMemoryError
       if (ls != nullptr) {
+        ResourceMark rm(THREAD);
         ls->print_cr("bootstrap method invocation wraps BSME around " PTR_FORMAT, p2i(exception));
         exception->print_on(ls);
       }
@@ -441,6 +442,7 @@ void Exceptions::wrap_dynamic_exception(bool is_indy, JavaThread* THREAD) {
 
     // Otherwise wrap the exception in a BootstrapMethodError
     if (ls != nullptr) {
+      ResourceMark rm(THREAD);
       ls->print_cr("%s throws BSME for " PTR_FORMAT, is_indy ? "invokedynamic" : "dynamic constant", p2i(exception));
       exception->print_on(ls);
     }


### PR DESCRIPTION
The issue is reproduced with 
make -- run-test JTREG_VERBOSE=all JTREG_RETAIN=all  TEST=runtime/ConstantPool/TestMethodHandleConstant.java  TEST_VM_OPTS="-Xlog:all=trace:file=vm.%p.log"

verified that it doesn't crash anymore. Also, run tier1 for sanity testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324861](https://bugs.openjdk.org/browse/JDK-8324861): Exceptions::wrap_dynamic_exception() doesn't have ResourceMark (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17620/head:pull/17620` \
`$ git checkout pull/17620`

Update a local copy of the PR: \
`$ git checkout pull/17620` \
`$ git pull https://git.openjdk.org/jdk.git pull/17620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17620`

View PR using the GUI difftool: \
`$ git pr show -t 17620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17620.diff">https://git.openjdk.org/jdk/pull/17620.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17620#issuecomment-1915339007)