### PR TITLE
JDK-8324930: java/lang/StringBuilder problem with concurrent jtreg runs

### DIFF
--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -55,7 +55,8 @@ exclusiveAccess.dirs=java/math/BigInteger/largeMemory \
 java/rmi/Naming java/util/prefs sun/management/jmxremote \
 sun/tools/jstatd sun/security/mscapi java/util/Arrays/largeMemory \
 java/util/BitSet/stream javax/rmi java/net/httpclient/websocket \
-com/sun/net/httpserver/simpleserver sun/tools/jhsdb
+com/sun/net/httpserver/simpleserver sun/tools/jhsdb \
+java/lang/StringBuilder
 
 # Group definitions
 groups=TEST.groups


### PR DESCRIPTION
On some Windows machines we see sometimes OOM errors because of high resource (memory/swap) consumption. This is especially seen when the jtreg runs have higher concurrency. A solution is to put the java/lang/StringBuilder tests in the exclusiveAccess.dirs group so that they are not executed concurrently, which helps to mitigate the resource shortages.
Of course this has the downside that on very large machines the concurrent execution is not done any more.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324930](https://bugs.openjdk.org/browse/JDK-8324930): java/lang/StringBuilder problem with concurrent jtreg runs (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17625/head:pull/17625` \
`$ git checkout pull/17625`

Update a local copy of the PR: \
`$ git checkout pull/17625` \
`$ git pull https://git.openjdk.org/jdk.git pull/17625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17625`

View PR using the GUI difftool: \
`$ git pr show -t 17625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17625.diff">https://git.openjdk.org/jdk/pull/17625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17625#issuecomment-1916386498)