### PR TITLE
8325108: POSIX map_memory_to_file calls release_memory incorrectly

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -328,12 +328,8 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
     warning("Failed mmap to file. (%s)", os::strerror(errno));
     return nullptr;
   }
-  if (base != nullptr && addr != base) {
-    if (::munmap(addr, size) != 0) {
-      warning("Could not release memory on unsuccessful file mapping");
-    }
-    return nullptr;
-  }
+  assert(base != nullptr && addr != base, "should not");
+
   return addr;
 }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -328,7 +328,8 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
     warning("Failed mmap to file. (%s)", os::strerror(errno));
     return nullptr;
   }
-  assert(base != nullptr && addr != base, "should not");
+
+  assert(base == nullptr || addr == base, "should not, base: %p, addr: %p", base, addr);
 
   return addr;
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -329,7 +329,7 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
     return nullptr;
   }
 
-  assert(base == nullptr || addr == base, "should not, base: %p, addr: %p", base, addr);
+  assert(base == nullptr || addr == base, "should not, base: " PTR_FORMAT " addr: " PTR_FORMAT, p2i(base), p2i(addr));
 
   return addr;
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -322,14 +322,14 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
   if (base != nullptr) {
     flags |= MAP_FIXED;
   }
-  char* addr = (char*)mmap(base, size, prot, flags, fd, 0);
+  char* addr = (char*)::mmap(base, size, prot, flags, fd, 0);
 
   if (addr == MAP_FAILED) {
     warning("Failed mmap to file. (%s)", os::strerror(errno));
     return nullptr;
   }
   if (base != nullptr && addr != base) {
-    if (!os::release_memory(addr, size)) {
+    if (::munmap(addr, size) != 0) {
       warning("Could not release memory on unsuccessful file mapping");
     }
     return nullptr;

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -30,6 +30,7 @@
 #include "runtime/os.hpp"
 #include "testutils.hpp"
 #include "unittest.hpp"
+#include <stdio.h>
 
 // Check NMT header for integrity, as well as expected type and size.
 static void check_expected_malloc_header(const void* payload, MEMFLAGS type, size_t size) {
@@ -155,3 +156,13 @@ TEST_VM(NMT, HeaderKeepsIntegrityAfterRevival) {
   hdr->revive();
   check_expected_malloc_header(p, mtTest, some_size);
 }
+
+#ifdef LINUX
+TEST_VM(NMT, FailingToMapMemoryToFileShouldNotCrash) {
+  FILE* file = tmpfile();
+  if (file != nullptr) {
+    // 0x123 is a completely bogus address on purpose.
+    os::map_memory_to_file((char*)0x123, 100, fileno(file));
+  }
+}
+#endif

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -30,7 +30,6 @@
 #include "runtime/os.hpp"
 #include "testutils.hpp"
 #include "unittest.hpp"
-#include <stdio.h>
 
 // Check NMT header for integrity, as well as expected type and size.
 static void check_expected_malloc_header(const void* payload, MEMFLAGS type, size_t size) {
@@ -156,13 +155,3 @@ TEST_VM(NMT, HeaderKeepsIntegrityAfterRevival) {
   hdr->revive();
   check_expected_malloc_header(p, mtTest, some_size);
 }
-
-#ifdef LINUX
-TEST_VM(NMT, FailingToMapMemoryToFileShouldNotCrash) {
-  FILE* file = tmpfile();
-  if (file != nullptr) {
-    // 0x123 is a completely bogus address on purpose.
-    os::map_memory_to_file((char*)0x123, 100, fileno(file));
-  }
-}
-#endif


### PR DESCRIPTION
Hi,

This PR fixes a small bug where `os::map_memory_to_file` attempts to unmap an incorrect mapping by calling `os::release_memory`. If NMT is turned on this will lead to a JVM crash, as the region was not previously mapped.

I'm fairly sure that this branch is actually dead code as `MAP_FIXED` is appended to the flags of the mmap call, and according to my man pages on mmap this will lead to mmap failing instead of giving another mapping to the address. However, I'd rather be on the safe side than sorry so I only do the minimal changes necessary to fix the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325108](https://bugs.openjdk.org/browse/JDK-8325108): POSIX map_memory_to_file calls release_memory incorrectly (**Bug** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 24, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17669/head:pull/17669` \
`$ git checkout pull/17669`

Update a local copy of the PR: \
`$ git checkout pull/17669` \
`$ git pull https://git.openjdk.org/jdk.git pull/17669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17669`

View PR using the GUI difftool: \
`$ git pr show -t 17669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17669.diff">https://git.openjdk.org/jdk/pull/17669.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17669#issuecomment-1921157904)
</details>
