### PR TITLE
8326370: Remove redundant and misplaced micros from StringBuffers

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuffers.java
@@ -29,7 +29,6 @@ import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
@@ -42,43 +41,6 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 5, time = 1)
 @Fork(3)
 public class StringBuffers {
-
-    private String name;
-    private String blaha;
-    private Sigurd sig;
-
-    @Setup
-    public void setup() {
-        name = "joe";
-        blaha = "sniglogigloienlitenapasomarengrodasjukadjavelhej";
-        sig = new Sigurd();
-    }
-
-    @Benchmark
-    public String appendAndToString() {
-        return "MyStringBuffer named:" + ((name == null) ? "unknown" : name) + ".";
-    }
-
-    @Benchmark
-    public String toStringComplex() {
-        return sig.toString();
-    }
-
-    static class Sigurd {
-        int x;
-        byte y;
-        String z = "yahoo";
-
-        @Override
-        public String toString() {
-            return Integer.toString(x) + "_" + Integer.toString((int) y) + "_" + z + "_";
-        }
-    }
-
-    @Benchmark
-    public String substring() {
-        return blaha.substring(30, 35);
-    }
 
     StringBuffer sb = new StringBuffer();
 


### PR DESCRIPTION
Some microbenchmarks in org.openjdk.bench.java.lang.StringBuffers seem out-of-place (not testing `StringBuffer`), redundant (covered by other tests like StringSubstring or the various String concatenation tests), or both. This cleans them out. 

My apologies to Sigurd.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326370](https://bugs.openjdk.org/browse/JDK-8326370): Remove redundant and misplaced micros from StringBuffers (**Enhancement** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17937/head:pull/17937` \
`$ git checkout pull/17937`

Update a local copy of the PR: \
`$ git checkout pull/17937` \
`$ git pull https://git.openjdk.org/jdk.git pull/17937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17937`

View PR using the GUI difftool: \
`$ git pr show -t 17937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17937.diff">https://git.openjdk.org/jdk/pull/17937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17937#issuecomment-1955093459)