### PR TITLE
8326414: Serial: Inline SerialHeap::create_rem_set

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -191,7 +191,7 @@ jint SerialHeap::initialize() {
   ReservedSpace young_rs = heap_rs.first_part(MaxNewSize);
   ReservedSpace old_rs = heap_rs.last_part(MaxNewSize);
 
-  _rem_set = create_rem_set(heap_rs.region());
+  _rem_set = new CardTableRS(heap_rs.region());
   _rem_set->initialize(young_rs.base(), old_rs.base());
 
   CardTableBarrierSet *bs = new CardTableBarrierSet(_rem_set);
@@ -204,11 +204,6 @@ jint SerialHeap::initialize() {
   GCInitLogger::print();
 
   return JNI_OK;
-}
-
-
-CardTableRS* SerialHeap::create_rem_set(const MemRegion& reserved_region) {
-  return new CardTableRS(reserved_region);
 }
 
 ReservedHeapSpace SerialHeap::allocate(size_t alignment) {

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -141,7 +141,6 @@ private:
 public:
   // Returns JNI_OK on success
   jint initialize() override;
-  virtual CardTableRS* create_rem_set(const MemRegion& reserved_region);
 
   // Does operations required after initialization has been done.
   void post_initialize() override;


### PR DESCRIPTION
Trivial inlining a single-line method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326414](https://bugs.openjdk.org/browse/JDK-8326414): Serial: Inline SerialHeap::create_rem_set (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17948/head:pull/17948` \
`$ git checkout pull/17948`

Update a local copy of the PR: \
`$ git checkout pull/17948` \
`$ git pull https://git.openjdk.org/jdk.git pull/17948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17948`

View PR using the GUI difftool: \
`$ git pr show -t 17948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17948.diff">https://git.openjdk.org/jdk/pull/17948.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17948#issuecomment-1956713981)