### PR TITLE
8325254: CKA_TOKEN private and secret keys are not necessarily sensitive

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -395,8 +395,9 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive = (attrs[0].getBoolean() ||
-                attrs[1].getBoolean() || !attrs[2].getBoolean());
+        boolean keySensitive =
+                (attrs[0].getBoolean() && P11Util.isNSS(session.token)) ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean();
 
         return switch (algorithm) {
             case "RSA" -> P11RSAPrivateKeyInternal.of(session, keyID, algorithm,


### PR DESCRIPTION
Hi,

May I have a review for this fix to [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254)?

With this change, CKA_TOKEN = true is used as an indicator of a sensitive private key (opaque) only if the token is NSS. The behavior previous to [JDK-8271566](https://bugs.openjdk.org/browse/JDK-8271566) is restored for non-NSS tokens.

No regressions observed in jdk/sun/security/pkcs11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325254](https://bugs.openjdk.org/browse/JDK-8325254): CKA_TOKEN private and secret keys are not necessarily sensitive (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17712/head:pull/17712` \
`$ git checkout pull/17712`

Update a local copy of the PR: \
`$ git checkout pull/17712` \
`$ git pull https://git.openjdk.org/jdk.git pull/17712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17712`

View PR using the GUI difftool: \
`$ git pr show -t 17712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17712.diff">https://git.openjdk.org/jdk/pull/17712.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17712#issuecomment-1928522670)