### PR TITLE
8325444: GHA: JDK-8325194 causes a regression

### DIFF
--- a/.github/actions/get-jtreg/action.yml
+++ b/.github/actions/get-jtreg/action.yml
@@ -56,8 +56,14 @@ runs:
 
     - name: 'Build JTReg'
       run: |
+        # If runner architecture is x64 set JAVA_HOME_17_X64 otherwise set to JAVA_HOME_17_arm64
+        if [[ '${{ runner.arch }}' == 'X64' ]]; then
+          JDK="$JAVA_HOME_17_X64"
+        else
+          JDK="$JAVA_HOME_17_arm64"
+        fi
         # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$(realpath bootjdk/jdk)"
+        bash make/build.sh --jdk "$JDK"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src


### PR DESCRIPTION
The [change](https://github.com/openjdk/jdk/commit/d1c82156ba6ede4b798ac15f935289cfcc99d1a0) for [JDK-8325194](https://bugs.openjdk.org/browse/JDK-8325194) broke get-jtreg because the way to determine the build jdk was not correct.

I then tried to use the bootstrap JDK with the correct wiring but it turned out that the build of JTReg fails with the current JDK, see [here](https://github.com/RealCLanger/jdk/actions/runs/7820130826/job/21334120478).

So I propose to fix it by going to the originally proposed solution using `$JAVA_HOME_17_<arch>`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325444](https://bugs.openjdk.org/browse/JDK-8325444): GHA: JDK-8325194 causes a regression (**Bug** - P3)


### Reviewers
 * [George Adams](https://openjdk.org/census#gdams) (@gdams - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17756/head:pull/17756` \
`$ git checkout pull/17756`

Update a local copy of the PR: \
`$ git checkout pull/17756` \
`$ git pull https://git.openjdk.org/jdk.git pull/17756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17756`

View PR using the GUI difftool: \
`$ git pr show -t 17756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17756.diff">https://git.openjdk.org/jdk/pull/17756.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17756#issuecomment-1932768904)