### PR TITLE
8326006: Allow TEST_VM_FLAGLESS to set flagless mode

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -664,8 +664,9 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     private String isFlagless() {
         boolean result = true;
-        if (System.getenv("TEST_VM_FLAGLESS") != null) {
-            return "" + "true".equalsIgnoreCase(System.getenv("TEST_VM_FLAGLESS"));
+        String flagless = System.getenv("TEST_VM_FLAGLESS");
+        if (flagless != null) {
+            return "" + "true".equalsIgnoreCase(flagless);
         }
 
         List<String> allFlags = allFlags().toList();

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -658,14 +658,14 @@ public class VMProps implements Callable<Map<String, String>> {
      * Checks if we are in <i>almost</i> out-of-box configuration, i.e. the flags
      * which JVM is started with don't affect its behavior "significantly".
      * {@code TEST_VM_FLAGLESS} enviroment variable can be used to force this
-     * method to return true and allow any flags.
+     * method to return true or false and allow or reject any flags.
      *
      * @return true if there are no JVM flags
      */
     private String isFlagless() {
         boolean result = true;
         if (System.getenv("TEST_VM_FLAGLESS") != null) {
-            return "" + result;
+            return "" + "true".equalsIgnoreCase(System.getenv("TEST_VM_FLAGLESS"));
         }
 
         List<String> allFlags = allFlags().toList();


### PR DESCRIPTION
Allow TEST_VM_FLAGLESS to enable/disable flagless tests execution explicitly.
Sometimes the tests are executed in the mode that is incompatible with flag-sensitive tests. This mode should be able to disable them explicitly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326006](https://bugs.openjdk.org/browse/JDK-8326006): Allow TEST_VM_FLAGLESS to set flagless mode (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [65859eed](https://git.openjdk.org/jdk/pull/17886/files/65859eed30e43f4c98d6f37f103f5d9aa23e00d5)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [65859eed](https://git.openjdk.org/jdk/pull/17886/files/65859eed30e43f4c98d6f37f103f5d9aa23e00d5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17886/head:pull/17886` \
`$ git checkout pull/17886`

Update a local copy of the PR: \
`$ git checkout pull/17886` \
`$ git pull https://git.openjdk.org/jdk.git pull/17886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17886`

View PR using the GUI difftool: \
`$ git pr show -t 17886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17886.diff">https://git.openjdk.org/jdk/pull/17886.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17886#issuecomment-1947573603)