### PR TITLE
JDK-8325037: x86: enable and fix hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java
@@ -44,13 +44,12 @@ public class TestRoundVectFloat {
 
   public static void main(String args[]) {
       TestFramework.runWithFlags("-XX:-TieredCompilation",
-                                 "-XX:UseAVX=1",
                                  "-XX:CompileThresholdScaling=0.3");
       System.out.println("PASSED");
   }
 
   @Test
-  @IR(applyIf = {"UseAVX", " > 1"}, counts = {"RoundVF" , " > 0 "})
+  @IR(applyIf = {"UseAVX", " > 1"}, counts = {IRNode.ROUND_VF , " > 0 "})
   public void test_round_float(int[] iout, float[] finp) {
       for (int i = 0; i < finp.length; i+=1) {
           iout[i] = Math.round(finp[i]);


### PR DESCRIPTION
Hi,
Can you help to review this simple patch to fix test TestRoundVectFloat.java?
Thanks!

FYI: This test is not actually tested, need to fix the test applying filter and IR matching rule.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325037](https://bugs.openjdk.org/browse/JDK-8325037): x86: enable and fix hotspot/jtreg/compiler/vectorization/TestRoundVectFloat.java (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17649/head:pull/17649` \
`$ git checkout pull/17649`

Update a local copy of the PR: \
`$ git checkout pull/17649` \
`$ git pull https://git.openjdk.org/jdk.git pull/17649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17649`

View PR using the GUI difftool: \
`$ git pr show -t 17649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17649.diff">https://git.openjdk.org/jdk/pull/17649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17649#issuecomment-1918796885)