### PR TITLE
8325574: Shenandoah: Simplify and enhance reporting of requested GCs

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -89,12 +89,7 @@ public:
     return _consecutive_degenerated_gcs;
   }
 
-  // Returns true if this is an 'explicit' gc request and ExplicitGCInvokesConcurrent is disabled,
-  // or if this is an 'implicit' gc request and ShenandoahImplicitGCInvokesConcurrent is disabled.
   static bool should_run_full_gc(GCCause::Cause cause);
-
-  // Returns false if this is an `explicit` gc request and DisableExplicitGC is active, otherwise
-  // returns true.
   static bool should_handle_requested_gc(GCCause::Cause cause);
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -89,7 +89,12 @@ public:
     return _consecutive_degenerated_gcs;
   }
 
+  // Returns true if this is an 'explicit' gc request and ExplicitGCInvokesConcurrent is disabled,
+  // or if this is an 'implicit' gc request and ShenandoahImplicitGCInvokesConcurrent is disabled.
   static bool should_run_full_gc(GCCause::Cause cause);
+
+  // Returns false if this is an `explicit` gc request and DisableExplicitGC is active, otherwise
+  // returns true.
   static bool should_handle_requested_gc(GCCause::Cause cause);
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -88,6 +88,9 @@ public:
   inline size_t consecutive_degenerated_gc_count() const {
     return _consecutive_degenerated_gcs;
   }
+
+  static bool should_run_full_gc(GCCause::Cause cause);
+  static bool should_handle_requested_gc(GCCause::Cause cause);
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHCOLLECTORPOLICY_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -48,8 +48,8 @@ private:
   size_t _alloc_failure_degenerated;
   size_t _alloc_failure_degenerated_upgrade_to_full;
   size_t _alloc_failure_full;
-  size_t _collection_causes[GCCause::_last_gc_cause];
-  size_t _degen_points[ShenandoahGC::_DEGENERATED_LIMIT];
+  size_t _collection_cause_counts[GCCause::_last_gc_cause];
+  size_t _degen_point_counts[ShenandoahGC::_DEGENERATED_LIMIT];
 
   ShenandoahSharedFlag _in_shutdown;
   ShenandoahTracer* _tracer;

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectorPolicy.hpp
@@ -48,10 +48,7 @@ private:
   size_t _alloc_failure_degenerated;
   size_t _alloc_failure_degenerated_upgrade_to_full;
   size_t _alloc_failure_full;
-  size_t _explicit_concurrent;
-  size_t _explicit_full;
-  size_t _implicit_concurrent;
-  size_t _implicit_full;
+  size_t _collection_causes[GCCause::_last_gc_cause];
   size_t _degen_points[ShenandoahGC::_DEGENERATED_LIMIT];
 
   ShenandoahSharedFlag _in_shutdown;
@@ -72,10 +69,7 @@ public:
   void record_alloc_failure_to_degenerated(ShenandoahGC::ShenandoahDegenPoint point);
   void record_alloc_failure_to_full();
   void record_degenerated_upgrade_to_full();
-  void record_explicit_to_concurrent();
-  void record_explicit_to_full();
-  void record_implicit_to_concurrent();
-  void record_implicit_to_full();
+  void record_collection_cause(GCCause::Cause cause);
 
   void record_shutdown();
   bool is_at_shutdown();

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -61,8 +61,8 @@ ShenandoahControlThread::ShenandoahControlThread() :
 void ShenandoahControlThread::run_service() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
 
-  GCMode default_mode = concurrent_normal;
-  GCCause::Cause default_cause = GCCause::_shenandoah_concurrent_gc;
+  const GCMode default_mode = concurrent_normal;
+  const GCCause::Cause default_cause = GCCause::_shenandoah_concurrent_gc;
   int sleep = ShenandoahControlIntervalMin;
 
   double last_shrink_time = os::elapsedTime();
