### PR TITLE
8316460: 4 javax/management tests ignore VM flags

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -75,4 +75,6 @@ java/lang/SecurityManager/modules/CustomSecurityManagerTest.java 0000000 generic
 java/util/PluggableLocale/PermissionTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
+javax/management/ImplementationVersion/ImplVersionTest.java 0000000 generic-all
 javax/management/remote/mandatory/subjectDelegation/SubjectDelegation1Test.java 0000000 generic-all
+javax/management/remote/mandatory/version/ImplVersionTest.java 0000000 generic-all

--- a/test/jdk/javax/management/ImplementationVersion/ImplVersionTest.java
+++ b/test/jdk/javax/management/ImplementationVersion/ImplVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,70 +30,48 @@
  * system property.
  * @author Luis-Miguel Alventosa
  *
- * @run clean ImplVersionTest ImplVersionCommand
+ * @library /test/lib
  * @run build ImplVersionTest ImplVersionCommand ImplVersionReader
  * @run main ImplVersionTest
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 
 public class ImplVersionTest {
 
-    public static void main(String[] args) {
-        try {
-            // Get OS name
-            //
-            String osName = System.getProperty("os.name");
-            System.out.println("osName = " + osName);
-            if ("Windows 98".equals(osName)) {
-                // Disable this test on Win98 due to parsing
-                // errors (bad handling of white spaces) when
-                // J2SE is installed under "Program Files".
-                //
-                System.out.println("This test is disabled on Windows 98.");
-                System.out.println("Bye! Bye!");
-                return;
-            }
-            // Get Java Home
-            //
-            String javaHome = System.getProperty("java.home");
-            System.out.println("javaHome = " + javaHome);
-            // Get test src
-            //
-            String testSrc = System.getProperty("test.src");
-            System.out.println("testSrc = " + testSrc);
-            // Get test classes
-            //
-            String testClasses = System.getProperty("test.classes");
-            System.out.println("testClasses = " + testClasses);
-            // Get boot class path
-            //
-            String command =
-                javaHome + File.separator + "bin" + File.separator + "java " +
-                " -classpath " + testClasses +
-                " -Djava.security.manager -Djava.security.policy==" + testSrc +
-                File.separator + "policy -Dtest.classes=" + testClasses +
-                " ImplVersionCommand " +
-                System.getProperty("java.runtime.version");
-            System.out.println("ImplVersionCommand Exec Command = " +command);
-            Process proc = Runtime.getRuntime().exec(command);
-            new ImplVersionReader(proc, proc.getInputStream()).start();
-            new ImplVersionReader(proc, proc.getErrorStream()).start();
-            int exitValue = proc.waitFor();
-            System.out.println("ImplVersionCommand Exit Value = " +
-                               exitValue);
-            if (exitValue != 0) {
-                System.out.println("TEST FAILED: Incorrect exit value " +
-                                   "from ImplVersionCommand");
-                System.exit(exitValue);
-            }
-            // Test OK!
-            //
-            System.out.println("Bye! Bye!");
-        } catch (Exception e) {
-            System.out.println("Unexpected exception caught = " + e);
-            e.printStackTrace();
-            System.exit(1);
+    public static void main(String[] args) throws Exception {
+        // Get test src
+        //
+        String testSrc = System.getProperty("test.src");
+        System.out.println("testSrc = " + testSrc);
+        // Get test classes
+        //
+        String testClasses = System.getProperty("test.classes");
+        System.out.println("testClasses = " + testClasses);
+        // Get boot class path
+        //
+        String[] command = new String[] {
+            "-Djava.security.manager",
+            "-Djava.security.policy==" + testSrc + File.separator + "policy",
+            "-Dtest.classes=" + testClasses,
+            "ImplVersionCommand",
+            System.getProperty("java.runtime.version")
+        };
+
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
+        Process proc = pb.start();
+        new ImplVersionReader(proc, proc.getInputStream()).start();
+        new ImplVersionReader(proc, proc.getErrorStream()).start();
+        int exitValue = proc.waitFor();
+        System.out.println("ImplVersionCommand Exit Value = " + exitValue);
+        if (exitValue != 0) {
+            throw new RuntimeException("TEST FAILED: Incorrect exit value " +
+                                       "from ImplVersionCommand " + exitValue);
         }
+        // Test OK!
+        //
+        System.out.println("Bye! Bye!");
     }
 }

--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -262,11 +262,9 @@ public class DefaultAgentFilterTest {
       * test other usages (Attributes, Query)
       */
     private static void testDefaultAgent(String propertyFile, String additionalArgument, int port, boolean testOperations) throws Exception {
-        List<String> pbArgs = new ArrayList<>(Arrays.asList(
-                "-cp",
-                System.getProperty("test.class.path"),
-                "-XX:+UsePerfData"
-        ));
+        List<String> pbArgs = new ArrayList<>();
+        pbArgs.add("-XX:+UsePerfData");
+
         // JMX config arguments, using propertyFile if non-null:
         pbArgs.add("-Dcom.sun.management.jmxremote.port=" + port);
         pbArgs.add("-Dcom.sun.management.jmxremote.authenticate=false");
@@ -280,7 +278,7 @@ public class DefaultAgentFilterTest {
         }
         pbArgs.add(TEST_APP_NAME);
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 pbArgs.toArray(new String[pbArgs.size()])
         );
 

--- a/test/jdk/javax/management/remote/mandatory/version/ImplVersionTest.java
+++ b/test/jdk/javax/management/remote/mandatory/version/ImplVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,69 +30,48 @@
  * system property.
  * @author Luis-Miguel Alventosa, Joel Feraud
  *
- * @run clean ImplVersionTest ImplVersionCommand
+ * @library /test/lib
  * @run build ImplVersionTest ImplVersionCommand ImplVersionReader
  * @run main ImplVersionTest
  */
+
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 
 public class ImplVersionTest {
 
-    public static void main(String[] args) {
-        try {
-            // Get OS name
-            //
-            String osName = System.getProperty("os.name");
-            System.out.println("osName = " + osName);
-            if ("Windows 98".equals(osName)) {
-                // Disable this test on Win98 due to parsing
-                // errors (bad handling of white spaces) when
-                // J2SE is installed under "Program Files".
-                //
-                System.out.println("This test is disabled on Windows 98.");
-                System.out.println("Bye! Bye!");
-                return;
-            }
+    public static void main(String[] args) throws Exception {
 
-            // Get Java Home
-            String javaHome = System.getProperty("java.home");
+        // Get test src
+        //
+        String testSrc = System.getProperty("test.src");
 
-            // Get test src
-            //
-            String testSrc = System.getProperty("test.src");
+        // Get test classes
+        String testClasses = System.getProperty("test.classes");
 
-            // Get test classes
-            String testClasses = System.getProperty("test.classes");
+        // Build command string
 
-            // Build command string
-            String command =
-                javaHome + File.separator + "bin" + File.separator + "java " +
-                " -classpath " + testClasses +
-                " -Djava.security.manager -Djava.security.policy==" + testSrc +
-                File.separator + "policy -Dtest.classes=" + testClasses +
-                " ImplVersionCommand " + System.getProperty("java.runtime.version");
-            System.out.println("ImplVersionCommand Exec Command = " + command);
+        String[] command = new String[] {
+            "-Djava.security.manager",
+            "-Djava.security.policy==" + testSrc + File.separator + "policy",
+            "-Dtest.classes=" + testClasses,
+            "ImplVersionCommand",
+            System.getProperty("java.runtime.version")
+        };
 
-            // Exec command
-            Process proc = Runtime.getRuntime().exec(command);
-            new ImplVersionReader(proc, proc.getInputStream()).start();
-            new ImplVersionReader(proc, proc.getErrorStream()).start();
-            int exitValue = proc.waitFor();
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(command);
+        Process proc = pb.start();
+        new ImplVersionReader(proc, proc.getInputStream()).start();
+        new ImplVersionReader(proc, proc.getErrorStream()).start();
+        int exitValue = proc.waitFor();
 
-            System.out.println("ImplVersionCommand Exit Value = " +
-                               exitValue);
-            if (exitValue != 0) {
-                System.out.println("TEST FAILED: Incorrect exit value " +
-                                   "from ImplVersionCommand");
-                System.exit(exitValue);
-            }
-            // Test OK!
-            System.out.println("Bye! Bye!");
-        } catch (Exception e) {
-            System.out.println("Unexpected exception caught = " + e);
-            e.printStackTrace();
-            System.exit(1);
+        System.out.println("ImplVersionCommand Exit Value = " + exitValue);
+        if (exitValue != 0) {
+            throw new RuntimeException("TEST FAILED: Incorrect exit value " +
+                                       "from ImplVersionCommand " + exitValue);
         }
+        // Test OK!
+        System.out.println("Bye! Bye!");
     }
 }

--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -468,10 +468,6 @@ public class HashedPasswordFileTest {
         perms.add(PosixFilePermission.OWNER_READ);
         perms.add(PosixFilePermission.OWNER_WRITE);
         Files.setPosixFilePermissions(file.toPath(), perms);
-
-        pbArgs.add("-cp");
-        pbArgs.add(System.getProperty("test.class.path"));
-
         pbArgs.add("-Dcom.sun.management.jmxremote.port=0");
         pbArgs.add("-Dcom.sun.management.jmxremote.authenticate=true");
         pbArgs.add("-Dcom.sun.management.jmxremote.password.file=" + file.getAbsolutePath());
@@ -481,7 +477,7 @@ public class HashedPasswordFileTest {
         pbArgs.add("jdk.management.agent/jdk.internal.agent=ALL-UNNAMED");
         pbArgs.add(TestApp.class.getSimpleName());
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                 pbArgs.toArray(new String[0]));
         Process process = ProcessTools.startProcess(
                 TestApp.class.getSimpleName(),


### PR DESCRIPTION
The tests 
javax/management/ImplementationVersion/ImplVersionTest.java
javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
javax/management/remote/mandatory/version/ImplVersionTest.java
javax/management/security/HashedPasswordFileTest.java
were updated to use
ProcessTools.createTestJavaProcessBuilder(...)

Tested by running tests with different jvm flags and tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316460](https://bugs.openjdk.org/browse/JDK-8316460): 4 javax/management tests ignore VM flags (**Sub-task** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17764/head:pull/17764` \
`$ git checkout pull/17764`

Update a local copy of the PR: \
`$ git checkout pull/17764` \
`$ git pull https://git.openjdk.org/jdk.git pull/17764/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17764`

View PR using the GUI difftool: \
`$ git pr show -t 17764`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17764.diff">https://git.openjdk.org/jdk/pull/17764.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17764#issuecomment-1933399015)