### PR TITLE
JDK-8325264: two compiler/intrinsics/float16 tests fail after JDK-8324724

### DIFF
--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -453,14 +453,14 @@ class StubRoutines: AllStatic {
   static address hf2f_adr()            { return _hf2f; }
 
   static jshort f2hf(jfloat x) {
-    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     assert(_f2hf != nullptr, "stub is not implemented on this platform");
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     typedef jshort (*f2hf_stub_t)(jfloat x);
     return ((f2hf_stub_t)_f2hf)(x);
   }
   static jfloat hf2f(jshort x) {
-    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     assert(_hf2f != nullptr, "stub is not implemented on this platform");
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     typedef jfloat (*hf2f_stub_t)(jshort x);
     return ((hf2f_stub_t)_hf2f)(x);
   }

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 #include "runtime/frame.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/stubCodeGenerator.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/macros.hpp"
 
 // StubRoutines provides entry points to assembly routines used by
@@ -452,11 +453,13 @@ class StubRoutines: AllStatic {
   static address hf2f_adr()            { return _hf2f; }
 
   static jshort f2hf(jfloat x) {
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     assert(_f2hf != nullptr, "stub is not implemented on this platform");
     typedef jshort (*f2hf_stub_t)(jfloat x);
     return ((f2hf_stub_t)_f2hf)(x);
   }
   static jfloat hf2f(jshort x) {
+    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
     assert(_hf2f != nullptr, "stub is not implemented on this platform");
     typedef jfloat (*hf2f_stub_t)(jshort x);
     return ((hf2f_stub_t)_hf2f)(x);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,9 +76,6 @@ compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
-compiler/intrinsics/float16/TestConstFloat16ToFloat.java 8325264 macosx-aarch64
-compiler/intrinsics/float16/Binary16Conversion.java 8325264 macosx-aarch64
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Fix for two JTREG test failures on OS_X after this commit - https://github.com/openjdk/jdk/commit/51853f7488afa69c0d14b0e96f1da84822cd83f1.

This is due to no permission to execute the stub code in the code cache. This patch fixes this problem by acquiring "WXExec" to be able to execute the instructions in code cache.

Both the tests - compiler/intrinsics/float16/TestAllFloat16ToFloat.java and compiler/intrinsics/float16/Binary16ConversionNaN.java pass on a MacOS machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8325264](https://bugs.openjdk.org/browse/JDK-8325264): two compiler/intrinsics/float16 tests fail after JDK-8324724 (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [affabc19](https://git.openjdk.org/jdk/pull/17733/files/affabc19da5782a8a245a858a6b1ced72605af43)
 * [Damon Fenacci](https://openjdk.org/census#dfenacci) (@dafedafe - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [affabc19](https://git.openjdk.org/jdk/pull/17733/files/affabc19da5782a8a245a858a6b1ced72605af43)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17733/head:pull/17733` \
`$ git checkout pull/17733`

Update a local copy of the PR: \
`$ git checkout pull/17733` \
`$ git pull https://git.openjdk.org/jdk.git pull/17733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17733`

View PR using the GUI difftool: \
`$ git pr show -t 17733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17733.diff">https://git.openjdk.org/jdk/pull/17733.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17733#issuecomment-1929900475)