### PR TITLE
8325750: Fix spelling of ForceTranslateFailure help message

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -240,7 +240,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
                 "name (a stub) or fully qualified name (an nmethod) contains this option's value as a substring."),
         ForceTranslateFailure(String.class, null, "Forces HotSpotJVMCIRuntime.translate to throw an exception in the context " +
                 "of the peer runtime. The value is a filter that can restrict the forced failure to matching translated " +
-                "objects. See HotSpotJVMCIRuntime.postTranslation for more details. This option exists soley to test " +
+                "objects. See HotSpotJVMCIRuntime.postTranslation for more details. This option exists solely to test " +
                 "correct handling of translation failure."),
         PrintConfig(Boolean.class, false, "Prints VM configuration available via JVMCI."),
         AuditHandles(Boolean.class, false, "Record stack trace along with scoped foreign object reference wrappers " +

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -241,7 +241,7 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         ForceTranslateFailure(String.class, null, "Forces HotSpotJVMCIRuntime.translate to throw an exception in the context " +
                 "of the peer runtime. The value is a filter that can restrict the forced failure to matching translated " +
                 "objects. See HotSpotJVMCIRuntime.postTranslation for more details. This option exists solely to test " +
-                "correct handling of translation failure."),
+                "correct handling of translation failures."),
         PrintConfig(Boolean.class, false, "Prints VM configuration available via JVMCI."),
         AuditHandles(Boolean.class, false, "Record stack trace along with scoped foreign object reference wrappers " +
                 "to debug issue with a wrapper being used after its scope has closed."),


### PR DESCRIPTION
This PR fixes a spelling mistake in the help text for the `jvmci.ForceTranslateFailure` option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325750](https://bugs.openjdk.org/browse/JDK-8325750): Fix spelling of ForceTranslateFailure help message (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17831/head:pull/17831` \
`$ git checkout pull/17831`

Update a local copy of the PR: \
`$ git checkout pull/17831` \
`$ git pull https://git.openjdk.org/jdk.git pull/17831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17831`

View PR using the GUI difftool: \
`$ git pr show -t 17831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17831.diff">https://git.openjdk.org/jdk/pull/17831.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17831#issuecomment-1941649154)