### PR TITLE
JDK-6801704: ChoiceFormat::applyPattern inconsistency for invalid patterns

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -235,7 +235,7 @@ public class ChoiceFormat extends NumberFormat {
      * throw an exception or succeed and discard the incorrect portion. A {@code
      * NumberFormatException} is thrown if a {@code limit} can not be
      * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
-     * if there are not ascending intervals, or missing {@code SubPatterns}.
+     * if a {@code SubPattern} is missing, or the intervals are not ascending.
      * Discarding the incorrect portion may result in a ChoiceFormat with
      * empty {@code limits} and {@code formats}.
      *
@@ -407,7 +407,7 @@ public class ChoiceFormat extends NumberFormat {
      * throw an exception or succeed and discard the incorrect portion. A {@code
      * NumberFormatException} is thrown if a {@code limit} can not be
      * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
-     * if there are not ascending intervals, or missing {@code SubPatterns}.
+     * if a {@code SubPattern} is missing, or the intervals are not ascending.
      * Discarding the incorrect portion may result in a ChoiceFormat with
      * empty {@code limits} and {@code formats}.
      *

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -238,7 +238,7 @@ public class ChoiceFormat extends NumberFormat {
      * Apply the given pattern to this ChoiceFormat object. The syntax and error
      * related caveats for the ChoiceFormat pattern can be found in the
      * {@linkplain ##patterns Patterns} section. Unlike {@link #setChoices(double[],
-     * String[])} this method will throw an {@code IllegalArgumentException} if
+     * String[])}, this method will throw an {@code IllegalArgumentException} if
      * the {@code limits} are not in ascending order.
      *
      * @param newPattern a pattern string
