### PR TITLE
8322927: Unused code in LIR_Assembler::verify_oop_map

### DIFF
--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -841,8 +841,6 @@ void LIR_Assembler::verify_oop_map(CodeEmitInfo* info) {
       if (v.is_oop()) {
         VMReg r = v.reg();
         if (!r->is_stack()) {
-          stringStream st;
-          st.print("bad oop %s at %d", r->as_Register()->name(), _masm->offset());
           _masm->verify_oop(r->as_Register());
         } else {
           _masm->verify_stack_oop(r->reg2stack() * VMRegImpl::stack_slot_size);


### PR DESCRIPTION
This is a trivial change to remove unused code.

Methods like as_string() or freeze() are not called for the stringStream object, so these are unused code. The object was used before the SPARC port was removed (071bd521bca).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322927](https://bugs.openjdk.org/browse/JDK-8322927): Unused code in LIR_Assembler::verify_oop_map (**Enhancement** - P4)


### Reviewers
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17721/head:pull/17721` \
`$ git checkout pull/17721`

Update a local copy of the PR: \
`$ git checkout pull/17721` \
`$ git pull https://git.openjdk.org/jdk.git pull/17721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17721`

View PR using the GUI difftool: \
`$ git pr show -t 17721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17721.diff">https://git.openjdk.org/jdk/pull/17721.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17721#issuecomment-1931394624)