### PR TITLE
8325309: Amend "Listeners and Threads" in AWTThreadIssues.html

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -5,7 +5,7 @@
   <title>AWT Threading Issues</title>
 </head>
 <!--
- Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,10 @@
 <a id="ListenersThreads"></a>
 <h2>Listeners and threads</h2>
 
-Unless otherwise noted all AWT listeners are notified on the event
+Unless otherwise noted, all AWT listeners are notified on the event
 dispatch thread. It is safe to remove/add listeners from any thread
-during dispatching, but the changes only effect subsequent notification.
-<br>For example, if a key listeners is added from another key listener, the
+during dispatching, but the changes only affect subsequent notification.
+<p>For example, if a key listener is added from another key listener, the
 newly added listener is only notified on subsequent key events.
 
 <a id="Autoshutdown"></a>


### PR DESCRIPTION
Replace _“effect”_ with _“affect”_¹ because the meaning in the phrase “…the changes only _effect_ subsequent notification” is to “have an effect on.”

Add a comma to separate a conditional clause from the main one.

Use `<p>` instead of `<br>`: the example should be either in-line or in a separate paragraph.

Amend grammar: “a key _listeners_ is added.” Here, the usage of the indefinite article and the singular form of _“to be”_ implies the subject is singular.

¹ For reference, see [‘Affect’ vs. ‘Effect’](https://www.merriam-webster.com/grammar/affect-vs-effect-usage-difference).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325309](https://bugs.openjdk.org/browse/JDK-8325309): Amend "Listeners and Threads" in AWTThreadIssues.html (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17725/head:pull/17725` \
`$ git checkout pull/17725`

Update a local copy of the PR: \
`$ git checkout pull/17725` \
`$ git pull https://git.openjdk.org/jdk.git pull/17725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17725`

View PR using the GUI difftool: \
`$ git pr show -t 17725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17725.diff">https://git.openjdk.org/jdk/pull/17725.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17725#issuecomment-1929031253)