### PR TITLE
JDK-8326530: Widen allowable error bound of Math.tan

### DIFF
--- a/src/java.base/share/classes/java/lang/Math.java
+++ b/src/java.base/share/classes/java/lang/Math.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,7 +212,7 @@ public final class Math {
      * <li>If the argument is zero, then the result is a zero with the
      * same sign as the argument.</ul>
      *
-     * <p>The computed result must be within 1 ulp of the exact result.
+     * <p>The computed result must be within 1.25 ulps of the exact result.
      * Results must be semi-monotonic.
      *
      * @param   a   an angle, in radians.


### PR DESCRIPTION
Widen acceptable error bound of Math.tan to accommodate the worst-case observed error which is slightly outside of the allowable range.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8326537](https://bugs.openjdk.org/browse/JDK-8326537) to be approved

### Issues
 * [JDK-8326530](https://bugs.openjdk.org/browse/JDK-8326530): Widen allowable error bound of Math.tan (**Bug** - P4)
 * [JDK-8326537](https://bugs.openjdk.org/browse/JDK-8326537): Widen allowable error bound of Math.tan (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17973/head:pull/17973` \
`$ git checkout pull/17973`

Update a local copy of the PR: \
`$ git checkout pull/17973` \
`$ git pull https://git.openjdk.org/jdk.git pull/17973/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17973`

View PR using the GUI difftool: \
`$ git pr show -t 17973`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17973.diff">https://git.openjdk.org/jdk/pull/17973.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17973#issuecomment-1960395394)