### PR TITLE
8325606: compiler/predicates/TestPredicatesBasic.java does not compile

### DIFF
--- a/test/hotspot/jtreg/compiler/predicates/TestPredicatesBasic.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestPredicatesBasic.java
@@ -83,7 +83,7 @@ public class TestPredicatesBasic {
     }
 
     @Test
-    @Arguments({Argument.NUMBER_42})
+    @Arguments(values = {Argument.NUMBER_42})
     // Null check, loop entrance check, array lower/upper bound check
     @IR(counts = {IRNode.IF, "4"})
     public void basicLimit(int limit) {
@@ -93,5 +93,4 @@ public class TestPredicatesBasic {
         }
     }
 }
-
 


### PR DESCRIPTION
The newly added test fails because https://github.com/openjdk/jdk/pull/17557 went in shortly before which changed the required format for `@Arguments`. This patch fixes this.

Tested locally.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325606](https://bugs.openjdk.org/browse/JDK-8325606): compiler/predicates/TestPredicatesBasic.java does not compile (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17801/head:pull/17801` \
`$ git checkout pull/17801`

Update a local copy of the PR: \
`$ git checkout pull/17801` \
`$ git pull https://git.openjdk.org/jdk.git pull/17801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17801`

View PR using the GUI difftool: \
`$ git pr show -t 17801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17801.diff">https://git.openjdk.org/jdk/pull/17801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17801#issuecomment-1938214193)