### PR TITLE
8325503: Add GC specific prefix for CheckForUnmarked related classes

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -72,7 +72,7 @@ void CardTableRS::maintain_old_to_young_invariant(TenuredGeneration* old_gen,
   }
 }
 
-class CheckForUnmarkedOops : public BasicOopIterateClosure {
+class SerialCheckForUnmarkedOops : public BasicOopIterateClosure {
   DefNewGeneration* _young_gen;
   CardTableRS* _card_table;
   HeapWord*    _unmarked_addr;
@@ -89,7 +89,7 @@ class CheckForUnmarkedOops : public BasicOopIterateClosure {
   }
 
  public:
-  CheckForUnmarkedOops(DefNewGeneration* young_gen, CardTableRS* card_table) :
+  SerialCheckForUnmarkedOops(DefNewGeneration* young_gen, CardTableRS* card_table) :
     _young_gen(young_gen),
     _card_table(card_table),
     _unmarked_addr(nullptr) {}
@@ -115,7 +115,7 @@ void CardTableRS::verify() {
     }
 
     void do_object(oop obj) override {
-      CheckForUnmarkedOops object_check(_young_gen, _card_table);
+      SerialCheckForUnmarkedOops object_check(_young_gen, _card_table);
       obj->oop_iterate(&object_check);
       // If this obj is imprecisely-marked, the card for obj-start must be dirty.
       if (object_check.has_unmarked_oop()) {


### PR DESCRIPTION
Add prefix some generic class names used for young-gc card verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325503](https://bugs.openjdk.org/browse/JDK-8325503): Add GC specific prefix for CheckForUnmarked related classes (**Bug** - P2)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17774/head:pull/17774` \
`$ git checkout pull/17774`

Update a local copy of the PR: \
`$ git checkout pull/17774` \
`$ git pull https://git.openjdk.org/jdk.git pull/17774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17774`

View PR using the GUI difftool: \
`$ git pr show -t 17774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17774.diff">https://git.openjdk.org/jdk/pull/17774.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17774#issuecomment-1934456092)