### PR TITLE
8325302: Files.move(REPLACE_EXISTING) throws NoSuchFileException on deleted target

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -930,12 +930,14 @@ abstract class UnixFileSystem
             } catch (UnixException x) {
                 // target is non-empty directory that can't be replaced.
                 if (targetAttrs.isDirectory() &&
-                   (x.errno() == EEXIST || x.errno() == ENOTEMPTY))
-                {
+                    (x.errno() == EEXIST || x.errno() == ENOTEMPTY)) {
                     throw new DirectoryNotEmptyException(
                         target.getPathForExceptionMessage());
                 }
-                x.rethrowAsIOException(target);
+                // ignore file not found otherwise rethrow
+                if (x.errno() != ENOENT) {
+                    x.rethrowAsIOException(target);
+                }
             }
         }
 
@@ -1061,12 +1063,14 @@ abstract class UnixFileSystem
             } catch (UnixException x) {
                 // target is non-empty directory that can't be replaced.
                 if (targetAttrs.isDirectory() &&
-                   (x.errno() == EEXIST || x.errno() == ENOTEMPTY))
-                {
+                    (x.errno() == EEXIST || x.errno() == ENOTEMPTY)) {
                     throw new DirectoryNotEmptyException(
                         target.getPathForExceptionMessage());
                 }
-                x.rethrowAsIOException(target);
+                // ignore file not found otherwise rethrow
+                if (x.errno() != ENOENT) {
+                    x.rethrowAsIOException(target);
+                }
             }
         }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,11 @@ class WindowsFileCopy {
                             target.getPathForExceptionMessage());
                     }
                 }
-                x.rethrowAsIOException(target);
+                // ignore file not found otherwise rethrow
+                if (x.lastError() != ERROR_FILE_NOT_FOUND &&
+                    x.lastError() != ERROR_PATH_NOT_FOUND) {
+                    x.rethrowAsIOException(target);
+                }
             }
         }
 
@@ -400,7 +404,11 @@ class WindowsFileCopy {
                             target.getPathForExceptionMessage());
                     }
                 }
-                x.rethrowAsIOException(target);
+                // ignore file not found otherwise rethrow
+                if (x.lastError() != ERROR_FILE_NOT_FOUND &&
+                    x.lastError() != ERROR_PATH_NOT_FOUND) {
+                    x.rethrowAsIOException(target);
+                }
             }
         }
 


### PR DESCRIPTION
When replacing an existing file as part of a non-atomic copy (`Files.copy`) or move (`Files.move`), ignore any file not found error encountered while trying to delete the target file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325302](https://bugs.openjdk.org/browse/JDK-8325302): Files.move(REPLACE_EXISTING) throws NoSuchFileException on deleted target (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17740/head:pull/17740` \
`$ git checkout pull/17740`

Update a local copy of the PR: \
`$ git checkout pull/17740` \
`$ git pull https://git.openjdk.org/jdk.git pull/17740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17740`

View PR using the GUI difftool: \
`$ git pr show -t 17740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17740.diff">https://git.openjdk.org/jdk/pull/17740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17740#issuecomment-1931024257)