### PR TITLE
JDK-8325266: Enable this-escape javac warning in jdk.javadoc

### DIFF
--- a/make/modules/jdk.javadoc/Java.gmk
+++ b/make/modules/jdk.javadoc/Java.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,5 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-
-DISABLED_WARNINGS_java += this-escape
 
 COPY += .xml .css .svg .js .js.template .png .txt


### PR DESCRIPTION
The jdk.javadoc module doesn't need the this-escape warning disabled to build; it should be enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325266](https://bugs.openjdk.org/browse/JDK-8325266): Enable this-escape javac warning in jdk.javadoc (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17715/head:pull/17715` \
`$ git checkout pull/17715`

Update a local copy of the PR: \
`$ git checkout pull/17715` \
`$ git pull https://git.openjdk.org/jdk.git pull/17715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17715`

View PR using the GUI difftool: \
`$ git pr show -t 17715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17715.diff">https://git.openjdk.org/jdk/pull/17715.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17715#issuecomment-1928523022)