### PR TITLE
8325024: java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java incorrect comment information

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -188,7 +188,7 @@ public class OCSPTimeout {
         rootOcsp.setDisableContentLength(true);
         rootOcsp.start();
 
-        // Wait 5 seconds for server ready
+        // Wait 60 seconds for server ready
         boolean readyStatus = rootOcsp.awaitServerReady(60, TimeUnit.SECONDS);
         if (!readyStatus) {
             throw new RuntimeException("Server not ready");


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325024](https://bugs.openjdk.org/browse/JDK-8325024): java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java incorrect comment information (**Bug** - P5)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17646/head:pull/17646` \
`$ git checkout pull/17646`

Update a local copy of the PR: \
`$ git checkout pull/17646` \
`$ git pull https://git.openjdk.org/jdk.git pull/17646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17646`

View PR using the GUI difftool: \
`$ git pr show -t 17646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17646.diff">https://git.openjdk.org/jdk/pull/17646.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17646#issuecomment-1918615608)