### PR TITLE
8325153: SEGV in stackChunkOopDesc::derelativize_address(int)

### DIFF
--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -544,7 +544,11 @@ jint StackWalk::fetchNextBatch(Handle stackStream, jint mode, jlong magic,
     // the continuation and it returns to let Java side set the continuation.
     // Now this batch starts right at the first frame of another continuation.
     if (last_batch_count > 0) {
-      log_debug(stackwalk)("advanced past %s", stream.method()->external_name());
+      // It is not always safe to dig out the name of the last frame
+      // here, i.e. stream.method()->external_name(), since it may
+      // have been reclaimed by HandleMark::pop_and_restore() together
+      // with the rest of the previous batch.
+      log_debug(stackwalk)("advanced past last frame decoded in the previous batch");
       stream.next();
     }
 


### PR DESCRIPTION
The JVM used to SEGV when running jdk/internal/vm/Continuation/Fuzz.java with '-Xlog:all=trace:file=hotspot.%p.log'

The problem was this line in StackWalk::fetchNextBatch() at src/hotspot/share/prims/stackwalk.cpp:547:

log_debug(stackwalk)("advanced past %s", stream.method()->external_name());

It is not always safe to dig out the name of the last frame here. The second batch is allocated on top of the first batch, so there is no crash when we dig out the last name from the first batch. However the third batch, is allocated on the same stack level as the second, which means that the second batch has been reclaimed. Thus trying to reach into the second batch when processing the third will cause a segmentation violation.

Now passes:
jdk/internal/vm/Continuation/Fuzz.java with '-Xlog:all=trace:file=hotspot.%p.log'
As well as tier1-tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325153](https://bugs.openjdk.org/browse/JDK-8325153): SEGV in stackChunkOopDesc::derelativize_address(int) (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17942/head:pull/17942` \
`$ git checkout pull/17942`

Update a local copy of the PR: \
`$ git checkout pull/17942` \
`$ git pull https://git.openjdk.org/jdk.git pull/17942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17942`

View PR using the GUI difftool: \
`$ git pr show -t 17942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17942.diff">https://git.openjdk.org/jdk/pull/17942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17942#issuecomment-1956525053)