### PR TITLE
8325213: Flags introduced by configure script are not passed to ADLC build

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -51,7 +51,7 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   endif
 
   # Set the C++ standard
-  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAG)
+  ADLC_CFLAGS += $(ADLC_LANGSTD_CXXFLAGS)
 
   # NOTE: The old build didn't set -DASSERT for windows but it doesn't seem to
   # hurt.


### PR DESCRIPTION
A trivial ADLC build fix. The ADLC_LANGSTD_CXXFLAGS should get passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325213](https://bugs.openjdk.org/browse/JDK-8325213): Flags introduced by configure script are not passed to ADLC build (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17705/head:pull/17705` \
`$ git checkout pull/17705`

Update a local copy of the PR: \
`$ git checkout pull/17705` \
`$ git pull https://git.openjdk.org/jdk.git pull/17705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17705`

View PR using the GUI difftool: \
`$ git pr show -t 17705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17705.diff">https://git.openjdk.org/jdk/pull/17705.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17705#issuecomment-1926454015)