### PR TITLE
8325471: CHeapBitMap(MEMFLAGS flags) constructor misleading use of super-constructor

### DIFF
--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -635,7 +635,7 @@ class CHeapBitMap : public GrowableBitMap<CHeapBitMap> {
   NONCOPYABLE(CHeapBitMap);
 
  public:
-  explicit CHeapBitMap(MEMFLAGS flags) : GrowableBitMap(0, false), _flags(flags) {}
+  explicit CHeapBitMap(MEMFLAGS flags) : GrowableBitMap(), _flags(flags) {}
   CHeapBitMap(idx_t size_in_bits, MEMFLAGS flags, bool clear = true);
   ~CHeapBitMap();
 


### PR DESCRIPTION
The `explicit CHeapBitMap(MEMFLAGS flags)` calls the `GrowableBitMap(bm_word_t* map, idx_t size_in_bits)` super-constructor with `GrowableBitMap(0, false)`. This works because `0` gets converted to `nullptr` and `false` gets converted to `0`. However this seems to have be a miss in the most recent refactoring and is misleading.

`explicit CHeapBitMap(MEMFLAGS flags)` should use `GrowableBitMap()` directly which creates an empty (uninitialised) bitmap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325471](https://bugs.openjdk.org/browse/JDK-8325471): CHeapBitMap(MEMFLAGS flags) constructor misleading use of super-constructor (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17768/head:pull/17768` \
`$ git checkout pull/17768`

Update a local copy of the PR: \
`$ git checkout pull/17768` \
`$ git pull https://git.openjdk.org/jdk.git pull/17768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17768`

View PR using the GUI difftool: \
`$ git pr show -t 17768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17768.diff">https://git.openjdk.org/jdk/pull/17768.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17768#issuecomment-1933632097)