### PR TITLE
8321075: RISC-V: UseSystemMemoryBarrier lacking proper OS support

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -85,6 +85,8 @@
 #endif
 
 // put OS-includes here
+# include <ctype.h>
+# include <stdlib.h>
 # include <sys/types.h>
 # include <sys/mman.h>
 # include <sys/stat.h>
@@ -340,6 +342,29 @@ static void next_line(FILE *f) {
   do {
     c = fgetc(f);
   } while (c != '\n' && c != EOF);
+}
+
+void os::Linux::kernel_version(long* major, long* minor) {
+  *major = -1;
+  *minor = -1;
+
+  struct utsname buffer;
+  int ret = uname(&buffer);
+  if (ret != 0) {
+    log_warning(os)("uname(2) failed to get kernel version: %s", os::errno_name(ret));
+    return;
+  }
+
+  char* walker = buffer.release;
+  long* set_v = major;
+  while (*minor == -1 && walker != nullptr) {
+    if (isdigit(walker[0])) {
+      *set_v = strtol(walker, &walker, 10);
+      set_v = minor;
+    } else {
+      ++walker;
+    }
+  }
 }
 
 bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu) {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -93,6 +93,8 @@ class os::Linux {
     bool     has_steal_ticks;
   };
 
+  static void kernel_version(long* major, long* minor);
+
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.
   static bool get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu);
   static bool _stack_is_executable;

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -68,7 +68,7 @@ bool LinuxSystemMemoryBarrier::initialize() {
   long major, minor;
   os::Linux::kernel_version(&major, &minor);
   if (!(major > 6 || (major == 6 && minor >= 9))) {
-    log_info(os)("Linux kernel %ld.%ld do not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
+    log_info(os)("Linux kernel %ld.%ld does not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
                  major, minor);
     return false;
   }

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -67,7 +67,7 @@ bool LinuxSystemMemoryBarrier::initialize() {
 // But RISCV actually don't support it until 6.9.
   long major, minor;
   os::Linux::kernel_version(&major, &minor);
-  if (!(major >= 6 && minor >= 9)) {
+  if (!(major > 6 || (major == 6 && minor >= 9))) {
     log_info(os)("Linux kernel %ld.%ld do not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
                  major, minor);
     return false;

--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "logging/log.hpp"
-#include "runtime/os.hpp"
+#include "os_linux.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/systemMemoryBarrier.hpp"
 
@@ -61,6 +61,18 @@ static long membarrier(int cmd, unsigned int flags, int cpu_id) {
 }
 
 bool LinuxSystemMemoryBarrier::initialize() {
+#if defined(RISCV)
+// RISCV port was introduced in kernel 4.4.
+// 4.4 also made membar private expedited mandatory.
+// But RISCV actually don't support it until 6.9.
+  long major, minor;
+  os::Linux::kernel_version(&major, &minor);
+  if (!(major >= 6 && minor >= 9)) {
+    log_info(os)("Linux kernel %ld.%ld do not support MEMBARRIER PRIVATE_EXPEDITED on RISC-V.",
+                 major, minor);
+    return false;
+  }
+#endif
   long ret = membarrier(MEMBARRIER_CMD_QUERY, 0, 0);
   if (ret < 0) {
     log_info(os)("MEMBARRIER_CMD_QUERY unsupported");


### PR DESCRIPTION
Hi, please consider.

RV port was pickup into mainline Linux 4.4.
The same version also made membar private expedited mandatory, but this was missed in RV port.
This means to we need to check kernel version in runtime to figure out if it's usable.

Kernel fix is here:
https://git.kernel.org/pub/scm/linux/kernel/git/palmer/linux.git/commit/?h=for-next&id=0420af54c2c2b7b3abbd986a41aded7cab0137ef

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321075](https://bugs.openjdk.org/browse/JDK-8321075): RISC-V: UseSystemMemoryBarrier lacking proper OS support (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [819c891c](https://git.openjdk.org/jdk/pull/17889/files/819c891c68d7079ee868ac27fec5c018652a2cd0)
 * [Yadong Wang](https://openjdk.org/census#yadongwang) (@yadongw - Committer)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17889/head:pull/17889` \
`$ git checkout pull/17889`

Update a local copy of the PR: \
`$ git checkout pull/17889` \
`$ git pull https://git.openjdk.org/jdk.git pull/17889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17889`

View PR using the GUI difftool: \
`$ git pr show -t 17889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17889.diff">https://git.openjdk.org/jdk/pull/17889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17889#issuecomment-1948369778)