### PR TITLE
8302850: Consider implementing a C1 clone intrinsic that uses ArrayCopyNode for primitive arrays

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -2526,7 +2526,9 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
    __ call_VM_leaf(entry, 3);
  }
 
-  __ bind(*stub->continuation());
+ if (stub != nullptr) {
+   __ bind(*stub->continuation());
+ }
 }
 
 

--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
@@ -1233,7 +1233,8 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
                       arrayOopDesc::header_size(op->type()),
                       array_element_size(op->type()),
                       op->klass()->as_register(),
-                      *op->stub()->entry());
+                      *op->stub()->entry(),
+                      op->zero_array());
   }
   __ bind(*op->stub()->continuation());
 }

--- a/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRGenerator_aarch64.cpp
@@ -913,6 +913,70 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   __ arraycopy(src.result(), src_pos.result(), dst.result(), dst_pos.result(), length.result(), tmp, expected_type, flags, info); // does add_safepoint
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+    assert(x->number_of_arguments() == 1, "wrong type");
+
+    LIRItem src(x->argument_at(0), this);
+    ciType* src_type = src.value()->exact_type();
+
+    LIRItem array(src.value(), this);
+    array.load_item();
+    LIR_Opr len = new_register(T_INT);
+    __ load(new LIR_Address(array.result(), arrayOopDesc::length_offset_in_bytes(), T_INT), len);
+    LIR_Opr len_r19 = FrameMap::r19_opr;
+    __ move(len, len_r19);
+
+    LIR_Opr array_reg = result_register_for(x->type());
+    LIR_Opr tmp1 = FrameMap::r10_oop_opr;
+    LIR_Opr tmp2 = FrameMap::r11_oop_opr;
+    LIR_Opr tmp3 = FrameMap::r5_oop_opr;
+    LIR_Opr tmp4 = array_reg;
+    LIR_Opr klass_reg = FrameMap::r3_metadata_opr;
+
+    ciArrayKlass* array_klass = src_type->as_array_klass();
+    BasicType elem_type = array_klass->element_type()->basic_type();
+
+    __ metadata2reg(array_klass->constant_encoding(), klass_reg);
+
+    CodeEmitInfo* info = state_for(x, x->state_before());
+    CodeStub* slow_path = new NewTypeArrayStub(klass_reg, len_r19, array_reg, info);
+    __ allocate_array(array_reg, len_r19, tmp1, tmp2, tmp3, tmp4, elem_type, klass_reg, slow_path, false);
+
+    LIRItem src_pos(new Constant(new IntConstant(0)), this);
+    LIR_Opr dst = new_register(T_OBJECT);
+    __ move(array_reg, dst);
+    LIRItem dst_pos(new Constant(new IntConstant(0)), this);
+
+    // operands for arraycopy must use fixed registers, otherwise
+    // LinearScan will fail allocation (because arraycopy always needs a
+    // call)
+
+    // The java calling convention will give us enough registers
+    // so that on the stub side the args will be perfect already.
+    // On the other slow/special case side we call C and the arg
+    // positions are not similar enough to pick one as the best.
+    // Also because the java calling convention is a "shifted" version
+    // of the C convention we can process the java args trivially into C
+    // args without worry of overwriting during the xfer
+
+    src.load_item_force     (FrameMap::as_oop_opr(j_rarg0));
+    src_pos.load_item_force (FrameMap::as_opr(j_rarg1));
+    LIR_Opr destination = FrameMap::as_oop_opr(j_rarg2);
+    __ move(dst, destination);
+    dst_pos.load_item_force (FrameMap::as_opr(j_rarg3));
+    LIR_Opr length = FrameMap::as_opr(j_rarg4);
+    __ move(len, length);
+    LIR_Opr tmp =           FrameMap::as_opr(j_rarg5);
+
+    int flags = 0;
+    ciArrayKlass* expected_type = src_type->as_array_klass();
+
+    __ arraycopy(src.result(), src_pos.result(), destination, dst_pos.result(), length, tmp, expected_type, flags, info); // does add_safepoint
+
+    LIR_Opr result = rlock_result(x);
+    __ move(dst, result);
+}
+
 void LIRGenerator::do_update_CRC32(Intrinsic* x) {
   assert(UseCRC32Intrinsics, "why are we here?");
   // Make all state_for calls early since they can emit code

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -271,7 +271,7 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
 
   verify_oop(obj);
 }
