### PR TITLE
8325372: Shenandoah: SIGSEGV crash in unnecessary_acquire due to LoadStore split through phi

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.hpp
@@ -65,6 +65,7 @@ private:
   static void test_in_cset(Node*& ctrl, Node*& not_cset_ctrl, Node* val, Node* raw_mem, PhaseIdealLoop* phase);
   static void move_gc_state_test_out_of_loop(IfNode* iff, PhaseIdealLoop* phase);
   static void merge_back_to_back_tests(Node* n, PhaseIdealLoop* phase);
+  static bool merge_point_safe(Node* region);
   static bool identical_backtoback_ifs(Node *n, PhaseIdealLoop* phase);
   static void fix_ctrl(Node* barrier, Node* region, const MemoryGraphFixer& fixer, Unique_Node_List& uses, Unique_Node_List& uses_to_ignore, uint last, PhaseIdealLoop* phase);
   static IfNode* find_unswitching_candidate(const IdealLoopTree *loop, PhaseIdealLoop* phase);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3408,6 +3408,7 @@ Node *MemBarNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           my_mem = load_node;
         } else {
           assert(my_mem->unique_out() == this, "sanity");
+          assert(!trailing_load_store(), "");
           del_req(Precedent);
           phase->is_IterGVN()->_worklist.push(my_mem); // remove dead node later
           my_mem = nullptr;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3408,7 +3408,7 @@ Node *MemBarNode::Ideal(PhaseGVN *phase, bool can_reshape) {
           my_mem = load_node;
         } else {
           assert(my_mem->unique_out() == this, "sanity");
-          assert(!trailing_load_store(), "");
+          assert(!trailing_load_store(), "load store node can't be eliminated");
           del_req(Precedent);
           phase->is_IterGVN()->_worklist.push(my_mem); // remove dead node later
           my_mem = nullptr;

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary 
+ * @requires vm.gc.Shenandoah
+ * @modules java.base/jdk.internal.misc:+open
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:-BackgroundCompilation TestUnsafeLoadStoreMergedHeapStableTests
+ *
+ *
+ */
+
+import jdk.internal.misc.Unsafe;
+
+import java.lang.reflect.Field;
+
+public class TestUnsafeLoadStoreMergedHeapStableTests {
+
+    static final jdk.internal.misc.Unsafe UNSAFE = Unsafe.getUnsafe();
+    static long F_OFFSET;
+
+    static class A {
+        Object f;
+    }
+
+    static {
+        try {
+            Field fField = A.class.getDeclaredField("f");
+            F_OFFSET = UNSAFE.objectFieldOffset(fField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static Object testHelper(boolean flag, Object o, long offset, Object x) {
+        if (flag) {
+            return UNSAFE.getAndSetObject(o, offset, x);
+        }
+        return null;
+    }
+
+    static Object field;
+
+    
+    static Object test1(boolean flag, Object o, long offset) {
+        return testHelper(flag, null, offset, field);
+    }
+
+    static Object test2(Object o, long offset) {
+        return UNSAFE.getAndSetObject(o, offset, field);
+    }
+
+    static public void main(String[] args) {
+        A a = new A();
+        for (int i = 0; i < 20_000; i++) {
+            testHelper(true, a, F_OFFSET, null);
+            test1(false, a, F_OFFSET);
+            test2(a, F_OFFSET);
+        }
+    }
+}

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
@@ -29,8 +29,6 @@
  * @modules java.base/jdk.internal.misc:+open
  *
  * @run main/othervm -XX:+UseShenandoahGC -XX:-BackgroundCompilation TestUnsafeLoadStoreMergedHeapStableTests
- *
- *
  */
 
 import jdk.internal.misc.Unsafe;

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestUnsafeLoadStoreMergedHeapStableTests.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @summary 
+ * @bug 8325372
+ * @summary fusion of heap stable test causes GetAndSet node to be removed
  * @requires vm.gc.Shenandoah
  * @modules java.base/jdk.internal.misc:+open
  *
@@ -63,7 +64,7 @@ public class TestUnsafeLoadStoreMergedHeapStableTests {
 
     static Object field;
 
-    
+
     static Object test1(boolean flag, Object o, long offset) {
         return testHelper(flag, null, offset, field);
     }


### PR DESCRIPTION
After shenandoah barrier expansion, a shenandoah specific pass looks
for heap stable checks that are back to back:

```
if (heap_stable) {
  // fast path 1
} else {
  // slow path 1
}
if (heap_stable) {
  // fast path 2
} else {
  // slow path 2
}
```

and fuse them:

```
if (heap_stable) {
  // fast path 1
  // fast path 2
} else {
  // slow path 1
  // slow path 2
}
```

In the case of the failure, a `GetAndSetP` (or `GetAndSetN`) node is
between the 2 heap_stable checks. The fusion of the 2 tests is
implemented by taking advantage of the split if c2 optimization. But
split if doesn't support having a `GetAndSet` node at the region where
split if happens (that can only happen with shenandoah late barrier
expansion). That causes the `GetAndSet` node to lose its `SCMemProj`
which can then result in the `GetAndSet` being entirely removed.

The fix I propose is to not perform the heap_stable fusion in this
particular case.

/cc hotspot-compiler,shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325372](https://bugs.openjdk.org/browse/JDK-8325372): Shenandoah: SIGSEGV crash in unnecessary_acquire due to LoadStore split through phi (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17926/head:pull/17926` \
`$ git checkout pull/17926`

Update a local copy of the PR: \
`$ git checkout pull/17926` \
`$ git pull https://git.openjdk.org/jdk.git pull/17926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17926`

View PR using the GUI difftool: \
`$ git pr show -t 17926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17926.diff">https://git.openjdk.org/jdk/pull/17926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17926#issuecomment-1953855680)