### PR TITLE
8325199: (zipfs) jdk/nio/zipfs/TestPosix.java failed 6 sub-tests

### DIFF
--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -747,8 +747,7 @@ public class TestPosix {
             return;
         }
         // The default environment creates MS-DOS entries, with zero 'external file attributes'
-        createEmptyZipFile(ZIP_FILE, ENV_DEFAULT);
-        try (FileSystem fs = FileSystems.newFileSystem(ZIP_FILE, ENV_DEFAULT)) {
+        try (FileSystem fs = createEmptyZipFile(ZIP_FILE, ENV_DEFAULT)) {
             Path path = fs.getPath("hello.txt");
             Files.createFile(path);
         }

--- a/test/jdk/jdk/nio/zipfs/TestPosix.java
+++ b/test/jdk/jdk/nio/zipfs/TestPosix.java
@@ -104,7 +104,6 @@ public class TestPosix {
     // misc
     private static final CopyOption[] COPY_ATTRIBUTES = {StandardCopyOption.COPY_ATTRIBUTES};
     private static final Map<String, ZipFileEntryInfo> ENTRIES = new HashMap<>();
-    private static final boolean isWindows = System.getProperty("os.name") .startsWith("Windows");
 
     private int entriesCreated;
 
@@ -742,10 +741,6 @@ public class TestPosix {
      */
     @Test
     public void setPermissionsShouldConvertToUnix() throws IOException {
-        // Temporarily skip test on Windows until intermittent failures are investigated
-        if(isWindows) {
-            return;
-        }
         // The default environment creates MS-DOS entries, with zero 'external file attributes'
         try (FileSystem fs = createEmptyZipFile(ZIP_FILE, ENV_DEFAULT)) {
             Path path = fs.getPath("hello.txt");

--- a/test/jdk/jdk/nio/zipfs/test.policy.posix
+++ b/test/jdk/jdk/nio/zipfs/test.policy.posix
@@ -4,7 +4,6 @@ grant {
     permission java.util.PropertyPermission "test.jdk","read";
     permission java.util.PropertyPermission "test.src","read";
     permission java.util.PropertyPermission "user.dir","read";
-    permission java.util.PropertyPermission "os.name","read";
     permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.module";
     permission java.lang.RuntimePermission "accessUserInformation";
 };


### PR DESCRIPTION
Please review this test which fixes an intermittent test failure on Windows for the `TestPosix` test.

The recently introduced test `setPermissionsShouldConvertToUnix` fails to close the `FileSystem` returned by `createEmptyZipFile`. The solution is to make this call within the 'try-with-resources' statement, ensuring it gets properly closed.