### PR TITLE
JDK-8326389: [test] improve assertEquals failure output

### DIFF
--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -199,10 +199,7 @@ public class Asserts {
      */
     public static void assertEquals(Object lhs, Object rhs, String msg) {
         if ((lhs != rhs) && ((lhs == null) || !(lhs.equals(rhs)))) {
-            msg = Objects.toString(msg, "assertEquals")
-                    + ": object \"" + Objects.toString(lhs)
-                    + "\" is not equal to \"" + Objects.toString(rhs) + "\"";
-            fail(msg);
+            fail((msg == null ? "assertEquals" : msg) + " expected: " + lhs + " but was: " + rhs);
         }
     }
 

--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -201,7 +201,7 @@ public class Asserts {
         if ((lhs != rhs) && ((lhs == null) || !(lhs.equals(rhs)))) {
             msg = Objects.toString(msg, "assertEquals")
                     + ": object \"" + Objects.toString(lhs)
-                    + "\" and object \"" + Objects.toString(rhs) + "\" are not equal";
+                    + "\" is not equal to \"" + Objects.toString(rhs) + "\"";
             fail(msg);
         }
     }

--- a/test/lib/jdk/test/lib/Asserts.java
+++ b/test/lib/jdk/test/lib/Asserts.java
@@ -200,8 +200,8 @@ public class Asserts {
     public static void assertEquals(Object lhs, Object rhs, String msg) {
         if ((lhs != rhs) && ((lhs == null) || !(lhs.equals(rhs)))) {
             msg = Objects.toString(msg, "assertEquals")
-                    + ": expected " + Objects.toString(lhs)
-                    + " to equal " + Objects.toString(rhs);
+                    + ": object \"" + Objects.toString(lhs)
+                    + "\" and object \"" + Objects.toString(rhs) + "\" are not equal";
             fail(msg);
         }
     }


### PR DESCRIPTION
Currently assertEquals has in the failure case sometimes confusing output like :

java.lang.RuntimeException: VM output should contain exactly one RTM locking statistics entry for method compiler.rtm.locking.TestRTMTotalCountIncrRate$Test::lock: expected 0 to equal 1
       at jdk.test.lib.Asserts.fail(Asserts.java:634)
       at jdk.test.lib.Asserts.assertEquals(Asserts.java:205)

(I don't think we really expected that for some reason 0 equals 1)
This should be improved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326389](https://bugs.openjdk.org/browse/JDK-8326389): [test] improve assertEquals failure output (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17952/head:pull/17952` \
`$ git checkout pull/17952`

Update a local copy of the PR: \
`$ git checkout pull/17952` \
`$ git pull https://git.openjdk.org/jdk.git pull/17952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17952`

View PR using the GUI difftool: \
`$ git pr show -t 17952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17952.diff">https://git.openjdk.org/jdk/pull/17952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17952#issuecomment-1956954510)