### PR TITLE
JDK-8252802: java launcher should set MALLOCOPTIONS and LDR_CNTRL in order to use 64KB pages on AIX

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -300,6 +300,19 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     char * jvmtype = NULL;
     char **argv = *pargv;
 
+#ifdef AIX
+      const char *mallocOptionsName = "MALLOCOPTIONS";
+      const char *mallocOptionsValue = "multiheap,considersize";
+      if (setenv(mallocOptionsName, mallocOptionsValue, 0) != 0) {
+          fprintf(stderr, "setenv('MALLOCOPTIONS=multiheap,considersize') failed: performance may be affected\n");
+      }
+      const char * ldrCntrlName = "LDR_CNTRL";
+      const char *ldrCntrlValue = "TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K";
+      if (setenv(ldrCntrlName, ldrCntrlValue, 0) != 0) {
+           fprintf(stderr, "setenv('LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K') failed: performance may be affected\n");
+      }
+#endif
+
 #ifdef SETENV_REQUIRED
     jboolean mustsetenv = JNI_FALSE;
     char *runpath = NULL; /* existing effective LD_LIBRARY_PATH setting */

--- a/test/jdk/java/lang/ProcessBuilder/Basic.java
+++ b/test/jdk/java/lang/ProcessBuilder/Basic.java
@@ -799,11 +799,15 @@ public class Basic {
     }
 
     /* Only used for AIX --
-     * AIX adds the variable AIXTHREAD_GUARDPAGES=0 to the environment.
-     * Remove it from the list of env variables
+     * AIX adds the variables AIXTHREAD_GUARDPAGES=0,
+     * LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K, and
+     * MALLOCOPTIONS=multiheap,considersize, to the environment.
+     * Remove them from the list of env variables
      */
     private static String removeAixExpectedVars(String vars) {
-        return vars.replace("AIXTHREAD_GUARDPAGES=0,", "");
+        return vars.replace("AIXTHREAD_GUARDPAGES=0,", "")
+                   .replace("LDR_CNTRL=TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K,","")
+                   .replace("MALLOCOPTIONS=multiheap,considersize,","");
     }
 
     private static String sortByLinesWindowsly(String text) {


### PR DESCRIPTION
DeCapo Benchmark Results (3 runs) :  

Before : 
===== DaCapo 9.12 h2 PASSED in 281402 msec =====
===== DaCapo 9.12 h2 PASSED in 269818 msec =====
===== DaCapo 9.12 h2 PASSED in 279279 msec =====
 
After:
===== DaCapo 9.12 h2 PASSED in 279192 msec =====
===== DaCapo 9.12 h2 PASSED in 269769 msec =====
===== DaCapo 9.12 h2 PASSED in 271577 msec ===== 

Environmental variables LDR_CNTRL and MALLOCOPTIONS has caused test/jdk/java/lang/ProcessBuilder/Basic.java failure.
Additional environmental variables has to removed from removeAixExpectedVars().

JBS Issue : [JDK-8252802](https://bugs.openjdk.org/browse/JDK-8252802)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8252802](https://bugs.openjdk.org/browse/JDK-8252802): java launcher should set MALLOCOPTIONS and LDR_CNTRL in order to use 64KB pages on AIX (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17906/head:pull/17906` \
`$ git checkout pull/17906`

Update a local copy of the PR: \
`$ git checkout pull/17906` \
`$ git pull https://git.openjdk.org/jdk.git pull/17906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17906`

View PR using the GUI difftool: \
`$ git pr show -t 17906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17906.diff">https://git.openjdk.org/jdk/pull/17906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17906#issuecomment-1951752170)