### PR TITLE
8324893: Rename JVMDITools.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMDITools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMDITools.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include "jvmdi.h"
-#include "JVMDITools.h"
+#include "JVMDITools.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/JVMDITools.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/JVMDITools.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/README
@@ -1,4 +1,4 @@
-Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -58,9 +58,9 @@ Short description of files:
     tree structures support:
         Denotation.java, TreeNodesDenotation.java
     RAS mode support:
-        RASagent.java, JVMTIagent.c
+        RASagent.java, JVMTIagent.cpp
     JVMDI tests support:
-        JVMDITools.h, JVMDITools.c
+        JVMDITools.hpp, JVMDITools.cpp
 
 Short description of subdirectories:
 


### PR DESCRIPTION
8324893: Rename JVMDITools.h

Please review this trivial change that renames the file
test/hotspot/jtreg/vmTestbase/nsk/share/JVMDITools.h to JVMDITools.hpp.  There
are no uses of NULL in this file to be fixed.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324893](https://bugs.openjdk.org/browse/JDK-8324893): Rename JVMDITools.h (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17636/head:pull/17636` \
`$ git checkout pull/17636`

Update a local copy of the PR: \
`$ git checkout pull/17636` \
`$ git pull https://git.openjdk.org/jdk.git pull/17636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17636`

View PR using the GUI difftool: \
`$ git pr show -t 17636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17636.diff">https://git.openjdk.org/jdk/pull/17636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17636#issuecomment-1917717741)