### PR TITLE
8325541: C2 SuperWord: refactor filter / split

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -572,13 +572,19 @@ bool SuperWord::SLP_extract() {
 
   extend_packlist();
 
+  // Combine pairs to longer packs
   combine_packs();
 
-  filter_packs_for_alignment();
+  // Split packs if they are too long
+  split_packs_for_max_vector_size();
 
+  // Now we only remove packs:
   construct_my_pack_map();
-
-  filter_packs();
+  filter_packs_for_power_of_2_size();
+  filter_packs_for_mutual_independence();
+  filter_packs_for_alignment();
+  filter_packs_for_implemented();
+  filter_packs_for_profitable();
 
   DEBUG_ONLY(verify_packs();)
 
@@ -1134,7 +1140,7 @@ bool SuperWord::independent(Node* s1, Node* s2) {
 // is the smallest depth of all nodes from the nodes list. Once we have
 // traversed all those nodes, and have not found another node from the
 // nodes list, we know that all nodes in the nodes list are independent.
-bool SuperWord::mutually_independent(Node_List* nodes) const {
+bool SuperWord::mutually_independent(const Node_List* nodes) const {
   ResourceMark rm;
   Unique_Node_List worklist;
   VectorSet nodes_set;
@@ -1534,6 +1540,7 @@ int SuperWord::unpack_cost(int ct) { return ct; }
 //------------------------------combine_packs---------------------------
 // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
 void SuperWord::combine_packs() {
+  assert(!_packset.is_empty(), "packset not empty");
 #ifdef ASSERT
   for (int i = 0; i < _packset.length(); i++) {
     assert(_packset.at(i) != nullptr, "no nullptr in packset");
@@ -1562,81 +1569,10 @@ void SuperWord::combine_packs() {
     }
   }
 
-  // Split packs which have size greater then max vector size.
-  for (int i = 0; i < _packset.length(); i++) {
-    Node_List* p1 = _packset.at(i);
-    if (p1 != nullptr) {
-      uint max_vlen = max_vector_size_in_def_use_chain(p1->at(0)); // Max elements in vector
-      assert(is_power_of_2(max_vlen), "sanity");
-      uint psize = p1->size();
-      if (!is_power_of_2(psize)) {
-        // We currently only support power-of-2 sizes for vectors.
-#ifndef PRODUCT
-        if (is_trace_superword_rejections()) {
-          tty->cr();
-          tty->print_cr("WARNING: Removed pack[%d] with size that is not a power of 2:", i);
-          print_pack(p1);
-        }
-#endif
-        _packset.at_put(i, nullptr);
-        continue;
-      }
-      if (psize > max_vlen) {
-        Node_List* pack = new Node_List();
-        for (uint j = 0; j < psize; j++) {
-          pack->push(p1->at(j));
-          if (pack->size() >= max_vlen) {
-            assert(is_power_of_2(pack->size()), "sanity");
-            _packset.append(pack);
-            pack = new Node_List();
-          }
-        }
-        _packset.at_put(i, nullptr);
-      }
-    }
-  }
-
-  // We know that the nodes in a pair pack were independent - this gives us independence
-  // at distance 1. But now that we may have more than 2 nodes in a pack, we need to check
-  // if they are all mutually independent. If there is a dependence we remove the pack.
-  // This is better than giving up completely - we can have partial vectorization if some
-  // are rejected and others still accepted.
-  //
-  // Examples with dependence at distance 1 (pack pairs are not created):
-  // for (int i ...) { v[i + 1] = v[i] + 5; }
-  // for (int i ...) { v[i] = v[i - 1] + 5; }
-  //
-  // Example with independence at distance 1, but dependence at distance 2 (pack pairs are
-  // created and we need to filter them out now):
-  // for (int i ...) { v[i + 2] = v[i] + 5; }
-  // for (int i ...) { v[i] = v[i - 2] + 5; }
-  //
-  // Note: dependencies are created when a later load may reference the same memory location
-  // as an earlier store. This happens in "read backward" or "store forward" cases. On the
-  // other hand, "read forward" or "store backward" cases do not have such dependencies:
-  // for (int i ...) { v[i] = v[i + 1] + 5; }
-  // for (int i ...) { v[i - 1] = v[i] + 5; }
-  for (int i = 0; i < _packset.length(); i++) {
-    Node_List* p = _packset.at(i);
-    if (p != nullptr) {
-      // reductions are trivially connected
-      if (!is_marked_reduction(p->at(0)) &&
-          !mutually_independent(p)) {
-#ifndef PRODUCT
-        if (is_trace_superword_rejections()) {
-          tty->cr();
-          tty->print_cr("WARNING: Found dependency at distance greater than 1.");
-          tty->print_cr("In pack[%d]", i);
-          print_pack(p);
-        }
-#endif
-        _packset.at_put(i, nullptr);
-      }
-    }
-  }
-
   // Remove all nullptr from packset
   compress_packset();
+
+  assert(!_packset.is_empty(), "must have combined some packs");
 
 #ifndef PRODUCT
   if (is_trace_superword_packset()) {
@@ -1644,6 +1580,122 @@ void SuperWord::combine_packs() {
     print_packset();
   }
 #endif
+}
+
+void SuperWord::split_packs_for_max_vector_size() {
+  assert(!_packset.is_empty(), "packset not empty");
+
+  for (int i = 0; i < _packset.length(); i++) {
+    Node_List* pack = _packset.at(i);
+    assert(pack != nullptr, "no nullptr in packset");
+    uint max_vlen = max_vector_size_in_def_use_chain(pack->at(0));
+    assert(is_power_of_2(max_vlen), "sanity");
+    uint pack_size = pack->size();
+    if (pack_size <= max_vlen) {
+      continue;
+    }
+    // Split off the "upper" nodes into new packs
+    Node_List* new_pack = new Node_List();
+    for (uint j = max_vlen; j < pack_size; j++) {
+      Node* n = pack->at(j);
+      // is new_pack full?
+      if (new_pack->size() >= max_vlen) {
+        assert(is_power_of_2(new_pack->size()), "sanity");
+        _packset.append(new_pack);
+        Node_List* new_pack = new Node_List();
+      }
+      new_pack->push(n);
+    }
+    // remaining new_pack
+    if (new_pack->size() > 1) {
+      _packset.append(new_pack);
+    }
+    // truncate
+    while (pack->size() > max_vlen) {
+      pack->pop();
+    }
+  }
+
+  assert(!_packset.is_empty(), "we only increased the number of packs");
+
+#ifndef PRODUCT
+  if (is_trace_superword_packset()) {
+    tty->print_cr("\nAfter Superword::split_packs_for_max_vector_size");
+    print_packset();
+  }
+#endif
+}
+
+template <typename FilterPredicate>
+void SuperWord::filter_packs(const char* filter_name,
+                             const char* error_message,
+                             FilterPredicate filter) {
+  int new_packset_length = 0;
+  for (int i = 0; i < _packset.length(); i++) {
+    Node_List* pack = _packset.at(i);
+    assert(pack != nullptr, "no nullptr in packset");
+    if (filter(pack)) {
+      assert(i >= new_packset_length, "only move packs down");
+      _packset.at_put(new_packset_length++, pack);
+    } else {
+      remove_pack_at(i);
+#ifndef PRODUCT
+      if (is_trace_superword_rejections()) {
+        tty->cr();
+        tty->print_cr("WARNING: Removed pack: %s:", error_message);
+        print_pack(pack);
+      }
+#endif
+    }
+  }
+
+  assert(_packset.length() >= new_packset_length, "filter only reduces number of packs");
+  _packset.trunc_to(new_packset_length);
+
+#ifndef PRODUCT
+  if (is_trace_superword_packset() && filter_name != nullptr) {
+    tty->print_cr("\nAfter %s:", filter_name);
+    print_packset();
+  }
+#endif
+}
+
+void SuperWord::filter_packs_for_power_of_2_size() {
+  filter_packs("SuperWord::filter_packs_for_power_of_2_size",
+               "size is not a power of 2",
+               [&](const Node_List* pack) {
+                 return is_power_of_2(pack->size());
+               });
+}
+
+// We know that the nodes in a pair pack were independent - this gives us independence
+// at distance 1. But now that we may have more than 2 nodes in a pack, we need to check
+// if they are all mutually independent. If there is a dependence we remove the pack.
+// This is better than giving up completely - we can have partial vectorization if some
+// are rejected and others still accepted.
+//
+// Examples with dependence at distance 1 (pack pairs are not created):
+// for (int i ...) { v[i + 1] = v[i] + 5; }
+// for (int i ...) { v[i] = v[i - 1] + 5; }
+//
+// Example with independence at distance 1, but dependence at distance 2 (pack pairs are
+// created and we need to filter them out now):
+// for (int i ...) { v[i + 2] = v[i] + 5; }
+// for (int i ...) { v[i] = v[i - 2] + 5; }
+//
+// Note: dependencies are created when a later load may reference the same memory location
+// as an earlier store. This happens in "read backward" or "store forward" cases. On the
+// other hand, "read forward" or "store backward" cases do not have such dependencies:
+// for (int i ...) { v[i] = v[i + 1] + 5; }
+// for (int i ...) { v[i - 1] = v[i] + 5; }
+void SuperWord::filter_packs_for_mutual_independence() {
+  filter_packs("SuperWord::filter_packs_for_mutual_independence",
+               "found dependency between nodes at distance greater than 1",
+               [&](const Node_List* pack) {
+                 // reductions are trivially connected
+                 return is_marked_reduction(pack->at(0)) ||
+                        mutually_independent(pack);
+               });
 }
 
 // Find the set of alignment solutions for load/store pack.
@@ -1691,41 +1743,51 @@ void SuperWord::filter_packs_for_alignment() {
   AlignmentSolution const* current = new TrivialAlignmentSolution();
   int mem_ops_count = 0;
   int mem_ops_rejected = 0;
+  int new_packset_length = 0;
   for (int i = 0; i < _packset.length(); i++) {
-    Node_List* p = _packset.at(i);
-    if (p != nullptr) {
-      if (p->at(0)->is_Load() || p->at(0)->is_Store()) {
-        mem_ops_count++;
-        // Find solution for pack p, and filter with current solution.
-        const AlignmentSolution* s = pack_alignment_solution(p);
-        const AlignmentSolution* intersect = current->filter(s);
+    Node_List* pack = _packset.at(i);
+    assert(pack != nullptr, "no nullptr in packset");
+    bool keep = true;
+    if (pack->at(0)->is_Load() || pack->at(0)->is_Store()) {
+      mem_ops_count++;
+      // Find solution for pack p, and filter with current solution.
+      const AlignmentSolution* s = pack_alignment_solution(pack);
+      const AlignmentSolution* intersect = current->filter(s);
 
 #ifndef PRODUCT
-        if (is_trace_align_vector()) {
-          tty->print("  solution for pack:         ");
-          s->print();
-          tty->print("  intersection with current: ");
-          intersect->print();
-        }
+      if (is_trace_align_vector()) {
+        tty->print("  solution for pack:         ");
+        s->print();
+        tty->print("  intersection with current: ");
+        intersect->print();
+      }
 #endif
 
-        if (intersect->is_empty()) {
-          // Solution failed or is not compatible, remove pack i.
+      if (intersect->is_empty()) {
+        // Solution failed or is not compatible, remove pack i.
 #ifndef PRODUCT
-          if (is_trace_superword_rejections() || is_trace_align_vector()) {
-            tty->print_cr("Rejected by AlignVector:");
-            p->at(0)->dump();
-          }
-#endif
-          _packset.at_put(i, nullptr);
-          mem_ops_rejected++;
-        } else {
-          // Solution is compatible.
-          current = intersect;
+        if (is_trace_superword_rejections() || is_trace_align_vector()) {
+          tty->print_cr("Rejected by AlignVector:");
+          pack->at(0)->dump();
         }
+#endif
+        keep = false;
+        mem_ops_rejected++;
+      } else {
+        // Solution is compatible.
+        current = intersect;
       }
     }
+    if (keep) {
+      assert(i >= new_packset_length, "only move packs down");
+      _packset.at_put(new_packset_length++, pack);
+    } else {
+      remove_pack_at(i);
+    }
   }
+
+  assert(_packset.length() >= new_packset_length, "filter only reduces number of packs");
+  _packset.trunc_to(new_packset_length);
 
 #ifndef PRODUCT
   if (is_trace_superword_info() || is_trace_align_vector()) {
@@ -1742,9 +1804,6 @@ void SuperWord::filter_packs_for_alignment() {
     // -> must change pre-limit to achieve alignment
     set_align_to_ref(current->as_constrained()->mem_ref());
   }
-
-  // Remove all nullptr from packset
-  compress_packset();
 
 #ifndef PRODUCT
   if (is_trace_superword_packset() || is_trace_align_vector()) {
@@ -1788,23 +1847,22 @@ void SuperWord::construct_my_pack_map() {
   }
 }
 
-//------------------------------filter_packs---------------------------
-// Remove packs that are not implemented or not profitable.
-void SuperWord::filter_packs() {
-  // Remove packs that are not implemented
-  for (int i = _packset.length() - 1; i >= 0; i--) {
-    Node_List* pk = _packset.at(i);
-    bool impl = implemented(pk);
-    if (!impl) {
-#ifndef PRODUCT
-      if (is_trace_superword_rejections()) {
-        tty->print_cr("Unimplemented");
-        pk->at(0)->dump();
-      }
-#endif
-      remove_pack_at(i);
-    }
-    Node *n = pk->at(0);
+// Remove packs that are not implemented
+void SuperWord::filter_packs_for_implemented() {
+  filter_packs("SuperWord::filter_packs_for_implemented",
+               "Unimplemented",
+               [&](const Node_List* pack) {
+                 return implemented(pack);
+               });
+}
+
+// Remove packs that are not profitable.
+void SuperWord::filter_packs_for_profitable() {
+  // Count the number of reductions vs other vector ops, for the
+  // reduction profitability heuristic.
+  for (int i = 0; i < _packset.length(); i++) {
+    Node_List* pack = _packset.at(i);
+    Node* n = pack->at(0);
     if (is_marked_reduction(n)) {
       _num_reductions++;
     } else {
@@ -1813,28 +1871,22 @@ void SuperWord::filter_packs() {
   }
 
   // Remove packs that are not profitable
-  bool changed;
-  do {
-    changed = false;
-    for (int i = _packset.length() - 1; i >= 0; i--) {
-      Node_List* pk = _packset.at(i);
-      bool prof = profitable(pk);
-      if (!prof) {
-#ifndef PRODUCT
-        if (is_trace_superword_rejections()) {
-          tty->print_cr("Unprofitable");
-          pk->at(0)->dump();
-        }
-#endif
-        remove_pack_at(i);
-        changed = true;
-      }
+  while (true) {
+    int old_packset_length = _packset.length();
+    filter_packs(nullptr, // don't dump each time
+                 "size is not a power of 2",
+                 [&](const Node_List* pack) {
+                   return profitable(pack);
+                 });
+    // Repeat until stable
+    if (old_packset_length == _packset.length()) {
+      break;
     }
-  } while (changed);
+  }
 
 #ifndef PRODUCT
   if (is_trace_superword_packset()) {
-    tty->print_cr("\nAfter Superword::filter_packs");
+    tty->print_cr("\nAfter Superword::filter_packs_for_profitable");
     print_packset();
     tty->cr();
   }
@@ -1843,7 +1895,7 @@ void SuperWord::filter_packs() {
 
 //------------------------------implemented---------------------------
 // Can code be generated for pack p?
-bool SuperWord::implemented(Node_List* p) {
+bool SuperWord::implemented(const Node_List* p) {
   bool retValue = false;
   Node* p0 = p->at(0);
   if (p0 != nullptr) {
@@ -1903,7 +1955,7 @@ bool SuperWord::requires_long_to_int_conversion(int opc) {
 
 //------------------------------same_inputs--------------------------
 // For pack p, are all idx operands the same?
-bool SuperWord::same_inputs(Node_List* p, int idx) {
+bool SuperWord::same_inputs(const Node_List* p, int idx) {
   Node* p0 = p->at(0);
   uint vlen = p->size();
   Node* p0_def = p0->in(idx);
@@ -1919,7 +1971,7 @@ bool SuperWord::same_inputs(Node_List* p, int idx) {
 
 //------------------------------profitable---------------------------
 // For pack p, are all operands and all uses (with in the block) vector?
-bool SuperWord::profitable(Node_List* p) {
+bool SuperWord::profitable(const Node_List* p) {
   Node* p0 = p->at(0);
   uint start, end;
   VectorNode::vector_operands(p0, &start, &end);
@@ -3382,7 +3434,7 @@ void SuperWord::remove_pack_at(int pos) {
     Node* s = p->at(i);
     set_my_pack(s, nullptr);
   }
-  _packset.remove_at(pos);
+  _packset.at_put(pos, nullptr);
 }
 
 void SuperWord::packset_sort(int n) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -519,10 +519,8 @@ bool SuperWord::SLP_extract() {
 
   extend_packset_with_more_pairs_by_following_use_and_def();
 
-  // Combine pairs to longer packs
   combine_pairs_to_longer_packs();
 
-  // Split packs if they are too long
   split_packs_longer_than_max_vector_size();
 
   // Now we only remove packs:
@@ -1701,7 +1699,7 @@ void SuperWord::filter_packs_for_alignment() {
   int mem_ops_rejected = 0;
 
   filter_packs("SuperWord::filter_packs_for_alignment",
-               "rejected by AlignVector (strinct alignment requirement)",
+               "rejected by AlignVector (strict alignment requirement)",
                [&](const Node_List* pack) {
                  // Only memops need to be aligned.
                  if (!pack->at(0)->is_Load() &&

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1600,9 +1600,9 @@ void SuperWord::split_packs_for_max_vector_size() {
       Node* n = pack->at(j);
       // is new_pack full?
       if (new_pack->size() >= max_vlen) {
-        assert(is_power_of_2(new_pack->size()), "sanity");
+        assert(is_power_of_2(new_pack->size()), "sanity %d", new_pack->size());
         _packset.append(new_pack);
-        Node_List* new_pack = new Node_List();
+        new_pack = new Node_List();
       }
       new_pack->push(n);
     }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1609,6 +1609,15 @@ void SuperWord::split_packs_for_max_vector_size() {
     // remaining new_pack
     if (new_pack->size() > 1) {
       _packset.append(new_pack);
+    } else {
+#ifndef PRODUCT
+      if (is_trace_superword_rejections()) {
+        tty->cr();
+        tty->print_cr("WARNING: Node dropped out of odd size pack:");
+        new_pack->at(0)->dump();
+        print_pack(pack);
+      }
+#endif
     }
     // truncate
     while (pack->size() > max_vlen) {

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -493,7 +493,7 @@ private:
   void set_alignment(Node* s1, Node* s2, int align);
   int data_size(Node* s);
   // Extend packset by following use->def and def->use links from pack members.
-  void extend_packlist();
+  void extend_packset_with_more_pairs_by_following_use_and_def();
   int adjust_alignment_for_type_conversion(Node* s, Node* t, int align);
   // Extend the packset by visiting operand definitions of nodes in pack p
   bool follow_use_defs(Node_List* p);
@@ -508,10 +508,10 @@ private:
   int unpack_cost(int ct);
 
   // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
-  void combine_packs();
+  void combine_pairs_to_longer_packs();
 
   // Split packs that are too long
-  void split_packs_for_max_vector_size();
+  void split_packs_longer_than_max_vector_size();
 
   // Filter out packs with various filter predicates
   template <typename FilterPredicate>

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -523,7 +523,7 @@ private:
   // Ensure all packs are aligned, if AlignVector is on.
   void filter_packs_for_alignment();
   // Find the set of alignment solutions for load/store pack.
-  const AlignmentSolution* pack_alignment_solution(Node_List* pack);
+  const AlignmentSolution* pack_alignment_solution(const Node_List* pack);
   // Compress packset, such that it has no nullptr entries.
   void compress_packset();
   // Construct the map from nodes to packs.

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -393,7 +393,7 @@ class SuperWord : public ResourceObj {
   // is pack good for converting into one vector node replacing bunches of Cmp, Bool, CMov nodes.
   static bool requires_long_to_int_conversion(int opc);
   // For pack p, are all idx operands the same?
-  bool same_inputs(Node_List* p, int idx);
+  bool same_inputs(const Node_List* p, int idx);
   // CloneMap utilities
   bool same_origin_idx(Node* a, Node* b) const;
   bool same_generation(Node* a, Node* b) const;
@@ -484,7 +484,7 @@ private:
   // Is there no data path from s1 to s2 or s2 to s1?
   bool independent(Node* s1, Node* s2);
   // Are all nodes in nodes list mutually independent?
-  bool mutually_independent(Node_List* nodes) const;
+  bool mutually_independent(const Node_List* nodes) const;
   // For a node pair (s1, s2) which is isomorphic and independent,
   // do s1 and s2 have similar input edges?
   bool have_similar_inputs(Node* s1, Node* s2);
@@ -508,6 +508,16 @@ private:
   int unpack_cost(int ct);
   // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
   void combine_packs();
+
+  // TODO
+  void split_packs_for_max_vector_size();
+
+  template <typename FilterPredicate>
+  void filter_packs(const char* filter_name,
+                    const char* error_message,
+                    FilterPredicate filter);
+  void filter_packs_for_power_of_2_size();
+  void filter_packs_for_mutual_independence();
   // Ensure all packs are aligned, if AlignVector is on.
   void filter_packs_for_alignment();
   // Find the set of alignment solutions for load/store pack.
@@ -516,8 +526,10 @@ private:
   void compress_packset();
   // Construct the map from nodes to packs.
   void construct_my_pack_map();
-  // Remove packs that are not implemented or not profitable.
-  void filter_packs();
+  // Remove packs that are not implemented.
+  void filter_packs_for_implemented();
+  // Remove packs that are not profitable.
+  void filter_packs_for_profitable();
   // Verify that for every pack, all nodes are mutually independent.
   // Also verify that packset and my_pack are consistent.
   DEBUG_ONLY(void verify_packs();)
@@ -531,9 +543,9 @@ private:
   // Create a vector operand for the nodes in pack p for operand: in(opd_idx)
   Node* vector_opd(Node_List* p, int opd_idx);
   // Can code be generated for pack p?
-  bool implemented(Node_List* p);
+  bool implemented(const Node_List* p);
   // For pack p, are all operands and all uses (with in the block) vector?
-  bool profitable(Node_List* p);
+  bool profitable(const Node_List* p);
   // Verify that all uses of packs are also packs, i.e. we do not need extract operations.
   DEBUG_ONLY(void verify_no_extract();)
   // Is use->in(u_idx) a vector use?

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -488,7 +488,6 @@ private:
   // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
   void combine_pairs_to_longer_packs();
 
-  // Split packs that are too long
   void split_packs_longer_than_max_vector_size();
 
   // Filter out packs with various filter predicates

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -506,12 +506,14 @@ private:
   int adjacent_profit(Node* s1, Node* s2);
   int pack_cost(int ct);
   int unpack_cost(int ct);
+
   // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
   void combine_packs();
 
-  // TODO
+  // Split packs that are too long
   void split_packs_for_max_vector_size();
 
+  // Filter out packs with various filter predicates
   template <typename FilterPredicate>
   void filter_packs(const char* filter_name,
                     const char* error_message,


### PR DESCRIPTION
A few filter / split methods are currently bunched together. We should peal them apart so that moving / changing things becomes easier in the future.

```
combine_packs -> refactored into:
  combine_packs (now really only combines)
  split_packs_for_max_vector_size
  filter_packs_for_power_of_2_size
  filter_packs_for_mutual_independence

filter_packs -> refactored into:
  filter_packs_for_implemented
  filter_packs_for_profitable
```

Since we have so many "filter" passes, I created a dedicated `SuperWord::filter_packs` method, that takes a `FilterPredicate` lambda. This also allows me now to systematically debug dump any packs that are rejected .

I also took the liberty to enforce a new invariant between passes: there cannot be any `nullptr` in the packlist.
Before the "filter" passes just set some packs to `nullptr`. I now shift all surviving packs down, and truncate the packlist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325541](https://bugs.openjdk.org/browse/JDK-8325541): C2 SuperWord: refactor filter / split (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [49f7a8b0](https://git.openjdk.org/jdk/pull/17785/files/49f7a8b0596ef3aecd761b1b1f4e10aa0d9c604d)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17785/head:pull/17785` \
`$ git checkout pull/17785`

Update a local copy of the PR: \
`$ git checkout pull/17785` \
`$ git pull https://git.openjdk.org/jdk.git pull/17785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17785`

View PR using the GUI difftool: \
`$ git pr show -t 17785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17785.diff">https://git.openjdk.org/jdk/pull/17785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17785#issuecomment-1935699713)