### PR TITLE
JDK-8325650: Table of contents scroll timeout not long enough

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -381,7 +381,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
         scrollTimeout = setTimeout(() => {
             scrollTimeout = null;
             handleScroll();
-        }, 50);
+        }, 100);
     }
     function handleScroll() {
         if (!sidebar || !sidebar.offsetParent || sidebar.classList.contains("hide-sidebar")) {
@@ -463,7 +463,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     // Resize handler
     function handleResize(e) {
         if (expanded) {
-            if (windowWidth != window.innerWidth) {
+            if (windowWidth !== window.innerWidth) {
                 collapse();
             } else {
                 expand();


### PR DESCRIPTION
Please review a simple change to increase a timeout value for suppression of scroll-following in the table of contents. This should have no visible effects to the user but may avoid flickering of the table of contents on slower computers. I also replaced a normal inequality operator (`!=`) with a strict one (`!==`) which is better practice when comparing equal types.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325650](https://bugs.openjdk.org/browse/JDK-8325650): Table of contents scroll timeout not long enough (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17811/head:pull/17811` \
`$ git checkout pull/17811`

Update a local copy of the PR: \
`$ git checkout pull/17811` \
`$ git pull https://git.openjdk.org/jdk.git pull/17811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17811`

View PR using the GUI difftool: \
`$ git pr show -t 17811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17811.diff">https://git.openjdk.org/jdk/pull/17811.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17811#issuecomment-1939071103)