### PR TITLE
8322239: [macos] a11y : java.lang.NullPointerException is thrown when focus is moved on the JTabbedPane

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -31,6 +31,7 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.FocusListener;
@@ -2337,7 +2338,12 @@ public class JTabbedPane extends JComponent
         }
 
         public Point getLocationOnScreen() {
-             Point parentLocation = parent.getLocationOnScreen();
+             Point parentLocation;
+             try {
+                 parentLocation = parent.getLocationOnScreen();
+             } catch (IllegalComponentStateException icse) {
+                 return null;
+             }
              Point componentLocation = getLocation();
              if (parentLocation == null || componentLocation == null) {
                  return null;

--- a/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JTabbedPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2339,13 +2339,16 @@ public class JTabbedPane extends JComponent
         public Point getLocationOnScreen() {
              Point parentLocation = parent.getLocationOnScreen();
              Point componentLocation = getLocation();
+             if (parentLocation == null || componentLocation == null) {
+                 return null;
+             }
              componentLocation.translate(parentLocation.x, parentLocation.y);
              return componentLocation;
         }
 
         public Point getLocation() {
              Rectangle r = getBounds();
-             return new Point(r.x, r.y);
+             return r == null ? null : new Point(r.x, r.y);
         }
 
         public void setLocation(Point p) {
@@ -2362,7 +2365,7 @@ public class JTabbedPane extends JComponent
 
         public Dimension getSize() {
             Rectangle r = getBounds();
-            return new Dimension(r.width, r.height);
+            return r == null ? null : new Dimension(r.width, r.height);
         }
 
         public void setSize(Dimension d) {

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8322239
+ * @summary [macos] a11y : java.lang.NullPointerException is thrown when
+ *          focus is moved on the JTabbedPane
+ * @key headful
+ * @run main TabbedPaneNPECheck
+ */
+
+import javax.accessibility.Accessible;
+import javax.accessibility.AccessibleComponent;
+import javax.accessibility.AccessibleContext;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.lang.reflect.InvocationTargetException;
+
+public class TabbedPaneNPECheck {
+    JTabbedPane pane;
+    static JFrame mainFrame;
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        TabbedPaneNPECheck me = new TabbedPaneNPECheck();
+        SwingUtilities.invokeAndWait(me::setupGUI);
+        try {
+            SwingUtilities.invokeAndWait(me::test);
+        } finally {
+            if(mainFrame != null) {
+                mainFrame.setVisible(false);
+                mainFrame.dispose();
+            }
+        }
+    }
+
+    public void setupGUI() {
+        mainFrame = new JFrame("TabbedPaneNPECheck");
+        pane = new JTabbedPane();
+        Dimension panelSize = new Dimension(200, 200);
+        for (int i = 0; i < 25; i++) {
+            JPanel p = new JPanel();
+            p.setMinimumSize(panelSize);
+            p.setMaximumSize(panelSize);
+            p.setSize(panelSize);
+            pane.addTab("Tab no." + i, p);
+        }
+        mainFrame.setLayout(new BorderLayout());
+        mainFrame.add(pane, BorderLayout.CENTER);
+        mainFrame.setLocationRelativeTo(null);
+        mainFrame.setSize(250, 250);
+        mainFrame.setVisible(true);
+    }
+
+    public void test() {
+        AccessibleContext context = pane.getAccessibleContext();
+        int nChild = context.getAccessibleChildrenCount();
+        for (int i = 0; i < nChild; i++) {
+            Accessible accessible = context.getAccessibleChild(i);
+            if (accessible instanceof AccessibleComponent) {
+                try {
+                    AccessibleComponent component = (AccessibleComponent) accessible;
+                    Point p = component.getLocationOnScreen();
+                    Rectangle r = component.getBounds();
+                } catch(NullPointerException npe){
+                    throw new RuntimeException("Unexpected NullPointerException " +
+                            "while getting accessible component bounds: " + npe);
+                }
+            }
+        }
+    }
+}

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -45,7 +45,7 @@ import javax.swing.SwingUtilities;
 
 public class TabbedPaneNPECheck {
     JTabbedPane pane;
-    static JFrame mainFrame;
+    JFrame mainFrame;
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
         TabbedPaneNPECheck me = new TabbedPaneNPECheck();
@@ -53,12 +53,7 @@ public class TabbedPaneNPECheck {
         try {
             SwingUtilities.invokeAndWait(me::test);
         } finally {
-            if (mainFrame != null) {
-                SwingUtilities.invokeAndWait(() -> {
-                    mainFrame.setVisible(false);
-                    mainFrame.dispose();
-                });
-            }
+            SwingUtilities.invokeAndWait(me::shutdownGUI);
         }
     }
 
@@ -92,9 +87,16 @@ public class TabbedPaneNPECheck {
                     Rectangle r = component.getBounds();
                 } catch (NullPointerException npe){
                     throw new RuntimeException("Unexpected NullPointerException " +
-                            "while getting accessible component bounds: " + npe);
+                            "while getting accessible component bounds: ", npe);
                 }
             }
+        }
+    }
+
+    public void shutdownGUI() {
+        if (mainFrame != null) {
+            mainFrame.setVisible(false);
+            mainFrame.dispose();
         }
     }
 }

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -54,8 +54,10 @@ public class TabbedPaneNPECheck {
             SwingUtilities.invokeAndWait(me::test);
         } finally {
             if (mainFrame != null) {
-                mainFrame.setVisible(false);
-                mainFrame.dispose();
+                SwingUtilities.invokeAndWait(() -> {
+                    mainFrame.setVisible(false);
+                    mainFrame.dispose();
+                });
             }
         }
     }

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -30,6 +30,11 @@
  * @run main TabbedPaneNPECheck
  */
 
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.lang.reflect.InvocationTargetException;
 import javax.accessibility.Accessible;
 import javax.accessibility.AccessibleComponent;
 import javax.accessibility.AccessibleContext;
