### PR TITLE
8326112: Javadoc snippet for Linker.Option.captureCallState is wrong

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -858,7 +858,7 @@ public sealed interface Linker permits AbstractLinker {
          * try (Arena arena = Arena.ofConfined()) {
          *     MemorySegment capturedState = arena.allocate(capturedStateLayout);
          *     handle.invoke(capturedState);
-         *     int errno = (int) errnoHandle.get(capturedState);
+         *     int errno = (int) errnoHandle.get(capturedState, 0L);
          *     // use errno
          * }
          * }


### PR DESCRIPTION
This PR proposes to add an offset parameter for a `VarHandle` invocation in the Javadoc snippet for `Linker.Option.captureCallState()`. The offset parameter was added in 22 but it was forgotten to add it in said Javadoc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326112](https://bugs.openjdk.org/browse/JDK-8326112): Javadoc snippet for Linker.Option.captureCallState is wrong (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17909/head:pull/17909` \
`$ git checkout pull/17909`

Update a local copy of the PR: \
`$ git checkout pull/17909` \
`$ git pull https://git.openjdk.org/jdk.git pull/17909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17909`

View PR using the GUI difftool: \
`$ git pr show -t 17909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17909.diff">https://git.openjdk.org/jdk/pull/17909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17909#issuecomment-1951926805)