### PR TITLE
8322767: TLS full handshake is slow with PKCS12KeyStore and X509KeyManagerImpl

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509KeyManagerImpl.java
@@ -347,48 +347,46 @@ final class X509KeyManagerImpl extends X509ExtendedKeyManager
             return false;
         }
 
-        synchronized (keyStore) {
-            Entry newEntry = keyStore.getEntry(alias,
-                    builder.getProtectionParameter(alias));
-            if (!(newEntry instanceof PrivateKeyEntry)) {
-                return false;
-            }
-
-            PrivateKeyEntry privateKeyEntry = (PrivateKeyEntry) newEntry;
-            PrivateKey privateKey = privateKeyEntry.getPrivateKey();
-            Certificate[] certs = privateKeyEntry.getCertificateChain();
-
-            if ((certs == null) || (certs.length == 0) ||
-                    !(certs[0] instanceof X509Certificate)) {
-                return false;
-            }
-
-            if (!(certs instanceof X509Certificate[])) {
-                Certificate[] tmp = new X509Certificate[certs.length];
-                System.arraycopy(certs, 0, tmp, 0, certs.length);
-                certs = tmp;
-            }
-
-            X509Certificate cert = (X509Certificate) certs[0];
-            PublicKey publicKey = cert.getPublicKey();
-            if (!privateKey.getAlgorithm().equals(publicKey.getAlgorithm())) {
-                return false;
-            }
-
-            // Add to credentials map
-            String builderAlias = builderIndex + "." + alias;
-            X509Credentials cred = new X509Credentials(privateKey,
-                    (X509Certificate[]) certs);
-            credentialsMap.put(builderAlias, cred);
-
-            if (SSLLogger.isOn && SSLLogger.isOn("keymanager")) {
-                SSLLogger.fine("found key for : " +
-                        "keystore builder index = " + builderIndex +
-                        " alias = " + alias, (Object[]) certs);
-            }
-
-            return true;
+        Entry newEntry = keyStore.getEntry(alias,
+                builder.getProtectionParameter(alias));
+        if (!(newEntry instanceof PrivateKeyEntry)) {
+            return false;
         }
+
+        PrivateKeyEntry privateKeyEntry = (PrivateKeyEntry) newEntry;
+        PrivateKey privateKey = privateKeyEntry.getPrivateKey();
+        Certificate[] certs = privateKeyEntry.getCertificateChain();
+
+        if ((certs == null) || (certs.length == 0) ||
+                !(certs[0] instanceof X509Certificate)) {
+            return false;
+        }
+
+        if (!(certs instanceof X509Certificate[])) {
+            Certificate[] tmp = new X509Certificate[certs.length];
+            System.arraycopy(certs, 0, tmp, 0, certs.length);
+            certs = tmp;
+        }
+
+        X509Certificate cert = (X509Certificate) certs[0];
+        PublicKey publicKey = cert.getPublicKey();
+        if (!privateKey.getAlgorithm().equals(publicKey.getAlgorithm())) {
+            return false;
+        }
+
+        // Add to credentials map
+        String builderAlias = builderIndex + "." + alias;
+        X509Credentials cred = new X509Credentials(privateKey,
+                (X509Certificate[]) certs);
+        credentialsMap.put(builderAlias, cred);
+
+        if (SSLLogger.isOn && SSLLogger.isOn("keymanager")) {
+            SSLLogger.fine("found key for : " +
+                    "keystore builder index = " + builderIndex +
+                    " alias = " + alias, (Object[]) certs);
+        }
+
+        return true;
     }
 
     // Update the credentialsMap with the up-to-date key and certificates

