### PR TITLE
8325681: C2 inliner rejects to inline a deeper callee because the methoddata of caller is immature.

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -462,7 +462,8 @@ int ciMethod::check_overflow(int c, Bytecodes::Code code) {
 ciCallProfile ciMethod::call_profile_at_bci(int bci) {
   ResourceMark rm;
   ciCallProfile result;
-  if (method_data() != nullptr && method_data()->is_mature()) {
+  // take CounterData regardless of maturity.
+  if (method_data() != nullptr) {
     ciProfileData* data = method_data()->bci_to_data(bci);
     if (data != nullptr && data->is_CounterData()) {
       // Every profiled call site has a counter.

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestUnderProfiledSubprocedure.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestUnderProfiledSubprocedure.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+import java.util.ArrayList;
+import java.util.Random;
+import jdk.test.lib.Utils;
+
+/*
+ * @test
+ * @bug 8325681
+ * @summary C2 inliner rejects to inline a deeper callee because the methoddata of caller is immature.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestUnderProfiledSubprocedure
+ */
+public class TestUnderProfiledSubprocedure {
+    @Test
+    @Arguments(setup = "setupCondition")
+    @IR(failOn = {IRNode.ALLOC_OF, "ArrayList"})
+    public void allocationExample(boolean cond) {
+        // We expect Iterative EA of C2 marks x and its associative array non-escaped.
+        var x = new ArrayList<Integer>();
+        if (cond) { // The branch is only taken with possibility ODD%.
+          x.add(0); // ArrayList::add(E) is a subprocedure. It calls ArrayList::add(E, Object[], int).
+                    // when C2 compiles method 'allocateExample', it's possible that the methoddata of ArrayList::add(E) hasn't been mature yet.
+                    // If C2 doesn't inline ArrayList.add, x is ArgEscaped.
+        }
+    }
+
+    // The tipping point is ProfileMaturityPercentage.
+    // When ODD < ProfileMaturityPercentage, it's likely that HotSpot brings method bar() to c2 with premature methoddata.
+    private static final int ODD = 10;
+    private static final Random RANDOM = Utils.getRandomInstance();
+    private static int val = RANDOM.nextInt(100);
+
+    @Setup
+    Object[] setupCondition() {
+        // return true with ODD% possibility.
+        return new Object[]{Boolean.valueOf(RANDOM.nextInt(100) < ODD)};
+    }
+
+    @Test
+    @Arguments(setup = "setupCondition")
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "bar"})
+    @IR(failOn = {IRNode.STATIC_CALL_OF_METHOD, "baz"})
+    public void foo(boolean cond) {
+        if (cond) {
+            bar();
+        }
+    }
+
+    public void bar() {
+        baz();
+    }
+
+    // method baz must be greater than 6 bytecodes(MaxTrivialSize), or it will be inlined as a trivia
+    public int baz() {
+        val = (val-1) * (val+1);
+        return val;
+    }
+
+    public static void main(String[] args)  {
+        TestFramework.run();
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestUnderProfiledSubprocedure.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestUnderProfiledSubprocedure.java
@@ -75,7 +75,7 @@ public class TestUnderProfiledSubprocedure {
         baz();
     }
 
-    // method baz must be greater than 6 bytecodes(MaxTrivialSize), or it will be inlined as a trivia
+    // method baz must be greater than 6 bytecodes(MaxTrivialSize), or it will be inlined as a trivial
     public int baz() {
         val = (val-1) * (val+1);
         return val;


### PR DESCRIPTION
This patch uses the methoddata of a method no matter it is mature or not to initialize `ciCallProfile`. Previously, C2 drops premature methoddata and leaves _count field of ciCallProfile -1. This leads C2 refuses to inline the callsite because its frequency is too low(-1 < MinInlineFrequencyRatio).  

In the given example, we observes that baz was not inlined because of 'low call site frequency'.  This is wrong because its real frequency is 10% > MinInlineFrequencyRatio. 

```
60 13 b 4 UnderProfiledSubprocedure::foo (9 bytes)
                              @ 5 UnderProfiledSubprocedure::bar (6 bytes) inline (hot)
                                @ 1 UnderProfiledSubprocedure::baz (19 bytes) failed to inline: low call site frequency
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325681](https://bugs.openjdk.org/browse/JDK-8325681): C2 inliner rejects to inline a deeper callee because the methoddata of caller is immature. (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17957/head:pull/17957` \
`$ git checkout pull/17957`

Update a local copy of the PR: \
`$ git checkout pull/17957` \
`$ git pull https://git.openjdk.org/jdk.git pull/17957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17957`

View PR using the GUI difftool: \
`$ git pr show -t 17957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17957.diff">https://git.openjdk.org/jdk/pull/17957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17957#issuecomment-1958742608)