### PR TITLE
8323520: Drop unnecessary virtual specifier in Space

### DIFF
--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -77,8 +77,8 @@ class Space: public CHeapObj<mtGC> {
   // Accessors
   HeapWord* bottom() const         { return _bottom; }
   HeapWord* end() const            { return _end;    }
-  virtual void set_bottom(HeapWord* value) { _bottom = value; }
-  virtual void set_end(HeapWord* value)    { _end = value; }
+  void set_bottom(HeapWord* value) { _bottom = value; }
+  void set_end(HeapWord* value)    { _end = value; }
 
   HeapWord* saved_mark_word() const  { return _saved_mark_word; }
 


### PR DESCRIPTION
Trivial removing `virtual` specifier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323520](https://bugs.openjdk.org/browse/JDK-8323520): Drop unnecessary virtual specifier in Space (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17823/head:pull/17823` \
`$ git checkout pull/17823`

Update a local copy of the PR: \
`$ git checkout pull/17823` \
`$ git pull https://git.openjdk.org/jdk.git pull/17823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17823`

View PR using the GUI difftool: \
`$ git pr show -t 17823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17823.diff">https://git.openjdk.org/jdk/pull/17823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17823#issuecomment-1940997294)