### PR TITLE
8325653: Erroneous exhaustivity analysis for primitive patterns

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1297,24 +1297,12 @@ public class Flow {
 
     private boolean isBpCovered(Type componentType, PatternDescription newNested) {
         if (newNested instanceof BindingPattern bp) {
-            var seltype = types.erasure(componentType);
+            Type seltype = types.erasure(componentType);
+            Type pattype = types.erasure(bp.type);
 
-            if (seltype.isPrimitive()) {
-                if (types.isSameType(bp.type, types.boxedClass(seltype).type)) {
-                    return true;
-                }
-
-                // if the target is unconditionally exact to the pattern, target is covered
-                if (types.isUnconditionallyExact(seltype, bp.type)) {
-                    return true;
-                }
-            } else if (seltype.isReference() && bp.type.isPrimitive() && types.isUnconditionallyExact(types.unboxedType(seltype), bp.type)) {
-                return true;
-            } else {
-                if (types.isSubtype(seltype, types.erasure(bp.type))) {
-                    return true;
-                }
-            }
+            return seltype.isPrimitive() ?
+                    types.isUnconditionallyExact(seltype, pattype) :
+                    (bp.type.isPrimitive() && types.isUnconditionallyExact(types.unboxedType(seltype), bp.type)) || types.isSubtype(seltype, pattype);
         }
         return false;
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1308,7 +1308,7 @@ public class Flow {
                 if (types.isUnconditionallyExact(seltype, bp.type)) {
                     return true;
                 }
-            } else if (seltype.isReference() && bp.type.isPrimitive() && types.isCastable(seltype, bp.type)) {
+            } else if (seltype.isReference() && bp.type.isPrimitive() && types.isUnconditionallyExact(types.unboxedType(seltype), bp.type)) {
                 return true;
             } else {
                 if (types.isSubtype(seltype, types.erasure(bp.type))) {

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8304487
+ * @bug 8304487 8325653
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile/fail/ref=PrimitivePatternsSwitchErrors.out -XDrawDiagnostics -XDshould-stop.at=FLOW PrimitivePatternsSwitchErrors.java
@@ -216,5 +216,29 @@ public class PrimitivePatternsSwitchErrors {
             case null    -> System.out.println("oops");
             default      -> System.out.println("any other integral value");
         }
+    }
+
+    public static int nonExhaustive4() {
+        Number n = Byte.valueOf((byte) 42);
+        return switch (n) { // Error - not exhaustive
+            case byte  b when b == 42 -> 1;
+            case byte  b -> -1 ;
+        };
+    }
+
+    public static int nonExhaustive5() {
+        Object n = 42;
+        return switch (n) { // Error - not exhaustive
+            case int  b when b == 42 -> 1;
+            case int  b -> -1 ;
+        };
+    }
+
+    public static int nonExhaustive6() {
+        Object n = 42;
+        return switch (n) { // Error - not exhaustive
+            case byte b -> -1 ;
+            case int b -> -2 ;
+        };
     }
 }

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
@@ -32,6 +32,9 @@ PrimitivePatternsSwitchErrors.java:44:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:52:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:201:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:207:9: compiler.err.not.exhaustive.statement
+PrimitivePatternsSwitchErrors.java:223:16: compiler.err.not.exhaustive
+PrimitivePatternsSwitchErrors.java:231:16: compiler.err.not.exhaustive
+PrimitivePatternsSwitchErrors.java:239:16: compiler.err.not.exhaustive
 - compiler.note.preview.filename: PrimitivePatternsSwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-34 errors
+37 errors


### PR DESCRIPTION
This PR fixes an exhaustivity analysis issue with primitive patterns, that was implementing the clause in [14.11.1.1](https://cr.openjdk.org/~abimpoudis/instanceof/jep455-20240122/specs/instanceof-jls.html#jls-14.11.1.1) erroneously (in the case where the selector is a reference type).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325653](https://bugs.openjdk.org/browse/JDK-8325653): Erroneous exhaustivity analysis for primitive patterns (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17810/head:pull/17810` \
`$ git checkout pull/17810`

Update a local copy of the PR: \
`$ git checkout pull/17810` \
`$ git pull https://git.openjdk.org/jdk.git pull/17810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17810`

View PR using the GUI difftool: \
`$ git pr show -t 17810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17810.diff">https://git.openjdk.org/jdk/pull/17810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17810#issuecomment-1939054875)