### PR TITLE
8325207: Support out of order classpath in AppCDS.

### DIFF
--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -548,6 +548,7 @@ public:
   void  init_heap_region_relocation();
   MapArchiveResult map_region(int i, intx addr_delta, char* mapped_base_address, ReservedSpace rs);
   bool  relocate_pointers_in_core_regions(intx addr_delta);
+  bool  is_out_of_order_path(int shared_path_start_idx, int num_paths, GrowableArray<const char*>* rp_array);
 
   static MemRegion _mapped_heap_memregion;
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/OutOfOrderClasspathTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OutOfOrderClasspathTest.java
@@ -46,7 +46,7 @@ public class OutOfOrderClasspathTest {
         String appJar = null;
         String outputDir = CDSTestUtils.getOutputDir();
         System.setProperty("test.noclasspath", "true");
-        String hiJar =  outputDir + File.separator + "hi.jar";
+        String hiJar = outputDir + File.separator + "hi.jar";
         String greetJar = outputDir + File.separator + "greet.jar";
 
         TestCommon.dump(appJar,

--- a/test/hotspot/jtreg/runtime/cds/appcds/OutOfOrderClasspathTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/OutOfOrderClasspathTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ *@test
+ *@summary Test app class path are different order between
+ *         dump time and using shared space time.
+ *@library /test/lib
+ *@compile test-classes/Greet.java
+ *@compile test-classes/Hi.java
+ *@run driver OutOfOrderClasspathTest
+ */
+
+import java.io.File;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class OutOfOrderClasspathTest {
+    public static void main(String[] args) throws Exception {
+        String[] testClasses = {"Hi", "Greet"};
+        JarBuilder.build("hi", "Hi", "Hi$MyClass");
+        JarBuilder.build("greet", "Greet");
+
+        String appJar = null;
+        String outputDir = CDSTestUtils.getOutputDir();
+        System.setProperty("test.noclasspath", "true");
+        String hiJar =  outputDir + File.separator + "hi.jar";
+        String greetJar = outputDir + File.separator + "greet.jar";
+
+        TestCommon.dump(appJar,
+            testClasses,
+            "-cp",
+            hiJar + File.pathSeparator + greetJar,
+            "Hi");
+
+        OutputAnalyzer out = TestCommon.exec(appJar,
+            "-cp",
+            greetJar + File.pathSeparator + hiJar,
+            "-Xlog:class+load",
+            "Hi");
+
+        TestCommon.checkExec(out, "Hi, how are you?");
+        out.shouldContain(" Hi source: shared objects file");
+        out.shouldContain(" Greet source: shared objects file");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -306,6 +306,7 @@ public class OptimizeModuleHandlingTest {
                    .shouldNotContain(OPTIMIZE_ENABLED)
                    .shouldNotContain(OPTIMIZE_DISABLED);
             });
+        //after sorting the classpath, the classpath is same as the dump time.
         tty("10. run with CDS on,  with main/test jars on classpath also with -Xbootclasspath/a:  should pass");
         TestCommon.run("-Xlog:cds",
                        "-cp", mainJar.toString() + PATH_SEPARATOR + testJar.toString(),
@@ -314,8 +315,8 @@ public class OptimizeModuleHandlingTest {
             .assertAbnormalExit(out -> {
                 out.shouldNotContain(CLASS_FOUND_MESSAGE)
                    .shouldNotContain(CLASS_NOT_FOUND_MESSAGE)
-                   .shouldNotContain(OPTIMIZE_ENABLED)
-                   .shouldContain(MAP_FAILED);
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(MAP_FAILED);
             });
 
         // Dump an archive with -Xbootclasspath/a


### PR DESCRIPTION
When a Java application runs with a wildcard classpath like this:
`java -cp "lib/*"`
JVM will expand "lib/*" to the actual jar list, but the order of the jar list may be different on different hosts, which depends on the underlying filesystem.

Dumping the AppCDS archive is usually done on a CI/CD environment, but using the shared archive is done on a production environment.
If there are many jars with a complex build procedure,  ensure the same orders are difficult.

The patch first sorts the runtime classpath and dump classpath, then checks path again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8325207](https://bugs.openjdk.org/browse/JDK-8325207)

### Issue
 * [JDK-8325207](https://bugs.openjdk.org/browse/JDK-8325207): Out of order app classpath in AppCDS (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17704/head:pull/17704` \
`$ git checkout pull/17704`

Update a local copy of the PR: \
`$ git checkout pull/17704` \
`$ git pull https://git.openjdk.org/jdk.git pull/17704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17704`

View PR using the GUI difftool: \
`$ git pr show -t 17704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17704.diff">https://git.openjdk.org/jdk/pull/17704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17704#issuecomment-2079196584)