### PR TITLE
8325682: Rename nsk_strace.h

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.hpp
@@ -35,7 +35,7 @@
 // Check for pending exception of the specified type
 // If it's present, then clear it
 #define EXCEPTION_CHECK(exceptionClass, recurDepth) \
-        if (EXCEPTION_OCCURRED != NULL) { \
+        if (EXCEPTION_OCCURRED != nullptr) { \
             jobject exception = EXCEPTION_OCCURRED; \
             if (env->IsInstanceOf(exception, exceptionClass) == JNI_TRUE) { \
                 EXCEPTION_CLEAR; \
@@ -45,22 +45,22 @@
 
 #define FIND_CLASS(_class, _className)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            env->FindClass(_className)) != NULL))\
+            env->FindClass(_className)) != nullptr))\
         exit(1)
 
 #define GET_OBJECT_CLASS(_class, _obj)\
     if (!NSK_JNI_VERIFY(env, (_class = \
-            env->GetObjectClass(_obj)) != NULL))\
+            env->GetObjectClass(_obj)) != nullptr))\
         exit(1)
 
 #define GET_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            env->GetFieldID(_class, _fieldName, _fieldSig)) != NULL))\
+            env->GetFieldID(_class, _fieldName, _fieldSig)) != nullptr))\
         exit(1)
 
 #define GET_STATIC_FIELD_ID(_fieldID, _class, _fieldName, _fieldSig)\
     if (!NSK_JNI_VERIFY(env, (_fieldID = \
-            env->GetStaticFieldID(_class, _fieldName, _fieldSig)) != NULL))\
+            env->GetStaticFieldID(_class, _fieldName, _fieldSig)) != nullptr))\
         exit(1)
 
 #define GET_STATIC_BOOL_FIELD(_value, _class, _fieldName)\
@@ -93,12 +93,12 @@
 
 #define GET_STATIC_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            env->GetStaticMethodID(_class, _methodName, _sig)) != NULL))\
+            env->GetStaticMethodID(_class, _methodName, _sig)) != nullptr))\
         exit(1)
 
 #define GET_METHOD_ID(_methodID, _class, _methodName, _sig)\
     if (!NSK_JNI_VERIFY(env, (_methodID = \
-            env->GetMethodID(_class, _methodName, _sig)) != NULL))\
+            env->GetMethodID(_class, _methodName, _sig)) != nullptr))\
         exit(1)
 
 #define CALL_STATIC_VOID_NOPARAM(_class, _methodName)\

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace003.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace004.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace005.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 #include "nsk_tools.h"
 
 extern "C" {

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace006.cpp
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace008.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace009.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace011.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace012.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace014.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/stress/strace/strace015.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 #include <stdio.h>
-#include "nsk_strace.h"
+#include "nsk_strace.hpp"
 
 extern "C" {
 


### PR DESCRIPTION
Please review this trivial change that renames the file
test/hotspot/jtreg/vmTestbase/nsk/stress/strace/nsk_strace.hpp
to nsk_strace.hpp. and replaces uses of NULL in that file.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325682](https://bugs.openjdk.org/browse/JDK-8325682): Rename nsk_strace.h (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17852/head:pull/17852` \
`$ git checkout pull/17852`

Update a local copy of the PR: \
`$ git checkout pull/17852` \
`$ git pull https://git.openjdk.org/jdk.git pull/17852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17852`

View PR using the GUI difftool: \
`$ git pr show -t 17852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17852.diff">https://git.openjdk.org/jdk/pull/17852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17852#issuecomment-1944843445)