### PR TITLE
JDK-8325743: test/jdk/java/nio/channels/unixdomain/SocketOptions.java enhance user name output in error case

### DIFF
--- a/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
+++ b/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
@@ -72,7 +72,7 @@ public class SocketOptions {
                 // Check returned user name
 
                 if (!s1.equals(s2)) {
-                    throw new RuntimeException("wrong username");
+                    throw new RuntimeException("wrong username, we got " + s1 + " but property user.name is " + s2);
                 }
 
                 // Try setting the option: Read only

--- a/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
+++ b/test/jdk/java/nio/channels/unixdomain/SocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,8 @@ public class SocketOptions {
                 // Check returned user name
 
                 if (!s1.equals(s2)) {
-                    throw new RuntimeException("wrong username, we got " + s1 + " but property user.name is " + s2);
+                    throw new RuntimeException("wrong username, actual " + s1 +
+                                               " but expected value from property user.name is " + s2);
                 }
 
                 // Try setting the option: Read only


### PR DESCRIPTION
In case of a bad running LDAP we got this output from test test/jdk/java/nio/channels/unixdomain/SocketOptions.java

java.lang.RuntimeException: wrong username
at SocketOptions.testPeerCred(SocketOptions.java:75)
at SocketOptions.main(SocketOptions.java:52)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1583)

It would be better to see the compared values (user name data we compare) and get them in the exception output.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325743](https://bugs.openjdk.org/browse/JDK-8325743): test/jdk/java/nio/channels/unixdomain/SocketOptions.java enhance user name output in error case (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [19e7a9b6](https://git.openjdk.org/jdk/pull/17829/files/19e7a9b617ad4119fb2c86ee00c81d624290a8c4)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17829/head:pull/17829` \
`$ git checkout pull/17829`

Update a local copy of the PR: \
`$ git checkout pull/17829` \
`$ git pull https://git.openjdk.org/jdk.git pull/17829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17829`

View PR using the GUI difftool: \
`$ git pr show -t 17829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17829.diff">https://git.openjdk.org/jdk/pull/17829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17829#issuecomment-1941580993)