### PR TITLE
JDK-8325306: Rename static huge pages to explicit huge pages

### DIFF
--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -36,15 +36,15 @@
 
 #include <dirent.h>
 
-StaticHugePageSupport::StaticHugePageSupport() :
+ExplicitHugePageSupport::ExplicitHugePageSupport() :
   _initialized(false), _pagesizes(), _default_hugepage_size(SIZE_MAX), _inconsistent(false) {}
 
-os::PageSizes StaticHugePageSupport::pagesizes() const {
+os::PageSizes ExplicitHugePageSupport::pagesizes() const {
   assert(_initialized, "Not initialized");
   return _pagesizes;
 }
 
-size_t StaticHugePageSupport::default_hugepage_size() const {
+size_t ExplicitHugePageSupport::default_hugepage_size() const {
   assert(_initialized, "Not initialized");
   return _default_hugepage_size;
 }
@@ -132,9 +132,9 @@ static os::PageSizes scan_hugepages() {
   return pagesizes;
 }
 
-void StaticHugePageSupport::print_on(outputStream* os) {
+void ExplicitHugePageSupport::print_on(outputStream* os) {
   if (_initialized) {
-    os->print_cr("Static hugepage support:");
+    os->print_cr("Explicit hugepage support:");
     for (size_t s = _pagesizes.smallest(); s != 0; s = _pagesizes.next_larger(s)) {
       os->print_cr("  hugepage size: " EXACTFMT, EXACTFMTARGS(s));
     }
@@ -143,18 +143,18 @@ void StaticHugePageSupport::print_on(outputStream* os) {
     os->print_cr("  unknown.");
   }
   if (_inconsistent) {
-    os->print_cr("  Support inconsistent. JVM will not use static hugepages.");
+    os->print_cr("  Support inconsistent. JVM will not use explicit hugepages.");
   }
 }
 
-void StaticHugePageSupport::scan_os() {
+void ExplicitHugePageSupport::scan_os() {
   _default_hugepage_size = scan_default_hugepagesize();
   if (_default_hugepage_size > 0) {
     _pagesizes = scan_hugepages();
     // See https://www.kernel.org/doc/Documentation/vm/hugetlbpage.txt: /proc/meminfo should match
     // /sys/kernel/mm/hugepages/hugepages-xxxx. However, we may run on a broken kernel (e.g. on WSL)
     // that only exposes /proc/meminfo but not /sys/kernel/mm/hugepages. In that case, we are not
-    // sure about the state of hugepage support by the kernel, so we won't use static hugepages.
+    // sure about the state of hugepage support by the kernel, so we won't use explicit hugepages.
     if (!_pagesizes.contains(_default_hugepage_size)) {
       log_info(pagesize)("Unexpected configuration: default pagesize (" SIZE_FORMAT ") "
                          "has no associated directory in /sys/kernel/mm/hugepages..", _default_hugepage_size);
@@ -307,18 +307,18 @@ void ShmemTHPSupport::print_on(outputStream* os) {
   }
 }
 
-StaticHugePageSupport HugePages::_static_hugepage_support;
+ExplicitHugePageSupport HugePages::_explicit_hugepage_support;
 THPSupport HugePages::_thp_support;
 ShmemTHPSupport HugePages::_shmem_thp_support;
 
 void HugePages::initialize() {
-  _static_hugepage_support.scan_os();
+  _explicit_hugepage_support.scan_os();
   _thp_support.scan_os();
   _shmem_thp_support.scan_os();
 }
 
 void HugePages::print_on(outputStream* os) {
-  _static_hugepage_support.print_on(os);
+  _explicit_hugepage_support.print_on(os);
   _thp_support.print_on(os);
   _shmem_thp_support.print_on(os);
 }

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -34,13 +34,13 @@ class outputStream;
 
 // Header contains the interface that reads OS information about
 // available hugepage support:
-// - class StaticHugePageSupport - about static (non-THP) hugepages
+// - class ExplicitHugePageSupport - about explicit (non-THP) hugepages
 // - class THPSupport - about transparent huge pages
 // and:
 // - class HugePages - a static umbrella wrapper
 
 // Information about static (non-thp) hugepages
-class StaticHugePageSupport {
+class ExplicitHugePageSupport {
   bool _initialized;
 
   // All supported hugepage sizes (sizes for which entries exist
@@ -56,7 +56,7 @@ class StaticHugePageSupport {
   bool _inconsistent;
 
 public:
-  StaticHugePageSupport();
+  ExplicitHugePageSupport();
 
   void scan_os();
 
@@ -122,18 +122,18 @@ public:
 // Umbrella static interface
 class HugePages : public AllStatic {
 
-  static StaticHugePageSupport _static_hugepage_support;
+  static ExplicitHugePageSupport _explicit_hugepage_support;
   static THPSupport _thp_support;
   static ShmemTHPSupport _shmem_thp_support;
 
 public:
 
-  static const StaticHugePageSupport& static_info() { return _static_hugepage_support; }
+  static const ExplicitHugePageSupport& explicit_hugepage_info() { return _explicit_hugepage_support; }
   static const THPSupport& thp_info() { return _thp_support; }
   static const ShmemTHPSupport& shmem_thp_info() { return _shmem_thp_support; }
 
-  static size_t default_static_hugepage_size()  { return _static_hugepage_support.default_hugepage_size(); }
-  static bool supports_static_hugepages()       { return default_static_hugepage_size() > 0 && !_static_hugepage_support.inconsistent(); }
+  static size_t default_explicit_hugepage_size() { return _explicit_hugepage_support.default_hugepage_size(); }
+  static bool supports_explicit_hugepages()      { return default_explicit_hugepage_size() > 0 && !_explicit_hugepage_support.inconsistent(); }
 
   static bool supports_thp()                    { return thp_mode() == THPMode::madvise || thp_mode() == THPMode::always; }
   static THPMode thp_mode()                     { return _thp_support.mode(); }

--- a/src/hotspot/os/linux/hugepages.hpp
+++ b/src/hotspot/os/linux/hugepages.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2011, 2023, Red Hat Inc. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -37,7 +37,7 @@
 
 #include <sys/mman.h>
 
-static bool using_static_hugepages()  { return UseLargePages && !UseTransparentHugePages; }
+static bool using_explicit_hugepages()  { return UseLargePages && !UseTransparentHugePages; }
 
 namespace {
   static void small_page_write(void* addr, size_t size) {
@@ -75,7 +75,7 @@ namespace {
 }
 
 TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_aligned) {
-  if (!using_static_hugepages()) {
+  if (!using_explicit_hugepages()) {
     return;
   }
   size_t lp = os::large_page_size();
@@ -91,7 +91,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_aligned) {
 }
 
 TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_without_addr) {
-  if (!using_static_hugepages()) {
+  if (!using_explicit_hugepages()) {
     return;
   }
   size_t lp = os::large_page_size();
@@ -118,7 +118,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_without_add
 }
 
 TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_good_req_addr) {
-  if (!using_static_hugepages()) {
+  if (!using_explicit_hugepages()) {
     return;
   }
   size_t lp = os::large_page_size();
@@ -159,7 +159,7 @@ TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_good_r
 
 
 TEST_VM(os_linux, reserve_memory_special_huge_tlbfs_size_not_aligned_with_bad_req_addr) {
-  if (!using_static_hugepages()) {
+  if (!using_explicit_hugepages()) {
     return;
   }
   size_t lp = os::large_page_size();
@@ -221,7 +221,7 @@ class TestReserveMemorySpecial : AllStatic {
   }
 
   static void test_reserve_memory_special_huge_tlbfs_size_aligned(size_t size, size_t alignment, size_t page_size) {
-    if (!using_static_hugepages()) {
+    if (!using_explicit_hugepages()) {
       return;
     }
     char* addr = os::reserve_memory_special(size, alignment, page_size, nullptr, false);
@@ -232,7 +232,7 @@ class TestReserveMemorySpecial : AllStatic {
   }
 
   static void test_reserve_memory_special_huge_tlbfs_size_aligned() {
-    if (!using_static_hugepages()) {
+    if (!using_explicit_hugepages()) {
       return;
     }
     size_t lp = os::large_page_size();
@@ -323,7 +323,7 @@ class TestReserveMemorySpecial : AllStatic {
   }
 
   static void test() {
-    if (!using_static_hugepages()) {
+    if (!using_explicit_hugepages()) {
       return;
     }
     test_reserve_memory_special_huge_tlbfs_size_aligned();

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, Red Hat Inc.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 // This is used e.g. in TestHugePageDetection to determine if the JVM detects the correct settings from the OS.
 class HugePageConfiguration {
 
-    public static class StaticHugePageConfig implements Comparable<StaticHugePageConfig> {
+    public static class ExplicitHugePageConfig implements Comparable<ExplicitHugePageConfig> {
         public long pageSize = -1;
         public long nr_hugepages = -1;
         public long nr_overcommit_hugepages = -1;
@@ -47,7 +47,7 @@ class HugePageConfiguration {
 
         @Override
         public String toString() {
-            return "StaticHugePageConfig{" +
+            return "ExplicitHugePageConfig{" +
                     "pageSize=" + pageSize +
                     ", nr_hugepages=" + nr_hugepages +
                     ", nr_overcommit_hugepages=" + nr_overcommit_hugepages +
@@ -55,13 +55,13 @@ class HugePageConfiguration {
         }
 
         @Override
-        public int compareTo(StaticHugePageConfig o) {
+        public int compareTo(ExplicitHugePageConfig o) {
             return (int) (pageSize - o.pageSize);
         }
     }
 
-    Set<StaticHugePageConfig> _staticHugePageConfigurations;
-    long _staticDefaultHugePageSize = -1;
+    Set<ExplicitHugePageConfig> _explicitHugePageConfigurations;
+    long _explicitDefaultHugePageSize = -1;
 
     enum THPMode {always, never, madvise}
     THPMode _thpMode;
@@ -70,12 +70,12 @@ class HugePageConfiguration {
     enum ShmemTHPMode {always, within_size, advise, never, deny, force, unknown}
     ShmemTHPMode _shmemThpMode;
 
-    public Set<StaticHugePageConfig> getStaticHugePageConfigurations() {
-        return _staticHugePageConfigurations;
+    public Set<ExplicitHugePageConfig> getExplicitHugePageConfigurations() {
+        return _explicitHugePageConfigurations;
     }
 
-    public long getStaticDefaultHugePageSize() {
-        return _staticDefaultHugePageSize;
+    public long getExplicitDefaultHugePageSize() {
+        return _explicitDefaultHugePageSize;
     }
 
     public THPMode getThpMode() {
@@ -95,14 +95,14 @@ class HugePageConfiguration {
         return _shmemThpMode;
     }
 
-    // Returns true if static huge pages are supported (whether or not we have configured the pools)
-    public boolean supportsStaticHugePages() {
-        return _staticDefaultHugePageSize > 0 && _staticHugePageConfigurations.size() > 0;
+    // Returns true if explicit huge pages are supported (whether or not we have configured the pools)
+    public boolean supportsExplicitHugePages() {
+        return _explicitDefaultHugePageSize > 0 && _explicitHugePageConfigurations.size() > 0;
     }
 
-    public HugePageConfiguration(Set<StaticHugePageConfig> _staticHugePageConfigurations, long _staticDefaultHugePageSize, THPMode _thpMode, long _thpPageSize, ShmemTHPMode _shmemThpMode) {
-        this._staticHugePageConfigurations = _staticHugePageConfigurations;
-        this._staticDefaultHugePageSize = _staticDefaultHugePageSize;
+    public HugePageConfiguration(Set<ExplicitHugePageConfig> explicitHugePageConfigurations, long explicitDefaultHugePageSize, THPMode _thpMode, long _thpPageSize, ShmemTHPMode _shmemThpMode) {
+        this._explicitHugePageConfigurations = explicitHugePageConfigurations;
+        this._explicitDefaultHugePageSize = explicitDefaultHugePageSize;
         this._thpMode = _thpMode;
         this._thpPageSize = _thpPageSize;
         this._shmemThpMode = _shmemThpMode;
@@ -111,8 +111,8 @@ class HugePageConfiguration {
     @Override
     public String toString() {
         return "Configuration{" +
-                "_staticHugePageConfigurations=" + _staticHugePageConfigurations +
-                ", _staticDefaultHugePageSize=" + _staticDefaultHugePageSize +
+                "_explicitHugePageConfigurations=" + _explicitHugePageConfigurations +
+                ", _explicitDefaultHugePageSize=" + _explicitDefaultHugePageSize +
                 ", _thpMode=" + _thpMode +
                 ", _thpPageSize=" + _thpPageSize +
                 ", _shmemThpMode=" + _shmemThpMode +
@@ -124,8 +124,8 @@ class HugePageConfiguration {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         HugePageConfiguration that = (HugePageConfiguration) o;
-        return _staticDefaultHugePageSize == that._staticDefaultHugePageSize && _thpPageSize == that._thpPageSize &&
-                Objects.equals(_staticHugePageConfigurations, that._staticHugePageConfigurations) && _thpMode == that._thpMode &&
+        return _explicitDefaultHugePageSize == that._explicitDefaultHugePageSize && _thpPageSize == that._thpPageSize &&
+                Objects.equals(_explicitHugePageConfigurations, that._explicitHugePageConfigurations) && _thpMode == that._thpMode &&
                 _shmemThpMode == that._shmemThpMode;
     }
 
@@ -145,8 +145,8 @@ class HugePageConfiguration {
         return 0;
     }
 
-    private static Set<StaticHugePageConfig> readSupportedHugePagesFromOS() throws IOException {
-        TreeSet<StaticHugePageConfig> hugePageConfigs = new TreeSet<>();
+    private static Set<ExplicitHugePageConfig> readSupportedHugePagesFromOS() throws IOException {
+        TreeSet<ExplicitHugePageConfig> hugePageConfigs = new TreeSet<>();
         Pattern pat = Pattern.compile("hugepages-(\\d+)kB");
         File[] subdirs = new File("/sys/kernel/mm/hugepages").listFiles();
         if (subdirs != null) {
@@ -154,7 +154,7 @@ class HugePageConfiguration {
                 String name = subdir.getName();
                 Matcher mat = pat.matcher(name);
                 if (mat.matches()) {
-                    StaticHugePageConfig config = new StaticHugePageConfig();
+                    ExplicitHugePageConfig config = new ExplicitHugePageConfig();
                     config.pageSize = Long.parseLong(mat.group(1)) * 1024;
                     try (FileReader fr = new FileReader(subdir.getAbsolutePath() + "/nr_hugepages");
                          BufferedReader reader = new BufferedReader(fr)) {
@@ -257,7 +257,7 @@ class HugePageConfiguration {
     public static HugePageConfiguration readFromJVMLog(OutputAnalyzer output) {
         // Expects output from -Xlog:pagesize
         // Example:
-        // [0.001s][info][pagesize] Static hugepage support:
+        // [0.001s][info][pagesize] Explicit hugepage support:
         // [0.001s][info][pagesize]   hugepage size: 2M
         // [0.001s][info][pagesize]   hugepage size: 1G
         // [0.001s][info][pagesize]   default hugepage size: 2M
@@ -266,7 +266,7 @@ class HugePageConfiguration {
         // [0.001s][info][pagesize]   THP pagesize: 2M
         // [0.001s][info][pagesize] Shared memory transparent hugepage (THP) support:
         // [0.001s][info][pagesize]   Shared memory THP mode: always
-        TreeSet<StaticHugePageConfig> staticHugePageConfigs = new TreeSet<>();
+        TreeSet<ExplicitHugePageConfig> explicitHugePageConfigs = new TreeSet<>();
         long defaultHugepageSize = 0;
         THPMode thpMode = THPMode.never;
         ShmemTHPMode shmemThpMode = ShmemTHPMode.unknown;
@@ -280,9 +280,9 @@ class HugePageConfiguration {
         for (String s : lines) {
             Matcher mat = patternHugepageSize.matcher(s);
             if (mat.matches()) {
-                StaticHugePageConfig config = new StaticHugePageConfig();
+                ExplicitHugePageConfig config = new ExplicitHugePageConfig();
                 config.pageSize = parseSIUnit(mat.group(1), mat.group(2));
-                staticHugePageConfigs.add(config);
+                explicitHugePageConfigs.add(config);
                 continue;
             }
             if (defaultHugepageSize == 0) {
@@ -309,7 +309,7 @@ class HugePageConfiguration {
             }
         }
 
-        return new HugePageConfiguration(staticHugePageConfigs, defaultHugepageSize, thpMode, thpPageSize, shmemThpMode);
+        return new HugePageConfiguration(explicitHugePageConfigs, defaultHugepageSize, thpMode, thpPageSize, shmemThpMode);
     }
 
 }

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -82,7 +82,7 @@ public class TestHugePageDecisionsAtVMStartup {
         // Note: If something goes wrong, the JVM warns but continues, so we should never see an exit value != 0
         out.shouldHaveExitValue(0);
 
-        // Static hugepages:
+        // Explicit hugepages:
         // Let X = the default hugepage size of the system (the one in /proc/meminfo).
         // The JVM will cycle through page sizes, starting at X, down to the smallest hugepage size.
         //
@@ -95,14 +95,14 @@ public class TestHugePageDecisionsAtVMStartup {
         // This picture gets more complex with -XX:LargePageSizeInBytes, which overrides the default
         // large page size; but we ignore this for now (feel free to extend the test to cover LBSiB too).
 
-        boolean haveUsableStaticHugePages = false;
-        if (configuration.supportsStaticHugePages()) {
-            long defaultLargePageSize = configuration.getStaticDefaultHugePageSize();
-            Set<HugePageConfiguration.StaticHugePageConfig> configs = configuration.getStaticHugePageConfigurations();
-            for (HugePageConfiguration.StaticHugePageConfig config: configs) {
+        boolean haveUsableExplicitHugePages = false;
+        if (configuration.supportsExplicitHugePages()) {
+            long defaultLargePageSize = configuration.getExplicitDefaultHugePageSize();
+            Set<HugePageConfiguration.ExplicitHugePageConfig> configs = configuration.getExplicitHugePageConfigurations();
+            for (HugePageConfiguration.ExplicitHugePageConfig config: configs) {
                 if (config.pageSize <= defaultLargePageSize) {
                     if (config.nr_hugepages > 0 || config.nr_overcommit_hugepages > 0) {
-                        haveUsableStaticHugePages = true; break;
+                        haveUsableExplicitHugePages = true; break;
                     }
                 }
             }
@@ -115,13 +115,13 @@ public class TestHugePageDecisionsAtVMStartup {
         if (!useLP) {
             out.shouldContain("[info][pagesize] Large page support disabled");
         } else if (useLP && !useTHP &&
-                 (!configuration.supportsStaticHugePages() || !haveUsableStaticHugePages)) {
+                 (!configuration.supportsExplicitHugePages() || !haveUsableExplicitHugePages)) {
             out.shouldContain(warningNoLP);
         } else if (useLP && useTHP && !configuration.supportsTHP()) {
             out.shouldContain(warningNoTHP);
         } else if (useLP && !useTHP &&
-                 configuration.supportsStaticHugePages() && haveUsableStaticHugePages) {
-            out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getStaticDefaultHugePageSize()));
+                 configuration.supportsExplicitHugePages() && haveUsableExplicitHugePages) {
+            out.shouldContain("[info][pagesize] Using the default large page size: " + buildSizeString(configuration.getExplicitDefaultHugePageSize()));
             out.shouldContain("[info][pagesize] UseLargePages=1, UseTransparentHugePages=0");
             out.shouldContain("[info][pagesize] Large page support enabled");
         } else if (useLP && useTHP && configuration.supportsTHP()) {

--- a/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
+++ b/test/hotspot/jtreg/runtime/os/TestHugePageDecisionsAtVMStartup.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, Red Hat Inc.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
I was asked at FOSDEM why I used the "Static" moniker for anything hugetlbfs-related. I could not really give an answer, and "Explicit" would be a clearer description.

This patch is just a 1:1 rename of "static" ->  "explicit". No functional changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325306](https://bugs.openjdk.org/browse/JDK-8325306): Rename static huge pages to explicit huge pages (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17723/head:pull/17723` \
`$ git checkout pull/17723`

Update a local copy of the PR: \
`$ git checkout pull/17723` \
`$ git pull https://git.openjdk.org/jdk.git pull/17723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17723`

View PR using the GUI difftool: \
`$ git pr show -t 17723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17723.diff">https://git.openjdk.org/jdk/pull/17723.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17723#issuecomment-1928991856)