### PR TITLE
8326062: ProblemList jcstress tests that are failing due to JDK-8325984

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -113,6 +113,11 @@ runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x
 runtime/os/TestTransparentHugePageUsage.java 8324776 linux-all
 runtime/Thread/TestAlwaysPreTouchStacks.java 8324781 linux-all
 
+applications/jcstress/accessAtomic.java 8325984 generic-all
+applications/jcstress/acqrel.java 8325984 generic-all
+applications/jcstress/atomicity.java 8325984 generic-all
+applications/jcstress/coherence.java 8325984 generic-all
+
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList jcstress tests that are failing due to JDK-8325984.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326062](https://bugs.openjdk.org/browse/JDK-8326062): ProblemList jcstress tests that are failing due to JDK-8325984 (**Sub-task** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17890/head:pull/17890` \
`$ git checkout pull/17890`

Update a local copy of the PR: \
`$ git checkout pull/17890` \
`$ git pull https://git.openjdk.org/jdk.git pull/17890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17890`

View PR using the GUI difftool: \
`$ git pr show -t 17890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17890.diff">https://git.openjdk.org/jdk/pull/17890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17890#issuecomment-1948729630)