### PR TITLE
8325858: Replace Unsafe usage in XEmbeddingContainer with FFM API

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,26 @@
 
 package sun.awt.X11;
 
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.lang.ref.Reference;
+import java.util.HashMap;
+
+import jdk.internal.misc.Unsafe;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * XAtom is a class that allows you to create and modify X Window properties.
  * An X Atom is an identifier for a property that you can set on any X Window.
  * Standard X Atom are defined by X11 and these atoms are defined in this class
  * for convenience. Common X Atoms like {@code XA_WM_NAME} are used to communicate with the
  * Window manager to let it know the Window name. The use and protocol for these
- * atoms are defined in the Inter client communications converntions manual.
+ * atoms are defined in the Inter client communications conventions manual.
  * User specified XAtoms are defined by specifying a name that gets Interned
  * by the XServer and an {@code XAtom} object is returned. An {@code XAtom} can also be created
- * by using a pre-exisiting atom like {@code XA_WM_CLASS}. A {@code display} has to be specified
+ * by using a pre-existing atom like {@code XA_WM_CLASS}. A {@code display} has to be specified
  * in order to create an {@code XAtom}. <p> <p>
  *
  * Once an {@code XAtom} instance is created, you can call get and set property methods to
@@ -57,13 +67,6 @@ package sun.awt.X11;
  * @author  Bino George
  * @since       1.5
  */
-
-import java.util.HashMap;
-
-import jdk.internal.misc.Unsafe;
-
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 public final class XAtom {
 
@@ -409,6 +412,21 @@ public final class XAtom {
      */
     public void setCard32Property(XBaseWindow window, long value) {
         setCard32Property(window.getWindow(), value);
+    }
+
+    /**
+     * Gets uninterpreted set of data from property and stores them in the data segment.
+     * Property type is the same as current atom, property is current atom.
+     * Property format is 32. Property 'delete' is false.
+     * Returns boolean if requested type, format, length match returned values
+     * and returned data pointer is not null.
+     */
+    public boolean getAtomData(long window, MemorySegment data) {
+        try {
+            return getAtomData(window, data.address(), (int) (data.byteSize() / ValueLayout.JAVA_INT.byteSize()));
+        } finally {
+            Reference.reachabilityFence(data);
+        }
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XAtom.java
@@ -428,8 +428,9 @@ public final class XAtom {
                 return false;
             }
             long bytes = (long) length * getAtomSize();
+            @SuppressWarnings("restricted")
             MemorySegment source = MemorySegment.ofAddress(getter.getData())
-                    .reinterpret(bytes, arena, ms -> {});
+                    .reinterpret(bytes, arena, null);
             MemorySegment.copy(source, 0, data, 0, bytes);
             return true;
         } finally {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XEmbedHelper.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XEmbedHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,11 @@ import sun.util.logging.PlatformLogger;
 
 import java.awt.AWTKeyStroke;
 import java.awt.event.InputEvent;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.VarHandle;
 
 /**
  * Common class for all XEmbed protocol participating classes.
@@ -76,7 +81,16 @@ public class XEmbedHelper {
     static final int XEMBED_MODIFIER_SUPER   = (1 << 3);
     static final int XEMBED_MODIFIER_HYPER   = (1 << 4);
 
+    static StructLayout X_EMBED_INFO_LAYOUT = MemoryLayout.structLayout(
+            ValueLayout.JAVA_INT.withName("protocol"),
+            ValueLayout.JAVA_INT.withName("flags")
+    );
+
+    static VarHandle X_EMBED_INFO_PROTOCOL = X_EMBED_INFO_LAYOUT.varHandle(PathElement.groupElement("protocol"));
+    static VarHandle X_EMBED_INFO_FLAGS = X_EMBED_INFO_LAYOUT.varHandle(PathElement.groupElement("flags"));
+
     static XAtom XEmbedInfo;
+
     static XAtom XEmbed;
 
     XEmbedHelper() {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddingContainer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddingContainer.java
@@ -74,7 +74,7 @@ public class XEmbeddingContainer extends XEmbedHelper implements XEventDispatche
     boolean checkXEmbed(long child) {
         try (Arena arena = Arena.ofConfined()){
             MemorySegment data = arena.allocate(X_EMBED_INFO_LAYOUT);
-            if (XEmbedInfo.getAtomData(child, data)) {
+            if (XEmbedInfo.getAtomData(child, arena, data)) {
                 int protocol = (int)X_EMBED_INFO_PROTOCOL.get(data, 0L);
                 int flags = (int)X_EMBED_INFO_FLAGS.get(data, 0L);
                 return true;


### PR DESCRIPTION
This PR proposes to remove the use of `Unsafe` in the class `XEmbeddingContainer ` and replace it with the supported FFM API.

I tried to make this PR as small as possible while opening up for migration of other classes later on (such as `XEmbedServer` which can be modified similarly under a separate PR).

There are also three drive-by fixes in this PR:
 * Moved JavaDocs for `XAtom` to its proper location and fixed two typos in the text
 * Declared a field in `XEmbeddingContainer` as `private final`
 * In `XAtom`, use a utility method `assertAtomInitialized()` instead of the current duplicated code

Tested and passed tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325858](https://bugs.openjdk.org/browse/JDK-8325858): Replace Unsafe usage in XEmbeddingContainer with FFM API (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17846/head:pull/17846` \
`$ git checkout pull/17846`

Update a local copy of the PR: \
`$ git checkout pull/17846` \
`$ git pull https://git.openjdk.org/jdk.git pull/17846/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17846`

View PR using the GUI difftool: \
`$ git pr show -t 17846`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17846.diff">https://git.openjdk.org/jdk/pull/17846.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17846#issuecomment-1943779516)