### PR TITLE
8324865: windows-x64-slowdebug still does not build after JDK-8324840

### DIFF
--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -25,7 +25,6 @@
 #include "precompiled.hpp"
 #include "jvm_io.h"
 #include "memory/allocation.hpp"
-#include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/stringUtils.hpp"
 
@@ -125,21 +124,8 @@ bool StringUtils::is_star_match(const char* star_pattern, const char* str) {
   return true; // all parts of pattern matched
 }
 
-StringUtils::CommaSeparatedStringIterator::CommaSeparatedStringIterator(ccstrlist option) {
-  // Immediately make a private copy of option, and
-  // replace spaces and newlines with comma.
-  _list = (char*) canonicalize(option);
-  _saved_ptr = _list;
-  _token = strtok_r(_saved_ptr, ",", &_saved_ptr);
-}
-
 StringUtils::CommaSeparatedStringIterator::~CommaSeparatedStringIterator() {
   FREE_C_HEAP_ARRAY(char, _list);
-}
-
-StringUtils::CommaSeparatedStringIterator& StringUtils::CommaSeparatedStringIterator::operator++() {
-  _token = strtok_r(nullptr, ",", &_saved_ptr);
-  return *this;
 }
 
 ccstrlist StringUtils::CommaSeparatedStringIterator::canonicalize(ccstrlist option_value) {

--- a/src/hotspot/share/utilities/stringUtils.cpp
+++ b/src/hotspot/share/utilities/stringUtils.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "jvm_io.h"
 #include "memory/allocation.hpp"
+#include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/stringUtils.hpp"
 
@@ -124,8 +125,21 @@ bool StringUtils::is_star_match(const char* star_pattern, const char* str) {
   return true; // all parts of pattern matched
 }
 
+StringUtils::CommaSeparatedStringIterator::CommaSeparatedStringIterator(ccstrlist option) {
+  // Immediately make a private copy of option, and
+  // replace spaces and newlines with comma.
+  _list = (char*) canonicalize(option);
+  _saved_ptr = _list;
+  _token = strtok_r(_saved_ptr, ",", &_saved_ptr);
+}
+
 StringUtils::CommaSeparatedStringIterator::~CommaSeparatedStringIterator() {
   FREE_C_HEAP_ARRAY(char, _list);
+}
+
+StringUtils::CommaSeparatedStringIterator& StringUtils::CommaSeparatedStringIterator::operator++() {
+  _token = strtok_r(nullptr, ",", &_saved_ptr);
+  return *this;
 }
 
 ccstrlist StringUtils::CommaSeparatedStringIterator::canonicalize(ccstrlist option_value) {

--- a/src/hotspot/share/utilities/stringUtils.hpp
+++ b/src/hotspot/share/utilities/stringUtils.hpp
@@ -27,8 +27,6 @@
 
 #include "memory/allStatic.hpp"
 
-#include <string.h>
-
 class StringUtils : AllStatic {
 public:
   // Replace the substring <from> with another string <to>. <to> must be
@@ -59,22 +57,13 @@ public:
     char* _list;
 
   public:
-    CommaSeparatedStringIterator(ccstrlist option) {
-      // Immediately make a private copy of option, and
-      // replace spaces and newlines with comma.
-      _list = (char*) canonicalize(option);
-      _saved_ptr = _list;
-      _token = strtok_r(_saved_ptr, ",", &_saved_ptr);
-    }
+    CommaSeparatedStringIterator(ccstrlist option);
 
     ~CommaSeparatedStringIterator();
 
     const char* operator*() const { return _token; }
 
-    CommaSeparatedStringIterator& operator++() {
-      _token = strtok_r(nullptr, ",", &_saved_ptr);
-      return *this;
-    }
+    CommaSeparatedStringIterator& operator++();
 
     ccstrlist canonicalize(ccstrlist option_value);
   };


### PR DESCRIPTION
[~jwaters] commented in the PR [#17613](https://github.com/openjdk/jdk/pull/17613) that on windows we have strtok_s instead of strtok_r. We may need to #include "runtime/os.hpp" which defined strtok_r for windows instead of <string.hpp>. 

Including os.hpp will increase compilation time for all files which inclide "stringUtils.hpp".
I suggest to move code from .hpp to .cpp file. It is used only by c2 and inlining of this code is not too important.

Tested tier1 and tier2 builds with precompiled headers off.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324865](https://bugs.openjdk.org/browse/JDK-8324865): windows-x64-slowdebug still does not build after JDK-8324840 (**Bug** - P2)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17622/head:pull/17622` \
`$ git checkout pull/17622`

Update a local copy of the PR: \
`$ git checkout pull/17622` \
`$ git pull https://git.openjdk.org/jdk.git pull/17622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17622`

View PR using the GUI difftool: \
`$ git pr show -t 17622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17622.diff">https://git.openjdk.org/jdk/pull/17622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17622#issuecomment-1915703607)