### PR TITLE
8325730: StringBuilder.toString allocation for the empty String

### DIFF
--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringBuffer.java
+++ b/src/java.base/share/classes/java/lang/StringBuffer.java
@@ -735,6 +735,9 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
     @Override
     @IntrinsicCandidate
     public synchronized String toString() {
+        if (length() == 0) {
+            return "";
+        }
         if (toStringCache == null) {
             return toStringCache = new String(this, null);
         }

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringBuilder.java
+++ b/src/java.base/share/classes/java/lang/StringBuilder.java
@@ -471,8 +471,11 @@ public final class StringBuilder
     @Override
     @IntrinsicCandidate
     public String toString() {
+        if (length() == 0) {
+            return "";
+        }
         // Create a copy, don't share the array
-        return new String(this);
+        return new String(this, null);
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,41 +43,10 @@ import java.util.concurrent.TimeUnit;
 @Fork(3)
 public class StringBuffers {
 
-    private String name;
-    private String blaha;
-    private Sigurd sig;
-
-    @Setup
-    public void setup() {
-        name = "joe";
-        blaha = "sniglogigloienlitenapasomarengrodasjukadjavelhej";
-        sig = new Sigurd();
-    }
+    StringBuffer sb = new StringBuffer();
 
     @Benchmark
-    public String appendAndToString() {
-        return "MyStringBuffer named:" + ((name == null) ? "unknown" : name) + ".";
+    public String emptyToString() {
+        return sb.toString();
     }
-
-    @Benchmark
-    public String toStringComplex() {
-        return sig.toString();
-    }
-
-    static class Sigurd {
-        int x;
-        byte y;
-        String z = "yahoo";
-
-        @Override
-        public String toString() {
-            return Integer.toString(x) + "_" + Integer.toString((int) y) + "_" + z + "_";
-        }
-    }
-
-    @Benchmark
-    public String substring() {
-        return blaha.substring(30, 35);
-    }
-
 }

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilderToString.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilderToString.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,6 +364,11 @@ public class StringBuilders {
         return sbUtf16.charAt(charAt_index);
     }
 
+    @Benchmark
+    public String emptyToString(Data data) {
+        return data.sb.toString();
+    }
+
     @State(Scope.Thread)
     public static class Data {
         int i = 0;
@@ -380,6 +385,7 @@ public class StringBuilders {
             }
         }
 
+        StringBuilder sb;
         String str;
         String utf16Str;
         CharSequence cs;
@@ -398,6 +404,7 @@ public class StringBuilders {
         }
 
         private void generateData() {
+            sb = new StringBuilder(length);
             char[] chars = "abcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
 
             StringBuilder sb = new StringBuilder(length);


### PR DESCRIPTION
JDK-8282429 accidentally removed an optimization (JDK-8240094) that ensured StringBuilder/StringBuffer::toString returns `""` when the builders are empty.

```
Name                         Cnt     Base      Error   Test   Error   Unit  Change
StringBuffers.emptyToString    5   12,289 ±    0,384  9,883 ± 0,721  ns/op   1,24x (p = 0,000*)
  :gc.alloc.rate                 1862,398 ±   57,647  0,007 ± 0,000 MB/sec   0,00x (p = 0,000*)
  :gc.alloc.rate.norm              24,000 ±    0,000  0,000 ± 0,000   B/op   0,00x (p = 0,000*)
  :gc.count                        31,000             0,000         counts
  :gc.time                         21,000                               ms
StringBuilders.emptyToString   5    4,146 ±    0,567  0,646 ± 0,003  ns/op   6,42x (p = 0,000*)
  :gc.alloc.rate                 9208,656 ± 1234,399  0,007 ± 0,000 MB/sec   0,00x (p = 0,000*)
  :gc.alloc.rate.norm              40,000 ±    0,000  0,000 ± 0,000   B/op   0,00x (p = 0,000*)
  :gc.count                        96,000             0,000         counts
  :gc.time                         64,000                               ms
  * = significant
```

