### PR TITLE
8325569: ProblemList gc/parallel/TestAlwaysPreTouchBehavior.java on linux

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -84,6 +84,7 @@ gc/epsilon/TestMemoryMXBeans.java 8206434 generic-all
 gc/g1/humongousObjects/objectGraphTest/TestObjectGraphAfterGC.java 8156755 generic-all
 gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all
 gc/g1/humongousObjects/TestHeapCounters.java 8178918 generic-all
+gc/parallel/TestAlwaysPreTouchBehavior.java 8325218 linux-all
 gc/TestAllocHumongousFragment.java#adaptive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all


### PR DESCRIPTION
Trivial fixes to ProblemList tests:

[JDK-8325569](https://bugs.openjdk.org/browse/JDK-8325569) ProblemList gc/parallel/TestAlwaysPreTouchBehavior.java on linux