### PR TITLE
8176520: Improve the accuracy of the instance size in hprof heap dumps

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -745,8 +745,7 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
             writeObjectID(null);
         }
 
-        if (k instanceof InstanceKlass) {
-            InstanceKlass ik = (InstanceKlass) k;
+        if (k instanceof InstanceKlass ik) {
             writeObjectID(ik.getClassLoader());
             writeObjectID(null);  // ik.getJavaMirror().getSigners());
             writeObjectID(null);  // ik.getJavaMirror().getProtectionDomain());
@@ -754,9 +753,10 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
             writeObjectID(null);
             writeObjectID(null);
             List<Field> fields = getInstanceFields(ik);
-            int instSize = getSizeForFields(fields);
-            classDataCache.put(ik, new ClassData(instSize, fields));
-            out.writeInt(instSize);
+            int fieldSize = getSizeForFields(fields);
+            classDataCache.put(ik, new ClassData(fieldSize, fields));
+            long instanceSize = ik.getSizeHelper() * VM.getVM().getBytesPerWord();
+            out.writeInt((int)instanceSize);
 
             // For now, ignore constant pool - HAT ignores too!
             // output number of cp entries as zero.

--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -72,6 +72,7 @@ serviceability/sa/ClhsdbVmStructsDump.java                    8307393   generic-
 serviceability/sa/ClhsdbWhere.java                            8307393   generic-all
 serviceability/sa/DeadlockDetectionTest.java                  8307393   generic-all
 serviceability/sa/JhsdbThreadInfoTest.java                    8307393   generic-all
+serviceability/sa/HeapDumpInstanceSize.java                   8307393   generic-all
 serviceability/sa/LingeredAppSysProps.java                    8307393   generic-all
 serviceability/sa/LingeredAppWithDefaultMethods.java          8307393   generic-all
 serviceability/sa/LingeredAppWithEnum.java                    8307393   generic-all

--- a/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Collection;
+import java.util.List;
+import java.io.File;
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.hprof.model.JavaClass;
+import jdk.test.lib.hprof.model.Snapshot;
+import jdk.test.lib.hprof.parser.Reader;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @bug 8240989
+ * @summary Test that heap dumpers (VM and SA) report correct instance size in HPROF_GC_CLASS_DUMP records
+ * @requires vm.jvmti
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run main/othervm HeapDumpInstanceSize
+ */
+
+public class HeapDumpInstanceSize {
+
+	private static Snapshot readHeapdump(File file) throws Exception {
+        System.out.println("Reading " + file + "...");
+        Snapshot snapshot = Reader.readFile(file.getPath(), true, 0);
+        System.out.println("Resolving snapshot...");
+        snapshot.resolve(true);
+        System.out.println("Snapshot resolved.");
+		return snapshot;
+	}
+
+    private static Snapshot heapdumpSA(long pid, String fileName) throws Exception {
+        File dumpFile = new File(fileName);
+        ClhsdbLauncher launcher = new ClhsdbLauncher();
+		String command = "dumpheap " + fileName;
+		List<String> cmds = List.of(command);
+		launcher.run(pid, cmds, null, null);
+        return readHeapdump(dumpFile);
+    }
+
+    private static Snapshot heapdumpVM(long pid, String fileName) throws Exception {
+        File dumpFile = new File(fileName);
+        // jcmd <pid> GC.heap_dump <file_path>
+        JDKToolLauncher launcher = JDKToolLauncher
+                .createUsingTestJDK("jcmd")
+                .addToolArg(Long.toString(pid))
+                .addToolArg("GC.heap_dump")
+                .addToolArg(dumpFile.getAbsolutePath());
+        OutputAnalyzer oa = ProcessTools.executeProcess(new ProcessBuilder(launcher.getCommand()));
+        System.out.println("Output: ");
+        System.out.println(oa.getOutput());
+
+        return readHeapdump(dumpFile);
+    }
+
+    private static void testClasses(String name, Snapshot snapshot, Snapshot otherSnapshot) {
+        System.out.println("Testing " + name + " classes...");
+        int cnt = 0;
+        // save the last error message to throw an exception
+        String errorMsg = null;
+        Collection<JavaClass> classes = snapshot.getClasses();
+        for (JavaClass cls: classes) {
+            JavaClass otherClass = otherSnapshot.findClass(cls.getName());
+            int instSize = cls.getInstanceSize();
+            if (otherClass == null) {
+                // it's ok, just log it
+                System.out.println("  - " + cls.getName() + ": only in " + name + " heapdump");
+            } else {
+                if (instSize != otherClass.getInstanceSize()) {
+                    errorMsg = "ERROR " + cls.getName() + " - different instance size: "
+                               + instSize + " != " + otherClass.getInstanceSize();
+                    System.out.println("  - " + errorMsg);
+                }
+            }
+
+            if (cls.isArray()) {
+                // for arrays instance size should be 0
+                if (instSize != 0) {
+                    errorMsg = "ERROR " + cls.getName()
+                               + " - instance size for array is not 0: " + instSize;
+                    System.out.println("  - " + errorMsg);
+                }
+            } else {
+                // non-array should have >0 instance size
+                if (instSize == 0) {
+                    errorMsg = "ERROR " + cls.getName() + ": instance size is 0";
+                    System.out.println("  - " + errorMsg);
+                }
+            }
+
+            cnt++;
+        }
+        System.out.println(name + ": found " + cnt + " classes.");
+        if (errorMsg != null) {
+            throw new RuntimeException(errorMsg);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        LingeredApp theApp = null;
+        try {
+            theApp = new LingeredApp();
+            LingeredApp.startApp(theApp);
+
+            try (Snapshot snapshot1 = heapdumpSA(theApp.getPid(), "sa_heapdump.hprof");
+                 Snapshot snapshot2 = heapdumpVM(theApp.getPid(), "vm_heapdump.hprof")) {
+                testClasses("SA", snapshot1, snapshot2);
+                testClasses("VM", snapshot2, snapshot1);
+            }
+        } finally {
+            LingeredApp.stopApp(theApp);
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
@@ -45,21 +45,21 @@ import jtreg.SkippedException;
 
 public class HeapDumpInstanceSize {
 
-	private static Snapshot readHeapdump(File file) throws Exception {
+    private static Snapshot readHeapdump(File file) throws Exception {
         System.out.println("Reading " + file + "...");
         Snapshot snapshot = Reader.readFile(file.getPath(), true, 0);
         System.out.println("Resolving snapshot...");
         snapshot.resolve(true);
         System.out.println("Snapshot resolved.");
-		return snapshot;
-	}
+        return snapshot;
+    }
 
     private static Snapshot heapdumpSA(long pid, String fileName) throws Exception {
         File dumpFile = new File(fileName);
         ClhsdbLauncher launcher = new ClhsdbLauncher();
-		String command = "dumpheap " + fileName;
-		List<String> cmds = List.of(command);
-		launcher.run(pid, cmds, null, null);
+        String command = "dumpheap " + fileName;
+        List<String> cmds = List.of(command);
+        launcher.run(pid, cmds, null, null);
         return readHeapdump(dumpFile);
     }
 

--- a/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
+++ b/test/hotspot/jtreg/serviceability/sa/HeapDumpInstanceSize.java
@@ -35,7 +35,7 @@ import jtreg.SkippedException;
 
 /**
  * @test
- * @bug 8240989
+ * @bug 8176520
  * @summary Test that heap dumpers (VM and SA) report correct instance size in HPROF_GC_CLASS_DUMP records
  * @requires vm.jvmti
  * @requires vm.hasSA

--- a/test/lib/jdk/test/lib/hprof/model/JavaClass.java
+++ b/test/lib/jdk/test/lib/hprof/model/JavaClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,7 +374,7 @@ public class JavaClass extends JavaHeapObject {
      *          type.
      */
     public int getInstanceSize() {
-        return instanceSize + mySnapshot.getMinimumObjectSize();
+        return instanceSize;
     }
 
 

--- a/test/lib/jdk/test/lib/hprof/model/Snapshot.java
+++ b/test/lib/jdk/test/lib/hprof/model/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -385,12 +385,10 @@ public class Snapshot implements AutoCloseable {
     }
 
     /**
-     * Return an Iterator of all of the classes in this snapshot.
+     * Return a Collection of all of the classes in this snapshot.
      **/
-    public Iterator<JavaClass> getClasses() {
-        // note that because classes is a TreeMap
-        // classes are already sorted by name
-        return classes.values().iterator();
+    public Collection<JavaClass> getClasses() {
+        return Collections.unmodifiableCollection(classes.values());
     }
 
     public JavaClass[] getClassesArray() {


### PR DESCRIPTION
The fix updates heap dumpers to report correct instance size value for HPROF_GC_CLASS_DUMP records (currently it's reported as size of all instance fields)

Testing: tier1, tier2, tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 24 to be approved (needs to be created)

### Issues
 * [JDK-8176520](https://bugs.openjdk.org/browse/JDK-8176520): Improve the accuracy of the instance size in hprof heap dumps (**Enhancement** - P4) ⚠️ Issue is not open.
 * [JDK-8326436](https://bugs.openjdk.org/browse/JDK-8326436): Improve the accuracy of the instance size in hprof heap dumps (**CSR**) (Withdrawn)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17855/head:pull/17855` \
`$ git checkout pull/17855`

Update a local copy of the PR: \
`$ git checkout pull/17855` \
`$ git pull https://git.openjdk.org/jdk.git pull/17855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17855`

View PR using the GUI difftool: \
`$ git pr show -t 17855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17855.diff">https://git.openjdk.org/jdk/pull/17855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17855#issuecomment-1944826659)