### PR TITLE
8326334: JFR failed assert(used(klass)) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
@@ -101,13 +101,12 @@ void JfrKlassUnloading::clear() {
   }
 }
 
-static bool add_to_unloaded_klass_set(traceid klass_id, bool current_epoch) {
+static void add_to_unloaded_klass_set(traceid klass_id, bool current_epoch) {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
   GrowableArray<traceid>* const unload_set = current_epoch ? get_unload_set() : get_unload_set_previous_epoch();
   assert(unload_set != nullptr, "invariant");
   assert(unload_set->find(klass_id) == -1, "invariant");
   unload_set->append(klass_id);
-  return true;
 }
 
 #if INCLUDE_MANAGEMENT
@@ -129,7 +128,8 @@ bool JfrKlassUnloading::on_unload(const Klass* k) {
   if (IS_JDK_JFR_EVENT_SUBKLASS(k)) {
     ++event_klass_unloaded_count;
   }
-  return USED_ANY_EPOCH(k) && add_to_unloaded_klass_set(JfrTraceId::load_raw(k), USED_THIS_EPOCH(k));
+  add_to_unloaded_klass_set(JfrTraceId::load_raw(k), true);
+  return USED_THIS_EPOCH(k);
 }
 
 bool JfrKlassUnloading::is_unloaded(traceid klass_id, bool previous_epoch /* false */) {

--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,9 +101,9 @@ void JfrKlassUnloading::clear() {
   }
 }
 
-static void add_to_unloaded_klass_set(traceid klass_id, bool current_epoch) {
+static void add_to_unloaded_klass_set(traceid klass_id) {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
-  GrowableArray<traceid>* const unload_set = current_epoch ? get_unload_set() : get_unload_set_previous_epoch();
+  GrowableArray<traceid>* const unload_set =  get_unload_set();
   assert(unload_set != nullptr, "invariant");
   assert(unload_set->find(klass_id) == -1, "invariant");
   unload_set->append(klass_id);
@@ -128,7 +128,7 @@ bool JfrKlassUnloading::on_unload(const Klass* k) {
   if (IS_JDK_JFR_EVENT_SUBKLASS(k)) {
     ++event_klass_unloaded_count;
   }
-  add_to_unloaded_klass_set(JfrTraceId::load_raw(k), true);
+  add_to_unloaded_klass_set(JfrTraceId::load_raw(k));
   return USED_THIS_EPOCH(k);
 }
 

--- a/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
+++ b/src/hotspot/share/jfr/support/jfrKlassUnloading.cpp
@@ -103,7 +103,7 @@ void JfrKlassUnloading::clear() {
 
 static void add_to_unloaded_klass_set(traceid klass_id) {
   assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
-  GrowableArray<traceid>* const unload_set =  get_unload_set();
+  GrowableArray<traceid>* const unload_set = get_unload_set();
   assert(unload_set != nullptr, "invariant");
   assert(unload_set->find(klass_id) == -1, "invariant");
   unload_set->append(klass_id);


### PR DESCRIPTION
Greetings,

please help review this adjustment for the JFR typeset class unloading logic.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326334](https://bugs.openjdk.org/browse/JDK-8326334): JFR failed assert(used(klass)) failed: invariant (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17934/head:pull/17934` \
`$ git checkout pull/17934`

Update a local copy of the PR: \
`$ git checkout pull/17934` \
`$ git pull https://git.openjdk.org/jdk.git pull/17934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17934`

View PR using the GUI difftool: \
`$ git pr show -t 17934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17934.diff">https://git.openjdk.org/jdk/pull/17934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17934#issuecomment-1954877005)