### PR TITLE
8324972: (bf) Make DirectByteBuffer.Deallocator idempotent

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -79,8 +79,8 @@ class Direct$Type$Buffer$RW$$BO$
 
     private static final class Deallocator implements Runnable {
 
-        private static final long INVOKED_OFFSET = Unsafe.getUnsafe()
-                .objectFieldOffset(Deallocator.class, "invoked");
+        private static final long INVOKED_OFFSET =
+                UNSAFE.objectFieldOffset(Deallocator.class, "invoked");
 
         private final long address;
         private final long size;
@@ -96,7 +96,7 @@ class Direct$Type$Buffer$RW$$BO$
 
         public void run() {
             // Ensure idempotency (paranoia)
-            if (Unsafe.getUnsafe().compareAndSetInt(this, INVOKED_OFFSET, 0, 1)) {
+            if (UNSAFE.compareAndSetInt(this, INVOKED_OFFSET, 0, 1)) {
                 UNSAFE.freeMemory(address);
                 Bits.unreserveMemory(size, capacity);
             }

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -31,9 +31,10 @@ import java.io.FileDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
+import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
 import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
@@ -78,25 +79,24 @@ class Direct$Type$Buffer$RW$$BO$
 
     private static final class Deallocator implements Runnable {
 
-        private static final AtomicIntegerFieldUpdater<Deallocator> UPDATER =
-                AtomicIntegerFieldUpdater.newUpdater(Deallocator.class, "invoked");
+        private static final long INVOKED_OFFSET = Unsafe.getUnsafe()
+                .objectFieldOffset(Deallocator.class, "invoked");
 
         private final long address;
         private final long size;
         private final int capacity;
-        private volatile int invoked;
+        private int invoked;
 
         private Deallocator(long address, long size, int capacity) {
             assert address != 0;
             this.address = address;
             this.size = size;
             this.capacity = capacity;
-            this.invoked = 0;
         }
 
         public void run() {
             // Ensure idempotency (paranoia)
-            if (UPDATER.compareAndSet(this, 0, 1)) {
+            if (Unsafe.getUnsafe().compareAndSetInt(this, INVOKED_OFFSET, 0, 1)) {
                 UNSAFE.freeMemory(address);
                 Bits.unreserveMemory(size, capacity);
             }

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.FileDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
@@ -75,14 +76,18 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[byte]
 
-    private record Deallocator(long address, long size, int capacity) implements Runnable {
+    private record Deallocator(long address, long size, int capacity, AtomicBoolean invoked) implements Runnable {
+
         private Deallocator {
             assert address != 0;
         }
 
         public void run() {
-            UNSAFE.freeMemory(address);
-            Bits.unreserveMemory(size, capacity);
+            // Ensure idempotency (paranoia)
+            if (invoked.compareAndSet(false, true)) {
+                UNSAFE.freeMemory(address);
+                Bits.unreserveMemory(size, capacity);
+            }
         }
     }
 
@@ -125,7 +130,7 @@ class Direct$Type$Buffer$RW$$BO$
             address = base;
         }
         try {
-            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap, new AtomicBoolean()));
         } catch (Throwable t) {
             // Prevent leak if the Deallocator or Cleaner fail for any reason
             UNSAFE.freeMemory(base);

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -31,7 +31,7 @@ import java.io.FileDescriptor;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import jdk.internal.foreign.MemorySessionImpl;
 import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
@@ -76,19 +76,32 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[byte]
 
-    private record Deallocator(long address, long size, int capacity, AtomicBoolean invoked) implements Runnable {
+    private static final class Deallocator implements Runnable {
 
-        private Deallocator {
+        private static final AtomicIntegerFieldUpdater<Deallocator> UPDATER =
+                AtomicIntegerFieldUpdater.newUpdater(Deallocator.class, "invoked");
+
+        private final long address;
+        private final long size;
+        private final int capacity;
+        private volatile int invoked;
+
+        private Deallocator(long address, long size, int capacity) {
             assert address != 0;
+            this.address = address;
+            this.size = size;
+            this.capacity = capacity;
+            this.invoked = 0;
         }
 
         public void run() {
             // Ensure idempotency (paranoia)
-            if (invoked.compareAndSet(false, true)) {
+            if (UPDATER.compareAndSet(this, 0, 1)) {
                 UNSAFE.freeMemory(address);
                 Bits.unreserveMemory(size, capacity);
             }
         }
+
     }
 
     private final Cleaner cleaner;
@@ -130,7 +143,7 @@ class Direct$Type$Buffer$RW$$BO$
             address = base;
         }
         try {
-            cleaner = Cleaner.create(this, new Deallocator(base, size, cap, new AtomicBoolean()));
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
         } catch (Throwable t) {
             // Prevent leak if the Deallocator or Cleaner fail for any reason
             UNSAFE.freeMemory(base);

--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -47,7 +47,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.WritableByteChannel;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;


### PR DESCRIPTION
This PR proposes to make deallocators and unmappers for memory regions idempotent. This is to prevent (likely very rare) duplicate invocations. 

There are no unit tests but it should be noted that the idempotent behavior (now correct) is similar to the  intended behavior before cf74b8c2a32f33019a13ce80b6667da502cc6722 but where idempotency was not guaranteed in a multi-threaded environment.

Passes tier1, 2, and 3 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324972](https://bugs.openjdk.org/browse/JDK-8324972): (bf) Make DirectByteBuffer.Deallocator idempotent (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17647/head:pull/17647` \
`$ git checkout pull/17647`

Update a local copy of the PR: \
`$ git checkout pull/17647` \
`$ git pull https://git.openjdk.org/jdk.git pull/17647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17647`

View PR using the GUI difftool: \
`$ git pr show -t 17647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17647.diff">https://git.openjdk.org/jdk/pull/17647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17647#issuecomment-1918643127)