### PR TITLE
8326135: Enhance adlc to report unused operands

### DIFF
--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -730,6 +730,8 @@ bool ArchDesc::check_usage() {
   }
 
   // these forms are coded in OperandForm::is_user_name_for_sReg
+  // it may happen no instruction use these operands, like stackSlotP in aarch64,
+  // but we can not desclare they are useless.
   callback.do_form_by_name("stackSlotI");
   callback.do_form_by_name("stackSlotP");
   callback.do_form_by_name("stackSlotD");

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it
@@ -738,7 +738,7 @@ bool ArchDesc::check_usage() {
   callback.do_form_by_name("stackSlotF");
   callback.do_form_by_name("stackSlotL");
 
-  // special generic vector operands used in Matcher::pd_specialize_generic_vector_operand
+  // special generic vector operands only used in Matcher::pd_specialize_generic_vector_operand
 #if defined(AARCH64)
   callback.do_form_by_name("vecA");
   callback.do_form_by_name("vecD");

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -738,6 +738,14 @@ bool ArchDesc::check_usage() {
   callback.do_form_by_name("stackSlotF");
   callback.do_form_by_name("stackSlotL");
 
+  // sReg* are initial created by adlc in ArchDesc::initBaseOpTypes()
+  // In ARM, no definition or usage in adfile, but they are reported as unused
+  callback.do_form_by_name("sRegI");
+  callback.do_form_by_name("sRegP");
+  callback.do_form_by_name("sRegD");
+  callback.do_form_by_name("sRegF");
+  callback.do_form_by_name("sRegL");
+
   // special generic vector operands only used in Matcher::pd_specialize_generic_vector_operand
 #if defined(AARCH64)
   callback.do_form_by_name("vecA");

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -763,7 +763,7 @@ bool ArchDesc::check_usage() {
       cnt++;
     }
   }
-  if (cnt) fprintf(stderr, "\n-------Warning: total %d unused operandsn", cnt);
+  if (cnt) fprintf(stderr, "\n-------Warning: total %d unused operands\n", cnt);
 
   return true;
 }

--- a/src/hotspot/share/adlc/archDesc.hpp
+++ b/src/hotspot/share/adlc/archDesc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/archDesc.hpp
+++ b/src/hotspot/share/adlc/archDesc.hpp
@@ -226,6 +226,7 @@ public:
   inline void getForm(EncodeForm **ptr)     { *ptr = _encode; }
 
   bool verify();
+  bool check_usage();
   void dump();
 
   // Helper utility that gets MatchList components from inside MatchRule

--- a/src/hotspot/share/adlc/forms.cpp
+++ b/src/hotspot/share/adlc/forms.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/forms.cpp
+++ b/src/hotspot/share/adlc/forms.cpp
@@ -362,6 +362,15 @@ void FormDict::dump() {
   _form.print(dumpkey, dumpform);
 }
 
+void FormDict::forms_do(FormClosure* f) {;
+  DictI iter(&_form);
+  for( ; iter.test(); ++iter ) {
+    Form* form = (Form*) iter._value;
+    assert(form != nullptr, "sanity");
+    f->do_form(form);
+  }
+}
+
 //------------------------------SourceForm-------------------------------------
 SourceForm::SourceForm(char* code) : _code(code) { }; // Constructor
 SourceForm::~SourceForm() {
@@ -373,4 +382,12 @@ void SourceForm::dump() {                    // Debug printer
 
 void SourceForm::output(FILE *fp) {
   fprintf(fp,"\n//%s\n%s\n",classname(),(_code?_code:""));
+}
+
+void FormClosure::do_form(Form* form) {
+  assert(false, "should not reach here");
+}
+
+void FormClosure::do_form_by_name(const char* name) {
+  assert(false, "should not reach here");
 }

--- a/src/hotspot/share/adlc/forms.hpp
+++ b/src/hotspot/share/adlc/forms.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/forms.hpp
+++ b/src/hotspot/share/adlc/forms.hpp
@@ -58,6 +58,7 @@ class Flag;
 class RewriteRule;
 class ConstructRule;
 class FormatRule;
+class FormClosure;
 class Peephole;
 class EncClass;
 class Interface;
@@ -114,6 +115,8 @@ public:
   const Form  *operator [](const char *name) const;  // Do a lookup
 
   void dump();
+  // iterate child forms recursively
+  void forms_do(FormClosure *f);
 };
 
 // ***** Master Class for ADL Parser Forms *****
@@ -162,6 +165,9 @@ public:
   virtual void dump()      { output(stderr); }    // Debug printer
   // Write info to output files
   virtual void output(FILE *fp)    { fprintf(fp,"Form Output"); }
+
+  // iterate child forms recursively
+  virtual void forms_do (FormClosure* f) { return; }
 
 public:
   // ADLC types, match the last character on ideal operands and instructions
@@ -254,6 +260,16 @@ public:
   };
 
 };
