### PR TITLE
JDK-8326089: Text incorrectly placed in breadcrumbs list in generated docs

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Navigation.java
@@ -321,18 +321,6 @@ public class Navigation {
     }
 
     /**
-     * Adds the summary links to the subnavigation.
-     *
-     * @param target the content to which the subnavigation will be added
-     */
-    private void addSummaryLinks(Content target) {
-        List<? extends Content> listContents = subNavLinks.stream().map(HtmlTree::LI).toList();
-        if (!listContents.isEmpty()) {
-            addListToNav(listContents, target);
-        }
-    }
-
-    /**
      * Adds the navigation Type detail link.
      *
      * @param kind the kind of member being documented
@@ -358,16 +346,6 @@ public class Navigation {
 
     private void addItemToList(Content list, Content item) {
         list.add(HtmlTree.LI(item));
-    }
-
-    private void addListToNav(List<? extends Content> listContents, Content target) {
-        int count = 0;
-        for (Content item : listContents) {
-            target.add(item);
-            if (count++ < listContents.size() - 1) {
-                target.add(Entity.NO_BREAK_SPACE).add(Entity.of("gt")).add(Entity.NO_BREAK_SPACE);
-            }
-        }
     }
 
     private void addActivePageLink(Content target, Content label, boolean display) {
@@ -555,9 +533,9 @@ public class Navigation {
         var subNavContent = HtmlTree.DIV(HtmlStyle.navContent);
 
         // Add the breadcrumb navigation links if present.
-        var ulBreadcrumbNav = HtmlTree.OL(HtmlStyle.subNavList);
-        addSummaryLinks(ulBreadcrumbNav);
-        subNavContent.addUnchecked(ulBreadcrumbNav);
+        var breadcrumbNav = HtmlTree.OL(HtmlStyle.subNavList);
+        breadcrumbNav.addAll(subNavLinks, HtmlTree::LI);
+        subNavContent.addUnchecked(breadcrumbNav);
 
         if (options.createIndex() && documentedPage != PageMode.SEARCH) {
             addSearch(subNavContent);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -257,6 +257,10 @@ ol.sub-nav-list li {
     list-style:none;
     scroll-snap-align: start;
 }
+ol.sub-nav-list li:not(:first-child) {
+    list-style-type: " > ";
+    margin-left: 20px;
+}
 ol.sub-nav-list a {
     padding: 3px;
 }

--- a/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
+++ b/test/langtools/jdk/javadoc/doclet/testModules/TestModulePackages.java
@@ -153,7 +153,6 @@ public class TestModulePackages extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">m</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html" class="current-selection">p</a></li>
                     </ol>
                     """);
@@ -161,7 +160,6 @@ public class TestModulePackages extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">o</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html" class="current-selection">p</a></li>
                     </ol>
                     """);
@@ -169,9 +167,7 @@ public class TestModulePackages extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">m</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html">p</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="C.html" class="current-selection">C</a></li>
                     </ol>
                     """);
@@ -179,9 +175,7 @@ public class TestModulePackages extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">o</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html">p</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="C.html" class="current-selection">C</a></li>
                     </ol>
                     """);

--- a/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
+++ b/test/langtools/jdk/javadoc/doclet/testNavigation/TestNavigation.java
@@ -411,7 +411,6 @@ public class TestNavigation extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="package-summary.html">Unnamed Package</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="C.html" class="current-selection">C</a></li>
                     </ol>""");
     }

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -144,16 +144,13 @@ public class TestPreview extends JavadocTester {
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">java.base</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html" class="current-selection">preview</a></li>
                     </ol>""");
         checkOutput("java.base/preview/Core.html", true,
                 """
                     <ol class="sub-nav-list">
                     <li><a href="../module-summary.html">java.base</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="package-summary.html">preview</a></li>
-                    &nbsp;&gt;&nbsp;
                     <li><a href="Core.html" class="current-selection">Core</a></li>
                     </ol>""");
     }


### PR DESCRIPTION
Please review a simple change to avoid placing non-list content in the breadcrumb navigation bar. The solution I chose is to use the ` > ` separator as list marker for all list items except the first one using the `list-style-type` CSS property. An alternative solution would have been to add the separator character to the list item content, but I think its role is that of a list marker rather than list content.

The visual presentation is very close to the previous solution with tiny bit more spacing between list items.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326089](https://bugs.openjdk.org/browse/JDK-8326089): Text incorrectly placed in breadcrumbs list in generated docs (**Bug** - P2)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17917/head:pull/17917` \
`$ git checkout pull/17917`

Update a local copy of the PR: \
`$ git checkout pull/17917` \
`$ git pull https://git.openjdk.org/jdk.git pull/17917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17917`

View PR using the GUI difftool: \
`$ git pr show -t 17917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17917.diff">https://git.openjdk.org/jdk/pull/17917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17917#issuecomment-1952469659)