### PR TITLE
8323089: networkaddress.cache.ttl is not a system property

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,8 +194,8 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  * caching. Likewise, a system admin can configure a different
  * negative caching TTL value when needed or extend the usage of the stale data.
  *
- * <p> Three Java security properties control the TTL values used for
- *  positive and negative host name resolution caching:
+ * <p> Three Java {@link java.security.Security security} properties control
+ * the TTL values used for positive and negative host name resolution caching:
  *
  * <dl style="margin-left:2em">
  * <dt><b>networkaddress.cache.ttl</b></dt>

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -194,7 +194,7 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  * caching. Likewise, a system admin can configure a different
  * negative caching TTL value when needed or extend the usage of the stale data.
  *
- * <p> Three Java {@link java.security.Security security} properties control
+ * <p> Three Java {@linkplain java.security.Security security} properties control
  * the TTL values used for positive and negative host name resolution caching:
  *
  * <dl style="margin-left:2em">

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -1,6 +1,6 @@
 <!DOCTYPE HTML>
 <!--
- Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -260,14 +260,14 @@ successful or not, so that subsequent identical requests will not
 have to access the naming service. These properties allow for some
 tuning on how the cache is operating.</P>
 <UL>
-	<LI><P><B>{@systemProperty networkaddress.cache.ttl}</B> (default: see below)<BR>
+	<LI><P><B>{@code networkaddress.cache.ttl}</B> (default: see below)<BR>
 	Value is an integer corresponding to the number of seconds successful
 	name lookups will be kept in the cache. A value of -1, or any other
 	negative value for that matter,	indicates a &ldquo;cache forever&rdquo;
 	policy, while a value of 0 (zero) means no caching. The default value
 	is -1 (forever) if a security manager is installed, and implementation-specific
 	when no security manager is installed.</P>
-	<LI><P><B>{@systemProperty networkaddress.cache.stale.ttl}</B> (default: see below)<BR>
+	<LI><P><B>{@code networkaddress.cache.stale.ttl}</B> (default: see below)<BR>
 	Value is an integer corresponding to the number of seconds that stale names
 	will be kept in the cache. A name is considered stale if the TTL has expired
 	and an attempt to lookup the host name again was not successful. This
@@ -276,7 +276,7 @@ tuning on how the cache is operating.</P>
 	A value of 0 (zero) or if the property is not set means do not use stale
 	names. Negative values are ignored.
 	The default value is implementation-specific.</P>
-	<LI><P><B>{@systemProperty networkaddress.cache.negative.ttl}</B> (default: {@code 10})<BR>
+	<LI><P><B>{@code networkaddress.cache.negative.ttl}</B> (default: {@code 10})<BR>
 	Value is an integer corresponding to the number of seconds an
 	unsuccessful name lookup will be kept in the cache. A value of -1,
 	or any negative value, means &ldquo;cache forever&rdquo;, while a
@@ -284,7 +284,7 @@ tuning on how the cache is operating.</P>
 </UL>
 <P>Since these 3 properties are part of the security policy, they are
 not set by either the -D option or the {@code System.setProperty()} API,
-instead they are set as security properties.</P>
+instead they are set as {@link java.security.Security security} properties.</P>
 <a id="Unixdomain"></a>
 <H2>Unix domain sockets</H2>
 <p>

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -284,7 +284,7 @@ tuning on how the cache is operating.</P>
 </UL>
 <P>Since these 3 properties are part of the security policy, they are
 not set by either the -D option or the {@code System.setProperty()} API,
-instead they are set as {@link java.security.Security security} properties.</P>
+instead they are set as {@linkplain java.security.Security security} properties.</P>
 <a id="Unixdomain"></a>
 <H2>Unix domain sockets</H2>
 <p>


### PR DESCRIPTION
Please review this documentation change that:
- removes networkcache.cache.*.ttl properties from the [System properties page](https://docs.oracle.com/en/java/javase/21/docs/api/system-properties.html)
- Adds a link to the Security class where security properties are mentioned

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323089](https://bugs.openjdk.org/browse/JDK-8323089): networkaddress.cache.ttl is not a system property (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17671/head:pull/17671` \
`$ git checkout pull/17671`

Update a local copy of the PR: \
`$ git checkout pull/17671` \
`$ git pull https://git.openjdk.org/jdk.git pull/17671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17671`

View PR using the GUI difftool: \
`$ git pr show -t 17671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17671.diff">https://git.openjdk.org/jdk/pull/17671.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17671#issuecomment-1922070882)