### PR TITLE
8326368: compare.sh -2bins prints ugly errors on Windows

### DIFF
--- a/make/scripts/compare.sh
+++ b/make/scripts/compare.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -699,14 +699,16 @@ compare_bin_file() {
         unset _NT_SYMBOL_PATH
         if [ "$(uname -o)" = "Cygwin" ]; then
             THIS=$(cygpath -msa $THIS)
-            OTHER=$(cygpath -msa $OTHER)
+            if [ -n "$OTHER" ]; then
+              OTHER=$(cygpath -msa $OTHER)
+            fi
         fi
         # Build an _NT_SYMBOL_PATH that contains all known locations for
         # pdb files.
         PDB_DIRS="$(ls -d \
             {$OTHER,$THIS}/support/modules_{cmds,libs}/{*,*/*} \
             {$OTHER,$THIS}/support/native/jdk.jpackage/* \
-            )"
+            2> /dev/null )"
         export _NT_SYMBOL_PATH="$(echo $PDB_DIRS | tr ' ' ';')"
     fi
 


### PR DESCRIPTION
The logic in the compare script assumes that we compare two directories, and so always have an `$OTHER`. If we are using `-2dirs`, this is not the case, causing `cygpath` and the following `ls` to fail and print error messages about missing paths. These are benign but annoying.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326368](https://bugs.openjdk.org/browse/JDK-8326368): compare.sh -2bins prints ugly errors on Windows (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17936/head:pull/17936` \
`$ git checkout pull/17936`

Update a local copy of the PR: \
`$ git checkout pull/17936` \
`$ git pull https://git.openjdk.org/jdk.git pull/17936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17936`

View PR using the GUI difftool: \
`$ git pr show -t 17936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17936.diff">https://git.openjdk.org/jdk/pull/17936.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17936#issuecomment-1954969547)