### PR TITLE
8325169: Reduce String::indexOf overheads

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2501,9 +2501,9 @@ public final class String
      * {@code fromIndex} were larger than the string length, or were negative.
      */
     public int indexOf(int ch, int fromIndex) {
-        fromIndex = Math.max(0, fromIndex);
-        return isLatin1() ? StringLatin1.indexOf(value, ch, fromIndex, value.length)
-                : StringUTF16.indexOf(value, ch, fromIndex, value.length >> 1);
+        fromIndex = Math.max(fromIndex, 0);
+        return isLatin1() ? StringLatin1.indexOf(value, ch, Math.min(fromIndex, value.length), value.length)
+                : StringUTF16.indexOf(value, ch, Math.min(fromIndex, value.length >> 1), value.length >> 1);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2444,7 +2444,8 @@ public final class String
      *          {@code -1} if the character does not occur.
      */
     public int indexOf(int ch) {
-        return indexOf(ch, 0);
+        return isLatin1() ? StringLatin1.indexOf(value, ch, 0, value.length)
+                : StringUTF16.indexOf(value, ch, 0, value.length >> 1);
     }
 
     /**
@@ -2500,8 +2501,9 @@ public final class String
      * {@code fromIndex} were larger than the string length, or were negative.
      */
     public int indexOf(int ch, int fromIndex) {
-        return isLatin1() ? StringLatin1.indexOf(value, ch, fromIndex, length())
-                : StringUTF16.indexOf(value, ch, fromIndex, length());
+        fromIndex = Math.max(0, fromIndex);
+        return isLatin1() ? StringLatin1.indexOf(value, ch, fromIndex, value.length)
+                : StringUTF16.indexOf(value, ch, fromIndex, value.length >> 1);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -310,7 +310,7 @@ final class StringLatin1 {
         };
     }
 
-    // Caller must ensure that fromIndex >= 0. If toIndex <= fromIndex or >= value.length, -1 will be returned.
+    // Caller must ensure that from- and toIndex are within bounds
     public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (!canEncode(ch)) {
             return -1;

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -314,11 +314,6 @@ final class StringLatin1 {
         if (!canEncode(ch)) {
             return -1;
         }
-        fromIndex = Math.max(fromIndex, 0);
-        toIndex = Math.min(toIndex, value.length);
-        if (fromIndex >= toIndex) {
-            return -1;
-        }
         return indexOfChar(value, ch, fromIndex, toIndex);
     }
 

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -310,6 +310,7 @@ final class StringLatin1 {
         };
     }
 
+    // Caller must ensure that fromIndex >= 0. If toIndex <= fromIndex or >= value.length, -1 will be returned.
     public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (!canEncode(ch)) {
             return -1;

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -604,7 +604,7 @@ final class StringUTF16 {
         };
     }
 
-    // Caller must ensure that fromIndex >= 0. If toIndex <= fromIndex or >= value.length >> 1, -1 will be returned.
+    // Caller must ensure that from- and toIndex are within bounds
     public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (ch < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
             // handle most cases here (ch is a BMP code point or a

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -605,11 +605,6 @@ final class StringUTF16 {
     }
 
     public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
-        fromIndex = Math.max(fromIndex, 0);
-        toIndex = Math.min(toIndex, value.length >> 1);
-        if (fromIndex >= toIndex) {
-            return -1;
-        }
         if (ch < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
             // handle most cases here (ch is a BMP code point or a
             // negative value (invalid code point))
@@ -716,11 +711,6 @@ final class StringUTF16 {
 
     @IntrinsicCandidate
     private static int indexOfChar(byte[] value, int ch, int fromIndex, int max) {
-        checkBoundsBeginEnd(fromIndex, max, value);
-        return indexOfCharUnsafe(value, ch, fromIndex, max);
-    }
-
-    private static int indexOfCharUnsafe(byte[] value, int ch, int fromIndex, int max) {
         for (int i = fromIndex; i < max; i++) {
             if (getChar(value, i) == ch) {
                 return i;

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -604,6 +604,7 @@ final class StringUTF16 {
         };
     }
 
+    // Caller must ensure that fromIndex >= 0. If toIndex <= fromIndex or >= value.length >> 1, -1 will be returned.
     public static int indexOf(byte[] value, int ch, int fromIndex, int toIndex) {
         if (ch < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
             // handle most cases here (ch is a BMP code point or a

--- a/test/micro/org/openjdk/bench/java/lang/StringIndexOf.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringIndexOf.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1)
+@Fork(value = 3)
 public class StringIndexOf {
 
     private String dataString;
@@ -109,6 +109,21 @@ public class StringIndexOf {
     @Benchmark
     public int searchChar16ShortSuccess() {
         return string16Short.indexOf(searchChar16);
+    }
+
+    @Benchmark
+    public int searchCharLongWithOffsetSuccess() {
+        return dataStringBig.indexOf(searchChar, 3);
+    }
+
+    @Benchmark
+    public int searchCharMediumWithOffsetSuccess() {
+        return searchStringBig.indexOf(searchChar, 3);
+    }
+
+    @Benchmark
+    public int searchCharShortWithOffsetSuccess() {
+        return searchString.indexOf(searchChar, 1);
     }
 
     @Benchmark


### PR DESCRIPTION
This patch streamlines and specializes various `String::indexOf` methods. Mainly avoids the need for clamping and doing checks that are redundant in almost all cases, moving the checks to the API boundary where they are needed. 

This improves performance both at peak and during startup/warmup. Since indexOf is heavily used in bootstrapping code it makes sense to slightly dial back abstraction and delegation, which in this case also brought some benefit to peak performance.

Testing: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325169](https://bugs.openjdk.org/browse/JDK-8325169): Reduce String::indexOf overheads (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**) ⚠️ Review applies to [aad343b3](https://git.openjdk.org/jdk/pull/17685/files/aad343b3763ac2e788a6ed9a714e897e0db38e1c)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17685/head:pull/17685` \
`$ git checkout pull/17685`

Update a local copy of the PR: \
`$ git checkout pull/17685` \
`$ git pull https://git.openjdk.org/jdk.git pull/17685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17685`

View PR using the GUI difftool: \
`$ git pr show -t 17685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17685.diff">https://git.openjdk.org/jdk/pull/17685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17685#issuecomment-1924052321)