### PR TITLE
8325983: Fix build failure after JDK-8324580

### DIFF
--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -318,8 +318,8 @@ size_t HugePages::thp_pagesize_fallback() {
     if (thp_pagesize() != 0) {
         return thp_pagesize();
     }
-    if (supports_static_hugepages()) {
-        return MIN2(default_static_hugepage_size(), 16 * M);
+    if (supports_explicit_hugepages()) {
+        return MIN2(default_explicit_hugepage_size(), 16 * M);
     }
     return 2 * M;
 }

--- a/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
+++ b/test/hotspot/jtreg/runtime/os/HugePageConfiguration.java
@@ -93,7 +93,7 @@ class HugePageConfiguration {
         if (pageSize != 0) {
             return pageSize;
         }
-        pageSize = getStaticDefaultHugePageSize();
+        pageSize = getExplicitDefaultHugePageSize();
         if (pageSize != 0) {
             return Math.min(pageSize, 16 * 1024 * 1024);
         }


### PR DESCRIPTION
I was informed, there is a build failure after [JDK-8324580](https://bugs.openjdk.org/browse/JDK-8324580). This is because there was an intermediate change [JDK-8325306](https://bugs.openjdk.org/browse/JDK-8325306) and while both changes worked independently, merged result does not build.

```
jdk/src/hotspot/os/linux/hugepages.cpp:321:9: error: 'supports_static_hugepages' was not declared in this scope; did you mean 'supports_explicit_hugepages'?
  321 | if (supports_static_hugepages()) {
      | ^~~~~~~~~~~~~~~~~~~~~~~~~
      | supports_explicit_hugepages
```