### PR TITLE
8321282: RISC-V: SpinPause() not implemented

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -410,10 +410,10 @@ extern "C" {
     if (UseZihintpause) {
       // PAUSE is encoded as a FENCE instruction with pred=W, succ=0, fm=0, rd=x0, and rs1=x0.
       // fence   w, 0
-      // To do: __asm__ volatile("pause " : : : "memory");
+      // To do: __asm__ volatile("pause " : : : );
       // We need to compile against march with zihintpause.
       // Currently we do not.
-      __asm__ volatile(".word 0x0100000f  " : : : "memory");
+      __asm__ volatile(".word 0x0100000f  " : : : );
       return 1;
     }
     return 0;

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -39,6 +39,7 @@
 #include "prims/jvm_misc.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/frame.inline.hpp"
+#include "runtime/globals.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/javaCalls.hpp"
@@ -406,6 +407,15 @@ static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
 
 extern "C" {
   int SpinPause() {
+    if (UseZihintpause) {
+      // PAUSE is encoded as a FENCE instruction with pred=W, succ=0, fm=0, rd=x0, and rs1=x0.
+      // fence   w, 0
+      // To do: __asm__ volatile("pause " : : : "memory");
+      // We need to compile against march with zihintpause.
+      // Currently we do not.
+      __asm__ volatile(".word 0x0100000f  " : : : "memory");
+      return 1;
+    }
     return 0;
   }
 

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -409,10 +409,9 @@ extern "C" {
   int SpinPause() {
     if (UseZihintpause) {
       // PAUSE is encoded as a FENCE instruction with pred=W, succ=0, fm=0, rd=x0, and rs1=x0.
-      // fence   w, 0
       // To do: __asm__ volatile("pause " : : : );
-      // We need to compile against march with zihintpause.
-      // Currently we do not.
+      // Since we're currently not passing '-march=..._zihintpause' to the compiler,
+      // it will not recognize the "pause" instruction, hence the hard-coded instruction.
       __asm__ volatile(".word 0x0100000f  " : : : );
       return 1;
     }


### PR DESCRIPTION
Hi, please consider.

Tested tier1 and targeted via gtest WaitBarrier which uses SpinPause(). (with UseZihintpause default true)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321282](https://bugs.openjdk.org/browse/JDK-8321282): RISC-V: SpinPause() not implemented (**Bug** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Author)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17820/head:pull/17820` \
`$ git checkout pull/17820`

Update a local copy of the PR: \
`$ git checkout pull/17820` \
`$ git pull https://git.openjdk.org/jdk.git pull/17820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17820`

View PR using the GUI difftool: \
`$ git pr show -t 17820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17820.diff">https://git.openjdk.org/jdk/pull/17820.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17820#issuecomment-1940661409)