### PR TITLE
8325972: Add -x to bash for building with LOG=debug

### DIFF
--- a/make/common/MakeBase.gmk
+++ b/make/common/MakeBase.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,10 @@ define SetupLogging
                 flock $$(FLOCK) \
                 $$(OUTPUTDIR)/build-profile.log $$(SHELL)
     endif
+  endif
+
+  ifneq ($$(findstring $$(LOG_LEVEL), debug trace),)
+    SHELL := $$(SHELL) -x
   endif
 
   ifeq ($$(LOG_LEVEL), trace)


### PR DESCRIPTION
I don't understand why I have never thought of this before. If we add `-x` to the set of bash arguments when running with LOG=debug, we get output of *all* shell commands that make is running, even those for $(shell).

This makes it soooo much easier to understand what is actually happening in the makefile! (To the point where we could actually consider moving other stuff away from the debug level.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325972](https://bugs.openjdk.org/browse/JDK-8325972): Add -x to bash for building with LOG=debug (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17875/head:pull/17875` \
`$ git checkout pull/17875`

Update a local copy of the PR: \
`$ git checkout pull/17875` \
`$ git pull https://git.openjdk.org/jdk.git pull/17875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17875`

View PR using the GUI difftool: \
`$ git pr show -t 17875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17875.diff">https://git.openjdk.org/jdk/pull/17875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17875#issuecomment-1946295476)