### PR TITLE
8325767: Serial: Move transform_stack_chunk out of TenuredGeneration::promote

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -862,6 +862,7 @@ oop DefNewGeneration::copy_to_survivor_space(oop old) {
       handle_promotion_failure(old);
       return old;
     }
+    ContinuationGCSupport::transform_stack_chunk(obj);
     new_obj_is_tenured = true;
   } else {
     // Prefetch beyond obj

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -862,7 +862,9 @@ oop DefNewGeneration::copy_to_survivor_space(oop old) {
       handle_promotion_failure(old);
       return old;
     }
+
     ContinuationGCSupport::transform_stack_chunk(obj);
+
     new_obj_is_tenured = true;
   } else {
     // Prefetch beyond obj

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -29,7 +29,6 @@
 #include "gc/serial/serialHeap.hpp"
 #include "gc/serial/tenuredGeneration.inline.hpp"
 #include "gc/shared/collectorCounters.hpp"
-#include "gc/shared/continuationGCSupport.inline.hpp"
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTrace.hpp"
@@ -436,10 +435,6 @@ oop TenuredGeneration::promote(oop obj, size_t obj_size) {
   // Copy to new location.
   Copy::aligned_disjoint_words(cast_from_oop<HeapWord*>(obj), result, obj_size);
   oop new_obj = cast_to_oop<HeapWord*>(result);
-
-  // Transform object if it is a stack chunk.
-  ContinuationGCSupport::transform_stack_chunk(new_obj);
-
   return new_obj;
 }
 


### PR DESCRIPTION
Trivial a method call from callee to caller.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325767](https://bugs.openjdk.org/browse/JDK-8325767): Serial: Move transform_stack_chunk out of TenuredGeneration::promote (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [0f875185](https://git.openjdk.org/jdk/pull/17836/files/0f8751859f4e9e23f87efb3c405d85fb46bc982d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17836/head:pull/17836` \
`$ git checkout pull/17836`

Update a local copy of the PR: \
`$ git checkout pull/17836` \
`$ git pull https://git.openjdk.org/jdk.git pull/17836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17836`

View PR using the GUI difftool: \
`$ git pr show -t 17836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17836.diff">https://git.openjdk.org/jdk/pull/17836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17836#issuecomment-1942221434)