### PR TITLE
8326129: Java Record Pattern Match leads to infinite loop

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -988,6 +988,7 @@ public class TransPatterns extends TreeTranslator {
                        commonBinding.type.tsym == currentBinding.type.tsym &&
                        commonBinding.isUnnamedVariable() == currentBinding.isUnnamedVariable() &&
                        !previousNullable &&
+                       !currentNullable &&
                        new TreeDiffer(List.of(commonBinding), List.of(currentBinding))
                                .scan(commonNestedExpression, currentNestedExpression)) {
                 accummulator.add(c.head);


### PR DESCRIPTION
Consider code like:
```
private int test(Box b) {
    return switch (b) {
        case Box(Integer i) -> 0;
        case Box(Object o) when check(o) -> 1;
        case Box(Object o) -> 2;
    };
}

public record Box(Object o) {}
```

Note the nested `Object o` both accept `null`.

javac will compile this using two nested switches, like:

```
int $restartIndex = 0;
return switch (b, $restartIndex) { //will start matching as $restartIndex
     case Box $b -> {
         int $nestedRestartIndex = 0;
         yield switch ($b.o(), $nestedRestartIndex) {  //will start matching as $nestedRestartIndex
             case Integer i -> 0;
             case null, Object o -> {
                 if (!check(o)) {
                     $nestedRestartIndex = 2;
                     continue-nested-switch; //goto to the start of the nested switch again, with the updated $nestedRestartIndex
                 }
                 yield 1;
             }
             default -> {
                  $restartIndex = 1;
                  continue-main-switch; //goto to begining of the main switch again, with the updated $restartIndex
             }
        };
    case Box(Object o) -> 2;
}
```

javac uses the restart index to implement (especially) guards - if the guard returns true, the matching (the whole switch) is restarted on the next case. javac tries to merge multiple cases with patterns with the same prefix into the same case, to reduce unnecessary matching.

There's a problem with the restarts, and that is that for `case null`, the restart index is ignored. I.e. even though the nested switch in `case null, Object o` sets the `$nestedRestartIndex` to 2, the switch will jump to `null` again after being restarted. This is because for the `null` selector, `SwitchBootstraps.typeSwitch` always returns `-1`.

The solution proposed here is to avoid factoring the nullable patterns into nested switches with any other patterns, as we cannot keep the semantics for the nested switch in such a case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326129](https://bugs.openjdk.org/browse/JDK-8326129): Java Record Pattern Match leads to infinite loop (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17951/head:pull/17951` \
`$ git checkout pull/17951`

Update a local copy of the PR: \
`$ git checkout pull/17951` \
`$ git pull https://git.openjdk.org/jdk.git pull/17951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17951`

View PR using the GUI difftool: \
`$ git pr show -t 17951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17951.diff">https://git.openjdk.org/jdk/pull/17951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17951#issuecomment-1956886080)