### PR TITLE
8324677: Specification clarification needed for JVM TI GetObjectMonitorUsage

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/ObjectReferenceImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ObjectReferenceImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -219,14 +219,19 @@ monitorInfo(PacketInputStream *in, PacketOutputStream *out)
             int i;
             (void)outStream_writeObjectRef(env, out, info.owner);
             (void)outStream_writeInt(out, info.entry_count);
-            (void)outStream_writeInt(out, info.waiter_count);
+            (void)outStream_writeInt(out, info.waiter_count + info.notify_waiter_count);
             for (i = 0; i < info.waiter_count; i++) {
                 (void)outStream_writeObjectRef(env, out, info.waiters[i]);
+            }
+            for (i = 0; i < info.notify_waiter_count; i++) {
+                (void)outStream_writeObjectRef(env, out, info.notify_waiters[i]);
             }
         }
 
         if (info.waiters != NULL )
             jvmtiDeallocate(info.waiters);
+        if (info.notify_waiters != NULL )
+            jvmtiDeallocate(info.notify_waiters);
 
     } END_WITH_LOCAL_REFS(env);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001/objmonusage001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001/objmonusage001.cpp
@@ -94,7 +94,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_GetObjectMonitorUsage_objmonusage001_check(JNIEnv *env,
         jclass cls, jint i, jobject obj,
-        jthread owner, jint entryCount, jint waiterCount) {
+        jthread owner, jint entryCount, jint notifyWaiterCount) {
     jvmtiError err;
     jvmtiMonitorUsage inf;
     jvmtiThreadInfo tinf;
@@ -157,9 +157,9 @@ Java_nsk_jvmti_GetObjectMonitorUsage_objmonusage001_check(JNIEnv *env,
         result = STATUS_FAILED;
     }
 
-    if (inf.waiter_count != waiterCount) {
+    if (inf.notify_waiter_count != notifyWaiterCount) {
         printf("(%d) waiter_count expected: %d, actually: %d\n",
-               i, waiterCount, inf.waiter_count);
+               i, notifyWaiterCount, inf.notify_waiter_count);
         result = STATUS_FAILED;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage003.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class objmonusage003 {
 
     native static int getRes();
     native static void check(Object obj, Thread owner,
-                             int entryCount, int waiterCount);
+                             int entryCount, int notifyWaiterCount);
 
     public static void main(String args[]) {
         args = nsk.share.jvmti.JVMTITest.commonInit(args);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage003/objmonusage003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage003/objmonusage003.cpp
@@ -95,7 +95,7 @@ jint  Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
 JNIEXPORT void JNICALL
 Java_nsk_jvmti_GetObjectMonitorUsage_objmonusage003_check(JNIEnv *env,
         jclass cls, jobject obj, jthread owner,
-        jint entryCount, jint waiterCount) {
+        jint entryCount, jint notifyWaiterCount) {
     jvmtiError err;
     jvmtiMonitorUsage inf;
     jvmtiThreadInfo tinf;
@@ -146,9 +146,9 @@ Java_nsk_jvmti_GetObjectMonitorUsage_objmonusage003_check(JNIEnv *env,
         result = STATUS_FAILED;
     }
 
-    if (inf.waiter_count != waiterCount) {
+    if (inf.notify_waiter_count != notifyWaiterCount) {
         printf("(%d) waiter_count expected: %d, actually: %d\n",
-               count, waiterCount, inf.waiter_count);
+               count, notifyWaiterCount, inf.notify_waiter_count);
         result = STATUS_FAILED;
     }
 }


### PR DESCRIPTION
The implementation of the JVM TI `GetObjectMonitorUsage` does not match the spec.
The function returns the following structure:
```
typedef struct {
    jthread owner;
    jint entry_count;
    jint waiter_count;
    jthread* waiters;
    jint notify_waiter_count;
    jthread* notify_waiters;
} jvmtiMonitorUsage;
```

The following four fields are defined this way:
```
waiter_count             [jint]         The number of threads waiting to own this monitor
waiters                      [jthread*] The waiter_count waiting threads
notify_waiter_count  [jint]         The number of threads waiting to be notified by this monitor
notify_waiters	[jthread*]           The notify_waiter_count threads waiting to be notified
```
The `waiters` has to include all threads waiting to enter the monitor or to re-enter it in `Object.wait()`.
The implementation also includes the threads waiting to be notified in `Object.wait()` which is wrong.
The `notify_waiters` has to include all threads waiting to be notified in `Object.wait()`.
The implementation also includes the threads waiting to re-enter the monitor in `Object.wait()` which is wrong.
This update makes it right.

The implementation of the JDWP command `ObjectReference.MonitorInfo (5)` is based on the JVM TI `GetObjectMonitorInfo()`. This update has a tweak to keep the existing behavior of this command.

The follwoing JVMTI vmTestbase tests are fixed to adopt to the `GetObjectMonitorUsage()` correct behavior:
```
  jvmti/GetObjectMonitorUsage/objmonusage001
  jvmti/GetObjectMonitorUsage/objmonusage003
```

The following JVMTI JCK tests have to be fixed to adopt to correct behavior:
```
vm/jvmti/GetObjectMonitorUsage/gomu001/gomu00101/gomu00101.html
vm/jvmti/GetObjectMonitorUsage/gomu001/gomu00101/gomu00101a.html
vm/jvmti/GetObjectMonitorUsage/gomu001/gomu00102/gomu00102.html
vm/jvmti/GetObjectMonitorUsage/gomu001/gomu00102/gomu00102a.html

```

A JCK bug will be filed and the tests have to be added into the JCK problem list located in the closed repository by a separate sub-task before integration of this update.

Also, please see and review the related CSR:
 [8324677](https://bugs.openjdk.org/browse/JDK-8324677) Specification clarification needed for JVM TI GetObjectMonitorUsage
 
Testing:
 - tested with mach5 tiers 1-6