### PR TITLE
JDK-8325078: Better escaping of single and double quotes in javac annotation toString() results

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Constants.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class Constants {
     }
 
     private static String formatChar(char c) {
-        return '\'' + Convert.quote(c) + '\'';
+        return '\'' + Convert.quote(c, true) + '\'';
     }
 
     private static String formatString(String s) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Convert.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/Convert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -298,7 +298,7 @@ public class Convert {
     public static String quote(String s) {
         StringBuilder buf = new StringBuilder();
         for (int i = 0; i < s.length(); i++) {
-            buf.append(quote(s.charAt(i)));
+            buf.append(quote(s.charAt(i), false));
         }
         return buf.toString();
     }
@@ -307,15 +307,21 @@ public class Convert {
      * Escapes a character if it has an escape sequence or is
      * non-printable ASCII.  Leaves non-ASCII characters alone.
      */
-    public static String quote(char ch) {
+    public static String quote(char ch, boolean charContext) {
+        /*
+         * In a char context, single quote (') must be escaped and
+         * double quote (") need not be escaped. In a non-char
+         * context, in other words a string context, the reverse is
+         * true.
+         */
         switch (ch) {
         case '\b':  return "\\b";
         case '\f':  return "\\f";
         case '\n':  return "\\n";
         case '\r':  return "\\r";
         case '\t':  return "\\t";
-        case '\'':  return "\\'";
-        case '\"':  return "\\\"";
+        case '\'':  return (charContext ? "\\'" : "'");
+        case '\"':  return (charContext ? "\""  : "\\\"");
         case '\\':  return "\\\\";
         default:
             return (isPrintableAscii(ch))

--- a/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
+++ b/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,7 +360,7 @@ public class CreateSymbolsTestImpl {
                            "public class T {\n" +
                            "  public static final java.lang.String STR = \"\\u0000\\u0001\\uffff\";\n" +
                            "  public static final java.lang.String EMPTY = \"\";\n" +
-                           "  public static final java.lang.String AMP = \"&amp;&&lt;<&gt;>&apos;\\'\";\n\n" +
+                           "  public static final java.lang.String AMP = \"&amp;&&lt;<&gt;>&apos;'\";\n\n" +
                            "  public T();\n" +
                            "}\n",
                            "t.T",

--- a/test/langtools/tools/javac/processing/model/element/AnnotationToStringTest.java
+++ b/test/langtools/tools/javac/processing/model/element/AnnotationToStringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8164819
+ * @bug 8164819 8325078
  * @summary Test of toString on normal annotations
  * @library /tools/javac/lib
  * @build   JavacTestingAbstractProcessor AnnotationToStringTest
@@ -281,8 +281,8 @@ public class AnnotationToStringTest extends JavacTestingAbstractProcessor {
         public short[]     f4;
 
         @ExpectedString(
-       "@CharArray({'a', 'b', 'c', '\\''})")
-        @CharArray({'a', 'b', 'c', '\''})
+       "@CharArray({'a', 'b', 'c', '\\'', '\"'})")
+        @CharArray({'a', 'b', 'c', '\'', '"'})
         public char[]      f5;
 
         @ExpectedString(
@@ -298,8 +298,8 @@ public class AnnotationToStringTest extends JavacTestingAbstractProcessor {
         public long[]      f7;
 
         @ExpectedString(
-       "@StringArray({\"A\", \"B\", \"C\", \"\\\"Quote\\\"\"})")
-        @StringArray({"A", "B", "C", "\"Quote\""})
+       "@StringArray({\"A\", \"B\", \"C\", \"\\\"Quote\\\"\", \"'\", \"\\\"\"})")
+        @StringArray({"A", "B", "C", "\"Quote\"", "'", "\""})
         public String[]    f8;
 
         @ExpectedString(


### PR DESCRIPTION
The javac version of https://github.com/openjdk/jdk/pull/17664

"A double quote character doesn't need to be escaped when it is a char literal and single quote character doesn't need to be escaped when it is in a string. This change updates the toString() output of annotations to account for the different escaping requirements of strings and characters."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325078](https://bugs.openjdk.org/browse/JDK-8325078): Better escaping of single and double quotes in javac annotation toString() results (**Enhancement** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17665/head:pull/17665` \
`$ git checkout pull/17665`

Update a local copy of the PR: \
`$ git checkout pull/17665` \
`$ git pull https://git.openjdk.org/jdk.git pull/17665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17665`

View PR using the GUI difftool: \
`$ git pr show -t 17665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17665.diff">https://git.openjdk.org/jdk/pull/17665.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17665#issuecomment-1920533514)