### PR TITLE
8325367: Rename nsk_list.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM04/em04t001/em04t001.cpp
@@ -28,7 +28,7 @@
 #include "jni_tools.h"
 #include "jvmti_tools.h"
 #include "JVMTITools.h"
-#include "nsk_list.h"
+#include "nsk_list.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/events/EM07/em07t002/em07t002.cpp
@@ -28,7 +28,7 @@
 #include "jni_tools.h"
 #include "jvmti_tools.h"
 #include "JVMTITools.h"
-#include "nsk_list.h"
+#include "nsk_list.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/README
@@ -46,8 +46,8 @@ The following source files declares a set of functions which
 provides support for lists of various objects
 
     Source files:
-        nsk_list.h
-        nsk_list.c
+        nsk_list.hpp
+        nsk_list.cpp
 
     Naming conventions:
         functions: nsk_list_*
@@ -119,7 +119,7 @@ Provides platform-independent support for running native threads:
 
 ---------------------------------------------------------------------------------
 
-nsk_list.h
+nsk_list.hpp
 
 Provides support for lists of various objects:
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.cpp
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "nsk_list.h"
+#include "nsk_list.hpp"
 #include "nsk_tools.h"
 
 extern "C" {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this trivial change that renames the file
test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_list.h to nsk_list.hpp.

Testing: mach5 tier1
Note that build would fail if #include updates were incorrect or incomplete.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325367](https://bugs.openjdk.org/browse/JDK-8325367): Rename nsk_list.h (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17758/head:pull/17758` \
`$ git checkout pull/17758`

Update a local copy of the PR: \
`$ git checkout pull/17758` \
`$ git pull https://git.openjdk.org/jdk.git pull/17758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17758`

View PR using the GUI difftool: \
`$ git pr show -t 17758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17758.diff">https://git.openjdk.org/jdk/pull/17758.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17758#issuecomment-1932863889)