### PR TITLE
8325176: Compiling native tests with clang on linux fails

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -146,6 +146,10 @@ ifeq ($(LSAN_ENABLED), true)
   BUILD_JDK_JTREG_EXTRA_FILES += $(TOPDIR)/make/data/lsan/lsan_default_options.c
 endif
 
+ifeq ($(TOOLCHAIN_TYPE), clang)
+  BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libSafeAllocationTest += -Wno-format
+endif
+
 # This evaluation is expensive and should only be done if this target was
 # explicitly called.
 ifneq ($(filter build-test-jdk-jtreg-native, $(MAKECMDGOALS)), )


### PR DESCRIPTION
While we do not have automatic testing of using clang instead of gcc on linux, we try to keep it in working condition. This is still the case for the JDK itself, but there is a native test which fails to compile with clang. This should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8325176`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8325176`.


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17688/head:pull/17688` \
`$ git checkout pull/17688`

Update a local copy of the PR: \
`$ git checkout pull/17688` \
`$ git pull https://git.openjdk.org/jdk.git pull/17688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17688`

View PR using the GUI difftool: \
`$ git pr show -t 17688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17688.diff">https://git.openjdk.org/jdk/pull/17688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17688#issuecomment-1924106615)