### PR TITLE
JDK-8326376: java -version failed with CONF=fastdebug -XX:InitialCodeCacheSize=1024K -XX:ReservedCodeCacheSize=1200k

### DIFF
--- a/src/hotspot/share/compiler/compilationFailureInfo.cpp
+++ b/src/hotspot/share/compiler/compilationFailureInfo.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/compiler/compilationFailureInfo.cpp
+++ b/src/hotspot/share/compiler/compilationFailureInfo.cpp
@@ -42,11 +42,16 @@
 #include "utilities/ostream.hpp"
 #include "utilities/nativeCallStack.hpp"
 
+int CompilationFailureInfo::current_compile_id_or_0() {
+  ciEnv* env = ciEnv::current();
+  return (env != nullptr) ? env->compile_id() : 0;
+}
+
 CompilationFailureInfo::CompilationFailureInfo(const char* failure_reason) :
   _stack(2),
   _failure_reason(os::strdup(failure_reason)),
   _elapsed_seconds(os::elapsedTime()),
-  _compile_id(ciEnv::current()->task()->compile_id())
+  _compile_id(current_compile_id_or_0())
 {}
 
 CompilationFailureInfo::~CompilationFailureInfo() {

--- a/src/hotspot/share/compiler/compilationFailureInfo.hpp
+++ b/src/hotspot/share/compiler/compilationFailureInfo.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2023, Red Hat, Inc. and/or its affiliates.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat, Inc. and/or its affiliates.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/compiler/compilationFailureInfo.hpp
+++ b/src/hotspot/share/compiler/compilationFailureInfo.hpp
@@ -40,6 +40,7 @@ class CompilationFailureInfo : public CHeapObj<mtCompiler> {
   char* const _failure_reason;
   const double _elapsed_seconds;
   const int _compile_id;
+  static int current_compile_id_or_0();
 public:
   CompilationFailureInfo(const char* failure_reason);
   ~CompilationFailureInfo();

--- a/test/hotspot/jtreg/compiler/startup/StartupOutput.java
+++ b/test/hotspot/jtreg/compiler/startup/StartupOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,15 @@ public class StartupOutput {
         out = new OutputAnalyzer(pb.start());
         // The VM should not crash but may return an error message because we don't have enough space for adapters
         int exitCode = out.getExitValue();
+        if (exitCode != 1 && exitCode != 0) {
+            throw new Exception("VM crashed with exit code " + exitCode);
+        }
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:InitialCodeCacheSize=1024K", "-XX:ReservedCodeCacheSize=1200k", "-version");
+        out = new OutputAnalyzer(pb.start());
+        // The VM should not crash but will probably fail with a "CodeCache is full. Compiler has been disabled." message
+        out.stdoutShouldNotContain("# A fatal error");
+        exitCode = out.getExitValue();
         if (exitCode != 1 && exitCode != 0) {
             throw new Exception("VM crashed with exit code " + exitCode);
         }


### PR DESCRIPTION
Please review this fix of a regression brought by https://bugs.openjdk.org/browse/JDK-8318444. Thanks to @sunny868 for reporting this.

We bail out during compiler initialization of C2. The thread's ciEnv does not have a CompileTask associated in that case, and that's why we are faulting.

I tested the patch on Linux x64 and confirmed the fix. I also tested with a compiler memory ceiling and the crash option (see https://bugs.openjdk.org/browse/JDK-8318016) and confirmed that the hs-err file contains valid compile ids when we have a valid compile task.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326376](https://bugs.openjdk.org/browse/JDK-8326376): java -version failed with CONF=fastdebug -XX:InitialCodeCacheSize=1024K -XX:ReservedCodeCacheSize=1200k (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17941/head:pull/17941` \
`$ git checkout pull/17941`

Update a local copy of the PR: \
`$ git checkout pull/17941` \
`$ git pull https://git.openjdk.org/jdk.git pull/17941/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17941`

View PR using the GUI difftool: \
`$ git pr show -t 17941`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17941.diff">https://git.openjdk.org/jdk/pull/17941.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17941#issuecomment-1956271107)