### PR TITLE
8326461: tools/jlink/CheckExecutable.java fails as .debuginfo files are not executable

### DIFF
--- a/test/jdk/tools/jlink/CheckExecutable.java
+++ b/test/jdk/tools/jlink/CheckExecutable.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public class CheckExecutable {
 
     // The bin directory may contain non-executable files (see 8132704)
-    private static final String IGNORE = "glob:{*.diz,jmc.ini}";
+    private static final String IGNORE = "glob:{*.diz,jmc.ini,*.debuginfo}";
 
     public static void main(String args[]) throws IOException {
         String JAVA_HOME = System.getProperty("java.home");


### PR DESCRIPTION
Before JDK-8325342(commit id:0bcece995840777db660811e4b20bb018e90439b), all the files in build/linux-x86_64-server-release/images/jdk/bin are executable:

![image](https://github.com/openjdk/jdk/assets/24123821/13f0eae2-7125-4d09-8793-8a5a10b785c2)


After JDK-8325342, all the *.debuginfo files in build/linux-x86_64-server-release/images/jdk/bin are not executable:

![image](https://github.com/openjdk/jdk/assets/24123821/c8d190f2-3db0-439b-82b9-5121567cb1d5)


This PR only modifies the testcase to adapt to the modification of the corresponding build script, ignoring the check of debuginfo file executable permissions, and the risk is low

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326461](https://bugs.openjdk.org/browse/JDK-8326461): tools/jlink/CheckExecutable.java fails as .debuginfo files are not executable (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17958/head:pull/17958` \
`$ git checkout pull/17958`

Update a local copy of the PR: \
`$ git checkout pull/17958` \
`$ git pull https://git.openjdk.org/jdk.git pull/17958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17958`

View PR using the GUI difftool: \
`$ git pr show -t 17958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17958.diff">https://git.openjdk.org/jdk/pull/17958.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17958#issuecomment-1958852878)