### PR TITLE
JDK-8325313: Header format error in TestIntrinsicBailOut after JDK-8317299

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestIntrinsicBailOut.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2021, 2022, THL A29 Limited, a Tencent company. All rights reserved.
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
There was a typo in the header of the test file of JDK-8317299 (comma missing after the year in the copyright notice).
Fixed it by adding the comma.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325313](https://bugs.openjdk.org/browse/JDK-8325313): Header format error in TestIntrinsicBailOut after JDK-8317299 (**Bug** - P2)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17726/head:pull/17726` \
`$ git checkout pull/17726`

Update a local copy of the PR: \
`$ git checkout pull/17726` \
`$ git pull https://git.openjdk.org/jdk.git pull/17726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17726`

View PR using the GUI difftool: \
`$ git pr show -t 17726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17726.diff">https://git.openjdk.org/jdk/pull/17726.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17726#issuecomment-1929114798)