--- a/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
+++ b/test/micro/org/openjdk/bench/java/security/SSLHandshake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,13 +75,15 @@ public class SSLHandshake {
     @Param({"TLSv1.2", "TLS"})
     String tlsVersion;
 
+    @Param({"SunX509", "PKIX"})
+    String keyMgr;
+
     @Setup(Level.Trial)
     public void init() throws Exception {
         KeyStore ks = TestCertificates.getKeyStore();
         KeyStore ts = TestCertificates.getTrustStore();
 
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance(
-                KeyManagerFactory.getDefaultAlgorithm());
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(keyMgr);
         kmf.init(ks, new char[0]);
 
         TrustManagerFactory tmf = TrustManagerFactory.getInstance(


### PR DESCRIPTION
For the PKIX KeyManager and PKCS12 Keystore, when the TLS server sends the ServerHello message and ultimately calls the X509KeyManagerImpl.chooseEngineServerAlias() method, it retrieves the private key from the keystore, decrypts it, and caches both the key and its certificate. This caching currently occurs only during a single handshake. Since decryption can be time-consuming, a modification has been implemented to cache the keystore entries at initialization time. This way, it won't be necessary to retrieve and decrypt the keys for multiple handshakes, which could lead to performance drawbacks.

A change was made to also update/refresh the cached entry as the certificates in the PKCS12 keystore may change, for scenarios like when the certificate expires and a new one is added under a different alias, and the certificate chain returned by the PKCS12 keystore is not the same as the one in the cache. While attempting to handle when to refresh a cached entry to accommodate keystore changes, we would like to know if you agree that this improvement is worth the risk. We would also like to know if you have a preference for other options:

1. Accept that PKIX+PKCS12 is slow.
2. Add a configuration option (system property, maybe) to decide the level of caching (1 - same as the existing one, 2 - same caching as in SunX509KeyManagerImpl, 3 - the new caching introduced in this change).

Additionally, the benchmark test SSLHandshake.java is modified to include a @Param annotation, allowing it to pass different KeyManagerFactory values (SunX509 and PKIX) to the benchmark method.

Running modified SSLHandshake.java test prior to the change that caches the PKCS12 keystore entries for PKIX:
Benchmark                 (keyMgr)  (resume)  (tlsVersion)   Mode  Cnt     Score     Error  Units
SSLHandshake.doHandshake   SunX509      true       TLSv1.2  thrpt   15  9346.292 ? 379.023  ops/s
SSLHandshake.doHandshake   SunX509      true           TLS  thrpt   15   940.175 ?  21.215  ops/s
SSLHandshake.doHandshake   SunX509     false       TLSv1.2  thrpt   15   594.418 ?  23.374  ops/s
SSLHandshake.doHandshake   SunX509     false           TLS  thrpt   15   534.030 ?  16.709  ops/s
SSLHandshake.doHandshake      PKIX      true       TLSv1.2  thrpt   15  9359.086 ? 246.257  ops/s
SSLHandshake.doHandshake      PKIX      true           TLS  thrpt   15   933.835 ?  81.388  ops/s
SSLHandshake.doHandshake      PKIX     false       TLSv1.2  thrpt   15   104.764 ?   3.237  ops/s
SSLHandshake.doHandshake      PKIX     false           TLS  thrpt   15    99.397 ?   5.645  ops/s

Running modified SSLHandshake.java test with the change that caches the PKCS12 keystore entries for PKIX:
Benchmark                 (keyMgr)  (resume)  (tlsVersion)   Mode  Cnt     Score     Error  Units
SSLHandshake.doHandshake   SunX509      true       TLSv1.2  thrpt   15  9580.548 ?  93.887  ops/s
SSLHandshake.doHandshake   SunX509      true           TLS  thrpt   15   897.413 ?  49.559  ops/s
SSLHandshake.doHandshake   SunX509     false       TLSv1.2  thrpt   15   516.918 ?  54.658  ops/s
SSLHandshake.doHandshake   SunX509     false           TLS  thrpt   15   472.145 ?  19.537  ops/s
SSLHandshake.doHandshake      PKIX      true       TLSv1.2  thrpt   15  9283.989 ? 218.025  ops/s
SSLHandshake.doHandshake      PKIX      true           TLS  thrpt   15   838.580 ? 100.300  ops/s
SSLHandshake.doHandshake      PKIX     false       TLSv1.2  thrpt   15   533.631 ?  57.975  ops/s
SSLHandshake.doHandshake      PKIX     false           TLS  thrpt   15   535.980 ?  10.160  ops/s

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322767](https://bugs.openjdk.org/browse/JDK-8322767): TLS full handshake is slow with PKCS12KeyStore and X509KeyManagerImpl (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17956/head:pull/17956` \
`$ git checkout pull/17956`

Update a local copy of the PR: \
`$ git checkout pull/17956` \
`$ git pull https://git.openjdk.org/jdk.git pull/17956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17956`

View PR using the GUI difftool: \
`$ git pr show -t 17956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17956.diff">https://git.openjdk.org/jdk/pull/17956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17956#issuecomment-2005374600)