### PR TITLE
8325510: Serial: Remove redundant arg in non_clean_card_iterate

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.hpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.hpp
@@ -56,7 +56,6 @@ class CardTableRS : public CardTable {
   template<typename Func>
   CardValue* find_first_clean_card(CardValue* start_card,
                                    CardValue* end_card,
-                                   CardTableRS* ct,
                                    Func& object_start);
 
 public:
@@ -89,8 +88,7 @@ public:
   // of mr. Clears the dirty cards as they are processed.
   void non_clean_card_iterate(TenuredSpace* sp,
                               MemRegion mr,
-                              OldGenScanClosure* cl,
-                              CardTableRS* ct);
+                              OldGenScanClosure* cl);
 
   bool is_in_young(const void* p) const override;
 };


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325510](https://bugs.openjdk.org/browse/JDK-8325510): Serial: Remove redundant arg in non_clean_card_iterate (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17775/head:pull/17775` \
`$ git checkout pull/17775`

Update a local copy of the PR: \
`$ git checkout pull/17775` \
`$ git pull https://git.openjdk.org/jdk.git pull/17775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17775`

View PR using the GUI difftool: \
`$ git pr show -t 17775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17775.diff">https://git.openjdk.org/jdk/pull/17775.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17775#issuecomment-1934507567)