### PR TITLE
8325563: Remove unused Space::is_in

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -117,9 +117,6 @@ class Space: public CHeapObj<mtGC> {
   bool is_in(const void* p) const {
     return used_region().contains(p);
   }
-  bool is_in(oop obj) const {
-    return is_in((void*)obj);
-  }
 
   // Returns true iff the given reserved memory of the space contains the
   // given address.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325563](https://bugs.openjdk.org/browse/JDK-8325563): Remove unused Space::is_in (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17791/head:pull/17791` \
`$ git checkout pull/17791`

Update a local copy of the PR: \
`$ git checkout pull/17791` \
`$ git pull https://git.openjdk.org/jdk.git pull/17791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17791`

View PR using the GUI difftool: \
`$ git pr show -t 17791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17791.diff">https://git.openjdk.org/jdk/pull/17791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17791#issuecomment-1936116845)