### PR TITLE
8320342: Use PassFailJFrame for TruncatedPopupMenuTest.java

### DIFF
--- a/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
+++ b/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
@@ -60,7 +60,6 @@ public class TruncatedPopupMenuTest {
                       .testUI(TruncatedPopupMenuTest::createTestUI)
                       .build()
                       .awaitAndCheck();
-
     }
 
     private static Frame createTestUI() {

--- a/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
+++ b/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/* @test
+ * @bug 5090643
+ * @key headful
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Menus added to the popup menu are truncated on XToolkit
+ * @run main/manual TruncatedPopupMenuTest
+ */
+
+public class TruncatedPopupMenuTest {
+    private static final String INSTRUCTIONS =
+            "1. Right-click on the Test Window.\n\n" +
+            "2. Look at the appeared popup menu.\n\n" +
+            "3. It should consist of one menu item (\"First simple menu item\")\n" +
+            "and one submenu (\"Just simple menu for the test\").\n\n" +
+            "4. The submenu should not be truncated. The submenu title text should\n" +
+            "be followed by a triangle. On the whole, menu should be good-looking.\n\n" +
+            "5. Left-click on the submenu (\"Just simple menu for the test\").\n" +
+            "After this operation, a submenu should popup. It should consist of\n"+
+            "one menu item (\"Second simple menu item \") and one submenu (\"Other Menu\").\n\n" +
+            "6. The submenu should not be truncated. The \"Other Menu\" text should be followed by\n" +
+            "a triangle.\n\n" +
+            "On the whole, menu should be good-looking.\n";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(20)
+                      .columns(55)
+                      .testUI(TruncatedPopupMenuTest::createTestUI)
+                      .build()
+                      .awaitAndCheck();
+
+    }
+
+    private static Frame createTestUI() {
+        Menu subMenu = new Menu("Just simple menu for the test");
+        subMenu.add(new MenuItem("Second simple menu item"));
+        subMenu.add(new Menu("Other Menu"));
+
+        PopupMenu popup = new PopupMenu();
+        popup.add(new MenuItem("First simple menu item"));
+        popup.add(subMenu);
+
+        Frame testUI = new Frame("TruncatedPopupMenuTest");
+        testUI.add(popup);
+        testUI.addMouseListener(new MouseAdapter() {
+            public void mousePressed(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    popup.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+            public void mouseReleased(MouseEvent me) {
+                if (me.isPopupTrigger()) {
+                    popup.show(me.getComponent(), me.getX(), me.getY());
+                }
+            }
+        });
+
+        testUI.setSize(400, 400);
+        return testUI;
+   }
+}

--- a/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
+++ b/test/jdk/java/awt/PopupMenu/TruncatedPopupMenuTest.java
@@ -28,7 +28,8 @@ import java.awt.PopupMenu;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
-/* @test
+/*
+ * @test
  * @bug 5090643
  * @key headful
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
Modified the test to use PassFailJFrame and open sourced it.
The test shows two windows, one for instructions and the other to perform testing on.
Tested locally and it works fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320342](https://bugs.openjdk.org/browse/JDK-8320342): Use PassFailJFrame for TruncatedPopupMenuTest.java (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - Committer) ⚠️ Review applies to [6c021d98](https://git.openjdk.org/jdk/pull/17641/files/6c021d984cf4423a4d6a3f0a69b38c3a7befe3be)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17641/head:pull/17641` \
`$ git checkout pull/17641`

Update a local copy of the PR: \
`$ git checkout pull/17641` \
`$ git pull https://git.openjdk.org/jdk.git pull/17641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17641`

View PR using the GUI difftool: \
`$ git pr show -t 17641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17641.diff">https://git.openjdk.org/jdk/pull/17641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17641#issuecomment-1917998103)