### PR TITLE
JDK-8325116: Amend jdk.ContainerConfiguration by swap related value

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -401,6 +401,15 @@ JVM_ENTRY_NO_ENV(jlong, jfr_host_total_memory(JNIEnv* env, jclass jvm))
 #endif
 JVM_END
 
+JVM_ENTRY_NO_ENV(jlong, jfr_host_total_swap_memory(JNIEnv* env, jclass jvm))
+#ifdef LINUX
+  // We want the host swap memory, not the container value.
+  return os::Linux::host_swap();
+#else
+  return os::total_swap_space();
+#endif
+JVM_END
+
 JVM_ENTRY_NO_ENV(void, jfr_emit_data_loss(JNIEnv* env, jclass jvm, jlong bytes))
   EventDataLoss::commit(bytes, min_jlong);
 JVM_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -157,6 +157,8 @@ jboolean JNICALL jfr_is_containerized(JNIEnv* env, jclass jvm);
 
 jlong JNICALL jfr_host_total_memory(JNIEnv* env, jclass jvm);
 
+jlong JNICALL jfr_host_total_swap_memory(JNIEnv* env, jclass jvm);
+
 void JNICALL jfr_emit_data_loss(JNIEnv* env, jclass jvm, jlong bytes);
 
 jlong JNICALL jfr_register_stack_filter(JNIEnv* env, jobject classes, jobject methods);

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -97,6 +97,7 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"isInstrumented", (char*)"(Ljava/lang/Class;)Z", (void*) jfr_is_class_instrumented,
       (char*)"isContainerized", (char*)"()Z", (void*) jfr_is_containerized,
       (char*)"hostTotalMemory", (char*)"()J", (void*) jfr_host_total_memory,
+      (char*)"hostTotalSwapMemory", (char*)"()J", (void*) jfr_host_total_swap_memory,
       (char*)"emitDataLoss", (char*)"(J)V", (void*)jfr_emit_data_loss,
       (char*)"registerStackFilter", (char*)"([Ljava/lang/String;[Ljava/lang/String;)J", (void*)jfr_register_stack_filter,
       (char*)"unregisterStackFilter", (char*)"(J)V", (void*)jfr_unregister_stack_filter

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ContainerConfigurationEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ContainerConfigurationEvent.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, DataDog. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, DataDog. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,4 +80,9 @@ public final class ContainerConfigurationEvent extends AbstractPeriodicEvent {
     @Description("Total memory of the host running the container")
     @DataAmount
     public long hostTotalMemory;
+
+    @Label("Container Host Total Swap Memory")
+    @Description("Total swap memory of the host running the container")
+    @DataAmount
+    public long hostTotalSwapMemory;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -628,6 +628,12 @@ public final class JVM {
     public static native long hostTotalMemory();
 
     /**
+     * Returns the total amount of swap memory of the host system whether or not this
+     * JVM runs in a container.
+     */
+    public static native long hostTotalSwapMemory();
+
+    /**
      * Emit a jdk.DataLoss event for the specified amount of bytes.
      *
      * @param bytes number of bytes that were lost

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -187,6 +187,7 @@ public final class JDKEvents {
             t.memoryLimit = containerMetrics.getMemoryLimit();
             t.swapMemoryLimit = containerMetrics.getMemoryAndSwapLimit();
             t.hostTotalMemory = JVM.hostTotalMemory();
+            t.hostTotalSwapMemory = JVM.hostTotalSwapMemory();
             t.commit();
         }
     }

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -129,7 +129,8 @@ public class TestJFREvents {
             .shouldContain(cpuSlicePeriodFld + " = " + expectedSlicePeriod)
             .shouldContain(cpuQuotaFld + " = " + expectedCPUs * expectedSlicePeriod)
             .shouldContain(memoryLimitFld + " = " + expectedMemoryLimit)
-            .shouldContain(totalMem + " = " + hostTotalMemory);
+            .shouldContain(totalMem + " = " + hostTotalMemory)
+            .shouldContain("hostTotalSwapMemory");
     }
 
     private static void testCpuUsage() throws Exception {


### PR DESCRIPTION
jdk.ContainerInformation event could get amended to report the host total swap values for Linux like was done in
https://bugs.openjdk.org/browse/JDK-8296671 by host total memory.
Two additional fields could be added hostSwapTotal, maybe hostSwapFree;
container free swap space in case we find a good implementation, could also be added to the implementation in os_linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325116](https://bugs.openjdk.org/browse/JDK-8325116): Amend jdk.ContainerConfiguration by swap related value (**Enhancement** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17865/head:pull/17865` \
`$ git checkout pull/17865`

Update a local copy of the PR: \
`$ git checkout pull/17865` \
`$ git pull https://git.openjdk.org/jdk.git pull/17865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17865`

View PR using the GUI difftool: \
`$ git pr show -t 17865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17865.diff">https://git.openjdk.org/jdk/pull/17865.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17865#issuecomment-1945589590)