### PR TITLE
Upgrade Multi-Size Page Handling for Enhanced Large Page Support in MSFT OpenJDK on Windows 

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3229,7 +3229,7 @@ static size_t large_page_init_decide_size() {
   }
 
   // Check if OS version is 11 or greater
-  if (schedules_all_processor_groups) {
+  if (win32::is_windows_11_or_greater() || win32::is_windows_server_2022_or_greater()) {
       // OS-specific logic for versions 11 or greater
       // You can implement specific checks or logic here for newer OS versions
 }
@@ -3258,6 +3258,7 @@ static size_t large_page_init_decide_size() {
   }
 
 #undef WARN
+#undef WARN1
 
   return size;
 }
@@ -3272,12 +3273,12 @@ void os::large_page_init() {
   if (_large_page_size > default_page_size) {
  #if !defined(IA32)
       // Check if the OS version is 11 or higher
-      if (schedules_all_processor_groups && EnableAllLargePageSizes) {
+      if ((win32::is_windows_11_or_greater() || win32::is_windows_server_2022_or_greater()) && EnableAllLargePageSizes) {
 
           // Additional logic needed for ARM architecture
           size_t min_size = GetLargePageMinimum();
 
-          // Populate _page_sizes with large page sizes less than or equal to _large_page_size.
+          // Populate _page_sizes with large page sizes less than or equal to _large_page_size, ensuring each page size is double the size of the previous one.
           for (size_t page_size = min_size; page_size < _large_page_size; page_size *= 2) {
               _page_sizes.add(page_size);
           }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -247,6 +247,9 @@ const int ObjectAlignmentInBytes = 8;
           "page size for the environment as the maximum)")                  \
           range(0, max_uintx)                                               \
                                                                             \
+  product(bool, EnableAllLargePageSizes, false, EXPERIMENTAL,               \
+          "Using high time resolution (for Windows 11+ and Win64 only)")    \ 
+                                                                            \
   product(size_t, LargePageHeapSizeThreshold, 128*M,                        \
           "Use large pages if maximum heap is at least this big")           \
           range(0, max_uintx)                                               \


### PR DESCRIPTION
This pull request introduces enhancements to the handling of large page sizes in the Microsoft OpenJDK for Windows systems, aiming to align its capabilities with those observed on Linux platforms. Investigation through SPECJBB benchmarks across various platforms revealed a 16-year-old limitation in handling large pages over 4MB for IA32/AMD64 architectures, with no such constraints for Windows on ARM64.

The goal of this change is to overcome the 4MB large page size limitation, thereby enhancing Windows' large page support to match Linux's more flexible handling capabilities. This decision was influenced by issues observed with code cache and large page utilization, alongside insights from Linux's implementation strategies. The implementation supports multiple large page sizes on recent versions of Windows (Windows Client version >=11 and Windows Server version >=22), specifically excluding the IA32 architecture.

Key changes and bug fixes include enabling Linux support for multiple huge page sizes with -XX:LargePageSizeInBytes, adapting similar logic for Windows support, and utilizing logic from JDK-8271195 to use the largest available large page size smaller than LargePageSizeInBytes when available. This approach is further supported by addressing several JDK bug reports and enhancement requests related to large page handling, ensuring a comprehensive update to large page management.

This update removes the 4MB limit on AMD64 for Windows 11+ and Server 22+, populating the shared array to enable fallback options on all architectures except IA32. The implementation introduces an experimental flag, defaulting to FALSE, to facilitate testing and gradual adoption of these changes. The flag allows users to opt-in to the new large page handling logic, with a warning mechanism implemented for cases where the requested large page size is not a multiple of the OS minimum page size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ Executable files are not allowed (file: test/hotspot/gtest/runtime/test_os_windows.cpp)

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/swing/AbstractButton/5049549/SE1.gif)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17972/head:pull/17972` \
`$ git checkout pull/17972`

Update a local copy of the PR: \
`$ git checkout pull/17972` \
`$ git pull https://git.openjdk.org/jdk.git pull/17972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17972`

View PR using the GUI difftool: \
`$ git pr show -t 17972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17972.diff">https://git.openjdk.org/jdk/pull/17972.diff</a>

</details>
