### PR TITLE
JDK-8322943: runtime/CompressedOops/CompressedClassPointers.java fails on AIX

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -2285,6 +2285,15 @@ extern "C" {
 static void set_page_size(size_t page_size) {
   OSInfo::set_vm_page_size(page_size);
   OSInfo::set_vm_allocation_granularity(page_size);
+  // use the same logic as in os::pd_attempt_reserve_memory_at to decide
+  // if mmap with granularity vm_page_size() or shmat with granularity 256MB is used.
+  if (os::vm_page_size() == 4*K) {
+    // mmap used
+    OSInfo::set_vm_shm_allocation_granularity(page_size);
+  } else {
+    // shmat used
+    OSInfo::set_vm_shm_allocation_granularity(256 * M);
+  }
 }
 
 // This is called _before_ the most of global arguments have been parsed.

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -2031,6 +2031,7 @@ void os::init(void) {
   size_t page_size = (size_t)getpagesize();
   OSInfo::set_vm_page_size(page_size);
   OSInfo::set_vm_allocation_granularity(page_size);
+  OSInfo::set_vm_shm_allocation_granularity(page_size);
   if (os::vm_page_size() == 0) {
     fatal("os_bsd.cpp: os::init: getpagesize() failed (%s)", os::strerror(errno));
   }

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4410,6 +4410,7 @@ void os::init(void) {
   size_t page_size = sys_pg_size;
   OSInfo::set_vm_page_size(page_size);
   OSInfo::set_vm_allocation_granularity(page_size);
+  OSInfo::set_vm_shm_allocation_granularity(page_size);
   if (os::vm_page_size() == 0) {
     fatal("os_linux.cpp: os::init: OSInfo::set_vm_page_size failed");
   }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4002,6 +4002,7 @@ void os::win32::initialize_system_info() {
   GetSystemInfo(&si);
   OSInfo::set_vm_page_size(si.dwPageSize);
   OSInfo::set_vm_allocation_granularity(si.dwAllocationGranularity);
+  OSInfo::set_vm_shm_allocation_granularity(si.dwAllocationGranularity);
   _processor_type  = si.dwProcessorType;
   _processor_level = si.wProcessorLevel;
   set_processor_count(si.dwNumberOfProcessors);

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -516,9 +516,7 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
 
   // The necessary attach point alignment for generated wish addresses.
   // This is needed to increase the chance of attaching for mmap and shmat.
-  const size_t os_attach_point_alignment =
-    AIX_ONLY(SIZE_256M)  // Known shm boundary alignment.
-    NOT_AIX(os::vm_allocation_granularity());
+  const size_t os_attach_point_alignment = os::vm_shm_allocation_granularity();
   const size_t attach_point_alignment = lcm(alignment, os_attach_point_alignment);
 
   char *aligned_heap_base_min_address = (char *)align_up((void *)HeapBaseMinAddress, alignment);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1873,12 +1873,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
 
   // In randomization mode: We require a minimum number of possible attach points for
   // randomness. Below that we refuse to reserve anything.
-  // Because AIX has an shmat alignment of 256MB, we have only 12 segments in the unscaled case,
-  // when min=0 and max=4GB and os::vm_shm_allocation_granularity() returns 256MB.
-  unsigned min_random_value_range = 16;
-  if (min == nullptr && (char*)(4 * G) == max && 256 * M == os::vm_shm_allocation_granularity()) {
-    min_random_value_range = 12;
-  }
+  constexpr unsigned min_random_value_range = 16;
 
   // In randomization mode: If the possible value range is below this threshold, we
   // use a total shuffle without regard for address space fragmentation, otherwise

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -432,6 +432,8 @@ class os: AllStatic {
 
   static size_t vm_allocation_granularity() { return OSInfo::vm_allocation_granularity(); }
 
+  static size_t vm_shm_allocation_granularity() { return OSInfo::vm_shm_allocation_granularity(); }
+
   // Returns the lowest address the process is allowed to map against.
   static size_t vm_min_address();
 

--- a/src/hotspot/share/runtime/osInfo.cpp
+++ b/src/hotspot/share/runtime/osInfo.cpp
@@ -27,4 +27,5 @@
 
 size_t OSInfo::_vm_page_size = 0;
 size_t OSInfo::_vm_allocation_granularity = 0;
+size_t OSInfo::_vm_shm_allocation_granularity = 0;
 

--- a/src/hotspot/share/runtime/osInfo.hpp
+++ b/src/hotspot/share/runtime/osInfo.hpp
@@ -33,6 +33,7 @@
 class OSInfo : AllStatic {
   static size_t    _vm_page_size;
   static size_t    _vm_allocation_granularity;
+  static size_t    _vm_shm_allocation_granularity;
 
 public:
   // Returns the byte size of a virtual memory page
@@ -40,6 +41,8 @@ public:
 
   // Returns the size, in bytes, of the granularity with which memory can be reserved using os::reserve_memory().
   static size_t vm_allocation_granularity() { return _vm_allocation_granularity; }
+
+  static size_t vm_shm_allocation_granularity() { return _vm_shm_allocation_granularity; }
 
   static void set_vm_page_size(size_t n) {
     assert(_vm_page_size == 0, "init only once");
@@ -49,6 +52,11 @@ public:
   static void set_vm_allocation_granularity(size_t n) {
     assert(_vm_allocation_granularity == 0, "init only once");
     _vm_allocation_granularity = n;
+  }
+
+  static void set_vm_shm_allocation_granularity(size_t n) {
+    assert(_vm_shm_allocation_granularity == 0, "init only once");
+    _vm_shm_allocation_granularity = n;
   }
 };
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -104,7 +104,6 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
-runtime/CompressedOops/CompressedClassPointers.java 8322943 aix-ppc64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le


### PR DESCRIPTION
Even after recent fixes like
https://bugs.openjdk.org/browse/JDK-8305765
the test runtime/CompressedOops/CompressedClassPointers.java fails on AIX.

This error results from the fact, that on AIX the shmat() allocation granularity is 256MB instead of the standard Pagesize (4KB or 64KB).

As a solution we introduce a new method  `os::vm_shm_allocation_granularity()`, which on all platforms except AIX returns the same value as  `os::vm_allocation_granularity()`, but on AIX it returns (in the apropriate cases) 256MB.

This new getter is used at all needed places instead of  `os::vm_allocation_granularity()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322943](https://bugs.openjdk.org/browse/JDK-8322943): runtime/CompressedOops/CompressedClassPointers.java fails on AIX (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17708/head:pull/17708` \
`$ git checkout pull/17708`

Update a local copy of the PR: \
`$ git checkout pull/17708` \
`$ git pull https://git.openjdk.org/jdk.git pull/17708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17708`

View PR using the GUI difftool: \
`$ git pr show -t 17708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17708.diff">https://git.openjdk.org/jdk/pull/17708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17708#issuecomment-1926857101)