### PR TITLE
8327042: G1: Parallelism used for redirty logged cards needs better control.

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -114,7 +114,7 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
 }
 
 size_t G1ParScanThreadState::flush_stats(size_t* surviving_young_words, uint num_workers, BufferNodeList* rdc_buffers) {
-  _rdc_local_qset.flush(rdc_buffers);
+  *rdc_buffers = _rdc_local_qset.flush();
   flush_numa_stats();
   // Update allocation statistics.
   _plab_allocator->flush_and_retire_stats(num_workers);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -113,15 +113,15 @@ G1ParScanThreadState::G1ParScanThreadState(G1CollectedHeap* g1h,
   initialize_numa_stats();
 }
 
-size_t G1ParScanThreadState::flush_stats(size_t* surviving_young_words, uint num_workers) {
-  _rdc_local_qset.flush();
+size_t G1ParScanThreadState::flush_stats(size_t* surviving_young_words, uint num_workers, BufferNodeList* rdc_buffers) {
+  _rdc_local_qset.flush(rdc_buffers);
   flush_numa_stats();
   // Update allocation statistics.
   _plab_allocator->flush_and_retire_stats(num_workers);
   _g1h->policy()->record_age_table(&_age_table);
 
   if (_evacuation_failed_info.has_failed()) {
-     _g1h->gc_tracer_stw()->report_evacuation_failed(_evacuation_failed_info);
+    _g1h->gc_tracer_stw()->report_evacuation_failed(_evacuation_failed_info);
   }
 
   size_t sum = 0;
@@ -593,7 +593,6 @@ const size_t* G1ParScanThreadStateSet::surviving_young_words() const {
 
 void G1ParScanThreadStateSet::flush_stats() {
   assert(!_flushed, "thread local state from the per thread states should be flushed once");
-
   for (uint worker_id = 0; worker_id < _num_workers; ++worker_id) {
     G1ParScanThreadState* pss = _states[worker_id];
     assert(pss != nullptr, "must be initialized");
@@ -604,7 +603,7 @@ void G1ParScanThreadStateSet::flush_stats() {
     // because it resets the PLAB allocator where we get this info from.
     size_t lab_waste_bytes = pss->lab_waste_words() * HeapWordSize;
     size_t lab_undo_waste_bytes = pss->lab_undo_waste_words() * HeapWordSize;
-    size_t copied_bytes = pss->flush_stats(_surviving_young_words_total, _num_workers) * HeapWordSize;
+    size_t copied_bytes = pss->flush_stats(_surviving_young_words_total, _num_workers, &_rdc_buffers[worker_id]) * HeapWordSize;
     size_t evac_fail_enqueued_cards = pss->evac_failure_enqueued_cards();
 
     p->record_or_add_thread_work_item(G1GCPhaseTimes::MergePSS, worker_id, copied_bytes, G1GCPhaseTimes::MergePSSCopiedBytes);
@@ -706,6 +705,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
     _rdcqs(G1BarrierSet::dirty_card_queue_set().allocator()),
     _preserved_marks_set(true /* in_c_heap */),
     _states(NEW_C_HEAP_ARRAY(G1ParScanThreadState*, num_workers, mtGC)),
+    _rdc_buffers(NEW_C_HEAP_ARRAY(BufferNodeList, num_workers, mtGC)),
     _surviving_young_words_total(NEW_C_HEAP_ARRAY(size_t, collection_set->young_region_length() + 1, mtGC)),
     _num_workers(num_workers),
     _flushed(false),
@@ -713,6 +713,7 @@ G1ParScanThreadStateSet::G1ParScanThreadStateSet(G1CollectedHeap* g1h,
   _preserved_marks_set.init(num_workers);
   for (uint i = 0; i < num_workers; ++i) {
     _states[i] = nullptr;
+    _rdc_buffers[i] = BufferNodeList();
   }
   memset(_surviving_young_words_total, 0, (collection_set->young_region_length() + 1) * sizeof(size_t));
 }
@@ -721,5 +722,6 @@ G1ParScanThreadStateSet::~G1ParScanThreadStateSet() {
   assert(_flushed, "thread local state from the per thread states should have been flushed");
   FREE_C_HEAP_ARRAY(G1ParScanThreadState*, _states);
   FREE_C_HEAP_ARRAY(size_t, _surviving_young_words_total);
+  FREE_C_HEAP_ARRAY(BufferNodeList, _rdc_buffers);
   _preserved_marks_set.reclaim();
 }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -614,6 +614,11 @@ void G1ParScanThreadStateSet::flush_stats() {
     delete pss;
     _states[worker_id] = nullptr;
   }
+
+  G1DirtyCardQueueSet& dcq = G1BarrierSet::dirty_card_queue_set();
+  dcq.merge_bufferlists(rdcqs());
+  rdcqs()->verify_empty();
+
   _flushed = true;
 }
 

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -166,7 +166,7 @@ public:
 
   // Pass locally gathered statistics to global state. Returns the total number of
   // HeapWords copied.
-  size_t flush_stats(size_t* surviving_young_words, uint num_workers);
+  size_t flush_stats(size_t* surviving_young_words, uint num_workers, BufferNodeList* buffer_log);
 
 private:
   void do_partial_array(PartialArrayScanTask task);
@@ -247,6 +247,7 @@ class G1ParScanThreadStateSet : public StackObj {
   G1RedirtyCardsQueueSet _rdcqs;
   PreservedMarksSet _preserved_marks_set;
   G1ParScanThreadState** _states;
+  BufferNodeList* _rdc_buffers;
   size_t* _surviving_young_words_total;
   uint _num_workers;
   bool _flushed;
@@ -260,12 +261,14 @@ class G1ParScanThreadStateSet : public StackObj {
   ~G1ParScanThreadStateSet();
 
   G1RedirtyCardsQueueSet* rdcqs() { return &_rdcqs; }
+  BufferNodeList* rdc_buffers() { return _rdc_buffers; }
   PreservedMarksSet* preserved_marks_set() { return &_preserved_marks_set; }
 
   void flush_stats();
   void record_unused_optional_region(HeapRegion* hr);
 
   G1ParScanThreadState* state_for_worker(uint worker_id);
+  uint num_workers() const { return _num_workers; }
 
   const size_t* surviving_young_words() const;
 };

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
@@ -65,11 +65,12 @@ void G1RedirtyCardsLocalQueueSet::enqueue(void* value) {
   }
 }
 
-void G1RedirtyCardsLocalQueueSet::flush(BufferNodeList* rdc_buffers) {
+BufferNodeList G1RedirtyCardsLocalQueueSet::flush() {
   flush_queue(_queue);
-  *rdc_buffers = _buffers;
+  BufferNodeList cur_buffers = _buffers;
   _shared_qset->add_bufferlist(_buffers);
   _buffers = BufferNodeList();
+  return cur_buffers;
 }
 
 // G1RedirtyCardsLocalQueueSet::Queue

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.cpp
@@ -65,8 +65,9 @@ void G1RedirtyCardsLocalQueueSet::enqueue(void* value) {
   }
 }
 
-void G1RedirtyCardsLocalQueueSet::flush() {
+void G1RedirtyCardsLocalQueueSet::flush(BufferNodeList* rdc_buffers) {
   flush_queue(_queue);
+  *rdc_buffers = _buffers;
   _shared_qset->add_bufferlist(_buffers);
   _buffers = BufferNodeList();
 }

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
@@ -56,7 +56,9 @@ public:
   void enqueue(void* value);
 
   // Transfer all completed buffers to the shared qset.
-  void flush(BufferNodeList* buffer_log);
+  // Returns the flushed BufferNodeList which is later used
+  // as a shortcut into the shared qset.
+  BufferNodeList flush();
 };
 
 // Card table entries to be redirtied and the cards reprocessed later.

--- a/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
+++ b/src/hotspot/share/gc/g1/g1RedirtyCardsQueue.hpp
@@ -56,7 +56,7 @@ public:
   void enqueue(void* value);
 
   // Transfer all completed buffers to the shared qset.
-  void flush();
+  void flush(BufferNodeList* buffer_log);
 };
 
 // Card table entries to be redirtied and the cards reprocessed later.

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -591,14 +591,16 @@ public:
 
 class G1PostEvacuateCollectionSetCleanupTask2::RedirtyLoggedCardsTask : public G1AbstractSubTask {
   G1RedirtyCardsQueueSet* _rdcqs;
-  BufferNode* volatile _nodes;
+  BufferNodeList* _rdc_buffers;
+  uint _num_buffer_lists;
   G1EvacFailureRegions* _evac_failure_regions;
 
 public:
-  RedirtyLoggedCardsTask(G1RedirtyCardsQueueSet* rdcqs, G1EvacFailureRegions* evac_failure_regions) :
+  RedirtyLoggedCardsTask(G1RedirtyCardsQueueSet* rdcqs, G1EvacFailureRegions* evac_failure_regions, BufferNodeList* rdc_buffers, uint num_buffer_lists) :
     G1AbstractSubTask(G1GCPhaseTimes::RedirtyCards),
     _rdcqs(rdcqs),
-    _nodes(rdcqs->all_completed_buffers()),
+    _rdc_buffers(rdc_buffers),
+    _num_buffer_lists(num_buffer_lists),
     _evac_failure_regions(evac_failure_regions) { }
 
   virtual ~RedirtyLoggedCardsTask() {
@@ -614,13 +616,23 @@ public:
 
   void do_work(uint worker_id) override {
     RedirtyLoggedCardTableEntryClosure cl(G1CollectedHeap::heap(), _evac_failure_regions);
-    BufferNode* next = Atomic::load(&_nodes);
-    while (next != nullptr) {
-      BufferNode* node = next;
-      next = Atomic::cmpxchg(&_nodes, node, node->next());
-      if (next == node) {
-        cl.apply_to_buffer(node, worker_id);
-        next = node->next();
+
+    uint start = worker_id;
+    for (uint i = 0; i < _num_buffer_lists; i++) {
+      uint index = (start + i) % _num_buffer_lists;
+
+      BufferNode* next = Atomic::load(&_rdc_buffers[index]._head);
+      BufferNode* tail = Atomic::load(&_rdc_buffers[index]._tail);
+
+      while (next != nullptr) {
+        BufferNode* node = next;
+        next = Atomic::cmpxchg(&_rdc_buffers[index]._head, node, (node != tail ) ? node->next() : nullptr);
+        if (next == node) {
+          cl.apply_to_buffer(node, worker_id);
+          next = (node != tail ) ? node->next() : nullptr;
+        } else {
+          break; // If there is contention, move to the next BufferNodeList
+        }
       }
     }
     record_work_item(worker_id, 0, cl.num_dirtied());
@@ -970,7 +982,10 @@ G1PostEvacuateCollectionSetCleanupTask2::G1PostEvacuateCollectionSetCleanupTask2
     add_parallel_task(new RestorePreservedMarksTask(per_thread_states->preserved_marks_set()));
     add_parallel_task(new ProcessEvacuationFailedRegionsTask(evac_failure_regions));
   }
-  add_parallel_task(new RedirtyLoggedCardsTask(per_thread_states->rdcqs(), evac_failure_regions));
+  add_parallel_task(new RedirtyLoggedCardsTask(per_thread_states->rdcqs(),
+                    evac_failure_regions, per_thread_states->rdc_buffers(),
+                    per_thread_states->num_workers()));
+
   if (UseTLAB && ResizeTLAB) {
     add_parallel_task(new ResizeTLABsTask());
   }

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -601,8 +601,6 @@ public:
     _num_buffer_lists(num_buffer_lists),
     _evac_failure_regions(evac_failure_regions) { }
 
-  virtual ~RedirtyLoggedCardsTask() = default;
-
   double worker_cost() const override {
     // Needs more investigation.
     return G1CollectedHeap::heap()->workers()->active_workers();


### PR DESCRIPTION
Please review this change that provides better scaling of the `RedirtyLoggedCardsTask` with high number of worker threads. In the current implementation, the threads  contend for access to the Log Buffers through a single BufferNode resulting in a bottleneck as we increase the threads. The cost per card is pretty low, thus the work distribution overhead dominates the task. 

The new approach preserves the BufferNodeList states from G1ParScanThreadState, which effectively act as fingers (short cuts) into the list of buffers within `G1RedirtyCardsQueueSet`. We use these  BufferNodeList states to distribute BufferNodes for "redirtying" to the worker threads. By creating multiple points of access to the buffers, this method significantly reduces synchronization overheads and eliminates the bottleneck.

I have attached results from the Big Ram Tester microbenchmark on a server that spins up 163 worker threads for the `RedirtyLoggedCardsTask`

![prepare_mixed](https://github.com/openjdk/jdk/assets/69453999/7120aa59-9b84-4e32-ac58-129ff31bb668)
![normal](https://github.com/openjdk/jdk/assets/69453999/7aafb72e-8f18-410d-9f1b-0c0adcd78b03)
![mixed](https://github.com/openjdk/jdk/assets/69453999/8a115d9c-56d3-4654-931e-1fa84987915d)
![concurrent_start](https://github.com/openjdk/jdk/assets/69453999/783d8804-b7b8-42a7-976c-4c217636157b)


Testing: Tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327042](https://bugs.openjdk.org/browse/JDK-8327042): G1: Parallelism used for redirty logged cards needs better control. (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [45b3032d](https://git.openjdk.org/jdk/pull/17963/files/45b3032d0da11aa0fa30f8deae1abf5cd8affbd0)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [395e0aea](https://git.openjdk.org/jdk/pull/17963/files/395e0aea1884d855850fdd0435833b96256c56fb)


### Contributors
 * Thomas Schatzl `<tschatzl@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17963/head:pull/17963` \
`$ git checkout pull/17963`

Update a local copy of the PR: \
`$ git checkout pull/17963` \
`$ git pull https://git.openjdk.org/jdk.git pull/17963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17963`

View PR using the GUI difftool: \
`$ git pr show -t 17963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17963.diff">https://git.openjdk.org/jdk/pull/17963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17963#issuecomment-1959421627)