### PR TITLE
8325731: Installation instructions for Debian/Ubuntu don't mention autoconf

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -526,7 +526,7 @@ header files as provided by your distribution.</p>
 <p>The basic tooling is provided as part of the core operating system,
 but you will most likely need to install developer packages.</p>
 <p>For apt-based distributions (Debian, Ubuntu, etc), try this:</p>
-<pre><code>sudo apt-get install build-essential</code></pre>
+<pre><code>sudo apt-get install build-essential autoconf</code></pre>
 <p>For rpm-based distributions (Fedora, Red Hat, etc), try this:</p>
 <pre><code>sudo yum groupinstall &quot;Development Tools&quot;</code></pre>
 <p>For Alpine Linux, aside from basic tooling, install the GNU versions

--- a/doc/building.md
+++ b/doc/building.md
@@ -349,7 +349,7 @@ will most likely need to install developer packages.
 For apt-based distributions (Debian, Ubuntu, etc), try this:
 
 ```
-sudo apt-get install build-essential
+sudo apt-get install build-essential autoconf
 ```
 
 For rpm-based distributions (Fedora, Red Hat, etc), try this:


### PR DESCRIPTION
So I added autoconf besides build-essential. With both packages, `bash configure` is runnable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325731](https://bugs.openjdk.org/browse/JDK-8325731): Installation instructions for Debian/Ubuntu don't mention autoconf (**Bug** - P5)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17826/head:pull/17826` \
`$ git checkout pull/17826`

Update a local copy of the PR: \
`$ git checkout pull/17826` \
`$ git pull https://git.openjdk.org/jdk.git pull/17826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17826`

View PR using the GUI difftool: \
`$ git pr show -t 17826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17826.diff">https://git.openjdk.org/jdk/pull/17826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17826#issuecomment-1941301479)