### PR TITLE
8326106: Write and clear stack trace table outside of safepoint

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -223,9 +223,6 @@ class StackTraceBlobInstaller {
   StackTraceBlobInstaller() : _cache(JfrOptionSet::old_object_queue_size()) {
     prepare_for_resolution();
   }
-  ~StackTraceBlobInstaller() {
-    JfrStackTraceRepository::clear_leak_profiler();
-  }
   void sample_do(ObjectSample* sample) {
     if (stack_trace_precondition(sample)) {
       add_to_leakp_set(sample);
@@ -280,11 +277,14 @@ void ObjectSampleCheckpoint::on_rotation(const ObjectSampler* sampler) {
   assert(LeakProfiler::is_running(), "invariant");
   JavaThread* const thread = JavaThread::current();
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(thread);)
-  // can safepoint here
-  ThreadInVMfromNative transition(thread);
-  MutexLocker lock(ClassLoaderDataGraph_lock);
-  // the lock is needed to ensure the unload lists do not grow in the middle of inspection.
-  install_stack_traces(sampler);
+  {
+    // can safepoint here
+    ThreadInVMfromNative transition(thread);
+    MutexLocker lock(ClassLoaderDataGraph_lock);
+    // the lock is needed to ensure the unload lists do not grow in the middle of inspection.
+    install_stack_traces(sampler);
+  }
+  JfrStackTraceRepository::clear_leak_profiler();
 }
 
 static bool is_klass_unloaded(traceid klass_id) {

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -573,9 +573,7 @@ void JfrRecorderService::pre_safepoint_write() {
     ObjectSampleCheckpoint::on_rotation(ObjectSampler::acquire());
   }
   write_storage(_storage, _chunkwriter);
-  if (_stack_trace_repository.is_modified()) {
-    write_stacktrace(_stack_trace_repository, _chunkwriter, false);
-  }
+  write_stacktrace(_stack_trace_repository, _chunkwriter, true);
 }
 
 void JfrRecorderService::invoke_safepoint_write() {

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -98,11 +98,10 @@ bool JfrStackTraceRepository::is_modified() const {
 }
 
 size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
+  MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
   if (_entries == 0) {
     return 0;
   }
-  MutexLocker lock(JfrStacktrace_lock, Mutex::_no_safepoint_check_flag);
-  assert(_entries > 0, "invariant");
   int count = 0;
   for (u4 i = 0; i < TABLE_SIZE; ++i) {
     JfrStackTrace* stacktrace = _table[i];
@@ -121,8 +120,8 @@ size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
   if (clear) {
     memset(_table, 0, sizeof(_table));
     _entries = 0;
+    _last_entries = 0;
   }
-  _last_entries = _entries;
   return count;
 }
 

--- a/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
+++ b/src/hotspot/share/jfr/recorder/stacktrace/jfrStackTraceRepository.cpp
@@ -120,8 +120,8 @@ size_t JfrStackTraceRepository::write(JfrChunkWriter& sw, bool clear) {
   if (clear) {
     memset(_table, 0, sizeof(_table));
     _entries = 0;
-    _last_entries = 0;
   }
+  _last_entries = _entries;
   return count;
 }
 


### PR DESCRIPTION
Greetings,

When the chunk rotates, serializing the stack trace table happens in two passes:

1. The pre-safepoint writes as much as possible but does not delete nodes.
2. The safepoint writes new entries incrementally in addition to deleting nodes and resetting buckets.

Since a global lock protects the stack trace table, hoisting the deletes and clearing the table outside safepoints makes sense. Doing so will minimize the stack trace table work needed during the safepoint. The tradeoff is that an identical stack trace can be written twice. However, this is low risk because the pre-safepoint and the safepoint operations happen back to back (i.e. there is only a tiny window for inserting a new stack trace).

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326106](https://bugs.openjdk.org/browse/JDK-8326106): Write and clear stack trace table outside of safepoint (**Enhancement** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17905/head:pull/17905` \
`$ git checkout pull/17905`

Update a local copy of the PR: \
`$ git checkout pull/17905` \
`$ git pull https://git.openjdk.org/jdk.git pull/17905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17905`

View PR using the GUI difftool: \
`$ git pr show -t 17905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17905.diff">https://git.openjdk.org/jdk/pull/17905.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17905#issuecomment-1951427075)