### PR TITLE
8325053: Serial: Move Generation::save_used_region to TenuredGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/genMarkSweep.cpp
+++ b/src/hotspot/share/gc/serial/genMarkSweep.cpp
@@ -441,10 +441,9 @@ void GenMarkSweep::invoke_at_safepoint(bool clear_all_softrefs) {
   // Increment the invocation count
   _total_invocations++;
 
-  // Capture used regions for each generation that will be
-  // subject to collection, so that card table adjustments can
-  // be made intelligently (see clear / invalidate further below).
-  gch->save_used_regions();
+  // Capture used regions for old-gen to reestablish old-to-young invariant
+  // after full-gc.
+  gch->old_gen()->save_used_region();
 
   allocate_stacks();
 

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -58,9 +58,6 @@ class GCStats;
 class Generation: public CHeapObj<mtGC> {
   friend class VMStructs;
  private:
-  MemRegion _prev_used_region; // for collectors that want to "remember" a value for
-                               // used region at some specific point during collection.
-
   GCMemoryManager* _gc_manager;
 
  protected:
@@ -119,9 +116,6 @@ class Generation: public CHeapObj<mtGC> {
   // Returns a region guaranteed to contain all the objects in the
   // generation.
   virtual MemRegion used_region() const { return _reserved; }
-
-  MemRegion prev_used_region() const { return _prev_used_region; }
-  virtual void  save_used_region()   { _prev_used_region = used_region(); }
 
   /* Returns "TRUE" iff "p" points into the reserved area of the generation. */
   bool is_in_reserved(const void* p) const {

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -294,11 +294,6 @@ size_t SerialHeap::used() const {
   return _young_gen->used() + _old_gen->used();
 }
 
-void SerialHeap::save_used_regions() {
-  _old_gen->save_used_region();
-  _young_gen->save_used_region();
-}
-
 size_t SerialHeap::max_capacity() const {
   return _young_gen->max_capacity() + _old_gen->max_capacity();
 }

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -162,9 +162,6 @@ public:
   size_t capacity() const override;
   size_t used() const override;
 
-  // Save the "used_region" for both generations.
-  void save_used_regions();
-
   size_t max_capacity() const override;
 
   HeapWord* mem_allocate(size_t size, bool*  gc_overhead_limit_was_exceeded) override;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -47,8 +47,6 @@ class TenuredGeneration: public Generation {
 
   MemRegion _prev_used_region;
 
-protected:
-
   // This is shared with other generations.
   CardTableRS* _rs;
   // This is local to this generation.

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -45,7 +45,9 @@ class TenuredGeneration: public Generation {
   // Abstractly, this is a subtype that gets access to protected fields.
   friend class VM_PopulateDumpSharedSpace;
 
- protected:
+  MemRegion _prev_used_region;
+
+protected:
 
   // This is shared with other generations.
   CardTableRS* _rs;
@@ -70,7 +72,6 @@ class TenuredGeneration: public Generation {
   GenerationCounters* _gen_counters;
   CSpaceCounters*     _space_counters;
 
-
   // Attempt to expand the generation by "bytes".  Expand by at a
   // minimum "expand_bytes".  Return true if some amount (not
   // necessarily the full "bytes") was done.
@@ -94,6 +95,9 @@ class TenuredGeneration: public Generation {
   size_t used() const;
   size_t free() const;
   MemRegion used_region() const;
+
+  MemRegion prev_used_region() const { return _prev_used_region; }
+  void save_used_region()   { _prev_used_region = used_region(); }
 
   void space_iterate(SpaceClosure* blk, bool usedOnly = false);
 


### PR DESCRIPTION
Trivial moving a field and its accessors from superclass to subclass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325053](https://bugs.openjdk.org/browse/JDK-8325053): Serial: Move Generation::save_used_region to TenuredGeneration (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Duveblad](https://openjdk.org/census#ehelin) (@edvbld - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17654/head:pull/17654` \
`$ git checkout pull/17654`

Update a local copy of the PR: \
`$ git checkout pull/17654` \
`$ git pull https://git.openjdk.org/jdk.git pull/17654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17654`

View PR using the GUI difftool: \
`$ git pr show -t 17654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17654.diff">https://git.openjdk.org/jdk/pull/17654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17654#issuecomment-1919176006)