### PR TITLE
8325936: jshell - crash on 'new Object().""'

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4999,10 +4999,15 @@ public class Attr extends JCTree.Visitor {
     public void visitStringTemplate(JCStringTemplate tree) {
         JCExpression processor = tree.processor;
         Type processorType = attribTree(processor, env, new ResultInfo(KindSelector.VAL, Type.noType));
-        chk.checkProcessorType(processor, processorType, env);
-        Type processMethodType = getProcessMethodType(tree, processorType);
-        tree.processMethodType = processMethodType;
-        Type resultType = processMethodType.getReturnType();
+        processorType = chk.checkProcessorType(processor, processorType, env);
+        Type resultType;
+        if (!processorType.isErroneous()) {
+            Type processMethodType = getProcessMethodType(tree, processorType);
+            tree.processMethodType = processMethodType;
+            resultType = processMethodType.getReturnType();
+        } else {
+            tree.processMethodType = resultType = types.createErrorType(processorType);
+        }
 
         Env<AttrContext> localEnv = env.dup(tree, env.info.dup());
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4999,9 +4999,8 @@ public class Attr extends JCTree.Visitor {
     public void visitStringTemplate(JCStringTemplate tree) {
         JCExpression processor = tree.processor;
         Type processorType = attribTree(processor, env, new ResultInfo(KindSelector.VAL, Type.noType));
-        processorType = chk.checkProcessorType(processor, processorType, env);
         Type resultType;
-        if (!processorType.isErroneous()) {
+        if (chk.checkProcessorType(processor)) {
             Type processMethodType = getProcessMethodType(tree, processorType);
             tree.processMethodType = processMethodType;
             resultType = processMethodType.getReturnType();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4475,17 +4475,17 @@ public class Check {
         }
     }
 
-    public Type checkProcessorType(JCExpression processor, Type resultType, Env<AttrContext> env) {
+    public boolean checkProcessorType(JCExpression processor) {
         Type processorType = processor.type;
         Type interfaceType = types.asSuper(processorType, syms.processorType.tsym);
 
         if (interfaceType == null)  {
             log.error(DiagnosticFlag.RESOLVE_ERROR, processor.pos,
                     Errors.NotAProcessorType(processorType.tsym));
-            return types.createErrorType(resultType);
+            return false;
         }
 
-        return resultType;
+        return true;
     }
 
     public void checkLeaksNotAccessible(Env<AttrContext> env, JCClassDecl check) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4479,17 +4479,10 @@ public class Check {
         Type processorType = processor.type;
         Type interfaceType = types.asSuper(processorType, syms.processorType.tsym);
 
-        if (interfaceType != null) {
-            List<Type> typeArguments = interfaceType.getTypeArguments();
-
-            if (typeArguments.size() == 2) {
-                resultType = typeArguments.head;
-            } else {
-                resultType = syms.objectType;
-            }
-        } else {
+        if (interfaceType == null)  {
             log.error(DiagnosticFlag.RESOLVE_ERROR, processor.pos,
                     Errors.NotAProcessorType(processorType.tsym));
+            return types.createErrorType(resultType);
         }
 
         return resultType;

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -65,12 +65,4 @@ public class ErrorRecoveryTest extends KullaTesting {
                    DiagCheck.DIAG_IGNORE,
                    ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
     }
-
-    public void testStringTemplateNotProcessor() {
-        assertEval("Object o = null;");
-        assertEval("o.\"\"",
-                   DiagCheck.DIAG_ERROR,
-                   DiagCheck.DIAG_IGNORE,
-                   ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
-    }
 }

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -65,4 +65,12 @@ public class ErrorRecoveryTest extends KullaTesting {
                    DiagCheck.DIAG_IGNORE,
                    ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
     }
+
+    public void testStringTemplateNotProcessor() {
+        assertEval("Object o = null;");
+        assertEval("o.\"\"",
+                   DiagCheck.DIAG_ERROR,
+                   DiagCheck.DIAG_IGNORE,
+                   ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
+    }
 }

--- a/test/langtools/jdk/jshell/ToolSimpleTest.java
+++ b/test/langtools/jdk/jshell/ToolSimpleTest.java
@@ -970,4 +970,11 @@ public class ToolSimpleTest extends ReplToolTesting {
                 (a) -> assertCommandOutputContains(a, "var a = a;", "cannot use 'var' on self-referencing variable")
         );
     }
+
+    @Test
+    public void testStringTemplateNotProcessor() {
+        test(false, new String[]{"--enable-preview"},
+                a -> assertCommandOutputContains(a, "new Object().\"\"", "not a processor type")
+        );
+    }
 }

--- a/test/langtools/tools/javac/diags/examples/StringTemplateNotProcessor.java
+++ b/test/langtools/tools/javac/diags/examples/StringTemplateNotProcessor.java
@@ -22,8 +22,6 @@
  */
 
  // key: compiler.note.preview.filename
- // key: compiler.err.cant.resolve.location.args
- // key: compiler.misc.location
  // key: compiler.note.preview.recompile
  // key: compiler.err.not.a.processor.type
  // options: --enable-preview  -source ${jdk.version}


### PR DESCRIPTION
This fixes a crash in jshell when the target of a StringTemplate is not a processor. We only look up the `process` method if the type is actually a processor. The added test case fails without that fix.

Please let me know what you think of this fix, and if there are things that should be changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325936](https://bugs.openjdk.org/browse/JDK-8325936): jshell - crash on 'new Object().""' (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17876/head:pull/17876` \
`$ git checkout pull/17876`

Update a local copy of the PR: \
`$ git checkout pull/17876` \
`$ git pull https://git.openjdk.org/jdk.git pull/17876/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17876`

View PR using the GUI difftool: \
`$ git pr show -t 17876`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17876.diff">https://git.openjdk.org/jdk/pull/17876.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17876#issuecomment-1946605605)