### PR TITLE
8316340: (bf) Missing {@inheritDoc} for exception in MappedByteBuffer::compact

### DIFF
--- a/src/java.base/share/classes/java/nio/MappedByteBuffer.java
+++ b/src/java.base/share/classes/java/nio/MappedByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -422,6 +422,7 @@ public abstract sealed class MappedByteBuffer
 
     /**
      * {@inheritDoc}
+     * @throws  ReadOnlyBufferException {@inheritDoc}
      */
     @Override
     public abstract MappedByteBuffer compact();


### PR DESCRIPTION
Explicitly add a throws clause for `ReadOnlyBufferException` to the specification of `MappedByteBuffer.compact`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316340](https://bugs.openjdk.org/browse/JDK-8316340): (bf) Missing {@<!---->inheritDoc} for exception in MappedByteBuffer::compact (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17835/head:pull/17835` \
`$ git checkout pull/17835`

Update a local copy of the PR: \
`$ git checkout pull/17835` \
`$ git pull https://git.openjdk.org/jdk.git pull/17835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17835`

View PR using the GUI difftool: \
`$ git pr show -t 17835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17835.diff">https://git.openjdk.org/jdk/pull/17835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17835#issuecomment-1942211956)