### PR TITLE
8325347: Rename native_thread.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab001/getjniftab001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetJNIFunctionTable/getjniftab001/getjniftab001.cpp
@@ -30,7 +30,7 @@
 #include "agent_common.h"
 
 #include "JVMTITools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass028/redefclass028.cpp
@@ -29,7 +29,7 @@
 #include "agent_common.h"
 
 #include "nsk_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass029/redefclass029.cpp
@@ -29,7 +29,7 @@
 #include "agent_common.h"
 
 #include "nsk_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses/redefclass030/redefclass030.cpp
@@ -29,7 +29,7 @@
 #include "agent_common.h"
 
 #include "nsk_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/setjniftab001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetJNIFunctionTable/setjniftab001/setjniftab001.cpp
@@ -30,7 +30,7 @@
 #include "agent_common.h"
 
 #include "JVMTITools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/hotswap/HS201/hs201t003/hs201t003.cpp
@@ -28,7 +28,7 @@
 #include "agent_common.h"
 
 #include "nsk_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/ji05t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI05/ji05t001/ji05t001.cpp
@@ -32,7 +32,7 @@
 #include "nsk_tools.h"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/jni_interception/JI06/ji06t001/ji06t001.cpp
@@ -32,7 +32,7 @@
 #include "nsk_tools.h"
 #include "JVMTITools.h"
 #include "jvmti_tools.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/agent_tools.cpp
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "native_thread.h"
+#include "native_thread.hpp"
 #include "jni_tools.h"
 #include "jvmti_tools.h"
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
@@ -1,4 +1,4 @@
-Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -36,8 +36,8 @@ Also this directory provides support for running native threads
 in a platform independent manner.
 
     Source files:
-        native_thread.h
-        native_thread.c
+        native_thread.hpp
+        native_thread.cpp
 
     Naming conventions:
         functions: THREAD_*
@@ -100,7 +100,7 @@ use special macroses defined in share/jni and share/jvmti frameworks.
 
 ---------------------------------------------------------------------------------
 
-native_thread.h
+native_thread.hpp
 
 Provides platform-independent support for running native threads:
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.cpp
@@ -25,7 +25,7 @@
 #include <stdio.h>
 
 /* testbase_nsk threads: */
-#include <native_thread.h>
+#include <native_thread.hpp>
 
 /***************************************************************/
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-#ifndef NSK_SHARE_NATIVE_NATIVE_THREAD_H
-#define NSK_SHARE_NATIVE_NATIVE_THREAD_H
+#ifndef NSK_SHARE_NATIVE_NATIVE_THREAD_HPP
+#define NSK_SHARE_NATIVE_NATIVE_THREAD_HPP
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.hpp
@@ -33,38 +33,38 @@ extern "C" {
 typedef int(*PROCEDURE)(void*);
 
 /**
- * Return a thread mirror, or NULL if failed.
+ * Return a thread mirror, or null if failed.
  */
 void* THREAD_new(PROCEDURE procedure, void* context);
 
 /**
- * Return the thread if started OK, or NULL if failed.
+ * Return the thread if started OK, or null if failed.
  */
 void* THREAD_start(void* thread);
 
 /**
  * Return 1 if the thread has been started, or 0 if not,
- * or -1 if thread==NULL.
+ * or -1 if thread==nullptr.
  */
 int THREAD_isStarted(void* thread);
 
 /**
  * Return 1 if the thread has been started and already has finished,
  * or 0 if the thread hasn't finish (or even hasn't been started),
- * or -1 if thread==NULL.
+ * or -1 if thread==nullptr.
  */
 int THREAD_hasFinished(void* thread);
 
 /**
  * Return thread->status if thread has finished,
  * or return 0 if thread hasn't finished,
- * or retuen -1 if thread==NULL.
+ * or retuen -1 if thread==nullptr.
  */
 int THREAD_status(void* thread);
 
 /**
  * Cycle with 1 second sleeps until the thread has finished;
- * or return immediately, if thread==NULL.
+ * or return immediately, if thread==nullptr.
  */
 void THREAD_waitFor(void* thread);
 

--- a/test/hotspot/jtreg/vmTestbase/vm/share/ProcessUtils.cpp
+++ b/test/hotspot/jtreg/vmTestbase/vm/share/ProcessUtils.cpp
@@ -21,7 +21,7 @@
  * questions.
  */
 #include "jni.h"
-#include "native_thread.h"
+#include "native_thread.hpp"
 #ifdef _WIN32
 #include <windows.h>
 #include <process.h>


### PR DESCRIPTION
Please review this trivial change that renames the file
test/hotspot/jtreg/vmTestbase/nsk/share/native/native_thread.h
to native_thread.hpp. and replaces uses of NULL in that file.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325347](https://bugs.openjdk.org/browse/JDK-8325347): Rename native_thread.h (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17737/head:pull/17737` \
`$ git checkout pull/17737`

Update a local copy of the PR: \
`$ git checkout pull/17737` \
`$ git pull https://git.openjdk.org/jdk.git pull/17737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17737`

View PR using the GUI difftool: \
`$ git pr show -t 17737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17737.diff">https://git.openjdk.org/jdk/pull/17737.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17737#issuecomment-1930840251)