### PR TITLE
JDK-8322218: Better escaping of single and double quotes in annotation toString() results

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotationInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,7 +271,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
     private static String toSourceString(char c) {
         StringBuilder sb = new StringBuilder(4);
         sb.append('\'');
-        sb.append(quote(c));
+        sb.append(quote(c, true));
         return sb.append('\'') .toString();
     }
 
@@ -279,15 +279,21 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
      * Escapes a character if it has an escape sequence or is
      * non-printable ASCII.  Leaves non-ASCII characters alone.
      */
-    private static String quote(char ch) {
+    private static String quote(char ch, boolean charContext) {
+        /*
+         * In a char context, single quote (') must be escaped and
+         * double quote (") need not be escaped. In a non-char
+         * context, in other words a string context, the reverse is
+         * true.
+         */
         switch (ch) {
         case '\b':  return "\\b";
         case '\f':  return "\\f";
         case '\n':  return "\\n";
         case '\r':  return "\\r";
         case '\t':  return "\\t";
-        case '\'':  return "\\'";
-        case '\"':  return "\\\"";
+        case '\'':  return (charContext ? "\\'" : "'");
+        case '\"':  return (charContext ? "\""  : "\\\"");
         case '\\':  return "\\\\";
         default:
             return (isPrintableAscii(ch))
@@ -323,7 +329,7 @@ class AnnotationInvocationHandler implements InvocationHandler, Serializable {
         StringBuilder sb = new StringBuilder();
         sb.append('"');
         for (int i = 0; i < s.length(); i++) {
-            sb.append(quote(s.charAt(i)));
+            sb.append(quote(s.charAt(i), false));
         }
         sb.append('"');
         return sb.toString();

--- a/test/jdk/java/lang/annotation/AnnotationToStringTest.java
+++ b/test/jdk/java/lang/annotation/AnnotationToStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8162817 8168921
+ * @bug 8162817 8168921 8322218
  * @summary Test of toString on normal annotations
  */
 
@@ -192,8 +192,8 @@ public class AnnotationToStringTest {
         public short[]     f4;
 
         @ExpectedString(
-       "@CharArray({'a', 'b', 'c', '\\''})")
-        @CharArray({'a', 'b', 'c', '\''})
+       "@CharArray({'a', 'b', 'c', '\\'', '\"'})")
+        @CharArray({'a', 'b', 'c', '\'', '"'})
         public char[]      f5;
 
         @ExpectedString(
@@ -209,8 +209,8 @@ public class AnnotationToStringTest {
         public long[]      f7;
 
         @ExpectedString(
-       "@StringArray({\"A\", \"B\", \"C\", \"\\\"Quote\\\"\"})")
-        @StringArray({"A", "B", "C", "\"Quote\""})
+       "@StringArray({\"A\", \"B\", \"C\", \"\\\"Quote\\\"\", \"'\", \"\\\"\"})")
+        @StringArray({"A", "B", "C", "\"Quote\"", "'", "\""})
         public String[]    f8;
 
         @ExpectedString(


### PR DESCRIPTION
A double quote character doesn't need to be escaped when it is a char literal and single quote character doesn't need to be escaped when it is in a string. This change updates the toString() output of annotations to account for the different escaping requirements of strings and characters.

Corresponding issue filed for javac's compile-time annotations: JDK-8325078.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322218](https://bugs.openjdk.org/browse/JDK-8322218): Better escaping of single and double quotes in annotation toString() results (**Bug** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17664/head:pull/17664` \
`$ git checkout pull/17664`

Update a local copy of the PR: \
`$ git checkout pull/17664` \
`$ git pull https://git.openjdk.org/jdk.git pull/17664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17664`

View PR using the GUI difftool: \
`$ git pr show -t 17664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17664.diff">https://git.openjdk.org/jdk/pull/17664.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17664#issuecomment-1920319624)