### PR TITLE
JDK-8325690: The scrollable element <div> with non-interactive content is not tabbable

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -727,7 +727,6 @@ div.checkboxes > label > input {
 }
 .col-first, .col-second, .col-constructor-name {
     vertical-align:top;
-    overflow: auto;
 }
 .col-last {
     white-space:normal;

--- a/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
+++ b/test/langtools/jdk/javadoc/doclet/testStylesheet/TestStylesheet.java
@@ -123,7 +123,6 @@ public class TestStylesheet extends JavadocTester {
                 """
                     .col-first, .col-second, .col-constructor-name {
                         vertical-align:top;
-                        overflow: auto;
                     }""",
                 """
                     .summary-table > div, .details-table > div {


### PR DESCRIPTION
The scrollable element <div> with non-interactive content is not tabbable. Grid columns in the javadoc stylesheet has overflow: auto, which is failing Accessibility checks.
https://bugs.openjdk.org/browse/JDK-8325690