### PR TITLE
8324724: Add Stub routines for FP16 conversions on aarch64

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2022, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -5474,6 +5474,32 @@ class StubGenerator: public StubCodeGenerator {
     return entry;
   }
 
+  // r0 = input (float16)
+  // v0 = result (float)
+  // v1 = temporary float register
+  address generate_float16ToFloat() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "float16ToFloat");
+    address entry = __ pc();
+    BLOCK_COMMENT("Entry:");
+    __ flt16_to_flt(v0, r0, v1);
+    __ ret(lr);
+    return entry;
+  }
+
+  // v0 = input (float)
+  // r0 = result (float16)
+  // v1 = temporary float register
+  address generate_floatToFloat16() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "floatToFloat16");
+    address entry = __ pc();
+    BLOCK_COMMENT("Entry:");
+    __ flt_to_flt16(r0, v0, v1);
+    __ ret(lr);
+    return entry;
+  }
+
   address generate_method_entry_barrier() {
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "nmethod_entry_barrier");
@@ -8326,6 +8352,12 @@ class StubGenerator: public StubCodeGenerator {
 
     if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_dcos)) {
       StubRoutines::_dcos = generate_dsin_dcos(/* isCos = */ true);
+    }
+
+    if (vmIntrinsics::is_intrinsic_available(vmIntrinsics::_float16ToFloat) &&
+        vmIntrinsics::is_intrinsic_available(vmIntrinsics::_floatToFloat16)) {
+      StubRoutines::_hf2f = generate_float16ToFloat();
+      StubRoutines::_f2hf = generate_floatToFloat16();
     }
   }
 


### PR DESCRIPTION
This commit - https://github.com/openjdk/jdk/commit/8cfd74f76afc9e5d50c52104fef9974784718dd4 adds stub routines for FP16 conversions for float/float16 constants on x86 to get an accurate compile time value of the nodes. This task adds similar stub routines for aarch64 as well.

With this patch, if the inputs to the conversion functions are constants, the stub routines are executed to determine the compile time values of the ConvHF2F/ConvF2HF nodes (in their respective Value() functions) and the ConvHF2F/ConvF2HF nodes are replaced with ConI/ConF nodes. This might help in further compiler optimizations like constant folding.

The following testcase was used to test the disassembly -

```
public class FloatConv {

    private static final short sconst;
    private static final float fconst;

    static {
        sconst = Short.MAX_VALUE;
        fconst = Float.MIN_VALUE;
    }

    @Benchmark
    public float hf2f() {
        return Float.float16ToFloat(sconst);
    }

    @Benchmark
    public short f2hf() {
        return Float.floatToFloat16(fconst);
    }
}
```

**Disassembly without patch :**

**FloatConv.f2hf() :-**
```
...
ldr   s17, 0x0000ffff918cec80
fcvt  h16, s17
smov  x0, v16.h[0]
...
ret
```

**FloatConv.hf2f() :-**
```
...
orr   w11, wzr, #0x7fff
mov   v16.h[0], w11
fcvt  s0, h16
...
ret
```

**Disassembly with patch :**

**FloatConv.hf2f() :-**
```
...
ldr   s0, 0x0000ffffb58ce880
...
ret
```

**FloatConv.f2hf() :-**
```
...
mov   w0, wzr
...
ret
```

With this patch, the conversion computation is done well in advance and the ConvHF2F/ConvF2HF nodes are replaced with the ConI/ConF nodes and thus the constant values are just loaded into registers and returned.

The tests in - "hotspot/jtreg/compiler/intrinsics/float16" pass on both aarch64 and x86.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324724](https://bugs.openjdk.org/browse/JDK-8324724): Add Stub routines for FP16 conversions on aarch64 (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17706/head:pull/17706` \
`$ git checkout pull/17706`

Update a local copy of the PR: \
`$ git checkout pull/17706` \
`$ git pull https://git.openjdk.org/jdk.git pull/17706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17706`

View PR using the GUI difftool: \
`$ git pr show -t 17706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17706.diff">https://git.openjdk.org/jdk/pull/17706.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17706#issuecomment-1926537142)