### PR TITLE
8326099: GZIPOutputStream should use Deflater.getBytesRead() instead of Deflater.getTotalIn()

### DIFF
--- a/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPOutputStream.java
@@ -208,7 +208,9 @@ public class GZIPOutputStream extends DeflaterOutputStream {
      */
     private void writeTrailer(byte[] buf, int offset) throws IOException {
         writeInt((int)crc.getValue(), buf, offset); // CRC-32 of uncompr. data
-        writeInt(def.getTotalIn(), buf, offset + 4); // Number of uncompr. bytes
+        // RFC 1952: Size of the original (uncompressed) input data modulo 2^32
+        int iSize = (int) def.getBytesRead();
+        writeInt(iSize, buf, offset + 4);
     }
 
     /*


### PR DESCRIPTION
Please review this cleanup PR in preparation for deprecating `Deflater.getTotalIn()` in JDK-8326096. 

This PR replaces `GZIPOutputStream.writeTrailer`'s call to `Deflater.getTotalIn()` with a call to `Deflater.getBytesRead()` followed by an explicit conversion to "modulo 2^32" (a cast to int) as described in RFC 1952:

```
 ISIZE (Input SIZE)
  This contains the size of the original (uncompressed) input
  data modulo 2^32.
```

Testing and verification: This should be trivially verifiable by code inspection. Nevertheless, I wrote a test which writes Integer.MAX_VALUE +1 bytes of uncompressed data and verified that the last four bytes written to the file was indeed as expected. (This test is not included in this PR because of its runtime and resource requirements).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326099](https://bugs.openjdk.org/browse/JDK-8326099): GZIPOutputStream should use Deflater.getBytesRead() instead of Deflater.getTotalIn() (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17900/head:pull/17900` \
`$ git checkout pull/17900`

Update a local copy of the PR: \
`$ git checkout pull/17900` \
`$ git pull https://git.openjdk.org/jdk.git pull/17900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17900`

View PR using the GUI difftool: \
`$ git pr show -t 17900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17900.diff">https://git.openjdk.org/jdk/pull/17900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17900#issuecomment-1950072082)