### PR TITLE
8325809: JFR: Remove unnecessary annotation

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import jdk.jfr.internal.Type;
 @Name(Type.EVENT_NAME_PREFIX + "ActiveRecording")
 @Label("Flight Recording")
 @Category("Flight Recorder")
-@StackTrace(false)
 @RemoveFields({"duration", "eventThread", "stackTrace"})
 public final class ActiveRecordingEvent extends AbstractJDKEvent {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import jdk.jfr.internal.Type;
 @Name(Type.EVENT_NAME_PREFIX + "ActiveSetting")
 @Label("Recording Setting")
 @Category("Flight Recorder")
-@StackTrace(false)
 @RemoveFields({"duration", "eventThread", "stackTrace"})
 public final class ActiveSettingEvent extends AbstractJDKEvent {
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ExceptionStatisticsEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ExceptionStatisticsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import jdk.jfr.internal.Type;
 @Category({ "Java Application", "Statistics" })
 @Description("Number of objects derived from java.lang.Throwable that have been created")
 @MirrorEvent(className = "jdk.internal.event.ExceptionStatisticsEvent")
-@StackTrace(false)
 public final class ExceptionStatisticsEvent extends AbstractPeriodicEvent {
 
     @Label("Exceptions Created")


### PR DESCRIPTION
Hi,

Could I have a review of change that removes an unnecessary annotation on some of the JDK events  The` @StackTrace(false)`is inherited from AbstractJDKEvent so it is not needed. Also, the events lack the `stackTrace` field.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325809](https://bugs.openjdk.org/browse/JDK-8325809): JFR: Remove unnecessary annotation (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17840/head:pull/17840` \
`$ git checkout pull/17840`

Update a local copy of the PR: \
`$ git checkout pull/17840` \
`$ git pull https://git.openjdk.org/jdk.git pull/17840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17840`

View PR using the GUI difftool: \
`$ git pr show -t 17840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17840.diff">https://git.openjdk.org/jdk/pull/17840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17840#issuecomment-1942937001)