### PR TITLE
8326066: Parallel: Remove redundant ParallelScavengeHeap::resize_all_tlabs

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -526,10 +526,6 @@ HeapWord* ParallelScavengeHeap::allocate_new_tlab(size_t min_size, size_t reques
   return result;
 }
 
-void ParallelScavengeHeap::resize_all_tlabs() {
-  CollectedHeap::resize_all_tlabs();
-}
-
 void ParallelScavengeHeap::prune_scavengable_nmethods() {
   ScavengableNMethods::prune_nmethods_not_into_young();
 }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -216,7 +216,6 @@ class ParallelScavengeHeap : public CollectedHeap {
   void do_full_collection(bool clear_all_soft_refs) override;
 
   void ensure_parsability(bool retire_tlabs) override;
-  void resize_all_tlabs() override;
 
   size_t tlab_capacity(Thread* thr) const override;
   size_t tlab_used(Thread* thr) const override;


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326066](https://bugs.openjdk.org/browse/JDK-8326066): Parallel: Remove redundant ParallelScavengeHeap::resize_all_tlabs (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17892/head:pull/17892` \
`$ git checkout pull/17892`

Update a local copy of the PR: \
`$ git checkout pull/17892` \
`$ git pull https://git.openjdk.org/jdk.git pull/17892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17892`

View PR using the GUI difftool: \
`$ git pr show -t 17892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17892.diff">https://git.openjdk.org/jdk/pull/17892.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17892#issuecomment-1948923275)