### PR TITLE
8318302: ThreadCountLimit.java failed with "Native memory allocation (mprotect) failed to protect 16384 bytes for memory to guard stack pages"

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -489,6 +489,10 @@ void VMError::print_native_stack(outputStream* st, frame fr, Thread* t, bool pri
 static void print_oom_reasons(outputStream* st) {
   st->print_cr("# Possible reasons:");
   st->print_cr("#   The system is out of physical RAM or swap space");
+#ifdef LINUX
+  st->print_cr("#   This process has exceeded the maximum number of memory mappings (check below");
+  st->print_cr("#     for `/proc/sys/vm/max_map_count` and `Total number of mappings`)");
+#endif
   if (UseCompressedOops) {
     st->print_cr("#   This process is running with CompressedOops enabled, and the Java Heap may be blocking the growth of the native heap");
   }

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -139,12 +139,12 @@ public class ThreadCountLimit {
 
     // Now that all threads have joined, we are away from dangerous
     // VM state and have enough memory to perform any other things.
-    if (!reachedNativeOOM) {
-       System.out.println("INFO: reached the time limit " + TIME_LIMIT_MS +
-                          " ms, with " + count + " threads created");
+    if (reachedNativeOOM) {
+      System.out.println("INFO: reached this process thread count limit with " +
+                         count + " threads created");
     } else {
-       System.out.println("INFO: reached this process thread count limit with " +
-                           count + " threads created");
+      System.out.println("INFO: reached the time limit " + TIME_LIMIT_MS +
+                         " ms, with " + count + " threads created");
     }
   }
 }

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -71,7 +71,7 @@ public class ThreadCountLimit {
     if (args.length == 0) {
       // Called from the driver process so exec a new JVM on Linux.
       if (Platform.isLinux()) {
-        // On Linux this test sometimes hit the limit for the maximum number of memory mappings,
+        // On Linux this test sometimes hits the limit for the maximum number of memory mappings,
         // which leads to various other failure modes. Run this test with a limit on how many
         // threads the process is allowed to create, so we hit that limit first.
 

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -26,6 +26,7 @@
  * @summary Stress test that reaches the process limit for thread count, or time limit.
  * @requires os.family != "aix"
  * @key stress
+ * @library /test/lib
  * @run main/othervm -Xmx1g ThreadCountLimit
  */
 
@@ -34,11 +35,16 @@
  * @summary Stress test that reaches the process limit for thread count, or time limit.
  * @requires os.family == "aix"
  * @key stress
+ * @library /test/lib
  * @run main/othervm -Xmx1g -XX:MaxExpectedDataSegmentSize=16g ThreadCountLimit
  */
 
 import java.util.concurrent.CountDownLatch;
 import java.util.ArrayList;
+
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class ThreadCountLimit {
 
@@ -61,21 +67,42 @@ public class ThreadCountLimit {
     }
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+      // Called from the driver process so exec a new JVM on Linux.
+      if (Platform.isLinux()) {
+        // On Linux this test sometimes hit the limit for the maximum number of memory mappings,
+        // which leads to various other failure modes. Run this test with a limit on how many
+        // threads the process is allowed to create, so we hit that limit first.
+
+        final String ULIMIT_CMD = "ulimit -u 4096";
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(ThreadCountLimit.class.getName());
+        String java_cmd = ProcessTools.getCommandLine(pb);
+        // Relaunch the test with args.length > 0, and the ulimit set
+        ProcessTools.executeCommand("bash", "-c", ULIMIT_CMD + " && " + java_cmd + " dummy")
+                    .shouldHaveExitValue(0);
+      } else {
+        // Not Linux so run directly.
+        test();
+      }
+    } else {
+      // This is the exec'd process so run directly.
+      test();
+    }
+  }
+
+  static void test() {
     CountDownLatch startSignal = new CountDownLatch(1);
     ArrayList<Worker> workers = new ArrayList<Worker>();
 
-    boolean reachedTimeLimit = false;
     boolean reachedNativeOOM = false;
-    int countAtTimeLimit = -1;
-    int countAtNativeOOM = -1;
 
     // This is dangerous loop: it depletes system resources,
     // so doing additional things there that may end up allocating
     // Java/native memory risks failing the VM prematurely.
     // Avoid doing unnecessary calls, printouts, etc.
 
-    int count = 1;
+    int count = 0;
     long start = System.currentTimeMillis();
     try {
       while (true) {
@@ -86,16 +113,15 @@ public class ThreadCountLimit {
 
         long end = System.currentTimeMillis();
         if ((end - start) > TIME_LIMIT_MS) {
-          reachedTimeLimit = true;
-          countAtTimeLimit = count;
+          // Windows always gets here, but we also get here if
+          // ulimit is set high enough.
           break;
         }
       }
     } catch (OutOfMemoryError e) {
       if (e.getMessage().contains("unable to create native thread")) {
-        // Linux, macOS path
+        // Linux, macOS path if we hit ulimit
         reachedNativeOOM = true;
-        countAtNativeOOM = count;
       } else {
         throw e;
       }
@@ -113,13 +139,12 @@ public class ThreadCountLimit {
 
     // Now that all threads have joined, we are away from dangerous
     // VM state and have enough memory to perform any other things.
-    if (reachedTimeLimit) {
-       // Windows path or a system with very large ulimit
+    if (!reachedNativeOOM) {
        System.out.println("INFO: reached the time limit " + TIME_LIMIT_MS +
-                          " ms, with " + countAtTimeLimit + " threads created");
-    } else if (reachedNativeOOM) {
+                          " ms, with " + count + " threads created");
+    } else {
        System.out.println("INFO: reached this process thread count limit with " +
-                           countAtNativeOOM + " threads created");
+                           count + " threads created");
     }
   }
 }

--- a/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
+++ b/test/hotspot/jtreg/runtime/Thread/ThreadCountLimit.java
@@ -77,9 +77,9 @@ public class ThreadCountLimit {
 
         final String ULIMIT_CMD = "ulimit -u 4096";
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(ThreadCountLimit.class.getName());
-        String java_cmd = ProcessTools.getCommandLine(pb);
+        String javaCmd = ProcessTools.getCommandLine(pb);
         // Relaunch the test with args.length > 0, and the ulimit set
-        ProcessTools.executeCommand("bash", "-c", ULIMIT_CMD + " && " + java_cmd + " dummy")
+        ProcessTools.executeCommand("bash", "-c", ULIMIT_CMD + " && " + javaCmd + " dummy")
                     .shouldHaveExitValue(0);
       } else {
         // Not Linux so run directly.


### PR DESCRIPTION
The test tries to create as many threads as possible in 5 seconds, with the intention of hitting platform limits on the maximum number of threads that can be created, so that we see that the VM reacts in a reasonable way. However on Linux, if the thread creation limit is high enough, and things run fast enough, then we can instead hit a fatal error when a mmap/mprotect returns E_NOMEM because the maximum number of memory mappings (default 65530) has been exceeded.

The fix to the test (courtesy @stefank ) is to re-exec the test on Linux with `ulimit -u` set to a much smaller value than the default (I chose 4096 as it still showed over 2000 threads were created before failure). This means we are unlikely to hit the default memory mapping limit before we hit the max threads limit.

I also updated the VM's OOM error message to include exceeding the maximum number of memory mappings as a possible cause (with a hint as to what to look for in the hs_err log).

Testing:
 - ran the test 10x on all platforms in our CI (plus local testing)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318302](https://bugs.openjdk.org/browse/JDK-8318302): ThreadCountLimit.java failed with "Native memory allocation (mprotect) failed to protect 16384 bytes for memory to guard stack pages" (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [b0ebf923](https://git.openjdk.org/jdk/pull/17959/files/b0ebf923bc2a6377100a9ccc182371bbac085a6d)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [263c7c41](https://git.openjdk.org/jdk/pull/17959/files/263c7c41815c40ee8e4b99f3b02f1ddf7253d046)


### Contributors
 * Stefan Karlsson `<stefank@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17959/head:pull/17959` \
`$ git checkout pull/17959`

Update a local copy of the PR: \
`$ git checkout pull/17959` \
`$ git pull https://git.openjdk.org/jdk.git pull/17959/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17959`

View PR using the GUI difftool: \
`$ git pr show -t 17959`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17959.diff">https://git.openjdk.org/jdk/pull/17959.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17959#issuecomment-1958869358)