### PR TITLE
8325215: Incorrect not exhaustive switch error

### DIFF
--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -2016,9 +2016,60 @@ public class Exhaustiveness extends TestRunner {
 
                    static int r(R r) {
                       return switch (r) {
-                          case R(A a,  V b) -> 1; // Any A with specific B
-                          case R(T a,  B b) -> 2; // Specific A with any B
-                          case R(U a,  W b) -> 3; // Specific A with specific B
+                          case R(A a, V b) -> 1; // Any A with specific B
+                          case R(T a, B b) -> 2; // Specific A with any B
+                          case R(U a, W b) -> 3; // Specific A with specific B
+                      };
+                   }
+               }
+               """);
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A permits T, U {}
+                   sealed interface B permits V, W {}
+
+                   static final class T implements A { public T() {} }
+                   static final class U implements A { public U() {} }
+
+                   static final class V implements B { public V() {} }
+                   static final class W implements B { public W() {} }
+
+                   final static record R(B b, A a) { }
+
+                   static int r(R r) {
+                      return switch (r) {
+                          case R(V b, A a) -> 1; // Any A with specific B
+                          case R(B b, T a) -> 2; // Specific A with any B
+                          case R(W b, U a) -> 3; // Specific A with specific B
+                      };
+                   }
+               }
+               """);
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A permits T, U {}
+                   sealed interface B permits V, W {}
+
+                   static final class T implements A { public T() {} }
+                   static final class U implements A { public U() {} }
+
+                   static final class V implements B { public V() {} }
+                   static final class W implements B { public W() {} }
+
+                   final static record X(B b) { }
+                   final static record R(A a, X x) { }
+
+                   static int r(R r) {
+                      return switch (r) {
+                          case R(A a, X(V b)) -> 1; // Any A with specific B
+                          case R(T a, X(B b)) -> 2; // Specific A with any B
+                          case R(U a, X(W b)) -> 3; // Specific A with specific B
                       };
                    }
                }

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -1992,6 +1992,35 @@ public class Exhaustiveness extends TestRunner {
                      }
                    }
                  }
+               }
+               """);
+    }
+
+    @Test //JDK-8325215:
+    public void testTooGenericPatternInRecord(Path base) throws Exception {
+        doTest(base,
+               new String[0],
+               """
+               package test;
+               public class Test {
+                   sealed interface A permits T, U {}
+                   sealed interface B permits V, W {}
+
+                   static final class T implements A { public T() {} }
+                   static final class U implements A { public U() {} }
+
+                   static final class V implements B { public V() {} }
+                   static final class W implements B { public W() {} }
+
+                   final static record R(A a, B b) { }
+
+                   static int r(R r) {
+                      return switch (r) {
+                          case R(A a,  V b) -> 1; // Any A with specific B
+                          case R(T a,  B b) -> 2; // Specific A with any B
+                          case R(U a,  W b) -> 3; // Specific A with specific B
+                      };
+                   }
                }
                """);
     }


### PR DESCRIPTION
Consider code like:
```
public class Test {

    sealed interface A permits T, U {}
    sealed interface B permits V, W {}
    static final class T implements A {}
    static final class U implements A {}
    static final class V implements B {}
    static final class W implements B {}
    final static record R(A a, B b) {}

    static int r(R r) {
        return switch (r) {
            case R(A a, V b) -> 1;
            case R(T a, W b) -> 2;
            case R(U a, W b) -> 3;
        };
    }
}
```

javac will correctly consider this to be exhaustive, as `R(T a, W b)` and `R(U a, W b)` can be merged into `R(A a, W b)`, and then `R(A a, V b)` and `R(A a, W b)` are merge into `R(A a, B b)` and then into `R`.

But, if we replace `R(T a, W b)` with a more general `R(T a, B b)`, which matches everything that `R(T a, W b)` does:
```
public class Test {

    sealed interface A permits T, U {}
    sealed interface B permits V, W {}
    static final class T implements A {}
    static final class U implements A {}
    static final class V implements B {}
    static final class W implements B {}
    final static record R(A a, B b) {}

    static int r(R r) {
        return switch (r) {
            case R(A a, V b) -> 1;
            case R(T a, B b) -> 2;
            case R(U a, W b) -> 3;
        };
    }
}
```

Leads to:
```
$ javac /tmp/Test.java
/tmp/Test.java:12: error: the switch expression does not cover all possible input values
        return switch (r) {
               ^
1 error
```

The issue is that the exhaustivity algorithm is no longer able to merge `R(T a, B b)` and `R(U a, W b)` into `R(A a, W b)`, as the second nested pattern is not the same.

The rules permit replacing patterns with more strict patterns, i.e. it is permitted to replace `R(T a, B b)` with `R(T a, W b)`, and hence proceed with the merging as in the original case. The trouble is that doing such conversions may lead to high computational complexity.

The proposal in this patch is to replace all binding patterns in all patterns with their transitive permitted subtypes, but only once, and only if the algorithm fails to determine the exhaustiveness using the standing approach. This may lead to a potentially significant performance penalty, but only in case where the algorithm would mark the switch exhaustive.

The main alternative to this proposal would be to allow the algorithm to see `B` and `W` as equivalent when attempting to merge  `R(T a, B b)` and `R(U a, W b)`. But, currently, this equivalence check is based on hash codes, which prevents doing the check using subtyping checks, and this hashing improved performance in "common" cases tremendously. So, I would like to attempt to keep that. But it is possible we might need to fall back on the subtyping check for equivalence instead of hashing if other solutions will prove to be unusable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325215](https://bugs.openjdk.org/browse/JDK-8325215): Incorrect not exhaustive switch error (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17949/head:pull/17949` \
`$ git checkout pull/17949`

Update a local copy of the PR: \
`$ git checkout pull/17949` \
`$ git pull https://git.openjdk.org/jdk.git pull/17949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17949`

View PR using the GUI difftool: \
`$ git pr show -t 17949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17949.diff">https://git.openjdk.org/jdk/pull/17949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17949#issuecomment-1956827637)