### PR TITLE
8325134: Serial: Remove Generation::used_region

### DIFF
--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -113,10 +113,6 @@ class Generation: public CHeapObj<mtGC> {
 
   MemRegion reserved() const { return _reserved; }
 
-  // Returns a region guaranteed to contain all the objects in the
-  // generation.
-  virtual MemRegion used_region() const { return _reserved; }
-
   /* Returns "TRUE" iff "p" points into the reserved area of the generation. */
   bool is_in_reserved(const void* p) const {
     return _reserved.contains(p);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -29,6 +29,7 @@
 #include "gc/serial/generation.hpp"
 #include "gc/shared/gcStats.hpp"
 #include "gc/shared/generationCounters.hpp"
+#include "gc/shared/space.hpp"
 #include "utilities/macros.hpp"
 
 class SerialBlockOffsetSharedArray;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -92,8 +92,8 @@ class TenuredGeneration: public Generation {
   size_t capacity() const;
   size_t used() const;
   size_t free() const;
-  MemRegion used_region() const;
 
+  MemRegion used_region() const { return space()->used_region(); }
   MemRegion prev_used_region() const { return _prev_used_region; }
   void save_used_region()   { _prev_used_region = used_region(); }
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -41,10 +41,6 @@ inline size_t TenuredGeneration::free() const {
   return space()->free();
 }
 
-inline MemRegion TenuredGeneration::used_region() const {
-  return space()->used_region();
-}
-
 inline bool TenuredGeneration::is_in(const void* p) const {
   return space()->is_in(p);
 }


### PR DESCRIPTION
Trivial removing dead code. The change of moving the definition to `tenuredGeneration.hpp` is needed to work around linking failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325134](https://bugs.openjdk.org/browse/JDK-8325134): Serial: Remove Generation::used_region (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17673/head:pull/17673` \
`$ git checkout pull/17673`

Update a local copy of the PR: \
`$ git checkout pull/17673` \
`$ git pull https://git.openjdk.org/jdk.git pull/17673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17673`

View PR using the GUI difftool: \
`$ git pr show -t 17673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17673.diff">https://git.openjdk.org/jdk/pull/17673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17673#issuecomment-1921632344)