### PR TITLE
8325800: Drop unused cups declaration from Oracle build configuration

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1179,12 +1179,6 @@ var getJibProfilesDependencies = function (input, common) {
             ext: "tar.gz",
             module: "devkit-macosx" + (input.build_cpu == "x64" ? "_x64" : ""),
             revision: (input.build_cpu == "x64" ? "Xcode11.3.1-MacOSX10.15+1.2" : devkit_platform_revisions[devkit_platform])
-        },
-
-        cups: {
-            organization: common.organization,
-            ext: "tar.gz",
-            revision: "1.0118+1.0"
         },
 
         jtreg: {


### PR DESCRIPTION
The cups dependency was used for Solaris builds, and has been unused since [JDK-8244224](https://bugs.openjdk.org/browse/JDK-8244224).

Testing: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325800](https://bugs.openjdk.org/browse/JDK-8325800): Drop unused cups declaration from Oracle build configuration (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17837/head:pull/17837` \
`$ git checkout pull/17837`

Update a local copy of the PR: \
`$ git checkout pull/17837` \
`$ git pull https://git.openjdk.org/jdk.git pull/17837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17837`

View PR using the GUI difftool: \
`$ git pr show -t 17837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17837.diff">https://git.openjdk.org/jdk/pull/17837.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17837#issuecomment-1942477919)