### PR TITLE
8325990: Remove use of snippet @replace annotation in java.base

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ import sun.security.action.GetPropertyAction;
  * char[] passwd;
  * if ((cons = System.console()) != null &&
  *     (passwd = cons.readPassword("[%s]", "Password:")) != null) {
- *     code: // @replace substring="code:" replacement="..."
+ *     ...
  *     java.util.Arrays.fill(passwd, ' ');
  * }
  * }

--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -2425,7 +2425,7 @@ public abstract class ResourceBundle {
      * {@snippet lang=java :
      * import java.util.*;
      * import static java.util.ResourceBundle.Control.*;
-     * code: // @replace substring="code:" replacement="..."
+     * ...
      * ResourceBundle bundle =
      *   ResourceBundle.getBundle("MyResources", Locale.forLanguageTag("fr-CH"),
      *                            ResourceBundle.Control.getControl(FORMAT_PROPERTIES));
@@ -2494,7 +2494,7 @@ public abstract class ResourceBundle {
      *         }
      *     });
      *
-     * code: // @replace substring="code:" replacement="..."
+     * ...
      *
      * private static class XMLResourceBundle extends ResourceBundle {
      *     private Properties props;
@@ -2506,7 +2506,7 @@ public abstract class ResourceBundle {
      *         return props.getProperty(key);
      *     }
      *     public Enumeration<String> getKeys() {
-     *         code: // @replace substring="code:" replacement="..."
+     *         ...
      *     }
      * }
      * }


### PR DESCRIPTION
Revert `@replace` snippet annotation construct to value of `replacement` attribute.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325990](https://bugs.openjdk.org/browse/JDK-8325990): Remove use of snippet @<!---->replace annotation in java.base (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17882/head:pull/17882` \
`$ git checkout pull/17882`

Update a local copy of the PR: \
`$ git checkout pull/17882` \
`$ git pull https://git.openjdk.org/jdk.git pull/17882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17882`

View PR using the GUI difftool: \
`$ git pr show -t 17882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17882.diff">https://git.openjdk.org/jdk/pull/17882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17882#issuecomment-1946978961)