### PR TITLE
8325994: JFR: Examples in JFR.start help use incorrect separator

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -418,9 +418,9 @@ final class DCmdStart extends AbstractDCmd {
                 $ jcmd <pid> JFR.start filename=dump.jfr
                 $ jcmd <pid> JFR.start filename=%s
                 $ jcmd <pid> JFR.start dumponexit=true
-                $ jcmd <pid> JFR.start maxage=1h,maxsize=1000M
+                $ jcmd <pid> JFR.start maxage=1h maxsize=1000M
                 $ jcmd <pid> JFR.start settings=profile
-                $ jcmd <pid> JFR.start delay=5m,settings=my.jfc
+                $ jcmd <pid> JFR.start delay=5m settings=my.jfc
                 $ jcmd <pid> JFR.start gc=high method-profiling=high
                 $ jcmd <pid> JFR.start jdk.JavaMonitorEnter#threshold=1ms
                 $ jcmd <pid> JFR.start +HelloWorld#enabled=true +HelloWorld#stackTrace=true


### PR DESCRIPTION
Could I have review of a fix that changes the separator in the help text for JFR.start from "," to " ".

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325994](https://bugs.openjdk.org/browse/JDK-8325994): JFR: Examples in JFR.start help use incorrect separator (**Bug** - P3)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17884/head:pull/17884` \
`$ git checkout pull/17884`

Update a local copy of the PR: \
`$ git checkout pull/17884` \
`$ git pull https://git.openjdk.org/jdk.git pull/17884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17884`

View PR using the GUI difftool: \
`$ git pr show -t 17884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17884.diff">https://git.openjdk.org/jdk/pull/17884.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17884#issuecomment-1947485640)