### PR TITLE
8323746: Add PathElement hashCode and equals

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jdk.internal.foreign.LayoutPath;
-import jdk.internal.foreign.LayoutPath.PathElementImpl.PathKind;
 import jdk.internal.foreign.Utils;
 import jdk.internal.foreign.layout.MemoryLayoutUtil;
 import jdk.internal.foreign.layout.PaddingLayoutImpl;
@@ -847,7 +846,13 @@ public sealed interface MemoryLayout
      *
      * @since 22
      */
-    sealed interface PathElement permits LayoutPath.PathElementImpl {
+    sealed interface PathElement
+            permits LayoutPath.DereferenceElement,
+            LayoutPath.GroupElementByIndex,
+            LayoutPath.GroupElementByName,
+            LayoutPath.SequenceElement,
+            LayoutPath.SequenceElementByIndex,
+            LayoutPath.SequenceElementByRange {
 
         /**
          * {@return a path element which selects a member layout with the given name in a
@@ -862,10 +867,7 @@ public sealed interface MemoryLayout
          * @param name the name of the member layout to be selected
          */
         static PathElement groupElement(String name) {
-            Objects.requireNonNull(name);
-            return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
-                                                  path -> path.groupElement(name),
-                                                  "groupElement(\"" + name + "\")");
+            return new LayoutPath.GroupElementByName(name);
         }
 
         /**
@@ -876,12 +878,7 @@ public sealed interface MemoryLayout
          * @throws IllegalArgumentException if {@code index < 0}
          */
         static PathElement groupElement(long index) {
-            if (index < 0) {
-                throw new IllegalArgumentException("Index < 0");
-            }
-            return new LayoutPath.PathElementImpl(PathKind.GROUP_ELEMENT,
-                                                  path -> path.groupElement(index),
-                                                  "groupElement(" + index + ")");
+            return new LayoutPath.GroupElementByIndex(index);
         }
 
         /**
@@ -892,12 +889,7 @@ public sealed interface MemoryLayout
          * @throws IllegalArgumentException if {@code index < 0}
          */
         static PathElement sequenceElement(long index) {
-            if (index < 0) {
-                throw new IllegalArgumentException("Index must be positive: " + index);
-            }
-            return new LayoutPath.PathElementImpl(PathKind.SEQUENCE_ELEMENT_INDEX,
-                                                  path -> path.sequenceElement(index),
-                                                  "sequenceElement(" + index + ")");
+            return new LayoutPath.SequenceElementByIndex(index);
         }
 
         /**
@@ -923,15 +915,7 @@ public sealed interface MemoryLayout
          * @throws IllegalArgumentException if {@code start < 0}, or {@code step == 0}
          */
         static PathElement sequenceElement(long start, long step) {
-            if (start < 0) {
-                throw new IllegalArgumentException("Start index must be positive: " + start);
-            }
-            if (step == 0) {
-                throw new IllegalArgumentException("Step must be != 0: " + step);
-            }
-            return new LayoutPath.PathElementImpl(PathKind.SEQUENCE_RANGE,
-                                                  path -> path.sequenceElement(start, step),
-                                                  "sequenceElement(" + start + ", " + step + ")");
+            return new LayoutPath.SequenceElementByRange(start, step);
         }
 
         /**
@@ -943,9 +927,7 @@ public sealed interface MemoryLayout
          * {@code 0 <= I < C}.
          */
         static PathElement sequenceElement() {
-            return new LayoutPath.PathElementImpl(PathKind.SEQUENCE_ELEMENT,
-                                                  LayoutPath::sequenceElement,
-                                                  "sequenceElement()");
+            return LayoutPath.SequenceElement.instance();
         }
 
         /**
@@ -953,9 +935,7 @@ public sealed interface MemoryLayout
          * {@linkplain AddressLayout#targetLayout() target layout} (where set)}
          */
         static PathElement dereferenceElement() {
-            return new LayoutPath.PathElementImpl(PathKind.DEREF_ELEMENT,
-                                                  LayoutPath::derefElement,
-                                                  "dereferenceElement()");
+            return LayoutPath.DereferenceElement.instance();
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ *  Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -363,54 +363,144 @@ public class LayoutPath {
                 .collect(joining(", selected from: "));
     }
 
-    /**
-     * This class provides an immutable implementation for the {@code PathElement} interface. A path element implementation
-     * is simply a pointer to one of the selector methods provided by the {@code LayoutPath} class.
-     */
-    public static final class PathElementImpl implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+    public record GroupElementByName(String name)
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
 
-        public enum PathKind {
-            SEQUENCE_ELEMENT("unbound sequence element"),
-            SEQUENCE_ELEMENT_INDEX("bound sequence element"),
-            SEQUENCE_RANGE("sequence range"),
-            GROUP_ELEMENT("group element"),
-            DEREF_ELEMENT("dereference element");
-
-            final String description;
-
-            PathKind(String description) {
-                this.description = description;
-            }
-
-            public String description() {
-                return description;
-            }
-        }
-
-        final PathKind kind;
-        final UnaryOperator<LayoutPath> pathOp;
-        final String stringRepresentation;
-
-        public PathElementImpl(PathKind kind,
-                               UnaryOperator<LayoutPath> pathOp,
-                               String stringRepresentation) {
-            this.kind = kind;
-            this.pathOp = pathOp;
-            this.stringRepresentation = stringRepresentation;
+        // Assert invariants
+        public GroupElementByName {
+            Objects.requireNonNull(name);
         }
 
         @Override
         public LayoutPath apply(LayoutPath layoutPath) {
-            return pathOp.apply(layoutPath);
-        }
-
-        public PathKind kind() {
-            return kind;
+            return layoutPath.groupElement(name);
         }
 
         @Override
         public String toString() {
-            return stringRepresentation;
+            return "groupElement(\"" + name + "\")";
         }
     }
+
+    public record GroupElementByIndex(long index)
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+
+        // Assert invariants
+        public GroupElementByIndex {
+            if (index < 0) {
+                throw new IllegalArgumentException("Index < 0");
+            }
+        }
+
+        @Override
+        public LayoutPath apply(LayoutPath layoutPath) {
+            return layoutPath.groupElement(index);
+        }
+
+        @Override
+        public String toString() {
+            return "groupElement(" + index + ")";
+        }
+
+    }
+
+    public record SequenceElementByIndex(long index)
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+
+        // Assert invariants
+        public SequenceElementByIndex {
+            if (index < 0) {
+                throw new IllegalArgumentException("Index < 0");
+            }
+        }
+
+        @Override
+        public LayoutPath apply(LayoutPath layoutPath) {
+            return layoutPath.sequenceElement(index);
+        }
+
+        @Override
+        public String toString() {
+            return "sequenceElement(" + index + ")";
+        }
+
+    }
+
+    public record SequenceElementByRange(long start, long step)
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+
+        // Assert invariants
+        public SequenceElementByRange {
+            if (start < 0) {
+                throw new IllegalArgumentException("Start index must be positive: " + start);
+            }
+            if (step == 0) {
+                throw new IllegalArgumentException("Step must be != 0: " + step);
+            }
+        }
+
+        @Override
+        public LayoutPath apply(LayoutPath layoutPath) {
+            return layoutPath.sequenceElement(start, step);
+        }
+
+        @Override
+        public String toString() {
+            return "sequenceElement(" + start + ", " + step + ")";
+        }
+
+    }
+
+    public record SequenceElement()
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+
+        private static final SequenceElement INSTANCE = new SequenceElement();
+
+        @Override
+        public LayoutPath apply(LayoutPath layoutPath) {
+            return layoutPath.sequenceElement();
+        }
+
+        @Override
+        public int hashCode() {
+            return 31;
+        }
+
+        @Override
+        public String toString() {
+            return "sequenceElement()";
+        }
+
+        public static MemoryLayout.PathElement instance() {
+            return INSTANCE;
+        }
+
+    }
+
+    public record DereferenceElement()
+            implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
+
+        private static final DereferenceElement INSTANCE = new DereferenceElement();
+
+        @Override
+        public LayoutPath apply(LayoutPath layoutPath) {
+            return layoutPath.derefElement();
+        }
+
+        @Override
+        public int hashCode() {
+            return 63;
+        }
+
+        @Override
+        public String toString() {
+            return "dereferenceElement()";
+        }
+
+        public static MemoryLayout.PathElement instance() {
+            return INSTANCE;
+        }
+
+    }
+
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -451,7 +451,7 @@ public class LayoutPath {
 
     }
 
