### PR TITLE
8325576: java/lang/ProcessHandle/InfoTest.java fails on systems with coreutils with --enable-single-binary

### DIFF
--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -292,7 +292,6 @@ public class InfoTest {
                 if (info.command().isPresent()) {
                     String command = info.command().get();
                     String expected = "sleep";
-
                     if (Platform.isWindows()) {
                         expected = "sleep.exe";
                     } else if (Platform.isBusybox("/bin/sleep")) {

--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -299,7 +299,7 @@ public class InfoTest {
                         // With busybox sleep is just a sym link to busybox.
                         // The busbox executable is seen as ProcessHandle.Info command.
                         expected = "busybox";
-                    } else if (Platform.isCoreutilsSingleExecutable("sleep")) {
+                    } else if (Platform.isCoreutilsSingleExecutable()) {
                         // With coreutils single executable sleep is just a script around coreutils.
                         // The coreutils executable is seen as ProcessHandle.Info command.
                         expected = "/usr/bin/coreutils";

--- a/test/jdk/java/lang/ProcessHandle/InfoTest.java
+++ b/test/jdk/java/lang/ProcessHandle/InfoTest.java
@@ -282,7 +282,6 @@ public class InfoTest {
     public static void test3() {
         try {
             for (long sleepTime : Arrays.asList(Utils.adjustTimeout(30), Utils.adjustTimeout(32))) {
-                boolean timeIsLastParam = false;
                 Process p = spawn("sleep", String.valueOf(sleepTime));
 
                 ProcessHandle.Info info = p.info();
@@ -304,7 +303,6 @@ public class InfoTest {
                         // With coreutils single executable sleep is just a script around coreutils.
                         // The coreutils executable is seen as ProcessHandle.Info command.
                         expected = "/usr/bin/coreutils";
-                        timeIsLastParam = true;
                     }
                     Assert.assertTrue(command.endsWith(expected), "Command: expected: \'" +
                             expected + "\', actual: " + command);
@@ -318,11 +316,7 @@ public class InfoTest {
                 if (info.arguments().isPresent()) {
                     String[] args = info.arguments().get();
                     if (args.length > 0) {
-                        if (timeIsLastParam) {
-                            Assert.assertEquals(args[args.length - 1], String.valueOf(sleepTime));
-                        } else {
-                            Assert.assertEquals(args[0], String.valueOf(sleepTime));
-                        }
+                        Assert.assertEquals(args[args.length - 1], String.valueOf(sleepTime));
                     }
                 }
                 p.destroy();

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -125,21 +125,10 @@ public class Platform {
         }
     }
 
-    public static boolean isCoreutilsSingleExecutable(String tool) {
-        try {
-            ProcessBuilder pb = new ProcessBuilder("coreutils", "--help");
-            pb.redirectErrorStream(true);
-            Process p = pb.start();
-            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            String line;
-            while ((line = b.readLine()) != null) {
-                if (line.contains(tool)) {
-                    return true;
-                }
-            }
-        } catch(Exception e) {
-        }
-        return false;
+    public static boolean isCoreutilsSingleExecutable() {
+        // If more distrobutions start using --enable-single-binary with coreutils
+        // additional path checks may be required.
+        return Paths.exist("/usr/bin/coreutils");
     }
 
     public static boolean isOSX() {

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -128,7 +128,7 @@ public class Platform {
     public static boolean isCoreutilsSingleExecutable() {
         // If more distrobutions start using --enable-single-binary with coreutils
         // additional path checks may be required.
-        return Paths.exist("/usr/bin/coreutils");
+        return Files.exists(Paths.get("/usr/bin/coreutils"));
     }
 
     public static boolean isOSX() {

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -125,6 +125,23 @@ public class Platform {
         }
     }
 
+    public static boolean isCoreutilsSingleExecutable(String tool) {
+        try {
+            ProcessBuilder pb = new ProcessBuilder("coreutils", "--help");
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line;
+            while ((line = b.readLine()) != null) {
+                if (line.contains(tool)) {
+                    return true;
+                }
+            }
+        } catch(Exception e) {
+        }
+        return false;
+    }
+
     public static boolean isOSX() {
         return isOs("mac");
     }


### PR DESCRIPTION
Ran the test on AmazonLinux 2 which has multiple binaries from coreutils package and no coreutils executable as well as AmazonLinux 2023 that uses `--enable-single-binary`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8325576: java/lang/ProcessHandle/InfoTest.java fails on systems with coreutils with --enable-single-binary`

### Issue
 * [JDK-8325576](https://bugs.openjdk.org/browse/JDK-8325576): java/lang/ProcessHandle/InfoTest.java fails on systems with coreutils with --enable-single-binary (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17798/head:pull/17798` \
`$ git checkout pull/17798`

Update a local copy of the PR: \
`$ git checkout pull/17798` \
`$ git pull https://git.openjdk.org/jdk.git pull/17798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17798`

View PR using the GUI difftool: \
`$ git pr show -t 17798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17798.diff">https://git.openjdk.org/jdk/pull/17798.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17798#issuecomment-1939122813)