### PR TITLE
JDK-8325687: SimpleJavaFileObject specification would benefit from implSpec

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,7 +165,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
          * The result of this method is undefined if this is an output
          * location.
          *
-         * @implNote This implementation returns true if the name includes
+         * @implSpec This implementation returns true if the name includes
          * the word "MODULE".
          *
          * @return true if this location is expected to contain modules

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -138,7 +138,7 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * {@inheritDoc FileObject}
      * @implSpec
      * This implementation wraps the result of {@link
-     * openOutputStream} in a {@link Writer}.
+     * #openOutputStream} in a {@link Writer}.
      *
      * @return a Writer wrapping the result of openOutputStream
      * @throws IllegalStateException {@inheritDoc}

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -103,7 +103,8 @@ public class SimpleJavaFileObject implements JavaFileObject {
     /**
      * {@inheritDoc FileObject}
      * @implSpec
-     * This implementation wraps the result of {@linkplain #getCharContent} in a Reader.
+     * This implementation wraps the result of {@linkplain
+     * #getCharContent} in a {@link Reader}.
      *
      * @param  ignoreEncodingErrors {@inheritDoc}
      * @return a Reader wrapping the result of getCharContent
@@ -136,7 +137,8 @@ public class SimpleJavaFileObject implements JavaFileObject {
     /**
      * {@inheritDoc FileObject}
      * @implSpec
-     * This implementation wraps the result of openOutputStream in a Writer.
+     * This implementation wraps the result of {@link
+     * openOutputStream} in a {@link Writer}.
      *
      * @return a Writer wrapping the result of openOutputStream
      * @throws IllegalStateException {@inheritDoc}

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -103,8 +103,8 @@ public class SimpleJavaFileObject implements JavaFileObject {
     /**
      * {@inheritDoc FileObject}
      * @implSpec
-     * This implementation wraps the result of {@linkplain
-     * #getCharContent} in a {@link Reader}.
+     * This implementation wraps the result of {@link #getCharContent}
+     * in a {@link Reader}.
      *
      * @param  ignoreEncodingErrors {@inheritDoc}
      * @return a Reader wrapping the result of getCharContent

--- a/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/SimpleJavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,10 +79,10 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
+     * {@inheritDoc FileObject}
+     * @implSpec
      * This implementation always throws {@linkplain
-     * UnsupportedOperationException}.  Subclasses can change this
-     * behavior as long as the contract of {@link FileObject} is
-     * obeyed.
+     * UnsupportedOperationException}.
      */
     @Override
     public InputStream openInputStream() throws IOException {
@@ -90,10 +90,10 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
+     * {@inheritDoc FileObject}
+     * @implSpec
      * This implementation always throws {@linkplain
-     * UnsupportedOperationException}.  Subclasses can change this
-     * behavior as long as the contract of {@link FileObject} is
-     * obeyed.
+     * UnsupportedOperationException}.
      */
     @Override
     public OutputStream openOutputStream() throws IOException {
@@ -101,9 +101,9 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
-     * Wraps the result of {@linkplain #getCharContent} in a Reader.
-     * Subclasses can change this behavior as long as the contract of
-     * {@link FileObject} is obeyed.
+     * {@inheritDoc FileObject}
+     * @implSpec
+     * This implementation wraps the result of {@linkplain #getCharContent} in a Reader.
      *
      * @param  ignoreEncodingErrors {@inheritDoc}
      * @return a Reader wrapping the result of getCharContent
@@ -123,10 +123,10 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
+     * {@inheritDoc FileObject}
+     * @implSpec
      * This implementation always throws {@linkplain
-     * UnsupportedOperationException}.  Subclasses can change this
-     * behavior as long as the contract of {@link FileObject} is
-     * obeyed.
+     * UnsupportedOperationException}.
      */
     @Override
     public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
@@ -134,9 +134,9 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
-     * Wraps the result of openOutputStream in a Writer.  Subclasses
-     * can change this behavior as long as the contract of {@link
-     * FileObject} is obeyed.
+     * {@inheritDoc FileObject}
+     * @implSpec
+     * This implementation wraps the result of openOutputStream in a Writer.
      *
      * @return a Writer wrapping the result of openOutputStream
      * @throws IllegalStateException {@inheritDoc}
@@ -149,9 +149,9 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
-     * This implementation returns {@code 0L}.  Subclasses can change
-     * this behavior as long as the contract of {@link FileObject} is
-     * obeyed.
+     * {@inheritDoc FileObject}
+     * @implSpec
+     * This implementation returns {@code 0L}.
      *
      * @return {@code 0L}
      */
@@ -161,9 +161,9 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
-     * This implementation does nothing.  Subclasses can change this
-     * behavior as long as the contract of {@link FileObject} is
-     * obeyed.
+     * {@inheritDoc FileObject}
+     * @implSpec
+     * This implementation does nothing.
      *
      * @return {@code false}
      */
@@ -181,6 +181,8 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
+     * {@inheritDoc JavaFileObject}
+     * @implSpec
      * This implementation compares the path of its URI to the given
      * simple name.  This method returns true if the given kind is
      * equal to the kind of this object, and if the path is equal to
@@ -190,9 +192,6 @@ public class SimpleJavaFileObject implements JavaFileObject {
      * <p>This method calls {@link #getKind} and {@link #toUri} and
      * does not access the fields {@link #uri} and {@link #kind}
      * directly.
-     *
-     * <p>Subclasses can change this behavior as long as the contract
-     * of {@link JavaFileObject} is obeyed.
      */
     @Override
     public boolean isNameCompatible(String simpleName, Kind kind) {
@@ -203,17 +202,17 @@ public class SimpleJavaFileObject implements JavaFileObject {
     }
 
     /**
-     * This implementation returns {@code null}.  Subclasses can
-     * change this behavior as long as the contract of
-     * {@link JavaFileObject} is obeyed.
+     * {@inheritDoc JavaFileObject}
+     * @implSpec
+     * This implementation returns {@code null}.
      */
     @Override
     public NestingKind getNestingKind() { return null; }
 
     /**
-     * This implementation returns {@code null}.  Subclasses can
-     * change this behavior as long as the contract of
-     * {@link JavaFileObject} is obeyed.
+     * {@inheritDoc JavaFileObject}
+     * @implSpec
+     * This implementation returns {@code null}.
      */
     @Override
     public Modifier getAccessLevel()  { return null; }


### PR DESCRIPTION
While reading the spec in the context of another potential change, noticed some cases where using implSpec would lead to a better structured specification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8325904](https://bugs.openjdk.org/browse/JDK-8325904) to be approved

### Issues
 * [JDK-8325687](https://bugs.openjdk.org/browse/JDK-8325687): SimpleJavaFileObject specification would benefit from implSpec (**Enhancement** - P4)
 * [JDK-8325904](https://bugs.openjdk.org/browse/JDK-8325904): SimpleJavaFileObject specification would benefit from implSpec (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [e5b57897](https://git.openjdk.org/jdk/pull/17854/files/e5b57897501613026d1a296406053351060a8488)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [fe974f62](https://git.openjdk.org/jdk/pull/17854/files/fe974f620ec6b8d939e2102e5988c1a9ea1fb633)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17854/head:pull/17854` \
`$ git checkout pull/17854`

Update a local copy of the PR: \
`$ git checkout pull/17854` \
`$ git pull https://git.openjdk.org/jdk.git pull/17854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17854`

View PR using the GUI difftool: \
`$ git pr show -t 17854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17854.diff">https://git.openjdk.org/jdk/pull/17854.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17854#issuecomment-1944739905)