### PR TITLE
JDK-8325862: set -XX:+ErrorFileToStderr when executing java in containers for some container related jtreg tests

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerRunOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,9 @@ public class DockerRunOptions {
         this.command = javaCmd;
         this.classToRun = classToRun;
         this.addJavaOpts(javaOpts);
+        // always print hserr to stderr in the docker tests to avoid
+        // trouble accessing it after a crash in the container
+        this.addJavaOpts("-XX:+ErrorFileToStderr");
     }
 
     public DockerRunOptions addDockerOpts(String... opts) {


### PR DESCRIPTION
To get easier access to the hserr file content, -XX:+ErrorFileToStderr should be set when executing test parts in a container.
Examples are the docker/container tests starting (docker) containers with java processes inside the container and not on the host.