### PR TITLE
8325340: Add ASCII fast-path to Data-/ObjectInputStream.readUTF

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -593,7 +593,9 @@ loop:   while (true) {
         // fast-path as regular UTF-8
         int count = JLA.countPositives(bytearr, 0, utflen);
         if (count == utflen) {
-            return new String(bytearr, 0, utflen, StandardCharsets.UTF_8);
+            // For ASCII-only bytes ISO-8859-1 is equivalent to UTF-8, but using the
+            // former charset avoids a redundant scan
+            return new String(bytearr, 0, utflen, StandardCharsets.ISO_8859_1);
         }
         return readUTFChars(in, bytearr, utflen, count);
     }

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -579,7 +579,9 @@ loop:   while (true) {
     public static final String readUTF(DataInput in) throws IOException {
         int utflen = in.readUnsignedShort();
         byte[] bytearr;
-        if (in instanceof DataInputStream dis) {
+        DataInputStream dis = null;
+        if (in instanceof DataInputStream) {
+            dis = (DataInputStream)in;
             if (dis.bytearr.length < utflen) {
                 dis.bytearr = new byte[utflen * 2];
             }
@@ -597,14 +599,8 @@ loop:   while (true) {
             // former charset avoids a redundant scan
             return new String(bytearr, 0, utflen, StandardCharsets.ISO_8859_1);
         }
-        return readUTFChars(in, bytearr, utflen, count);
-    }
-
-    private static String readUTFChars(DataInput in, byte[] bytearr, int utflen, int count) throws IOException {
-        int c, char2, char3;
-        int chararr_count = count;
         char[] chararr;
-        if (in instanceof DataInputStream dis) {
+        if (dis != null) {
             if (dis.chararr.length < utflen) {
                 dis.chararr = new char[utflen * 2];
             }
@@ -613,6 +609,12 @@ loop:   while (true) {
             chararr = new char[utflen];
         }
         JLA.inflateBytesToChars(bytearr, 0, chararr, 0, count);
+        return readUTFChars(bytearr, count, chararr, utflen);
+    }
+
+    private static String readUTFChars(byte[] bytearr, int count, char[] chararr, int utflen) throws IOException {
+        int c, char2, char3;
+        int chararr_count = count;
         while (count < utflen) {
             c = (int) bytearr[count] & 0xff;
             switch (c >> 4) {

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -2996,6 +2996,8 @@ public class ObjectInputStream
         private static final int CHAR_BUF_SIZE = 256;
         /** readBlockHeader() return value indicating header read may block */
         private static final int HEADER_BLOCKED = -2;
+        /** access to internal methods to count ASCII and inflate latin1/ASCII bytes to char */
+        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
         /** buffer for reading general/block data */
         private final byte[] buf = new byte[MAX_BLOCK_SIZE];
@@ -3725,8 +3727,6 @@ public class ObjectInputStream
 
             return sbuf.toString();
         }
-
-        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
         /**
          * Reads span of UTF-encoded characters out of internal buffer

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -3682,7 +3682,9 @@ public class ObjectInputStream
                 if (avail >= utflen) {
                     ascii = JLA.countPositives(buf, pos, (int)utflen);
                     if (ascii == utflen) {
-                        String utf = new String(buf, pos, (int)utflen, StandardCharsets.UTF_8);
+                        // For ASCII-only bytes we can treat the bytes as ISO-8859-1 and
+                        // avoid a redundant scan
+                        String utf = new String(buf, pos, (int)utflen, StandardCharsets.ISO_8859_1);
                         pos += (int)utflen;
                         return utf;
                     }

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -679,6 +679,7 @@ public abstract class Charset
                     defaultCharset = cs;
                 else
                     defaultCharset = sun.nio.cs.UTF_8.INSTANCE;
+                Charset.forName("UTF-8");
             }
         }
         return defaultCharset;


### PR DESCRIPTION
Adding a fast-path for ASCII-only modified UTF-8 strings deserialied via Data- and ObjectInputStream