### PR TITLE
8322750: Test "api/java_awt/interactive/SystemTrayTests.html" failed because A blue ball icon is added outside of the system tray

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_HRGB;
 import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VBGR;
 import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_LCD_VRGB;
 import static java.awt.RenderingHints.VALUE_TEXT_ANTIALIAS_ON;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 import java.awt.color.ColorSpace;
 
@@ -47,6 +48,9 @@ import java.awt.image.DataBuffer;
 import java.awt.image.DataBufferByte;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -238,6 +242,71 @@ public abstract class UNIXToolkit extends SunToolkit
             setDesktopProperty(longname, img);
         }
         return img;
+    }
+
+    private static volatile Boolean shouldDisableSystemTray = null;
+
+    /**
+     * There is an issue displaying the xembed icons in appIndicators
+     * area with certain Gnome Shell versions.
+     * To avoid any loss of quality of service, we are disabling
+     * SystemTray support in such cases.
+     *
+     * @return true if system tray should be disabled
+     */
+    public boolean shouldDisableSystemTray() {
+        Boolean result = shouldDisableSystemTray;
+        if (result == null) {
+            synchronized (GTK_LOCK) {
+                result = shouldDisableSystemTray;
+                if (result == null) {
+                    if ("gnome".equals(getDesktop())) {
+                        @SuppressWarnings("removal")
+                        Integer gnomeShellMajorVersion =
+                                AccessController
+                                        .doPrivileged((PrivilegedAction<Integer>)
+                                                this::getGnomeShellMajorVersion);
+
+                        if (gnomeShellMajorVersion == null
+                                || gnomeShellMajorVersion < 45) {
+
+                            return shouldDisableSystemTray = true;
+                        }
+                    }
+                    shouldDisableSystemTray = result = false;
+                }
+            }
+        }
+        return result;
+    }
+
+    private Integer getGnomeShellMajorVersion() {
+        try {
+            Process process =
+                new ProcessBuilder("/usr/bin/gnome-shell", "--version")
+                        .start();
+            try (InputStreamReader isr = new InputStreamReader(process.getInputStream());
+                 BufferedReader reader = new BufferedReader(isr)) {
+
+                if (process.waitFor(2, SECONDS) &&  process.exitValue() == 0) {
+                    String line = reader.readLine();
+                    if (line != null) {
+                        String[] versionComponents = line
+                                .replaceAll("[^\\d.]", "")
+                                .split("\\.");
+
+                        if (versionComponents.length >= 1) {
+                            return Integer.parseInt(versionComponents[0]);
+                        }
+                    }
+                }
+            }
+        } catch (IOException
+                 | InterruptedException
+                 | NumberFormatException ignored) {
+        }
+
+        return null;
     }
 
     /**

--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -303,6 +303,7 @@ public abstract class UNIXToolkit extends SunToolkit
             }
         } catch (IOException
                  | InterruptedException
+                 | IllegalThreadStateException
                  | NumberFormatException ignored) {
         }
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
@@ -49,15 +49,18 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
     private static final XAtom _NET_SYSTEM_TRAY_OPCODE = XAtom.get("_NET_SYSTEM_TRAY_OPCODE");
     private static final XAtom _NET_WM_ICON = XAtom.get("_NET_WM_ICON");
     private static final long SYSTEM_TRAY_REQUEST_DOCK = 0;
+    private final boolean shouldDisableSystemTray;
 
     XSystemTrayPeer(SystemTray target) {
         this.target = target;
         peerInstance = this;
 
-        selection.addSelectionListener(this);
-
         UNIXToolkit tk = (UNIXToolkit)Toolkit.getDefaultToolkit();
-        if (!tk.shouldDisableSystemTray()) {
+        shouldDisableSystemTray = tk.shouldDisableSystemTray();
+
+        if (!shouldDisableSystemTray) {
+            selection.addSelectionListener(this);
+
             long selection_owner = selection.getOwner(SCREEN);
             available = (selection_owner != XConstants.None);
 
@@ -68,6 +71,10 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
     }
 
     public void ownerChanged(int screen, XMSelection sel, long newOwner, long data, long timestamp) {
+        if (shouldDisableSystemTray) {
+            return;
+        }
+
         if (screen != SCREEN) {
             return;
         }
@@ -81,6 +88,10 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
     }
 
     public void ownerDeath(int screen, XMSelection sel, long deadOwner) {
+        if (shouldDisableSystemTray) {
+            return;
+        }
+
         if (screen != SCREEN) {
             return;
         }

--- a/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XSystemTrayPeer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.awt.peer.SystemTrayPeer;
 import sun.awt.SunToolkit;
 import sun.awt.AppContext;
 import sun.awt.AWTAccessor;
+import sun.awt.UNIXToolkit;
 import sun.util.logging.PlatformLogger;
 
 public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
@@ -55,11 +56,14 @@ public class XSystemTrayPeer implements SystemTrayPeer, XMSelectionListener {
 
         selection.addSelectionListener(this);
 
-        long selection_owner = selection.getOwner(SCREEN);
-        available = (selection_owner != XConstants.None);
+        UNIXToolkit tk = (UNIXToolkit)Toolkit.getDefaultToolkit();
+        if (!tk.shouldDisableSystemTray()) {
+            long selection_owner = selection.getOwner(SCREEN);
+            available = (selection_owner != XConstants.None);
 
-        if (log.isLoggable(PlatformLogger.Level.FINE)) {
-            log.fine(" check if system tray is available. selection owner: " + selection_owner);
+            if (log.isLoggable(PlatformLogger.Level.FINE)) {
+                log.fine(" check if system tray is available. selection owner: " + selection_owner);
+            }
         }
     }
 


### PR DESCRIPTION
There is an issue displaying the xembed icons in the appIndicators area which are not displayed correctly with certain Gnome Shell versions.
It was already fixed [externally](https://gitlab.gnome.org/3v1n0/gnome-shell/-/commit/20a81d786697f40880e81d867453b1bad9524ec1).

However this is still a blocker on systems that have not received this fix, so this fix disables a SystemTray's support for Gnome Shell < 45 versions.

Gnome Shell version detection has the following logic:
* execute `/usr/bin/gnome-shell --version`
* parse its output to extract the major version
* disable the SystemTray support if the version < 45 or parsing failed for some reason


The numbering convention changed with the introduction of Gnome Shell 40.
The old numbering convention is also handled correctly(e.g. [3.38.1](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/d15f6c75b19be1e32ec24165f09b3e74afaf7395/NEWS#L1134))

This is a simplified fix to make it easier to backport it.
The improved solution will be to [receive the ShellVersion property via the DBUS API](https://unix.stackexchange.com/questions/73212/how-to-get-the-gnome-version/73225#73225)

Testing looks good:
Oracle Linux 7.9, Gnome Shell 3.28.3
Ubuntu 22.04, Gnome Shell 42.9
Ubuntu 23.04, Gnome Shell 44.3
Ubuntu 23.10, Gnome Shell 45.0
Fedora 38, Gnome Shell 44.0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322750](https://bugs.openjdk.org/browse/JDK-8322750): Test "api/java_awt/interactive/SystemTrayTests.html" failed because A blue ball icon is added outside of the system tray (**Bug** - P2)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**) ⚠️ Review applies to [7e1b315b](https://git.openjdk.org/jdk/pull/17860/files/7e1b315ba0e7a0117ac91319f081f4fb01d2f862)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [7e1b315b](https://git.openjdk.org/jdk/pull/17860/files/7e1b315ba0e7a0117ac91319f081f4fb01d2f862)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17860/head:pull/17860` \
`$ git checkout pull/17860`

Update a local copy of the PR: \
`$ git checkout pull/17860` \
`$ git pull https://git.openjdk.org/jdk.git pull/17860/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17860`

View PR using the GUI difftool: \
`$ git pr show -t 17860`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17860.diff">https://git.openjdk.org/jdk/pull/17860.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17860#issuecomment-1945210184)