### PR TITLE
JDK-8325255 jdk.internal.util.ReferencedKeySet::add using wrong test

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
@@ -148,7 +148,7 @@ public final class ReferencedKeySet<T> extends AbstractSet<T> {
 
     @Override
     public boolean add(T e) {
-        return intern(e) == null;
+        return intern(e) == e;
     }
 
     @Override

--- a/test/jdk/jdk/internal/util/ReferencedKeyTest.java
+++ b/test/jdk/jdk/internal/util/ReferencedKeyTest.java
@@ -127,6 +127,11 @@ public class ReferencedKeyTest {
         assertTrue(element1 == intern1, "intern failed"); // must be same object
         assertTrue(intern2 != null, "intern failed");
         assertTrue(element3 == intern3, "intern failed");
+
+        Long value1 = new Long(BASE_KEY + 999);
+        Long value2 = new Long(BASE_KEY + 999);
+        assertTrue(set.add(value1), "key not added");
+        assertTrue(!set.add(value2), "key should not have been added");
     }
 
     // Borrowed from jdk.test.lib.util.ForceGC but couldn't use from java.base/jdk.internal.util


### PR DESCRIPTION
Currently, add is returning intern(e) == null which will always be false. The correct test is intern(e) == e , that is, true when element is newly added.