### PR TITLE
8325074: ZGC fails assert(index == 0 || is_power_of_2(index)) failed: Incorrect load shift: 11

### DIFF
--- a/src/hotspot/share/gc/z/zBarrierSet.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.cpp
@@ -152,11 +152,12 @@ void ZBarrierSet::on_slowpath_allocation_exit(JavaThread* thread, oop new_obj) {
   deoptimize_allocation(thread);
 }
 
-void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj, size_t size) {
+void ZBarrierSet::clone_obj_array(objArrayOop src_obj, objArrayOop dst_obj) {
   volatile zpointer* src = (volatile zpointer*)src_obj->base();
   volatile zpointer* dst = (volatile zpointer*)dst_obj->base();
+  const int length = src_obj->length();
 
-  for (const zpointer* const end = cast_from_oop<const zpointer*>(src_obj) + size; src < end; src++, dst++) {
+  for (const volatile zpointer* const end = src + length; src < end; src++, dst++) {
     zaddress elem = ZBarrier::load_barrier_on_oop_field(src);
     // We avoid healing here because the store below colors the pointer store good,
     // hence avoiding the cost of a CAS.

--- a/src/hotspot/share/gc/z/zBarrierSet.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.hpp
@@ -39,7 +39,7 @@ public:
   static ZBarrierSetAssembler* assembler();
   static bool barrier_needed(DecoratorSet decorators, BasicType type);
 
-  static void clone_obj_array(objArrayOop src, objArrayOop dst, size_t size);
+  static void clone_obj_array(objArrayOop src, objArrayOop dst);
 
   virtual void on_thread_create(Thread* thread);
   virtual void on_thread_destroy(Thread* thread);

--- a/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/z/zBarrierSet.inline.hpp
@@ -439,7 +439,7 @@ inline void ZBarrierSet::AccessBarrier<decorators, BarrierSetT>::clone_in_heap(o
     // for cloning arrays transform the clone to an optimized allocation
     // and arraycopy sequence, so the performance of this runtime call
     // does not matter for object arrays.
-    clone_obj_array(objArrayOop(src), objArrayOop(dst), size);
+    clone_obj_array(objArrayOop(src), objArrayOop(dst));
     return;
   }
 


### PR DESCRIPTION
`ZBarrierSet::clone_obj_array` incorrectly treats the payload of an ObjArray as `[base, obj + size[`. With non standard object alignment (`ObjectAlignmentInBytes`) there may be padding words at the end. 

Change `ZBarrierSet::clone_obj_array` to instead use `[base, base + length[` as the payload.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325074](https://bugs.openjdk.org/browse/JDK-8325074): ZGC fails assert(index == 0 || is_power_of_2(index)) failed: Incorrect load shift: 11 (**Bug** - P2)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17863/head:pull/17863` \
`$ git checkout pull/17863`

Update a local copy of the PR: \
`$ git checkout pull/17863` \
`$ git pull https://git.openjdk.org/jdk.git pull/17863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17863`

View PR using the GUI difftool: \
`$ git pr show -t 17863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17863.diff">https://git.openjdk.org/jdk/pull/17863.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17863#issuecomment-1945485852)