### PR TITLE
8318603: Parallelize sun/java2d/marlin/ClipShapeTest.java

### DIFF
--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,49 +55,37 @@ import javax.imageio.stream.ImageOutputStream;
 /*
  * @test id=Poly
  * @bug 8191814
- * @summary Verifies that Marlin rendering generates the same
- * images with and without clipping optimization with all possible
- * stroke (cap/join) and/or dashes or fill modes (EO rules)
- * for paths made of either 9 lines, 4 quads, 2 cubics (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
- *
+ * @summary Runs the test with "-poly" option
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly
  */
 
 /*
  * @test id=PolyDoDash
  * @bug 8191814
- * @summary Verifies that Marlin rendering generates the same
- * images with and without clipping optimization with all possible
- * stroke (cap/join) and/or dashes or fill modes (EO rules)
- * for paths made of either 9 lines, 4 quads, 2 cubics (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
- *
+ * @summary Runs the test with "-poly -doDash" options
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly -doDash
  */
 
 /*
  * @test id=Cubic
  * @bug 8191814
- * @summary Verifies that Marlin rendering generates the same
- * images with and without clipping optimization with all possible
- * stroke (cap/join) and/or dashes or fill modes (EO rules)
- * for paths made of either 9 lines, 4 quads, 2 cubics (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
- *
+ * @summary Runs the test with "-cubic" option
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic
  */
 
 /*
  * @test id=CubicDoDash
  * @bug 8191814
- * @summary Verifies that Marlin rendering generates the same
- * images with and without clipping optimization with all possible
- * stroke (cap/join) and/or dashes or fill modes (EO rules)
- * for paths made of either 9 lines, 4 quads, 2 cubics (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
- *
+ * @summary Runs the test with "-cubic -doDash" options
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic -doDash
+ */
+
+/**
+ * Verifies that Marlin rendering generates the same images with and without
+ * clipping optimization with all possible stroke (cap/join) and/or dashes or
+ * fill modes (EO rules) for paths made of either 9 lines, 4 quads, 2 cubics
+ * (random)
+ * Note: Use the argument -slow to run more intensive tests (too much time)
  */
 public final class ClipShapeTest {
 

--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -84,8 +84,10 @@ import javax.imageio.stream.ImageOutputStream;
  * Verifies that Marlin rendering generates the same images with and without
  * clipping optimization with all possible stroke (cap/join) and/or dashes or
  * fill modes (EO rules) for paths made of either 9 lines, 4 quads, 2 cubics
- * (random)
- * Note: Use the argument -slow to run more intensive tests (too much time)
+ * (random).
+ * <p>
+ * Note: Use the argument {@code -slow} to run more intensive tests (too much
+ * time).
  */
 public final class ClipShapeTest {
 

--- a/test/jdk/sun/java2d/marlin/ClipShapeTest.java
+++ b/test/jdk/sun/java2d/marlin/ClipShapeTest.java
@@ -52,8 +52,8 @@ import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 
-/**
- * @test
+/*
+ * @test id=Poly
  * @bug 8191814
  * @summary Verifies that Marlin rendering generates the same
  * images with and without clipping optimization with all possible
@@ -62,10 +62,43 @@ import javax.imageio.stream.ImageOutputStream;
  * Note: Use the argument -slow to run more intensive tests (too much time)
  *
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly
+ */
+
+/*
+ * @test id=PolyDoDash
+ * @bug 8191814
+ * @summary Verifies that Marlin rendering generates the same
+ * images with and without clipping optimization with all possible
+ * stroke (cap/join) and/or dashes or fill modes (EO rules)
+ * for paths made of either 9 lines, 4 quads, 2 cubics (random)
+ * Note: Use the argument -slow to run more intensive tests (too much time)
+ *
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -poly -doDash
+ */
+
+/*
+ * @test id=Cubic
+ * @bug 8191814
+ * @summary Verifies that Marlin rendering generates the same
+ * images with and without clipping optimization with all possible
+ * stroke (cap/join) and/or dashes or fill modes (EO rules)
+ * for paths made of either 9 lines, 4 quads, 2 cubics (random)
+ * Note: Use the argument -slow to run more intensive tests (too much time)
+ *
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic
+ */
+
+/*
+ * @test id=CubicDoDash
+ * @bug 8191814
+ * @summary Verifies that Marlin rendering generates the same
+ * images with and without clipping optimization with all possible
+ * stroke (cap/join) and/or dashes or fill modes (EO rules)
+ * for paths made of either 9 lines, 4 quads, 2 cubics (random)
+ * Note: Use the argument -slow to run more intensive tests (too much time)
+ *
  * @run main/othervm/timeout=300 -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine ClipShapeTest -cubic -doDash
-*/
+ */
 public final class ClipShapeTest {
 
     // test options:


### PR DESCRIPTION
The ClipShapeTest test is split into 4 different tests which could be executed in parallel.

The execution time is changed from:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/sun/java2d/marlin/ClipShapeTest.java
                                                         1     1     0     0   
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'macosx-aarch64-server-release'

real	2m58.673s
user	3m8.847s
sys	0m11.845s
```

to:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/sun/java2d/marlin/ClipShapeTest.java
                                                         4     4     0     0   
==============================
TEST SUCCESS

Finished building target 'run-test' in configuration 'macosx-aarch64-server-release'

real	1m17.752s
user	3m25.308s
sys	0m12.987s

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318603](https://bugs.openjdk.org/browse/JDK-8318603): Parallelize sun/java2d/marlin/ClipShapeTest.java (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [67e3d2c5](https://git.openjdk.org/jdk/pull/17719/files/67e3d2c5548c3a5f8e0bbec6ac60ed190770dc3c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17719/head:pull/17719` \
`$ git checkout pull/17719`

Update a local copy of the PR: \
`$ git checkout pull/17719` \
`$ git pull https://git.openjdk.org/jdk.git pull/17719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17719`

View PR using the GUI difftool: \
`$ git pr show -t 17719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17719.diff">https://git.openjdk.org/jdk/pull/17719.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17719#issuecomment-1928982003)