### PR TITLE
8325001: Typo in the javadocs for the Arena::ofShared method

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -258,7 +258,7 @@ public interface Arena extends SegmentAllocator, AutoCloseable {
     }
 
     /**
-     * {@return a new shared arena} Segments allocated with the global arena can be
+     * {@return a new shared arena} Segments allocated with the shared arena can be
      *          {@linkplain MemorySegment#isAccessibleBy(Thread) accessed} by any thread.
      * <p>
      * Memory segments {@linkplain #allocate(long, long) allocated} by the returned arena


### PR DESCRIPTION
This PR fixes a typo in the documentation for the `Arena::ofShared`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325001](https://bugs.openjdk.org/browse/JDK-8325001): Typo in the javadocs for the Arena::ofShared method (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17653/head:pull/17653` \
`$ git checkout pull/17653`

Update a local copy of the PR: \
`$ git checkout pull/17653` \
`$ git pull https://git.openjdk.org/jdk.git pull/17653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17653`

View PR using the GUI difftool: \
`$ git pr show -t 17653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17653.diff">https://git.openjdk.org/jdk/pull/17653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17653#issuecomment-1919086614)