### PR TITLE
8325436: G1: Remove unused G1RegionMarkStats::is_clear

### DIFF
--- a/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
+++ b/src/hotspot/share/gc/g1/g1RegionMarkStatsCache.hpp
@@ -48,8 +48,6 @@ struct G1RegionMarkStats {
   // are updated by the atomic mark. We do not remark objects after overflow.
   void clear_during_overflow() {
   }
-
-  bool is_clear() const { return _live_words == 0; }
 };
 
 // Per-marking thread cache for the region mark statistics.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325436](https://bugs.openjdk.org/browse/JDK-8325436): G1: Remove unused G1RegionMarkStats::is_clear (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17751/head:pull/17751` \
`$ git checkout pull/17751`

Update a local copy of the PR: \
`$ git checkout pull/17751` \
`$ git pull https://git.openjdk.org/jdk.git pull/17751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17751`

View PR using the GUI difftool: \
`$ git pr show -t 17751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17751.diff">https://git.openjdk.org/jdk/pull/17751.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17751#issuecomment-1932273231)