+
+class FormClosure {
+public:
+    FormClosure() = default;
+    virtual ~FormClosure() = default;
+
+    virtual void do_form(Form* form);
+    virtual void do_form_by_name(const char* name);
+};
+
 
 //------------------------------FormList---------------------------------------
 class FormList {

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -198,6 +198,20 @@ void RegisterForm::output(FILE *fp) {          // Write info to output files
   fprintf(fp,"-------------------- end  RegisterForm --------------------\n");
 }
 
+void RegisterForm::forms_do(FormClosure *f) {
+  const char *name = nullptr;
+  if (_current_ac) f->do_form(_current_ac);
+  for(_rdefs.reset(); (name = _rdefs.iter()) != nullptr;) {
+    f->do_form((RegDef*)_regDef[name]);
+  }
+  for (_rclasses.reset(); (name = _rclasses.iter()) != nullptr;) {
+    f->do_form((RegClass*)_regClass[name]);
+  }
+  for (_aclasses.reset(); (name = _aclasses.iter()) != nullptr;) {
+    f->do_form((AllocClass*)_allocClass[name]);
+  }
+}
+
 //------------------------------RegDef-----------------------------------------
 // Constructor
 RegDef::RegDef(char *regname, char *callconv, char *c_conv, char * idealtype, char * encode, char * concrete)
@@ -322,6 +336,13 @@ void RegClass::output(FILE *fp) {           // Write info to output files
   fprintf(fp,"--- done with entries for reg_class %s\n\n",_classid);
 }
 
+void RegClass::forms_do(FormClosure *f) {
+  const char *name = nullptr;
+  for( _regDefs.reset(); (name = _regDefs.iter()) != nullptr; ) {
+    f->do_form((RegDef*)_regDef[name]);
+  }
+}
+
 void RegClass::declare_register_masks(FILE* fp) {
   const char* prefix = "";
   const char* rc_name_to_upper = toUpper(_classid);
@@ -434,6 +455,14 @@ void AllocClass::output(FILE *fp) {       // Write info to output files
     ((RegDef*)_regDef[name])->output(fp);
   }
   fprintf(fp,"--- done with entries for alloc_class %s\n\n",_classid);
+}
+
+void AllocClass::forms_do(FormClosure* f) {
+  const char *name;
+  for(_regDefs.reset(); (name = _regDefs.iter()) != nullptr;) {
+    f->do_form((RegDef*)_regDef[name]);
+  }
+  return;
 }
 
 //==============================Frame Handling=================================
@@ -704,6 +733,15 @@ void Peephole::output(FILE *fp) {         // Write info to output files
   if( _replace != nullptr )     _replace->output(fp);
   // Output the next entry
   if( _next ) _next->output(fp);
+}
+
+void Peephole::forms_do(FormClosure *f) {
+  if (_predicate) f->do_form(_predicate);
+  if (_match) f->do_form(_match);
+  if (_procedure) f->do_form(_procedure);
+  if (_constraint) f->do_form(_constraint);
+  if (_replace) f->do_form(_replace);
+  return;
 }
 
 //----------------------------PeepPredicate------------------------------------

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formsopt.hpp
+++ b/src/hotspot/share/adlc/formsopt.hpp
@@ -123,6 +123,7 @@ public:
 
   void dump();                     // Debug printer
   void output(FILE *fp);           // Write info to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------RegDef-----------------------------------------
@@ -199,6 +200,7 @@ public:
 
   void dump();                  // Debug printer
   void output(FILE *fp);        // Write info to output files
+  virtual void forms_do(FormClosure* f);
 
   virtual bool has_stack_version() {
     return _stack_or_reg;
@@ -305,6 +307,11 @@ public:
   char* condition_code() {
     return _condition_code;
   }
+
+  virtual void forms_do(FormClosure* f) {
+    if (_rclasses[0]) f->do_form(_rclasses[0]);
+    if (_rclasses[1]) f->do_form(_rclasses[1]);
+  }
 };
 
 //------------------------------AllocClass-------------------------------------
@@ -325,6 +332,7 @@ public:
 
   void dump();                  // Debug printer
   void output(FILE *fp);        // Write info to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 
@@ -568,6 +576,7 @@ public:
 
   void dump();                     // Debug printer
   void output(FILE *fp);           // Write info to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 class PeepPredicate : public Form {

--- a/src/hotspot/share/adlc/formssel.cpp
+++ b/src/hotspot/share/adlc/formssel.cpp
@@ -1498,6 +1498,24 @@ void InstructForm::output(FILE *fp) {
   if (_peephole)  _peephole->output(fp);
 }
 
+void InstructForm::forms_do(FormClosure *f) {
+  if (_cisc_spill_alternate) f->do_form(_cisc_spill_alternate);
+  if (_short_branch_form) f->do_form(_short_branch_form);
+  _localNames.forms_do(f);
+  if (_matrule) f->do_form(_matrule);
+  if (_opcode) f->do_form(_opcode);
+  if (_insencode) f->do_form(_insencode);
+  if (_constant) f->do_form(_constant);
+  if (_attribs) f->do_form(_attribs);
+  if (_predicate) f->do_form(_predicate);
+  _effects.forms_do(f);
+  if (_exprule) f->do_form(_exprule);
+  if (_rewrule) f->do_form(_rewrule);
+  if (_format) f->do_form(_format);
+  if (_peephole) f->do_form(_peephole);
+  assert(_components.count() == 0, "skip components");
+}
+
 void MachNodeForm::dump() {
   output(stderr);
 }
@@ -1615,6 +1633,14 @@ void EncodeForm::output(FILE *fp) {          // Write info to output files
   }
   fprintf(fp,"-------------------- end  EncodeForm --------------------\n");
 }
