### PR TITLE
8324824: AArch64: Detect Ampere-1B core and update default options for Ampere CPUs

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -143,10 +143,18 @@ void VM_Version::initialize() {
     }
   }
 
-  // Ampere CPUs: Ampere-1 and Ampere-1A
-  if (_cpu == CPU_AMPERE && ((_model == CPU_MODEL_AMPERE_1) || (_model == CPU_MODEL_AMPERE_1A))) {
+  // Ampere CPUs
+  if (_cpu == CPU_AMPERE && ((_model == CPU_MODEL_AMPERE_1)  ||
+                             (_model == CPU_MODEL_AMPERE_1A) ||
+                             (_model == CPU_MODEL_AMPERE_1B))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
+    }
+    if (FLAG_IS_DEFAULT(OnSpinWaitInst)) {
+      FLAG_SET_DEFAULT(OnSpinWaitInst, "isb");
+    }
+    if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
+      FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
   }
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -110,7 +110,8 @@ enum Ampere_CPU_Model {
     CPU_MODEL_ALTRA     = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
     CPU_MODEL_ALTRAMAX  = 0xd0c, /* CPU implementer is CPU_ARM, Neoverse N1 */
     CPU_MODEL_AMPERE_1  = 0xac3, /* CPU implementer is CPU_AMPERE */
-    CPU_MODEL_AMPERE_1A = 0xac4  /* CPU implementer is CPU_AMPERE */
+    CPU_MODEL_AMPERE_1A = 0xac4, /* CPU implementer is CPU_AMPERE */
+    CPU_MODEL_AMPERE_1B = 0xac5  /* AMPERE_1B core Implements ARMv8.7 with CSSC, MTE, SM3/SM4 extensions */
 };
 
 #define CPU_FEATURE_FLAGS(decl)               \


### PR DESCRIPTION
Added CPU detection for Ampere-1B, and updated the default options for AmpereOne, Ampere-1A/1B to have `-XX:+UseSIMDForMemoryOps` and `-XX:OnSpinWaitInst=isb -XX:OnSpinWaitInstCount=2`.

Tests done:
1. GitHub Actions (GHA) sanity tests: https://github.com/cnqpzhang/jdk/actions/runs/7786881426
2. OpenJDK bundled JMH, `make run-test TEST="jtreg:hotspot/jtreg/compiler/onSpinWait*"` , `make run-test TEST="micro:ThreadOnSpinWait*"`, no issue found, and `ThreadOnSpinWaitProducerConsumer.trial` showed ~3x better scores (us/op).
3. Jtreg tier1/tier2 sanity check on AmpereOne AArch64 platforms, Ampere-1A systems as well, no new issues found.

Signed-off-by: Patrick Zhang [patrick@os.amperecomputing.com](mailto:patrick@os.amperecomputing.com)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324824](https://bugs.openjdk.org/browse/JDK-8324824): AArch64: Detect Ampere-1B core and update default options for Ampere CPUs (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17722/head:pull/17722` \
`$ git checkout pull/17722`

Update a local copy of the PR: \
`$ git checkout pull/17722` \
`$ git pull https://git.openjdk.org/jdk.git pull/17722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17722`

View PR using the GUI difftool: \
`$ git pr show -t 17722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17722.diff">https://git.openjdk.org/jdk/pull/17722.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17722#issuecomment-1928920328)