### PR TITLE
8325587: Shenandoah: ShenandoahLock should allow blocking in VM

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1003,7 +1003,11 @@ HeapWord* ShenandoahHeap::allocate_memory(ShenandoahAllocRequest& req) {
 }
 
 HeapWord* ShenandoahHeap::allocate_memory_under_lock(ShenandoahAllocRequest& req, bool& in_new_region) {
-  ShenandoahHeapLocker locker(lock());
+  // If we are dealing with mutator allocation, then we may need to block for safepoint.
+  // We cannot block for safepoint for GC allocations, because there is a high chance
+  // we are already running at safepoint or from stack watermark machinery, and we cannot
+  // block again.
+  ShenandoahHeapLocker locker(lock(), req.is_mutator_alloc());
   return _free_set->allocate(req, in_new_region);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -28,8 +28,55 @@
 
 #include "gc/shenandoah/shenandoahLock.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/os.inline.hpp"
+
+void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
+  Thread* thread = Thread::current();
+  if (allow_block_for_safepoint && thread->is_Java_thread()) {
+    contended_lock_or_block(JavaThread::cast(thread));
+  } else {
+    contended_lock_no_block();
+  }
+}
+
+void ShenandoahLock::contended_lock_no_block() {
+  int ctr = 0;
+  int yields = 0;
+  while (Atomic::cmpxchg(&_state, 0, 1) != 0) {
+    ++ctr;
+    if ((ctr & 0xFFF) == 0 || !os::is_MP()) {
+      if (yields > 5) {
+        os::naked_short_sleep(1);
+      } else {
+        os::naked_yield();
+        ++yields;
+      }
+    } else {
+      SpinPause();
+    }
+  }
+}
+
+void ShenandoahLock::contended_lock_or_block(JavaThread* java_thread) {
+  int ctr = 0;
+  int yields = 0;
+  while (Atomic::cmpxchg(&_state, 0, 1) != 0) {
+    ++ctr;
+    if ((ctr & 0xFFF) == 0 || !os::is_MP()) {
+      ThreadBlockInVM tbivm(java_thread);
+      if (yields > 5) {
+        os::naked_short_sleep(1);
+      } else {
+        os::naked_yield();
+        ++yields;
+      }
+    } else {
+      SpinPause();
+    }
+  }
+}
 
 ShenandoahSimpleLock::ShenandoahSimpleLock() {
   assert(os::mutex_init_done(), "Too early!");


### PR DESCRIPTION
`ShenandoahLock` is a spinlock that is supposed to guard heap state. That lock is normally only lightly contended, as threads normally only allocate large TLABs/GCLABs. So we just summarily delegated to `Thread::{SpinAcquire,SpinRelease}`, which spins a bit, and then starts going to sleep/yield dance on contention.

This does not work well when there are lots of threads near the OOM conditions. Then, most of these threads would fail to allocate the TLAB, go for out-of-TLAB alloc, start lock acquisition, and spend _a lot_ of time trying to acquire the lock. The handshake/safepoint would think those threads are running, even when they are actually yielding or sleeping. As seen in bug report, a handshake operation over many such threads could then take hundreds of seconds.

The solution is to notify VM that we are blocking before going for `sleep` or `yield`. This is similar to what other VM code does near such yields. This involves state transitions, so it is only cheap to do near the actual blocking. Protecting the whole lock with VM transition would be very slow.

I also de-uglified bits of adjacent code.

Additional testing:
 - [x] Original Extremem reproducer does not have outliers anymore
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `all` passes with `-XX:+UseShenandoahGC` (some old failures, but quite a few "timeouts" also disappear)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325587](https://bugs.openjdk.org/browse/JDK-8325587): Shenandoah: ShenandoahLock should allow blocking in VM (**Bug** - P3)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17813/head:pull/17813` \
`$ git checkout pull/17813`

Update a local copy of the PR: \
`$ git checkout pull/17813` \
`$ git pull https://git.openjdk.org/jdk.git pull/17813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17813`

View PR using the GUI difftool: \
`$ git pr show -t 17813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17813.diff">https://git.openjdk.org/jdk/pull/17813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17813#issuecomment-1944378317)