### PR TITLE
8324933: ConcurrentHashTable::statistics_calculate synchronization is expensive

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1227,13 +1227,10 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   size_t literal_bytes = 0;
   InternalTable* table = get_table();
   size_t num_batches = table->_size / batch_size;
-  for (size_t start_batch = 0; start_batch < _table->_size; start_batch += batch_size) {
-    size_t batch_end = MIN2(start_batch + batch_size, _table->_size);
-    }
+  for (size_t batch_start = 0; batch_start < _table->_size; batch_start += batch_size) {
+    size_t batch_end = MIN2(batch_start + batch_size, _table->_size);
     ScopedCS cs(thread, this);
-    for (size_t bucket_it = batch_start;
-         bucket_it < batch_end;
-         bucket_it++) {
+    for (size_t bucket_it = batch_start; bucket_it < batch_end; bucket_it++) {
       size_t count = 0;
       Bucket* bucket = table->get_bucket(bucket_it);
       if (bucket->have_redirect() || bucket->is_locked()) {

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1227,15 +1227,8 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   size_t literal_bytes = 0;
   InternalTable* table = get_table();
   size_t num_batches = table->_size / batch_size;
-  for (size_t current_batch = 0; current_batch <= num_batches; current_batch++) {
-    size_t batch_start = current_batch * batch_size;
-    size_t batch_end;
-    if (current_batch == num_batches) {
-      // Last batch; walk over the remaining part of the table
-      batch_end = batch_start + table->_size % batch_size;
-    } else {
-      // Not last batch; walk over the current batch
-      batch_end = batch_start + batch_size;
+  for (size_t start_batch = 0; start_batch < _table->_size; start_batch += batch_size) {
+    size_t batch_end = MIN2(start_batch + batch_size, _table->_size);
     }
     ScopedCS cs(thread, this);
     for (size_t bucket_it = batch_start;

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1228,6 +1228,8 @@ inline TableStatistics ConcurrentHashTable<CONFIG, F>::
   InternalTable* table = get_table();
   size_t num_batches = table->_size / batch_size;
   for (size_t batch_start = 0; batch_start < _table->_size; batch_start += batch_size) {
+    // We batch the use of ScopedCS here as it has been found to be quite expensive to
+    // invoke it for every single bucket.
     size_t batch_end = MIN2(batch_start + batch_size, _table->_size);
     ScopedCS cs(thread, this);
     for (size_t bucket_it = batch_start; bucket_it < batch_end; bucket_it++) {


### PR DESCRIPTION
In the ConcurrentHashTable::statistics_calculate function, we enter and exit a ScopedCS with the global counter for every single bucket. This has showed up to be pretty intense on some machines. We should make the synchronization a bit less intense here. This patch adds simple batching so we synchronize once per 128 buckets instead of every single one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324933](https://bugs.openjdk.org/browse/JDK-8324933): ConcurrentHashTable::statistics_calculate synchronization is expensive (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [3b26cf9c](https://git.openjdk.org/jdk/pull/17629/files/3b26cf9c95de14c3e4b90162e32801a823244f76)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [3b26cf9c](https://git.openjdk.org/jdk/pull/17629/files/3b26cf9c95de14c3e4b90162e32801a823244f76)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17629/head:pull/17629` \
`$ git checkout pull/17629`

Update a local copy of the PR: \
`$ git checkout pull/17629` \
`$ git pull https://git.openjdk.org/jdk.git pull/17629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17629`

View PR using the GUI difftool: \
`$ git pr show -t 17629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17629.diff">https://git.openjdk.org/jdk/pull/17629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17629#issuecomment-1916583216)