+
+void EncodeForm::forms_do(FormClosure* f) {
+  const char *name;
+  for (_eclasses.reset(); (name = _eclasses.iter()) != nullptr;) {
+    f->do_form((EncClass*)_encClass[name]);
+  }
+}
+
 //------------------------------EncClass---------------------------------------
 EncClass::EncClass(const char *name)
   : _localNames(cmpstr,hashstr, Form::arena), _name(name) {
@@ -1703,6 +1729,15 @@ void EncClass::output(FILE *fp) {
     }
   }
 
+}
+
+void EncClass::forms_do(FormClosure *f) {
+  _parameter_type.reset();
+  const char *type = _parameter_type.iter();
+  for ( ; type != nullptr ; type = _parameter_type.iter() ) {
+    f->do_form_by_name(type);
+  }
+  _localNames.forms_do(f);
 }
 
 //------------------------------Opcode-----------------------------------------
@@ -1833,6 +1868,15 @@ void InsEncode::output(FILE *fp) {
   } // done with encodings
 
   fprintf(fp,"\n");
+}
+
+void InsEncode::forms_do(FormClosure *f) {
+  _encoding.reset();
+  NameAndList *encoding = (NameAndList*)_encoding.iter();
+  for( ; encoding != nullptr; encoding = (NameAndList*)_encoding.iter() ) {
+    // just check name, other operands will be checked as instruction parameters
+    f->do_form_by_name(encoding->name());
+  }
 }
 
 //------------------------------Effect-----------------------------------------
@@ -1968,6 +2012,19 @@ void ExpandRule::output(FILE *fp) {         // Write info to output files
   }
 }
 
