### PR TITLE
8325038: runtime/cds/appcds/ProhibitedPackage.java can fail with UseLargePages

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ProhibitedPackage.java
@@ -54,7 +54,7 @@ public class ProhibitedPackage {
             // will be ignored during dumping.
             TestCommon.dump(appJar,  classlist, "-Xlog:cds")
                 .shouldContain("Dumping")
-                .shouldContain("[cds] Prohibited package for non-bootstrap classes: java/lang/Prohibited.class")
+                .shouldContain("Prohibited package for non-bootstrap classes: java/lang/Prohibited.class")
                 .shouldHaveExitValue(0);
         }
 


### PR DESCRIPTION
A simple test fix by not checking the `[cds]` tag in the output because the tag may have spaces if there's other log output message with longer log tag before it.

Tested manually with `-XX:+UseLargePages`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325038](https://bugs.openjdk.org/browse/JDK-8325038): runtime/cds/appcds/ProhibitedPackage.java can fail with UseLargePages (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17738/head:pull/17738` \
`$ git checkout pull/17738`

Update a local copy of the PR: \
`$ git checkout pull/17738` \
`$ git pull https://git.openjdk.org/jdk.git pull/17738/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17738`

View PR using the GUI difftool: \
`$ git pr show -t 17738`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17738.diff">https://git.openjdk.org/jdk/pull/17738.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17738#issuecomment-1930882313)