### PR TITLE
8325610: CTW: Add StressIncrementalInlining to stress options

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -299,6 +299,7 @@ public class CtwRunner {
                 "-XX:+StressIGVN",
                 "-XX:+StressCCP",
                 "-XX:+StressMacroExpansion",
+                "-XX:+StressIncrementalInlining",
                 // StressSeed is uint
                 "-XX:StressSeed=" + Math.abs(rng.nextInt())));
 


### PR DESCRIPTION
CtwRunner opts-in into [various C2 randomizers](https://github.com/openjdk/jdk/blob/6a12362660d6221beb3a059dc90d06a8068cce39/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java#L297-L301)

I think we forgot to add -XX:+StressIncrementalInlining there, which was added by [JDK-8319879](https://bugs.openjdk.org/browse/JDK-8319879).

tested by `./ctwrunner.sh modules:java.base`

I can see `-XX:+StressIncrementalInlining` in `modules_java_base_0.cmd`

```
-Xbatch
-XX:-ShowMessageBoxOnError
-XX:+UnlockDiagnosticVMOptions
-XX:+DisplayVMOutputToStderr
-DCompileTheWorldStartAt=0
-DCompileTheWorldStopAt=7671
-XX:+WhiteBoxAPI
-Xbootclasspath/a:.
--add-exports
java.base/jdk.internal.jimage=ALL-UNNAMED
--add-exports
java.base/jdk.internal.misc=ALL-UNNAMED
--add-exports
java.base/jdk.internal.reflect=ALL-UNNAMED
--add-exports
java.base/jdk.internal.access=ALL-UNNAMED
-XX:+LogCompilation
-XX:LogFile=hotspot_modules_java_base_0_%p.log
-XX:ErrorFile=hs_err_modules_java_base_0_%p.log
-XX:ReplayDataFile=replay_modules_java_base_0_%p.log
-XX:CompileCommand=exclude,java/lang/invoke/MethodHandle.*
-XX:+IgnoreUnrecognizedVMOptions
-XX:+StressLCM
-XX:+StressGCM
-XX:+StressIGVN
-XX:+StressCCP
-XX:+StressMacroExpansion
-XX:+StressIncrementalInlining
-XX:StressSeed=1785134692

sun.hotspot.tools.ctw.CompileTheWorld
modules:java.base
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325610](https://bugs.openjdk.org/browse/JDK-8325610): CTW: Add StressIncrementalInlining to stress options (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Xin Liu](https://openjdk.org/census#xliu) (@navyxliu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17897/head:pull/17897` \
`$ git checkout pull/17897`

Update a local copy of the PR: \
`$ git checkout pull/17897` \
`$ git pull https://git.openjdk.org/jdk.git pull/17897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17897`

View PR using the GUI difftool: \
`$ git pr show -t 17897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17897.diff">https://git.openjdk.org/jdk/pull/17897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17897#issuecomment-1949409238)