### PR TITLE
8325672

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1103,6 +1103,7 @@ private:
   // Compute the Ideal Node to Loop mapping
   PhaseIdealLoop(PhaseIterGVN& igvn, LoopOptsMode mode) :
     PhaseTransform(Ideal_Loop),
+    _loop_or_ctrl(igvn.C->comp_arena()),
     _igvn(igvn),
     _verify_me(nullptr),
     _verify_only(false),
@@ -1117,6 +1118,7 @@ private:
   // or only verify that the graph is valid if verify_me is null.
   PhaseIdealLoop(PhaseIterGVN& igvn, const PhaseIdealLoop* verify_me = nullptr) :
     PhaseTransform(Ideal_Loop),
+    _loop_or_ctrl(igvn.C->comp_arena()),
     _igvn(igvn),
     _verify_me(verify_me),
     _verify_only(verify_me == nullptr),


### PR DESCRIPTION
If we don't do that, we can get in trouble with ResourceMarks inside the PhaseIdealLoop. If the array is updated because of new nodes, and this grows the area in a ResourceMark scope, then the data behind _loop_or_ctrl becomes invalid, and we get use-after-free memory corruption bugs.

The array was added in [JDK-8302670](https://bugs.openjdk.org/browse/JDK-8302670), so we should backport down to JDK21.

I don't yet have a reproducer. But this triggered with my patch for [JDK-8325589](https://bugs.openjdk.org/browse/JDK-8325589). See https://github.com/openjdk/jdk/pull/17800#discussion_r1486534950.