### PR TITLE
8325247: Memory leak in SessionKeyRef class def when using PKCS11 security provider

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1533,6 +1533,8 @@ final class NativeKeyHolder {
                     // destroy
                     this.keyID = 0;
                     this.ref.removeNativeKey();
+                    // prevent enqueuing SessionKeyRef until removeNativeKey is done
+                    Reference.reachabilityFence(this);
                 } else {
                     if (cnt < 0) {
                         // should never happen as we start count at 1 and pair get/release calls

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -1532,9 +1532,12 @@ final class NativeKeyHolder {
 
                     // destroy
                     this.keyID = 0;
-                    this.ref.removeNativeKey();
-                    // prevent enqueuing SessionKeyRef until removeNativeKey is done
-                    Reference.reachabilityFence(this);
+                    try {
+                        this.ref.removeNativeKey();
+                    } finally {
+                        // prevent enqueuing SessionKeyRef until removeNativeKey is done
+                        Reference.reachabilityFence(this);
+                    }
                 } else {
                     if (cnt < 0) {
                         // should never happen as we start count at 1 and pair get/release calls


### PR DESCRIPTION
The reported leak was caused by the death of the `Cleanup-SunPKCS11` thread. The cleanup thread in turn died because of an exception thrown from `removeNativeKey` that resulted from 2 threads executing that method at the same time.

This PR adds a reachabilityFence to ensure that the key will only be enqueued for cleanup after the user thread is done with the `removeNativeKey` call.

No new regression test; the issue is extremely hard to reproduce in a reasonable time. Existing tier1-3 tests continue to pass.

In JBS I attached a PoC patch that changes the relative timing of operations; with that patch and without the changes from this PR I am able to reproduce the issue within a few seconds. With the changes from this PR the issue did not reproduce after 10 minutes of testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325247](https://bugs.openjdk.org/browse/JDK-8325247): Memory leak in SessionKeyRef class def when using PKCS11 security provider (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17870/head:pull/17870` \
`$ git checkout pull/17870`

Update a local copy of the PR: \
`$ git checkout pull/17870` \
`$ git pull https://git.openjdk.org/jdk.git pull/17870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17870`

View PR using the GUI difftool: \
`$ git pr show -t 17870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17870.diff">https://git.openjdk.org/jdk/pull/17870.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17870#issuecomment-1945929411)