### PR TITLE
JDK-8325139: JFR SwapSpace event - add free swap space information on Linux when running in a container environment

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -264,6 +264,7 @@ class CgroupSubsystem: public CHeapObj<mtInternal> {
     virtual jlong pids_current() = 0;
     virtual jlong memory_usage_in_bytes() = 0;
     virtual jlong memory_and_swap_limit_in_bytes() = 0;
+    virtual jlong memory_and_swap_usage_in_bytes() = 0;
     virtual jlong memory_soft_limit_in_bytes() = 0;
     virtual jlong memory_max_usage_in_bytes() = 0;
     virtual jlong rss_usage_in_bytes() = 0;

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,9 +177,6 @@ jlong CgroupV1Subsystem::memory_and_swap_usage_in_bytes() {
       GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.memsw.usage_in_bytes",
                          "mem swap usage is: ", JULONG_FORMAT, JULONG_FORMAT, memory_swap_usage);
       return (jlong)memory_swap_usage;
-    } else {
-      // no swap
-      return 0;
     }
   }
   return memory_usage_in_bytes();

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -168,6 +168,19 @@ jlong CgroupV1Subsystem::memory_and_swap_limit_in_bytes() {
   return memory_swap;
 }
 
+jlong CgroupV1Subsystem::memory_and_swap_usage_in_bytes() {
+  // isSwapEnabled - maybe compute once and save?
+  GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.memsw.limit_in_bytes", "Memory and Swap Limit is: ", JULONG_FORMAT, JULONG_FORMAT, memsw_bytes);
+  GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.swappiness", "Swappiness is: ", JULONG_FORMAT, JULONG_FORMAT, swappiness);
+  if (memsw_bytes > 0 && swappiness > 0) {
+      GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.memsw.usage_in_bytes",
+                     "mem swap usage is: ", JULONG_FORMAT, JULONG_FORMAT, memory_swap_usage);
+      return memory_swap_usage;
+  }
+  // fallback like we use in mbean code
+  return memory_usage_in_bytes();
+}
+
 jlong CgroupV1Subsystem::read_mem_swappiness() {
   GET_CONTAINER_INFO(julong, _memory->controller(), "/memory.swappiness",
                      "Swappiness is: ", JULONG_FORMAT, JULONG_FORMAT, swappiness);

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -76,6 +76,7 @@ class CgroupV1Subsystem: public CgroupSubsystem {
   public:
     jlong read_memory_limit_in_bytes();
     jlong memory_and_swap_limit_in_bytes();
+    jlong memory_and_swap_usage_in_bytes();
     jlong memory_soft_limit_in_bytes();
     jlong memory_usage_in_bytes();
     jlong memory_max_usage_in_bytes();

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -185,7 +185,7 @@ jlong CgroupV2Subsystem::memory_and_swap_usage_in_bytes() {
     if (memory_usage >= 0) {
         char* mem_swp_current_str = mem_swp_current_val();
         jlong swap_current = limit_from_str(mem_swp_current_str);
-        return memory_usage + swap_current;
+        return memory_usage + (swap_current >= 0 ? swap_current : 0);
     }
     return memory_usage; // not supported or unlimited case
 }

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -187,7 +187,7 @@ jlong CgroupV2Subsystem::memory_and_swap_usage_in_bytes() {
         jlong swap_current = limit_from_str(mem_swp_current_str);
         return memory_usage + swap_current;
     }
-    return memory_usage; // case of no memory limits
+    return memory_usage; // not supported or unlimited case
 }
 
 char* CgroupV2Subsystem::mem_swp_limit_val() {

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.cpp
@@ -180,6 +180,16 @@ jlong CgroupV2Subsystem::memory_and_swap_limit_in_bytes() {
   return swap_limit;
 }
 
+jlong CgroupV2Subsystem::memory_and_swap_usage_in_bytes() {
+    jlong memory_usage = memory_usage_in_bytes();
+    if (memory_usage >= 0) {
+        char* mem_swp_current_str = mem_swp_current_val();
+        jlong swap_current = limit_from_str(mem_swp_current_str);
+        return memory_usage + swap_current;
+    }
+    return memory_usage; // case of no memory limits
+}
+
 char* CgroupV2Subsystem::mem_swp_limit_val() {
   GET_CONTAINER_INFO_CPTR(cptr, _unified, "/memory.swap.max",
                          "Memory and Swap Limit is: %s", "%1023s", mem_swp_limit_str, 1024);

--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -75,6 +75,7 @@ class CgroupV2Subsystem: public CgroupSubsystem {
     int cpu_period();
     int cpu_shares();
     jlong memory_and_swap_limit_in_bytes();
+    jlong memory_and_swap_usage_in_bytes();
     jlong memory_soft_limit_in_bytes();
     jlong memory_usage_in_bytes();
     jlong memory_max_usage_in_bytes();

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -77,6 +77,11 @@ jlong OSContainer::memory_and_swap_limit_in_bytes() {
   return cgroup_subsystem->memory_and_swap_limit_in_bytes();
 }
 
+jlong OSContainer::memory_and_swap_usage_in_bytes() {
+  assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
+  return cgroup_subsystem->memory_and_swap_usage_in_bytes();
+}
+
 jlong OSContainer::memory_soft_limit_in_bytes() {
   assert(cgroup_subsystem != nullptr, "cgroup subsystem not available");
   return cgroup_subsystem->memory_soft_limit_in_bytes();

--- a/src/hotspot/os/linux/osContainer_linux.hpp
+++ b/src/hotspot/os/linux/osContainer_linux.hpp
@@ -52,6 +52,7 @@ class OSContainer: AllStatic {
 
   static jlong memory_limit_in_bytes();
   static jlong memory_and_swap_limit_in_bytes();
+  static jlong memory_and_swap_usage_in_bytes();
   static jlong memory_soft_limit_in_bytes();
   static jlong memory_usage_in_bytes();
   static jlong memory_max_usage_in_bytes();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -311,7 +311,6 @@ static jlong host_free_swap() {
   return (jlong)(si.freeswap * si.mem_unit);
 }
 
-
 jlong os::free_swap_space() {
   jlong host_free_swap_val = host_free_swap();
   if (OSContainer::is_containerized()) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -313,23 +313,17 @@ jlong os::free_swap_space() {
       if (delta_limit <= 0) {
         return 0;
       }
-      // should we do multiple trys like we do in Java management code ?
-      // cgroupv1 : memory.memsw.usage_in_bytes (CgroupV1Subsystem.java)
-      // cgroupv2 : long swapUsage = getLongVal("memory.swap.current", NO_SWAP); memoryUsage + swapUsage;  (CgroupV2Subsystem.java)
-      //jlong memSwapUsage = containerMetrics.getMemoryAndSwapUsage();
       jlong mem_swap_usage = OSContainer::memory_and_swap_usage_in_bytes();
       jlong mem_usage = OSContainer::memory_usage_in_bytes();
       if (mem_swap_usage > 0 && mem_usage > 0) {
         jlong delta_usage = mem_swap_usage - mem_usage;
         if (delta_usage >= 0) {
           jlong free_swap = delta_limit - delta_usage;
-          if (free_swap >= 0) {
-            return free_swap;
-          }
+          return free_swap >= 0 ? free_swap : 0;
         }
       }
     }
-    return -1; // check the fallback - maybe use something better ?
+    return -1;
   } else {
     struct sysinfo si;
     int ret = sysinfo(&si);

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -217,14 +217,32 @@ public class TestJFREvents {
 
     private static void testSwapMemory(String memValueToSet, String swapValueToSet, String expectedTotalValue, String expectedFreeValue) throws Exception {
         Common.logNewTestCase("Memory: --memory = " + memValueToSet + " --memory-swap = " + swapValueToSet);
-        DockerTestUtils.dockerRunJava(
+         OutputAnalyzer out = DockerTestUtils.dockerRunJava(
                                       commonDockerOpts()
                                       .addDockerOpts("--memory=" + memValueToSet)
                                       .addDockerOpts("--memory-swap=" + swapValueToSet)
-                                      .addClassOptions("jdk.SwapSpace"))
-            .shouldHaveExitValue(0)
+                                      .addClassOptions("jdk.SwapSpace"));
+         out.shouldHaveExitValue(0)
             .shouldContain("totalSize = " + expectedTotalValue)
-            .shouldContain("freeSize = " + expectedFreeValue);
+            .shouldContain("freeSize = ");
+         List<String> ls = out.asLinesWithoutVMWarnings();
+         for (String cur : ls) {
+             int idx = cur.indexOf("freeSize = ");
+             if (idx != -1) {
+                 int startNbr = idx+11;
+                 int endNbr = cur.indexOf(' ', startNbr);
+                 if (endNbr == -1) endNbr = cur.length();
+                 String freeSizeStr = cur.substring(startNbr, endNbr);
+                 long freeval = Long.parseLong(freeSizeStr);
+                 long totalval = Long.parseLong(expectedTotalValue);
+                 if (0 <= freeval && freeval <= totalval) {
+                     System.out.println("Found freeSize value " + freeval + " is fine");
+                 } else {
+                     System.out.println("Found freeSize value " + freeval + " is bad");
+                     throw new Exception("Found free size value is bad");
+                 }
+             }
+         }
     }
 
 

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,10 @@ public class TestJFREvents {
             testMemory("200m", "" + 200*MB);
             testMemory("500m", "" + 500*MB);
             testMemory("1g", "" + 1024*MB);
+
+            // see https://docs.docker.com/config/containers/resource_constraints/
+            testSwapMemory("200m", "200m", "" + 0*MB, "" + 0*MB);
+            testSwapMemory("200m", "300m", "" + 100*MB, "" + 100*MB);
 
             testProcessInfo();
 
@@ -208,6 +212,19 @@ public class TestJFREvents {
                                       .addClassOptions("jdk.PhysicalMemory"))
             .shouldHaveExitValue(0)
             .shouldContain("totalSize = " + expectedValue);
+    }
+
+
+    private static void testSwapMemory(String memValueToSet, String swapValueToSet, String expectedTotalValue, String expectedFreeValue) throws Exception {
+        Common.logNewTestCase("Memory: --memory = " + memValueToSet + " --memory-swap = " + swapValueToSet);
+        DockerTestUtils.dockerRunJava(
+                                      commonDockerOpts()
+                                      .addDockerOpts("--memory=" + memValueToSet)
+                                      .addDockerOpts("--memory-swap=" + swapValueToSet)
+                                      .addClassOptions("jdk.SwapSpace"))
+            .shouldHaveExitValue(0)
+            .shouldContain("totalSize = " + expectedTotalValue)
+            .shouldContain("freeSize = " + expectedFreeValue);
     }
 
 


### PR DESCRIPTION
The JFR SwapSpace event (added by [JDK-8324287](https://bugs.openjdk.org/browse/JDK-8324287)) has been added but in a Linux containerized environment we currently just report -1, this should be enhanced. There is already some code in the mbeans (but in Java) that does something similar .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325139](https://bugs.openjdk.org/browse/JDK-8325139): JFR SwapSpace event - add free swap space information on Linux when running in a container environment (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [bdbfe371](https://git.openjdk.org/jdk/pull/17966/files/bdbfe3714797347eeddbcf3bedd5ed2d05a37749)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17966/head:pull/17966` \
`$ git checkout pull/17966`

Update a local copy of the PR: \
`$ git checkout pull/17966` \
`$ git pull https://git.openjdk.org/jdk.git pull/17966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17966`

View PR using the GUI difftool: \
`$ git pr show -t 17966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17966.diff">https://git.openjdk.org/jdk/pull/17966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17966#issuecomment-1959707487)