### PR TITLE
JDK-8326140: src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp ReleaseStringChars might be missing in early returns

### DIFF
--- a/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
+++ b/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
@@ -84,13 +84,19 @@ AccessBridgeJavaEntryPoints::~AccessBridgeJavaEntryPoints() {
 
 #define EXCEPTION_CHECK_WITH_RELEASE(situationDescription, returnVal, js, stringBytes)          \
     if (exception = jniEnv->ExceptionOccurred()) {                                              \
-        PrintDebugString("[ERROR]: *** Exception occured while doing: %s; returning %d", situationDescription, returnVal);   \
+        PrintDebugString("[ERROR]: *** Exception occured while doing: %s - call to GetStringLength; returning %d", situationDescription, returnVal);   \
         jniEnv->ExceptionDescribe();                                                            \
         jniEnv->ExceptionClear();                                                               \
         jniEnv->ReleaseStringChars(js, stringBytes);                                            \
         return (returnVal);                                                                     \
     }                                                                                           \
-    jniEnv->ReleaseStringChars(js, stringBytes);
+    jniEnv->ReleaseStringChars(js, stringBytes);                                                \
+    if (exception = jniEnv->ExceptionOccurred()) {                                              \
+        PrintDebugString("[ERROR]: *** Exception occured while doing: %s - call to ReleaseStringChars; returning %d", situationDescription, returnVal);   \
+        jniEnv->ExceptionDescribe();                                                            \
+        jniEnv->ExceptionClear();                                                               \
+        return (returnVal);                                                                     \
+    }
 
 #define EXCEPTION_CHECK_VOID(situationDescription)                                              \
     if (exception = jniEnv->ExceptionOccurred()) {                                              \
@@ -1225,8 +1231,7 @@ AccessBridgeJavaEntryPoints::getVirtualAccessibleName (
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(name, stringBytes, nameSize - 1);
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod (
                 accessBridgeObject,
                 decrementReferenceMethod, js);
@@ -1389,8 +1394,7 @@ AccessBridgeJavaEntryPoints::getTextAttributesInRange(const jobject accessibleCo
                 length = jniEnv->GetStringLength(js);
                 test_attributes.fullAttributesString[length < (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t)) ?
                                                      length : (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-                EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
-                EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
+                EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex", FALSE, js, stringBytes);
                 jniEnv->CallVoidMethod(accessBridgeObject,
                                        decrementReferenceMethod, js);
                 EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to CallVoidMethod()", FALSE);
@@ -1743,8 +1747,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->name, stringBytes, (sizeof(info->name) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             info->name[length < (sizeof(info->name) / sizeof(wchar_t)) ?
                        length : (sizeof(info->name) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -1774,8 +1777,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->description, stringBytes, (sizeof(info->description) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName", FALSE, js, stringBytes);
             info->description[length < (sizeof(info->description) / sizeof(wchar_t)) ?
                               length : (sizeof(info->description) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -1805,8 +1807,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole - call to GetStringChars()", FALSE);
             wcsncpy(info->role, stringBytes, (sizeof(info->role) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole", FALSE, js, stringBytes);
             info->role[length < (sizeof(info->role) / sizeof(wchar_t)) ?
                        length : (sizeof(info->role) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -1836,8 +1837,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->role_en_US, stringBytes, (sizeof(info->role_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole_en_US - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole_en_US", FALSE, js, stringBytes);
             info->role_en_US[length < (sizeof(info->role_en_US) / sizeof(wchar_t)) ?
                              length : (sizeof(info->role_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -1866,8 +1866,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState - call to GetStringChars()", FALSE);
             wcsncpy(info->states, stringBytes, (sizeof(info->states) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState", FALSE, js, stringBytes);
             info->states[length < (sizeof(info->states) / sizeof(wchar_t)) ?
                          length : (sizeof(info->states) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -1896,8 +1895,7 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->states_en_US, stringBytes, (sizeof(info->states_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState_en_US - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState_en_US", FALSE, js, stringBytes);
             info->states_en_US[length < (sizeof(info->states_en_US) / sizeof(wchar_t)) ?
                                length : (sizeof(info->states_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
             jniEnv->CallVoidMethod(accessBridgeObject,
@@ -2811,8 +2809,7 @@ AccessBridgeJavaEntryPoints::getAccessibleRelationSet(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRelation key - call to GetStringChars()", FALSE);
             wcsncpy(relationSet->relations[i].key, stringBytes, (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRelation key - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRelation key - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRelation key", FALSE, js, stringBytes);
             relationSet->relations[i].key [length < (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)) ?
                                            length : (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t))-2] = (wchar_t) 0;
             // jniEnv->CallVoidMethod(accessBridgeObject,
@@ -2916,8 +2913,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertext(jobject accessibleContext,
                 length = (sizeof(hypertext->links[i].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[i].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                                     decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3052,8 +3048,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertextExt(const jobject accessibleC
                 length = (sizeof(hypertext->links[bufIndex].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[bufIndex].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3170,8 +3165,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleHyperlink(jobject hypertext,
             length = (sizeof(info->text) / sizeof(wchar_t)) - 2;
         }
         info->text[length] = (wchar_t) 0;
-        EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
-        EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
+        EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text", FALSE, js, stringBytes);
         // jniEnv->CallVoidMethod(accessBridgeObject,
         //                        decrementReferenceMethod, js);
         //EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to CallVoidMethod()", FALSE);
@@ -3298,8 +3292,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleIcons(jobject accessibleContext,
                 length = (sizeof(icons->iconInfo[i].description) / sizeof(wchar_t)) - 2;
             }
             icons->iconInfo[i].description[length] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleIcon description - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleIcon description - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleIcon description", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleIcon description - call to CallVoidMethod()", FALSE);
@@ -3376,8 +3369,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleActions(jobject accessibleContext
                 length = (sizeof(actions->actionInfo[i].name ) / sizeof(wchar_t)) - 2;
             }
             actions->actionInfo[i].name [length] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAction name  - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleAction name  - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAction name", FALSE, js, stringBytes);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleAction name  - call to CallVoidMethod()", FALSE);
@@ -3557,8 +3549,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             length = jniEnv->GetStringLength(js);
             textItems->word[length < (sizeof(textItems->word) / sizeof(wchar_t)) ?
                             length : (sizeof(textItems->word) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleWordAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleWordAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to CallVoidMethod()", FALSE);
@@ -3592,8 +3583,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             } else {
                 textItems->sentence[(sizeof(textItems->sentence) / sizeof(wchar_t))-2] = (wchar_t) 0;
             }
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleSentenceAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleSentenceAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to CallVoidMethod()", FALSE);
@@ -3667,8 +3657,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextSelectionInfo(jobject accessibleCo
             length = jniEnv->GetStringLength(js);
             selectionInfo->selectedText[length < (sizeof(selectionInfo->selectedText) / sizeof(wchar_t)) ?
                                         length : (sizeof(selectionInfo->selectedText) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextSelectedText - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextSelectedText", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to CallVoidMethod()", FALSE);
@@ -3883,8 +3872,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->backgroundColor[length < (sizeof(attributes->backgroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->backgroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting BackgroundColorFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting BackgroundColorFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -3919,8 +3907,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->foregroundColor[length < (sizeof(attributes->foregroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->foregroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting ForegroundColorFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting ForegroundColorFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -3955,8 +3942,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fontFamily[length < (sizeof(attributes->fontFamily) / sizeof(wchar_t)) ?
                                    length : (sizeof(attributes->fontFamily) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting FontFamilyFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting FontFamilyFromAttributeSet", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to CallVoidMethod()", FALSE);
@@ -4160,8 +4146,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fullAttributesString[length < (sizeof(attributes->fullAttributesString) / sizeof(wchar_t)) ?
                                              length : (sizeof(attributes->fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to CallVoidMethod()", FALSE);
@@ -4402,8 +4387,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextRange(jobject accessibleContext,
             PrintDebugString("[INFO]:  Accessible Text stringBytes length = %d", length);
             text[length < len ? length : len - 2] = (wchar_t) 0;
             wPrintDebugString(L"[INFO]:   Accessible Text 'text' after null termination = %ls", text);
-            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextRange - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleTextRange - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextRange", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleTextRange - call to CallVoidMethod()", FALSE);
@@ -4446,8 +4430,7 @@ AccessBridgeJavaEntryPoints::getCurrentAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting CurrentAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting CurrentAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to CallVoidMethod()", FALSE);
@@ -4488,8 +4471,7 @@ AccessBridgeJavaEntryPoints::getMaximumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting MaximumAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MaximumAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to CallVoidMethod()", FALSE);
@@ -4530,8 +4512,7 @@ AccessBridgeJavaEntryPoints::getMinimumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK_WITH_RELEASE("Getting MinimumAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
-            EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to ReleaseStringChars()", FALSE);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MinimumAccessibleValue", FALSE, js, stringBytes);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to CallVoidMethod()", FALSE);

--- a/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
+++ b/src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,16 @@ AccessBridgeJavaEntryPoints::~AccessBridgeJavaEntryPoints() {
         jniEnv->ExceptionClear();                                                               \
         return (returnVal);                                                                     \
     }
+
+#define EXCEPTION_CHECK_WITH_RELEASE(situationDescription, returnVal, js, stringBytes)          \
+    if (exception = jniEnv->ExceptionOccurred()) {                                              \
+        PrintDebugString("[ERROR]: *** Exception occured while doing: %s; returning %d", situationDescription, returnVal);   \
+        jniEnv->ExceptionDescribe();                                                            \
+        jniEnv->ExceptionClear();                                                               \
+        jniEnv->ReleaseStringChars(js, stringBytes);                                            \
+        return (returnVal);                                                                     \
+    }                                                                                           \
+    jniEnv->ReleaseStringChars(js, stringBytes);
 
 #define EXCEPTION_CHECK_VOID(situationDescription)                                              \
     if (exception = jniEnv->ExceptionOccurred()) {                                              \
@@ -1215,8 +1225,7 @@ AccessBridgeJavaEntryPoints::getVirtualAccessibleName (
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(name, stringBytes, nameSize - 1);
             length = jniEnv->GetStringLength(js);
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod (
                 accessBridgeObject,
@@ -1380,8 +1389,7 @@ AccessBridgeJavaEntryPoints::getTextAttributesInRange(const jobject accessibleCo
                 length = jniEnv->GetStringLength(js);
                 test_attributes.fullAttributesString[length < (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t)) ?
                                                      length : (sizeof(test_attributes.fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-                EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE);
-                jniEnv->ReleaseStringChars(js, stringBytes);
+                EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
                 EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
                 jniEnv->CallVoidMethod(accessBridgeObject,
                                        decrementReferenceMethod, js);
@@ -1735,11 +1743,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->name, stringBytes, (sizeof(info->name) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             info->name[length < (sizeof(info->name) / sizeof(wchar_t)) ?
                        length : (sizeof(info->name) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleName - call to CallVoidMethod()", FALSE);
@@ -1767,11 +1774,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleName - call to GetStringChars()", FALSE);
             wcsncpy(info->description, stringBytes, (sizeof(info->description) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleName - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             info->description[length < (sizeof(info->description) / sizeof(wchar_t)) ?
                               length : (sizeof(info->description) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleName - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleName - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleName - call to CallVoidMethod()", FALSE);
@@ -1799,11 +1805,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole - call to GetStringChars()", FALSE);
             wcsncpy(info->role, stringBytes, (sizeof(info->role) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleRole - call to ReleaseStringChars()", FALSE);
             info->role[length < (sizeof(info->role) / sizeof(wchar_t)) ?
                        length : (sizeof(info->role) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRole - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleRole - call to CallVoidMethod()", FALSE);
@@ -1831,11 +1836,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->role_en_US, stringBytes, (sizeof(info->role_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRole_en_US - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to ReleaseStringChars()", FALSE);
             info->role_en_US[length < (sizeof(info->role_en_US) / sizeof(wchar_t)) ?
                              length : (sizeof(info->role_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleRole_en_US - call to CallVoidMethod()", FALSE);
@@ -1862,11 +1866,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState - call to GetStringChars()", FALSE);
             wcsncpy(info->states, stringBytes, (sizeof(info->states) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleState - call to ReleaseStringChars()", FALSE);
             info->states[length < (sizeof(info->states) / sizeof(wchar_t)) ?
                          length : (sizeof(info->states) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleState - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleState - call to CallVoidMethod()", FALSE);
@@ -1893,11 +1896,10 @@ AccessBridgeJavaEntryPoints::getAccessibleContextInfo(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleState_en_US - call to GetStringChars()", FALSE);
             wcsncpy(info->states_en_US, stringBytes, (sizeof(info->states_en_US) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleState_en_US - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to ReleaseStringChars()", FALSE);
             info->states_en_US[length < (sizeof(info->states_en_US) / sizeof(wchar_t)) ?
                                length : (sizeof(info->states_en_US) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleState_en_US - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
             EXCEPTION_CHECK("Getting AccessibleState_en_US - call to CallVoidMethod()", FALSE);
@@ -2809,11 +2811,10 @@ AccessBridgeJavaEntryPoints::getAccessibleRelationSet(jobject accessibleContext,
             EXCEPTION_CHECK("Getting AccessibleRelation key - call to GetStringChars()", FALSE);
             wcsncpy(relationSet->relations[i].key, stringBytes, (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)));
             length = jniEnv->GetStringLength(js);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleRelation key - call to GetStringLength()", FALSE, js, stringBytes);
+            EXCEPTION_CHECK("Getting AccessibleRelation key - call to ReleaseStringChars()", FALSE);
             relationSet->relations[i].key [length < (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t)) ?
                                            length : (sizeof(relationSet->relations[i].key ) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleRelation key - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
-            EXCEPTION_CHECK("Getting AccessibleRelation key - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
             //EXCEPTION_CHECK("Getting AccessibleRelation key - call to CallVoidMethod()", FALSE);
@@ -2915,8 +2916,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertext(jobject accessibleContext,
                 length = (sizeof(hypertext->links[i].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[i].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                                     decrementReferenceMethod, js);
@@ -3052,8 +3052,7 @@ AccessBridgeJavaEntryPoints::getAccessibleHypertextExt(const jobject accessibleC
                 length = (sizeof(hypertext->links[bufIndex].text) / sizeof(wchar_t)) - 2;
             }
             hypertext->links[bufIndex].text[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
@@ -3171,8 +3170,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleHyperlink(jobject hypertext,
             length = (sizeof(info->text) / sizeof(wchar_t)) - 2;
         }
         info->text[length] = (wchar_t) 0;
-        EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE);
-        jniEnv->ReleaseStringChars(js, stringBytes);
+        EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleHyperlink text - call to GetStringLength()", FALSE, js, stringBytes);
         EXCEPTION_CHECK("Getting AccessibleHyperlink text - call to ReleaseStringChars()", FALSE);
         // jniEnv->CallVoidMethod(accessBridgeObject,
         //                        decrementReferenceMethod, js);
@@ -3300,8 +3298,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleIcons(jobject accessibleContext,
                 length = (sizeof(icons->iconInfo[i].description) / sizeof(wchar_t)) - 2;
             }
             icons->iconInfo[i].description[length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleIcon description - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleIcon description - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleIcon description - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
@@ -3379,8 +3376,7 @@ BOOL AccessBridgeJavaEntryPoints::getAccessibleActions(jobject accessibleContext
                 length = (sizeof(actions->actionInfo[i].name ) / sizeof(wchar_t)) - 2;
             }
             actions->actionInfo[i].name [length] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleAction name  - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAction name  - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleAction name  - call to ReleaseStringChars()", FALSE);
             // jniEnv->CallVoidMethod(accessBridgeObject,
             //                        decrementReferenceMethod, js);
@@ -3561,8 +3557,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             length = jniEnv->GetStringLength(js);
             textItems->word[length < (sizeof(textItems->word) / sizeof(wchar_t)) ?
                             length : (sizeof(textItems->word) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleWordAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleWordAtIndex - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -3597,8 +3592,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextItems(jobject accessibleContext,
             } else {
                 textItems->sentence[(sizeof(textItems->sentence) / sizeof(wchar_t))-2] = (wchar_t) 0;
             }
-            EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleSentenceAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleSentenceAtIndex - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -3673,8 +3667,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextSelectionInfo(jobject accessibleCo
             length = jniEnv->GetStringLength(js);
             selectionInfo->selectedText[length < (sizeof(selectionInfo->selectedText) / sizeof(wchar_t)) ?
                                         length : (sizeof(selectionInfo->selectedText) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextSelectedText - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleTextSelectedText - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -3890,8 +3883,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->backgroundColor[length < (sizeof(attributes->backgroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->backgroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting BackgroundColorFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting BackgroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -3927,8 +3919,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->foregroundColor[length < (sizeof(attributes->foregroundColor) / sizeof(wchar_t)) ?
                                         length : (sizeof(attributes->foregroundColor) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting ForegroundColorFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting ForegroundColorFromAttributeSet - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -3964,8 +3955,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fontFamily[length < (sizeof(attributes->fontFamily) / sizeof(wchar_t)) ?
                                    length : (sizeof(attributes->fontFamily) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting FontFamilyFromAttributeSet - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting FontFamilyFromAttributeSet - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -4170,8 +4160,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextAttributes(jobject accessibleConte
             length = jniEnv->GetStringLength(js);
             attributes->fullAttributesString[length < (sizeof(attributes->fullAttributesString) / sizeof(wchar_t)) ?
                                              length : (sizeof(attributes->fullAttributesString) / sizeof(wchar_t))-2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleAttributesAtIndex - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleAttributesAtIndex - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -4413,8 +4402,7 @@ AccessBridgeJavaEntryPoints::getAccessibleTextRange(jobject accessibleContext,
             PrintDebugString("[INFO]:  Accessible Text stringBytes length = %d", length);
             text[length < len ? length : len - 2] = (wchar_t) 0;
             wPrintDebugString(L"[INFO]:   Accessible Text 'text' after null termination = %ls", text);
-            EXCEPTION_CHECK("Getting AccessibleTextRange - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting AccessibleTextRange - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting AccessibleTextRange - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -4458,8 +4446,7 @@ AccessBridgeJavaEntryPoints::getCurrentAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting CurrentAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting CurrentAccessibleValue - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -4501,8 +4488,7 @@ AccessBridgeJavaEntryPoints::getMaximumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MaximumAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting MaximumAccessibleValue - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);
@@ -4544,8 +4530,7 @@ AccessBridgeJavaEntryPoints::getMinimumAccessibleValueFromContext(jobject access
             wcsncpy(value, stringBytes, len);
             length = jniEnv->GetStringLength(js);
             value[length < len ? length : len - 2] = (wchar_t) 0;
-            EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to GetStringLength()", FALSE);
-            jniEnv->ReleaseStringChars(js, stringBytes);
+            EXCEPTION_CHECK_WITH_RELEASE("Getting MinimumAccessibleValue - call to GetStringLength()", FALSE, js, stringBytes);
             EXCEPTION_CHECK("Getting MinimumAccessibleValue - call to ReleaseStringChars()", FALSE);
             jniEnv->CallVoidMethod(accessBridgeObject,
                                    decrementReferenceMethod, js);


### PR DESCRIPTION
In AccessBridgeJavaEntryPoints.cpp we have a couple of exception checks with potential early returns. Those miss ReleaseStringChars .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326140](https://bugs.openjdk.org/browse/JDK-8326140): src/jdk.accessibility/windows/native/libjavaaccessbridge/AccessBridgeJavaEntryPoints.cpp ReleaseStringChars might be missing in early returns (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [4beaad99](https://git.openjdk.org/jdk/pull/17915/files/4beaad991e38ebbba86cfb2ddf142876764f49ae)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17915/head:pull/17915` \
`$ git checkout pull/17915`

Update a local copy of the PR: \
`$ git checkout pull/17915` \
`$ git pull https://git.openjdk.org/jdk.git pull/17915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17915`

View PR using the GUI difftool: \
`$ git pr show -t 17915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17915.diff">https://git.openjdk.org/jdk/pull/17915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17915#issuecomment-1952423339)