### PR TITLE
8318812: LauncherHelper.checkAndLoadMain closes jar file that's about to be re-opened

### DIFF
--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -873,7 +873,7 @@ public final class LauncherHelper {
                 try {
                     jarFile.close();
                 } catch (IOException ioe) {
-                    abort(ioe, "java.launcher.jar.error1", what);
+                    abort(ioe, "java.launcher.jar.error5", what);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -816,9 +816,10 @@ public final class LauncherHelper {
     private static Class<?> loadMainClass(int mode, String what) {
         // get the class name
         String cn = null;
-        // In LM_JAR mode, put the underlying file in the JarFile/ZipFile cache.
-        // This will avoid needing to re-parse the manifest when the JAR file
-        // is opened on the class path, triggered by Class.forName below.
+        // In LM_JAR mode, keep the underlying file open to retain it in
+        // the JarFile/ZipFile cache. This will avoid needing to re-parse
+        // the central directory when the file is opened on the class path,
+        // triggered by Class.forName below.
         JarFile jarFile = null;
         switch (mode) {
             case LM_CLASS:

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -821,13 +821,17 @@ public final class LauncherHelper {
         // get the class name
         String cn;
         // store the jar file
-        JarFile jarFile;
+        JarFile jarFile = null;
         switch (mode) {
             case LM_CLASS:
                 cn = what;
                 break;
             case LM_JAR:
-                jarFile = new JarFile(what);
+                try {
+                    jarFile = new JarFile(what);
+                } catch (IOException ioe) {
+                    abort(ioe, "java.launcher.jar.error1", what);
+                }
                 cn = getMainClassFromJar(what, jarFile);
                 break;
             default:

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -261,6 +261,8 @@ java.launcher.jar.error1=\
 java.launcher.jar.error2=manifest not found in {0}
 java.launcher.jar.error3=no main manifest attribute, in {0}
 java.launcher.jar.error4=error loading java agent in {0}
+java.launcher.jar.error5=\
+    Error: An unexpected error occurred while trying to close file {0}
 java.launcher.jar.error.illegal.ena.value=\
     Error: illegal value \"{0}\" for Enable-Native-Access manifest attribute. Only 'ALL-UNNAMED' is allowed
 java.launcher.init.error=initialization error


### PR DESCRIPTION
Please review this PR that makes the launcher helper keep a reference to the executable JAR file active after extracting the name of the main class and returning it as Class instance. Now, when loading classes from the JAR file, it hasn't to be re-opened.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318812](https://bugs.openjdk.org/browse/JDK-8318812): LauncherHelper.checkAndLoadMain closes jar file that's about to be re-opened (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [202a4ef4](https://git.openjdk.org/jdk/pull/17843/files/202a4ef454a55fcd483c4f406752728606be4dbb)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17843/head:pull/17843` \
`$ git checkout pull/17843`

Update a local copy of the PR: \
`$ git checkout pull/17843` \
`$ git pull https://git.openjdk.org/jdk.git pull/17843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17843`

View PR using the GUI difftool: \
`$ git pr show -t 17843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17843.diff">https://git.openjdk.org/jdk/pull/17843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17843#issuecomment-1943547331)