### PR TITLE
8325200: [BACKOUT] (zipfs) Regression in Files.setPosixFilePermissions called on existing MSDOS entries

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -646,8 +646,6 @@ class ZipFileSystem extends FileSystem {
             }
             if (perms == null) {
                 e.posixPerms = -1;
-            } else if (e.posixPerms == -1) {
-                e.posixPerms = ZipUtils.permsToFlags(perms);
             } else {
                 e.posixPerms = ZipUtils.permsToFlags(perms) |
                         (e.posixPerms & 0xFE00); // Preserve unrelated bits

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -61,7 +61,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @test
- * @bug 8213031 8273935 8324635
+ * @bug 8213031 8273935
  * @summary Test POSIX ZIP file operations.
  * @modules jdk.zipfs
  *          jdk.jartool
@@ -719,7 +719,7 @@ public class TestPosix {
     }
 
     /**
-     * Verify that calling Files.setPosixFilePermissions with the current
+     * Verify that calling Files.setPosixPermissions with the current
      * permission set does not change the 'external file attributes' field.
      *
      * @throws IOException if an unexpected IOException occurs
@@ -731,53 +731,6 @@ public class TestPosix {
             // Set permissions to their current value
             Files.setPosixFilePermissions(path, Files.getPosixFilePermissions(path));
         });
-    }
-
-    /**
-     * Verify that calling Files.setPosixFilePermissions on an MS-DOS entry
-     * results in only the expected permission bits being set
-     *
-     * @throws IOException if an unexpected IOException occurs
-     */
-    @Test
-    public void setPermissionsShouldConvertToUnix() throws IOException {
-        // The default environment creates MS-DOS entries, with zero 'external file attributes'
-        createEmptyZipFile(ZIP_FILE, ENV_DEFAULT);
-        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_DEFAULT)) {
-            Path path = fs.getPath("hello.txt");
-            Files.createFile(path);
-        }
-        // The CEN header is now as follows:
-        //
-        //   004A CENTRAL HEADER #1     02014B50
-        //   004E Created Zip Spec      14 '2.0'
-        //   004F Created OS            00 'MS-DOS'
-        //   0050 Extract Zip Spec      14 '2.0'
-        //   0051 Extract OS            00 'MS-DOS'
-        //   [...]
-        //   0070 Ext File Attributes   00000000
-
-        // Sanity check that all 'external file attributes' bits are all zero
-        verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "0");
-
-        // Convert to a UNIX entry by calling Files.setPosixFilePermissions
-        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_POSIX)) {
-            Path path = fs.getPath("hello.txt");
-            Files.setPosixFilePermissions(path, EnumSet.of(OWNER_READ));
-        }
-
-        // The CEN header should now be as follows:
-        //
-        // 004A CENTRAL HEADER #1     02014B50
-        // 004E Created Zip Spec      14 '2.0'
-        // 004F Created OS            03 'Unix'
-        // 0050 Extract Zip Spec      14 '2.0'
-        // 0051 Extract OS            00 'MS-DOS'
-        // [...]
-        // 0070 Ext File Attributes   01000000
-
-        // The first of the nine trailing permission bits should be set
-        verifyExternalFileAttribute(Files.readAllBytes(ZIP_FILE), "100000000");
     }
 
     /**


### PR DESCRIPTION
Please review this backout of [JDK-8324635](https://bugs.openjdk.org/browse/JDK-8324635).

That change introduced a new test in `TestPosix` which fails on Windows. Since `TestPosix` does not run on GHA and I don't have easy access to test this on Windows, I suggest this backup to allow more time to fix the failing test properly.

The change in this backout was generated automatically using `git revert a18b03b86fdd0eef773badbced46607a8e5a068a`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325200](https://bugs.openjdk.org/browse/JDK-8325200): [BACKOUT] (zipfs) Regression in Files.setPosixFilePermissions called on existing MSDOS entries (**Sub-task** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17699/head:pull/17699` \
`$ git checkout pull/17699`

Update a local copy of the PR: \
`$ git checkout pull/17699` \
`$ git pull https://git.openjdk.org/jdk.git pull/17699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17699`

View PR using the GUI difftool: \
`$ git pr show -t 17699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17699.diff">https://git.openjdk.org/jdk/pull/17699.diff</a>

</details>
