### PR TITLE
8323972: C2 compilation fails with assert(!x->as_Loop()->is_loop_nest_inner_loop()) failed: loop was transformed

### DIFF
--- a/test/hotspot/jtreg/compiler/longcountedloops/TestInaccurateInnerLoopLimit.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestInaccurateInnerLoopLimit.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8323972
+ * @summary C2 compilation fails with assert(!x->as_Loop()->is_loop_nest_inner_loop()) failed: loop was transformed
+ *
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,TestInaccurateInnerLoopLimit::test* -XX:-TieredCompilation TestInaccurateInnerLoopLimit
+ *
+ */
+
+public class TestInaccurateInnerLoopLimit {
+
+    public static void main(String args[]) {
+        test();
+    }
+
+    public static void test() {
+        for (long i = 9223372034707292164L; i > 9223372034707292158L; i += -2L) { }
+    }
+}


### PR DESCRIPTION
Long counted loop are transformed into a loop nest of 2 "regular"
loops and in a subsequent loop opts round, the inner loop is
transformed into a counted loop. The limit for the inner loop is set,
when the loop nest is created, so it's expected there's no need for a
loop limit check when the counted loop is created. The assert fires
because, when the counted loop is created, it is found that it needs a
loop limit check. The reason for that is that the limit is
transformed, between nest creation and counted loop creation, in a way
that the range of values of the inner loop's limit becomes
unknown. The limit when the nest is created is:

```
 111  ConL  === 0  [[ 112 ]]  #long:-9223372034707292158
 106  Phi  === 105 20 94  [[ 112 ]]  #long:9223372034707292160..9223372034707292164:www !orig=72 !jvms: TestInaccurateInnerLoopLimit::test @ bci:12 (line 40)
 112  AddL  === _ 106 111  [[ 122 ]]  !orig=[110]
 122  ConvL2I  === _ 112  [[ ]]  #int
```

The type of 122 is `2..6` but it is then transformed to:

```
 106  Phi  === 105 20 154  [[ 191 130 137 ]]  #long:9223372034707292160..9223372034707292164:www !orig=[72] !jvms: TestInaccurateInnerLoopLimit::test @ bci:12 (line 40)
 191  ConvL2I  === _ 106  [[ 196 ]]  #int
 195  ConI  === 0  [[ 196 ]]  #int:max-1
 196  SubI  === _ 195 191  [[ 201 127 ]]  !orig=[123]
```

That is the `(ConvL2I (AddL ...))` is transformed into a `(SubI
(ConvL2I ))`. `ConvL2I` for an input that's out of the int range of
values returns TypeInt::INT and the bounds of the limit are lost. I
propose adding a `CastII` after the `ConvL2I` so the range of values
of the limit doesn't get lost.

