### PR TITLE
8299023: TestPLABResize.java and TestPLABPromotion.java are failing intermittently

### DIFF
--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABPromotion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8141278 8141141
  * @summary Test PLAB promotion
  * @requires vm.gc.G1
- * @requires !vm.flightRecorder
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management

--- a/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
+++ b/test/hotspot/jtreg/gc/g1/plab/TestPLABResize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 8141278 8141141
  * @summary Test for PLAB resizing
  * @requires vm.gc.G1
- * @requires !vm.flightRecorder
+ * @requires vm.flagless
  * @library /test/lib /
  * @modules java.base/jdk.internal.misc
  * @modules java.management


### PR DESCRIPTION
These 2 tests are too sensitive for memory usage. They are failing intermittently with JFR, C1-only and some other modes that break their expectations.
It would be better just to disable their execution with any additional parameters.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299023](https://bugs.openjdk.org/browse/JDK-8299023): TestPLABResize.java and TestPLABPromotion.java are failing intermittently (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17887/head:pull/17887` \
`$ git checkout pull/17887`

Update a local copy of the PR: \
`$ git checkout pull/17887` \
`$ git pull https://git.openjdk.org/jdk.git pull/17887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17887`

View PR using the GUI difftool: \
`$ git pr show -t 17887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17887.diff">https://git.openjdk.org/jdk/pull/17887.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17887#issuecomment-1947638148)