### PR TITLE
8325464: GCCause.java out of sync with gcCause.hpp

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
@@ -57,17 +57,17 @@ public enum GCCause {
 
   _dcmd_gc_run ("Diagnostic Command"),
 
+  _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
+  _shenandoah_stop_vm ("Stopping VM"),
+  _shenandoah_concurrent_gc ("Concurrent GC"),
+  _shenandoah_upgrade_to_full_gc ("Upgrade To Full GC"),
+
   _z_timer ("Timer"),
   _z_warmup ("Warmup"),
   _z_allocation_rate ("Allocation Rate"),
   _z_allocation_stall ("Allocation Stall"),
   _z_proactive ("Proactive"),
   _z_high_usage ("High Usage"),
-
-  _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
-  _shenandoah_stop_vm ("Stopping VM"),
-  _shenandoah_concurrent_gc ("Concurrent GC"),
-  _shenandoah_upgrade_to_full_gc ("Upgrade To Full GC"),
 
   _last_gc_cause ("ILLEGAL VALUE - last gc cause - ILLEGAL VALUE");
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,21 +37,23 @@ public enum GCCause {
   _heap_dump ("Heap Dump Initiated GC"),
   _wb_young_gc ("WhiteBox Initiated Young GC"),
   _wb_full_gc ("WhiteBox Initiated Full GC"),
+  _wb_breakpoint ("WhiteBox Initiated Run to Breakpoint"),
 
   _no_gc ("No GC"),
   _no_cause_specified ("Unknown GCCause"),
   _allocation_failure ("Allocation Failure"),
 
-  _tenured_generation_full ("Tenured Generation Full"),
+  _codecache_GC_threshold ("CodeCache GC Threshold"),
+  _codecache_GC_aggressive ("CodeCache GC Aggressive"),
   _metadata_GC_threshold ("Metadata GC Threshold"),
   _metadata_GC_clear_soft_refs ("Metadata GC Clear Soft References"),
 
-  _old_generation_expanded_on_last_scavenge ("Old Generation Expanded On Last Scavenge"),
-  _old_generation_too_full_to_scavenge ("Old Generation Too Full To Scavenge"),
   _adaptive_size_policy ("Ergonomics"),
 
   _g1_inc_collection_pause ("G1 Evacuation Pause"),
+  _g1_compaction_pause ("G1 Compaction Pause"),
   _g1_humongous_allocation ("G1 Humongous Allocation"),
+  _g1_periodic_collection ("G1 Periodic Collection"),
 
   _dcmd_gc_run ("Diagnostic Command"),
 
@@ -60,11 +62,11 @@ public enum GCCause {
   _z_allocation_rate ("Allocation Rate"),
   _z_allocation_stall ("Allocation Stall"),
   _z_proactive ("Proactive"),
+  _z_high_usage ("High Usage"),
 
   _shenandoah_allocation_failure_evac ("Allocation Failure During Evacuation"),
   _shenandoah_stop_vm ("Stopping VM"),
   _shenandoah_concurrent_gc ("Concurrent GC"),
-  _shenandoah_traversal_gc ("Traversal GC"),
   _shenandoah_upgrade_to_full_gc ("Upgrade To Full GC"),
 
   _last_gc_cause ("ILLEGAL VALUE - last gc cause - ILLEGAL VALUE");


### PR DESCRIPTION
These two files (`GCCause.java` and `gcCause.hpp`) should be in sync by design, see comments in these two files. However, some recent changes (e.g. [JDK-8240239](https://bugs.openjdk.org/browse/JDK-8240239)) to `gcCause.hpp` were not simultaneously reflected in `GCCause.java`. This patch updates `GCCause.java` to keep sync with latest `gcCause.hpp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325464](https://bugs.openjdk.org/browse/JDK-8325464): GCCause.java out of sync with gcCause.hpp (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17766/head:pull/17766` \
`$ git checkout pull/17766`

Update a local copy of the PR: \
`$ git checkout pull/17766` \
`$ git pull https://git.openjdk.org/jdk.git pull/17766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17766`

View PR using the GUI difftool: \
`$ git pr show -t 17766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17766.diff">https://git.openjdk.org/jdk/pull/17766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17766#issuecomment-1933432138)