### PR TITLE
8323681: SA PointerFinder code should support G1

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/G1CollectedHeap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,17 @@ public class G1CollectedHeap extends CollectedHeap {
             HeapRegion hr = iter.next();
             hrcl.doHeapRegion(hr);
         }
+    }
+
+    public HeapRegion heapRegionForAddress(Address addr) {
+        Iterator<HeapRegion> iter = heapRegionIterator();
+        while (iter.hasNext()) {
+            HeapRegion hr = iter.next();
+            if (hr.isInRegion(addr)) {
+                return hr;
+            }
+        }
+        return null;
     }
 
     public CollectedHeapName kind() {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -138,6 +138,10 @@ public class HeapRegion extends ContiguousSpace implements LiveRegionsProvider {
 
     public static long getPointerSize() {
         return pointerSize;
+    }
+
+    public boolean isInRegion(Address addr) {
+        return (addr.greaterThanOrEqual(bottom()) && addr.lessThan(top()));
     }
 
     public void printOn(PrintStream tty) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/g1/HeapRegion.java
@@ -141,7 +141,7 @@ public class HeapRegion extends ContiguousSpace implements LiveRegionsProvider {
     }
 
     public boolean isInRegion(Address addr) {
-        return (addr.greaterThanOrEqual(bottom()) && addr.lessThan(top()));
+        return (addr.greaterThanOrEqual(bottom()) && addr.lessThan(end()));
     }
 
     public void printOn(PrintStream tty) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -27,6 +27,7 @@ package sun.jvm.hotspot.utilities;
 import sun.jvm.hotspot.code.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
+import sun.jvm.hotspot.gc.g1.*;
 import sun.jvm.hotspot.gc.serial.*;
 import sun.jvm.hotspot.gc.shared.*;
 import sun.jvm.hotspot.interpreter.*;
@@ -104,8 +105,7 @@ public class PointerFinder {
 
       // If we are using the SerialHeap, find out which generation the address is in
       if (heap instanceof SerialHeap) {
-        SerialHeap sh = (SerialHeap) heap;
-        loc.heap = heap;
+        SerialHeap sh = (SerialHeap)heap;
         for (int i = 0; i < sh.nGens(); i++) {
           Generation g = sh.getGen(i);
           if (g.isIn(a)) {
@@ -116,6 +116,16 @@ public class PointerFinder {
 
         if (Assert.ASSERTS_ENABLED) {
           Assert.that(loc.gen != null, "Should have found this address in a generation");
+        }
+      }
+
+      // If we are using the G1CollectedHeap, find out which region the address is in
+      if (heap instanceof G1CollectedHeap) {
+        G1CollectedHeap g1 = (G1CollectedHeap)heap;
+        loc.hr = g1.heapRegionForAddress(a);
+
+        if (Assert.ASSERTS_ENABLED) {
+          Assert.that(loc.hr != null, "Should have found this address in a g1 heap region");
         }
       }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerFinder.java
@@ -123,10 +123,12 @@ public class PointerFinder {
       if (heap instanceof G1CollectedHeap) {
         G1CollectedHeap g1 = (G1CollectedHeap)heap;
         loc.hr = g1.heapRegionForAddress(a);
-
-        if (Assert.ASSERTS_ENABLED) {
-          Assert.that(loc.hr != null, "Should have found this address in a g1 heap region");
-        }
+        // We don't assert that loc.hr is not null like we do for the SerialHeap. This is
+        // because heap.isIn(a) can return true if the address is anywhere in G1's mapped
+        // memory, even if that area of memory is not in use by a G1 HeapRegion. So there
+        // may in fact be no HeapRegion for the address even though it is in the heap.
+        // Leaving loc.hr == null in this case will result in PointerFinder saying that
+        // the address is "In unknown section of Java the heap", which is what we want.
       }
 
       return loc;

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -311,7 +311,7 @@ public class PointerLocation {
             }
         } else {
             // Address is some other heap type that we haven't special cased yet.
-            tty.println("In unknown section of Java heap");
+            tty.println("In unknown section of the Java heap");
         }
       }
     } else if (isInInterpreter()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -291,13 +291,14 @@ public class PointerLocation {
         if (getGeneration() != null) {
           // Address is in SerialGC heap
           if (isInNewGen()) {
-              tty.print("In heap new generation:");
+              tty.print("In new generation of SerialGC heap");
           } else if (isInOldGen()) {
-              tty.print("In heap old generation:");
+              tty.print("In old generation of SerialGC heap");
           } else {
-              tty.print("In unknown heap generation:");
+              tty.print("In unknown generation of SerialGC heap");
           }
           if (verbose) {
+              tty.print(":");
               getGeneration().printOn(tty); // does not include "\n"
           }
           tty.println();

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -28,6 +28,7 @@ import java.io.*;
 import sun.jvm.hotspot.code.*;
 import sun.jvm.hotspot.debugger.*;
 import sun.jvm.hotspot.debugger.cdbg.*;
+import sun.jvm.hotspot.gc.g1.*;
 import sun.jvm.hotspot.gc.serial.*;
 import sun.jvm.hotspot.gc.shared.*;
 import sun.jvm.hotspot.interpreter.*;
@@ -57,7 +58,8 @@ public class PointerLocation {
   ClosestSymbol nativeSymbol;
 
   CollectedHeap heap;
-  Generation gen;
+  Generation gen;  // Serial heap generation
+  HeapRegion hr;   // G1 heap region
 
   // If UseTLAB was enabled and the pointer was found in a
   // currently-active TLAB, these will be set
@@ -123,7 +125,11 @@ public class PointerLocation {
   }
 
   public Generation getGeneration() {
-      return gen;
+    return gen; // SerialHeap generation
+  }
+
+  public HeapRegion getHeapRegion() {
+    return hr; // G1 heap region
   }
 
   /** This may be true if isInNewGen is also true */
@@ -278,18 +284,35 @@ public class PointerLocation {
         } else {
           tty.format("\"%s\" %s\n", thread.getThreadName(), thread);
         }
-      } else {
-        if (isInNewGen()) {
-          tty.print("In new generation ");
-        } else if (isInOldGen()) {
-          tty.print("In old generation ");
-        } else {
-          tty.print("In unknown section of Java heap");
-        }
+      }
+      // This section provides details about where in the heap the address is located,
+      // but we only want to do that if it is not in a TLAB or if verbose requested.
+      if (!isInTLAB() || verbose) {
         if (getGeneration() != null) {
-          getGeneration().printOn(tty); // does not include "\n"
+          // Address is in SerialGC heap
+          if (isInNewGen()) {
+              tty.print("In heap new generation:");
+          } else if (isInOldGen()) {
+              tty.print("In heap old generation:");
+          } else {
+              tty.print("In unknown heap generation:");
+          }
+          if (verbose) {
+              getGeneration().printOn(tty); // does not include "\n"
+          }
+          tty.println();
+        } else if (getHeapRegion() != null) {
+            // Address is in the G1 heap
+            if (verbose) {
+                tty.print("In G1 heap ");
+                getHeapRegion().printOn(tty); // includes "\n"
+            } else {
+                tty.println("In G1 heap region");
+            }
+        } else {
+            // Address is some other heap type that we haven't special cased yet.
+            tty.println("In unknown section of Java heap");
         }
-        tty.println();
       }
     } else if (isInInterpreter()) {
       tty.print("In interpreter codelet: ");


### PR DESCRIPTION
This PR adds G1 support to PointerFinder/PointerLocation. Previously we only had SerialGC support. Previously for G1 addresses SA would only report that the address is "In unknown section of Java heap" with no other details. Now it provides details for G1 addresses. Here are some examples for clhsdb `threadcontext` output. `threadcontext` dumps the contents of the thread's registers, some of which are often in the java heap. In the output below the first line is without verbose output and the 2nd is with:

```
rbp: 0x00000000a0004080: In G1 heap region
rbp: 0x00000000a0004080: In G1 heap Region: 0x00000000a0000000,0x00000000a0018a30,0x00000000a1000000:Old
```

I also added an improvement to how SA deals with addresses in the TLAB. It used to only report that the address is in a TLAB and provide details about the TLAB in verbose mode. Now if verbose mode is used, the heap region information is included after the TLAB information. Here again is an example without and with verbose output:

```
rsi: 0x0000000166000000: In TLAB for thread "main" sun.jvm.hotspot.runtime.JavaThread@0x00007f11c8029250
rsi: 0x0000000166000000: In TLAB for thread ("main" #1 prio=5 tid=0x00007f11c8029250 nid=1503 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
   JavaThread state: _thread_in_java
)  [0x0000000166000000,0x00000001662d0c90,0x00000001667ffdc0,{0x0000000166800000})
In G1 heap Region: 0x0000000166000000,0x0000000166800000,0x0000000167000000:Eden
```

Note at the end it indicates the address is in the Eden space, which is probably always the case for G1 TLAB addresses. For SerialGC is shows something similar.

```
rsi: 0x0000000088ff99e0: In TLAB for thread "main" sun.jvm.hotspot.runtime.JavaThread@0x00007f0544029110
rsi: 0x0000000088ff99e0: In TLAB for thread ("main" #1 prio=5 tid=0x00007f0544029110 nid=3098 runnable [0x0000000000000000]
   java.lang.Thread.State: RUNNABLE
   JavaThread state: _thread_in_java
)  [0x0000000088ff99e0,0x000000008978c090,0x0000000089ae54b0,{0x0000000089ae56f0})
In heap new generation:  eden [0x0000000080200000,0x0000000089ae56f0,0x00000000a2420000) space capacity = 572653568, 27.99656213789626 used
  from [0x00000000a6860000,0x00000000a6860030,0x00000000aaca0000) space capacity = 71565312, 6.707160027472528E-5 used
  to   [0x00000000a2420000,0x00000000a2420000,0x00000000a6860000) space capacity = 71565312, 0.0 used
```

Testing all svc test in tier1, tier2, and tier5. Currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323681](https://bugs.openjdk.org/browse/JDK-8323681): SA PointerFinder code should support G1 (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [37b3f17b](https://git.openjdk.org/jdk/pull/17691/files/37b3f17b77315e9fe6911c18bbd257e25d8ab013)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) ⚠️ Review applies to [37b3f17b](https://git.openjdk.org/jdk/pull/17691/files/37b3f17b77315e9fe6911c18bbd257e25d8ab013)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17691/head:pull/17691` \
`$ git checkout pull/17691`

Update a local copy of the PR: \
`$ git checkout pull/17691` \
`$ git pull https://git.openjdk.org/jdk.git pull/17691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17691`

View PR using the GUI difftool: \
`$ git pr show -t 17691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17691.diff">https://git.openjdk.org/jdk/pull/17691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17691#issuecomment-1924901035)