### PR TITLE
8325081: Move '_soft_ref_policy' to 'CollectedHeap'

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonHeap.hpp
@@ -37,7 +37,6 @@
 class EpsilonHeap : public CollectedHeap {
   friend class VMStructs;
 private:
-  SoftRefPolicy _soft_ref_policy;
   EpsilonMonitoringSupport* _monitoring_support;
   MemoryPool* _pool;
   GCMemoryManager _memory_manager;
@@ -63,10 +62,6 @@ public:
 
   const char* name() const override {
     return "Epsilon";
-  }
-
-  SoftRefPolicy* soft_ref_policy() override {
-    return &_soft_ref_policy;
   }
 
   jint initialize() override;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1137,7 +1137,6 @@ G1CollectedHeap::G1CollectedHeap() :
   _workers(nullptr),
   _card_table(nullptr),
   _collection_pause_end(Ticks::now()),
-  _soft_ref_policy(),
   _old_set("Old Region Set", new OldRegionSetChecker()),
   _humongous_set("Humongous Region Set", new HumongousRegionSetChecker()),
   _bot(nullptr),
@@ -1524,10 +1523,6 @@ void G1CollectedHeap::ref_processing_init() {
                            ParallelGCThreads,                    // degree of mt discovery
                            false,                                // Reference discovery is not concurrent
                            &_is_alive_closure_stw);              // is alive closure
-}
-
-SoftRefPolicy* G1CollectedHeap::soft_ref_policy() {
-  return &_soft_ref_policy;
 }
 
 size_t G1CollectedHeap::capacity() const {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -178,8 +178,6 @@ private:
 
   Ticks _collection_pause_end;
 
-  SoftRefPolicy      _soft_ref_policy;
-
   static size_t _humongous_object_threshold_in_words;
 
   // These sets keep track of old and humongous regions respectively.
@@ -926,8 +924,6 @@ public:
   G1CollectionSet* collection_set() { return &_collection_set; }
 
   inline bool is_collection_set_candidate(const HeapRegion* r) const;
-
-  SoftRefPolicy* soft_ref_policy() override;
 
   void initialize_serviceability() override;
   MemoryUsage memory_usage() override;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -80,8 +80,6 @@ class ParallelScavengeHeap : public CollectedHeap {
   static PSAdaptiveSizePolicy*       _size_policy;
   static PSGCAdaptivePolicyCounters* _gc_policy_counters;
 
-  SoftRefPolicy _soft_ref_policy;
-
   unsigned int _death_march_count;
 
   GCMemoryManager* _young_manager;
@@ -134,8 +132,6 @@ class ParallelScavengeHeap : public CollectedHeap {
   const char* name() const override {
     return "Parallel";
   }
-
-  SoftRefPolicy* soft_ref_policy() override { return &_soft_ref_policy; }
 
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -94,7 +94,6 @@ SerialHeap::SerialHeap() :
     _young_gen(nullptr),
     _old_gen(nullptr),
     _rem_set(nullptr),
-    _soft_ref_policy(),
     _gc_policy_counters(new GCPolicyCounters("Copy:MSC", 2, 2)),
     _incremental_collection_failed(false),
     _young_manager(nullptr),

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -90,8 +90,6 @@ private:
   // The singleton CardTable Remembered Set.
   CardTableRS* _rem_set;
 
-  SoftRefPolicy _soft_ref_policy;
-
   GCPolicyCounters* _gc_policy_counters;
 
   // Indicates that the most recent previous incremental collection failed.
@@ -153,8 +151,6 @@ public:
 
   MemRegion reserved_region() const { return _reserved; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
-
-  SoftRefPolicy* soft_ref_policy() override { return &_soft_ref_policy; }
 
   // Performance Counter support
   GCPolicyCounters* counters()     { return _gc_policy_counters; }

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -242,6 +242,7 @@ bool CollectedHeap::is_oop(oop object) const {
 CollectedHeap::CollectedHeap() :
   _capacity_at_last_gc(0),
   _used_at_last_gc(0),
+  _soft_ref_policy(),
   _is_gc_active(false),
   _last_whole_heap_examined_time_ns(os::javaTimeNanos()),
   _total_collections(0),

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/shared/gcCause.hpp"
 #include "gc/shared/gcWhen.hpp"
+#include "gc/shared/softRefPolicy.hpp"
 #include "gc/shared/verifyOption.hpp"
 #include "memory/allocation.hpp"
 #include "memory/metaspace.hpp"
@@ -56,7 +57,6 @@ class GCMemoryManager;
 class MemoryPool;
 class MetaspaceSummary;
 class ReservedHeapSpace;
-class SoftRefPolicy;
 class Thread;
 class ThreadClosure;
 class VirtualSpaceSummary;
@@ -104,6 +104,8 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // Historic gc information
   size_t _capacity_at_last_gc;
   size_t _used_at_last_gc;
+
+  SoftRefPolicy _soft_ref_policy;
 
   // First, set it to java_lang_Object.
   // Then, set it to FillerObject after the FillerObject_klass loading is complete.
@@ -403,7 +405,7 @@ protected:
   void increment_total_full_collections() { _total_full_collections++; }
 
   // Return the SoftRefPolicy for the heap;
-  virtual SoftRefPolicy* soft_ref_policy() = 0;
+  SoftRefPolicy* soft_ref_policy() { return &_soft_ref_policy; }
 
   virtual MemoryUsage memory_usage();
   virtual GrowableArray<GCMemoryManager*> memory_managers() = 0;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -517,7 +517,6 @@ ShenandoahHeap::ShenandoahHeap(ShenandoahCollectorPolicy* policy) :
   _stw_memory_manager("Shenandoah Pauses"),
   _cycle_memory_manager("Shenandoah Cycles"),
   _gc_timer(new ConcurrentGCTimer()),
-  _soft_ref_policy(),
   _log_min_obj_alignment_in_bytes(LogMinObjAlignmentInBytes),
   _ref_processor(new ShenandoahReferenceProcessor(MAX2(_max_workers, 1U))),
   _marking_context(nullptr),

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -432,15 +432,12 @@ private:
   GCMemoryManager              _stw_memory_manager;
   GCMemoryManager              _cycle_memory_manager;
   ConcurrentGCTimer*           _gc_timer;
-  SoftRefPolicy                _soft_ref_policy;
-
   // For exporting to SA
   int                          _log_min_obj_alignment_in_bytes;
 public:
   ShenandoahMonitoringSupport* monitoring_support()          { return _monitoring_support;    }
   GCMemoryManager* cycle_memory_manager()                    { return &_cycle_memory_manager; }
   GCMemoryManager* stw_memory_manager()                      { return &_stw_memory_manager;   }
-  SoftRefPolicy* soft_ref_policy()                  override { return &_soft_ref_policy;      }
 
   GrowableArray<GCMemoryManager*> memory_managers() override;
   GrowableArray<MemoryPool*> memory_pools() override;

--- a/src/hotspot/share/gc/x/xCollectedHeap.cpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.cpp
@@ -50,7 +50,6 @@ XCollectedHeap* XCollectedHeap::heap() {
 }
 
 XCollectedHeap::XCollectedHeap() :
-    _soft_ref_policy(),
     _barrier_set(),
     _initialize(&_barrier_set),
     _heap(),
@@ -93,10 +92,6 @@ public:
 void XCollectedHeap::stop() {
   XStopConcurrentGCThreadClosure cl;
   gc_threads_do(&cl);
-}
-
-SoftRefPolicy* XCollectedHeap::soft_ref_policy() {
-  return &_soft_ref_policy;
 }
 
 size_t XCollectedHeap::max_capacity() const {

--- a/src/hotspot/share/gc/x/xCollectedHeap.hpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.hpp
@@ -42,7 +42,6 @@ class XCollectedHeap : public CollectedHeap {
   friend class ::VMStructs;
 
 private:
-  SoftRefPolicy     _soft_ref_policy;
   XBarrierSet       _barrier_set;
   XInitialize       _initialize;
   XHeap             _heap;
@@ -64,8 +63,6 @@ public:
   jint initialize() override;
   void initialize_serviceability() override;
   void stop() override;
-
-  SoftRefPolicy* soft_ref_policy() override;
 
   size_t max_capacity() const override;
   size_t capacity() const override;

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -58,8 +58,7 @@ ZCollectedHeap* ZCollectedHeap::heap() {
 }
 
 ZCollectedHeap::ZCollectedHeap()
-  : _soft_ref_policy(),
-    _barrier_set(),
+  : _barrier_set(),
     _initialize(&_barrier_set),
     _heap(),
     _driver_minor(new ZDriverMinor()),
@@ -104,10 +103,6 @@ void ZCollectedHeap::stop() {
   ZAbort::abort();
   ZStopConcurrentGCThreadClosure cl;
   gc_threads_do(&cl);
-}
-
-SoftRefPolicy* ZCollectedHeap::soft_ref_policy() {
-  return &_soft_ref_policy;
 }
 
 size_t ZCollectedHeap::max_capacity() const {

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -42,7 +42,6 @@ class ZCollectedHeap : public CollectedHeap {
   friend class VMStructs;
 
 private:
-  SoftRefPolicy     _soft_ref_policy;
   ZBarrierSet       _barrier_set;
   ZInitialize       _initialize;
   ZHeap             _heap;
@@ -65,8 +64,6 @@ public:
   jint initialize() override;
   void initialize_serviceability() override;
   void stop() override;
-
-  SoftRefPolicy* soft_ref_policy() override;
 
   size_t max_capacity() const override;
   size_t capacity() const override;


### PR DESCRIPTION
trivial

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325081](https://bugs.openjdk.org/browse/JDK-8325081): Move '_soft_ref_policy' to 'CollectedHeap' (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17693/head:pull/17693` \
`$ git checkout pull/17693`

Update a local copy of the PR: \
`$ git checkout pull/17693` \
`$ git pull https://git.openjdk.org/jdk.git pull/17693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17693`

View PR using the GUI difftool: \
`$ git pr show -t 17693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17693.diff">https://git.openjdk.org/jdk/pull/17693.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17693#issuecomment-1925204847)