### PR TITLE
8325257: jshell reports NoSuchFieldError with instanceof primitive type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2998,7 +2998,7 @@ public class Lower extends TreeTranslator {
                             boxIfNeeded(make.Ident(dollar_s), types.unboxedType(tree.expr.type)));
                 } else {
                     exactnessCheck = make.at(tree.pos())
-                            .TypeTest(tree.expr, make.Type(types.boxedClass(tree.pattern.type).type))
+                            .TypeTest(make.Ident(dollar_s), make.Type(types.boxedClass(tree.pattern.type).type))
                             .setType(syms.booleanType);
                 }
 

--- a/test/langtools/jdk/jshell/PrimitiveInstanceOfTest.java
+++ b/test/langtools/jdk/jshell/PrimitiveInstanceOfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 8304487
+ * @bug 8304487 8325257
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @build KullaTesting TestingInputStream
  * @run testng PrimitiveInstanceOfTest
@@ -47,6 +47,17 @@ public class PrimitiveInstanceOfTest extends KullaTesting {
         assertEval("Integer i = 42;");
         assertEval("i instanceof Integer");
         assertEval("i instanceof Number");
+    }
+
+    public void testInstanceOfObjectToPrimitive() {
+        assertEval("Object o = 1L;");
+        assertEval("o instanceof long");
+        assertEval("o instanceof Long");
+    }
+
+    public void testInstanceOfPrimitiveToPrimitiveInvokingExactnessMethod() {
+        assertEval("int b = 1024;");
+        assertEval("b instanceof byte");
     }
 
     @org.testng.annotations.BeforeMethod

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfTypeComparisonOp.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfTypeComparisonOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,17 @@
 
 /*
  * @test
- * @bug 8304487
+ * @bug 8304487 8325257
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile PrimitiveInstanceOfTypeComparisonOp.java
  * @run main/othervm PrimitiveInstanceOfTypeComparisonOp
  */
 public class PrimitiveInstanceOfTypeComparisonOp {
+    public static final int qualI = 42;
 
     public static void main(String[] args) {
+        assertEquals(true,  qualifiedExprConversion());
         assertEquals(true,  identityPrimitiveConversion());
         assertEquals(true,  wideningPrimitiveConversion());
         assertEquals(true,  narrowingPrimitiveConversion());
@@ -49,6 +51,10 @@ public class PrimitiveInstanceOfTypeComparisonOp {
         assertEquals(true,  patternExtractRecordComponent());
         assertEquals(true,  exprMethod());
         assertEquals(true,  exprStaticallyQualified());
+    }
+
+    public static boolean qualifiedExprConversion() {
+        return PrimitiveInstanceOfTypeComparisonOp.qualI instanceof int;
     }
 
     public static boolean identityPrimitiveConversion() {


### PR DESCRIPTION
Fixed compiler bug during lowering of the type test, where the let expression was using the `expr` of the old `tree` and not of the translated one. The latter manifested as a JShell error. Added compiler test as well. e.g., 

```
class $JShell$2 {
    
    $JShell$2() {
        super();
    }
    public static boolean $1;
    
    public static Object do_it$() throws Throwable {
        return Boolean.valueOf($1 = (let /*synthetic*/ final Object tmp184$ = $JShell$1.o 
                                     in tmp184$ != null && o instanceof Long));                          
                                                        // ^
    }
} 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325257](https://bugs.openjdk.org/browse/JDK-8325257): jshell reports NoSuchFieldError with instanceof primitive type (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17729/head:pull/17729` \
`$ git checkout pull/17729`

Update a local copy of the PR: \
`$ git checkout pull/17729` \
`$ git pull https://git.openjdk.org/jdk.git pull/17729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17729`

View PR using the GUI difftool: \
`$ git pr show -t 17729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17729.diff">https://git.openjdk.org/jdk/pull/17729.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17729#issuecomment-1929264348)