### PR TITLE
8326152: Bad copyright header in test/jdk/java/util/zip/DeflaterDictionaryTests.java

### DIFF
--- a/test/jdk/java/util/zip/DeflaterDictionaryTests.java
+++ b/test/jdk/java/util/zip/DeflaterDictionaryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Can I get a review of this change which fixes the copyright header on `DeflaterDictionaryTests.java`?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326152](https://bugs.openjdk.org/browse/JDK-8326152): Bad copyright header in test/jdk/java/util/zip/DeflaterDictionaryTests.java (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17911/head:pull/17911` \
`$ git checkout pull/17911`

Update a local copy of the PR: \
`$ git checkout pull/17911` \
`$ git pull https://git.openjdk.org/jdk.git pull/17911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17911`

View PR using the GUI difftool: \
`$ git pr show -t 17911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17911.diff">https://git.openjdk.org/jdk/pull/17911.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17911#issuecomment-1952056044)