### PR TITLE
8324832: JFR: Improve sorting of 'jfr summary'

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Summary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -144,6 +144,7 @@ final class Summary extends Command {
             println(" Start: " + DATE_FORMAT.format(Instant.ofEpochSecond(epochSeconds, adjustNanos)) + " (UTC)");
             println(" Duration: " + (totalDuration + 500_000_000) / 1_000_000_000 + " s");
             List<Statistics> statsList = new ArrayList<>(stats.values());
+            statsList.sort((u, v) -> u.name.compareTo(v.name));
             statsList.sort((u, v) -> Long.compare(v.count, u.count));
             println();
             String header = "      Count  Size (bytes) ";


### PR DESCRIPTION
Could I have a review of a change that improves the sorting for the summary command. 

Testing: /test/jdk/jdk/jfr/tool

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324832](https://bugs.openjdk.org/browse/JDK-8324832): JFR: Improve sorting of 'jfr summary' (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17637/head:pull/17637` \
`$ git checkout pull/17637`

Update a local copy of the PR: \
`$ git checkout pull/17637` \
`$ git pull https://git.openjdk.org/jdk.git pull/17637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17637`

View PR using the GUI difftool: \
`$ git pr show -t 17637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17637.diff">https://git.openjdk.org/jdk/pull/17637.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17637#issuecomment-1917716440)