### PR TITLE
8325748: Serial: Move Generation::promote to TenuredGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -142,15 +142,6 @@ class Generation: public CHeapObj<mtGC> {
   // Thread-local allocation buffers
   virtual bool supports_tlab_allocation() const { return false; }
 
-  // "obj" is the address of an object in a younger generation.  Allocate space
-  // for "obj" in the current (or some higher) generation, and copy "obj" into
-  // the newly allocated space, if possible, returning the result (or null if
-  // the allocation failed).
-  //
-  // The "obj_size" argument is just obj->size(), passed along so the caller can
-  // avoid repeating the virtual call to retrieve it.
-  virtual oop promote(oop obj, size_t obj_size);
-
   // Returns "true" iff collect() should subsequently be called on this
   // this generation. See comment below.
   // This is a generic implementation which can be overridden.

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -29,6 +29,7 @@
 #include "gc/serial/serialHeap.hpp"
 #include "gc/serial/tenuredGeneration.inline.hpp"
 #include "gc/shared/collectorCounters.hpp"
+#include "gc/shared/continuationGCSupport.inline.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTrace.hpp"
@@ -411,6 +412,35 @@ bool TenuredGeneration::promotion_attempt_is_safe(size_t max_promotion_in_bytes)
     res? "":" not", available, res? ">=":"<", av_promo, max_promotion_in_bytes);
 
   return res;
+}
+
+oop TenuredGeneration::promote(oop obj, size_t obj_size) {
+  assert(obj_size == obj->size(), "bad obj_size passed in");
+
+#ifndef PRODUCT
+  if (SerialHeap::heap()->promotion_should_fail()) {
+    return nullptr;
+  }
+#endif  // #ifndef PRODUCT
+
+  // Allocate new object.
+  HeapWord* result = allocate(obj_size, false);
+  if (result == nullptr) {
+    // Promotion of obj into gen failed.  Try to expand and allocate.
+    result = expand_and_allocate(obj_size, false);
+    if (result == nullptr) {
+      return nullptr;
+    }
+  }
+
+  // Copy to new location.
+  Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), result, obj_size);
+  oop new_obj = cast_to_oop<HeapWord*>(result);
+
+  // Transform object if it is a stack chunk.
+  ContinuationGCSupport::transform_stack_chunk(new_obj);
+
+  return new_obj;
 }
 
 void TenuredGeneration::collect(bool   full,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -160,6 +160,14 @@ class TenuredGeneration: public Generation {
   // might be attempted in the worst case.
   bool promotion_attempt_is_safe(size_t max_promoted_in_bytes) const;
 
+  // "obj" is the address of an object in young-gen.  Allocate space for "obj"
+  // in the old-gen, and copy "obj" into the newly allocated space, if
+  // possible, returning the result (or null if the allocation failed).
+  //
+  // The "obj_size" argument is just obj->size(), passed along so the caller can
+  // avoid repeating the virtual call to retrieve it.
+  oop promote(oop obj, size_t obj_size);
+
   virtual void verify();
   virtual void print_on(outputStream* st) const;
 };


### PR DESCRIPTION
Trivial moving a method, and minor doc revision.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325748](https://bugs.openjdk.org/browse/JDK-8325748): Serial: Move Generation::promote to TenuredGeneration (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17830/head:pull/17830` \
`$ git checkout pull/17830`

Update a local copy of the PR: \
`$ git checkout pull/17830` \
`$ git pull https://git.openjdk.org/jdk.git pull/17830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17830`

View PR using the GUI difftool: \
`$ git pr show -t 17830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17830.diff">https://git.openjdk.org/jdk/pull/17830.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17830#issuecomment-1941609504)