### PR TITLE
8321192 : j.a.PrintJob/ImageTest/ImageTest.java: Fail or skip the test if there's no printer

### DIFF
--- a/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
+++ b/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
@@ -41,7 +41,7 @@ import javax.imageio.ImageIO;
  * @test
  * @bug 4242308 4255603
  * @key printer
- * @library /java/awt/regtesthelpers /test/lib
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Tests printing of images
  * @run main/manual ImageTest

--- a/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
+++ b/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import javax.imageio.ImageIO;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -36,15 +35,14 @@ import java.awt.image.BufferedImage;
 import java.awt.print.PrinterJob;
 import java.io.File;
 import java.io.IOException;
-
-import jtreg.SkippedException;
+import javax.imageio.ImageIO;
 
 /*
  * @test
  * @bug 4242308 4255603
  * @key printer
  * @library /java/awt/regtesthelpers /test/lib
- * @build PassFailJFrame jtreg.SkippedException
+ * @build PassFailJFrame
  * @summary Tests printing of images
  * @run main/manual ImageTest
  */
@@ -59,6 +57,7 @@ public final class ImageTest {
             img = getToolkit().getImage("image.gif");
         }
 
+        @Override
         public void paint(Graphics g) {
             int width = img.getWidth(this);
             int height = img.getHeight(this);
@@ -75,10 +74,11 @@ public final class ImageTest {
             g.drawImage(img, 10, 75, width, height, this);
         }
 
-        public void setPrintJob(PrintJob pj) {
+        private void setPrintJob(PrintJob pj) {
             pjob = pj;
         }
 
+        @Override
         public boolean imageUpdate(Image img, int infoflags,
                                    int x, int y, int w, int h) {
             if ((infoflags & ALLBITS) != 0) {
@@ -105,7 +105,7 @@ public final class ImageTest {
             }
         });
         f.add(b);
-        f.setBounds(0, 50, 700, 350);
+        f.setSize(700, 350);
 
         return f;
     }
@@ -146,9 +146,9 @@ public final class ImageTest {
             """;
 
     public static void main(String[] args) throws Exception {
+
         if (PrinterJob.lookupPrintServices().length == 0) {
-            throw new SkippedException("Printer not configured or available."
-                    + " Test cannot continue.");
+            throw new RuntimeException("Printer not configured or available.");
         }
 
         createImage();

--- a/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
+++ b/test/jdk/java/awt/PrintJob/ImageTest/ImageTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.imageio.ImageIO;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.PrintJob;
+import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
+import java.awt.print.PrinterJob;
+import java.io.File;
+import java.io.IOException;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 4242308 4255603
+ * @key printer
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame jtreg.SkippedException
+ * @summary Tests printing of images
+ * @run main/manual ImageTest
+ */
+public final class ImageTest {
+
+    private static final class ImageFrame extends Frame {
+        final Image img;
+        PrintJob pjob;
+
+        private ImageFrame() {
+            super("ImageFrame");
+            img = getToolkit().getImage("image.gif");
+        }
+
+        public void paint(Graphics g) {
+            int width = img.getWidth(this);
+            int height = img.getHeight(this);
+            if (pjob != null) {
+                System.out.println("Size " + pjob.getPageDimension());
+                Dimension dim = pjob.getPageDimension();
+                if (width > dim.width) {
+                    width = dim.width - 30; // take care of paper margin
+                }
+                if (height > dim.height) {
+                    height = dim.height - 30;
+                }
+            }
+            g.drawImage(img, 10, 75, width, height, this);
+        }
+
+        public void setPrintJob(PrintJob pj) {
+            pjob = pj;
+        }
+
+        public boolean imageUpdate(Image img, int infoflags,
+                                   int x, int y, int w, int h) {
+            if ((infoflags & ALLBITS) != 0) {
+                repaint();
+                return false;
+            }
+            return true;
+        }
+    }
+
+    private static Frame init() {
+        ImageFrame f = new ImageFrame();
+        f.setLayout(new FlowLayout());
+        Button b = new Button("Print");
+        b.addActionListener(e -> {
+            PrintJob pj = Toolkit.getDefaultToolkit()
+                    .getPrintJob(f, "ImageTest", null);
+            if (pj != null) {
+                f.setPrintJob(pj);
+                Graphics pg = pj.getGraphics();
+                f.paint(pg);
+                pg.dispose();
+                pj.end();
+            }
+        });
+        f.add(b);
+        f.setBounds(0, 50, 700, 350);
+
+        return f;
+    }
+
+    private static void createImage() throws IOException {
+        final BufferedImage bufferedImage =
+                new BufferedImage(600, 230, BufferedImage.TYPE_INT_RGB);
+        Graphics2D g2d = bufferedImage.createGraphics();
+
+        g2d.setColor(new Color(0xE7E7E7));
+        g2d.fillRect(0, 0, bufferedImage.getWidth(), bufferedImage.getHeight());
+
+        g2d.setColor(Color.YELLOW);
+        g2d.fillRect(0, 6, 336, 40);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Yellow rectangle", 10, 30);
+
+        g2d.setColor(Color.CYAN);
+        g2d.fillRect(132, 85, 141, 138);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Cyan rectangle", 142, 148);
+
+        g2d.setColor(Color.MAGENTA);
+        g2d.fillRect(432, 85, 141, 138);
+        g2d.setColor(Color.BLACK);
+        g2d.drawString("Magenta rectangle", 442, 148);
+
+        g2d.dispose();
+
+        ImageIO.write(bufferedImage, "gif", new File("image.gif"));
+    }
+
+    private static final String INSTRUCTIONS = """
+             Click the Print button on the Frame. Select a printer from the
+             print dialog and click 'OK'. Verify that the image displayed
+             in the Frame is correctly printed. Test printing in both Color
+             and Monochrome.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        if (PrinterJob.lookupPrintServices().length == 0) {
+            throw new SkippedException("Printer not configured or available."
+                    + " Test cannot continue.");
+        }
+
+        createImage();
+
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 1)
+                .columns(45)
+                .testUI(ImageTest::init)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Hi Reviewers,
I have updated the test with 'PassFailJFrame' with programmatically generating image and print , please review and let me know your suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321192](https://bugs.openjdk.org/browse/JDK-8321192): j.a.PrintJob/ImageTest/ImageTest.java: Fail or skip the test if there's no printer (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [351bd721](https://git.openjdk.org/jdk/pull/17790/files/351bd721cb051a01ba9f78160007f7b16f5042d7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17790/head:pull/17790` \
`$ git checkout pull/17790`

Update a local copy of the PR: \
`$ git checkout pull/17790` \
`$ git pull https://git.openjdk.org/jdk.git pull/17790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17790`

View PR using the GUI difftool: \
`$ git pr show -t 17790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17790.diff">https://git.openjdk.org/jdk/pull/17790.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17790#issuecomment-1936089643)