### PR TITLE
8326196: Serial: Remove SerialHeap::generation_iterate

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -951,17 +951,6 @@ void SerialHeap::prepare_for_verify() {
   ensure_parsability(false);        // no need to retire TLABs
 }
 
-void SerialHeap::generation_iterate(GenClosure* cl,
-                                    bool old_to_young) {
-  if (old_to_young) {
-    cl->do_generation(_old_gen);
-    cl->do_generation(_young_gen);
-  } else {
-    cl->do_generation(_young_gen);
-    cl->do_generation(_old_gen);
-  }
-}
-
 bool SerialHeap::is_maximal_no_gc() const {
   // We don't expand young-gen except at a GC.
   return _old_gen->is_maximal_no_gc();
@@ -1059,18 +1048,10 @@ void SerialHeap::gc_epilogue(bool full) {
 };
 
 #ifndef PRODUCT
-class GenGCSaveTopsBeforeGCClosure: public SerialHeap::GenClosure {
- private:
- public:
-  void do_generation(Generation* gen) {
-    gen->record_spaces_top();
-  }
-};
-
 void SerialHeap::record_gen_tops_before_GC() {
   if (ZapUnusedHeapArea) {
-    GenGCSaveTopsBeforeGCClosure blk;
-    generation_iterate(&blk, false);  // not old-to-young.
+    _young_gen->record_spaces_top();
+    _old_gen->record_spaces_top();
   }
 }
 #endif  // not PRODUCT

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -249,10 +249,6 @@ public:
     virtual void do_generation(Generation* gen) = 0;
   };
 
-  // Apply "cl.do_generation" to all generations in the heap
-  // If "old_to_young" determines the order.
-  void generation_iterate(GenClosure* cl, bool old_to_young);
-
   // Return "true" if all generations have reached the
   // maximal committed limit that they can reach, without a garbage
   // collection.


### PR DESCRIPTION
Trivial inlining generation iteration logic based on the fact of having a static number of generations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326196](https://bugs.openjdk.org/browse/JDK-8326196): Serial: Remove SerialHeap::generation_iterate (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17916/head:pull/17916` \
`$ git checkout pull/17916`

Update a local copy of the PR: \
`$ git checkout pull/17916` \
`$ git pull https://git.openjdk.org/jdk.git pull/17916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17916`

View PR using the GUI difftool: \
`$ git pr show -t 17916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17916.diff">https://git.openjdk.org/jdk/pull/17916.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17916#issuecomment-1952466430)