### PR TITLE
8322962: Upcall stub might go undetected when freezing frames

### DIFF
--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -245,8 +245,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(rmethod, entry);
   __ str(rmethod, Address(rthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
 
+  __ push_cont_fastpath(rthread);
+
   __ ldr(rscratch1, Address(rmethod, Method::from_compiled_offset()));
   __ blr(rscratch1);
+
+  __ pop_cont_fastpath(rthread);
 
     // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -243,9 +243,13 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ load_const_optimized(R19_method, (intptr_t)entry);
   __ std(R19_method, in_bytes(JavaThread::callee_target_offset()), R16_thread);
 
+  __ push_cont_fastpath();
+
   __ ld(call_target_address, in_bytes(Method::from_compiled_offset()), R19_method);
   __ mtctr(call_target_address);
   __ bctrl();
+
+  __ pop_cont_fastpath();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
@@ -267,8 +267,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(xmethod, entry);
   __ sd(xmethod, Address(xthread, JavaThread::callee_target_offset())); // just in case callee is deoptimized
 
+  __ push_cont_fastpath(xthread);
+
   __ ld(t0, Address(xmethod, Method::from_compiled_offset()));
   __ jalr(t0);
+
+  __ pop_cont_fastpath(xthread);
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -300,7 +300,11 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
   __ mov_metadata(rbx, entry);
   __ movptr(Address(r15_thread, JavaThread::callee_target_offset()), rbx); // just in case callee is deoptimized
 
+  __ push_cont_fastpath();
+
   __ call(Address(rbx, Method::from_compiled_offset()));
+
+  __ pop_cont_fastpath();
 
   // return value shuffle
   if (!needs_return_buffer) {

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -390,7 +390,7 @@ public:
   inline int size_if_fast_freeze_available();
 
 #ifdef ASSERT
-  bool interpreted_native_or_deoptimized_on_stack();
+  bool check_valid_fast_path();
 #endif
 
 protected:
@@ -1514,7 +1514,10 @@ static bool monitors_on_stack(JavaThread* thread) {
   return false;
 }
 
-bool FreezeBase::interpreted_native_or_deoptimized_on_stack() {
+// There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c
+// adapter or called Deoptimization::unpack_frames. As for native frames, upcalls from JNI also go through the
+// interpreter (see JavaCalls::call_helper), while the UpcallLinker explicitly sets cont_fastpath.
+bool FreezeBase::check_valid_fast_path() {
   ContinuationEntry* ce = _thread->last_continuation();
   RegisterMap map(_thread,
                   RegisterMap::UpdateMap::skip,
@@ -1522,11 +1525,11 @@ bool FreezeBase::interpreted_native_or_deoptimized_on_stack() {
                   RegisterMap::WalkContinuation::skip);
   map.set_include_argument_oops(false);
   for (frame f = freeze_start_frame(); Continuation::is_frame_in_continuation(ce, f); f = f.sender(&map)) {
-    if (f.is_interpreted_frame() || f.is_native_frame() || f.is_deoptimized_frame()) {
-      return true;
+    if (!f.is_compiled_frame() || f.is_deoptimized_frame()) {
+      return false;
     }
   }
-  return false;
+  return true;
 }
 #endif // ASSERT
 
@@ -1588,11 +1591,7 @@ static inline int freeze_internal(JavaThread* current, intptr_t* const sp) {
 
   Freeze<ConfigT> freeze(current, cont, sp);
 
-  // There are no interpreted frames if we're not called from the interpreter and we haven't ancountered an i2c
-  // adapter or called Deoptimization::unpack_frames. Calls from native frames also go through the interpreter
-  // (see JavaCalls::call_helper).
-  assert(!current->cont_fastpath()
-         || (current->cont_fastpath_thread_state() && !freeze.interpreted_native_or_deoptimized_on_stack()), "");
+  assert(!current->cont_fastpath() || freeze.check_valid_fast_path(), "");
   bool fast = UseContinuationFastPath && current->cont_fastpath();
   if (fast && freeze.size_if_fast_freeze_available() > 0) {
     freeze.freeze_fast_existing_chunk();

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -43,6 +43,7 @@ import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import jdk.test.lib.thread.VThreadRunner;
+import jdk.test.lib.thread.VThreadPinner;
 
 public class GetStackTraceALotWhenPinned {
 
@@ -65,13 +66,14 @@ public class GetStackTraceALotWhenPinned {
                 barrier.await();
 
                 Thread.yield();
-                synchronized (GetStackTraceALotWhenPinned.class) {
-                    if (timed) {
+                boolean b = timed;
+                VThreadPinner.runPinned(() -> {
+                    if (b) {
                         LockSupport.parkNanos(Long.MAX_VALUE);
                     } else {
                         LockSupport.park();
                     }
-                }
+                });
                 timed = !timed;
             }
         });


### PR DESCRIPTION
Please review this simple fix. There is a missing push_cont_fastpath()/pop_cont_fastpath() around the call to Java in the upcall stub. Because of this, if from that upcall a virtual thread tries to yield, and all the other methods in the stack are compiled, we will incorrectly take the freeze fast path and freeze everything in the stack including the native frames. By forcing the slow path instead we will identify the upcall stub and pin the vthread.

The issue can be easily reproduced by running the modified version of test GetStackTraceALotWhenPinned.java included in this patch. I also tested the fix by running tiers1-3 in mach5. 

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322962](https://bugs.openjdk.org/browse/JDK-8322962): Upcall stub might go undetected when freezing frames (**Bug** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) ⚠️ Review applies to [5404cf02](https://git.openjdk.org/jdk/pull/17964/files/5404cf0283ce00293159478510036326f0130102)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [5404cf02](https://git.openjdk.org/jdk/pull/17964/files/5404cf0283ce00293159478510036326f0130102)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [5404cf02](https://git.openjdk.org/jdk/pull/17964/files/5404cf0283ce00293159478510036326f0130102)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [5404cf02](https://git.openjdk.org/jdk/pull/17964/files/5404cf0283ce00293159478510036326f0130102)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17964/head:pull/17964` \
`$ git checkout pull/17964`

Update a local copy of the PR: \
`$ git checkout pull/17964` \
`$ git pull https://git.openjdk.org/jdk.git pull/17964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17964`

View PR using the GUI difftool: \
`$ git pr show -t 17964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17964.diff">https://git.openjdk.org/jdk/pull/17964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17964#issuecomment-1959600585)