### PR TITLE
8325570: Update to Graphviz 9.0.0

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -92,6 +92,8 @@ id="toc-build-tools-requirements">Build Tools Requirements</a>
 <li><a href="#autoconf" id="toc-autoconf">Autoconf</a></li>
 <li><a href="#gnu-make" id="toc-gnu-make">GNU Make</a></li>
 <li><a href="#gnu-bash" id="toc-gnu-bash">GNU Bash</a></li>
+<li><a href="#graphviz-and-pandoc" id="toc-graphviz-and-pandoc">Graphviz
+and Pandoc</a></li>
 </ul></li>
 <li><a href="#running-configure" id="toc-running-configure">Running
 Configure</a>
@@ -862,6 +864,13 @@ e.g. <code>configure MAKE=/opt/gnu/make</code>.</p>
 href="https://www.gnu.org/software/bash">GNU Bash</a>. No other shells
 are supported.</p>
 <p>At least version 3.2 of GNU Bash must be used.</p>
+<h3 id="graphviz-and-pandoc">Graphviz and Pandoc</h3>
+<p>In order to build the full docs (see the
+<code>--enable-full-docs</code> configure option) <a
+href="https://www.graphviz.org">Graphviz</a> and <a
+href="https://pandoc.org">Pandoc</a> are required. Any recent versions
+should work. For reference, and subject to change, Oracle builds use
+Graphviz 9.0.0 and Pandoc 2.19.2.</p>
 <h2 id="running-configure">Running Configure</h2>
 <p>To build the JDK, you need a "configuration", which consists of a
 directory where to store the build output, coupled with information

--- a/doc/building.md
+++ b/doc/building.md
@@ -685,6 +685,14 @@ shells are supported.
 
 At least version 3.2 of GNU Bash must be used.
 