+void ExpandRule::forms_do(FormClosure *f) {
+  NameAndList *expand_instr = nullptr;
+  // Iterate over the instructions 'node' expands into
+  for(reset_instructions(); (expand_instr = iter_instructions()) != nullptr; ) {
+    f->do_form_by_name(expand_instr->name());
+  }
+  _newopers.reset();
+  const char* oper = _newopers.iter();
+  for(; oper != nullptr; oper = _newopers.iter()) {
+    f->do_form_by_name(oper);
+  }
+}
+
 //------------------------------RewriteRule------------------------------------
 RewriteRule::RewriteRule(char* params, char* block)
   : _tempParams(params), _tempBlock(block) { };  // Constructor
@@ -1982,6 +2039,12 @@ void RewriteRule::output(FILE *fp) {         // Write info to output files
   fprintf(fp,"\nRewrite Rule:\n%s\n%s\n",
           (_tempParams?_tempParams:""),
           (_tempBlock?_tempBlock:""));
+}
+
+void RewriteRule::forms_do(FormClosure *f) {
+  if (_condition) f->do_form(_condition);
+  if (_instrs) f->do_form(_instrs);
+  if (_opers) f->do_form(_opers);
 }
 
 
@@ -2064,6 +2127,13 @@ void OpClassForm::output(FILE *fp) {
     fprintf(fp,"%s, ",name);
   }
   fprintf(fp,"\n");
+}
+
+void OpClassForm::forms_do(FormClosure* f) {
+  const char *name;
+  for(_oplst.reset(); (name = _oplst.iter()) != nullptr;) {
+    f->do_form_by_name(name);
+  }
 }
 
 
@@ -2691,6 +2761,22 @@ void OperandForm::output(FILE *fp) {
   if (_format)     _format->dump();
 }
 
+void OperandForm::forms_do(FormClosure* f) {
+  if (_matrule)    f->do_form(_matrule);
+  if (_interface)  f->do_form(_interface);
+  if (_attribs)    f->do_form(_attribs);
+  if (_predicate)  f->do_form(_predicate);
+  if (_constraint) f->do_form(_constraint);
+  if (_construct)  f->do_form(_construct);
+  if (_format)     f->do_form(_format);
+  _localNames.forms_do(f);
+  const char* opclass = nullptr;
+  for ( _classes.reset(); (opclass = _classes.iter()) != nullptr; ) {
+    f->do_form_by_name(opclass);
+  }
+  assert(_components.count() == 0, "skip _compnets");
+}
+
 //------------------------------Constraint-------------------------------------
 Constraint::Constraint(const char *func, const char *arg)
   : _func(func), _arg(arg) {
@@ -2710,6 +2796,10 @@ void Constraint::dump() {
 void Constraint::output(FILE *fp) {           // Write info to output files
   assert((_func != nullptr && _arg != nullptr),"missing constraint function or arg");
   fprintf(fp,"Constraint: %s ( %s )\n", _func, _arg);
+}
+
+void Constraint::forms_do(FormClosure *f) {
+  f->do_form_by_name(_arg);
 }
 
 //------------------------------Predicate--------------------------------------
@@ -3539,6 +3629,12 @@ void MatchNode::output(FILE *fp) {
   }
 }
 
+void MatchNode::forms_do(FormClosure *f) {
+  f->do_form_by_name(_name);
+  if (_lChild) f->do_form(_lChild);
+  if (_rChild) f->do_form(_rChild);
+}
+
 int MatchNode::needs_ideal_memory_edge(FormDict &globals) const {
   static const char *needs_ideal_memory_list[] = {
     "StoreI","StoreL","StoreP","StoreN","StoreNKlass","StoreD","StoreF" ,
@@ -3606,6 +3702,7 @@ int InstructForm::needs_base_oop_edge(FormDict &globals) const {
 
   return _matrule ? _matrule->needs_base_oop_edge() : 0;
 }
+
 
 
 //-------------------------cisc spilling methods-------------------------------
@@ -4332,6 +4429,18 @@ void MatchRule::output(FILE *fp) {
   fprintf(fp,"\n   nesting depth = %d\n", _depth);
   if (_result) fprintf(fp,"   Result Type = %s", _result);
   fprintf(fp,"\n");
+}
+
+void MatchRule::forms_do(FormClosure* f) {
+  // keep sync with MatchNode::forms_do
+  f->do_form_by_name(_name);
+  if (_lChild) f->do_form(_lChild);
+  if (_rChild) f->do_form(_rChild);
+
+  // handle next rule
+  if (_next) {
+    f->do_form(_next);
+  }
 }
 
 //------------------------------Attribute--------------------------------------

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/formssel.hpp
+++ b/src/hotspot/share/adlc/formssel.hpp
@@ -310,6 +310,7 @@ public:
 
   virtual void dump();             // Debug printer
   virtual void output(FILE *fp);   // Write to output files
+  virtual void forms_do(FormClosure *f);
 };
 
 //------------------------------EncodeForm-------------------------------------
@@ -333,6 +334,7 @@ public:
 
   void dump();                     // Debug printer
   void output(FILE *fp);           // Write info to output files
+  virtual void forms_do(FormClosure *f);
 };
 
 //------------------------------EncClass---------------------------------------
@@ -377,6 +379,7 @@ public:
   bool verify();
   void dump();
   void output(FILE *fp);
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------MachNode---------------------------------------
@@ -468,6 +471,7 @@ public:
 
   void dump();
   void output(FILE *fp);
+  virtual void forms_do(FormClosure *f);
 };
 
 //------------------------------Effect-----------------------------------------
