### PR TITLE
8325941: Remove unused Space::block_size

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -168,26 +168,6 @@ HeapWord* ContiguousSpace::block_start_const(const void* p) const {
   }
 }
 
-size_t ContiguousSpace::block_size(const HeapWord* p) const {
-  assert(MemRegion(bottom(), end()).contains(p),
-         "p (" PTR_FORMAT ") not in space [" PTR_FORMAT ", " PTR_FORMAT ")",
-         p2i(p), p2i(bottom()), p2i(end()));
-  HeapWord* current_top = top();
-  assert(p <= current_top,
-         "p > current top - p: " PTR_FORMAT ", current top: " PTR_FORMAT,
-         p2i(p), p2i(current_top));
-  assert(p == current_top || oopDesc::is_oop(cast_to_oop(p)),
-         "p (" PTR_FORMAT ") is not a block start - "
-         "current_top: " PTR_FORMAT ", is_oop: %s",
-         p2i(p), p2i(current_top), BOOL_TO_STR(oopDesc::is_oop(cast_to_oop(p))));
-  if (p < current_top) {
-    return cast_to_oop(p)->size();
-  } else {
-    assert(p == current_top, "just checking");
-    return pointer_delta(end(), (HeapWord*) p);
-  }
-}
-
 // This version requires locking.
 inline HeapWord* ContiguousSpace::allocate_impl(size_t size) {
   assert(Heap_lock->owned_by_self() ||

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -133,11 +133,6 @@ class Space: public CHeapObj<mtGC> {
   // object or a non-object.  If "p" is not in the space, return null.
   virtual HeapWord* block_start_const(const void* p) const = 0;
 
-  // Requires "addr" to be the start of a chunk, and returns its size.
-  // "addr + size" is required to be the start of a new chunk, or the end
-  // of the active area of the heap.
-  virtual size_t block_size(const HeapWord* addr) const = 0;
-
   // Allocation (return null if full).  Assumes the caller has established
   // mutually exclusive access to the space.
   virtual HeapWord* allocate(size_t word_size) = 0;
@@ -258,7 +253,6 @@ protected:
 
   // Very inefficient implementation.
   HeapWord* block_start_const(const void* p) const override;
-  size_t block_size(const HeapWord* p) const override;
 
   // Addresses for inlined allocation
   HeapWord** top_addr() { return &_top; }


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325941](https://bugs.openjdk.org/browse/JDK-8325941): Remove unused Space::block_size (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17869/head:pull/17869` \
`$ git checkout pull/17869`

Update a local copy of the PR: \
`$ git checkout pull/17869` \
`$ git pull https://git.openjdk.org/jdk.git pull/17869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17869`

View PR using the GUI difftool: \
`$ git pr show -t 17869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17869.diff">https://git.openjdk.org/jdk/pull/17869.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17869#issuecomment-1945828945)