-void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2, int header_size, int f, Register klass, Label& slow_case) {
+void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2, int header_size, int f, Register klass, Label& slow_case, bool zero_array) {
   assert_different_registers(obj, len, t1, t2, klass);
 
   // determine alignment mask
@@ -293,7 +293,9 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
   initialize_header(obj, klass, len, t1, t2);
 
   // clear rest of allocated space
-  initialize_body(obj, arr_size, header_size * BytesPerWord, t1, t2);
+  if (zero_array) {
+    initialize_body(obj, arr_size, header_size * BytesPerWord, t1, t2);
+  }
   if (Compilation::current()->bailed_out()) {
     return;
   }

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
@@ -100,7 +100,8 @@ using MacroAssembler::null_check;
   // header_size: size of object header in words
   // f          : element scale factor
   // slow_case  : exit to slow case implementation if fast allocation fails
-  void allocate_array(Register obj, Register len, Register t, Register t2, int header_size, int f, Register klass, Label& slow_case);
+  // zero_array : zero the allocated array or not
+  void allocate_array(Register obj, Register len, Register t, Register t2, int header_size, int f, Register klass, Label& slow_case, bool zero_array);
 
   int  rsp_offset() const { return _rsp_offset; }
   void set_rsp_offset(int n) { _rsp_offset = n; }

--- a/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/c1_LIRGenerator_arm.cpp
@@ -872,6 +872,10 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
                tmp, expected_type, flags, info);
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+  Unimplemented();
+}
+
 void LIRGenerator::do_update_CRC32(Intrinsic* x) {
   fatal("CRC32 intrinsic is not implemented on this platform");
 }

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -783,6 +783,9 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   set_no_result(x);
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+  Unimplemented();
+}
 
 // _i2l, _i2f, _i2d, _l2i, _l2f, _l2d, _f2i, _f2l, _f2d, _d2i, _d2l, _d2f
 // _i2b, _i2c, _i2s

--- a/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRGenerator_riscv.cpp
@@ -771,6 +771,10 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
                expected_type, flags, info); // does add_safepoint
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+  Unimplemented();
+}
+
 void LIRGenerator::do_update_CRC32(Intrinsic* x) {
   ShouldNotReachHere();
 }

--- a/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRGenerator_s390.cpp
@@ -738,6 +738,10 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
                length.result(), tmp, expected_type, flags, info); // does add_safepoint
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+  Unimplemented();
+}
+
 // _i2l, _i2f, _i2d, _l2i, _l2f, _l2d, _f2i, _f2l, _f2d, _d2i, _d2l, _d2f
 // _i2b, _i2c, _i2s
 void LIRGenerator::do_Convert(Convert* x) {

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -1638,7 +1638,8 @@ void LIR_Assembler::emit_alloc_array(LIR_OpAllocArray* op) {
                       arrayOopDesc::header_size(op->type()),
                       array_element_size(op->type()),
                       op->klass()->as_register(),
-                      *op->stub()->entry());
+                      *op->stub()->entry(),
+                      op->zero_array());
   }
   __ bind(*op->stub()->continuation());
 }

--- a/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRAssembler_x86.cpp
@@ -3471,7 +3471,9 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
   address entry = StubRoutines::select_arraycopy_function(basic_type, aligned, disjoint, name, false);
   __ call_VM_leaf(entry, 0);
 
