### PR TITLE
8325742: Remove MetaWord usage from MemRegion

### DIFF
--- a/src/hotspot/share/memory/memRegion.hpp
+++ b/src/hotspot/share/memory/memRegion.hpp
@@ -54,10 +54,6 @@ public:
     _start(start), _word_size(pointer_delta(end, start)) {
     assert(end >= start, "incorrect constructor arguments");
   }
-  MemRegion(MetaWord* start, MetaWord* end) :
-    _start((HeapWord*)start), _word_size(pointer_delta(end, start)) {
-    assert(end >= start, "incorrect constructor arguments");
-  }
 
   MemRegion intersection(const MemRegion mr2) const;
   // regions must overlap or be adjacent


### PR DESCRIPTION
There's a MemRegion constructor that takes MetaWord*s arguments. This is left-over from the permgen removal and it isn't used anymore. I propose that we remove it. 