### PR TITLE
8325248: Serial: Remove Generation::space_iterate

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -673,12 +673,15 @@ void DefNewGeneration::object_iterate(ObjectClosure* blk) {
   from()->object_iterate(blk);
 }
 
-
-void DefNewGeneration::space_iterate(SpaceClosure* blk,
-                                     bool usedOnly) {
-  blk->do_space(eden());
-  blk->do_space(from());
-  blk->do_space(to());
+HeapWord* DefNewGeneration::block_start(const void* p) const {
+  if (eden()->is_in_reserved(p)) {
+    return eden()->block_start_const(p);
+  }
+  if (from()->is_in_reserved(p)) {
+    return from()->block_start_const(p);
+  }
+  assert(to()->is_in_reserved(p), "inv");
+  return to()->block_start_const(p);
 }
 
 // The last collection bailed out, we are running out of heap space,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -208,7 +208,7 @@ class DefNewGeneration: public Generation {
   // Iteration
   void object_iterate(ObjectClosure* blk);
 
-  void space_iterate(SpaceClosure* blk, bool usedOnly = false);
+  HeapWord* block_start(const void* p) const;
 
   // Allocation support
   virtual bool should_allocate(size_t word_size, bool is_tlab) {

--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -122,25 +122,3 @@ oop Generation::promote(oop obj, size_t obj_size) {
 
   return new_obj;
 }
-
-// Some of these are mediocre general implementations.  Should be
-// overridden to get better performance.
-
-class GenerationBlockStartClosure : public SpaceClosure {
- public:
-  const void* _p;
-  HeapWord* _start;
-  virtual void do_space(Space* s) {
-    if (_start == nullptr && s->is_in_reserved(_p)) {
-      _start = s->block_start(_p);
-    }
-  }
-  GenerationBlockStartClosure(const void* p) { _p = p; _start = nullptr; }
-};
-
-HeapWord* Generation::block_start(const void* p) const {
-  GenerationBlockStartClosure blk(p);
-  // Cast away const
-  ((Generation*)this)->space_iterate(&blk);
-  return blk._start;
-}

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -118,9 +118,6 @@ class Generation: public CHeapObj<mtGC> {
     return _reserved.contains(p);
   }
 
-  // Iteration - do not use for time critical operations
-  virtual void space_iterate(SpaceClosure* blk, bool usedOnly = false) = 0;
-
   // Returns "true" iff this generation should be used to allocate an
   // object of the given size.  Young generations might
   // wish to exclude very large objects, for example, since, if allocated
@@ -201,14 +198,6 @@ class Generation: public CHeapObj<mtGC> {
   // Printing
   virtual const char* name() const = 0;
   virtual const char* short_name() const = 0;
-
-  // Block abstraction.
-
-  // Returns the address of the start of the "block" that contains the
-  // address "addr".  We say "blocks" instead of "object" since some heaps
-  // may not pack objects densely; a chunk may either be an object or a
-  // non-object.
-  virtual HeapWord* block_start(const void* addr) const;
 
   virtual void print() const;
   virtual void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -263,9 +263,8 @@ void TenuredGeneration::compute_new_size_inner() {
   }
 }
 
-void TenuredGeneration::space_iterate(SpaceClosure* blk,
-                                                 bool usedOnly) {
-  blk->do_space(space());
+HeapWord* TenuredGeneration::block_start(const void* p) const {
+  return space()->block_start_const(p);
 }
 
 void TenuredGeneration::younger_refs_iterate(OopIterateClosure* blk) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -98,7 +98,7 @@ class TenuredGeneration: public Generation {
   MemRegion prev_used_region() const { return _prev_used_region; }
   void save_used_region()   { _prev_used_region = used_region(); }
 
-  void space_iterate(SpaceClosure* blk, bool usedOnly = false);
+  HeapWord* block_start(const void* p) const;
 
   void younger_refs_iterate(OopIterateClosure* blk);
 


### PR DESCRIPTION
Trivial removing `space_iterate` and inlining `block_start` to both subclasses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325248](https://bugs.openjdk.org/browse/JDK-8325248): Serial: Remove Generation::space_iterate (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17709/head:pull/17709` \
`$ git checkout pull/17709`

Update a local copy of the PR: \
`$ git checkout pull/17709` \
`$ git pull https://git.openjdk.org/jdk.git pull/17709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17709`

View PR using the GUI difftool: \
`$ git pr show -t 17709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17709.diff">https://git.openjdk.org/jdk/pull/17709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17709#issuecomment-1927121466)