### PR TITLE
8325152: Clarify specification of java.io.RandomAccessFile.setLength

### DIFF
--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -673,7 +673,7 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      *
      * <p> In all cases, after this method returns, the file offset as returned
      * by the {@linkplain #getFilePointer getFilePointer} method will equal the
-     * minimum of {@code newLength} and the file offset before this method was
+     * minimum of the desired length and the file offset before this method was
      * called, even if the length is unchanged.  In other words, this method
      * constrains the file offset to the closed interval {@code [0,newLength]}.
      *

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -660,19 +660,26 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
      * Sets the length of this file.
      *
      * <p> If the present length of the file as returned by the
-     * {@code length} method is greater than the {@code newLength}
-     * argument then the file will be truncated.  In this case, if the file
-     * offset as returned by the {@code getFilePointer} method is greater
-     * than {@code newLength} then after this method returns the offset
-     * will be equal to {@code newLength}.
+     * {@linkplain #length length} method is greater than the desired length
+     * of the file specified by the {@code newLength} argument, then the file
+     * will be truncated.
      *
-     * <p> If the present length of the file as returned by the
-     * {@code length} method is smaller than the {@code newLength}
-     * argument then the file will be extended.  In this case, the contents of
-     * the extended portion of the file are not defined.
+     * <p> If the present length of the file is smaller than the desired length,
+     * then the file will be extended.  The contents of the extended portion of
+     * the file are not defined.
+     *
+     * <p> If the present length of the file is equal to the desired length,
+     * then the file and its length will be unchanged.
+     *
+     * <p> In all cases, after this method returns, the file offset as returned
+     * by the {@linkplain #getFilePointer getFilePointer} method will equal the
+     * minimum of {@code newLength} and the file offset before this method was
+     * called, even if the length is unchanged.  In other words, this method
+     * constrains the file offset to the closed interval {@code [0,newLength]}.
      *
      * @param      newLength    The desired length of the file
-     * @throws     IOException  If an I/O error occurs
+     * @throws     IOException  If the argument is negative or
+     *                          if some other I/O error occurs
      * @since      1.2
      */
     public void setLength(long newLength) throws IOException {


### PR DESCRIPTION
Modify the specification verbiage of `java.io.RandomAccessFile.setLength` to account for the effect of the method on the file offset as returned by `getFilePointer`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8325260](https://bugs.openjdk.org/browse/JDK-8325260) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8325152](https://bugs.openjdk.org/browse/JDK-8325152): Clarify specification of java.io.RandomAccessFile.setLength (**Enhancement** - P4)
 * [JDK-8325260](https://bugs.openjdk.org/browse/JDK-8325260): Clarify specification of java.io.RandomAccessFile.setLength (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17679/head:pull/17679` \
`$ git checkout pull/17679`

Update a local copy of the PR: \
`$ git checkout pull/17679` \
`$ git pull https://git.openjdk.org/jdk.git pull/17679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17679`

View PR using the GUI difftool: \
`$ git pr show -t 17679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17679.diff">https://git.openjdk.org/jdk/pull/17679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17679#issuecomment-1922579864)