### PR TITLE
8314275: Incorrect stepping in switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1428,6 +1428,9 @@ public class Gen extends JCTree.Visitor {
                     code.put4(caseidx + 4, offsets[i]);
                 }
             }
+
+            // Emit line position for the end of the switch
+            code.statBegin(TreeInfo.endPos(swtch));
         }
         code.endScopes(limit);
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1429,8 +1429,10 @@ public class Gen extends JCTree.Visitor {
                 }
             }
 
-            // Emit line position for the end of the switch
-            code.statBegin(TreeInfo.endPos(swtch));
+            if (swtch instanceof JCSwitchExpression) {
+                 // Emit line position for the end of a switch expression
+                 code.statBegin(TreeInfo.endPos(swtch));
+            }
         }
         code.endScopes(limit);
     }

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8314275.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8314275.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8314275
+ * @summary Tests a line number table attribute for switch expression
+ * @library /tools/lib /tools/javac/lib ../lib
+ * @enablePreview
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          java.base/jdk.internal.classfile.impl
+ * @build toolbox.ToolBox InMemoryFileManager TestBase
+ * @build LineNumberTestBase TestCase
+ * @run main T8314275
+ */
+import java.util.List;
+public class T8314275 extends LineNumberTestBase {
+    public static void main(String[] args) throws Exception {
+        new T8314275().test();
+    }
+
+    public void test() throws Exception {
+        test(List.of(TEST_CASE));
+    }
+
+    private static final TestCase[] TEST_CASE = new TestCase[] {
+        new TestCase("""
+                 public class T8314275 {                               // 1
+                     private static double multiply(Integer i) {       // 2
+                          double cr = 15;                              // 3
+                          cr = switch (i) {                            // 4
+                              case 1 -> cr * 1;                        // 5
+                              case 2 -> cr * 2;                        // 6
+                              default -> cr * 4;                       // 7
+                          };                                           // 8
+                          return cr;                                   // 9
+                      }                                                // 10
+                 }                                                     // 11
+                 """,
+                List.of(1, 3, 4, 5, 6, 7, 8, 9),
+                "T8314275")
+    };
+}

--- a/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8314275.java
+++ b/test/langtools/tools/javac/classfiles/attributes/LineNumberTable/T8314275.java
@@ -46,19 +46,34 @@ public class T8314275 extends LineNumberTestBase {
 
     private static final TestCase[] TEST_CASE = new TestCase[] {
         new TestCase("""
-                 public class T8314275 {                               // 1
-                     private static double multiply(Integer i) {       // 2
-                          double cr = 15;                              // 3
-                          cr = switch (i) {                            // 4
-                              case 1 -> cr * 1;                        // 5
-                              case 2 -> cr * 2;                        // 6
-                              default -> cr * 4;                       // 7
-                          };                                           // 8
-                          return cr;                                   // 9
-                      }                                                // 10
-                 }                                                     // 11
-                 """,
-                List.of(1, 3, 4, 5, 6, 7, 8, 9),
-                "T8314275")
+             public class T8314275Expression {                     // 1
+                 private static double multiply(Integer i) {       // 2
+                      double cr = 15;                              // 3
+                      cr = switch (i) {                            // 4
+                          case 1 -> cr * 1;                        // 5
+                          case 2 -> cr * 2;                        // 6
+                          default -> cr * 4;                       // 7
+                      };                                           // 8
+                      return cr;                                   // 9
+                  }                                                //10
+             }                                                     //11
+             """,
+            List.of(1, 3, 4, 5, 6, 7, 8, 9),
+            "T8314275Expression"),
+        new TestCase("""
+             public class T8314275Statement {                      // 1
+                 private static double multiply(Integer i) {       // 2
+                      double cr = 15;                              // 3
+                      switch (i) {                                 // 4
+                          case 1: cr *= 1; break;                  // 5
+                          case 2: cr *= 2; break;                  // 6
+                          default: cr *= 4;                        // 7
+                      };                                           // 8
+                      return cr;                                   // 9
+                  }                                                //10
+             }                                                     //11
+             """,
+                List.of(1, 3, 4, 5, 6, 7, 9),
+                "T8314275Statement")
     };
 }


### PR DESCRIPTION
In code like the one below, the observable effect was that if the user debugs the following method, `multiply` called with `1`, the debugger steps from line 4 to line 6 (instead of 7) giving the impression that line 6 is going to be executed. The reason is that the `LineNumberTable` did not include an entry at the end of the `switch` mapping the statement that follows, to bytecode.

```java
1 private static double multiply(Integer i) { 
2   double cr = 15;                              
3    cr = switch (i) {                            
4        case 1 -> cr * 1;                       
5        case 2 -> cr * 2;                      
6        default -> cr * 4;                     
7    };                                           
8    return cr;                              
9 }   
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314275](https://bugs.openjdk.org/browse/JDK-8314275): Incorrect stepping in switch (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17772/head:pull/17772` \
`$ git checkout pull/17772`

Update a local copy of the PR: \
`$ git checkout pull/17772` \
`$ git pull https://git.openjdk.org/jdk.git pull/17772/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17772`

View PR using the GUI difftool: \
`$ git pr show -t 17772`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17772.diff">https://git.openjdk.org/jdk/pull/17772.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17772#issuecomment-1934252641)