### PR TITLE
8321703: jdeps generates illegal dot file containing nodesep=0,500000

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -32,6 +32,7 @@ import static java.util.stream.Collectors.*;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.lang.module.FindException;
 import java.lang.module.ResolutionException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -534,7 +535,7 @@ class JdepsTask {
                 log.println(getMessage("main.usage.summary", PROGNAME));
             }
             return EXIT_CMDERR;
-        } catch (ResolutionException e) {
+        } catch (ResolutionException | FindException e) {
             reportError("err.exception.message", e.getMessage());
             return EXIT_CMDERR;
         } catch (IOException e) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/ModuleDotGraph.java
@@ -353,7 +353,7 @@ public class ModuleDotGraph {
                  PrintWriter out = new PrintWriter(writer)) {
 
                 out.format("digraph \"%s\" {%n", name);
-                out.format("  nodesep=%f;%n", attributes.nodeSep());
+                out.format((Locale)null, "  nodesep=%f;%n", attributes.nodeSep());
                 out.format((Locale)null, "  ranksep=%f;%n", attributes.rankSep());
                 out.format("  pencolor=transparent;%n");
                 out.format("  node [shape=plaintext, fontcolor=\"%s\", fontname=\"%s\","


### PR DESCRIPTION
Trivial fix.  Call `PrintWriter::format` with null `Locale` to format with no localization.
 
This PR also fixes JDK-8325262 to print `FindException` message without the stack trace to indicate clearer that the given module path is incorrect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8321703](https://bugs.openjdk.org/browse/JDK-8321703): jdeps generates illegal dot file containing nodesep=0,500000 (**Bug** - P4)
 * [JDK-8325262](https://bugs.openjdk.org/browse/JDK-8325262): jdeps can drop printing stack trace when FindException is thrown due to modules not found (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17713/head:pull/17713` \
`$ git checkout pull/17713`

Update a local copy of the PR: \
`$ git checkout pull/17713` \
`$ git pull https://git.openjdk.org/jdk.git pull/17713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17713`

View PR using the GUI difftool: \
`$ git pr show -t 17713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17713.diff">https://git.openjdk.org/jdk/pull/17713.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17713#issuecomment-1928522513)