### PR TITLE
8325882: Serial: Move is_maximal_no_gc to TenuredGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -201,9 +201,6 @@ class DefNewGeneration: public Generation {
   // Return true if the expansion was successful.
   bool expand(size_t bytes);
 
-  // DefNewGeneration cannot currently expand except at
-  // a GC.
-  virtual bool is_maximal_no_gc() const { return true; }
 
   // Iteration
   void object_iterate(ObjectClosure* blk);

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -105,12 +105,6 @@ class Generation: public CHeapObj<mtGC> {
   // The largest number of contiguous free bytes in this or any higher generation.
   virtual size_t max_contiguous_available() const;
 
-  // Returns true if this generation cannot be expanded further
-  // without a GC. Override as appropriate.
-  virtual bool is_maximal_no_gc() const {
-    return _virtual_space.uncommitted_size() == 0;
-  }
-
   MemRegion reserved() const { return _reserved; }
 
   /* Returns "TRUE" iff "p" points into the reserved area of the generation. */

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -963,7 +963,8 @@ void SerialHeap::generation_iterate(GenClosure* cl,
 }
 
 bool SerialHeap::is_maximal_no_gc() const {
-  return _young_gen->is_maximal_no_gc() && _old_gen->is_maximal_no_gc();
+  // We don't expand young-gen except at a GC.
+  return _old_gen->is_maximal_no_gc();
 }
 
 void SerialHeap::save_marks() {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -98,6 +98,12 @@ class TenuredGeneration: public Generation {
   MemRegion prev_used_region() const { return _prev_used_region; }
   void save_used_region()   { _prev_used_region = used_region(); }
 
+  // Returns true if this generation cannot be expanded further
+  // without a GC.
+  bool is_maximal_no_gc() const {
+    return _virtual_space.uncommitted_size() == 0;
+  }
+
   HeapWord* block_start(const void* p) const;
 
   void scan_old_to_young_refs();


### PR DESCRIPTION
Trivial moving a method from superclass to subclass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325882](https://bugs.openjdk.org/browse/JDK-8325882): Serial: Move is_maximal_no_gc to TenuredGeneration (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17850/head:pull/17850` \
`$ git checkout pull/17850`

Update a local copy of the PR: \
`$ git checkout pull/17850` \
`$ git pull https://git.openjdk.org/jdk.git pull/17850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17850`

View PR using the GUI difftool: \
`$ git pr show -t 17850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17850.diff">https://git.openjdk.org/jdk/pull/17850.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17850#issuecomment-1944196293)