### PR TITLE
Add intrinsic for new method System.myTrap

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.cpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.cpp
@@ -132,6 +132,7 @@ bool vmIntrinsics::can_trap(vmIntrinsics::ID id) {
   case vmIntrinsics::_setCurrentThread:
   case vmIntrinsics::_scopedValueCache:
   case vmIntrinsics::_setScopedValueCache:
+  case vmIntrinsics::_myTrap:
   case vmIntrinsics::_dabs:
   case vmIntrinsics::_fabs:
   case vmIntrinsics::_iabs:
@@ -270,6 +271,7 @@ bool vmIntrinsics::disabled_by_jvm_flags(vmIntrinsics::ID id) {
   case vmIntrinsics::_setCurrentThread:
   case vmIntrinsics::_scopedValueCache:
   case vmIntrinsics::_setScopedValueCache:
+  case vmIntrinsics::_myTrap:
   case vmIntrinsics::_floatToRawIntBits:
   case vmIntrinsics::_intBitsToFloat:
   case vmIntrinsics::_doubleToRawLongBits:

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -292,6 +292,9 @@ class methodHandle;
   do_intrinsic(_setScopedValueCache,      java_lang_Thread,       setScopedValueCache_name, setScopedValueCache_signature, F_SN) \
    do_name(     setScopedValueCache_name,                        "setScopedValueCache")                                 \
    do_signature(setScopedValueCache_signature,                   "([Ljava/lang/Object;)V")                              \
+  do_intrinsic(_myTrap,      java_lang_System,       myTrap_name, void_method_signature, F_SN) \
+   do_name(     myTrap_name,                        "myTrap")                                 \
+            \
   do_intrinsic(_findScopedValueBindings,  java_lang_Thread,       findScopedValueBindings_name, void_object_signature, F_SN) \
    do_name(     findScopedValueBindings_name,                    "findScopedValueBindings")                             \
                                                                                                                         \

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -311,6 +311,9 @@ JVM_ScopedValueCache(JNIEnv *env, jclass threadClass);
 JNIEXPORT void JNICALL
 JVM_SetScopedValueCache(JNIEnv *env, jclass threadClass, jobject theCache);
 
+JNIEXPORT void JNICALL
+JVM_MyTrap(JNIEnv *env, jclass theClass);
+
 JNIEXPORT jobject JNICALL
 JVM_FindScopedValueBindings(JNIEnv *env, jclass threadClass);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3180,6 +3180,10 @@ JVM_ENTRY(void, JVM_SetScopedValueCache(JNIEnv* env, jclass threadClass,
   thread->set_scopedValueCache(objs);
 JVM_END
 
+JVM_ENTRY(void, JVM_MyTrap(JNIEnv* env, jclass threadClass))
+  asm("nop");
+JVM_END
+
 // java.lang.SecurityManager ///////////////////////////////////////////////////////////////////////
 
 JVM_ENTRY(jobjectArray, JVM_GetClassContext(JNIEnv *env))

--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -2113,6 +2113,7 @@ public final class Math {
      */
     @IntrinsicCandidate
     public static int min(int a, int b) {
+        System.myTrap();
         return (a <= b) ? a : b;
     }
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2344,6 +2344,14 @@ public final class System {
         VM.initLevel(4);
     }
 
+    /**
+     * Some words
+     *
+     *
+     */
+    @IntrinsicCandidate
+    public static native void myTrap();
+
     private static void setJavaLangAccess() {
         // Allow privileged classes outside of java.lang
         SharedSecrets.setJavaLangAccess(new JavaLangAccess() {

--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -40,6 +40,7 @@ static JNINativeMethod methods[] = {
     {"currentTimeMillis", "()J",              (void *)&JVM_CurrentTimeMillis},
     {"nanoTime",          "()J",              (void *)&JVM_NanoTime},
     {"arraycopy",     "(" OBJ "I" OBJ "II)V", (void *)&JVM_ArrayCopy},
+    {"myTrap", "()V", (void *)&JVM_MyTrap},
 };
 
 #undef OBJ

--- a/src/java.base/unix/classes/sun/nio/fs/UnixDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixDirectoryStream.java
@@ -155,6 +155,7 @@ class UnixDirectoryStream
         private Path readNextEntry() {
             assert Thread.holdsLock(this);
 
+            System.myTrap();
             for (;;) {
                 byte[] nameAsBytes = null;
 


### PR DESCRIPTION
This PR is not for integration. It is provided to showcase example code, provided by @theRealAph, that implements an intrinsic for a Java native method and uses it as a debugging aid.

The patch modifies a few locations in the JDK to invoke the intrinsic. gdb can be used to break when the intrinsic implementation is called, allowing the user to view the Java stack or return in order to step through interpreter or compiled code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17730/head:pull/17730` \
`$ git checkout pull/17730`

Update a local copy of the PR: \
`$ git checkout pull/17730` \
`$ git pull https://git.openjdk.org/jdk.git pull/17730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17730`

View PR using the GUI difftool: \
`$ git pr show -t 17730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17730.diff">https://git.openjdk.org/jdk/pull/17730.diff</a>

</details>
