### PR TITLE
8326100: DeflaterDictionaryTests should use Deflater.getBytesWritten instead of Deflater.getTotalOut

### DIFF
--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,9 +95,9 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getTotalOut(),
-                    deflater.getTotalOut(), compressedDataLength);
+            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getBytesWritten(),
+                    deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
             // Decompress the bytes
@@ -143,9 +143,9 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getTotalOut(),
-                    deflater.getTotalOut(), compressedDataLength);
+            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getBytesWritten(),
+                    deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
             // Decompress the bytes
@@ -197,9 +197,9 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getTotalOut:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getTotalOut(),
-                    deflater.getTotalOut(), compressedDataLength);
+            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
+                            " compressed length: %s%n", deflater.getBytesWritten(),
+                    deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
             // Decompress the bytes

--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -95,8 +95,8 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getBytesWritten(),
+            System.out.printf("Deflater::getBytesWritten:%d, Deflater::getAdler: %d," +
+                            " compressed length: %d%n", deflater.getBytesWritten(),
                     deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
@@ -112,7 +112,7 @@ public class DeflaterDictionaryTests {
                 System.out.println("Did not need to use a Dictionary");
             }
             inflater.finished();
-            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+            System.out.printf("Inflater::getAdler:%d, length: %d%n",
                     inflater.getAdler(), resultLength);
 
             Assert.assertEquals(SRC_DATA.length(), resultLength);
@@ -143,8 +143,8 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getBytesWritten(),
+            System.out.printf("Deflater::getBytesWritten:%d, Deflater::getAdler: %d," +
+                            " compressed length: %d%n", deflater.getBytesWritten(),
                     deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
@@ -160,7 +160,7 @@ public class DeflaterDictionaryTests {
                 System.out.println("Did not need to use a Dictionary");
             }
             inflater.finished();
-            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+            System.out.printf("Inflater::getAdler:%d, length: %d%n",
                     inflater.getAdler(), resultLength);
 
             Assert.assertEquals(SRC_DATA.length(), resultLength);
@@ -197,8 +197,8 @@ public class DeflaterDictionaryTests {
             deflater.setInput(input);
             deflater.finish();
             int compressedDataLength = deflater.deflate(output, 0, output.length, Deflater.NO_FLUSH);
-            System.out.printf("Deflater::getBytesWritten:%s, Deflater::getAdler: %s," +
-                            " compressed length: %s%n", deflater.getBytesWritten(),
+            System.out.printf("Deflater::getBytesWritten:%d, Deflater::getAdler: %d," +
+                            " compressed length: %d%n", deflater.getBytesWritten(),
                     deflater.getAdler(), compressedDataLength);
             deflater.finished();
 
@@ -214,7 +214,7 @@ public class DeflaterDictionaryTests {
                 System.out.println("Did not need to use a Dictionary");
             }
             inflater.finished();
-            System.out.printf("Inflater::getAdler:%s, length: %s%n",
+            System.out.printf("Inflater::getAdler:%d, length: %d%n",
                     inflater.getAdler(), resultLength);
 
             Assert.assertEquals(SRC_DATA.length(), resultLength);


### PR DESCRIPTION
Please review this test-only cleanup PR in preparation for deprecating `Deflater.getTotalOut()` in JDK-8326096.

This PR replaces various calls in`test/jdk/java/util/zip/DeflaterDictionaryTests.java` to `Deflater.getTotalOut()` with calls to `Deflater.getBytesWritten()` when formatting some debugging output lines. 

Additionally, various debug output lines claim to print the result of calling `Deflater.getAdler`, but instead prints the output of `Deflater.getTotalOut'. This PR fixes this to print the actual Adler value instead.

Testing and verification: This is a test-only fix affecting only debug output. I have added the `noreg-self` label to the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326100](https://bugs.openjdk.org/browse/JDK-8326100): DeflaterDictionaryTests should use Deflater.getBytesWritten instead of Deflater.getTotalOut (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17901/head:pull/17901` \
`$ git checkout pull/17901`

Update a local copy of the PR: \
`$ git checkout pull/17901` \
`$ git pull https://git.openjdk.org/jdk.git pull/17901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17901`

View PR using the GUI difftool: \
`$ git pr show -t 17901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17901.diff">https://git.openjdk.org/jdk/pull/17901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17901#issuecomment-1950122230)