### PR TITLE
8325202: gc/g1/TestMarkStackOverflow.java intermittently crash: G1CMMarkStack::ChunkAllocator::allocate_new_chunk

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -214,7 +214,7 @@ bool G1CMMarkStack::ChunkAllocator::try_expand_to(size_t desired_capacity) {
   return false;
 }
 
-bool G1CMMarkStack::ChunkAllocator::expand() {
+bool G1CMMarkStack::ChunkAllocator::try_expand() {
   size_t new_capacity = _capacity * 2;
   return try_expand_to(new_capacity);
 }
@@ -270,7 +270,7 @@ bool G1CMMarkStack::ChunkAllocator::reserve(size_t new_capacity) {
 }
 
 void G1CMMarkStack::expand() {
-  _chunk_allocator.expand();
+  _chunk_allocator.try_expand();
 }
 
 void G1CMMarkStack::add_chunk_to_list(TaskQueueEntryChunk* volatile* list, TaskQueueEntryChunk* elem) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -152,8 +152,8 @@ G1CMMarkStack::TaskQueueEntryChunk* G1CMMarkStack::ChunkAllocator::allocate_new_
 
     MutexLocker x(MarkStackChunkList_lock, Mutex::_no_safepoint_check_flag);
     if (Atomic::load_acquire(&_buckets[bucket]) == nullptr) {
-      size_t new_capacity = MIN2(bucket_size(bucket) * 2, _max_capacity);
-      if (!expand(new_capacity)) {
+      size_t desired_capacity = bucket_size(bucket) * 2;
+      if (!try_expand_to(desired_capacity)) {
         return nullptr;
       }
     }
@@ -197,24 +197,26 @@ bool G1CMMarkStack::ChunkAllocator::initialize(size_t initial_capacity, size_t m
   return true;
 }
 
-bool G1CMMarkStack::ChunkAllocator::expand(size_t new_capacity) {
+bool G1CMMarkStack::ChunkAllocator::try_expand_to(size_t desired_capacity) {
   if (_capacity == _max_capacity) {
     log_debug(gc)("Can not expand overflow mark stack further, already at maximum capacity of " SIZE_FORMAT " chunks.", _capacity);
     return false;
   }
 
   size_t old_capacity = _capacity;
-  if (reserve(new_capacity)) {
+  desired_capacity = MIN2(desired_capacity, _max_capacity);
+
+  if (reserve(desired_capacity)) {
     log_debug(gc)("Expanded the mark stack capacity from " SIZE_FORMAT " to " SIZE_FORMAT " chunks",
-                  old_capacity, new_capacity);
+                  old_capacity, desired_capacity);
     return true;
   }
   return false;
 }
 
 bool G1CMMarkStack::ChunkAllocator::expand() {
-  size_t new_capacity = MIN2(_capacity * 2, _max_capacity);
-  return expand(new_capacity);
+  size_t new_capacity = _capacity * 2;
+  return try_expand_to(new_capacity);
 }
 
 G1CMMarkStack::ChunkAllocator::~ChunkAllocator() {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -227,7 +227,7 @@ private:
 
     // Expand the mark stack doubling its size.
     bool expand();
-    bool expand(size_t new_capacity);
+    bool try_expand_to(size_t desired_capacity);
 
     TaskQueueEntryChunk* allocate_new_chunk();
   };

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -226,6 +226,7 @@ private:
     size_t capacity() const { return _capacity; }
 
     bool expand();
+    bool expand(size_t new_capacity);
 
     TaskQueueEntryChunk* allocate_new_chunk();
   };

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -145,7 +145,7 @@ private:
     // within the bucket. Additionally, each new bucket added to the growable array doubles the capacity of
     // the growable array.
     //
-    // Illustration of the Growable Array data structure.
+    // Illustration of the growable array data structure.
     //
     //        +----+        +----+----+
     //        |    |------->|    |    |
@@ -174,7 +174,7 @@ private:
     size_t bucket_size(size_t bucket) {
       return (bucket == 0) ?
               _min_capacity :
-              _min_capacity * ( 1ULL << (bucket -1));
+              _min_capacity * ( 1ULL << (bucket - 1));
     }
 
     static unsigned int find_highest_bit(uintptr_t mask) {
@@ -225,6 +225,7 @@ private:
 
     size_t capacity() const { return _capacity; }
 
+    // Expand the mark stack doubling its size.
     bool expand();
     bool expand(size_t new_capacity);
 

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -226,7 +226,7 @@ private:
     size_t capacity() const { return _capacity; }
 
     // Expand the mark stack doubling its size.
-    bool expand();
+    bool try_expand();
     bool try_expand_to(size_t desired_capacity);
 
     TaskQueueEntryChunk* allocate_new_chunk();


### PR DESCRIPTION
Please review this bug fix to guarantee that expanding the G1CMMarkStack considers the expected capacity for the thread triggering the expansion instead of expanding based on current capacity. 

Failure Mode:
Assume current stack capacity is 1:

1: Thread 1: Obtains `cur_idx` as 1 and notices that the associated bucket is not allocated, indicating insufficient capacity. It then attempts to double the capacity to 2.
2: Thread 2: Obtains `cur_idx` as 2 and finds that the bucket associated with index 2 is also not allocated. Consequently, Thread 2 also tries to expand the stack.
3: Due to a delay in Thread 1's execution, Thread 2 acquires the lock first and initiates the expansion by calling the `expand()` function. This function doubles the capacity from 1 to 2.
4: However, upon returning from the expansion, the bucket associated with `cur_idx` 2 remains unallocated. Consequently, when Thread 2 tries to access this bucket, it crashes.

The problem is that the `expand()` function is called without considering the specific thread context that necessitated the expansion. Instead, it expands the capacity based on the current size of the stack, leading to races when multiple threads concurrently attempt to expand the stack's capacity.

Testing: - Tier 1 -3 
               - 2M test iterations (bug is reproducible ~1/100k test iterations)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325202](https://bugs.openjdk.org/browse/JDK-8325202): gc/g1/TestMarkStackOverflow.java intermittently crash: G1CMMarkStack::ChunkAllocator::allocate_new_chunk (**Bug** - P2)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [181eada3](https://git.openjdk.org/jdk/pull/17912/files/181eada35b064ab079f3ecbda033928a256a7280)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17912/head:pull/17912` \
`$ git checkout pull/17912`

Update a local copy of the PR: \
`$ git checkout pull/17912` \
`$ git pull https://git.openjdk.org/jdk.git pull/17912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17912`

View PR using the GUI difftool: \
`$ git pr show -t 17912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17912.diff">https://git.openjdk.org/jdk/pull/17912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17912#issuecomment-1952219800)