### PR TITLE
JDK-8325432: enhance assert message "relocation addr must be in this section"

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,7 +209,7 @@ class CodeSection {
   }
   void    set_locs_point(address pc) {
     assert(pc >= locs_point(), "relocation addr may not decrease");
-    assert(allocates2(pc),     "relocation addr must be in this section");
+    assert(allocates2(pc),     "relocation addr " INTPTR_FORMAT " must be in this section from " INTPTR_FORMAT " to " INTPTR_FORMAT, p2i(pc), p2i(_start), p2i(_limit));
     _locs_point = pc;
   }
 


### PR DESCRIPTION
The assert message "relocation addr must be in this section" in codeBuffer.hpp could be enhanced by printing the pointer and section information.
See also
https://bugs.openjdk.org/browse/JDK-8325326
8325326: compiler/codecache/TestStressCodeBuffers.java assertion on AIX

where we run into the assertion since 2 days.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325432](https://bugs.openjdk.org/browse/JDK-8325432): enhance assert message "relocation addr must be in this section" (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17749/head:pull/17749` \
`$ git checkout pull/17749`

Update a local copy of the PR: \
`$ git checkout pull/17749` \
`$ git pull https://git.openjdk.org/jdk.git pull/17749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17749`

View PR using the GUI difftool: \
`$ git pr show -t 17749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17749.diff">https://git.openjdk.org/jdk/pull/17749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17749#issuecomment-1932135455)