### PR TITLE
8326235: RISC-V: Size CodeCache for short calls encoding

### DIFF
--- a/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
@@ -50,6 +50,9 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 
 #define USE_POINTERS_TO_REGISTER_IMPL_ARRAY
 
+// auipc useable for all cc -> cc calls and jumps
+#define CODE_CACHE_SIZE_LIMIT ((2*G)-(2*K))
+
 // The expected size in bytes of a cache line.
 #define DEFAULT_CACHE_LINE_SIZE 64
 

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -581,12 +581,15 @@ extern uint64_t OopEncodingHeapMax;
 
 // Machine dependent stuff
 
+#include CPU_HEADER(globalDefinitions)
+
 // The maximum size of the code cache.  Can be overridden by targets.
+#ifndef CODE_CACHE_SIZE_LIMIT
 #define CODE_CACHE_SIZE_LIMIT (2*G)
+#endif
+
 // Allow targets to reduce the default size of the code cache.
 #define CODE_CACHE_DEFAULT_LIMIT CODE_CACHE_SIZE_LIMIT
-
-#include CPU_HEADER(globalDefinitions)
 
 // To assure the IRIW property on processors that are not multiple copy
 // atomic, sync instructions must be issued between volatile reads to


### PR DESCRIPTION
Hi, please consider.

This limits the code cache to a size such that all code cache -> code cache calls and jump may always use auipc+jalr.
(this is what we do in practice)
Thus we can fix the encoding for those and not have variable encoding.
The reduction of the size is just 2k, but due to option passing the real reduction is probably 1M.
-XX:ReservedCodeCacheSize=2047M (down from 2048)

Note, specifying '2G' gives the message:

> Invalid ReservedCodeCacheSize=2048M. Must be at most 2047M.

Manually test, no test I found uses this large code cache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326235](https://bugs.openjdk.org/browse/JDK-8326235): RISC-V: Size CodeCache for short calls encoding (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Antonios Printezis](https://openjdk.org/census#tonyp) (@gctony - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17924/head:pull/17924` \
`$ git checkout pull/17924`

Update a local copy of the PR: \
`$ git checkout pull/17924` \
`$ git pull https://git.openjdk.org/jdk.git pull/17924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17924`

View PR using the GUI difftool: \
`$ git pr show -t 17924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17924.diff">https://git.openjdk.org/jdk/pull/17924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17924#issuecomment-1953708646)