@@ -37,11 +42,6 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTabbedPane;
 import javax.swing.SwingUtilities;
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Point;
-import java.awt.Rectangle;
-import java.lang.reflect.InvocationTargetException;
 
 public class TabbedPaneNPECheck {
     JTabbedPane pane;
@@ -53,7 +53,7 @@ public class TabbedPaneNPECheck {
         try {
             SwingUtilities.invokeAndWait(me::test);
         } finally {
-            if(mainFrame != null) {
+            if (mainFrame != null) {
                 mainFrame.setVisible(false);
                 mainFrame.dispose();
             }
@@ -88,7 +88,7 @@ public class TabbedPaneNPECheck {
                     AccessibleComponent component = (AccessibleComponent) accessible;
                     Point p = component.getLocationOnScreen();
                     Rectangle r = component.getBounds();
-                } catch(NullPointerException npe){
+                } catch (NullPointerException npe){
                     throw new RuntimeException("Unexpected NullPointerException " +
                             "while getting accessible component bounds: " + npe);
                 }

--- a/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
+++ b/test/jdk/javax/swing/JTabbedPane/TabbedPaneNPECheck.java
@@ -85,7 +85,7 @@ public class TabbedPaneNPECheck {
                     AccessibleComponent component = (AccessibleComponent) accessible;
                     Point p = component.getLocationOnScreen();
                     Rectangle r = component.getBounds();
-                } catch (NullPointerException npe){
+                } catch (NullPointerException npe) {
                     throw new RuntimeException("Unexpected NullPointerException " +
                             "while getting accessible component bounds: ", npe);
                 }


### PR DESCRIPTION
Add null check for the Aqua LnF situation when tab is hidden die to the tabs overflow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322239](https://bugs.openjdk.org/browse/JDK-8322239): [macos] a11y : java.lang.NullPointerException is thrown when focus is moved on the JTabbedPane (**Bug** - P3)


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) ⚠️ Review applies to [dfab2416](https://git.openjdk.org/jdk/pull/17736/files/dfab2416a65e279ca40cbcb829c25d02eb282e6b)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [dfab2416](https://git.openjdk.org/jdk/pull/17736/files/dfab2416a65e279ca40cbcb829c25d02eb282e6b)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17736/head:pull/17736` \
`$ git checkout pull/17736`

Update a local copy of the PR: \
`$ git checkout pull/17736` \
`$ git pull https://git.openjdk.org/jdk.git pull/17736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17736`

View PR using the GUI difftool: \
`$ git pr show -t 17736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17736.diff">https://git.openjdk.org/jdk/pull/17736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17736#issuecomment-1930684079)