### PR TITLE
8311002: missing @since info in 21 files in jdk.security.auth

### DIFF
--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTDomainPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTDomainPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,8 @@ import java.security.Principal;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTDomainPrincipal implements Principal, java.io.Serializable {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTNumericCredential.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTNumericCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package com.sun.security.auth;
 /**
  * This class abstracts an NT security token
  * and provides a mechanism to do same-process security impersonation.
+ *
+ * @since 1.4
  */
 
 public class NTNumericCredential {

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSid.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,8 @@ import java.security.Principal;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTSid implements Principal, java.io.Serializable {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidDomainPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidDomainPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ package com.sun.security.auth;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTSidDomainPrincipal extends NTSid {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidGroupPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidGroupPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ package com.sun.security.auth;
  * @see java.security.Principal
  * @see javax.security.auth.Subject
  * @see com.sun.security.auth.NTSid
+ *
+ * @since 1.4
  */
 public class NTSidGroupPrincipal extends NTSid {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidPrimaryGroupPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidPrimaryGroupPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ package com.sun.security.auth;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTSidPrimaryGroupPrincipal extends NTSid {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidUserPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTSidUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,8 @@ package com.sun.security.auth;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTSidUserPrincipal extends NTSid {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/NTUserPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/NTUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import java.security.Principal;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class NTUserPrincipal implements Principal, java.io.Serializable {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/PrincipalComparator.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/PrincipalComparator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,8 @@ package com.sun.security.auth;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public interface PrincipalComparator {
     /**

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixNumericGroupPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixNumericGroupPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,8 @@ import java.util.Objects;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class UnixNumericGroupPrincipal implements
                                         Principal,

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixNumericUserPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixNumericUserPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import java.security.Principal;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class UnixNumericUserPrincipal implements
                                         Principal,

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixPrincipal.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/UnixPrincipal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import java.security.Principal;
  *
  * @see java.security.Principal
  * @see javax.security.auth.Subject
+ *
+ * @since 1.4
  */
 public class UnixPrincipal implements Principal, java.io.Serializable {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/callback/TextCallbackHandler.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/callback/TextCallbackHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ import sun.security.util.ConsoleCallbackHandler;
  * This can be used by a JAAS application to instantiate a
  * CallbackHandler
  * @see javax.security.auth.callback
+ *
+ * @since 1.4
  */
 
 public class TextCallbackHandler implements CallbackHandler {

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/login/ConfigFile.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/login/ConfigFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,8 @@ import java.net.URI;
  *
  * @see javax.security.auth.login.LoginContext
  * @see java.security.Security security properties
+ *
+ * @since 1.4
  */
 public class ConfigFile extends Configuration {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/JndiLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/JndiLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,7 @@ import static sun.security.util.ResourcesMgr.getAuthResourceString;
  *                  have completed.
  * </pre>
  *
+ * @since 1.4
  */
 public class JndiLoginModule implements LoginModule {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/KeyStoreLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,6 +110,8 @@ import static sun.security.util.ResourcesMgr.getAuthResourceString;
  *      privateKeyPasswordURL must not be specified.</dd>
  *
  * </dl>
+ *
+ * @since 1.4
  */
 public class KeyStoreLoginModule implements LoginModule {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/Krb5LoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -364,6 +364,8 @@ import static sun.security.util.ResourcesMgr.getAuthResourceString;
  * </blockquote>
  *
  * @author Ram Marti
+ *
+ * @since 1.4
  */
 
 public class Krb5LoginModule implements LoginModule {

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/NTLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/NTLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,8 @@ import com.sun.security.auth.NTNumericCredential;
  * will be output to the output stream, System.out.
  *
  * @see javax.security.auth.spi.LoginModule
+ *
+ * @since 1.4
  */
 public class NTLoginModule implements LoginModule {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/NTSystem.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/NTSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ package com.sun.security.auth.module;
  * This class implementation retrieves and makes available NT
  * security information for the current user.
  *
+ * @since 1.4
  */
 public class NTSystem {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/UnixLoginModule.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/UnixLoginModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import com.sun.security.auth.UnixNumericGroupPrincipal;
  * If set to true in the login Configuration,
  * debug messages will be output to the output stream, System.out.
  *
+ * @since 1.4
  */
 public class UnixLoginModule implements LoginModule {
 

--- a/src/jdk.security.auth/share/classes/com/sun/security/auth/module/UnixSystem.java
+++ b/src/jdk.security.auth/share/classes/com/sun/security/auth/module/UnixSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package com.sun.security.auth.module;
 /**
  * This class implementation retrieves and makes available Unix
  * UID/GID/groups information for the current user.
+ *
+ * @since 1.4
  */
 public class UnixSystem {
 


### PR DESCRIPTION
Add `@since` info. JAAS was included in JDK 1.4 and these classes were all in the initial release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311002](https://bugs.openjdk.org/browse/JDK-8311002): missing @<!---->since info in 21 files in jdk.security.auth (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17969/head:pull/17969` \
`$ git checkout pull/17969`

Update a local copy of the PR: \
`$ git checkout pull/17969` \
`$ git pull https://git.openjdk.org/jdk.git pull/17969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17969`

View PR using the GUI difftool: \
`$ git pr show -t 17969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17969.diff">https://git.openjdk.org/jdk/pull/17969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17969#issuecomment-1960057848)