### PR TITLE
8324679: Replace NULL with nullptr in HotSpot .ad files

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4663,7 +4663,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -4795,7 +4795,7 @@ operand immN()
   interface(CONST_INTER);
 %}
 
-// Narrow nullptr Pointer Immediate
+// Narrow Null Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);
@@ -7219,7 +7219,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# null ptr" %}
+  format %{ "mov  $dst, $con\t# null pointer" %}
 
   ins_encode(aarch64_enc_mov_p0(dst, con));
 
@@ -7233,7 +7233,7 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# null ptr" %}
+  format %{ "mov  $dst, $con\t# null pointer" %}
 
   ins_encode(aarch64_enc_mov_p1(dst, con));
 
@@ -7275,7 +7275,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# compressed null ptr" %}
+  format %{ "mov  $dst, $con\t# compressed null pointer" %}
 
   ins_encode(aarch64_enc_mov_n0(dst, con));
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1237,7 +1237,7 @@ source %{
 
     // r27 is not allocatable when compressed oops is on and heapbase is not
     // zero, compressed klass pointers doesn't use r27 after JDK-8234794
-    if (UseCompressedOops && (CompressedOops::ptrs_base() != NULL)) {
+    if (UseCompressedOops && (CompressedOops::ptrs_base() != nullptr)) {
       _NO_SPECIAL_REG32_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
       _NO_SPECIAL_REG_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
       _NO_SPECIAL_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r27->as_VMReg()));
@@ -1581,7 +1581,7 @@ bool needs_releasing_store(const Node *n)
 {
   // assert n->is_Store();
   StoreNode *st = n->as_Store();
-  return st->trailing_membar() != NULL;
+  return st->trailing_membar() != nullptr;
 }
 
 // predicate controlling translation of CAS
@@ -1593,9 +1593,9 @@ bool needs_acquiring_load_exclusive(const Node *n)
   assert(is_CAS(n->Opcode(), true), "expecting a compare and swap");
   LoadStoreNode* ldst = n->as_LoadStore();
   if (is_CAS(n->Opcode(), false)) {
-    assert(ldst->trailing_membar() != NULL, "expected trailing membar");
+    assert(ldst->trailing_membar() != nullptr, "expected trailing membar");
   } else {
-    return ldst->trailing_membar() != NULL;
+    return ldst->trailing_membar() != nullptr;
   }
 
   // so we can just return true here
@@ -1734,7 +1734,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
     st->print("mov  rscratch1, #%d\n\t", framesize - 2 * wordSize);
     st->print("sub  sp, sp, rscratch1");
   }
-  if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("\n\t");
     st->print("ldr  rscratch1, [guard]\n\t");
     st->print("dmb ishld\n\t");