-  __ bind(*stub->continuation());
+  if (stub != nullptr) {
+    __ bind(*stub->continuation());
+  }
 }
 
 void LIR_Assembler::emit_updatecrc32(LIR_OpUpdateCRC32* op) {

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1100,6 +1100,9 @@ void LIRGenerator::do_Clone(Intrinsic* x) {
   __ move(len, length);
 
   LIR_Opr tmp =           (FrameMap::rsi_opr);
+
+  FrameMap* f = Compilation::current()->frame_map();
+  f->update_reserved_argument_area_size(3 * BytesPerWord);
 #else
 
   // The java calling convention will give us enough registers

--- a/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp
@@ -1051,6 +1051,86 @@ void LIRGenerator::do_ArrayCopy(Intrinsic* x) {
   __ arraycopy(src.result(), src_pos.result(), dst.result(), dst_pos.result(), length.result(), tmp, expected_type, flags, info); // does add_safepoint
 }
 
+void LIRGenerator::do_Clone(Intrinsic* x) {
+  assert(x->number_of_arguments() == 1, "wrong type");
+
+  LIRItem src(x->argument_at(0), this);
+  ciType* src_type = src.value()->exact_type();
+
+  LIRItem array(src.value(), this);
+  array.load_item();
+  LIR_Opr len = new_register(T_INT);
+  __ load(new LIR_Address(array.result(), arrayOopDesc::length_offset_in_bytes(), T_INT), len);
+  LIR_Opr len_rbx = FrameMap::rbx_opr;
+  __ move(len, len_rbx);
+
+  LIR_Opr array_reg = result_register_for(x->type());
+  LIR_Opr tmp1 = FrameMap::rcx_oop_opr;
+  LIR_Opr tmp2 = FrameMap::rsi_oop_opr;
+  LIR_Opr tmp3 = FrameMap::rdi_oop_opr;
+  LIR_Opr tmp4 = array_reg;
+  LIR_Opr klass_reg = FrameMap::rdx_metadata_opr;
+
+  ciArrayKlass* array_klass = src_type->as_array_klass();
+  BasicType elem_type = array_klass->element_type()->basic_type();
+
+  __ metadata2reg(array_klass->constant_encoding(), klass_reg);
+
+  CodeEmitInfo* info = state_for(x, x->state_before());
+  CodeStub* slow_path = new NewTypeArrayStub(klass_reg, len_rbx, array_reg, info);
+  __ allocate_array(array_reg, len_rbx, tmp1, tmp2, tmp3, tmp4, elem_type, klass_reg, slow_path, false);
+
+  LIRItem src_pos(new Constant(new IntConstant(0)), this);
+  LIR_Opr dst = new_register(T_OBJECT);
+  __ move(array_reg, dst);
+  LIRItem dst_pos(new Constant(new IntConstant(0)), this);
+
+  // operands for arraycopy must use fixed registers, otherwise
+  // LinearScan will fail allocation (because arraycopy always needs a
+  // call)
+
+#ifndef _LP64
+
+  src.load_item_force     (FrameMap::rcx_oop_opr);
+  src_pos.load_item_force (FrameMap::rdx_opr);
+  LIR_Opr destination = FrameMap::rax_oop_opr;
+  __ move(dst, destination);
+  dst_pos.load_item_force (FrameMap::rbx_opr);
+  LIR_Opr length = FrameMap::rdi_opr;
+  __ move(len, length);
+
+  LIR_Opr tmp =           (FrameMap::rsi_opr);
+#else
+
+  // The java calling convention will give us enough registers
+  // so that on the stub side the args will be perfect already.
+  // On the other slow/special case side we call C and the arg
+  // positions are not similar enough to pick one as the best.
+  // Also because the java calling convention is a "shifted" version
+  // of the C convention we can process the java args trivially into C
+  // args without worry of overwriting during the xfer
+
+
+  src.load_item_force     (FrameMap::as_oop_opr(j_rarg0));
+  src_pos.load_item_force (FrameMap::as_opr(j_rarg1));
+  LIR_Opr destination = FrameMap::as_oop_opr(j_rarg2);
+  __ move(dst, destination);
+  dst_pos.load_item_force (FrameMap::as_opr(j_rarg3));
+  LIR_Opr length = FrameMap::as_opr(j_rarg4);
+  __ move(len, length);
+
+  LIR_Opr tmp =           FrameMap::as_opr(j_rarg5);
+#endif // LP64
+
+  int flags = 0;
+  ciArrayKlass* expected_type = src_type->as_array_klass();
+
+  __ arraycopy(src.result(), src_pos.result(), destination, dst_pos.result(), length, tmp, expected_type, flags, info); // does add_safepoint
+
+  LIR_Opr result = rlock_result(x);
+  __ move(dst, result);
+}
+
 void LIRGenerator::do_update_CRC32(Intrinsic* x) {
   assert(UseCRC32Intrinsics, "need AVX and LCMUL instructions support");
   // Make all state_for calls early since they can emit code

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.cpp
@@ -262,7 +262,7 @@ void C1_MacroAssembler::initialize_object(Register obj, Register klass, Register
   verify_oop(obj);
 }
 
-void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2, int header_size, Address::ScaleFactor f, Register klass, Label& slow_case) {
+void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, Register t2, int header_size, Address::ScaleFactor f, Register klass, Label& slow_case, bool zero_array) {
   assert(obj == rax, "obj must be in rax, for cmpxchg");
   assert_different_registers(obj, len, t1, t2, klass);
 
@@ -283,9 +283,11 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
 
   initialize_header(obj, klass, len, t1, t2);
 
-  // clear rest of allocated space
-  const Register len_zero = len;
-  initialize_body(obj, arr_size, header_size * BytesPerWord, len_zero);
+  if (zero_array) {
+    // clear rest of allocated space
+    const Register len_zero = len;
+    initialize_body(obj, arr_size, header_size * BytesPerWord, len_zero);
+  }
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == rax, "must be");

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
@@ -89,7 +89,8 @@
   // header_size: size of object header in words
   // f          : element scale factor
   // slow_case  : exit to slow case implementation if fast allocation fails
-  void allocate_array(Register obj, Register len, Register t, Register t2, int header_size, Address::ScaleFactor f, Register klass, Label& slow_case);
+  // zero_array : zero the allocated array or not
+  void allocate_array(Register obj, Register len, Register t, Register t2, int header_size, Address::ScaleFactor f, Register klass, Label& slow_case, bool zero_array);
 
   int  rsp_offset() const { return _rsp_offset; }
   void set_rsp_offset(int n) { _rsp_offset = n; }

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -235,6 +235,9 @@ bool Compiler::is_intrinsic_supported(vmIntrinsics::ID id) {
   case vmIntrinsics::_counterTime:
 #endif
   case vmIntrinsics::_getObjectSize:
+#if defined(X86) || defined(AARCH64)
+  case vmIntrinsics::_clone:
+#endif
     break;
   case vmIntrinsics::_blackhole:
     break;

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2133,11 +2133,24 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
     if ((code == Bytecodes::_invokestatic && klass->is_initialized()) || // invokestatic involves an initialization barrier on declaring class
         code == Bytecodes::_invokespecial ||
         (code == Bytecodes::_invokevirtual && target->is_final_method()) ||
-        code == Bytecodes::_invokedynamic) {
+        code == Bytecodes::_invokedynamic ||
+        target->get_Method()->intrinsic_id() == vmIntrinsics::_clone) {
       // static binding => check if callee is ok
       ciMethod* inline_target = (cha_monomorphic_target != nullptr) ? cha_monomorphic_target : target;
       bool holder_known = (cha_monomorphic_target != nullptr) || (exact_target != nullptr);
-      bool success = try_inline(inline_target, holder_known, false /* ignore_return */, code, better_receiver);
+      bool success;
+
+      // Clone intrinsic and inlining can only kick when instance is a primitive array,
+      // or when the target of the clone is not a Phi node
+      ciType* receiver_type;
+      if (target->get_Method()->intrinsic_id() == vmIntrinsics::_clone &&
+          ((receiver_type = state()->stack_at(state()->stack_size() - inline_target->arg_size())->exact_type()) == nullptr || // clone target is phi
+          !receiver_type->is_array_klass() || // not array
+          !receiver_type->as_array_klass()->element_type()->is_primitive_type())) { // not primitive array
+        success = false;
+      } else {
+        success = try_inline(inline_target, holder_known, false /* ignore_return */, code, better_receiver);
+      }
 
       CHECK_BAILOUT();
       clear_inline_bailout();

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -353,7 +353,11 @@ LIR_OpArrayCopy::LIR_OpArrayCopy(LIR_Opr src, LIR_Opr src_pos, LIR_Opr dst, LIR_
   , _tmp(tmp)
   , _expected_type(expected_type)
   , _flags(flags) {
-  _stub = new ArrayCopyStub(this);
+  if (expected_type != nullptr && flags == 0) {
+    _stub = nullptr;
+  } else {
+    _stub = new ArrayCopyStub(this);
+  }
 }
 
 LIR_OpUpdateCRC32::LIR_OpUpdateCRC32(LIR_Opr crc, LIR_Opr val, LIR_Opr res)
@@ -999,7 +1003,10 @@ void LIR_OpLabel::emit_code(LIR_Assembler* masm) {
 
 void LIR_OpArrayCopy::emit_code(LIR_Assembler* masm) {
   masm->emit_arraycopy(this);
-  masm->append_code_stub(stub());
+  ArrayCopyStub* code_stub = stub();
+  if (code_stub != nullptr) {
+    masm->append_code_stub(code_stub);
+  }
 }
 
 void LIR_OpUpdateCRC32::emit_code(LIR_Assembler* masm) {

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -1365,7 +1365,7 @@ void LIR_List::allocate_object(LIR_Opr dst, LIR_Opr t1, LIR_Opr t2, LIR_Opr t3, 
                            stub));
 }
 
-void LIR_List::allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, LIR_Opr t3,LIR_Opr t4, BasicType type, LIR_Opr klass, CodeStub* stub) {
+void LIR_List::allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, LIR_Opr t3,LIR_Opr t4, BasicType type, LIR_Opr klass, CodeStub* stub, bool zero_array) {
   append(new LIR_OpAllocArray(
                            klass,
                            len,
@@ -1375,7 +1375,8 @@ void LIR_List::allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, L
                            t3,
                            t4,
                            type,
-                           stub));
+                           stub,
+                           zero_array));
 }
 
 void LIR_List::shift_left(LIR_Opr value, LIR_Opr count, LIR_Opr dst, LIR_Opr tmp) {

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -1750,9 +1750,10 @@ class LIR_OpAllocArray : public LIR_Op {
   LIR_Opr   _tmp4;
   BasicType _type;
   CodeStub* _stub;
+  bool      _zero_array;
 
  public:
-  LIR_OpAllocArray(LIR_Opr klass, LIR_Opr len, LIR_Opr result, LIR_Opr t1, LIR_Opr t2, LIR_Opr t3, LIR_Opr t4, BasicType type, CodeStub* stub)
+  LIR_OpAllocArray(LIR_Opr klass, LIR_Opr len, LIR_Opr result, LIR_Opr t1, LIR_Opr t2, LIR_Opr t3, LIR_Opr t4, BasicType type, CodeStub* stub, bool zero_array)
     : LIR_Op(lir_alloc_array, result, nullptr)
     , _klass(klass)
     , _len(len)
@@ -1761,7 +1762,8 @@ class LIR_OpAllocArray : public LIR_Op {
     , _tmp3(t3)
     , _tmp4(t4)
     , _type(type)
-    , _stub(stub) {}
+    , _stub(stub)
+    , _zero_array(zero_array) {}
 
   LIR_Opr   klass()   const                      { return _klass;       }
   LIR_Opr   len()     const                      { return _len;         }
@@ -1772,6 +1774,7 @@ class LIR_OpAllocArray : public LIR_Op {
   LIR_Opr   tmp4()    const                      { return _tmp4;        }
   BasicType type()    const                      { return _type;        }
   CodeStub* stub()    const                      { return _stub;        }
+  bool zero_array()    const                     { return _zero_array;  }
 
   virtual void emit_code(LIR_Assembler* masm);
   virtual LIR_OpAllocArray * as_OpAllocArray () { return this; }
@@ -2302,7 +2305,7 @@ class LIR_List: public CompilationResourceObj {
   void irem(LIR_Opr left, int   right, LIR_Opr res, LIR_Opr tmp, CodeEmitInfo* info);
 
   void allocate_object(LIR_Opr dst, LIR_Opr t1, LIR_Opr t2, LIR_Opr t3, LIR_Opr t4, int header_size, int object_size, LIR_Opr klass, bool init_check, CodeStub* stub);
-  void allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, LIR_Opr t3,LIR_Opr t4, BasicType type, LIR_Opr klass, CodeStub* stub);
+  void allocate_array(LIR_Opr dst, LIR_Opr len, LIR_Opr t1,LIR_Opr t2, LIR_Opr t3,LIR_Opr t4, BasicType type, LIR_Opr klass, CodeStub* stub, bool zero_array = true);
 
   // jump is an unconditional branch
   void jump(BlockBegin* block) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -2977,6 +2977,7 @@ void LIRGenerator::do_Intrinsic(Intrinsic* x) {
   case vmIntrinsics::_dexp :          // fall through
   case vmIntrinsics::_dpow :          do_MathIntrinsic(x); break;
   case vmIntrinsics::_arraycopy:      do_ArrayCopy(x);     break;
+  case vmIntrinsicID::_clone:         do_Clone(x);         break;
 
   case vmIntrinsics::_fmaD:           do_FmaIntrinsic(x); break;
   case vmIntrinsics::_fmaF:           do_FmaIntrinsic(x); break;

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -264,6 +264,7 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   void do_MathIntrinsic(Intrinsic* x);
   void do_LibmIntrinsic(Intrinsic* x);
   void do_ArrayCopy(Intrinsic* x);
+  void do_Clone(Intrinsic* x);
   void do_CompareAndSwap(Intrinsic* x, ValueType* type);
   void do_PreconditionsCheckIndex(Intrinsic* x, BasicType type);
   void do_FPIntrinsics(Intrinsic* x);


### PR DESCRIPTION
Adding C1 intrinsic for primitive array clone invocations for aarch64 and x86 architectures.

The intrinsic includes a change to avoid zeroing the newly allocated array because its contents are copied over within the same intrinsic with arraycopy. This means that the performance of primitive array clone exceeds that of primitive array copy. As an example, here are the microbenchmark results on darwin/aarch64:

```
$ make test TEST="micro:java.lang.ArrayClone" MICRO="JAVA_OPTIONS=-XX:TieredStopAtLevel=1"
Benchmark                 (size)  Mode  Cnt    Score    Error  Units
ArrayClone.byteArraycopy       0  avgt   15    3.476 ?  0.018  ns/op
ArrayClone.byteArraycopy      10  avgt   15    3.740 ?  0.017  ns/op
ArrayClone.byteArraycopy     100  avgt   15    7.124 ?  0.010  ns/op
ArrayClone.byteArraycopy    1000  avgt   15   39.301 ?  0.106  ns/op
ArrayClone.byteClone           0  avgt   15    3.478 ?  0.008  ns/op
ArrayClone.byteClone          10  avgt   15    3.562 ?  0.007  ns/op
ArrayClone.byteClone         100  avgt   15    5.888 ?  0.206  ns/op
ArrayClone.byteClone        1000  avgt   15   25.762 ?  0.203  ns/op
ArrayClone.intArraycopy        0  avgt   15    3.199 ?  0.016  ns/op
ArrayClone.intArraycopy       10  avgt   15    4.521 ?  0.008  ns/op
ArrayClone.intArraycopy      100  avgt   15   17.429 ?  0.039  ns/op
ArrayClone.intArraycopy     1000  avgt   15  178.432 ?  0.777  ns/op
ArrayClone.intClone            0  avgt   15    3.406 ?  0.016  ns/op
ArrayClone.intClone           10  avgt   15    4.272 ?  0.006  ns/op
ArrayClone.intClone          100  avgt   15   13.110 ?  0.122  ns/op
ArrayClone.intClone         1000  avgt   15  113.196 ? 13.400  ns/op
```

It also includes an optimization to avoid instantiating the array copy stub in scenarios like this.

I run hotspot compiler tests successfully limiting them to C1 compilation darwin/aarch64, linux/x86_64 and linux/686. E.g.

```
$ make test TEST="hotspot_compiler" JTREG="JAVA_OPTIONS=-XX:TieredStopAtLevel=1"
...
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/hotspot/jtreg:hotspot_compiler          1234  1234     0     0
```

One question I had is what to do about non-primitive object arrays, see my [question](https://bugs.openjdk.org/browse/JDK-8302850?focusedId=14634879&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14634879) on the issue. @cl4es any thoughts?

Thanks @rwestrel for his help shaping this up :)