### PR TITLE
8325451: Missed elimination of assertion predicates

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4359,11 +4359,11 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
 }
 
 void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) {
-  for (int i = 0; i < C->template_assertion_predicate_count(); i++) {
-    Node* opaque4 = C->template_assertion_predicate_opaq_node(i);
-    assert(opaque4->Opcode() == Op_Opaque4, "must be");
-    if (!useful_predicates.member(opaque4)) { // not in the useful list
-      _igvn.replace_node(opaque4, opaque4->in(2));
+  for (int i = C->template_assertion_predicate_count(); i > 0; i--) {
+    Node* n = C->template_assertion_predicate_opaq_node(i - 1);
+    assert(n->Opcode() == Op_Opaque4, "must be");
+    if (!useful_predicates.member(n)) { // not in the useful list
+      _igvn.replace_node(n, n->in(2));
     }
   }
 }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4360,10 +4360,10 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
 
 void PhaseIdealLoop::eliminate_useless_template_assertion_predicates(Unique_Node_List& useful_predicates) {
   for (int i = C->template_assertion_predicate_count(); i > 0; i--) {
-    Node* n = C->template_assertion_predicate_opaq_node(i - 1);
-    assert(n->Opcode() == Op_Opaque4, "must be");
-    if (!useful_predicates.member(n)) { // not in the useful list
-      _igvn.replace_node(n, n->in(2));
+    Node* opaque4 = C->template_assertion_predicate_opaq_node(i - 1);
+    assert(opaque4->Opcode() == Op_Opaque4, "must be");
+    if (!useful_predicates.member(opaque4)) { // not in the useful list
+      _igvn.replace_node(opaque4, opaque4->in(2));
     }
   }
 }

--- a/test/hotspot/jtreg/compiler/predicates/TestPredicatesBasic.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestPredicatesBasic.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.predicates;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8325451
+ * @summary Test basic loop predicates
+ * @library /test/lib /
+ * @run driver compiler.predicates.TestPredicatesBasic
+ */
+public class TestPredicatesBasic {
+    public static final int size = 100;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @DontInline
+    private void blackhole(int i) {}
+
+    @DontInline
+    private int[] getArr() {
+        int[] arr = new int[size];
+        for (int i = 0; i < size; ++i) {
+            arr[i] = i;
+        }
+        return arr;
+    }
+
+    @Test
+    // Null check, loop entrance check, array upper bound check
+    @IR(counts = {IRNode.IF, "3"})
+    public void basic() {
+        int[] arr = getArr();
+        for (int i = 0; i < arr.length; ++i) {
+            blackhole(arr[i]);
+        }
+    }
+
+    @Test
+    // Null check, loop entrance check, array upper bound check
+    @IR(counts = {IRNode.IF, "4"})
+    public void basicMinus() {
+        int[] arr = getArr();
+        for (int i = 0; i < arr.length - 1; ++i) {
+            blackhole(arr[i]);
+        }
+    }
+
+    @Test
+    // Null check, loop entrance check, array lower/upper bound check
+    @IR(counts = {IRNode.IF, "4"})
+    public void basicNeg() {
+        int[] arr = getArr();
+        for (int i = arr.length - 1; i >= 0; --i) {
+            blackhole(arr[i]);
+        }
+    }
+
+    @Test
+    @Arguments({Argument.NUMBER_42})
+    // Null check, loop entrance check, array lower/upper bound check
+    @IR(counts = {IRNode.IF, "4"})
+    public void basicLimit(int limit) {
+        int[] arr = getArr();
+        for (int i = 0; i < limit; ++i) {
+            blackhole(arr[i]);
+        }
+    }
+}
+
+


### PR DESCRIPTION
For this example:

```
public void blackhole(int[] arr) {
  for (int i = 0; i < arr.length; ++i) {
    blackhole(arr[i]);
  }
}
```

We generate predicates for the lower/upper bound. The lower bound predicate gets optimized away, but the associated assertion predicate remains in the code.

The issue is that we iterate over list `C->template_assertion_predicate_opaq_node`, and we delete items from it in `_igvn.replace_node(n, n->in(2))`. I was surprised that this actually removes an item from the predicates list. Here is the trace:

```
#0  Compile::remove_template_assertion_predicate_opaq (this=0x7fffb5d5a7e0, n=0x7fff84097eb0) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/compile.hpp:776
#1  0x00007ffff5313c53 in Compile::remove_useless_node (this=0x7fffb5d5a7e0, dead=0x7fff84097eb0) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/compile.cpp:395
#2  0x00007ffff5cebb95 in PhaseIterGVN::remove_globally_dead_node (this=0x7fffb5d584e0, dead=0x7fff84097eb0) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/phaseX.cpp:1380
#3  0x00007ffff52241ce in PhaseIterGVN::remove_dead_node (this=0x7fffb5d584e0, dead=0x7fff84097eb0) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/phaseX.hpp:527
#4  0x00007ffff5cebfc7 in PhaseIterGVN::subsume_node (this=0x7fffb5d584e0, old=0x7fff84097eb0, nn=0x7fff8408fb80) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/phaseX.cpp:1429
#5  0x00007ffff50045bf in PhaseIterGVN::replace_node (this=0x7fffb5d584e0, old=0x7fff84097eb0, nn=0x7fff8408fb80) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/phaseX.hpp:539
#6  0x00007ffff5aec060 in PhaseIdealLoop::eliminate_useless_template_assertion_predicates (this=0x7fffb5d58120, useful_predicates=...) at /local/home/joshcao/pea/jdk/src/hotspot/share/opto/loopnode.cpp:4366
```

We can fix this by iterating in reverse over the linked list.

Caveat: this patch only affects the first test `TestPredicateBasic::basic()`. Adding the other tests for completeness and can potentially be improved in other work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325451](https://bugs.openjdk.org/browse/JDK-8325451): Missed elimination of assertion predicates (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [ac2b3291](https://git.openjdk.org/jdk/pull/17767/files/ac2b3291eceea887d31bf5835ed0656bec3bda4e)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17767/head:pull/17767` \
`$ git checkout pull/17767`

Update a local copy of the PR: \
`$ git checkout pull/17767` \
`$ git pull https://git.openjdk.org/jdk.git pull/17767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17767`

View PR using the GUI difftool: \
`$ git pr show -t 17767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17767.diff">https://git.openjdk.org/jdk/pull/17767.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17767#issuecomment-1933449019)