### PR TITLE
8325201: (zipfs) Disable TestPosix.setPermissionsShouldConvertToUnix which fails on Windows

### DIFF
--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -42,7 +42,6 @@ import java.util.spi.ToolProvider;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
@@ -105,6 +104,7 @@ public class TestPosix {
     // misc
     private static final CopyOption[] COPY_ATTRIBUTES = {StandardCopyOption.COPY_ATTRIBUTES};
     private static final Map<String, ZipFileEntryInfo> ENTRIES = new HashMap<>();
+    private static final boolean isWindows = System.getProperty("os.name") .startsWith("Windows");
 
     private int entriesCreated;
 
@@ -741,8 +741,11 @@ public class TestPosix {
      * @throws IOException if an unexpected IOException occurs
      */
     @Test
-    @Disabled
     public void setPermissionsShouldConvertToUnix() throws IOException {
+        // Temporarily skip test on Windows until intermittent failures are investigated
+        if(isWindows) {
+            return;
+        }
         // The default environment creates MS-DOS entries, with zero 'external file attributes'
         createEmptyZipFile(ZIP_FILE, ENV_DEFAULT);
         try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_DEFAULT)) {

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -42,6 +42,7 @@ import java.util.spi.ToolProvider;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
@@ -740,6 +741,7 @@ public class TestPosix {
      * @throws IOException if an unexpected IOException occurs
      */
     @Test
+    @Disabled
     public void setPermissionsShouldConvertToUnix() throws IOException {
         // The default environment creates MS-DOS entries, with zero 'external file attributes'
         createEmptyZipFile(ZIP_FILE, ENV_DEFAULT);

--- a/test/jdk/jdk/nio/zipfs/test.policy.posix
+++ b/test/jdk/jdk/nio/zipfs/test.policy.posix
@@ -4,6 +4,7 @@ grant {
     permission java.util.PropertyPermission "test.jdk","read";
     permission java.util.PropertyPermission "test.src","read";
     permission java.util.PropertyPermission "user.dir","read";
+    permission java.util.PropertyPermission "os.name","read";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.module";
     permission java.lang.RuntimePermission "accessUserInformation";
 };


### PR DESCRIPTION
Can I please get a review for this trivial change to disable the test `TestPosix.setPermissionsShouldConvertToUnix` on Windows?

This test was recently introduced in [JDK-8324635](https://bugs.openjdk.org/browse/JDK-8324635), but fails intermittently on Windows CI runs. (See [JDK-8325199](https://bugs.openjdk.org/browse/JDK-8325199))

To reduce CI noise, I suggest we simply disable this test on Windows for now.  The actual fix of the failing test will be investigated and fixed as a follow-up PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325201](https://bugs.openjdk.org/browse/JDK-8325201): (zipfs) Disable TestPosix.setPermissionsShouldConvertToUnix which fails on Windows (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17700/head:pull/17700` \
`$ git checkout pull/17700`

Update a local copy of the PR: \
`$ git checkout pull/17700` \
`$ git pull https://git.openjdk.org/jdk.git pull/17700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17700`

View PR using the GUI difftool: \
`$ git pr show -t 17700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17700.diff">https://git.openjdk.org/jdk/pull/17700.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17700#issuecomment-1925823432)