### PR TITLE
8325382: (fc) FileChannel.transferTo throws IOException when position equals size

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/FileChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -857,20 +857,18 @@ public class FileChannelImpl
             if (position > sz)
                 return 0;
 
-            // Now position <= sz so remaining >= 0 and
-            // remaining == 0 if and only if sz == 0
-            long remaining = sz - position;
-
-            // Adjust count only if remaining > 0, i.e.,
-            // sz > position which means sz > 0
-            if (remaining > 0 && remaining < count)
-                count = remaining;
-
             // System calls supporting fast transfers might not work on files
             // which advertise zero size such as those in Linux /proc
             if (sz > 0) {
-                // Attempt a direct transfer, if the kernel supports it, limiting
-                // the number of bytes according to which platform
+                // Now sz > 0 and position <= sz so remaining >= 0 and
+                // remaining == 0 if and only if sz == position
+                long remaining = sz - position;
+
+                if (remaining >= 0 && remaining < count)
+                    count = remaining;
+
+                // Attempt a direct transfer, if the kernel supports it,
+                // limiting the number of bytes according to which platform
                 int icount = (int) Math.min(count, nd.maxDirectTransferSize());
                 long n;
                 if ((n = transferToDirect(position, icount, target)) >= 0)

--- a/test/jdk/java/nio/channels/FileChannel/Transfer.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 
 import jdk.test.lib.RandomFactory;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class Transfer {
@@ -160,14 +161,14 @@ public class Transfer {
     }
 
     @Test
-    public void transferToTrusted() throws IOException { // for bug 8325382
+    public void transferToNoThrow() throws IOException { // for bug 8325382
         File source = File.createTempFile("before", "after");
         source.deleteOnExit();
 
         CharSequence csq = "Reality is greater than the sum of its parts.";
         Files.writeString(source.toPath(), csq);
         final long length = csq.length();
-        assert source.length() == length;
+        Assert.assertEquals(source.length(), length);
 
         File target = File.createTempFile("before", "after");
         target.deleteOnExit();
@@ -179,7 +180,10 @@ public class Transfer {
             // The count of bytes requested to transfer must exceed
             // FileChannelImpl.MAPPED_TRANSFER_THRESHOLD which is
             // currently 16384
-            chSource.transferTo(length, 16385, chTarget);
+            long n = chSource.transferTo(length, 16385, chTarget);
+
+            // At the end of the input so no bytes should be transferred
+            Assert.assertEquals(n, 0);
         }
     }
 

--- a/test/jdk/java/nio/channels/FileChannel/Transfer.java
+++ b/test/jdk/java/nio/channels/FileChannel/Transfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4434723 4482726 4559072 4795550 5081340 5103988 6984545
+ * @bug 4434723 4482726 4559072 4795550 5081340 5103988 6984545 8325382
  * @summary Test FileChannel.transferFrom and transferTo (use -Dseed=X to set PRNG seed)
  * @library ..
  * @library /test/lib
@@ -48,6 +48,7 @@ import java.nio.channels.Pipe;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
+import java.nio.file.Files;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
@@ -155,6 +156,30 @@ public class Transfer {
             source.close();
 
             f.delete();
+        }
+    }
+
+    @Test
+    public void transferToTrusted() throws IOException { // for bug 8325382
+        File source = File.createTempFile("before", "after");
+        source.deleteOnExit();
+
+        CharSequence csq = "Reality is greater than the sum of its parts.";
+        Files.writeString(source.toPath(), csq);
+        final long length = csq.length();
+        assert source.length() == length;
+
+        File target = File.createTempFile("before", "after");
+        target.deleteOnExit();
+
+        try (FileInputStream in = new FileInputStream(source);
+             FileOutputStream out = new FileOutputStream(target);
+             FileChannel chSource = in.getChannel();
+             FileChannel chTarget = out.getChannel()) {
+            // The count of bytes requested to transfer must exceed
+            // FileChannelImpl.MAPPED_TRANSFER_THRESHOLD which is
+            // currently 16384
+            chSource.transferTo(length, 16385, chTarget);
         }
     }
 


### PR DESCRIPTION
In `FileChannelImpl.transferTo`, do not clamp the number of bytes to transfer to the number remaining in the source `FileChannel` unless the size of the source is positive. When clamping, do not use the strict inequality `remaining > 0`, but rather allow clamping to zero.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325382](https://bugs.openjdk.org/browse/JDK-8325382): (fc) FileChannel.transferTo throws IOException when position equals size (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17796/head:pull/17796` \
`$ git checkout pull/17796`

Update a local copy of the PR: \
`$ git checkout pull/17796` \
`$ git pull https://git.openjdk.org/jdk.git pull/17796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17796`

View PR using the GUI difftool: \
`$ git pr show -t 17796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17796.diff">https://git.openjdk.org/jdk/pull/17796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17796#issuecomment-1936526107)