### PR TITLE
8321192 : j.a.PrintJob/ImageTest/ImageTest.java: Fail or skip the test if there's no printer

### DIFF
--- a/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
+++ b/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.PrintJob;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.awt.print.PrinterJob;
+import java.io.File;
+import java.io.IOException;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 4242308 4255603
+ * @key printer
+ * @library /test/jdk/java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @summary Tests printing of images
+ * @run main/manual ImageTest
+ */
+public final class ImageTest {
+
+    private static final class ImageFrame extends Frame {
+        final Image img;
+        PrintJob pjob;
+
+        private ImageFrame() {
+            super("ImageFrame");
+            img = getToolkit().getImage("image.gif");
+        }
+
+        public void paint(Graphics g) {
+            int width = img.getWidth(this);
+            int height = img.getHeight(this);
+            if (pjob != null) {
+                System.out.println("Size " + pjob.getPageDimension());
+                Dimension dim = pjob.getPageDimension();
+                if (width > dim.width) {
+                    width = dim.width - 30; // take care of paper margin
+                }
+                if (height > dim.height) {
+                    height = dim.height - 30;
+                }
+            }
+            g.drawImage(img, 10, 75, width, height, this);
+        }
+
+        public void setPrintJob(PrintJob pj) {
+            pjob = pj;
+        }
+
+        public boolean imageUpdate(Image img, int infoflags,
+                                   int x, int y, int w, int h) {
+            if ((infoflags & ALLBITS) != 0) {
+                repaint();
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private static Frame init() {
+        ImageFrame f = new ImageFrame();
+        f.setLayout(new FlowLayout());
+        Button b = new Button("Print");
+        b.addActionListener(e -> {
+            PrintJob pj = Toolkit.getDefaultToolkit()
+                    .getPrintJob(f, "ImageTest", null);
+            if (pj != null) {
+                f.setPrintJob(pj);
+                Graphics pg = pj.getGraphics();
+                f.paint(pg);
+                pg.dispose();
+                pj.end();
+            }
+        });
+        f.add(b);
+        f.setBounds(0, 50, 700, 350);
+
+        return f;
+    }
+
+    private static void createImage() throws IOException {
+        final BufferedImage bufferedImage =
+                new BufferedImage(600, 230, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = bufferedImage.createGraphics();
+
+        g2d.setColor(new Color(0xE7E7E7));
+        g2d.fillRect(0, 0, bufferedImage.getWidth(), bufferedImage.getHeight());
+
+        g2d.setColor(Color.YELLOW);
+        g2d.fillRect(0, 6, 336, 40);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Yellow rectangle", 10, 30);
+
+        g2d.setColor(Color.CYAN);
+        g2d.fillRect(132, 85, 141, 138);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Cyan rectangle", 142, 148);
+
+        g2d.setColor(Color.MAGENTA);
+        g2d.fillRect(432, 85, 141, 138);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Magenta rectangle", 442, 148);
+
+        g2d.dispose();
+
+        ImageIO.write(bufferedImage, "gif", new File("image.gif"));
+    }
+
+    private static final String INSTRUCTIONS = """
+             Click the Print button on the Frame. Select a printer from the
+             print dialog and click 'OK'. Verify that the image displayed
+             in the Frame is correctly printed. Test printing in both Color
+             and Monochrome.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        createImage();
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .testUI(ImageTest::init)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Hi Reviewers,
Open source image test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8321192`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8321192`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17783/head:pull/17783` \
`$ git checkout pull/17783`

Update a local copy of the PR: \
`$ git checkout pull/17783` \
`$ git pull https://git.openjdk.org/jdk.git pull/17783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17783`

View PR using the GUI difftool: \
`$ git pr show -t 17783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17783.diff">https://git.openjdk.org/jdk/pull/17783.diff</a>

</details>
