### PR TITLE
8325502: JFR: The type of EventSystemProcess::pid should be long

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
- Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -808,7 +808,7 @@
   </Event>
 
   <Event name="SystemProcess" category="Operating System" label="System Process" period="endChunk">
-    <Field type="string" name="pid" label="Process Identifier" />
+    <Field type="long" name="pid" label="Process Identifier" />
     <Field type="string" name="commandLine" label="Command Line" />
   </Event>
 

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,6 @@ TRACE_REQUEST_FUNC(CPUTimeStampCounter) {
 }
 
 TRACE_REQUEST_FUNC(SystemProcess) {
-  char pid_buf[16];
   SystemProcess* processes = nullptr;
   int num_of_processes = 0;
   JfrTicks start_time = JfrTicks::now();
@@ -249,10 +248,10 @@ TRACE_REQUEST_FUNC(SystemProcess) {
     log_debug(jfr, system)( "Unable to generate requestable event SystemProcesses");
     return;
   }
-  JfrTicks end_time = JfrTicks::now();
   if (ret_val == FUNCTIONALITY_NOT_IMPLEMENTED) {
     return;
   }
+  JfrTicks end_time = JfrTicks::now();
   if (ret_val == OS_OK) {
     // feature is implemented, write real event
     while (processes != nullptr) {
@@ -267,9 +266,8 @@ TRACE_REQUEST_FUNC(SystemProcess) {
       if (info == nullptr) {
          info = "?";
       }
-      jio_snprintf(pid_buf, sizeof(pid_buf), "%d", processes->pid());
       EventSystemProcess event(UNTIMED);
-      event.set_pid(pid_buf);
+      event.set_pid(processes->pid());
       event.set_commandLine(info);
       event.set_starttime(start_time);
       event.set_endtime(end_time);

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -248,11 +248,8 @@ TRACE_REQUEST_FUNC(SystemProcess) {
     log_debug(jfr, system)( "Unable to generate requestable event SystemProcesses");
     return;
   }
-  if (ret_val == FUNCTIONALITY_NOT_IMPLEMENTED) {
-    return;
-  }
-  JfrTicks end_time = JfrTicks::now();
   if (ret_val == OS_OK) {
+    JfrTicks end_time = JfrTicks::now();
     // feature is implemented, write real event
     while (processes != nullptr) {
       SystemProcess* tmp = processes;

--- a/test/jdk/jdk/jfr/event/os/TestSystemProcess.java
+++ b/test/jdk/jdk/jfr/event/os/TestSystemProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class TestSystemProcess {
         Events.hasEvents(events);
         for (RecordedEvent event : events) {
             System.out.println("Event: " + event);
-            Events.assertField(event, "pid").notEmpty();
+            Events.assertField(event, "pid");
         }
     }
 }


### PR DESCRIPTION
Hi,

Please review this patch that changes the type of `EventSystemProcess::pid` to `long`

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325502](https://bugs.openjdk.org/browse/JDK-8325502): JFR: The type of EventSystemProcess::pid should be long (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17773/head:pull/17773` \
`$ git checkout pull/17773`

Update a local copy of the PR: \
`$ git checkout pull/17773` \
`$ git pull https://git.openjdk.org/jdk.git pull/17773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17773`

View PR using the GUI difftool: \
`$ git pr show -t 17773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17773.diff">https://git.openjdk.org/jdk/pull/17773.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17773#issuecomment-1934281139)