### PR TITLE
JDK-8325004: Support a "table-of-contents" for some Markdown spec docs

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -635,6 +635,10 @@ $(foreach m, $(ALL_MODULES), \
   ) \
 )
 
+# Customization for specific files
+
+jdk.javadoc_doc-comment-spec.md_TOC := --toc
+
 ifeq ($(ENABLE_PANDOC), true)
   # For all markdown files in $module/share/specs directories, convert them to
   # html, if we have pandoc (otherwise we'll just skip this).
@@ -655,7 +659,7 @@ ifeq ($(ENABLE_PANDOC), true)
             FILES := $f, \
             DEST := $(DOCS_OUTPUTDIR)/specs/, \
             CSS := $(GLOBAL_SPECS_DEFAULT_CSS_FILE), \
-            OPTIONS := -V include-before='$(SPECS_TOP)' -V include-after='$(SPECS_BOTTOM_$($m_$f_NOF_SUBDIRS))', \
+            OPTIONS := $($m_$(notdir $f)_TOC) -V include-before='$(SPECS_TOP)' -V include-after='$(SPECS_BOTTOM_$($m_$f_NOF_SUBDIRS))', \
             REPLACEMENTS := \
 		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION) ; \
 		@@VERSION_STRING@@ => $(VERSION_STRING), \


### PR DESCRIPTION
Please review a small change, at least as a "proof of concept", to allow customized options to be given to `pandoc` based on the module and filename for a spec.

The goal is to allow a Markdown spec file to have an auto-generated table-of-contents, by including the `--toc` option when running pandoc for specific documents.

There may be better ways to achieve this goal; while I have a working knowledge of this makefile, I'm not an expert. In particular, I tried to find a way to defer the evaluation of the option, so that the declaration of the value did not have to appear before its use in the macros.  But I could only get it to work as presented here.

No other support for a TOC is needed, since we already generate TOCs for other pages, like tool guides (man pages.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325004](https://bugs.openjdk.org/browse/JDK-8325004): Support a "table-of-contents" for some Markdown spec docs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17642/head:pull/17642` \
`$ git checkout pull/17642`

Update a local copy of the PR: \
`$ git checkout pull/17642` \
`$ git pull https://git.openjdk.org/jdk.git pull/17642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17642`

View PR using the GUI difftool: \
`$ git pr show -t 17642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17642.diff">https://git.openjdk.org/jdk/pull/17642.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17642#issuecomment-1918168179)