### PR TITLE
8320534: fatal error for the NMTBenchmark test run for the mainline build

### DIFF
--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 package org.openjdk.bench.vm.runtime;
 
 import org.openjdk.jmh.annotations.*;
-import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 
 import jdk.internal.misc.Unsafe;
@@ -36,7 +35,7 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@State(Scope.Benchmark)
+@State(Scope.Thread)
 @Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 public abstract class NMTBenchmark {
@@ -106,16 +105,8 @@ public abstract class NMTBenchmark {
     }
   }
 
-  @Setup
-  public void setup(BenchmarkParams params) throws InterruptedException {
-    if (params.getThreads() != 1)
-      throw new InterruptedException("This benchmark should run only with one thread.");
-  }
-
   @Benchmark
-  public void mixAllocateFreeMemory(BenchmarkParams params, Blackhole bh) throws InterruptedException{
-    if (params.getThreads() != 1)
-      throw new InterruptedException("This benchmark should run only with one thread.");
+  public void mixAallocateFreeMemory(Blackhole bh) throws InterruptedException{
 
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
@@ -172,10 +163,7 @@ public abstract class NMTBenchmark {
   }
 
   @Benchmark
-  public void onlyAllocateMemory(BenchmarkParams params) throws InterruptedException {
-    if (params.getThreads() != 1)
-      throw new InterruptedException("This benchmark should run only with one thread.");
-
+  public void onlyAllocateMemory() throws InterruptedException {
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
       throw new InterruptedException();
@@ -206,10 +194,7 @@ public abstract class NMTBenchmark {
   }
 
   @Benchmark
-  public void mixAllocateReallocateMemory(BenchmarkParams params) throws InterruptedException {
-    if (params.getThreads() != 1)
-      throw new InterruptedException("This benchmark should run only with one thread.");
-
+  public void mixAllocateReallocateMemory() throws InterruptedException {
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
       throw new InterruptedException();

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 package org.openjdk.bench.vm.runtime;
 
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.BenchmarkParams;
 import org.openjdk.jmh.infra.Blackhole;
 
 import jdk.internal.misc.Unsafe;
@@ -85,10 +86,12 @@ public abstract class NMTBenchmark {
       if (i % 3 == 1) alloc1(i);
       if (i % 3 == 2) alloc2(i);
     }
+
     private void alloc0(int i) {
       if (unsafe == null) return;
       addresses[i] = unsafe.allocateMemory(S);
     }
+
     private void alloc1(int i) { alloc0(i); }
     private void alloc2(int i) { alloc1(i); }
 
@@ -103,8 +106,16 @@ public abstract class NMTBenchmark {
     }
   }
 
+  @Setup
+  public void setup(BenchmarkParams params) throws InterruptedException {
+    if (params.getThreads() != 1)
+      throw new InterruptedException("This benchmark should run only with one thread.");
+  }
+
   @Benchmark
-  public void mixAallocateFreeMemory(Blackhole bh) throws InterruptedException{
+  public void mixAllocateFreeMemory(BenchmarkParams params, Blackhole bh) throws InterruptedException{
+    if (params.getThreads() != 1)
+      throw new InterruptedException("This benchmark should run only with one thread.");
 
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
@@ -161,7 +172,10 @@ public abstract class NMTBenchmark {
   }
 
   @Benchmark
-  public void onlyAllocateMemory() throws InterruptedException {
+  public void onlyAllocateMemory(BenchmarkParams params) throws InterruptedException {
+    if (params.getThreads() != 1)
+      throw new InterruptedException("This benchmark should run only with one thread.");
+
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
       throw new InterruptedException();
@@ -192,7 +206,10 @@ public abstract class NMTBenchmark {
   }
 
   @Benchmark
-  public void mixAllocateReallocateMemory() throws InterruptedException {
+  public void mixAllocateReallocateMemory(BenchmarkParams params) throws InterruptedException {
+    if (params.getThreads() != 1)
+      throw new InterruptedException("This benchmark should run only with one thread.");
+
     Unsafe unsafe = Unsafe.getUnsafe();
     if (unsafe == null) {
       throw new InterruptedException();


### PR DESCRIPTION
This benchmark creates and manages threads internally. So, the number of threads is determined by the benchmark and cannot be set in command line arguments.
The number of threads in BenchmarkParams is checked and an exception is thrown if it is invalid.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320534](https://bugs.openjdk.org/browse/JDK-8320534): fatal error for the NMTBenchmark test run for the mainline build (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17824/head:pull/17824` \
`$ git checkout pull/17824`

Update a local copy of the PR: \
`$ git checkout pull/17824` \
`$ git pull https://git.openjdk.org/jdk.git pull/17824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17824`

View PR using the GUI difftool: \
`$ git pr show -t 17824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17824.diff">https://git.openjdk.org/jdk/pull/17824.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17824#issuecomment-1941238212)