### PR TITLE
JDK-8325876: crashes in docker container tests on Linuxppc64le Power8 machines

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -809,7 +809,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       elif test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
         # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
-        # After we switch to Power9+, we can use higher releases than Ubuntu 20.04 in class DockerfileConfig used for container tests
         $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power8"
       fi
     elif test "x$FLAGS_CPU" = xs390x; then

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -809,6 +809,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
       elif test "x$FLAGS_CPU" = xppc64le; then
         # Little endian machine uses ELFv2 ABI.
         # Use Power8, this is the first CPU to support PPC64 LE with ELFv2 ABI.
+        # After we switch to Power9+, we can use higher releases than Ubuntu 20.04 in class DockerfileConfig used for container tests
         $1_CFLAGS_CPU_JVM="${$1_CFLAGS_CPU_JVM} -DABI_ELFv2 -mcpu=power8 -mtune=power8"
       fi
     elif test "x$FLAGS_CPU" = xs390x; then

--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,11 @@ public class DockerfileConfig {
             return version;
         }
 
+        // Ubuntu 22.04 ppc started to crash in libz inflateReset on Power8 based host
+        // those recent Ubuntu versions only work on Power9+
+        if (Platform.isPPC()) {
+            return "20.04";
+        }
         return "latest";
     }
 }


### PR DESCRIPTION
We noticed recently crashes in docker container tests on **Linuxppc64le Power8** machines. Those tests use 'ubuntu ppc64le latest' for the container.
The crash looks like this :

containers/docker/TestContainerInfo.java

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
# SIGILL (0x4) at pc=0x00007fffa18cfc50, pid=1, tid=7
#
# JRE version: OpenJDK Runtime Environment (23.0) (fastdebug build 23-internal-adhoc.jenkinsi.jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 23-internal-adhoc.jenkinsi.jdk, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, serial gc, linux-ppc64le)
# Problematic frame:
# C [libz.so.1+0xfc50] inflateReset+0x60
#
# Core dump will be written. Default location: //core.1
#
# An error report file with more information is saved as:
# //hs_err_pid1.log


```
However 'ubuntu ppc64le latest' (and even 'ubuntu ppc64le 22.04') does not work any more on **Power8** machines.
See https://ubuntu.com/download/server/power : "Starting with Ubuntu 22.04 LTS, POWER9 and POWER10 processors are supported.
The support for POWER8 ends with Ubuntu 21.10, respectively Ubuntu 20.04 LTS, which is still supported for several years."

So we should consider changing the image on Linux ppc64le to avoid unwanted crashes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325876](https://bugs.openjdk.org/browse/JDK-8325876): crashes in docker container tests on Linuxppc64le Power8 machines (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [1bf5171c](https://git.openjdk.org/jdk/pull/17867/files/1bf5171c6d0d63c221853dec69dae0495ed701c6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17867/head:pull/17867` \
`$ git checkout pull/17867`

Update a local copy of the PR: \
`$ git checkout pull/17867` \
`$ git pull https://git.openjdk.org/jdk.git pull/17867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17867`

View PR using the GUI difftool: \
`$ git pr show -t 17867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17867.diff">https://git.openjdk.org/jdk/pull/17867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17867#issuecomment-1945641775)