### PR TITLE
8326458: Menu mnemonics don't toggle in Windows LAF when F10 is pressed

### DIFF
--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -139,6 +139,7 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private static class TakeFocus extends AbstractAction {
+        static boolean mnemonicShowHideFlag = false;
         public void actionPerformed(ActionEvent e) {
             JMenuBar menuBar = (JMenuBar)e.getSource();
             JMenu menu = menuBar.getMenu(0);
@@ -148,10 +149,15 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
                 MenuElement[] path = new MenuElement[2];
                 path[0] = (MenuElement)menuBar;
                 path[1] = (MenuElement)menu;
-                msm.setSelectedPath(path);
-
-                // toggle between show and hide mnemonics
-                WindowsLookAndFeel.setMnemonicHidden(!WindowsLookAndFeel.isMnemonicHidden());
+                if (!mnemonicShowHideFlag) {
+                    msm.setSelectedPath(path);
+                    WindowsLookAndFeel.setMnemonicHidden(false);
+                    mnemonicShowHideFlag = true;
+                } else {
+                    msm.clearSelectedPath();
+                    WindowsLookAndFeel.setMnemonicHidden(true);
+                    mnemonicShowHideFlag = false;
+                }
                 WindowsLookAndFeel.repaintRootPane(menuBar);
             }
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -139,7 +139,7 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
      */
     @SuppressWarnings("serial") // Superclass is not serializable across versions
     private static class TakeFocus extends AbstractAction {
-        static boolean mnemonicShowHideFlag = false;
+        @Override
         public void actionPerformed(ActionEvent e) {
             JMenuBar menuBar = (JMenuBar)e.getSource();
             JMenu menu = menuBar.getMenu(0);

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -150,8 +150,8 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
                 path[1] = (MenuElement)menu;
                 msm.setSelectedPath(path);
 
-                // show mnemonics
-                WindowsLookAndFeel.setMnemonicHidden(false);
+                // toggle between show and hide mnemonics
+                WindowsLookAndFeel.setMnemonicHidden(!WindowsLookAndFeel.isMnemonicHidden());
                 WindowsLookAndFeel.repaintRootPane(menuBar);
             }
         }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -146,17 +146,17 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
             if (menu != null) {
                 MenuSelectionManager msm =
                     MenuSelectionManager.defaultManager();
-                MenuElement[] path = new MenuElement[2];
-                path[0] = (MenuElement)menuBar;
-                path[1] = (MenuElement)menu;
-                if (!mnemonicShowHideFlag) {
-                    msm.setSelectedPath(path);
-                    WindowsLookAndFeel.setMnemonicHidden(false);
-                    mnemonicShowHideFlag = true;
-                } else {
+                MenuElement[] selectedPath = msm.getSelectedPath();
+                //MenuElement[] path = new MenuElement[2];
+                //path[0] = (MenuElement)menuBar;
+                //path[1] = (MenuElement)menu;
+                if (selectedPath.length > 0 && (selectedPath[0] instanceof JMenuBar)) {
                     msm.clearSelectedPath();
                     WindowsLookAndFeel.setMnemonicHidden(true);
-                    mnemonicShowHideFlag = false;
+                } else {
+                    MenuElement[] path = {menuBar, menu};
+                    msm.setSelectedPath(path);
+                    WindowsLookAndFeel.setMnemonicHidden(false);
                 }
                 WindowsLookAndFeel.repaintRootPane(menuBar);
             }

--- a/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
+++ b/src/java.desktop/windows/classes/com/sun/java/swing/plaf/windows/WindowsMenuBarUI.java
@@ -147,9 +147,6 @@ public class WindowsMenuBarUI extends BasicMenuBarUI
                 MenuSelectionManager msm =
                     MenuSelectionManager.defaultManager();
                 MenuElement[] selectedPath = msm.getSelectedPath();
-                //MenuElement[] path = new MenuElement[2];
-                //path[0] = (MenuElement)menuBar;
-                //path[1] = (MenuElement)menu;
                 if (selectedPath.length > 0 && (selectedPath[0] instanceof JMenuBar)) {
                     msm.clearSelectedPath();
                     WindowsLookAndFeel.setMnemonicHidden(true);

--- a/test/jdk/javax/swing/JMenu/TestMenuMnemonic.java
+++ b/test/jdk/javax/swing/JMenu/TestMenuMnemonic.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8326458
+ * @key headful
+ * @requires (os.family == "windows")
+ * @modules java.desktop/com.sun.java.swing.plaf.windows
+ * @summary Verifies if menu mnemonics toggle between show or hide
+ *          on F10 press in windows LAF.
+ * @run main TestMenuMnemonic
+ */
+
+import java.awt.event.KeyEvent;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import javax.swing.JMenuBar;
+import javax.swing.MenuElement;
+import javax.swing.MenuSelectionManager;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import com.sun.java.swing.plaf.windows.WindowsLookAndFeel;
+
+public class TestMenuMnemonic {
+
+    private static JFrame frame;
+    private static JMenuBar menuBar;
+    private static JMenu fileMenu;
+    private static JMenu editMenu;
+    private static JMenuItem item1;
+    private static JMenuItem item2;
+    private static int expectedMnemonicShowHideCount = 5;
+
+    public static void main(String[] args) throws Exception {
+        UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
+        Robot robot = new Robot();
+        robot.setAutoDelay(100);
+        int mnemonicHideCount = 0;
+        int mnemonicShowCount = 0;
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                createAndShowUI();
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            for (int i = 0; i < 10; i++) {
+                robot.keyPress(KeyEvent.VK_F10);
+                robot.waitForIdle();
+                robot.delay(50);
+                robot.keyRelease(KeyEvent.VK_F10);
+                MenuSelectionManager msm =
+                        MenuSelectionManager.defaultManager();
+                MenuElement[] selectedPath = msm.getSelectedPath();
+                if (WindowsLookAndFeel.isMnemonicHidden()) {
+                    mnemonicHideCount++;
+                    // check if selection is cleared when mnemonics are hidden
+                    if (selectedPath.length != 0) {
+                        throw new RuntimeException("Menubar is active even after" +
+                                " mnemonics are hidden");
+                    }
+                } else {
+                    mnemonicShowCount++;
+                    if (selectedPath.length == 0 &&
+                        (selectedPath[0] != menuBar || selectedPath[1] != fileMenu)) {
+                        throw new RuntimeException("No Menu and Menubar is active when" +
+                                " mnemonics are shown");
+                    }
+                }
+            }
+            robot.waitForIdle();
+            robot.delay(1000);
+            if (mnemonicShowCount != expectedMnemonicShowHideCount
+                && mnemonicHideCount != expectedMnemonicShowHideCount) {
+                throw new RuntimeException("Mismatch in Mnemonic show/hide on F10 press");
+            }
+
+
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new JFrame("Test Menu Mnemonic Show/Hide");
+        menuBar  = new JMenuBar();
+        fileMenu = new JMenu("File");
+        editMenu = new JMenu("Edit");
+        fileMenu.setMnemonic(KeyEvent.VK_F);
+        editMenu.setMnemonic(KeyEvent.VK_E);
+        item1 = new JMenuItem("Item 1");
+        item2 = new JMenuItem("Item 2");
+        fileMenu.add(item1);
+        fileMenu.add(item2);
+        menuBar.add(fileMenu);
+        menuBar.add(editMenu);
+        frame.setJMenuBar(menuBar);
+        frame.pack();
+        frame.setSize(250, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+    }
+}
+

--- a/test/jdk/javax/swing/JMenuBar/TestMenuMnemonic.java
+++ b/test/jdk/javax/swing/JMenuBar/TestMenuMnemonic.java
@@ -50,15 +50,16 @@ public class TestMenuMnemonic {
     private static JFrame frame;
     private static JMenuBar menuBar;
     private static JMenu fileMenu;
+
     private static final AtomicInteger mnemonicHideCount = new AtomicInteger(0);
     private static final AtomicInteger mnemonicShowCount = new AtomicInteger(0);
 
+    private static final int EXPECTED = 5;
+
     public static void main(String[] args) throws Exception {
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.windows.WindowsLookAndFeel");
-        final int EXPECTED = 5;
         Robot robot = new Robot();
         robot.setAutoDelay(100);
-
 
         try {
             SwingUtilities.invokeAndWait(TestMenuMnemonic::createAndShowUI);
@@ -94,7 +95,7 @@ public class TestMenuMnemonic {
         MenuElement[] selectedPath = msm.getSelectedPath();
         if (WindowsLookAndFeel.isMnemonicHidden()) {
             mnemonicHideCount.getAndIncrement();
-            // check if selection is cleared when mnemonics are hidden
+            // Check if selection is cleared when mnemonics are hidden
             if (selectedPath.length != 0) {
                 throw new RuntimeException("Menubar is active after" +
                         " mnemonics are hidden");


### PR DESCRIPTION
Menu mnemonic doesn't toggle between show and hide state when F10 is pressed. Behavior is not similar to windows native application. Fix is to ensure that menu mnemonic state toggles between show and hide.

Can be verified with SwingSet2 application. 
CI tests are green with the fix. Link posted in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326458](https://bugs.openjdk.org/browse/JDK-8326458): Menu mnemonics don't toggle in Windows LAF when F10 is pressed (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [83818438](https://git.openjdk.org/jdk/pull/17961/files/8381843861e90c45a53ffc5cf8cd818872a8ea85)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17961/head:pull/17961` \
`$ git checkout pull/17961`

Update a local copy of the PR: \
`$ git checkout pull/17961` \
`$ git pull https://git.openjdk.org/jdk.git pull/17961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17961`

View PR using the GUI difftool: \
`$ git pr show -t 17961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17961.diff">https://git.openjdk.org/jdk/pull/17961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17961#issuecomment-1959232928)