### PR TITLE
8324998: Add test cases for String.regionMatches comparing Turkic dotted/dotless I with uppercase latin I

### DIFF
--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/String/CompactString/RegionMatches.java
+++ b/test/jdk/java/lang/String/CompactString/RegionMatches.java
@@ -96,9 +96,13 @@ public class RegionMatches extends CompactString {
                 // Turkish I with dot
                 new Object[] { "\u0130", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0130", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0130", false, 0, "I", 0, 1, false },
+                new Object[] { "\u0130", true,  0, "I", 0, 1, true },
                 // i without dot
                 new Object[] { "\u0131", false, 0, "i", 0, 1, false },
                 new Object[] { "\u0131", true,  0, "i", 0, 1, true },
+                new Object[] { "\u0131", false, 0, "I", 0, 1, false },
+                new Object[] { "\u0131", true,  0, "I", 0, 1, true },
                 // Exhaustive list of 1-char latin1 strings that match
                 // case-insensitively:
                 // for (char c1 = 0; c1 < 255; c1++) {


### PR DESCRIPTION
Please review this test-only PR which improves test coverage of `String.regionMatches` when comparing the Turkic "dotted I" and "dotless i" characters with their latin cousins. 

The test `CompactStrings/RegionMatches.java` currently includes cases comparing these characters against the lowercase latin "i" character, but not against the corresponding uppercase latin "I" character. It would be good to add test cases for the uppercase I as well.

This was originally found in #12637, which was closed without being integrated. I think this test coverage enhancement is worth rescuing from that PR, where it did prove to catch a regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324998](https://bugs.openjdk.org/browse/JDK-8324998): Add test cases for String.regionMatches comparing Turkic dotted/dotless I with uppercase latin I (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17639/head:pull/17639` \
`$ git checkout pull/17639`

Update a local copy of the PR: \
`$ git checkout pull/17639` \
`$ git pull https://git.openjdk.org/jdk.git pull/17639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17639`

View PR using the GUI difftool: \
`$ git pr show -t 17639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17639.diff">https://git.openjdk.org/jdk/pull/17639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17639#issuecomment-1917804270)