### PR TITLE
8325203: System.exit(0) kills the launched 3rd party application

### DIFF
--- a/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
+++ b/src/jdk.jpackage/windows/native/applauncher/WinLauncher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ void launchApp() {
         }
         JOBOBJECT_EXTENDED_LIMIT_INFORMATION jobInfo = { };
         jobInfo.BasicLimitInformation.LimitFlags =
-                                          JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+                JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK;
         if (!SetInformationJobObject(jobHandle.get(),
                 JobObjectExtendedLimitInformation, &jobInfo, sizeof(jobInfo))) {
             JP_THROW(SysError(tstrings::any() <<


### PR DESCRIPTION
Tested with the use case from the CR.

The idea of the fix is to prevent grandchildren processes from being automatically attached to the job killing all processes attached to it when the job object is destroyed.

Filed a follow-up https://bugs.openjdk.org/browse/JDK-8325525 CR to track adding a jtreg test for the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325203](https://bugs.openjdk.org/browse/JDK-8325203): System.exit(0) kills the launched 3rd party application (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17779/head:pull/17779` \
`$ git checkout pull/17779`

Update a local copy of the PR: \
`$ git checkout pull/17779` \
`$ git pull https://git.openjdk.org/jdk.git pull/17779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17779`

View PR using the GUI difftool: \
`$ git pr show -t 17779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17779.diff">https://git.openjdk.org/jdk/pull/17779.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17779#issuecomment-1934927713)