### PR TITLE
8326127: JFR: Add SafepointCleanupTask to hardToTestEvents of TestLookForUntestedEvents

### DIFF
--- a/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
+++ b/test/jdk/jdk/jfr/event/metadata/TestLookForUntestedEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,8 @@ public class TestLookForUntestedEvents {
         Arrays.asList(
             "DataLoss", "IntFlag", "ReservedStackActivation", "NativeLibraryUnload",
             "DoubleFlag", "UnsignedLongFlagChanged", "IntFlagChanged",
-            "UnsignedIntFlag", "UnsignedIntFlagChanged", "DoubleFlagChanged")
+            "UnsignedIntFlag", "UnsignedIntFlagChanged", "DoubleFlagChanged",
+            "SafepointCleanupTask")
     );
 
     // GC uses specific framework to test the events, instead of using event names literally.

--- a/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSafepointEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,6 @@ public class TestSafepointEvents {
     static final String[] EVENT_NAMES = new String[] {
         EventNames.SafepointBegin,
         EventNames.SafepointStateSynchronization,
-        // EventNames.SafepointCleanupTask,
         EventNames.SafepointCleanup,
         EventNames.SafepointEnd
     };


### PR DESCRIPTION
Greetings,

[JDK-8322630](https://bugs.openjdk.org/browse/JDK-8322630) made the `EventSafepointCleanupTask` hard to test. We'd better move it to hardToTestEvents of TestLookForUntestedEvents instead of commenting out it.

Denghui

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326127](https://bugs.openjdk.org/browse/JDK-8326127): JFR: Add SafepointCleanupTask to hardToTestEvents of TestLookForUntestedEvents (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17907/head:pull/17907` \
`$ git checkout pull/17907`

Update a local copy of the PR: \
`$ git checkout pull/17907` \
`$ git pull https://git.openjdk.org/jdk.git pull/17907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17907`

View PR using the GUI difftool: \
`$ git pr show -t 17907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17907.diff">https://git.openjdk.org/jdk/pull/17907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17907#issuecomment-1951821228)