+### Graphviz and Pandoc
+
+In order to build the full docs (see the `--enable-full-docs`
+configure option) [Graphviz](https://www.graphviz.org) and
+[Pandoc](https://pandoc.org) are required. Any recent versions should
+work. For reference, and subject to change, Oracle builds use Graphviz
+9.0.0 and Pandoc 2.19.2.
+
 ## Running Configure
 
 To build the JDK, you need a "configuration", which consists of a directory

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -441,7 +441,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "macosx-x64": {
             target_os: "macosx",
             target_cpu: "x64",
-            dependencies: ["devkit", "gtest", "pandoc"],
+            dependencies: ["devkit", "gtest", "graphviz", "pandoc"],
             configure_args: concat(common.configure_args_64bit, "--with-zlib=system",
                 "--with-macosx-version-max=11.00.00",
                 "--enable-compatible-cds-alignment",
@@ -453,7 +453,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "macosx-aarch64": {
             target_os: "macosx",
             target_cpu: "aarch64",
-            dependencies: ["devkit", "gtest", "pandoc"],
+            dependencies: ["devkit", "gtest", "graphviz", "pandoc"],
             configure_args: concat(common.configure_args_64bit,
                 "--with-macosx-version-max=11.00.00"),
         },
@@ -486,7 +486,7 @@ var getJibProfilesProfiles = function (input, common, data) {
         "linux-aarch64": {
             target_os: "linux",
             target_cpu: "aarch64",
-            dependencies: ["devkit", "gtest", "build_devkit", "pandoc"],
+            dependencies: ["devkit", "gtest", "build_devkit", "graphviz", "pandoc"],
             configure_args: [
                 "--with-zlib=system",
                 "--disable-dtrace",
@@ -1237,7 +1237,7 @@ var getJibProfilesDependencies = function (input, common) {
         graphviz: {
             organization: common.organization,
             ext: "tar.gz",
-            revision: "2.38.0-1+1.1",
+            revision: "9.0.0+1.0",
             module: "graphviz-" + input.target_platform,
             configure_args: "DOT=" + input.get("graphviz", "install_path") + "/dot",
             environment_path: input.get("graphviz", "install_path")

--- a/make/devkit/createGraphvizBundle.sh
+++ b/make/devkit/createGraphvizBundle.sh
@@ -1,6 +1,6 @@
-#!/bin/bash -e
+#!/bin/bash
 #
-# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,38 +26,106 @@
 # Create a bundle in the current directory, containing what's needed to run
 # the 'dot' program from the graphviz suite by the OpenJDK build.
 
-TMPDIR=`mktemp -d -t graphvizbundle-XXXX`
-trap "rm -rf \"$TMPDIR\"" EXIT
+set -eux
 
-ORIG_DIR=`pwd`
-cd "$TMPDIR"
-GRAPHVIZ_VERSION=2.38.0-1
-PACKAGE_VERSION=1.1
-TARGET_PLATFORM=linux_x64
-BUNDLE_NAME=graphviz-$TARGET_PLATFORM-$GRAPHVIZ_VERSION+$PACKAGE_VERSION.tar.gz
-wget http://www.graphviz.org/pub/graphviz/stable/redhat/el6/x86_64/os/graphviz-$GRAPHVIZ_VERSION.el6.x86_64.rpm
-wget http://www.graphviz.org/pub/graphviz/stable/redhat/el6/x86_64/os/graphviz-libs-$GRAPHVIZ_VERSION.el6.x86_64.rpm
-wget http://www.graphviz.org/pub/graphviz/stable/redhat/el6/x86_64/os/graphviz-plugins-core-$GRAPHVIZ_VERSION.el6.x86_64.rpm
-wget http://www.graphviz.org/pub/graphviz/stable/redhat/el6/x86_64/os/graphviz-plugins-x-$GRAPHVIZ_VERSION.el6.x86_64.rpm
-wget http://public-yum.oracle.com/repo/OracleLinux/OL6/latest/x86_64/getPackage/libtool-ltdl-2.2.6-15.5.el6.x86_64.rpm
+mydir="$(cd -- $(dirname ${BASH_SOURCE[0]}) && pwd)"
+me="${mydir}/$(basename ${BASH_SOURCE[0]})"
 
-mkdir graphviz
-cd graphviz
-for rpm in ../*.rpm; do
-  rpm2cpio $rpm | cpio --extract --make-directories
-done
+EXPAT_VERSION="2.6.0"
+EXPAT_URL="https://github.com/libexpat/libexpat/releases/download/R_${EXPAT_VERSION//./_}/expat-${EXPAT_VERSION}.tar.gz"
+EXPAT_SHA256="a13447b9aa67d7c860783fdf6820f33ebdea996900d6d8bbc50a628f55f099f7"
 
-cat > dot << EOF
+GRAPHVIZ_VERSION="9.0.0"
+GRAPHVIZ_URL="https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/${GRAPHVIZ_VERSION}/graphviz-${GRAPHVIZ_VERSION}.tar.xz"
+GRAPHVIZ_SHA256="6c9afda06a732af7658c2619ee713d2545818c3ff19b7b8fd48effcd06d57bf6"
+
+uname_s="$(uname -s)"
+case ${uname_s} in
+    Linux)
+        bundle_os="linux"
+        shacmd="sha256sum --strict --check -"
+        lib_path_var="LD_LIBRARY_PATH"
+        ;;
+    Darwin)
+        bundle_os="macosx"
+        shacmd="shasum -a 256 --strict --check -"
+        lib_path_var="DYLD_LIBRARY_PATH"
+        ;;
+    *)
+        echo "Unknown OS: ${uname_s}"
+        exit 1
+        ;;
+esac
+uname_m="$(uname -m)"
+case ${uname_m} in
+    aarch64|arm64)
+        bundle_cpu="aarch64"
+        ;;
+    x86_64)
+        bundle_cpu="x64"
+        ;;
+esac
+bundle_platform="${bundle_os}_${bundle_cpu}"
+
+build_dir="${mydir}/../../build/graphviz"
+download_dir="${build_dir}/download"
+install_dir="${build_dir}/result/graphviz-${bundle_platform}-${GRAPHVIZ_VERSION}"
+bundle_file="${install_dir}.tar.gz"
+
+expat_dir="${build_dir}/expat"
+expat_src_dir="${expat_dir}/src"
+
+graphviz_dir="${build_dir}/graphviz"
+graphviz_src_dir="${graphviz_dir}/src"
+graphviz_doc_dir="${install_dir}/doc"
+
+mkdir -p "${build_dir}"
+cd "${build_dir}"
+
+download_and_unpack() {
+    local url="$1"
+    local sha256="$2"
+    local file="$3"
+    local dir="$4"
+
+    mkdir -p "$(dirname "${file}")"
+    if [ ! -f "${file}" ]; then
+        curl -L -o "${file}" "${url}"
+    fi
+    echo "${sha256}  ${file}" | ${shacmd}
+    if [ ! -d "${dir}" ]; then
+        mkdir -p "${dir}"
+        tar --extract --file "${file}" --directory "${dir}" --strip-components 1
+    fi
+}
+
+download_and_unpack "${EXPAT_URL}" "${EXPAT_SHA256}" "${download_dir}/expat.tar.gz" "${expat_src_dir}"
+download_and_unpack "${GRAPHVIZ_URL}" "${GRAPHVIZ_SHA256}" "${download_dir}/graphviz.tar.gz" "${graphviz_src_dir}"
+
+(
+    cd "${expat_src_dir}"
+    ./configure --prefix="${install_dir}"
+    make -j install
+)
+
+(
+    cd "${graphviz_src_dir}"
+    ./configure --prefix="${install_dir}" EXPAT_CFLAGS="-I${install_dir}/include" EXPAT_LIBS="-L${install_dir}/lib -lexpat"
+    make -j install
+)
+
+cat > "${install_dir}/dot" << EOF
 #!/bin/bash
 # Get an absolute path to this script
-this_script_dir=\`dirname \$0\`
-this_script_dir=\`cd \$this_script_dir > /dev/null && pwd\`
-export LD_LIBRARY_PATH="\$this_script_dir/usr/lib64:\$LD_LIBRARY_PATH"
-exec \$this_script_dir/usr/bin/dot "\$@"
+this_script_dir="\$(dirname \$0)"
+this_script_dir="\$(cd \${this_script_dir} > /dev/null && pwd)"
+export ${lib_path_var}="\${this_script_dir}/lib:\${this_script_dir}/lib/graphviz"
+exec "\${this_script_dir}/bin/dot" "\$@"
 EOF
-chmod +x dot
-export LD_LIBRARY_PATH="$TMPDIR/graphviz/usr/lib64:$LD_LIBRARY_PATH"
+chmod +x "${install_dir}/dot"
 # create config file
-./dot -c
-tar -cvzf ../$BUNDLE_NAME *
-cp ../$BUNDLE_NAME "$ORIG_DIR"
+"${install_dir}/dot" -c
+
+cp "${me}" "${install_dir}"
+
+tar --create --gzip --file "${bundle_file}" -C "${install_dir}" .


### PR DESCRIPTION
Graphviz (aka. dotty/dot) is used when building "full" docs, and in particular for creating various module graph images (.svg). This change upgrades the Graphviz version used to 9.0.0 (latest).

In particular, the change:

* Updates the createGraphvizBundle.sh script (currently broken) to build graphviz from source
* Updates doc/building.{md,html} to reflect the role of Graphviz and Pandoc in the build
* The version of of the graphviz dependency used when building at Oracle (in jib-profiles.js)

Since, in addition to the changes in this PR itself, the exact version of Graphviz has an effect on the generated images, I have uploaded the docs generated by graphviz 9.0.0 here: https://cr.openjdk.org/~mikael/graphviz-9.0.0/cmp-v1/docs/api/. For baseline the latest jdk23 docs, which uses graphviz 2.38.0, should do the trick: https://download.java.net/java/early_access/jdk23/docs/api/.

For example, picking a random .svg file:

baseline (graphviz 2.38.0): https://download.java.net/java/early_access/jdk23/docs/api/java.base/java/lang/classfile/Signature/RefTypeSig-sealed-graph.svg
new (graphviz 9.0.0): https://cr.openjdk.org/~mikael/graphviz-9.0.0/cmp-v1/docs/api/java.base/java/lang/classfile/Signature/RefTypeSig-sealed-graph.svg


Testing: tier1, manual inspection of a few of the generated .svg files

As far as I can tell there are only very minor differences between the old (2.38.0) and new (9.0.0) .svg files. In particular, it seems like the new graphs are ever so slightly (5-10% or so) larger, but otherwise appear to be identical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325570](https://bugs.openjdk.org/browse/JDK-8325570): Update to Graphviz 9.0.0 (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17794/head:pull/17794` \
`$ git checkout pull/17794`

Update a local copy of the PR: \
`$ git checkout pull/17794` \
`$ git pull https://git.openjdk.org/jdk.git pull/17794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17794`

View PR using the GUI difftool: \
`$ git pr show -t 17794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17794.diff">https://git.openjdk.org/jdk/pull/17794.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17794#issuecomment-1936459998)