@@ -72,21 +72,21 @@ void ShenandoahControlThread::run_service() {
   // Having a period 10x lower than the delay would mean we hit the
   // shrinking with lag of less than 1/10-th of true delay.
   // ShenandoahUncommitDelay is in msecs, but shrink_period is in seconds.
-  double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
+  const double shrink_period = (double)ShenandoahUncommitDelay / 1000 / 10;
 
-  ShenandoahCollectorPolicy* policy = heap->shenandoah_policy();
-  ShenandoahHeuristics* heuristics = heap->heuristics();
+  ShenandoahCollectorPolicy* const policy = heap->shenandoah_policy();
+  ShenandoahHeuristics* const heuristics = heap->heuristics();
   while (!in_graceful_shutdown() && !should_terminate()) {
     // Figure out if we have pending requests.
-    bool alloc_failure_pending = _alloc_failure_gc.is_set();
-    bool is_gc_requested = _gc_requested.is_set();
-    GCCause::Cause requested_gc_cause = _requested_gc_cause;
+    const bool alloc_failure_pending = _alloc_failure_gc.is_set();
+    const bool is_gc_requested = _gc_requested.is_set();
+    const GCCause::Cause requested_gc_cause = _requested_gc_cause;
 
     // This control loop iteration has seen this much allocation.
-    size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
+    const size_t allocs_seen = Atomic::xchg(&_allocs_seen, (size_t)0, memory_order_relaxed);
 
     // Check if we have seen a new target for soft max heap size.
-    bool soft_max_changed = heap->check_soft_max_changed();
+    const bool soft_max_changed = heap->check_soft_max_changed();
 
     // Choose which GC mode to run in. The block below should select a single mode.
     GCMode mode = none;
@@ -142,7 +142,7 @@ void ShenandoahControlThread::run_service() {
       heap->soft_ref_policy()->set_should_clear_all_soft_refs(true);
     }
 
-    bool gc_requested = (mode != none);
+    const bool gc_requested = (mode != none);
     assert (!gc_requested || cause != GCCause::_last_gc_cause, "GC cause should be set");
 
     if (gc_requested) {
@@ -251,7 +251,7 @@ void ShenandoahControlThread::run_service() {
       }
     }
 
-    double current = os::elapsedTime();
+    const double current = os::elapsedTime();
 
     if (ShenandoahUncommit && (is_gc_requested || soft_max_changed || (current - last_shrink_time > shrink_period))) {
       // Explicit GC tries to uncommit everything down to min capacity.

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -87,7 +87,8 @@ private:
   // Blocks until GC is over.
   void handle_requested_gc(GCCause::Cause cause);
 
-  bool is_explicit_gc(GCCause::Cause cause) const;
+  static bool is_explicit_gc(GCCause::Cause cause);
+  static bool should_run_full_gc(GCCause::Cause cause);
 
 public:
   // Constructor

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.hpp
@@ -87,9 +87,6 @@ private:
   // Blocks until GC is over.
   void handle_requested_gc(GCCause::Cause cause);
 
-  static bool is_explicit_gc(GCCause::Cause cause);
-  static bool should_run_full_gc(GCCause::Cause cause);
-
 public:
   // Constructor
   ShenandoahControlThread();

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -44,6 +44,7 @@ ShenandoahGCSession::ShenandoahGCSession(GCCause::Cause cause) :
   _tracer(_heap->tracer()) {
   assert(!ShenandoahGCPhase::is_current_phase_valid(), "No current GC phase");
 
+  _heap->shenandoah_policy()->record_collection_cause(cause);
   _heap->set_gc_cause(cause);
   _timer->register_gc_start();
   _tracer->report_gc_start(cause, _timer->gc_start());


### PR DESCRIPTION
Shenandoah distinguishes between 'implicit' and 'explicit' GC requests. The distinction is used to decide whether or not a request is serviced concurrently or with a full GC. The data collected is also included in the end-of-process report. This change simplifies handling of these requests and adds a tally of the underlying GC causes to the end-of-process report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325574](https://bugs.openjdk.org/browse/JDK-8325574): Shenandoah: Simplify and enhance reporting of requested GCs (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [ce06e434](https://git.openjdk.org/jdk/pull/17795/files/ce06e4342230ccd26a60975e1eb9f2c92224910e)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [ce06e434](https://git.openjdk.org/jdk/pull/17795/files/ce06e4342230ccd26a60975e1eb9f2c92224910e)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [8d174e81](https://git.openjdk.org/jdk/pull/17795/files/8d174e816eb49900f5074055b2a5da3d1c76ab55)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17795/head:pull/17795` \
`$ git checkout pull/17795`

Update a local copy of the PR: \
`$ git checkout pull/17795` \
`$ git pull https://git.openjdk.org/jdk.git pull/17795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17795`

View PR using the GUI difftool: \
`$ git pr show -t 17795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17795.diff">https://git.openjdk.org/jdk/pull/17795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17795#issuecomment-1936510939)