### PR TITLE
8311003: missing @since info in jdk.security.jgss

### DIFF
--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/AuthorizationDataEntry.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/AuthorizationDataEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@ package com.sun.security.jgss;
 
 /**
  * Kerberos 5 AuthorizationData entry.
+ *
+ * @since 1.7
  */
 public final class AuthorizationDataEntry {
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/ExtendedGSSContext.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/ExtendedGSSContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@ import org.ietf.jgss.*;
  * The extended GSSContext interface for supporting additional
  * functionalities not defined by {@code org.ietf.jgss.GSSContext},
  * such as querying context-specific attributes.
+ *
+ * @since 1.7
  */
 public interface ExtendedGSSContext extends GSSContext {
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/GSSUtil.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/GSSUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import org.ietf.jgss.GSSCredential;
 /**
  * GSS-API Utilities for using in conjunction with Sun Microsystem's
  * implementation of Java GSS-API.
+ *
+ * @since 1.4
  */
 public class GSSUtil {
     /**

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireSecContextPermission.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireSecContextPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,8 @@ import java.security.BasicPermission;
  * method.
  *
  * <p>The target name is the {@link InquireType} allowed.
+ *
+ * @since 1.7
  */
 public final class InquireSecContextPermission extends BasicPermission {
     private static final long serialVersionUID = -7131173349668647297L;

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireType.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/InquireType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package com.sun.security.jgss;
 /**
  * Attribute types that can be specified as an argument of
  * {@link com.sun.security.jgss.ExtendedGSSContext#inquireSecContext}
+ *
+ * @since 1.7
  */
 public enum InquireType {
     /**

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/package-info.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/package-info.java
@@ -26,5 +26,7 @@
 /**
  * This package defines classes and interfaces for the JDK extensions
  * to the GSS-API.
+ *
+ * @since 1.4
  */
 package com.sun.security.jgss;


### PR DESCRIPTION
Add the `@since` info. Most of the classes were introduced in https://bugs.openjdk.org/browse/JDK-6710360. `GSSUtil.java` was there since the 1st batch of JGSS classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311003](https://bugs.openjdk.org/browse/JDK-8311003): missing @<!---->since info in jdk.security.jgss (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17968/head:pull/17968` \
`$ git checkout pull/17968`

Update a local copy of the PR: \
`$ git checkout pull/17968` \
`$ git pull https://git.openjdk.org/jdk.git pull/17968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17968`

View PR using the GUI difftool: \
`$ git pr show -t 17968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17968.diff">https://git.openjdk.org/jdk/pull/17968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17968#issuecomment-1959884230)