### PR TITLE
8325456: Rename nsk_mutex.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <stdlib.h>
-#include "nsk_mutex.h"
+#include "nsk_mutex.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,8 +21,8 @@
  * questions.
  */
 
-#ifndef NSK_MUTEX_H
-#define NSK_MUTEX_H
+#ifndef NSK_MUTEX_HPP
+#define NSK_MUTEX_HPP
 
 extern "C" {
 


### PR DESCRIPTION
Please review this trivial change that renames the file
test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_mutex.h to nsk_mutex.hpp.

Testing: mach5 tier1

The usage is odd.  The header is only included by the associated .cpp file.
That .cpp file is included by only one other file, and that file is compiled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325456](https://bugs.openjdk.org/browse/JDK-8325456): Rename nsk_mutex.h (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17762/head:pull/17762` \
`$ git checkout pull/17762`

Update a local copy of the PR: \
`$ git checkout pull/17762` \
`$ git pull https://git.openjdk.org/jdk.git pull/17762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17762`

View PR using the GUI difftool: \
`$ git pr show -t 17762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17762.diff">https://git.openjdk.org/jdk/pull/17762.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17762#issuecomment-1933378339)