### PR TITLE
8325270 ProblemList two compiler/intrinsics/float16 tests that fail due to JDK-8324724

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,6 +76,9 @@ compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
+compiler/intrinsics/float16/TestConstFloat16ToFloat.java 8325264 macosx-aarch64
+compiler/intrinsics/float16/Binary16Conversion.java 8325264 macosx-aarch64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
A trivial fix to ProblemList two compiler/intrinsics/float16 tests that fail due to JDK-8324724

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325270](https://bugs.openjdk.org/browse/JDK-8325270): ProblemList two compiler/intrinsics/float16 tests that fail due to JDK-8324724 (**Sub-task** - P1)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17716/head:pull/17716` \
`$ git checkout pull/17716`

Update a local copy of the PR: \
`$ git checkout pull/17716` \
`$ git pull https://git.openjdk.org/jdk.git pull/17716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17716`

View PR using the GUI difftool: \
`$ git pr show -t 17716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17716.diff">https://git.openjdk.org/jdk/pull/17716.diff</a>

</details>
