### PR TITLE
8326412: debuginfo files should not have executable bit set

### DIFF
--- a/make/common/native/DebugSymbols.gmk
+++ b/make/common/native/DebugSymbols.gmk
@@ -76,7 +76,8 @@ define CreateDebugSymbols
           # so we can run it after strip is called, since strip can sometimes mangle the
           # embedded debuglink, which we want to avoid.
           $1_CREATE_DEBUGINFO_CMDS := \
-              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) $$(NEWLINE)
+              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) && \
+              $$(CHMOD) -x $$($1_DEBUGINFO_FILES)
           $1_CREATE_DEBUGLINK_CMDS := $(CD) $$($1_SYMBOLS_DIR) && \
               $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
 


### PR DESCRIPTION
When we create our debuginfo files on linux, we use objcopy to create a copy of the corresponding lib*.so or executable. In the latter case, objcopy will keep the executable bit. While this is a reasonable assumption for objcopy, we really treat the debuginfo files as data, not as executables in their own right, so we should strip the executable bit.

This was found when working with [JDK-8325342](https://bugs.openjdk.org/browse/JDK-8325342), and I there attempted to properly locate all executables and only executables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326412](https://bugs.openjdk.org/browse/JDK-8326412): debuginfo files should not have executable bit set (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17947/head:pull/17947` \
`$ git checkout pull/17947`

Update a local copy of the PR: \
`$ git checkout pull/17947` \
`$ git pull https://git.openjdk.org/jdk.git pull/17947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17947`

View PR using the GUI difftool: \
`$ git pr show -t 17947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17947.diff">https://git.openjdk.org/jdk/pull/17947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17947#issuecomment-1956635337)