@@ -1783,9 +1783,9 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ build_frame(framesize);
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+    if (BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
       // Dummy labels for just measuring the code size
       Label dummy_slow_path;
       Label dummy_continuation;
@@ -2153,12 +2153,12 @@ void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   if (!ra_)
     st->print("N%d = SpillCopy(N%d)", _idx, in(1)->_idx);
   else
-    implementation(NULL, ra_, false, st);
+    implementation(nullptr, ra_, false, st);
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -2249,7 +2249,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2267,7 +2267,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2410,7 +2410,7 @@ MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* generic_opnd, 
     case Op_VecX: return new vecXOper();
   }
   ShouldNotReachHere();
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -2583,7 +2583,7 @@ Assembler::Condition to_assembler_cond(BoolTest::mask cond) {
 
 // Binary src (Replicate con)
 bool is_valid_sve_arith_imm_pattern(Node* n, Node* m) {
-  if (n == NULL || m == NULL) {
+  if (n == nullptr || m == nullptr) {
     return false;
   }
 
@@ -2624,7 +2624,7 @@ bool is_valid_sve_arith_imm_pattern(Node* n, Node* m) {
 // (XorV src (Replicate m1))
 // (XorVMask src (MaskAll m1))
 bool is_vector_bitwise_not_pattern(Node* n, Node* m) {
-  if (n != NULL && m != NULL) {
+  if (n != nullptr && m != nullptr) {
     return (n->Opcode() == Op_XorV || n->Opcode() == Op_XorVMask) &&
            VectorNode::is_all_ones_vector(m);
   }
@@ -3430,7 +3430,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL || con == (address)1) {
+    if (con == nullptr || con == (address)1) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3473,7 +3473,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3492,7 +3492,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -3675,7 +3675,7 @@ encode %{
      Label miss;
      C2_MacroAssembler _masm(&cbuf);
      __ check_klass_subtype_slow_path(sub_reg, super_reg, temp_reg, result_reg,
-                                     NULL, &miss,
+                                     nullptr, &miss,
                                      /*set_cond_codes:*/ true);
      if ($primary) {
        __ mov(result_reg, zr);
@@ -3691,7 +3691,7 @@ encode %{
     if (!_method) {
       // A call to a runtime wrapper, e.g. new, new_typeArray_Java, uncommon_trap.
       call = __ trampoline_call(Address(addr, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3705,7 +3705,7 @@ encode %{
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
                                                   : static_call_Relocation::spec(method_index);
       call = __ trampoline_call(Address(addr, rspec));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3716,7 +3716,7 @@ encode %{
       } else {
         // Emit stub for static call
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, call);
-        if (stub == NULL) {
+        if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
         }
@@ -3735,7 +3735,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     int method_index = resolved_method_index(cbuf);
     address call = __ ic_call((address)$meth$$method, method_index);
-    if (call == NULL) {
+    if (call == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -3764,7 +3764,7 @@ encode %{
     CodeBlob *cb = CodeCache::find_blob(entry);
     if (cb) {
       address call = __ trampoline_call(Address(entry, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -4663,7 +4663,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -4795,7 +4795,7 @@ operand immN()
   interface(CONST_INTER);
 %}
 
-// Narrow NULL Pointer Immediate
+// Narrow nullptr Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);
@@ -7219,7 +7219,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# NULL ptr" %}
+  format %{ "mov  $dst, $con\t# null ptr" %}
 
   ins_encode(aarch64_enc_mov_p0(dst, con));
 
@@ -7233,7 +7233,7 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# NULL ptr" %}
+  format %{ "mov  $dst, $con\t# null ptr" %}
 
   ins_encode(aarch64_enc_mov_p1(dst, con));
 
@@ -7275,7 +7275,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   match(Set dst con);
 
   ins_cost(INSN_COST);
-  format %{ "mov  $dst, $con\t# compressed NULL ptr" %}
+  format %{ "mov  $dst, $con\t# compressed null ptr" %}
 
   ins_encode(aarch64_enc_mov_n0(dst, con));
 
@@ -15257,7 +15257,7 @@ instruct clearArray_reg_reg(iRegL_R11 cnt, iRegP_R10 base, Universe dummy, rFlag
 
   ins_encode %{
     address tpc = __ zero_words($base$$Register, $cnt$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -15278,7 +15278,7 @@ instruct clearArray_imm_reg(immL cnt, iRegP_R10 base, iRegL_R11 temp, Universe d
 
   ins_encode %{
     address tpc = __ zero_words($base$$Register, (uint64_t)$cnt$$constant);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17143,7 +17143,7 @@ instruct array_equalsB(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
     address tpc = __ arrays_equals($ary1$$Register, $ary2$$Register,
                                    $tmp1$$Register, $tmp2$$Register, $tmp3$$Register,
                                    $result$$Register, $tmp$$Register, 1);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17168,7 +17168,7 @@ instruct array_equalsC(iRegP_R1 ary1, iRegP_R2 ary2, iRegI_R0 result,
     address tpc = __ arrays_equals($ary1$$Register, $ary2$$Register,
                                    $tmp1$$Register, $tmp2$$Register, $tmp3$$Register,
                                    $result$$Register, $tmp$$Register, 2);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17183,7 +17183,7 @@ instruct count_positives(iRegP_R1 ary1, iRegI_R2 len, iRegI_R0 result, rFlagsReg
   format %{ "count positives byte[] $ary1,$len -> $result" %}
   ins_encode %{
     address tpc = __ count_positives($ary1$$Register, $len$$Register, $result$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -17226,7 +17226,7 @@ instruct string_inflate(Universe dummy, iRegP_R0 src, iRegP_R1 dst, iRegI_R2 len
     address tpc = __ byte_array_inflate($src$$Register, $dst$$Register, $len$$Register,
                                         $vtmp0$$FloatRegister, $vtmp1$$FloatRegister,
                                         $vtmp2$$FloatRegister, $tmp$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -804,7 +804,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf,
 
 #ifndef PRODUCT
 void MachSpillCopyNode::format( PhaseRegAlloc *ra_, outputStream *st ) const {
-  implementation( nullptr, ra_, false, st );
+  implementation(nullptr, ra_, false, st );
 }
 #endif
 

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -195,7 +195,7 @@ void emit_call_reloc(CodeBuffer &cbuf, const MachCallNode *n, MachOper *m, Reloc
   assert(maybe_far_call(n) == !__ reachable_from_cache(target), "sanity");
   assert(cache_reachable() == __ cache_fully_reachable(), "sanity");
 
-  assert(target != NULL, "need real address");
+  assert(target != nullptr, "need real address");
 
   int ret_addr_offset = -1;
   if (rspec.type() == relocInfo::runtime_call_type) {
@@ -290,7 +290,7 @@ void MachPrologNode::format( PhaseRegAlloc *ra_, outputStream *st ) const {
     st->print   ("SUB    R_SP, R_SP, " SIZE_FORMAT,framesize);
   }
 
-  if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("ldr t0, [guard]\n\t");
     st->print("ldr t1, [Rthread, #thread_disarmed_guard_value_offset]\n\t");
     st->print("cmp t0, t1\n\t");
@@ -332,7 +332,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ sub_slow(SP, SP, framesize);
   }
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->nmethod_entry_barrier(&_masm);
   }
@@ -454,7 +454,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf,
     return size;            // Self copy, no move
 
 #ifdef TODO
-  if (bottom_type()->isa_vect() != NULL) {
+  if (bottom_type()->isa_vect() != nullptr) {
   }
 #endif
 
@@ -804,16 +804,16 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf,
 
 #ifndef PRODUCT
 void MachSpillCopyNode::format( PhaseRegAlloc *ra_, outputStream *st ) const {
-  implementation( NULL, ra_, false, st );
+  implementation( nullptr, ra_, false, st );
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation( &cbuf, ra_, false, NULL );
+  implementation( &cbuf, ra_, false, nullptr );
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
-  return implementation( NULL, ra_, true, NULL );
+  return implementation( nullptr, ra_, true, nullptr );
 }
 
 //=============================================================================
@@ -903,7 +903,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -926,7 +926,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -1026,11 +1026,11 @@ bool Matcher::vector_needs_partial_operations(Node* node, const TypeVect* vt) {
 }
 
 const RegMask* Matcher::predicate_reg_mask(void) {
-  return NULL;
+  return nullptr;
 }
 
 const TypeVectMask* Matcher::predicate_reg_type(const Type* elemTy, int length) {
-  return NULL;
+  return nullptr;
 }
 
 // Vector calling convention not yet implemented.
@@ -1094,7 +1094,7 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -1242,7 +1242,7 @@ encode %{
 
       // Emit stubs for static call.
       address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
+      if (stub == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -1987,7 +1987,7 @@ operand immNKlass()
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1987,7 +1987,7 @@ operand immNKlass()
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -431,7 +431,7 @@ OptoRegPair c2::return_value(int ideal_reg) {
 //       will point.
 
 int MachCallStaticJavaNode::ret_addr_offset() {
-  bool far = (_method == NULL) ? maybe_far_call(this) : !cache_reachable();
+  bool far = (_method == nullptr) ? maybe_far_call(this) : !cache_reachable();
   return ((far ? 3 : 1) + (_method_handle_invoke ? 1 : 0)) *
     NativeInstruction::instruction_size;
 }

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -1026,7 +1026,7 @@ bool followed_by_acquire(const Node *load) {
   assert(load->is_Load(), "So far implemented only for loads.");
 
   // Find MemBarAcquire.
-  const Node *mba = NULL;
+  const Node *mba = nullptr;
   for (DUIterator_Fast imax, i = load->fast_outs(imax); i < imax; i++) {
     const Node *out = load->fast_out(i);
     if (out->Opcode() == Op_MemBarAcquire) {
@@ -1043,7 +1043,7 @@ bool followed_by_acquire(const Node *load) {
   // edge to assure no other operations are in between the two nodes.
   //
   // So first get the Proj node, mem_proj, to use it to iterate forward.
-  Node *mem_proj = NULL;
+  Node *mem_proj = nullptr;
   for (DUIterator_Fast imax, i = mba->fast_outs(imax); i < imax; i++) {
     mem_proj = mba->fast_out(i);      // Runs out of bounds and asserts if Proj not found.
     assert(mem_proj->is_Proj(), "only projections here");
@@ -1270,7 +1270,7 @@ source %{
 
 void CallStubImpl::emit_trampoline_stub(C2_MacroAssembler &_masm, int destination_toc_offset, int insts_call_instruction_offset) {
   address stub = __ emit_trampoline_stub(destination_toc_offset, insts_call_instruction_offset);
-  if (stub == NULL) {
+  if (stub == nullptr) {
     ciEnv::current()->record_out_of_memory_failure();
   }
 }
@@ -1305,11 +1305,11 @@ EmitCallOffsets emit_call_with_trampoline_stub(C2_MacroAssembler &_masm, address
   offsets.insts_call_instruction_offset = __ offset();
 
   // No entry point given, use the current pc.
-  if (entry_point == NULL) entry_point = __ pc();
+  if (entry_point == nullptr) entry_point = __ pc();
 
   // Put the entry point as a constant into the constant pool.
   const address entry_point_toc_addr   = __ address_constant(entry_point, RelocationHolder::none);
-  if (entry_point_toc_addr == NULL) {
+  if (entry_point_toc_addr == nullptr) {
     ciEnv::current()->record_out_of_memory_failure();
     return offsets;
   }
@@ -1355,8 +1355,8 @@ void MachConstantBaseNode::postalloc_expand(GrowableArray <Node *> *nodes, Phase
   MachNode *m1 = new loadToc_hiNode();
   MachNode *m2 = new loadToc_loNode();
 
-  m1->add_req(NULL);
-  m2->add_req(NULL, m1);
+  m1->add_req(nullptr);
+  m2->add_req(nullptr, m1);
   m1->_opnds[0] = op_dst;
   m2->_opnds[0] = op_dst;
   m2->_opnds[1] = op_dst;
@@ -1398,7 +1398,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
     st->print("push frame %ld\n\t", -framesize);
   }
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     st->print("nmethod entry barrier\n\t");
   }
 }
@@ -1554,7 +1554,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ std(return_pc, _abi0(lr), callers_sp);
   }
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->nmethod_entry_barrier(&_masm, push_frame_temp);
   }
@@ -1724,7 +1724,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   if (src_lo == dst_lo && src_hi == dst_hi)
     return size;            // Self copy, no move.
 
-  if (bottom_type()->isa_vect() != NULL && ideal_reg() == Op_VecX) {
+  if (bottom_type()->isa_vect() != nullptr && ideal_reg() == Op_VecX) {
     // Memory->Memory Spill.
     if (src_lo_rc == rc_stack && dst_lo_rc == rc_stack) {
       int src_offset = ra_->reg2offset(src_lo);
@@ -1910,16 +1910,16 @@ void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   if (!ra_)
     st->print("N%d = SpillCopy(N%d)", _idx, in(1)->_idx);
   else
-    implementation(NULL, ra_, false, st);
+    implementation(nullptr, ra_, false, st);
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
-  return implementation(NULL, ra_, true, NULL);
+  return implementation(nullptr, ra_, true, nullptr);
 }
 
 #ifndef PRODUCT
@@ -1985,7 +1985,7 @@ void MachUEPNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   assert_different_registers(ic_klass, receiver_klass, R11_scratch1, R3_ARG1);
   assert(R11_scratch1 == R11, "need prologue scratch register");
 
-  // Check for NULL argument if we don't have implicit null checks.
+  // Check for nullptr argument if we don't have implicit null checks.
   if (!ImplicitNullChecks || !os::zero_page_read_protected()) {
     if (TrapBasedNullChecks) {
       __ trap_null_check(R3_ARG1);
@@ -1999,7 +1999,7 @@ void MachUEPNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
       __ bind(valid);
     }
   }
-  // Assume argument is not NULL, load klass from receiver.
+  // Assume argument is not nullptr, load klass from receiver.
   __ load_klass(receiver_klass, R3_ARG1);
 
   if (TrapBasedICMissChecks) {
@@ -2062,7 +2062,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) return 0; // CodeBuffer::expand failed
+  if (base == nullptr) return 0; // CodeBuffer::expand failed
 
   int offset = __ offset();
   __ b64_patchable((address)OptoRuntime::exception_blob()->content_begin(),
@@ -2079,7 +2079,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) return 0; // CodeBuffer::expand failed
+  if (base == nullptr) return 0; // CodeBuffer::expand failed
 
   int offset = __ offset();
   __ bl64_patchable((address)SharedRuntime::deopt_blob()->unpack(),
@@ -2193,11 +2193,11 @@ bool Matcher::vector_needs_partial_operations(Node* node, const TypeVect* vt) {
 }
 
 const RegMask* Matcher::predicate_reg_mask(void) {
-  return NULL;
+  return nullptr;
 }
 
 const TypeVectMask* Matcher::predicate_reg_type(const Type* elemTy, int length) {
-  return NULL;
+  return nullptr;
 }
 
 // Vector calling convention not yet implemented.
@@ -2275,7 +2275,7 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 /* TODO: PPC port
 // Make a new machine dependent decode node (with its operands).
 MachTypeNode *Matcher::make_decode_node() {
-  assert(CompressedOops::base() == NULL && CompressedOops::shift() == 0,
+  assert(CompressedOops::base() == nullptr && CompressedOops::shift() == 0,
          "This method is only implemented for unscaled cOops mode so far");
   MachTypeNode *decode = new decodeN_unscaledNode();
   decode->set_opnd_array(0, new iRegPdstOper());
@@ -2286,7 +2286,7 @@ MachTypeNode *Matcher::make_decode_node() {
 
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -2545,7 +2545,7 @@ encode %{
     // Create a non-oop constant, no relocation needed.
     // If it is an IC, it has a virtual_call_Relocation.
     const_toc_addr = __ long_constant((jlong)$src$$constant);
-    if (const_toc_addr == NULL) {
+    if (const_toc_addr == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -2568,7 +2568,7 @@ encode %{
       // Create a non-oop constant, no relocation needed.
       // If it is an IC, it has a virtual_call_Relocation.
       const_toc_addr = __ long_constant((jlong)$src$$constant);
-      if (const_toc_addr == NULL) {
+      if (const_toc_addr == nullptr) {
         ciEnv::current()->record_out_of_memory_failure();
         return;
       }
@@ -2607,8 +2607,8 @@ loadConLNodesTuple loadConLNodesTuple_create(PhaseRegAlloc *ra_, Node *toc, immL
     loadConL_loNode *m2 = new loadConL_loNode();
 
     // inputs for new nodes
-    m1->add_req(NULL, toc);
-    m2->add_req(NULL, m1);
+    m1->add_req(nullptr, toc);
+    m2->add_req(nullptr, m1);
 
     // operands for new nodes
     m1->_opnds[0] = new iRegLdstOper(); // dst
@@ -2632,14 +2632,14 @@ loadConLNodesTuple loadConLNodesTuple_create(PhaseRegAlloc *ra_, Node *toc, immL
     // Create result.
     nodes._large_hi = m1;
     nodes._large_lo = m2;
-    nodes._small = NULL;
+    nodes._small = nullptr;
     nodes._last = nodes._large_lo;
     assert(m2->bottom_type()->isa_long(), "must be long");
   } else {
     loadConLNode *m2 = new loadConLNode();
 
     // inputs for new nodes
-    m2->add_req(NULL, toc);
+    m2->add_req(nullptr, toc);
 
     // operands for new nodes
     m2->_opnds[0] = new iRegLdstOper(); // dst
@@ -2653,8 +2653,8 @@ loadConLNodesTuple loadConLNodesTuple_create(PhaseRegAlloc *ra_, Node *toc, immL
     ra_->set_pair(m2->_idx, reg_second, reg_first);
 
     // Create result.
-    nodes._large_hi = NULL;
-    nodes._large_lo = NULL;
+    nodes._large_hi = nullptr;
+    nodes._large_lo = nullptr;
     nodes._small = m2;
     nodes._last = nodes._small;
     assert(m2->bottom_type()->isa_long(), "must be long");
@@ -2687,10 +2687,10 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
     xxspltdNode *m4 = new  xxspltdNode();
 
     // inputs for new nodes
-    m1->add_req(NULL, toc);
-    m2->add_req(NULL, m1);
-    m3->add_req(NULL, m2);
-    m4->add_req(NULL, m3);
+    m1->add_req(nullptr, toc);
+    m2->add_req(nullptr, m1);
+    m3->add_req(nullptr, m2);
+    m4->add_req(nullptr, m3);
 
     // operands for new nodes
     m1->_opnds[0] = new  iRegLdstOper(); // dst
@@ -2727,7 +2727,7 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
     nodes._large_lo = m2;
     nodes._moved = m3;
     nodes._replicated = m4;
-    nodes._small = NULL;
+    nodes._small = nullptr;
     nodes._last = nodes._replicated;
     assert(m2->bottom_type()->isa_long(), "must be long");
   } else {
@@ -2736,7 +2736,7 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
     xxspltdNode *m4 = new  xxspltdNode();
 
     // inputs for new nodes
-    m2->add_req(NULL, toc);
+    m2->add_req(nullptr, toc);
 
     // operands for new nodes
     m2->_opnds[0] = new  iRegLdstOper(); // dst
@@ -2760,8 +2760,8 @@ loadConLReplicatedNodesTuple loadConLReplicatedNodesTuple_create(Compile *C, Pha
     ra_->set_pair(m2->_idx, reg_second, reg_first);
 
     // Create result.
-    nodes._large_hi = NULL;
-    nodes._large_lo = NULL;
+    nodes._large_hi = nullptr;
+    nodes._large_lo = nullptr;
     nodes._small = m2;
     nodes._moved = m3;
     nodes._replicated = m4;
@@ -2815,7 +2815,7 @@ encode %{
       const_toc_addr = __ long_constant((jlong)$src$$constant);
     }
 
-    if (const_toc_addr == NULL) {
+    if (const_toc_addr == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -2846,7 +2846,7 @@ encode %{
         const_toc_addr = __ long_constant((jlong)$src$$constant);
       }
 
-      if (const_toc_addr == NULL) {
+      if (const_toc_addr == nullptr) {
         ciEnv::current()->record_out_of_memory_failure();
         return;
       }
@@ -2870,8 +2870,8 @@ encode %{
       loadConP_loNode *m2 = new loadConP_loNode();
 
       // inputs for new nodes
-      m1->add_req(NULL, n_toc);
-      m2->add_req(NULL, m1);
+      m1->add_req(nullptr, n_toc);
+      m2->add_req(nullptr, m1);
 
       // operands for new nodes
       m1->_opnds[0] = new iRegPdstOper(); // dst
@@ -2896,7 +2896,7 @@ encode %{
       loadConPNode *m2 = new loadConPNode();
 
       // inputs for new nodes
-      m2->add_req(NULL, n_toc);
+      m2->add_req(nullptr, n_toc);
 
       // operands for new nodes
       m2->_opnds[0] = new iRegPdstOper(); // dst
@@ -2923,7 +2923,7 @@ encode %{
       m2 = new loadConFNode();
     }
     // inputs for new nodes
-    m2->add_req(NULL, n_toc);
+    m2->add_req(nullptr, n_toc);
 
     // operands for new nodes
     m2->_opnds[0] = op_dst;
@@ -2947,7 +2947,7 @@ encode %{
       m2 = new loadConDNode();
     }
     // inputs for new nodes
-    m2->add_req(NULL, n_toc);
+    m2->add_req(nullptr, n_toc);
 
     // operands for new nodes
     m2->_opnds[0] = op_dst;
@@ -3258,9 +3258,9 @@ encode %{
     Label d;   // dummy
     __ bind(d);
     Label* p = ($lbl$$label);
-    // `p' is `NULL' when this encoding class is used only to
+    // `p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
-    Label& l = (NULL == p)? d : *(p);
+    Label& l = (nullptr == p)? d : *(p);
     int cc = $cmp$$cmpcode;
     int flags_reg = $crx$$reg;
     assert((Assembler::bcondCRbiIs1 & ~Assembler::bcondCRbiIs0) == 8, "check encoding");
@@ -3287,9 +3287,9 @@ encode %{
     Label d;    // dummy
     __ bind(d);
     Label* p = ($lbl$$label);
-    // `p' is `NULL' when this encoding class is used only to
+    // `p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
-    Label& l = (NULL == p)? d : *(p);
+    Label& l = (nullptr == p)? d : *(p);
     int cc = $cmp$$cmpcode;
     int flags_reg = $crx$$reg;
     int bhint = Assembler::bhintNoHint;
@@ -3431,7 +3431,7 @@ encode %{
 
       // Put the entry point as a constant into the constant pool.
       const address entry_point_toc_addr = __ address_constant(entry_point, RelocationHolder::none);
-      if (entry_point_toc_addr == NULL) {
+      if (entry_point_toc_addr == nullptr) {
         ciEnv::current()->record_out_of_memory_failure();
         return;
       }
@@ -3453,7 +3453,7 @@ encode %{
 
       // The stub for call to interpreter.
       address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
+      if (stub == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -3470,7 +3470,7 @@ encode %{
       // Create a call trampoline stub for the given method.
       const address entry_point = !($meth$$method) ? 0 : (address)$meth$$method;
       const address entry_point_const = __ address_constant(entry_point, RelocationHolder::none);
-      if (entry_point_const == NULL) {
+      if (entry_point_const == nullptr) {
         ciEnv::current()->record_out_of_memory_failure();
         return;
       }
@@ -3479,13 +3479,13 @@ encode %{
       if (ra_->C->env()->failing()) { return; } // Code cache may be full.
 
       // Build relocation at call site with ic position as data.
-      assert((_load_ic_hi_node != NULL && _load_ic_node == NULL) ||
-             (_load_ic_hi_node == NULL && _load_ic_node != NULL),
+      assert((_load_ic_hi_node != nullptr && _load_ic_node == nullptr) ||
+             (_load_ic_hi_node == nullptr && _load_ic_node != nullptr),
              "must have one, but can't have both");
-      assert((_load_ic_hi_node != NULL && _load_ic_hi_node->_cbuf_insts_offset != -1) ||
-             (_load_ic_node != NULL    && _load_ic_node->_cbuf_insts_offset != -1),
+      assert((_load_ic_hi_node != nullptr && _load_ic_hi_node->_cbuf_insts_offset != -1) ||
+             (_load_ic_node != nullptr    && _load_ic_node->_cbuf_insts_offset != -1),
              "must contain instruction offset");
-      const int virtual_call_oop_addr_offset = _load_ic_hi_node != NULL
+      const int virtual_call_oop_addr_offset = _load_ic_hi_node != nullptr
         ? _load_ic_hi_node->_cbuf_insts_offset
         : _load_ic_node->_cbuf_insts_offset;
       const address virtual_call_oop_addr = __ addr_at(virtual_call_oop_addr_offset);
@@ -3625,7 +3625,7 @@ encode %{
     const address start_pc = __ pc();
 
 #if defined(ABI_ELFv2)
-    address entry= !($meth$$method) ? NULL : (address)$meth$$method;
+    address entry= !($meth$$method) ? nullptr : (address)$meth$$method;
     __ call_c(entry, relocInfo::runtime_call_type);
     __ post_call_nop();
 #else
@@ -3682,13 +3682,13 @@ encode %{
 
 
     // Create nodes and operands for loading the env pointer.
-    if (fd->env() != NULL) {
+    if (fd->env() != nullptr) {
       loadConLNodes_Env = loadConLNodesTuple_create(ra_, n_toc, new immLOper((jlong) fd->env()),
                                                     OptoReg::Name(R11_H_num), OptoReg::Name(R11_num));
     } else {
-      loadConLNodes_Env._large_hi = NULL;
-      loadConLNodes_Env._large_lo = NULL;
-      loadConLNodes_Env._small    = NULL;
+      loadConLNodes_Env._large_hi = nullptr;
+      loadConLNodes_Env._large_lo = nullptr;
+      loadConLNodes_Env._small    = nullptr;
       loadConLNodes_Env._last = new loadConL16Node();
       loadConLNodes_Env._last->_opnds[0] = new iRegLdstOper();
       loadConLNodes_Env._last->_opnds[1] = new immL16Oper(0);
@@ -3702,7 +3702,7 @@ encode %{
     // mtctr node
     MachNode *mtctr = new CallLeafDirect_mtctrNode();
 
-    assert(loadConLNodes_Entry._last != NULL, "entry must exist");
+    assert(loadConLNodes_Entry._last != nullptr, "entry must exist");
     mtctr->add_req(0, loadConLNodes_Entry._last);
 
     mtctr->_opnds[0] = new iRegLdstOper();
@@ -3722,7 +3722,7 @@ encode %{
     call->_guaranteed_safepoint = false;
     call->_oop_map     = _oop_map;
     guarantee(!_jvms, "You must clone the jvms and adapt the offsets by fix_jvms().");
-    call->_jvms        = NULL;
+    call->_jvms        = nullptr;
     call->_jvmadj      = _jvmadj;
     call->_in_rms      = _in_rms;
     call->_nesting     = _nesting;
@@ -3826,7 +3826,7 @@ frame %{
   // opcodes. This simplifies the register allocator.
   c_return_value %{
     assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||
-            (ideal_reg == Op_RegN && CompressedOops::base() == NULL && CompressedOops::shift() == 0),
+            (ideal_reg == Op_RegN && CompressedOops::base() == nullptr && CompressedOops::shift() == 0),
             "only return normal values");
     // enum names from opcodes.hpp:    Op_Node Op_Set Op_RegN       Op_RegI       Op_RegP       Op_RegF       Op_RegD       Op_RegL
     static int typeToRegLo[Op_RegL+1] = { 0,   0,     R3_num,   R3_num,   R3_num,   F1_num,   F1_num,   R3_num };
@@ -3837,7 +3837,7 @@ frame %{
   // Location of compiled Java return values.  Same as C
   return_value %{
     assert((ideal_reg >= Op_RegI && ideal_reg <= Op_RegL) ||
-            (ideal_reg == Op_RegN && CompressedOops::base() == NULL && CompressedOops::shift() == 0),
+            (ideal_reg == Op_RegN && CompressedOops::base() == nullptr && CompressedOops::shift() == 0),
             "only return normal values");
     // enum names from opcodes.hpp:    Op_Node Op_Set Op_RegN       Op_RegI       Op_RegP       Op_RegF       Op_RegD       Op_RegL
     static int typeToRegLo[Op_RegL+1] = { 0,   0,     R3_num,   R3_num,   R3_num,   F1_num,   F1_num,   R3_num };
@@ -4110,7 +4110,7 @@ operand immN() %{
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immN_0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);
@@ -4682,7 +4682,7 @@ operand iRegN2P(iRegNsrc reg) %{
 %}
 
 operand iRegN2P_klass(iRegNsrc reg) %{
-  predicate(CompressedKlassPointers::base() == NULL && CompressedKlassPointers::shift() == 0);
+  predicate(CompressedKlassPointers::base() == nullptr && CompressedKlassPointers::shift() == 0);
   constraint(ALLOC_IN_RC(bits32_reg_ro));
   match(DecodeNKlass reg);
   format %{ "$reg" %}
@@ -4751,7 +4751,7 @@ operand indirectNarrow(iRegNsrc reg) %{
 %}
 
 operand indirectNarrow_klass(iRegNsrc reg) %{
-  predicate(CompressedKlassPointers::base() == NULL && CompressedKlassPointers::shift() == 0);
+  predicate(CompressedKlassPointers::base() == nullptr && CompressedKlassPointers::shift() == 0);
   constraint(ALLOC_IN_RC(bits64_reg_ro));
   match(DecodeNKlass reg);
   op_cost(100);
@@ -4780,7 +4780,7 @@ operand indOffset16Narrow(iRegNsrc reg, immL16 offset) %{
 %}
 
 operand indOffset16Narrow_klass(iRegNsrc reg, immL16 offset) %{
-  predicate(CompressedKlassPointers::base() == NULL && CompressedKlassPointers::shift() == 0);
+  predicate(CompressedKlassPointers::base() == nullptr && CompressedKlassPointers::shift() == 0);
   constraint(ALLOC_IN_RC(bits64_reg_ro));
   match(AddP (DecodeNKlass reg) offset);
   op_cost(100);
@@ -4809,7 +4809,7 @@ operand indOffset16NarrowAlg4(iRegNsrc reg, immL16Alg4 offset) %{
 %}
 
 operand indOffset16NarrowAlg4_klass(iRegNsrc reg, immL16Alg4 offset) %{
-  predicate(CompressedKlassPointers::base() == NULL && CompressedKlassPointers::shift() == 0);
+  predicate(CompressedKlassPointers::base() == nullptr && CompressedKlassPointers::shift() == 0);
   constraint(ALLOC_IN_RC(bits64_reg_ro));
   match(AddP (DecodeNKlass reg) offset);
   op_cost(100);
@@ -5544,7 +5544,7 @@ instruct loadN2P_unscaled(iRegPdst dst, memory mem) %{
 
 instruct loadN2P_klass_unscaled(iRegPdst dst, memory mem) %{
   match(Set dst (DecodeNKlass (LoadNKlass mem)));
-  predicate(CompressedKlassPointers::base() == NULL && CompressedKlassPointers::shift() == 0 &&
+  predicate(CompressedKlassPointers::base() == nullptr && CompressedKlassPointers::shift() == 0 &&
             _kids[0]->_leaf->as_Load()->is_unordered());
   ins_cost(MEMORY_REF_COST);
 
@@ -5954,7 +5954,7 @@ instruct loadConL_Ex(iRegLdst dst, immL src) %{
   postalloc_expand( postalloc_expand_load_long_constant(dst, src, constanttablebase) );
 %}
 
-// Load NULL as compressed oop.
+// Load nullptr as compressed oop.
 instruct loadConN0(iRegNdst dst, immN_0 src) %{
   match(Set dst src);
   ins_cost(DEFAULT_COST);
@@ -6045,9 +6045,9 @@ instruct loadConN_Ex(iRegNdst dst, immN src) %{
     MachNode *m1 = new loadConN_hiNode();
     MachNode *m2 = new loadConN_loNode();
     MachNode *m3 = new clearMs32bNode();
-    m1->add_req(NULL);
-    m2->add_req(NULL, m1);
-    m3->add_req(NULL, m2);
+    m1->add_req(nullptr);
+    m2->add_req(nullptr, m1);
+    m3->add_req(nullptr, m2);
     m1->_opnds[0] = op_dst;
     m1->_opnds[1] = op_src;
     m2->_opnds[0] = op_dst;
@@ -6123,7 +6123,7 @@ instruct loadConNKlass_Ex(iRegNdst dst, immNKlass src) %{
   postalloc_expand %{
     // Load high bits into register. Sign extended.
     MachNode *m1 = new loadConNKlass_hiNode();
-    m1->add_req(NULL);
+    m1->add_req(nullptr);
     m1->_opnds[0] = op_dst;
     m1->_opnds[1] = op_src;
     ra_->set_pair(m1->_idx, ra_->get_reg_second(this), ra_->get_reg_first(this));
@@ -6133,7 +6133,7 @@ instruct loadConNKlass_Ex(iRegNdst dst, immNKlass src) %{
     if (!Assembler::is_uimm((jlong)CompressedKlassPointers::encode((Klass *)op_src->constant()), 31)) {
       // Value might be 1-extended. Mask out these bits.
       m2 = new loadConNKlass_maskNode();
-      m2->add_req(NULL, m1);
+      m2->add_req(nullptr, m1);
       m2->_opnds[0] = op_dst;
       m2->_opnds[1] = op_src;
       m2->_opnds[2] = op_dst;
@@ -6142,7 +6142,7 @@ instruct loadConNKlass_Ex(iRegNdst dst, immNKlass src) %{
     }
 
     MachNode *m3 = new loadConNKlass_loNode();
-    m3->add_req(NULL, m2);
+    m3->add_req(nullptr, m2);
     m3->_opnds[0] = op_dst;
     m3->_opnds[1] = op_src;
     m3->_opnds[2] = op_dst;
@@ -6243,7 +6243,7 @@ instruct loadConF(regF dst, immF src, iRegLdst toc) %{
   size(4);
   ins_encode %{
     address float_address = __ float_constant($src$$constant);
-    if (float_address == NULL) {
+    if (float_address == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -6267,7 +6267,7 @@ instruct loadConFComp(regF dst, immF src, iRegLdst toc) %{
     FloatRegister Rdst    = $dst$$FloatRegister;
     Register Rtoc         = $toc$$Register;
     address float_address = __ float_constant($src$$constant);
-    if (float_address == NULL) {
+    if (float_address == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -6305,7 +6305,7 @@ instruct loadConD(regD dst, immD src, iRegLdst toc) %{
   size(4);
   ins_encode %{
     address float_address = __ double_constant($src$$constant);
-    if (float_address == NULL) {
+    if (float_address == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -6330,7 +6330,7 @@ instruct loadConDComp(regD dst, immD src, iRegLdst toc) %{
     FloatRegister Rdst    = $dst$$FloatRegister;
     Register      Rtoc    = $toc$$Register;
     address float_address = __ double_constant($src$$constant);
-    if (float_address == NULL) {
+    if (float_address == nullptr) {
       ciEnv::current()->record_out_of_memory_failure();
       return;
     }
@@ -6632,7 +6632,7 @@ instruct cond_sub_base(iRegNdst dst, flagsRegSrc crx, iRegPsrc src1) %{
   predicate(false);
 
   format %{ "BEQ     $crx, done\n\t"
-            "SUB     $dst, $src1, heapbase \t// encode: subtract base if != NULL\n"
+            "SUB     $dst, $src1, heapbase \t// encode: subtract base if != nullptr\n"
             "done:" %}
   ins_encode %{
     Label done;
@@ -6701,7 +6701,7 @@ instruct encodeP_not_null_base_null(iRegNdst dst, iRegPsrc src) %{
   predicate(CompressedOops::shift() != 0 &&
             CompressedOops::base() ==0);
 
-  format %{ "SRDI    $dst, $src, #3 \t// encodeP, $src != NULL" %}
+  format %{ "SRDI    $dst, $src, #3 \t// encodeP, $src != nullptr" %}
   size(4);
   ins_encode %{
     __ srdi($dst$$Register, $src$$Register, CompressedOops::shift() & 0x3f);
@@ -6762,7 +6762,7 @@ instruct cond_add_base(iRegPdst dst, flagsRegSrc crx, iRegPsrc src) %{
   predicate(false);
 
   format %{ "BEQ     $crx, done\n\t"
-            "ADD     $dst, $src, heapbase \t// DecodeN: add oop base if $src != NULL\n"
+            "ADD     $dst, $src, heapbase \t// DecodeN: add oop base if $src != nullptr\n"
             "done:" %}
   ins_encode %{
     Label done;
@@ -6850,7 +6850,7 @@ instruct decodeN_Disjoint_notNull_Ex(iRegPdst dst, iRegNsrc src) %{
             "RLDIMI  $dst, $src, shift, 32-shift \t// decode with disjoint base" %}
   postalloc_expand %{
     loadBaseNode *n1 = new loadBaseNode();
-    n1->add_req(NULL);
+    n1->add_req(nullptr);
     n1->_opnds[0] = op_dst;
 
     decodeN_mergeDisjointNode *n2 = new decodeN_mergeDisjointNode();
@@ -6882,7 +6882,7 @@ instruct decodeN_Disjoint_isel_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
   format %{ "DecodeN  $dst, $src \t// decode with disjoint base using isel" %}
   postalloc_expand %{
     loadBaseNode *n1 = new loadBaseNode();
-    n1->add_req(NULL);
+    n1->add_req(nullptr);
     n1->_opnds[0] = op_dst;
 
     cmpN_reg_imm0Node *n_compare  = new cmpN_reg_imm0Node();
@@ -6929,7 +6929,7 @@ instruct decodeN_notNull_addBase_Ex(iRegPdst dst, iRegNsrc src) %{
             CompressedOops::base() != 0);
   ins_cost(2 * DEFAULT_COST);
 
-  format %{ "DecodeN $dst, $src \t// $src != NULL, postalloc expanded" %}
+  format %{ "DecodeN $dst, $src \t// $src != nullptr, postalloc expanded" %}
   postalloc_expand( postalloc_expand_decode_oop_not_null(dst, src));
 %}
 
@@ -7086,7 +7086,7 @@ instruct decodeNKlass_notNull_addBase_Ex(iRegPdst dst, iRegLsrc base, iRegNsrc s
   //effect(kill src); // We need a register for the immediate result after shifting.
   predicate(false);
 
-  format %{ "DecodeNKlass $dst =  $base + ($src << 3) \t// $src != NULL, postalloc expanded" %}
+  format %{ "DecodeNKlass $dst =  $base + ($src << 3) \t// $src != nullptr, postalloc expanded" %}
   postalloc_expand %{
     decodeNKlass_add_baseNode *n1 = new decodeNKlass_add_baseNode();
     n1->add_req(n_region, n_base, n_src);
@@ -7115,7 +7115,7 @@ instruct decodeNKlass_notNull_addBase_ExEx(iRegPdst dst, iRegNsrc src) %{
   // predicate(CompressedKlassPointers::shift() != 0 &&
   //           CompressedKlassPointers::base() != 0);
 
-  //format %{ "DecodeNKlass $dst, $src \t// $src != NULL, expanded" %}
+  //format %{ "DecodeNKlass $dst, $src \t// $src != nullptr, expanded" %}
 
   ins_cost(DEFAULT_COST*2);  // Don't count constant.
   expand %{
@@ -7602,7 +7602,7 @@ instruct compareAndSwapL_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, iRegLsrc
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                $res$$Register, NULL, true);
+                $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
       __ isync();
     } else {
@@ -7621,7 +7621,7 @@ instruct compareAndSwapP_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, iRegPsrc
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                $res$$Register, NULL, true);
+                $res$$Register, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
       __ isync();
     } else {
@@ -7815,7 +7815,7 @@ instruct weakCompareAndSwapL_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, iReg
     // value is never passed to caller.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
-                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, NULL, true, /*weak*/ true);
+                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -7831,7 +7831,7 @@ instruct weakCompareAndSwapL_acq_regP_regL_regL(iRegIdst res, iRegPdst mem_ptr, 
     // value is never passed to caller.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
-                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, NULL, true, /*weak*/ true);
+                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -7845,7 +7845,7 @@ instruct weakCompareAndSwapP_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, iReg
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone,
-                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, NULL, true, /*weak*/ true);
+                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -7861,7 +7861,7 @@ instruct weakCompareAndSwapP_acq_regP_regP_regP(iRegIdst res, iRegPdst mem_ptr, 
     // value is never passed to caller.
     __ cmpxchgd(CCR0, R0, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 support_IRIW_for_not_multiple_copy_atomic_cpu ? MacroAssembler::MemBarAcq : MacroAssembler::MemBarFenceAfter,
-                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, NULL, true, /*weak*/ true);
+                MacroAssembler::cmpxchgx_hint_atomic_update(), $res$$Register, nullptr, true, /*weak*/ true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -8081,7 +8081,7 @@ instruct compareAndExchangeL_regP_regL_regL(iRegLdst res, iRegPdst mem_ptr, iReg
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                noreg, NULL, true);
+                noreg, nullptr, true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -8095,7 +8095,7 @@ instruct compareAndExchangeL_acq_regP_regL_regL(iRegLdst res, iRegPdst mem_ptr, 
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                noreg, NULL, true);
+                noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
       __ isync();
     } else {
@@ -8116,7 +8116,7 @@ instruct compareAndExchangeP_regP_regP_regP(iRegPdst res, iRegPdst mem_ptr, iReg
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                noreg, NULL, true);
+                noreg, nullptr, true);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -8131,7 +8131,7 @@ instruct compareAndExchangeP_acq_regP_regP_regP(iRegPdst res, iRegPdst mem_ptr, 
     // CmpxchgX sets CCR0 to cmpX(src1, src2) and Rres to 'true'/'false'.
     __ cmpxchgd(CCR0, $res$$Register, $src1$$Register, $src2$$Register, $mem_ptr$$Register,
                 MacroAssembler::MemBarNone, MacroAssembler::cmpxchgx_hint_atomic_update(),
-                noreg, NULL, true);
+                noreg, nullptr, true);
     if (support_IRIW_for_not_multiple_copy_atomic_cpu) {
       __ isync();
     } else {
@@ -12043,9 +12043,9 @@ instruct branch(label labl) %{
      Label d;    // dummy
      __ bind(d);
      Label* p = $labl$$label;
-     // `p' is `NULL' when this encoding class is used only to
+     // `p' is `nullptr' when this encoding class is used only to
      // determine the size of the encoded instruction.
-     Label& l = (NULL == p)? d : *(p);
+     Label& l = (nullptr == p)? d : *(p);
      __ b(l);
   %}
   ins_pipe(pipe_class_default);
@@ -12139,7 +12139,7 @@ instruct partialSubtypeCheck(iRegPdst result, iRegP_N2P subklass, iRegP_N2P supe
   format %{ "PartialSubtypeCheck $result = ($subklass instanceOf $superklass) tmp: $tmp_klass, $tmp_arrayptr" %}
   ins_encode %{
     __ check_klass_subtype_slow_path($subklass$$Register, $superklass$$Register, $tmp_arrayptr$$Register,
-                                     $tmp_klass$$Register, NULL, $result$$Register);
+                                     $tmp_klass$$Register, nullptr, $result$$Register);
   %}
   ins_pipe(pipe_class_default);
 %}
@@ -12670,7 +12670,7 @@ instruct indexOf_U(iRegIdst result, iRegPsrc haystack, rscratch1RegI haycnt, iRe
   ins_encode %{
     __ string_indexof($result$$Register,
                       $haystack$$Register, $haycnt$$Register,
-                      $needle$$Register, NULL, $needlecnt$$Register, 0,  // needlecnt not constant.
+                      $needle$$Register, nullptr, $needlecnt$$Register, 0,  // needlecnt not constant.
                       $tmp1$$Register, $tmp2$$Register, $tmp3$$Register, $tmp4$$Register, StrIntrinsicNode::UU);
   %}
   ins_pipe(pipe_class_compare);
@@ -12691,7 +12691,7 @@ instruct indexOf_L(iRegIdst result, iRegPsrc haystack, rscratch1RegI haycnt, iRe
   ins_encode %{
     __ string_indexof($result$$Register,
                       $haystack$$Register, $haycnt$$Register,
-                      $needle$$Register, NULL, $needlecnt$$Register, 0,  // needlecnt not constant.
+                      $needle$$Register, nullptr, $needlecnt$$Register, 0,  // needlecnt not constant.
                       $tmp1$$Register, $tmp2$$Register, $tmp3$$Register, $tmp4$$Register, StrIntrinsicNode::LL);
   %}
   ins_pipe(pipe_class_compare);
@@ -12712,7 +12712,7 @@ instruct indexOf_UL(iRegIdst result, iRegPsrc haystack, rscratch1RegI haycnt, iR
   ins_encode %{
     __ string_indexof($result$$Register,
                       $haystack$$Register, $haycnt$$Register,
-                      $needle$$Register, NULL, $needlecnt$$Register, 0,  // needlecnt not constant.
+                      $needle$$Register, nullptr, $needlecnt$$Register, 0,  // needlecnt not constant.
                       $tmp1$$Register, $tmp2$$Register, $tmp3$$Register, $tmp4$$Register, StrIntrinsicNode::UL);
   %}
   ins_pipe(pipe_class_compare);

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -4110,7 +4110,7 @@ operand immN() %{
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immN_0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1196,13 +1196,13 @@ bool is_CAS(int opcode, bool maybe_volatile)
 // returns true if CAS needs to use an acquiring load otherwise false
 bool needs_acquiring_load_reserved(const Node *n)
 {
-  assert(n != NULL && is_CAS(n->Opcode(), true), "expecting a compare and swap");
+  assert(n != nullptr && is_CAS(n->Opcode(), true), "expecting a compare and swap");
 
   LoadStoreNode* ldst = n->as_LoadStore();
-  if (n != NULL && is_CAS(n->Opcode(), false)) {
-    assert(ldst != NULL && ldst->trailing_membar() != NULL, "expected trailing membar");
+  if (n != nullptr && is_CAS(n->Opcode(), false)) {
+    assert(ldst != nullptr && ldst->trailing_membar() != nullptr, "expected trailing membar");
   } else {
-    return ldst != NULL && ldst->trailing_membar() != NULL;
+    return ldst != nullptr && ldst->trailing_membar() != nullptr;
   }
   // so we can just return true here
   return true;
@@ -1247,7 +1247,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   sd(t1, Address(sp, wordSize))  ->  sd
   //   jalr(t0)                       ->  jalr
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
-  if (cb != NULL) {
+  if (cb != nullptr) {
     return 1 * NativeInstruction::instruction_size;
   } else {
     return 11 * NativeInstruction::instruction_size;
@@ -1286,7 +1286,7 @@ int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
 
 #ifndef PRODUCT
 void MachBreakpointNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
-  assert_cond(st != NULL);
+  assert_cond(st != nullptr);
   st->print("BREAKPOINT");
 }
 #endif
@@ -1342,14 +1342,14 @@ uint MachConstantBaseNode::size(PhaseRegAlloc* ra_) const {
 
 #ifndef PRODUCT
 void MachConstantBaseNode::format(PhaseRegAlloc* ra_, outputStream* st) const {
-  assert_cond(st != NULL);
+  assert_cond(st != nullptr);
   st->print("-- \t// MachConstantBaseNode (empty encoding)");
 }
 #endif
 
 #ifndef PRODUCT
 void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
-  assert_cond(st != NULL && ra_ != NULL);
+  assert_cond(st != nullptr && ra_ != nullptr);
   Compile* C = ra_->C;
 
   int framesize = C->output()->frame_slots() << LogBytesPerInt;
@@ -1363,7 +1363,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   if (PreserveFramePointer) { st->print("sub  fp, sp, #%d\n\t", 2 * wordSize); }
   st->print("sub sp, sp, #%d\n\t", framesize);
 
-  if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (C->stub_function() == nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("ld  t0, [guard]\n\t");
     st->print("membar LoadLoad\n\t");
     st->print("ld  t1, [xthread, #thread_disarmed_guard_value_offset]\n\t");
@@ -1377,7 +1377,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
 #endif
 
 void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
 
@@ -1392,7 +1392,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ nop();  // 4 bytes
   }
 
-  assert_cond(C != NULL);
+  assert_cond(C != nullptr);
 
   if (C->clinit_barrier_on_entry()) {
     assert(!C->method()->holder()->is_not_initialized(), "initialization should have been started");
@@ -1412,9 +1412,9 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   __ build_frame(framesize);
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
-    if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+    if (BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
       // Dummy labels for just measuring the code size
       Label dummy_slow_path;
       Label dummy_continuation;
@@ -1451,7 +1451,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
 uint MachPrologNode::size(PhaseRegAlloc* ra_) const
 {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   return MachNode::size(ra_); // too many variables; just compute it
                               // the hard way
 }
@@ -1465,9 +1465,9 @@ int MachPrologNode::reloc() const
 
 #ifndef PRODUCT
 void MachEpilogNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
-  assert_cond(st != NULL && ra_ != NULL);
+  assert_cond(st != nullptr && ra_ != nullptr);
   Compile* C = ra_->C;
-  assert_cond(C != NULL);
+  assert_cond(C != nullptr);
   int framesize = C->output()->frame_size_in_bytes();
 
   st->print("# pop frame %d\n\t", framesize);
@@ -1491,10 +1491,10 @@ void MachEpilogNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
 #endif
 
 void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   Compile* C = ra_->C;
   C2_MacroAssembler _masm(&cbuf);
-  assert_cond(C != NULL);
+  assert_cond(C != nullptr);
   int framesize = C->output()->frame_size_in_bytes();
 
   __ remove_frame(framesize);
@@ -1517,7 +1517,7 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 }
 
 uint MachEpilogNode::size(PhaseRegAlloc *ra_) const {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   // Variable size. Determine dynamically.
   return MachNode::size(ra_);
 }
@@ -1568,7 +1568,7 @@ static enum RC rc_class(OptoReg::Name reg) {
 }
 
 uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, bool do_size, outputStream *st) const {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   Compile* C = ra_->C;
 
   // Get registers to move.
@@ -1599,7 +1599,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   int src_offset = ra_->reg2offset(src_lo);
   int dst_offset = ra_->reg2offset(dst_lo);
 
-  if (bottom_type()->isa_vect() != NULL) {
+  if (bottom_type()->isa_vect() != nullptr) {
     uint ireg = ideal_reg();
     if (ireg == Op_VecA && cbuf) {
       C2_MacroAssembler _masm(cbuf);
@@ -1640,7 +1640,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
         ShouldNotReachHere();
       }
     }
-  } else if (cbuf != NULL) {
+  } else if (cbuf != nullptr) {
     C2_MacroAssembler _masm(cbuf);
     switch (src_lo_rc) {
       case rc_int:
@@ -1711,7 +1711,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     }
   }
 
-  if (st != NULL) {
+  if (st != nullptr) {
     st->print("spill ");
     if (src_lo_rc == rc_stack) {
       st->print("[sp, #%d] -> ", src_offset);
@@ -1745,16 +1745,16 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
 
 #ifndef PRODUCT
 void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
-  if (ra_ == NULL) {
+  if (ra_ == nullptr) {
     st->print("N%d = SpillCopy(N%d)", _idx, in(1)->_idx);
   } else {
-    implementation(NULL, ra_, false, st);
+    implementation(nullptr, ra_, false, st);
   }
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -1765,7 +1765,7 @@ uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
 
 #ifndef PRODUCT
 void BoxLockNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
-  assert_cond(ra_ != NULL && st != NULL);
+  assert_cond(ra_ != nullptr && st != nullptr);
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
   int reg = ra_->get_reg_first(this);
   st->print("add %s, sp, #%d\t# box lock",
@@ -1777,7 +1777,7 @@ void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   C2_MacroAssembler _masm(&cbuf);
   Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see BoxLockNode::size()
 
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   int offset = ra_->reg2offset(in_RegMask(0).find_first_elem());
   int reg    = ra_->get_encode(this);
 
@@ -1805,7 +1805,7 @@ uint BoxLockNode::size(PhaseRegAlloc *ra_) const {
 #ifndef PRODUCT
 void MachUEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
 {
-  assert_cond(st != NULL);
+  assert_cond(st != nullptr);
   st->print_cr("# MachUEPNode");
   if (UseCompressedClassPointers) {
     st->print_cr("\tlwu t0, [j_rarg0, oopDesc::klass_offset_in_bytes()]\t# compressed klass");
@@ -1838,7 +1838,7 @@ void MachUEPNode::emit(CodeBuffer& cbuf, PhaseRegAlloc* ra_) const
 
 uint MachUEPNode::size(PhaseRegAlloc* ra_) const
 {
-  assert_cond(ra_ != NULL);
+  assert_cond(ra_ != nullptr);
   return MachNode::size(ra_);
 }
 
@@ -1855,7 +1855,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -1873,7 +1873,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf)
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2038,7 +2038,7 @@ int Matcher::scalable_vector_reg_size(const BasicType bt) {
 
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -2141,10 +2141,10 @@ const RegMask Matcher::method_handle_invoke_SP_save_mask() {
 }
 
 bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
-  assert_cond(addp != NULL);
+  assert_cond(addp != nullptr);
   for (DUIterator_Fast imax, i = addp->fast_outs(imax); i < imax; i++) {
     Node* u = addp->fast_out(i);
-    if (u != NULL && u->is_Mem()) {
+    if (u != nullptr && u->is_Mem()) {
       int opsize = u->as_Mem()->memory_size();
       assert(opsize > 0, "unexpected memory operand size");
       if (u->as_Mem()->memory_size() != (1 << shift)) {
@@ -2157,7 +2157,7 @@ bool size_fits_all_mem_uses(AddPNode* addp, int shift) {
 
 // Should the Matcher clone input 'm' of node 'n'?
 bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
-  assert_cond(m != NULL);
+  assert_cond(m != nullptr);
   if (is_vshift_con_pattern(n, m)) { // ShiftV src (ShiftCntV con)
     mstack.push(m, Visit);           // m = ShiftCntV
     return true;
@@ -2216,7 +2216,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL || con == (address)1) {
+    if (con == nullptr || con == (address)1) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -2246,7 +2246,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -2265,7 +2265,7 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       relocInfo::relocType rtype = $src->constant_reloc();
@@ -2351,7 +2351,7 @@ encode %{
     Label done;
     C2_MacroAssembler _masm(&cbuf);
     __ check_klass_subtype_slow_path(sub_reg, super_reg, temp_reg, result_reg,
-                                     NULL, &miss);
+                                     nullptr, &miss);
     if ($primary) {
       __ mv(result_reg, zr);
     } else {
@@ -2372,12 +2372,12 @@ encode %{
     Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see ret_addr_offset
 
     address addr = (address)$meth$$method;
-    address call = NULL;
-    assert_cond(addr != NULL);
+    address call = nullptr;
+    assert_cond(addr != nullptr);
     if (!_method) {
       // A call to a runtime wrapper, e.g. new, new_typeArray_Java, uncommon_trap.
       call = __ trampoline_call(Address(addr, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -2391,7 +2391,7 @@ encode %{
       RelocationHolder rspec = _optimized_virtual ? opt_virtual_call_Relocation::spec(method_index)
                                                   : static_call_Relocation::spec(method_index);
       call = __ trampoline_call(Address(addr, rspec));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -2403,7 +2403,7 @@ encode %{
       } else {
         // Emit stub for static call
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, call);
-        if (stub == NULL) {
+        if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
         }
@@ -2418,7 +2418,7 @@ encode %{
     Assembler::IncompressibleRegion ir(&_masm);  // Fixed length: see ret_addr_offset
     int method_index = resolved_method_index(cbuf);
     address call = __ ic_call((address)$meth$$method, method_index);
-    if (call == NULL) {
+    if (call == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }
@@ -2444,9 +2444,9 @@ encode %{
     // which loads the absolute address into a register.
     address entry = (address)$meth$$method;
     CodeBlob *cb = CodeCache::find_blob(entry);
-    if (cb != NULL) {
+    if (cb != nullptr) {
       address call = __ trampoline_call(Address(entry, relocInfo::runtime_call_type));
-      if (call == NULL) {
+      if (call == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -2894,7 +2894,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -3015,7 +3015,7 @@ operand immN()
   interface(CONST_INTER);
 %}
 
-// Narrow NULL Pointer Immediate
+// Narrow nullptr Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);
@@ -4893,7 +4893,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   match(Set dst con);
 
   ins_cost(ALU_COST);
-  format %{ "mv  $dst, $con\t# NULL ptr, #@loadConP0" %}
+  format %{ "mv  $dst, $con\t# null ptr, #@loadConP0" %}
 
   ins_encode(riscv_enc_mov_zero(dst));
 
@@ -4944,7 +4944,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   match(Set dst con);
 
   ins_cost(ALU_COST);
-  format %{ "mv  $dst, $con\t# compressed NULL ptr, #@loadConN0" %}
+  format %{ "mv  $dst, $con\t# compressed null ptr, #@loadConN0" %}
 
   ins_encode(riscv_enc_mov_zero(dst));
 
@@ -10338,7 +10338,7 @@ instruct clearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, iRegP_R30 tmp1,
 
   ins_encode %{
     address tpc = __ zero_words($base$$Register, $cnt$$Register);
-    if (tpc == NULL) {
+    if (tpc == nullptr) {
       ciEnv::current()->record_failure("CodeCache is full");
       return;
     }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2894,7 +2894,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -3015,7 +3015,7 @@ operand immN()
   interface(CONST_INTER);
 %}
 
-// Narrow nullptr Pointer Immediate
+// Narrow Null Pointer Immediate
 operand immN0()
 %{
   predicate(n->get_narrowcon() == 0);
@@ -4893,7 +4893,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   match(Set dst con);
 
   ins_cost(ALU_COST);
-  format %{ "mv  $dst, $con\t# null ptr, #@loadConP0" %}
+  format %{ "mv  $dst, $con\t# null pointer, #@loadConP0" %}
 
   ins_encode(riscv_enc_mov_zero(dst));
 
@@ -4944,7 +4944,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   match(Set dst con);
 
   ins_cost(ALU_COST);
-  format %{ "mv  $dst, $con\t# compressed null ptr, #@loadConN0" %}
+  format %{ "mv  $dst, $con\t# compressed null pointer, #@loadConN0" %}
 
   ins_encode(riscv_enc_mov_zero(dst));
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -3744,7 +3744,7 @@ void MacroAssembler::compare_klass_ptr(Register Rop1, int64_t disp, Register Rba
       Register current = Rop1;
       Label    done;
 
-      if (maybenull) {       // null ptr must be preserved!
+      if (maybenull) {       // null pointer must be preserved!
         z_ltgr(Z_R0, current);
         z_bre(done);
         current = Z_R0;
@@ -3883,7 +3883,7 @@ void MacroAssembler::compare_heap_oop(Register Rop1, Address mem, bool maybenull
     Label done;
     int   pow2_offset = get_oop_base_complement(Z_R1, ((uint64_t)(intptr_t)base));
 
-    if (maybenull) {       // null ptr must be preserved!
+    if (maybenull) {       // null pointer must be preserved!
       z_ltgr(Z_R0, Rop1);
       z_bre(done);
     }
@@ -4123,7 +4123,7 @@ void MacroAssembler::oop_decoder(Register Rdst, Register Rsrc, bool maybenull, R
       Label done;
 
       // Rsrc contains a narrow oop. Thus we are sure the leftmost <oop_shift> bits will never be set.
-      if (maybenull) {  // null ptr must be preserved!
+      if (maybenull) {  // null pointer must be preserved!
         z_slag(Rdst, Rsrc, oop_shift);  // Arithmetic shift sets the condition code.
         z_bre(done);
       } else {
@@ -4185,7 +4185,7 @@ void MacroAssembler::oop_decoder(Register Rdst, Register Rsrc, bool maybenull, R
 
       // Scale oop and check for null.
       // Rsrc contains a narrow oop. Thus we are sure the leftmost <oop_shift> bits will never be set.
-      if (maybenull) {  // null ptr must be preserved!
+      if (maybenull) {  // null pointer must be preserved!
         z_slag(Rdst_tmp, Rsrc, oop_shift);  // Arithmetic shift sets the condition code.
         z_bre(done);
       } else {

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2966,7 +2966,7 @@ operand immN8() %{
   interface(CONST_INTER);
 %}
 
-// Narrow nullptr Pointer Immediate
+// Narrow Null Pointer Immediate
 operand immN0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);
@@ -4314,7 +4314,7 @@ instruct loadConP0(iRegP dst, immP0 src, flagsReg cr) %{
   match(Set dst src);
   effect(KILL cr);
   size(4);
-  format %{ "XGR     $dst,$dst\t # null ptr" %}
+  format %{ "XGR     $dst,$dst\t # null pointer" %}
   opcode(XGR_ZOPC);
   ins_encode(z_rreform(dst, dst));
   ins_pipe(pipe_class_dummy);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -740,7 +740,7 @@ int emit_call_reloc(C2_MacroAssembler &_masm, intptr_t entry_point, relocInfo::r
   if (rtype == relocInfo::runtime_call_w_cp_type) {
     assert((__ offset() & 2) == 0, "misaligned emit_call_reloc");
     address call_addr = __ call_c_opt((address)entry_point);
-    if (call_addr == NULL) {
+    if (call_addr == nullptr) {
       Compile::current()->env()->record_out_of_memory_failure();
       return -1;
     }
@@ -835,7 +835,7 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
   st->print_cr("push_frame %d", (int)-framesize);
   st->print("\t");
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     st->print("nmethod entry barrier\n\t");
   }
 }
@@ -890,7 +890,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     constant_table.set_table_base_offset(constant_table.calculate_table_base_offset());
   }
 
-  if (C->stub_function() == NULL) {
+  if (C->stub_function() == nullptr) {
     BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
     bs->nmethod_entry_barrier(&_masm);
   }
@@ -1056,7 +1056,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
   bool src12 = Immediate::is_uimm12(src_offset);
   bool dst12 = Immediate::is_uimm12(dst_offset);
 
-  const char   *mnemo = NULL;
+  const char   *mnemo = nullptr;
   unsigned long opc = 0;
 
   // Memory->Memory Spill. Use Z_R0 to hold the value.
@@ -1199,7 +1199,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
 #if !defined(PRODUCT)
 void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *os) const {
   if (ra_ && ra_->node_regs_max_index() > 0) {
-    implementation(NULL, ra_, false, os);
+    implementation(nullptr, ra_, false, os);
   } else {
     if (req() == 2 && in(1)) {
       os->print("N%d = N%d\n", _idx, in(1)->_idx);
@@ -1217,11 +1217,11 @@ void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream *os) const {
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
-  return implementation(NULL, ra_, true, NULL);
+  return implementation(nullptr, ra_, true, nullptr);
 }
 
 //=============================================================================
@@ -1446,7 +1446,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer &cbuf) {
   C2_MacroAssembler _masm(&cbuf);
 
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     return 0;          // CodeBuffer::expand failed
   }
 
@@ -1467,7 +1467,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   C2_MacroAssembler _masm(&cbuf);
   address        base = __ start_a_stub(size_deopt_handler());
 
-  if (base == NULL) {
+  if (base == nullptr) {
     return 0;  // CodeBuffer::expand failed
   }
 
@@ -1533,11 +1533,11 @@ bool Matcher::vector_needs_partial_operations(Node* node, const TypeVect* vt) {
 }
 
 const RegMask* Matcher::predicate_reg_mask(void) {
-  return NULL;
+  return nullptr;
 }
 
 const TypeVectMask* Matcher::predicate_reg_type(const Type* elemTy, int length) {
-  return NULL;
+  return nullptr;
 }
 
 // Vector calling convention not yet implemented.
@@ -1602,7 +1602,7 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* original_opnd, uint ideal_reg, bool is_temp) {
   ShouldNotReachHere(); // generic vector operands not supported
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -1948,12 +1948,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
     __ z_brul(l);
   %}
 
@@ -1961,12 +1961,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
     __ z_bru(l);
   %}
 
@@ -1974,12 +1974,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
     __ z_brcl((Assembler::branch_condition)$cmp$$cmpcode, l);
   %}
 
@@ -1987,12 +1987,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
     __ z_brc((Assembler::branch_condition)$cmp$$cmpcode, l);
   %}
 
@@ -2000,12 +2000,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
     Assembler::branch_condition cc = (Assembler::branch_condition)$cmp$$cmpcode;
     unsigned long instr = $primary;
     if (instr == CRJ_ZOPC) {
@@ -2024,12 +2024,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
 
     unsigned long instr = $primary;
     if (instr == CR_ZOPC) {
@@ -2050,12 +2050,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
 
     Assembler::branch_condition cc = (Assembler::branch_condition)$cmp$$cmpcode;
     unsigned long instr = $primary;
@@ -2075,12 +2075,12 @@ encode %{
     C2_MacroAssembler _masm(&cbuf);
     Label* p = $lbl$$label;
 
-    // 'p' is `NULL' when this encoding class is used only to
+    // 'p' is `nullptr' when this encoding class is used only to
     // determine the size of the encoded instruction.
     // Use a bound dummy label in that case.
     Label d;
     __ bind(d);
-    Label& l = (NULL == p) ? d : *(p);
+    Label& l = (nullptr == p) ? d : *(p);
 
     unsigned long instr = $primary;
     if (instr == CHI_ZOPC) {
@@ -2112,7 +2112,7 @@ encode %{
 
     assert((__ offset() & 2) == 0, "misaligned z_enc_java_to_runtime_call");
     address call_addr = __ call_c_opt((address)$meth$$method);
-    if (call_addr == NULL) {
+    if (call_addr == nullptr) {
       Compile::current()->env()->record_out_of_memory_failure();
       return;
     }
@@ -2143,11 +2143,11 @@ encode %{
                                      static_call_Relocation::spec(method_index));
       }
     }
-    assert(__ inst_mark() != NULL, "emit_call_reloc must set_inst_mark()");
+    assert(__ inst_mark() != nullptr, "emit_call_reloc must set_inst_mark()");
 
     if (_method) { // Emit stub for static call.
       address stub = CompiledStaticCall::emit_to_interp_stub(cbuf);
-      if (stub == NULL) {
+      if (stub == nullptr) {
         ciEnv::current()->record_failure("CodeCache is full");
         return;
       }
@@ -2162,7 +2162,7 @@ encode %{
     int vtable_index = this->_vtable_index;
     if (vtable_index == -4) {
       Register ic_reg = reg_to_register_object(Matcher::inline_cache_reg_encode());
-      address virtual_call_oop_addr = NULL;
+      address virtual_call_oop_addr = nullptr;
 
       AddressLiteral empty_ic((address) Universe::non_oop_word());
       virtual_call_oop_addr = __ pc();
@@ -2929,7 +2929,7 @@ operand immP8() %{
 // POINTER specific values
 //-----------------------------------
 
-// Pointer Immediate: NULL
+// Pointer Immediate: nullptr
 operand immP0() %{
   predicate(n->get_ptr() == 0);
   match(ConP);
@@ -2966,7 +2966,7 @@ operand immN8() %{
   interface(CONST_INTER);
 %}
 
-// Narrow NULL Pointer Immediate
+// Narrow nullptr Pointer Immediate
 operand immN0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);
@@ -3383,7 +3383,7 @@ operand inline_cache_regP(iRegP reg) %{
 // Operands to remove register moves in unscaled mode.
 // Match read/write registers with an EncodeP node if neither shift nor add are required.
 operand iRegP2N(iRegP reg) %{
-  predicate(CompressedOops::shift() == 0 && _leaf->as_EncodeP()->in(0) == NULL);
+  predicate(CompressedOops::shift() == 0 && _leaf->as_EncodeP()->in(0) == nullptr);
   constraint(ALLOC_IN_RC(z_memory_ptr_reg));
   match(EncodeP reg);
   format %{ "$reg" %}
@@ -3391,8 +3391,8 @@ operand iRegP2N(iRegP reg) %{
 %}
 
 operand iRegN2P(iRegN reg) %{
-  predicate(CompressedOops::base() == NULL && CompressedOops::shift() == 0 &&
-            _leaf->as_DecodeN()->in(0) == NULL);
+  predicate(CompressedOops::base() == nullptr && CompressedOops::shift() == 0 &&
+            _leaf->as_DecodeN()->in(0) == nullptr);
   constraint(ALLOC_IN_RC(z_memory_ptr_reg));
   match(DecodeN reg);
   format %{ "$reg" %}
@@ -4236,7 +4236,7 @@ instruct loadConL_pcrelTOC(iRegL dst, immL src) %{
   format %{ "LGRL    $dst,[pcrelTOC]\t # load long $src from table" %}
   ins_encode %{
     address long_address = __ long_constant($src$$constant);
-    if (long_address == NULL) {
+    if (long_address == nullptr) {
       Compile::current()->env()->record_out_of_memory_failure();
       return;
     }
@@ -4292,14 +4292,14 @@ instruct loadConP_pcrelTOC(iRegP dst, immP src) %{
     } else if (constant_reloc == relocInfo::metadata_type) {
       AddressLiteral a = __ constant_metadata_address((Metadata *)$src$$constant);
       address const_toc_addr = __ address_constant((address)a.value(), RelocationHolder::none);
-      if (const_toc_addr == NULL) {
+      if (const_toc_addr == nullptr) {
         Compile::current()->env()->record_out_of_memory_failure();
         return;
       }
       __ load_long_pcrelative($dst$$Register, const_toc_addr);
     } else {          // Non-oop pointers, e.g. card mark base, heap top.
       address long_address = __ long_constant((jlong)$src$$constant);
-      if (long_address == NULL) {
+      if (long_address == nullptr) {
         Compile::current()->env()->record_out_of_memory_failure();
         return;
       }
@@ -4314,7 +4314,7 @@ instruct loadConP0(iRegP dst, immP0 src, flagsReg cr) %{
   match(Set dst src);
   effect(KILL cr);
   size(4);
-  format %{ "XGR     $dst,$dst\t # NULL ptr" %}
+  format %{ "XGR     $dst,$dst\t # null ptr" %}
   opcode(XGR_ZOPC);
   ins_encode(z_rreform(dst, dst));
   ins_pipe(pipe_class_dummy);
@@ -4660,7 +4660,7 @@ instruct loadConNKlass(iRegN dst, immNKlass src) %{
 
 instruct decodeLoadN(iRegP dst, memory mem) %{
   match(Set dst (DecodeN (LoadN mem)));
-  predicate(false && (CompressedOops::base()==NULL)&&(CompressedOops::shift()==0));
+  predicate(false && (CompressedOops::base()==nullptr)&&(CompressedOops::shift()==0));
   ins_cost(MEMORY_REF_COST);
   size(Z_DISP3_SIZE);
   format %{ "DecodeLoadN  $dst,$mem\t # (cOop Load+Decode)" %}
@@ -4671,7 +4671,7 @@ instruct decodeLoadN(iRegP dst, memory mem) %{
 
 instruct decodeLoadNKlass(iRegP dst, memory mem) %{
   match(Set dst (DecodeNKlass (LoadNKlass mem)));
-  predicate(false && (CompressedKlassPointers::base()==NULL)&&(CompressedKlassPointers::shift()==0));
+  predicate(false && (CompressedKlassPointers::base()==nullptr)&&(CompressedKlassPointers::shift()==0));
   ins_cost(MEMORY_REF_COST);
   size(Z_DISP3_SIZE);
   format %{ "DecodeLoadNKlass  $dst,$mem\t # (load/decode NKlass)" %}
@@ -4699,7 +4699,7 @@ instruct decodeLoadConNKlass(iRegP dst, immNKlass src) %{
 instruct decodeN(iRegP dst, iRegN src, flagsReg cr) %{
   match(Set dst (DecodeN src));
   effect(KILL cr);
-  predicate(CompressedOops::base() == NULL || !ExpandLoadingBaseDecode);
+  predicate(CompressedOops::base() == nullptr || !ExpandLoadingBaseDecode);
   ins_cost(MEMORY_REF_COST+3 * DEFAULT_COST + BRANCH_COST);
   // TODO: s390 port size(VARIABLE_SIZE);
   format %{ "decodeN  $dst,$src\t # (decode cOop)" %}
@@ -4723,7 +4723,7 @@ instruct decodeN_NN(iRegP dst, iRegN src, flagsReg cr) %{
   effect(KILL cr);
   predicate((n->bottom_type()->make_ptr()->ptr() == TypePtr::NotNull ||
              n->bottom_type()->is_oopptr()->ptr() == TypePtr::Constant) &&
-            (CompressedOops::base()== NULL || !ExpandLoadingBaseDecode_NN));
+            (CompressedOops::base()== nullptr || !ExpandLoadingBaseDecode_NN));
   ins_cost(MEMORY_REF_COST+2 * DEFAULT_COST);
   // TODO: s390 port size(VARIABLE_SIZE);
   format %{ "decodeN  $dst,$src\t # (decode cOop NN)" %}
@@ -4749,7 +4749,7 @@ instruct decodeN_NN(iRegP dst, iRegN src, flagsReg cr) %{
     effect(KILL cr);
     predicate(false);
     // TODO: s390 port size(VARIABLE_SIZE);
-    format %{ "decodeN  $dst = ($src == 0) ? NULL : ($src << 3) + $base + pow2_offset\t # (decode cOop)" %}
+    format %{ "decodeN  $dst = ($src == 0) ? nullptr : ($src << 3) + $base + pow2_offset\t # (decode cOop)" %}
     ins_encode %{
       __ oop_decoder($dst$$Register, $src$$Register, true, $base$$Register,
                      (jlong)MacroAssembler::get_oop_base_pow2_offset((uint64_t)(intptr_t)CompressedOops::base()));
@@ -4774,7 +4774,7 @@ instruct decodeN_NN(iRegP dst, iRegN src, flagsReg cr) %{
 // Decoder for heapbased mode peeling off loading the base.
 instruct decodeN_Ex(iRegP dst, iRegN src, flagsReg cr) %{
   match(Set dst (DecodeN src));
-  predicate(CompressedOops::base() != NULL && ExpandLoadingBaseDecode);
+  predicate(CompressedOops::base() != nullptr && ExpandLoadingBaseDecode);
   ins_cost(MEMORY_REF_COST+3 * DEFAULT_COST + BRANCH_COST);
   // TODO: s390 port size(VARIABLE_SIZE);
   expand %{
@@ -4790,7 +4790,7 @@ instruct decodeN_NN_Ex(iRegP dst, iRegN src, flagsReg cr) %{
   match(Set dst (DecodeN src));
   predicate((n->bottom_type()->make_ptr()->ptr() == TypePtr::NotNull ||
              n->bottom_type()->is_oopptr()->ptr() == TypePtr::Constant) &&
-            CompressedOops::base() != NULL && ExpandLoadingBaseDecode_NN);
+            CompressedOops::base() != nullptr && ExpandLoadingBaseDecode_NN);
   ins_cost(MEMORY_REF_COST+2 * DEFAULT_COST);
   // TODO: s390 port size(VARIABLE_SIZE);
   expand %{
@@ -6069,7 +6069,7 @@ instruct addP_reg_reg_imm12(iRegP dst, memoryRegP src1, iRegL src2, uimmL12 con)
 
 instruct addP_regN_reg_imm12(iRegP dst, iRegP_N2P src1, iRegL src2, uimmL12 con) %{
   match(Set dst (AddP (AddP src1 src2) con));
-  predicate( PreferLAoverADD && CompressedOops::base() == NULL && CompressedOops::shift() == 0);
+  predicate( PreferLAoverADD && CompressedOops::base() == nullptr && CompressedOops::shift() == 0);
   ins_cost(DEFAULT_COST_LOW);
   size(4);
   format %{ "LA      $dst,$con($src1,$src2)\t # ptr d12(x,b)" %}
@@ -6091,7 +6091,7 @@ instruct addP_reg_reg_imm20(iRegP dst, memoryRegP src1, iRegL src2, immL20 con) 
 
 instruct addP_regN_reg_imm20(iRegP dst, iRegP_N2P src1, iRegL src2, immL20 con) %{
   match(Set dst (AddP (AddP src1 src2) con));
-  predicate( PreferLAoverADD && CompressedOops::base() == NULL && CompressedOops::shift() == 0);
+  predicate( PreferLAoverADD && CompressedOops::base() == nullptr && CompressedOops::shift() == 0);
   ins_cost(DEFAULT_COST);
   // TODO: s390 port size(FIXED_SIZE);
   format %{ "LAY     $dst,$con($src1,$src2)\t # ptr d20(x,b)" %}
@@ -8427,7 +8427,7 @@ instruct compP_reg_imm0(flagsReg cr, iRegP_N2P op1, immP0 op2) %{
 // Don't use LTGFR which performs sign extend.
 instruct compP_decode_reg_imm0(flagsReg cr, iRegN op1, immP0 op2) %{
   match(Set cr (CmpP (DecodeN op1) op2));
-  predicate(CompressedOops::base() == NULL && CompressedOops::shift() == 0);
+  predicate(CompressedOops::base() == nullptr && CompressedOops::shift() == 0);
   ins_cost(DEFAULT_COST_LOW);
   size(2);
   format %{ "LTR    $op1, $op1\t # ptr" %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1312,7 +1312,7 @@ int HandlerImpl::emit_exception_handler(CodeBuffer& cbuf) {
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_exception_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -1330,7 +1330,7 @@ int HandlerImpl::emit_deopt_handler(CodeBuffer& cbuf) {
   // That's why we must use the macroassembler to generate a handler.
   C2_MacroAssembler _masm(&cbuf);
   address base = __ start_a_stub(size_deopt_handler());
-  if (base == NULL) {
+  if (base == nullptr) {
     ciEnv::current()->record_failure("CodeCache is full");
     return 0;  // CodeBuffer::expand failed
   }
@@ -2181,7 +2181,7 @@ MachOper* Matcher::pd_specialize_generic_vector_operand(MachOper* generic_opnd, 
     }
   }
   ShouldNotReachHere();
-  return NULL;
+  return nullptr;
 }
 
 bool Matcher::is_reg2reg_move(MachNode* m) {
@@ -2350,7 +2350,7 @@ class FusedPatternMatcher {
   int _con_op;
 
   static int match_next(Node* n, int next_op, int next_op_idx) {
-    if (n->in(1) == NULL || n->in(2) == NULL) {
+    if (n->in(1) == nullptr || n->in(2) == nullptr) {
       return -1;
     }
 
@@ -2417,7 +2417,7 @@ class FusedPatternMatcher {
 
 static bool is_bmi_pattern(Node* n, Node* m) {
   assert(UseBMI1Instructions, "sanity");
-  if (n != NULL && m != NULL) {
+  if (n != nullptr && m != nullptr) {
     if (m->Opcode() == Op_LoadI) {
       FusedPatternMatcher<TypeInt> bmii(n, m, Op_ConI);
       return bmii.match(Op_AndI, -1, Op_SubI,  1,  0)  ||
@@ -7441,7 +7441,7 @@ instruct vround_reg_evex(vec dst, vec src, rRegP tmp, vec xtmp1, vec xtmp2, kReg
 // --------------------------------- VectorMaskCmp --------------------------------------
 
 instruct vcmpFD(legVec dst, legVec src1, legVec src2, immI8 cond) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL &&
+  predicate(n->bottom_type()->isa_vectmask() == nullptr &&
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  8 && // src1
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
             is_floating_point_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
@@ -7461,7 +7461,7 @@ instruct vcmpFD(legVec dst, legVec src1, legVec src2, immI8 cond) %{
 
 instruct evcmpFD64(vec dst, vec src1, vec src2, immI8 cond, kReg ktmp) %{
   predicate(Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 64 && // src1
-            n->bottom_type()->isa_vectmask() == NULL &&
+            n->bottom_type()->isa_vectmask() == nullptr &&
             is_floating_point_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1 T_FLOAT, T_DOUBLE
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
   effect(TEMP ktmp);
@@ -7501,7 +7501,7 @@ instruct evcmpFD(kReg dst, vec src1, vec src2, immI8 cond) %{
 %}
 
 instruct vcmp_direct(legVec dst, legVec src1, legVec src2, immI8 cond) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL &&
+  predicate(n->bottom_type()->isa_vectmask() == nullptr &&
             !Matcher::is_unsigned_booltest_pred(n->in(2)->get_int()) &&
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  4 && // src1
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
@@ -7521,7 +7521,7 @@ instruct vcmp_direct(legVec dst, legVec src1, legVec src2, immI8 cond) %{
 %}
 
 instruct vcmp_negate(legVec dst, legVec src1, legVec src2, immI8 cond, legVec xtmp) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL &&
+  predicate(n->bottom_type()->isa_vectmask() == nullptr &&
             !Matcher::is_unsigned_booltest_pred(n->in(2)->get_int()) &&
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  4 && // src1
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
@@ -7542,7 +7542,7 @@ instruct vcmp_negate(legVec dst, legVec src1, legVec src2, immI8 cond, legVec xt
 %}
 
 instruct vcmpu(legVec dst, legVec src1, legVec src2, immI8 cond, legVec xtmp) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL &&
+  predicate(n->bottom_type()->isa_vectmask() == nullptr &&
             Matcher::is_unsigned_booltest_pred(n->in(2)->get_int()) &&
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) >=  4 && // src1
             Matcher::vector_length_in_bytes(n->in(1)->in(1)) <= 32 && // src1
@@ -7569,7 +7569,7 @@ instruct vcmpu(legVec dst, legVec src1, legVec src2, immI8 cond, legVec xtmp) %{
 %}
 
 instruct vcmp64(vec dst, vec src1, vec src2, immI8 cond, kReg ktmp) %{
-  predicate((n->bottom_type()->isa_vectmask() == NULL &&
+  predicate((n->bottom_type()->isa_vectmask() == nullptr &&
              Matcher::vector_length_in_bytes(n->in(1)->in(1)) == 64) && // src1
              is_integral_type(Matcher::vector_element_basic_type(n->in(1)->in(1)))); // src1
   match(Set dst (VectorMaskCmp (Binary src1 src2) cond));
@@ -7785,7 +7785,7 @@ instruct blendvp(vec dst, vec src, vec mask, rxmm0 tmp) %{
 
 instruct vblendvpI(legVec dst, legVec src1, legVec src2, legVec mask) %{
   predicate(UseAVX > 0 && !EnableX86ECoreOpts &&
-            n->in(2)->bottom_type()->isa_vectmask() == NULL &&
+            n->in(2)->bottom_type()->isa_vectmask() == nullptr &&
             Matcher::vector_length_in_bytes(n) <= 32 &&
             is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorBlend (Binary src1 src2) mask));
@@ -7799,7 +7799,7 @@ instruct vblendvpI(legVec dst, legVec src1, legVec src2, legVec mask) %{
 
 instruct vblendvpFD(legVec dst, legVec src1, legVec src2, legVec mask) %{
   predicate(UseAVX > 0 && !EnableX86ECoreOpts &&
-            n->in(2)->bottom_type()->isa_vectmask() == NULL &&
+            n->in(2)->bottom_type()->isa_vectmask() == nullptr &&
             Matcher::vector_length_in_bytes(n) <= 32 &&
             !is_integral_type(Matcher::vector_element_basic_type(n)));
   match(Set dst (VectorBlend (Binary src1 src2) mask));
@@ -7813,7 +7813,7 @@ instruct vblendvpFD(legVec dst, legVec src1, legVec src2, legVec mask) %{
 
 instruct vblendvp(legVec dst, legVec src1, legVec src2, legVec mask, legVec vtmp) %{
   predicate(UseAVX > 0 && EnableX86ECoreOpts &&
-            n->in(2)->bottom_type()->isa_vectmask() == NULL &&
+            n->in(2)->bottom_type()->isa_vectmask() == nullptr &&
             Matcher::vector_length_in_bytes(n) <= 32);
   match(Set dst (VectorBlend (Binary src1 src2) mask));
   format %{ "vector_blend  $dst,$src1,$src2,$mask\t! using $vtmp as TEMP" %}
@@ -7829,7 +7829,7 @@ instruct vblendvp(legVec dst, legVec src1, legVec src2, legVec mask, legVec vtmp
 
 instruct evblendvp64(vec dst, vec src1, vec src2, vec mask, kReg ktmp) %{
   predicate(Matcher::vector_length_in_bytes(n) == 64 &&
-            n->in(2)->bottom_type()->isa_vectmask() == NULL);
+            n->in(2)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorBlend (Binary src1 src2) mask));
   format %{ "vector_blend  $dst,$src1,$src2,$mask\t! using k2 as TEMP" %}
   effect(TEMP ktmp);
@@ -8046,7 +8046,7 @@ instruct ktest_ge8(rFlagsRegU cr, kReg src1, kReg src2) %{
 //------------------------------------- LoadMask --------------------------------------------
 
 instruct loadMask(legVec dst, legVec src) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL && !VM_Version::supports_avx512vlbw());
+  predicate(n->bottom_type()->isa_vectmask() == nullptr && !VM_Version::supports_avx512vlbw());
   match(Set dst (VectorLoadMask src));
   effect(TEMP dst);
   format %{ "vector_loadmask_byte $dst, $src\n\t" %}
@@ -8086,7 +8086,7 @@ instruct loadMask_evex(kReg dst, vec src,  vec xtmp) %{
 //------------------------------------- StoreMask --------------------------------------------
 
 instruct vstoreMask1B(vec dst, vec src, immI_1 size) %{
-  predicate(Matcher::vector_length(n) < 64 && n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(Matcher::vector_length(n) < 64 && n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst, $src \t! elem size is $size byte[s]" %}
   ins_encode %{
@@ -8104,7 +8104,7 @@ instruct vstoreMask1B(vec dst, vec src, immI_1 size) %{
 %}
 
 instruct vstoreMask2B(vec dst, vec src, vec xtmp, immI_2 size) %{
-  predicate(Matcher::vector_length(n) <= 16 && n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(Matcher::vector_length(n) <= 16 && n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorStoreMask src size));
   effect(TEMP_DEF dst, TEMP xtmp);
   format %{ "vector_store_mask $dst, $src \t! elem size is $size byte[s]" %}
@@ -8127,7 +8127,7 @@ instruct vstoreMask2B(vec dst, vec src, vec xtmp, immI_2 size) %{
 %}
 
 instruct vstoreMask4B(vec dst, vec src, vec xtmp, immI_4 size) %{
-  predicate(UseAVX <= 2 && Matcher::vector_length(n) <= 8 && n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(UseAVX <= 2 && Matcher::vector_length(n) <= 8 && n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst, $src \t! elem size is $size byte[s]" %}
   effect(TEMP_DEF dst, TEMP xtmp);
@@ -8187,7 +8187,7 @@ instruct storeMask8B_avx(vec dst, vec src, immI_8 size, vec vtmp) %{
 %}
 
 instruct vstoreMask4B_evex_novectmask(vec dst, vec src, immI_4 size) %{
-  predicate(UseAVX > 2 && n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(UseAVX > 2 && n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst, $src \t! elem size is $size byte[s]" %}
   ins_encode %{
@@ -8203,7 +8203,7 @@ instruct vstoreMask4B_evex_novectmask(vec dst, vec src, immI_4 size) %{
 %}
 
 instruct vstoreMask8B_evex_novectmask(vec dst, vec src, immI_8 size) %{
-  predicate(UseAVX > 2 && n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(UseAVX > 2 && n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorStoreMask src size));
   format %{ "vector_store_mask $dst, $src \t! elem size is $size byte[s]" %}
   ins_encode %{
@@ -9040,7 +9040,7 @@ instruct vmask_tolong_evex(rRegL dst, kReg mask, rFlagsReg cr) %{
 %}
 
 instruct vmask_tolong_bool(rRegL dst, vec mask, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskToLong mask));
   format %{ "vector_tolong_bool $dst, $mask \t! using $xtmp as TEMP" %}
   effect(TEMP_DEF dst, TEMP xtmp, KILL cr);
@@ -9056,7 +9056,7 @@ instruct vmask_tolong_bool(rRegL dst, vec mask, vec xtmp, rFlagsReg cr) %{
 %}
 
 instruct vmask_tolong_avx(rRegL dst, vec mask, immI size, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskToLong (VectorStoreMask mask size)));
   format %{ "vector_tolong_avx $dst, $mask \t! using $xtmp as TEMP" %}
   effect(TEMP_DEF dst, TEMP xtmp, KILL cr);
@@ -9089,7 +9089,7 @@ instruct vmask_truecount_evex(rRegI dst, kReg mask, rRegL tmp, rFlagsReg cr) %{
 %}
 
 instruct vmask_truecount_bool(rRegI dst, vec mask, rRegL tmp, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskTrueCount mask));
   effect(TEMP_DEF dst, TEMP tmp, TEMP xtmp, KILL cr);
   format %{ "vector_truecount_bool $dst, $mask \t! using $tmp, $xtmp as TEMP" %}
@@ -9105,7 +9105,7 @@ instruct vmask_truecount_bool(rRegI dst, vec mask, rRegL tmp, vec xtmp, rFlagsRe
 %}
 
 instruct vmask_truecount_avx(rRegI dst, vec mask, immI size, rRegL tmp, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskTrueCount (VectorStoreMask mask size)));
   effect(TEMP_DEF dst, TEMP tmp, TEMP xtmp, KILL cr);
   format %{ "vector_truecount_avx $dst, $mask \t! using $tmp, $xtmp as TEMP" %}
@@ -9139,7 +9139,7 @@ instruct vmask_first_or_last_true_evex(rRegI dst, kReg mask, rRegL tmp, rFlagsRe
 %}
 
 instruct vmask_first_or_last_true_bool(rRegI dst, vec mask, rRegL tmp, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskFirstTrue mask));
   match(Set dst (VectorMaskLastTrue mask));
   effect(TEMP_DEF dst, TEMP tmp, TEMP xtmp, KILL cr);
@@ -9156,7 +9156,7 @@ instruct vmask_first_or_last_true_bool(rRegI dst, vec mask, rRegL tmp, vec xtmp,
 %}
 
 instruct vmask_first_or_last_true_avx(rRegI dst, vec mask, immI size, rRegL tmp, vec xtmp, rFlagsReg cr) %{
-  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == NULL);
+  predicate(n->in(1)->in(1)->bottom_type()->isa_vectmask() == nullptr);
   match(Set dst (VectorMaskFirstTrue (VectorStoreMask mask size)));
   match(Set dst (VectorMaskLastTrue (VectorStoreMask mask size)));
   effect(TEMP_DEF dst, TEMP tmp, TEMP xtmp, KILL cr);
@@ -10011,7 +10011,7 @@ instruct mask_not_imm(kReg dst, kReg src, immI_M1 cnt) %{
 %}
 
 instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2, vec xtmp) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL && Matcher::vector_length(n) <= 8);
+  predicate(n->bottom_type()->isa_vectmask() == nullptr && Matcher::vector_length(n) <= 8);
   match(Set dst (VectorLongToMask src));
   effect(TEMP dst, TEMP rtmp1, TEMP rtmp2, TEMP xtmp);
   format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2, $xtmp as TEMP" %}
@@ -10026,7 +10026,7 @@ instruct long_to_maskLE8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2, vec x
 
 
 instruct long_to_maskGT8_avx(vec dst, rRegL src, rRegL rtmp1, rRegL rtmp2, vec xtmp1, rFlagsReg cr) %{
-  predicate(n->bottom_type()->isa_vectmask() == NULL && Matcher::vector_length(n) > 8);
+  predicate(n->bottom_type()->isa_vectmask() == nullptr && Matcher::vector_length(n) > 8);
   match(Set dst (VectorLongToMask src));
   effect(TEMP dst, TEMP rtmp1, TEMP rtmp2, TEMP xtmp1, KILL cr);
   format %{ "long_to_mask_avx $dst, $src\t! using $rtmp1, $rtmp2, $xtmp1, as TEMP" %}

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -614,7 +614,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int framesize = C->output()->frame_size_in_bytes();
   int bangsize = C->output()->bang_size_in_bytes();
 
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != NULL);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, C->in_24_bit_fp_mode(), C->stub_function() != nullptr);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 
@@ -1052,7 +1052,7 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
   if( src_first == dst_first && src_second == dst_second )
     return size;            // Self copy, no move
 
-  if (bottom_type()->isa_vect() != NULL && bottom_type()->isa_vectmask() == NULL) {
+  if (bottom_type()->isa_vect() != nullptr && bottom_type()->isa_vectmask() == nullptr) {
     uint ireg = ideal_reg();
     assert((src_first_rc != rc_int && dst_first_rc != rc_int), "sanity");
     assert((src_first_rc != rc_float && dst_first_rc != rc_float), "sanity");
@@ -1320,12 +1320,12 @@ uint MachSpillCopyNode::implementation( CodeBuffer *cbuf, PhaseRegAlloc *ra_, bo
 
 #ifndef PRODUCT
 void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream* st) const {
-  implementation( NULL, ra_, false, st );
+  implementation( nullptr, ra_, false, st );
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation( &cbuf, ra_, false, NULL );
+  implementation( &cbuf, ra_, false, nullptr );
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -1725,7 +1725,7 @@ encode %{
 
     MacroAssembler _masm(&cbuf);
     __ check_klass_subtype_slow_path(Resi, Reax, Recx, Redi,
-                                     NULL, &miss,
+                                     nullptr, &miss,
                                      /*set_cond_codes:*/ true);
     if ($primary) {
       __ xorptr(Redi, Redi);
@@ -1843,7 +1843,7 @@ encode %{
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);
-        if (stub == NULL) {
+        if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
         }
@@ -3396,7 +3396,7 @@ operand immP() %{
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immP0() %{
   predicate( n->get_ptr() == 0 );
   match(ConP);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -3396,7 +3396,7 @@ operand immP() %{
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immP0() %{
   predicate( n->get_ptr() == 0 );
   match(ConP);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2179,7 +2179,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -2207,7 +2207,7 @@ operand immNKlass() %{
   interface(CONST_INTER);
 %}
 
-// nullptr Pointer Immediate
+// Null Pointer Immediate
 operand immN0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);
@@ -4902,7 +4902,7 @@ instruct loadConF(regF dst, immF con) %{
 instruct loadConN0(rRegN dst, immN0 src, rFlagsReg cr) %{
   match(Set dst src);
   effect(KILL cr);
-  format %{ "xorq    $dst, $src\t# compressed null ptr" %}
+  format %{ "xorq    $dst, $src\t# compressed null pointer" %}
   ins_encode %{
     __ xorq($dst$$Register, $dst$$Register);
   %}
@@ -5169,7 +5169,7 @@ instruct storeImmP0(memory mem, immP0 zero)
   ins_pipe(ialu_mem_reg);
 %}
 
-// Store nullptr Pointer, mark word, or other simple pointer constant.
+// Store Null Pointer, mark word, or other simple pointer constant.
 instruct storeImmP(memory mem, immP31 src)
 %{
   predicate(n->as_Store()->barrier_data() == 0);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -706,7 +706,7 @@ void MachPrologNode::format(PhaseRegAlloc* ra_, outputStream* st) const {
     st->print("# stack alignment check");
 #endif
   }
-  if (C->stub_function() != NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
+  if (C->stub_function() != nullptr && BarrierSet::barrier_set()->barrier_set_nmethod() != nullptr) {
     st->print("\n\t");
     st->print("cmpl    [r15_thread + #disarmed_guard_value_offset], #disarmed_guard_value\t");
     st->print("\n\t");
@@ -741,7 +741,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
     __ bind(L_skip_barrier);
   }
 
-  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != NULL);
+  __ verified_entry(framesize, C->output()->need_stack_bang(bangsize)?bangsize:0, false, C->stub_function() != nullptr);
 
   C->output()->set_frame_complete(cbuf.insts_size());
 
@@ -970,7 +970,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer* cbuf,
                                        PhaseRegAlloc* ra_,
                                        bool do_size,
                                        outputStream* st) const {
-  assert(cbuf != NULL || st  != NULL, "sanity");
+  assert(cbuf != nullptr || st  != nullptr, "sanity");
   // Get registers to move
   OptoReg::Name src_second = ra_->get_reg_second(in(1));
   OptoReg::Name src_first = ra_->get_reg_first(in(1));
@@ -989,7 +989,7 @@ uint MachSpillCopyNode::implementation(CodeBuffer* cbuf,
     // Self copy, no move
     return 0;
   }
-  if (bottom_type()->isa_vect() != NULL && bottom_type()->isa_vectmask() == NULL) {
+  if (bottom_type()->isa_vect() != nullptr && bottom_type()->isa_vectmask() == nullptr) {
     uint ireg = ideal_reg();
     assert((src_first_rc != rc_int && dst_first_rc != rc_int), "sanity");
     assert((ireg == Op_VecS || ireg == Op_VecD || ireg == Op_VecX || ireg == Op_VecY || ireg == Op_VecZ ), "sanity");
@@ -1428,12 +1428,12 @@ uint MachSpillCopyNode::implementation(CodeBuffer* cbuf,
 
 #ifndef PRODUCT
 void MachSpillCopyNode::format(PhaseRegAlloc *ra_, outputStream* st) const {
-  implementation(NULL, ra_, false, st);
+  implementation(nullptr, ra_, false, st);
 }
 #endif
 
 void MachSpillCopyNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
-  implementation(&cbuf, ra_, false, NULL);
+  implementation(&cbuf, ra_, false, nullptr);
 }
 
 uint MachSpillCopyNode::size(PhaseRegAlloc *ra_) const {
@@ -1784,7 +1784,7 @@ encode %{
 
     MacroAssembler _masm(&cbuf);
     __ check_klass_subtype_slow_path(Rrsi, Rrax, Rrcx, Rrdi,
-                                     NULL, &miss,
+                                     nullptr, &miss,
                                      /*set_cond_codes:*/ true);
     if ($primary) {
       __ xorptr(Rrdi, Rrdi);
@@ -1841,7 +1841,7 @@ encode %{
       } else {
         // Emit stubs for static call.
         address stub = CompiledStaticCall::emit_to_interp_stub(cbuf, mark);
-        if (stub == NULL) {
+        if (stub == nullptr) {
           ciEnv::current()->record_failure("CodeCache is full");
           return;
         }
@@ -2179,7 +2179,7 @@ operand immP()
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immP0()
 %{
   predicate(n->get_ptr() == 0);
@@ -2207,7 +2207,7 @@ operand immNKlass() %{
   interface(CONST_INTER);
 %}
 
-// NULL Pointer Immediate
+// nullptr Pointer Immediate
 operand immN0() %{
   predicate(n->get_narrowcon() == 0);
   match(ConN);
@@ -3121,7 +3121,7 @@ operand indPosIndexScaleOffset(any_RegP reg, immL32 off, rRegI idx, immI2 scale)
 
 // Indirect Narrow Oop Plus Offset Operand
 // Note: x86 architecture doesn't support "scale * index + offset" without a base
-// we can't free r12 even with CompressedOops::base() == NULL.
+// we can't free r12 even with CompressedOops::base() == nullptr.
 operand indCompressedOopOffset(rRegN reg, immL32 off) %{
   predicate(UseCompressedOops && (CompressedOops::shift() == Address::times_8));
   constraint(ALLOC_IN_RC(ptr_reg));
@@ -4902,7 +4902,7 @@ instruct loadConF(regF dst, immF con) %{
 instruct loadConN0(rRegN dst, immN0 src, rFlagsReg cr) %{
   match(Set dst src);
   effect(KILL cr);
-  format %{ "xorq    $dst, $src\t# compressed NULL ptr" %}
+  format %{ "xorq    $dst, $src\t# compressed null ptr" %}
   ins_encode %{
     __ xorq($dst$$Register, $dst$$Register);
   %}
@@ -4916,7 +4916,7 @@ instruct loadConN(rRegN dst, immN src) %{
   format %{ "movl    $dst, $src\t# compressed ptr" %}
   ins_encode %{
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       __ set_narrow_oop($dst$$Register, (jobject)$src$$constant);
@@ -4932,7 +4932,7 @@ instruct loadConNKlass(rRegN dst, immNKlass src) %{
   format %{ "movl    $dst, $src\t# compressed klass ptr" %}
   ins_encode %{
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       ShouldNotReachHere();
     } else {
       __ set_narrow_klass($dst$$Register, (Klass*)$src$$constant);
@@ -5158,7 +5158,7 @@ instruct storeP(memory mem, any_RegP src)
 
 instruct storeImmP0(memory mem, immP0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL) && n->as_Store()->barrier_data() == 0);
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr) && n->as_Store()->barrier_data() == 0);
   match(Set mem (StoreP mem zero));
 
   ins_cost(125); // XXX
@@ -5169,7 +5169,7 @@ instruct storeImmP0(memory mem, immP0 zero)
   ins_pipe(ialu_mem_reg);
 %}
 
-// Store NULL Pointer, mark word, or other simple pointer constant.
+// Store nullptr Pointer, mark word, or other simple pointer constant.
 instruct storeImmP(memory mem, immP31 src)
 %{
   predicate(n->as_Store()->barrier_data() == 0);
@@ -5210,7 +5210,7 @@ instruct storeNKlass(memory mem, rRegN src)
 
 instruct storeImmN0(memory mem, immN0 zero)
 %{
-  predicate(CompressedOops::base() == NULL);
+  predicate(CompressedOops::base() == nullptr);
   match(Set mem (StoreN mem zero));
 
   ins_cost(125); // XXX
@@ -5229,7 +5229,7 @@ instruct storeImmN(memory mem, immN src)
   format %{ "movl    $mem, $src\t# compressed ptr" %}
   ins_encode %{
     address con = (address)$src$$constant;
-    if (con == NULL) {
+    if (con == nullptr) {
       __ movl($mem$$Address, 0);
     } else {
       __ set_narrow_oop($mem$$Address, (jobject)$src$$constant);
@@ -5253,7 +5253,7 @@ instruct storeImmNKlass(memory mem, immNKlass src)
 // Store Integer Immediate
 instruct storeImmI0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreI mem zero));
 
   ins_cost(125); // XXX
@@ -5279,7 +5279,7 @@ instruct storeImmI(memory mem, immI src)
 // Store Long Immediate
 instruct storeImmL0(memory mem, immL0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreL mem zero));
 
   ins_cost(125); // XXX
@@ -5305,7 +5305,7 @@ instruct storeImmL(memory mem, immL32 src)
 // Store Short/Char Immediate
 instruct storeImmC0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreC mem zero));
 
   ins_cost(125); // XXX
@@ -5332,7 +5332,7 @@ instruct storeImmI16(memory mem, immI16 src)
 // Store Byte Immediate
 instruct storeImmB0(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreB mem zero));
 
   ins_cost(125); // XXX
@@ -5358,7 +5358,7 @@ instruct storeImmB(memory mem, immI8 src)
 // Store CMS card-mark Immediate
 instruct storeImmCM0_reg(memory mem, immI_0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreCM mem zero));
 
   ins_cost(125); // XXX
@@ -5397,7 +5397,7 @@ instruct storeF(memory mem, regF src)
 // Store immediate Float value (it is faster than store from XMM register)
 instruct storeF0(memory mem, immF0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreF mem zero));
 
   ins_cost(25); // XXX
@@ -5436,7 +5436,7 @@ instruct storeD(memory mem, regD src)
 // Store immediate double 0.0 (it is faster than store from XMM register)
 instruct storeD0_imm(memory mem, immD0 src)
 %{
-  predicate(!UseCompressedOops || (CompressedOops::base() != NULL));
+  predicate(!UseCompressedOops || (CompressedOops::base() != nullptr));
   match(Set mem (StoreD mem src));
 
   ins_cost(50);
@@ -5449,7 +5449,7 @@ instruct storeD0_imm(memory mem, immD0 src)
 
 instruct storeD0(memory mem, immD0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL));
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr));
   match(Set mem (StoreD mem zero));
 
   ins_cost(25); // XXX
@@ -11680,7 +11680,7 @@ instruct testP_reg(rFlagsReg cr, rRegP src, immP0 zero)
 // any compare to a zero should be eq/neq.
 instruct testP_mem(rFlagsReg cr, memory op, immP0 zero)
 %{
-  predicate((!UseCompressedOops || (CompressedOops::base() != NULL)) &&
+  predicate((!UseCompressedOops || (CompressedOops::base() != nullptr)) &&
             n->in(1)->as_Load()->barrier_data() == 0);
   match(Set cr (CmpP (LoadP op) zero));
 
@@ -11694,7 +11694,7 @@ instruct testP_mem(rFlagsReg cr, memory op, immP0 zero)
 
 instruct testP_mem_reg0(rFlagsReg cr, memory mem, immP0 zero)
 %{
-  predicate(UseCompressedOops && (CompressedOops::base() == NULL) &&
+  predicate(UseCompressedOops && (CompressedOops::base() == nullptr) &&
             n->in(1)->as_Load()->barrier_data() == 0);
   match(Set cr (CmpP (LoadP mem) zero));
 
@@ -11777,7 +11777,7 @@ instruct testN_reg(rFlagsReg cr, rRegN src, immN0 zero) %{
 
 instruct testN_mem(rFlagsReg cr, memory mem, immN0 zero)
 %{
-  predicate(CompressedOops::base() != NULL);
+  predicate(CompressedOops::base() != nullptr);
   match(Set cr (CmpN (LoadN mem) zero));
 
   ins_cost(500); // XXX
@@ -11790,7 +11790,7 @@ instruct testN_mem(rFlagsReg cr, memory mem, immN0 zero)
 
 instruct testN_mem_reg0(rFlagsReg cr, memory mem, immN0 zero)
 %{
-  predicate(CompressedOops::base() == NULL);
+  predicate(CompressedOops::base() == nullptr);
   match(Set cr (CmpN (LoadN mem) zero));
 
   format %{ "cmpl    R12, $mem\t# compressed ptr (R12_heapbase==0)" %}


### PR DESCRIPTION
This is a straightforward mechanical (sed) replacement of NULL with nullptr.  One string was adjusted to not say nullptr ptr.  nullptr makes sense in the comments so I didn't change them.

Tested with tier1 Oracle platforms and build test with linux-x64-zero,linux-x64-zero-debug,linux-s390x-open,linux-arm32-debug,linux-ppc64le-debug,linux-riscv64-debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324679](https://bugs.openjdk.org/browse/JDK-8324679): Replace NULL with nullptr in HotSpot .ad files (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [019b6027](https://git.openjdk.org/jdk/pull/17658/files/019b6027f94518c84a9b0beb5f77a5cf8d531ca7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17658/head:pull/17658` \
`$ git checkout pull/17658`

Update a local copy of the PR: \
`$ git checkout pull/17658` \
`$ git pull https://git.openjdk.org/jdk.git pull/17658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17658`

View PR using the GUI difftool: \
`$ git pr show -t 17658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17658.diff">https://git.openjdk.org/jdk/pull/17658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17658#issuecomment-1919528471)