### PR TITLE
8325551: Remove unused obj_is_alive and block_start in Space

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -140,11 +140,6 @@ void ContiguousSpace::verify() const {
   guarantee(p == top(), "end of last object must match end of space");
 }
 
-bool Space::obj_is_alive(const HeapWord* p) const {
-  assert (block_is_obj(p), "The address should point to an object");
-  return true;
-}
-
 void ContiguousSpace::object_iterate(ObjectClosure* blk) {
   HeapWord* addr = bottom();
   while (addr < top()) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -141,12 +141,6 @@ class Space: public CHeapObj<mtGC> {
   // object or a non-object.  If "p" is not in the space, return null.
   virtual HeapWord* block_start_const(const void* p) const = 0;
 
-  // The non-const version may have benevolent side effects on the data
-  // structure supporting these calls, possibly speeding up future calls.
-  // The default implementation, however, is simply to call the const
-  // version.
-  HeapWord* block_start(const void* p);
-
   // Requires "addr" to be the start of a chunk, and returns its size.
   // "addr + size" is required to be the start of a new chunk, or the end
   // of the active area of the heap.
@@ -155,10 +149,6 @@ class Space: public CHeapObj<mtGC> {
   // Requires "addr" to be the start of a block, and returns "TRUE" iff
   // the block is an object.
   virtual bool block_is_obj(const HeapWord* addr) const = 0;
-
-  // Requires "addr" to be the start of a block, and returns "TRUE" iff
-  // the block is an object and the object is alive.
-  bool obj_is_alive(const HeapWord* addr) const;
 
   // Allocation (return null if full).  Assumes the caller has established
   // mutually exclusive access to the space.

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -146,10 +146,6 @@ class Space: public CHeapObj<mtGC> {
   // of the active area of the heap.
   virtual size_t block_size(const HeapWord* addr) const = 0;
 
-  // Requires "addr" to be the start of a block, and returns "TRUE" iff
-  // the block is an object.
-  virtual bool block_is_obj(const HeapWord* addr) const = 0;
-
   // Allocation (return null if full).  Assumes the caller has established
   // mutually exclusive access to the space.
   virtual HeapWord* allocate(size_t word_size) = 0;
@@ -271,8 +267,6 @@ protected:
   // Very inefficient implementation.
   HeapWord* block_start_const(const void* p) const override;
   size_t block_size(const HeapWord* p) const override;
-  // If a block is in the allocated area, it is an object.
-  bool block_is_obj(const HeapWord* p) const override { return p < top(); }
 
   // Addresses for inlined allocation
   HeapWord** top_addr() { return &_top; }

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -34,10 +34,6 @@
 #include "runtime/prefetch.inline.hpp"
 #include "runtime/safepoint.hpp"
 
-inline HeapWord* Space::block_start(const void* p) {
-  return block_start_const(p);
-}
-
 #if INCLUDE_SERIALGC
 inline HeapWord* TenuredSpace::allocate(size_t size) {
   HeapWord* res = ContiguousSpace::allocate(size);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325551](https://bugs.openjdk.org/browse/JDK-8325551): Remove unused obj_is_alive and block_start in Space (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17786/head:pull/17786` \
`$ git checkout pull/17786`

Update a local copy of the PR: \
`$ git checkout pull/17786` \
`$ git pull https://git.openjdk.org/jdk.git pull/17786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17786`

View PR using the GUI difftool: \
`$ git pr show -t 17786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17786.diff">https://git.openjdk.org/jdk/pull/17786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17786#issuecomment-1935766136)