### PR TITLE
8326158: Javadoc for java.time.DayOfWeek#minus(long)

### DIFF
--- a/src/java.base/share/classes/java/time/DayOfWeek.java
+++ b/src/java.base/share/classes/java/time/DayOfWeek.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -370,7 +370,7 @@ public enum DayOfWeek implements TemporalAccessor, TemporalAdjuster {
     /**
      * Returns the day-of-week that is the specified number of days before this one.
      * <p>
-     * The calculation rolls around the start of the year from Monday to Sunday.
+     * The calculation rolls around the start of the week from Monday to Sunday.
      * The specified period may be negative.
      * <p>
      * This instance is immutable and unaffected by this method call.


### PR DESCRIPTION
Fixing a typo in the said method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326158](https://bugs.openjdk.org/browse/JDK-8326158): Javadoc for java.time.DayOfWeek#minus(long) (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17933/head:pull/17933` \
`$ git checkout pull/17933`

Update a local copy of the PR: \
`$ git checkout pull/17933` \
`$ git pull https://git.openjdk.org/jdk.git pull/17933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17933`

View PR using the GUI difftool: \
`$ git pr show -t 17933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17933.diff">https://git.openjdk.org/jdk/pull/17933.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17933#issuecomment-1954839853)