-    public static final class SequenceElement
+    public record SequenceElement()
             implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
 
         private static final SequenceElement INSTANCE = new SequenceElement();
@@ -477,7 +477,7 @@ public class LayoutPath {
 
     }
 
-    public static final class DereferenceElement
+    public record DereferenceElement()
             implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
 
         private static final DereferenceElement INSTANCE = new DereferenceElement();

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -451,7 +451,7 @@ public class LayoutPath {
 
     }
 
-    public record SequenceElement()
+    public static final class SequenceElement
             implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
 
         private static final SequenceElement INSTANCE = new SequenceElement();
@@ -477,7 +477,7 @@ public class LayoutPath {
 
     }
 
-    public record DereferenceElement()
+    public static final class DereferenceElement
             implements MemoryLayout.PathElement, UnaryOperator<LayoutPath> {
 
         private static final DereferenceElement INSTANCE = new DereferenceElement();

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -462,11 +462,6 @@ public class LayoutPath {
         }
 
         @Override
-        public int hashCode() {
-            return 31;
-        }
-
-        @Override
         public String toString() {
             return "sequenceElement()";
         }
@@ -487,9 +482,11 @@ public class LayoutPath {
             return layoutPath.derefElement();
         }
 
+        // Overriding here will ensure DereferenceElement will have a hash code
+        // that is different from the hash code of SequenceElement.
         @Override
         public int hashCode() {
-            return 63;
+            return 31;
         }
 
         @Override

--- a/test/jdk/java/foreign/TestLayoutPaths.java
+++ b/test/jdk/java/foreign/TestLayoutPaths.java
@@ -312,6 +312,13 @@ public class TestLayoutPaths {
     }
 
     @Test
+    public void testHashCodeCollision() {
+        PathElement sequenceElement = PathElement.sequenceElement();
+        PathElement dereferenceElement = PathElement.dereferenceElement();
+        assertNotEquals(sequenceElement.hashCode(), dereferenceElement.hashCode());
+    }
+
+    @Test
     public void testGroupElementIndexToString() {
         PathElement e = PathElement.groupElement(2);
         assertEquals(e.toString(), "groupElement(2)");


### PR DESCRIPTION
This PR proposes to implement `hashCode()` and `equals()` methods for implementations of `PathElement`.

In doing so, the previous `PathElementImpl` was removed and replaced in favor of distinct `record` implementations, each reflecting its own path element selection type. This also allowed the `PathKind` to be removed as this piece of information is now carried in the sealed type hierarchy. 

It is worth noting, the implementations resides in the `jdk.internal` package and consequently, they are not exposed to clients. So, we could use pattern matching (for example) internally but not in client code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323746](https://bugs.openjdk.org/browse/JDK-8323746): Add PathElement hashCode and equals (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [5685e31a](https://git.openjdk.org/jdk/pull/17651/files/5685e31a59debd5c2fba09671869eed78638b399)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17651/head:pull/17651` \
`$ git checkout pull/17651`

Update a local copy of the PR: \
`$ git checkout pull/17651` \
`$ git pull https://git.openjdk.org/jdk.git pull/17651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17651`

View PR using the GUI difftool: \
`$ git pr show -t 17651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17651.diff">https://git.openjdk.org/jdk/pull/17651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17651#issuecomment-1919075357)