### PR TITLE
8325754: Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1127,13 +1127,18 @@ public abstract class AbstractQueuedLongSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -1506,13 +1506,18 @@ public abstract class AbstractQueuedSynchronizer
         private void doSignal(ConditionNode first, boolean all) {
             while (first != null) {
                 ConditionNode next = first.nextWaiter;
+
                 if ((firstWaiter = next) == null)
                     lastWaiter = null;
+                else
+                    first.nextWaiter = null; // GC assistance
+
                 if ((first.getAndUnsetStatus(COND) & COND) != 0) {
                     enqueue(first);
                     if (!all)
                         break;
                 }
+
                 first = next;
             }
         }


### PR DESCRIPTION
More aggressively breaking chains in order to prevent nodes promoted to older generations standing in the way for collecting younger nodes. I decided that it was most efficient to add this logic to the else-branch of updating the firstWaiter and lastWaiter.

There's a race with unlinkCancelledWaiters() but according to @DougLea it should be a benign one.

There's a performance impact of this, but as it is a plain write, and one to null at that, it should be acceptable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325754](https://bugs.openjdk.org/browse/JDK-8325754): Dead AbstractQueuedSynchronizer$ConditionNodes survive minor garbage collections (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17950/head:pull/17950` \
`$ git checkout pull/17950`

Update a local copy of the PR: \
`$ git checkout pull/17950` \
`$ git pull https://git.openjdk.org/jdk.git pull/17950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17950`

View PR using the GUI difftool: \
`$ git pr show -t 17950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17950.diff">https://git.openjdk.org/jdk/pull/17950.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17950#issuecomment-1956869071)