### PR TITLE
8325159: C2 SuperWord: measure time for CITime

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -37,6 +37,7 @@
 #include "opto/mulnode.hpp"
 #include "opto/movenode.hpp"
 #include "opto/opaquenode.hpp"
+#include "opto/phase.hpp"
 #include "opto/predicates.hpp"
 #include "opto/rootnode.hpp"
 #include "opto/runtime.hpp"
@@ -1101,6 +1102,8 @@ void IdealLoopTree::policy_unroll_slp_analysis(CountedLoopNode *cl, PhaseIdealLo
   // Enable this functionality target by target as needed
   if (SuperWordLoopUnrollAnalysis) {
     if (!cl->was_slp_analyzed()) {
+      Compile::TracePhase tp("autoVectorize", &Phase::timers[Phase::_t_autoVectorize]);
+
       SuperWord sw(phase);
       sw.transform_loop(this, false);
 

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4865,6 +4865,7 @@ void PhaseIdealLoop::build_and_optimize() {
 
   // Convert scalar to superword operations at the end of all loop opts.
   if (C->do_superword() && C->has_loops() && !C->major_progress()) {
+    Compile::TracePhase tp("autoVectorize", &timers[_t_autoVectorize]);
     // SuperWord transform
     SuperWord sw(this);
     for (LoopTreeIterator iter(_ltree_root); !iter.done(); iter.next()) {

--- a/src/hotspot/share/opto/phase.cpp
+++ b/src/hotspot/share/opto/phase.cpp
@@ -81,6 +81,7 @@ void Phase::print_timers() {
     tty->print_cr ("             Prune Useless:   %7.3f s", timers[_t_vector_pru].seconds());
     tty->print_cr ("         Renumber Live:       %7.3f s", timers[_t_renumberLive].seconds());
     tty->print_cr ("         IdealLoop:           %7.3f s", timers[_t_idealLoop].seconds());
+    tty->print_cr ("           AutoVectorize:     %7.3f s", timers[_t_autoVectorize].seconds());
     tty->print_cr ("         IdealLoop Verify:    %7.3f s", timers[_t_idealLoopVerify].seconds());
     tty->print_cr ("         Cond Const Prop:     %7.3f s", timers[_t_ccp].seconds());
     tty->print_cr ("         GVN 2:               %7.3f s", timers[_t_iterGVN2].seconds());

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -82,6 +82,7 @@ public:
           _t_vector_pru,
       _t_renumberLive,
       _t_idealLoop,
+        _t_autoVectorize,
       _t_idealLoopVerify,
       _t_ccp,
       _t_iterGVN2,


### PR DESCRIPTION
I want to add SuperWord / AutoVectorization time to `CITime`.

This is for @vnkozlov who requested I measure the time difference for https://github.com/openjdk/jdk/pull/17624

Example:
```
...
    C2 Compile Time:        2.757 s
       Parse:                 0.027 s
       Optimize:              2.505 s
         Escape Analysis:       0.000 s
           Conn Graph:            0.000 s
           Macro Eliminate:       0.000 s
         GVN 1:                 0.007 s
         Incremental Inline:    0.000 s
           IdealLoop:             0.000 s
          (IGVN:                  0.000 s)
          (Inline:                0.000 s)
          (Prune Useless:         0.000 s)
           Other:                 0.000 s
         Vector:                0.000 s
           Box elimination:     0.000 s
             IGVN:              0.000 s
             Prune Useless:     0.000 s
         Renumber Live:         0.000 s
         IdealLoop:             2.345 s
           AutoVectorize:       1.507 s       <------------ added this
         IdealLoop Verify:      0.000 s
         Cond Const Prop:       0.014 s
         GVN 2:                 0.008 s
         Macro Expand:          0.023 s
         Barrier Expand:        0.000 s
         Graph Reshape:         0.004 s
         Other:                 0.103 s
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325159](https://bugs.openjdk.org/browse/JDK-8325159): C2 SuperWord: measure time for CITime (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17683/head:pull/17683` \
`$ git checkout pull/17683`

Update a local copy of the PR: \
`$ git checkout pull/17683` \
`$ git pull https://git.openjdk.org/jdk.git pull/17683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17683`

View PR using the GUI difftool: \
`$ git pr show -t 17683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17683.diff">https://git.openjdk.org/jdk/pull/17683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17683#issuecomment-1923567768)