### PR TITLE
8324937: GHA: Avoid multiple test suites per job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,11 +90,15 @@ jobs:
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 compiler part 2'
-            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2 test/hotspot/jtreg/:tier1_compiler_not_xcomp'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_2'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 compiler part 3'
             test-suite: 'test/hotspot/jtreg/:tier1_compiler_3'
+            debug-suffix: -debug
+
+          - test-name: 'hs/tier1 compiler not-xcomp'
+            test-suite: 'test/hotspot/jtreg/:tier1_compiler_not_xcomp'
             debug-suffix: -debug
 
           - test-name: 'hs/tier1 gc'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,7 @@ jobs:
           - 'hs/tier1 compiler part 1'
           - 'hs/tier1 compiler part 2'
           - 'hs/tier1 compiler part 3'
+          - 'hs/tier1 compiler not-xcomp'
           - 'hs/tier1 gc'
           - 'hs/tier1 runtime'
           - 'hs/tier1 serviceability'

--- a/test/hotspot/jtreg/compiler/codegen/TestIntDoubleVect.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestIntDoubleVect.java
@@ -83,7 +83,6 @@ public class TestIntDoubleVect {
       System.exit(97);
     }
     System.out.println("PASSED");
-    System.exit(1);
   }
 
   static int test() {

--- a/test/hotspot/jtreg/compiler/codegen/TestIntDoubleVect.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestIntDoubleVect.java
@@ -83,6 +83,7 @@ public class TestIntDoubleVect {
       System.exit(97);
     }
     System.out.println("PASSED");
+    System.exit(1);
   }
 
   static int test() {


### PR DESCRIPTION
See the description in the bug. This mitigates the issue by splitting out the only test job that has two test suites in it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324937](https://bugs.openjdk.org/browse/JDK-8324937): GHA: Avoid multiple test suites per job (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17627/head:pull/17627` \
`$ git checkout pull/17627`

Update a local copy of the PR: \
`$ git checkout pull/17627` \
`$ git pull https://git.openjdk.org/jdk.git pull/17627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17627`

View PR using the GUI difftool: \
`$ git pr show -t 17627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17627.diff">https://git.openjdk.org/jdk/pull/17627.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17627#issuecomment-1917476818)