@@ -403,7 +403,7 @@ public class ChoiceFormat extends NumberFormat {
      * Constructs a ChoiceFormat with limits and corresponding formats
      * based on the pattern. The syntax and error related caveats for the
      * ChoiceFormat pattern can be found in the {@linkplain ##patterns Patterns}
-     * section. Unlike {@link #ChoiceFormat(double[], String[])} this method will
+     * section. Unlike {@link #ChoiceFormat(double[], String[])}, this constructor will
      * throw an {@code IllegalArgumentException} if the {@code limits} are not
      * in ascending order.
      *

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -231,7 +231,7 @@ public class ChoiceFormat extends NumberFormat {
      * method will throw an {@code IllegalArgumentException} if the {@code
      * limits} are not in ascending order.
      *
-     * @implSpec Given an incorrect pattern, this implementation may either
+     * @implNote Given an incorrect pattern, this implementation may either
      * throw an exception or succeed and discard the incorrect
      * portion. Discarding the incorrect portion may result in a ChoiceFormat
      * with empty {@code limits} and {@code choices}.
@@ -400,7 +400,7 @@ public class ChoiceFormat extends NumberFormat {
      * The syntax for the ChoiceFormat pattern can be seen in the {@linkplain
      * ##patterns Patterns} section.
      *
-     * @implSpec Given an incorrect pattern, this implementation may either
+     * @implNote Given an incorrect pattern, this implementation may either
      * throw an exception or succeed and discard the incorrect
      * portion. Discarding the incorrect portion may result in a ChoiceFormat
      * with empty {@code limits} and {@code choices}.

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -232,9 +232,12 @@ public class ChoiceFormat extends NumberFormat {
      * limits} are not in ascending order.
      *
      * @implNote Given an incorrect pattern, this implementation may either
-     * throw an exception or succeed and discard the incorrect
-     * portion. Discarding the incorrect portion may result in a ChoiceFormat
-     * with empty {@code limits} and {@code choices}.
+     * throw an exception or succeed and discard the incorrect portion. A {@code
+     * NumberFormatException} is thrown if a {@code limit} can not be
+     * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
+     * if there are not ascending intervals, or missing {@code SubPatterns}.
+     * Discarding the incorrect portion may result in a ChoiceFormat with
+     * empty {@code limits} and {@code formats}.
      *
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
@@ -401,9 +404,12 @@ public class ChoiceFormat extends NumberFormat {
      * ##patterns Patterns} section.
      *
      * @implNote Given an incorrect pattern, this implementation may either
-     * throw an exception or succeed and discard the incorrect
-     * portion. Discarding the incorrect portion may result in a ChoiceFormat
-     * with empty {@code limits} and {@code choices}.
+     * throw an exception or succeed and discard the incorrect portion. A {@code
+     * NumberFormatException} is thrown if a {@code limit} can not be
+     * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
+     * if there are not ascending intervals, or missing {@code SubPatterns}.
+     * Discarding the incorrect portion may result in a ChoiceFormat with
+     * empty {@code limits} and {@code formats}.
      *
      * @param newPattern the new pattern string
      * @throws    NullPointerException if {@code newPattern} is

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -232,7 +232,7 @@ public class ChoiceFormat extends NumberFormat {
      * limits} are not in ascending order.
      *
      * @implSpec Given an incorrect pattern, this implementation may either
-     * throw an {@code IllegalArgumentException} or succeed and discard the incorrect
+     * throw an exception or succeed and discard the incorrect
      * portion. Discarding the incorrect portion may result in a ChoiceFormat
      * with empty {@code limits} and {@code choices}.
      *
@@ -401,7 +401,7 @@ public class ChoiceFormat extends NumberFormat {
      * ##patterns Patterns} section.
      *
      * @implSpec Given an incorrect pattern, this implementation may either
-     * throw an {@code IllegalArgumentException} or succeed and discard the incorrect
+     * throw an exception or succeed and discard the incorrect
      * portion. Discarding the incorrect portion may result in a ChoiceFormat
      * with empty {@code limits} and {@code choices}.
      *

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -230,6 +230,12 @@ public class ChoiceFormat extends NumberFormat {
      * Patterns} section. Unlike {@link #setChoices(double[], String[])} this
      * method will throw an {@code IllegalArgumentException} if the {@code
      * limits} are not in ascending order.
+     *
+     * @implSpec Given an incorrect pattern, this implementation may either
+     * throw an {@code IllegalArgumentException} or succeed and discard the incorrect
+     * portion. Discarding the incorrect portion may result in a ChoiceFormat
+     * with empty {@code limits} and {@code choices}.
+     *
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
      *            is {@code null}
@@ -393,6 +399,11 @@ public class ChoiceFormat extends NumberFormat {
      * based on the pattern.
      * The syntax for the ChoiceFormat pattern can be seen in the {@linkplain
      * ##patterns Patterns} section.
+     *
+     * @implSpec Given an incorrect pattern, this implementation may either
+     * throw an {@code IllegalArgumentException} or succeed and discard the incorrect
+     * portion. Discarding the incorrect portion may result in a ChoiceFormat
+     * with empty {@code limits} and {@code choices}.
      *
      * @param newPattern the new pattern string
      * @throws    NullPointerException if {@code newPattern} is

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -132,6 +132,16 @@ import java.util.Arrays;
  * Use two single quotes in a row to produce a literal single quote. For example,
  * {@code new ChoiceFormat("1# ''one'' ").format(1)} returns {@code " 'one' "}.
  *
+ * @apiNote A subclass could perform more consistent pattern validation by
+ * throwing an {@code IllegalArgumentException} for all incorrect cases.
+ * @implNote Given an incorrect pattern, this implementation may either
+ * throw an exception or succeed and discard the incorrect portion. A {@code
+ * NumberFormatException} is thrown if a {@code limit} can not be
+ * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
+ * if a {@code SubPattern} is missing, or the intervals are not ascending.
+ * Discarding the incorrect portion may result in a ChoiceFormat with
+ * empty {@code limits} and {@code formats}.
+ *
  * <h2>Usage Information</h2>
  *
  * <p>
@@ -225,19 +235,11 @@ public class ChoiceFormat extends NumberFormat {
     private static final long serialVersionUID = 1795184449645032964L;
 
     /**
-     * Apply the given pattern to this ChoiceFormat object. The syntax
-     * for the ChoiceFormat pattern can be seen in the {@linkplain ##patterns
-     * Patterns} section. Unlike {@link #setChoices(double[], String[])} this
-     * method will throw an {@code IllegalArgumentException} if the {@code
-     * limits} are not in ascending order.
-     *
-     * @implNote Given an incorrect pattern, this implementation may either
-     * throw an exception or succeed and discard the incorrect portion. A {@code
-     * NumberFormatException} is thrown if a {@code limit} can not be
-     * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
-     * if a {@code SubPattern} is missing, or the intervals are not ascending.
-     * Discarding the incorrect portion may result in a ChoiceFormat with
-     * empty {@code limits} and {@code formats}.
+     * Apply the given pattern to this ChoiceFormat object. The syntax and error
+     * related caveats for the ChoiceFormat pattern can be found in the
+     * {@linkplain ##patterns Patterns} section. Unlike {@link #setChoices(double[],
+     * String[])} this method will throw an {@code IllegalArgumentException} if
+     * the {@code limits} are not in ascending order.
      *
      * @param newPattern a pattern string
      * @throws    NullPointerException if {@code newPattern}
@@ -399,17 +401,9 @@ public class ChoiceFormat extends NumberFormat {
 
     /**
      * Constructs a ChoiceFormat with limits and corresponding formats
-     * based on the pattern.
-     * The syntax for the ChoiceFormat pattern can be seen in the {@linkplain
-     * ##patterns Patterns} section.
-     *
-     * @implNote Given an incorrect pattern, this implementation may either
-     * throw an exception or succeed and discard the incorrect portion. A {@code
-     * NumberFormatException} is thrown if a {@code limit} can not be
-     * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
-     * if a {@code SubPattern} is missing, or the intervals are not ascending.
-     * Discarding the incorrect portion may result in a ChoiceFormat with
-     * empty {@code limits} and {@code formats}.
+     * based on the pattern. The syntax and error related caveats for the
+     * ChoiceFormat pattern can be found in the {@linkplain ##patterns Patterns}
+     * section.
      *
      * @param newPattern the new pattern string
      * @throws    NullPointerException if {@code newPattern} is

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -403,7 +403,9 @@ public class ChoiceFormat extends NumberFormat {
      * Constructs a ChoiceFormat with limits and corresponding formats
      * based on the pattern. The syntax and error related caveats for the
      * ChoiceFormat pattern can be found in the {@linkplain ##patterns Patterns}
-     * section.
+     * section. Unlike {@link #ChoiceFormat(double[], String[])} this method will
+     * throw an {@code IllegalArgumentException} if the {@code limits} are not
+     * in ascending order.
      *
      * @param newPattern the new pattern string
      * @throws    NullPointerException if {@code newPattern} is


### PR DESCRIPTION
Please review this PR and [CSR](https://bugs.openjdk.org/browse/JDK-8317756) which defines the behavior for creating ChoiceFormats with incorrect patterns. The wording is added to both the ChoiceFormat constructor and ChoiceFormat::applyPattern method.

While ideally the inconsistent behavior itself could be fixed, this behavior has been long-standing for 20+ years and the benefit of consistent error handling does not outweigh the risk of breaking applications that may be relying on the "expected" incorrect behavior.

Examples of the range of behavior, (all examples violate the pattern syntax defined in the class description)

```
// no limit -> throws an expected IllegalArgumentException
var a = new ChoiceFormat("#foo");
// no limit or relation in the last subPattern -> discards the incorrect portion, 'baz' and continues
var b = new ChoiceFormat("0#foo|1#bar|baz"); 
b.format(2); // returns 'bar'
// no relation or limit -> discards the incorrect portion, 'foo' and continues
var c = new ChoiceFormat("foo");
c.format(1); // throws AIOOBE
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8317756](https://bugs.openjdk.org/browse/JDK-8317756) to be approved

### Issues
 * [JDK-6801704](https://bugs.openjdk.org/browse/JDK-6801704): ChoiceFormat::applyPattern inconsistency for invalid patterns (**Bug** - P5)
 * [JDK-8317756](https://bugs.openjdk.org/browse/JDK-8317756): ChoiceFormat::applyPattern inconsistency for invalid patterns (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [8e5bbe05](https://git.openjdk.org/jdk/pull/17856/files/8e5bbe05698a3b034b892c08483ba4d33c3239fa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17856/head:pull/17856` \
`$ git checkout pull/17856`

Update a local copy of the PR: \
`$ git checkout pull/17856` \
`$ git pull https://git.openjdk.org/jdk.git pull/17856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17856`

View PR using the GUI difftool: \
`$ git pr show -t 17856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17856.diff">https://git.openjdk.org/jdk/pull/17856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17856#issuecomment-1944852377)