### PR TITLE
8326421: Add jtreg test for large arrayCopy disjoint case.

### DIFF
--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjointLarge.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjointLarge.java
@@ -29,7 +29,7 @@ import java.util.Random;
  * @bug 8310159
  * @summary Test large arrayCopy.
  *
- * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch compiler.arraycopy.TestArrayCopyDisjointLarge
+ * @run main/timeout=600 compiler.arraycopy.TestArrayCopyDisjointLarge
  *
  */
 
@@ -70,15 +70,18 @@ public class TestArrayCopyDisjointLarge {
 
     public static void main(String [] args) {
         int base_size = 2621440;
+        Random r = new Random(1024);
         int [] lengths = {base_size - 1, base_size, base_size + 1, base_size + 63, base_size + 64,
-                                base_size + 65, base_size + 255, base_size + 256, base_size + 257};
+                                base_size + 65, base_size + 255, base_size + 256, base_size + 257,
+                                base_size + r.nextInt(2048)};
         setup();
 
-        for (int i = 0 ; i < 10 ; i++ ) {
+        for (int i = 0 ; i < 20 ; i++ ) {
             testByte(lengths[i % lengths.length], 0, 0);
             testByte(lengths[i % lengths.length], 0, 9);
             testByte(lengths[i % lengths.length], 9, 0);
             testByte(lengths[i % lengths.length], 9, 9);
+            testByte(lengths[i % lengths.length], r.nextInt(2048) , r.nextInt(2048));
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjointLarge.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyDisjointLarge.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.arraycopy;
+import java.util.Random;
+
+/**
+ * @test
+ * @bug 8310159
+ * @summary Test large arrayCopy.
+ *
+ * @run main/othervm/timeout=600 -XX:-TieredCompilation -Xbatch compiler.arraycopy.TestArrayCopyDisjointLarge
+ *
+ */
+
+public class TestArrayCopyDisjointLarge {
+
+    public static final int ARRLEN = 4194304;
+    public static int fromPos, toPos;
+    public static byte[] fromByteArr, toByteArr;
+
+    public static void setup() {
+        fromPos = 0;
+        toPos = 0;
+
+        fromByteArr = new byte[ARRLEN];
+        toByteArr = new byte[ARRLEN];
+        for (int i = 0 ; i < ARRLEN ; i++) {
+            fromByteArr[i] = (byte)i;
+        }
+    }
+
+    public static void validate(String msg, byte[] toByteArr, int length, int fromPos, int toPos) {
+        for(int i = 0 ; i < length; i++) {
+            if (fromByteArr[i + fromPos] != toByteArr[i + toPos]) {
+                System.out.println(msg + "[" + toByteArr.getClass() + "] Result mismtach at i = " + i
+                                + " expected = " + fromByteArr[i + fromPos]
+                                + " actual   = " + toByteArr[i + toPos]
+                                + " fromPos = " + fromPos
+                                + " toPos = " + toPos);
+                throw new Error("Fail");
+            }
+        }
+    }
+
+    public static void testByte(int length, int fromPos, int toPos) {
+        System.arraycopy(fromByteArr, fromPos, toByteArr, toPos, length);
+        validate(" Test ByteArr ", toByteArr, length, fromPos, toPos);
+    }
+
+    public static void main(String [] args) {
+        int base_size = 2621440;
+        int [] lengths = {base_size - 1, base_size, base_size + 1, base_size + 63, base_size + 64,
+                                base_size + 65, base_size + 255, base_size + 256, base_size + 257};
+        setup();
+
+        for (int i = 0 ; i < 10 ; i++ ) {
+            testByte(lengths[i % lengths.length], 0, 0);
+            testByte(lengths[i % lengths.length], 0, 9);
+            testByte(lengths[i % lengths.length], 9, 0);
+            testByte(lengths[i % lengths.length], 9, 9);
+        }
+    }
+}


### PR DESCRIPTION
Hi All,

Added a new jtreg test case for large arrayCopy disjoint case. 
This will test byte array copy operation for aligned and non aligned cases with array length greater than 2.5MB.

Please review and provide your feedback.

Thanks,
Swati
Intel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326421](https://bugs.openjdk.org/browse/JDK-8326421): Add jtreg test for large arrayCopy disjoint case. (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Contributors
 * Steve Dohrmann `<steve.dohrmann@intel.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17962/head:pull/17962` \
`$ git checkout pull/17962`

Update a local copy of the PR: \
`$ git checkout pull/17962` \
`$ git pull https://git.openjdk.org/jdk.git pull/17962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17962`

View PR using the GUI difftool: \
`$ git pr show -t 17962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17962.diff">https://git.openjdk.org/jdk/pull/17962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17962#issuecomment-1959420098)