### PR TITLE
8316992: Potential null pointer from get_current_thread JVMCI helper function.

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -179,20 +179,11 @@ Handle JavaArgumentUnboxer::next_arg(BasicType expectedType) {
   CompilerThreadCanCallJava ccj(thread, __is_hotspot);     \
   JVMCIENV_FROM_JNI(JVMCI::compilation_tick(thread), env); \
 
-static JavaThread* get_current_thread(bool allow_null=true) {
-  Thread* thread = Thread::current_or_null_safe();
-  if (thread == nullptr) {
-    assert(allow_null, "npe");
-    return nullptr;
-  }
-  return JavaThread::cast(thread);
-}
-
 // Entry to native method implementation that transitions
 // current thread to '_thread_in_vm'.
 #define C2V_VMENTRY(result_type, name, signature)        \
   JNIEXPORT result_type JNICALL c2v_ ## name signature { \
-  JavaThread* thread = get_current_thread();             \
+  JavaThread* thread = JavaThread::current_or_null();    \
   if (thread == nullptr) {                               \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
         err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
@@ -203,7 +194,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
 
 #define C2V_VMENTRY_(result_type, name, signature, result) \
   JNIEXPORT result_type JNICALL c2v_ ## name signature { \
-  JavaThread* thread = get_current_thread();             \
+  JavaThread* thread = JavaThread::current_or_null();    \
   if (thread == nullptr) {                               \
     env->ThrowNew(JNIJVMCI::InternalError::clazz(),      \
         err_msg("Cannot call into HotSpot from JVMCI shared library without attaching current thread")); \
@@ -219,7 +210,7 @@ static JavaThread* get_current_thread(bool allow_null=true) {
 // current thread to '_thread_in_vm'.
 #define C2V_VMENTRY_PREFIX(result_type, name, signature) \
   JNIEXPORT result_type JNICALL c2v_ ## name signature { \
-  JavaThread* thread = get_current_thread();
+  JavaThread* thread = JavaThread::current_or_null();
 
 #define C2V_END }
 
@@ -2616,7 +2607,7 @@ static void attachSharedLibraryThread(JNIEnv* env, jbyteArray name, jboolean as_
   if (res != JNI_OK) {
     JNI_THROW("attachSharedLibraryThread", InternalError, err_msg("Trying to attach thread returned %d", res));
   }
-  JavaThread* thread = get_current_thread(false);
+  JavaThread* thread = JavaThread::thread_from_jni_environment(hotspotEnv);
   const char* attach_error;
   {
     // Transition to VM


### PR DESCRIPTION
Refactors some JVMCI C++ code that leads a static analysis tool to think a nullptr can be passed to [`Atomic::PlatformStore<4ull>::operator()<int>`](https://github.com/openjdk/jdk/blob/b75c134facc4dbd9f171024a12994dda818c5471/src/hotspot/share/runtime/atomic.hpp#L616-L624).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316992](https://bugs.openjdk.org/browse/JDK-8316992): Potential null pointer from get_current_thread JVMCI helper function. (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17676/head:pull/17676` \
`$ git checkout pull/17676`

Update a local copy of the PR: \
`$ git checkout pull/17676` \
`$ git pull https://git.openjdk.org/jdk.git pull/17676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17676`

View PR using the GUI difftool: \
`$ git pr show -t 17676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17676.diff">https://git.openjdk.org/jdk/pull/17676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17676#issuecomment-1929670412)