### PR TITLE
8325437: Safepoint polling in monitor deflation can cause massive logs

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1932,11 +1932,10 @@ void ObjectSynchronizer::chk_in_use_list(outputStream* out, int *error_cnt_p) {
 void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
                                           int* error_cnt_p) {
   if (n->owner_is_DEFLATER_MARKER()) {
-    // This should not happen, but if it does, it is not fatal.
-    out->print_cr("WARNING: monitor=" INTPTR_FORMAT ": in-use monitor is "
-                  "deflated.", p2i(n));
+    // This could happen when monitor deflation blocks for a safepoint.
     return;
   }
+
   if (n->header().value() == 0) {
     out->print_cr("ERROR: monitor=" INTPTR_FORMAT ": in-use monitor must "
                   "have non-null _header field.", p2i(n));


### PR DESCRIPTION
If `-Xlog:monitorinflation=debug` is used and `ObjectSynchronizer::chk_in_use_entry` is called while monitor deflation is safepoint polled/blocked, we have deflated monitors in the in-use list and we get a huge number of lines stating:
```
[10.570s][debug][monitorinflation] WARNING: monitor=0x00007fa1004f8480: in-use monitor is deflated.
````

This comes from the following code:
```
void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
                                          int* error_cnt_p) {
  if (n->owner_is_DEFLATER_MARKER()) {
    // This should not happen, but if it does, it is not fatal.
    out->print_cr("WARNING: monitor=" INTPTR_FORMAT ": in-use monitor is "
                  "deflated.", p2i(n));
    return;
  }
```

There are tentative plans to rewrite the monitor deflation to unlink deflated monitors from the in-use list *before* the safepoint polls, but I'd like to suggest that we make an interim patch that turns off this warning.