### PR TITLE
8325542: CTW: Runner can produce negative StressSeed

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import java.util.Random;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -266,7 +267,7 @@ public class CtwRunner {
     private String[] cmd(long classStart, long classStop) {
         String phase = phaseName(classStart);
         Path file = Paths.get(phase + ".cmd");
-        var rng = Utils.getRandomInstance();
+        Random rng = Utils.getRandomInstance();
 
         ArrayList<String> Args = new ArrayList<String>(Arrays.asList(
                 "-Xbatch",
@@ -300,7 +301,7 @@ public class CtwRunner {
                 "-XX:+StressCCP",
                 "-XX:+StressMacroExpansion",
                 // StressSeed is uint
-                "-XX:StressSeed=" + Math.abs(rng.nextInt())));
+                "-XX:StressSeed=" + rng.nextInt(Integer.MAX_VALUE)));
 
         for (String arg : CTW_EXTRA_ARGS.split(",")) {
             Args.add(arg);


### PR DESCRIPTION
CtwRunner does `abs(random.nextInt())`, which would break when random returns Integer.MIN_VALUE. Its abs() would be negative, which would be caught by JVM argument parsing code as incorrectly specified option. This would yield a very rare CTW failure.

We fix this by using `nextInt(Integer.MAX_VALUE)`, which always returns a non-negative number in [0, MAX_VALUE). This is what [jcstress does](https://github.com/openjdk/jcstress/blob/84bd76e115604e81e721674eff0ff39c5a3bf3b8/jcstress-core/src/main/java/org/openjdk/jcstress/vm/VMSupport.java#L565).

I also make a change so that `rng` has explicit type. I think we prefer explicit types for most cases.

Tested with `./ctwrunner.sh modules:java.base`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325542](https://bugs.openjdk.org/browse/JDK-8325542): CTW: Runner can produce negative StressSeed (**Bug** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17896/head:pull/17896` \
`$ git checkout pull/17896`

Update a local copy of the PR: \
`$ git checkout pull/17896` \
`$ git pull https://git.openjdk.org/jdk.git pull/17896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17896`

View PR using the GUI difftool: \
`$ git pr show -t 17896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17896.diff">https://git.openjdk.org/jdk/pull/17896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17896#issuecomment-1949395725)