### PR TITLE
8326233 Utils#copySSLParameters loses needClientAuth Setting

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -617,7 +617,7 @@ public final class Utils {
     }
 
     public static SSLParameters copySSLParameters(SSLParameters p) {
-        SSLParameters p1 = new SSLParameters();
+        final SSLParameters p1 = new SSLParameters();
         p1.setAlgorithmConstraints(p.getAlgorithmConstraints());
         p1.setCipherSuites(p.getCipherSuites());
         // JDK 8 EXCL START
@@ -625,7 +625,12 @@ public final class Utils {
         p1.setMaximumPacketSize(p.getMaximumPacketSize());
         // JDK 8 EXCL END
         p1.setEndpointIdentificationAlgorithm(p.getEndpointIdentificationAlgorithm());
-        p1.setNeedClientAuth(p.getNeedClientAuth());
+        if (p.getNeedClientAuth()) {
+            p1.setNeedClientAuth(true);
+        }
+        if (p.getWantClientAuth()) {
+            p1.setWantClientAuth(true);
+        }
         String[] protocols = p.getProtocols();
         if (protocols != null) {
             p1.setProtocols(protocols.clone());
@@ -633,7 +638,6 @@ public final class Utils {
         p1.setSNIMatchers(p.getSNIMatchers());
         p1.setServerNames(p.getServerNames());
         p1.setUseCipherSuitesOrder(p.getUseCipherSuitesOrder());
-        p1.setWantClientAuth(p.getWantClientAuth());
         return p1;
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -617,7 +617,7 @@ public final class Utils {
     }
 
     public static SSLParameters copySSLParameters(SSLParameters p) {
-        final SSLParameters p1 = new SSLParameters();
+        SSLParameters p1 = new SSLParameters();
         p1.setAlgorithmConstraints(p.getAlgorithmConstraints());
         p1.setCipherSuites(p.getCipherSuites());
         // JDK 8 EXCL START

--- a/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ import static org.testng.Assert.*;
 
 /*
  * @test
- * @bug 8209137
+ * @bug 8209137 8326233
  * @summary HttpClient[.Builder] API and behaviour checks
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext
@@ -270,6 +270,34 @@ public class HttpClientBuilderTest {
         c.setProtocols(new String[] { "D" });
         try (var closer = closeable(builder)) {
             assertTrue(closer.build().sslParameters().getProtocols()[0].equals("C"));
+        }
+        // test defaults for needClientAuth and wantClientAuth
+        builder.sslParameters(new SSLParameters());
+        try (var closer = closeable(builder)) {
+            assertFalse(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be false");
+            assertFalse(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be false");
+        }
+        // needClientAuth = true and thus wantClientAuth = false
+        final SSLParameters needClientAuthParams = new SSLParameters();
+        needClientAuthParams.setNeedClientAuth(true);
+        builder.sslParameters(needClientAuthParams);
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be true");
+            assertFalse(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be false");
+        }
+        // wantClientAuth = true and thus needClientAuth = false
+        final SSLParameters wantClientAuthParams = new SSLParameters();
+        wantClientAuthParams.setWantClientAuth(true);
+        builder.sslParameters(wantClientAuthParams);
+        try (var closer = closeable(builder)) {
+            assertTrue(closer.build().sslParameters().getWantClientAuth(),
+                    "wantClientAuth() was expected to be true");
+            assertFalse(closer.build().sslParameters().getNeedClientAuth(),
+                    "needClientAuth() was expected to be false");
         }
     }
 

--- a/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpClientBuilderTest.java
@@ -280,7 +280,7 @@ public class HttpClientBuilderTest {
                     "wantClientAuth() was expected to be false");
         }
         // needClientAuth = true and thus wantClientAuth = false
-        final SSLParameters needClientAuthParams = new SSLParameters();
+        SSLParameters needClientAuthParams = new SSLParameters();
         needClientAuthParams.setNeedClientAuth(true);
         builder.sslParameters(needClientAuthParams);
         try (var closer = closeable(builder)) {
@@ -290,7 +290,7 @@ public class HttpClientBuilderTest {
                     "wantClientAuth() was expected to be false");
         }
         // wantClientAuth = true and thus needClientAuth = false
-        final SSLParameters wantClientAuthParams = new SSLParameters();
+        SSLParameters wantClientAuthParams = new SSLParameters();
         wantClientAuthParams.setWantClientAuth(true);
         builder.sslParameters(wantClientAuthParams);
         try (var closer = closeable(builder)) {


### PR DESCRIPTION
Can I please get a review for this change which proposes to fix https://bugs.openjdk.org/browse/JDK-8326233?

As noted in the issue, when the `java.net.HttpClient.Builder` is configured with a `SSLParameters` instance whose `needClientAuth` is set to true, then it is expected that the `HttpClient` that's built from such a build will have its `SSLParameters` with `needClientAuth` as `true` and `wantClientAuth` as `false`. But due to a bug in the internal implementation of a the `HttpClient`, the value for `needClientAuth` was getting reset to `false`. The commit in this PR fixes that issue and introduces a jtreg tests which reproduces the issue and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326233](https://bugs.openjdk.org/browse/JDK-8326233): Utils#copySSLParameters loses needClientAuth Setting (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) ⚠️ Review applies to [1b253398](https://git.openjdk.org/jdk/pull/17923/files/1b25339826860c677a27cac40a70931c92f6f47e)
 * [John Jiang](https://openjdk.org/census#jjiang) (@johnshajiang - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17923/head:pull/17923` \
`$ git checkout pull/17923`

Update a local copy of the PR: \
`$ git checkout pull/17923` \
`$ git pull https://git.openjdk.org/jdk.git pull/17923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17923`

View PR using the GUI difftool: \
`$ git pr show -t 17923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17923.diff">https://git.openjdk.org/jdk/pull/17923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17923#issuecomment-1953564518)