### PR TITLE
8325316: Enable -pedantic -Wpedantic for gcc

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -584,6 +584,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     # no-strict-aliasing everywhere!)
     TOOLCHAIN_CFLAGS_JDK_CONLY="-fno-strict-aliasing"
 
+    TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM -pedantic -Wpedantic"
+    TOOLCHAIN_CFLAGS_JDK="$TOOLCHAIN_CFLAGS_JDK -pedantic -Wpedantic"
+
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     # Restrict the debug information created by Clang to avoid
     # too big object files and speed the build up a little bit

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -82,8 +82,7 @@
 // *before* the attribute check.  We use fortification in fastdebug builds,
 // so uses of functions that are both forbidden and fortified won't cause
 // forbidden warnings in such builds.
-#define FORBID_C_FUNCTION(signature, alternative) \
-  extern "C" __attribute__((__warning__(alternative))) signature;
+#define FORBID_C_FUNCTION(signature, alternative) [[gnu::__warning__(alternative)]] signature;
 
 // Disable warning attribute over the scope of the affected statement.
 // The name serves only to document the intended function.

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -82,7 +82,7 @@
 // *before* the attribute check.  We use fortification in fastdebug builds,
 // so uses of functions that are both forbidden and fortified won't cause
 // forbidden warnings in such builds.
-#define FORBID_C_FUNCTION(signature, alternative) [[gnu::__warning__(alternative)]] signature;
+#define FORBID_C_FUNCTION(signature, alternative) [[gnu::__warning__(alternative)]] signature
 
 // Disable warning attribute over the scope of the affected statement.
 // The name serves only to document the intended function.


### PR DESCRIPTION
Similarly to [JDK-8325163](https://bugs.openjdk.org/browse/JDK-8325163), this enables pedantic mode for gcc, ensuring stricter Standard conformance and allowing for buggy and broken code previously undetectable by gcc to be caught

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325316](https://bugs.openjdk.org/browse/JDK-8325316): Enable -pedantic -Wpedantic for gcc (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17727/head:pull/17727` \
`$ git checkout pull/17727`

Update a local copy of the PR: \
`$ git checkout pull/17727` \
`$ git pull https://git.openjdk.org/jdk.git pull/17727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17727`

View PR using the GUI difftool: \
`$ git pr show -t 17727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17727.diff">https://git.openjdk.org/jdk/pull/17727.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17727#issuecomment-1929150237)