@@ -515,6 +519,7 @@ public:
 
   void dump();                    // Debug printer
   void output(FILE *fp);          // Write info to output files
+  virtual void forms_do(FormClosure *f);
 };
 
 //---------------------------------Flag----------------------------------------
@@ -554,6 +559,7 @@ public:
   ~RewriteRule();                  // Destructor
   void dump();                     // Debug printer
   void output(FILE *fp);           // Write info to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 
@@ -584,6 +590,7 @@ public:
   virtual bool ideal_only() const;
   virtual void dump();             // Debug printer
   virtual void output(FILE *fp);   // Write to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------OperandForm------------------------------------
@@ -711,6 +718,7 @@ public:
 
   virtual void dump();             // Debug printer
   virtual void output(FILE *fp);   // Write to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------Constraint-------------------------------------
@@ -729,6 +737,7 @@ public:
 
   void dump();                     // Debug printer
   void output(FILE *fp);           // Write info to output files
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------Predicate--------------------------------------
@@ -1014,6 +1023,7 @@ public:
 
   void dump();
   void output(FILE *fp);
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------MatchRule--------------------------------------
@@ -1075,6 +1085,7 @@ public:
   void dump();
   void output_short(FILE *fp);
   void output(FILE *fp);
+  virtual void forms_do(FormClosure* f);
 };
 
 //------------------------------Attribute--------------------------------------

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/adlc/main.cpp
+++ b/src/hotspot/share/adlc/main.cpp
@@ -186,6 +186,9 @@ int main(int argc, char *argv[])
   // Verify that the results of the parse are consistent
   AD.verify();
 
+  // Check defined operands are used
+  AD.check_usage();
+
   // Prepare to generate the result files:
   AD.generateMatchLists();
   AD.identify_unique_operands();


### PR DESCRIPTION
Some operands are defined in adfile but no one used them. But it's hard to find them manually. So I try to enhance adlc to report them after parsing the whole adfile.

I added a helper Form::forms_do to recursively visit child forms. After parsing, adlc will start from all instructions to mark all used forms. And report unvisited operands as unused. By this way, I can find 44 unused operands for aarch64, 12 for x86_64 and 4 for riscv64. The report is like
```
...
Warning: unused operand (vRegD_V28)
Warning: unused operand (vRegD_V29)
Warning: unused operand (vRegD_V30)
Warning: unused operand (vRegD_V31)
Warning: unused operand (lr_RegP)
Warning: unused operand (indOffI)
Warning: unused operand (indOffL)
Warning: unused operand (thread_anchor_pc)
-------Warning: total 44 unused operands
```

I tested and find they can be safely removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326135](https://bugs.openjdk.org/browse/JDK-8326135): Enhance adlc to report unused operands (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17910/head:pull/17910` \
`$ git checkout pull/17910`

Update a local copy of the PR: \
`$ git checkout pull/17910` \
`$ git pull https://git.openjdk.org/jdk.git pull/17910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17910`

View PR using the GUI difftool: \
`$ git pr show -t 17910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17910.diff">https://git.openjdk.org/jdk/pull/17910.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17910#issuecomment-1951972275)