### PR TITLE
8326541: [AArch64] ZGC C2 load barrier stub considers the length of live registers when spilling registers

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1126,6 +1126,10 @@ extern RegMask _NO_SPECIAL_REG32_mask;
 extern RegMask _NO_SPECIAL_REG_mask;
 extern RegMask _NO_SPECIAL_PTR_REG_mask;
 
+// Figure out which register class each belongs in: rc_int, rc_float or
+// rc_stack.
+enum RC { rc_bad, rc_int, rc_float, rc_predicate, rc_stack };
+
 class CallStubImpl {
 
   //--------------------------------------------------------------
@@ -1903,10 +1907,6 @@ const Pipeline * MachEpilogNode::pipeline() const {
 }
 
 //=============================================================================
-
-// Figure out which register class each belongs in: rc_int, rc_float or
-// rc_stack.
-enum RC { rc_bad, rc_int, rc_float, rc_predicate, rc_stack };
 
 static enum RC rc_class(OptoReg::Name reg) {
 

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1081,6 +1081,35 @@ void ZBarrierSetAssembler::generate_c1_store_barrier_runtime_stub(StubAssembler*
 
 #ifdef COMPILER2
 
+OptoReg::Name ZBarrierSetAssembler::encode_float_vector_register_size(const Node* node, OptoReg::Name opto_reg) {
+  switch (node->ideal_reg()) {
+    case Op_RegF:
+      // No need to refine. The original encoding is already fine to distinguish.
+      assert(opto_reg % 4 == 0, "Float register should only occupy a single slot");
+      break;
+    // Use different encoding values of the same fp/vector register to help distinguish different sizes.
+    // Such as V16. The OptoReg::name and its corresponding slot value are
+    // "V16": 64, "V16_H": 65, "V16_J": 66, "V16_K": 67.
+    case Op_RegD:
+    case Op_VecD:
+      opto_reg &= ~3;
+      opto_reg |= 1;
+      break;
+    case Op_VecX:
+      opto_reg &= ~3;
+      opto_reg |= 2;
+      break;
+    case Op_VecA:
+      opto_reg &= ~3;
+      opto_reg |= 3;
+      break;
+    default:
+      assert(false, "unexpected ideal register");
+      ShouldNotReachHere();
+  }
+  return opto_reg;
+}
+
 OptoReg::Name ZBarrierSetAssembler::refine_register(const Node* node, OptoReg::Name opto_reg) {
   if (!OptoReg::is_reg(opto_reg)) {
     return OptoReg::Bad;
@@ -1088,7 +1117,7 @@ OptoReg::Name ZBarrierSetAssembler::refine_register(const Node* node, OptoReg::N
 
   const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
   if (vm_reg->is_FloatRegister()) {
-    return opto_reg & ~1;
+    opto_reg = encode_float_vector_register_size(node, opto_reg);
   }
 
   return opto_reg;
@@ -1099,28 +1128,82 @@ OptoReg::Name ZBarrierSetAssembler::refine_register(const Node* node, OptoReg::N
 
 class ZSaveLiveRegisters {
 private:
+  struct RegisterData {
+    VMReg _reg;
+    int   _slots; // slots occupied once pushed into stack
+
+    // Used by GrowableArray::find()
+    bool operator == (const RegisterData& other) {
+      return _reg == other._reg;
+    }
+  };
+
   MacroAssembler* const _masm;
   RegSet                _gp_regs;
   FloatRegSet           _fp_regs;
+  FloatRegSet           _neon_regs;
+  FloatRegSet           _sve_regs;
   PRegSet               _p_regs;
 
 public:
   void initialize(ZBarrierStubC2* stub) {
-    // Record registers that needs to be saved/restored
+    int index = -1;
+    GrowableArray<RegisterData> registers;
+    VMReg prev_vm_reg = VMRegImpl::Bad();
+
     RegMaskIterator rmi(stub->live());
     while (rmi.has_next()) {
-      const OptoReg::Name opto_reg = rmi.next();
-      if (OptoReg::is_reg(opto_reg)) {
-        const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
-        if (vm_reg->is_Register()) {
-          _gp_regs += RegSet::of(vm_reg->as_Register());
-        } else if (vm_reg->is_FloatRegister()) {
-          _fp_regs += FloatRegSet::of(vm_reg->as_FloatRegister());
-        } else if (vm_reg->is_PRegister()) {
-          _p_regs += PRegSet::of(vm_reg->as_PRegister());
+      OptoReg::Name opto_reg = rmi.next();
+      VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
+
+      if (vm_reg->is_Register()) {
+        // GPR may have one or two slots in regmask
+        // Determine whether the current vm_reg is the same physical register as the previous one
+        if (is_same_register(vm_reg, prev_vm_reg)) {
+          registers.at(index)._slots++;
         } else {
-          fatal("Unknown register type");
+          RegisterData reg_data = { vm_reg, 1 };
+          index = registers.append(reg_data);
         }
+      } else if (vm_reg->is_FloatRegister()) {
+        // We have size encoding in OptoReg of stub->live()
+        // After encoding, float/neon/sve register has only one slot in regmask
+        // Decode it to get the actual size
+        VMReg vm_reg_base = vm_reg->as_FloatRegister()->as_VMReg();
+        int slots = decode_float_vector_register_size(opto_reg);
+        RegisterData reg_data = { vm_reg_base, slots };
+        index = registers.append(reg_data);
+      } else if (vm_reg->is_PRegister()) {
+        // PRegister has only one slot in regmask
+        RegisterData reg_data = { vm_reg, 1 };
+        index = registers.append(reg_data);
+      } else {
+        assert(false, "Unknown register type");
+        ShouldNotReachHere();
+      }
+      prev_vm_reg = vm_reg;
+    }
+
+    // Record registers that needs to be saved/restored
+    for (GrowableArrayIterator<RegisterData> it = registers.begin(); it != registers.end(); ++it) {
+      RegisterData reg_data = *it;
+      VMReg vm_reg = reg_data._reg;
+      int slots = reg_data._slots;
+      if (vm_reg->is_Register()) {
+        assert(slots == 1 || slots == 2, "Unexpected register save size");
+        _gp_regs += RegSet::of(vm_reg->as_Register());
+      } else if (vm_reg->is_FloatRegister()) {
+        if (slots == 1 || slots == 2) {
+          _fp_regs += FloatRegSet::of(vm_reg->as_FloatRegister());
+        } else if (slots == 4) {
+          _neon_regs += FloatRegSet::of(vm_reg->as_FloatRegister());
+        } else {
+          assert(slots == Matcher::scalable_vector_reg_size(T_FLOAT), "Unexpected register save size");
+          _sve_regs += FloatRegSet::of(vm_reg->as_FloatRegister());
+        }
+      } else {
+        assert(vm_reg->is_PRegister() && slots == 1, "Unknown register type");
+        _p_regs += PRegSet::of(vm_reg->as_PRegister());
       }
     }
 
@@ -1130,12 +1213,65 @@ public:
     } else {
       _gp_regs -= RegSet::range(r19, r30) + RegSet::of(r8, r9);
     }
+
+    // Remove C-ABI SOE fp registers
+    _fp_regs -= FloatRegSet::range(v8, v15);
+  }
+
+  static enum RC rc_class(VMReg reg) {
+    if (reg->is_reg()) {
+      if (reg->is_Register()) {
+        return rc_int;
+      } else if (reg->is_FloatRegister()) {
+        return rc_float;
+      } else if (reg->is_PRegister()) {
+        return rc_predicate;
+      }
+    }
+    if (reg->is_stack()) {
+      return rc_stack;
+    }
+    return rc_bad;
+  }
+
+  static bool is_same_register(VMReg reg1, VMReg reg2) {
+    if (reg1 == reg2) {
+      return true;
+    }
+    if (rc_class(reg1) == rc_class(reg2)) {
+      if (reg1->is_Register()) {
+        return reg1->as_Register() == reg2->as_Register();
+      } else if (reg1->is_FloatRegister()) {
+        return reg1->as_FloatRegister() == reg2->as_FloatRegister();
+      } else if (reg1->is_PRegister()) {
+        return reg1->as_PRegister() == reg2->as_PRegister();
+      }
+    }
+    return false;
+  }
+
+  static int decode_float_vector_register_size(OptoReg::Name opto_reg) {
+    switch (opto_reg & 3) {
+      case 0:
+        return 1;
+      case 1:
+        return 2;
+      case 2:
+        return 4;
+      case 3:
+        return Matcher::scalable_vector_reg_size(T_FLOAT);
+      default:
+        ShouldNotReachHere();
+        return 0;
+    }
   }
 
   ZSaveLiveRegisters(MacroAssembler* masm, ZBarrierStubC2* stub)
     : _masm(masm),
       _gp_regs(),
       _fp_regs(),
+      _neon_regs(),
+      _sve_regs(),
       _p_regs() {
 
     // Figure out what registers to save/restore
@@ -1143,14 +1279,18 @@ public:
 
     // Save registers
     __ push(_gp_regs, sp);
-    __ push_fp(_fp_regs, sp);
+    __ push_fp(_fp_regs, sp, MacroAssembler::PushPopFp);
+    __ push_fp(_neon_regs, sp, MacroAssembler::PushPopNeon);
+    __ push_fp(_sve_regs, sp, MacroAssembler::PushPopSVE);
     __ push_p(_p_regs, sp);
   }
 
   ~ZSaveLiveRegisters() {
     // Restore registers
     __ pop_p(_p_regs, sp);
-    __ pop_fp(_fp_regs, sp);
+    __ pop_fp(_sve_regs, sp, MacroAssembler::PushPopSVE);
+    __ pop_fp(_neon_regs, sp, MacroAssembler::PushPopNeon);
+    __ pop_fp(_fp_regs, sp, MacroAssembler::PushPopFp);
 
     // External runtime call may clobber ptrue reg
     __ reinitialize_ptrue();

--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,6 +187,9 @@ public:
 #endif // COMPILER1
 
 #ifdef COMPILER2
+  OptoReg::Name encode_float_vector_register_size(const Node* node,
+                                                  OptoReg::Name opto_reg);
+
   OptoReg::Name refine_register(const Node* node,
                                 OptoReg::Name opto_reg);
 

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -444,6 +444,15 @@ class MacroAssembler: public Assembler {
 
   // macro assembly operations needed for aarch64
 
+public:
+
+  enum FpPushPopMode {
+    PushPopFull,
+    PushPopSVE,
+    PushPopNeon,
+    PushPopFp
+  };
+
   // first two private routines for loading 32 bit or 64 bit constants
 private:
 
@@ -453,8 +462,8 @@ private:
   int push(unsigned int bitset, Register stack);
   int pop(unsigned int bitset, Register stack);
 
-  int push_fp(unsigned int bitset, Register stack);
-  int pop_fp(unsigned int bitset, Register stack);
+  int push_fp(unsigned int bitset, Register stack, FpPushPopMode mode);
+  int pop_fp(unsigned int bitset, Register stack, FpPushPopMode mode);
 
   int push_p(unsigned int bitset, Register stack);
   int pop_p(unsigned int bitset, Register stack);
@@ -462,11 +471,12 @@ private:
   void mov(Register dst, Address a);
 
 public:
+
   void push(RegSet regs, Register stack) { if (regs.bits()) push(regs.bits(), stack); }
   void pop(RegSet regs, Register stack) { if (regs.bits()) pop(regs.bits(), stack); }
 
-  void push_fp(FloatRegSet regs, Register stack) { if (regs.bits()) push_fp(regs.bits(), stack); }
-  void pop_fp(FloatRegSet regs, Register stack) { if (regs.bits()) pop_fp(regs.bits(), stack); }
+  void push_fp(FloatRegSet regs, Register stack, FpPushPopMode mode = PushPopFull) { if (regs.bits()) push_fp(regs.bits(), stack, mode); }
+  void pop_fp(FloatRegSet regs, Register stack, FpPushPopMode mode = PushPopFull) { if (regs.bits()) pop_fp(regs.bits(), stack, mode); }
 
   static RegSet call_clobbered_gp_registers();
 

--- a/src/hotspot/cpu/aarch64/vmreg_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vmreg_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,7 @@ inline Register as_Register() {
 }
 
 inline FloatRegister as_FloatRegister() {
-  assert( is_FloatRegister() && is_even(value()), "must be" );
+  assert( is_FloatRegister(), "must be" );
   // Yuk
   return ::as_FloatRegister((value() - ConcreteRegisterImpl::max_gpr) /
                             FloatRegister::max_slots_per_register);


### PR DESCRIPTION
Currently ZGC C2 load barrier stub saves the whole live register regardless of what size of register is live on aarch64.
Considering the size of SVE register is an implementation-defined multiple of 128 bits, up to 2048 bits,
even the use of a floating point may cause the maximum 2048 bits stack occupied.
Hence I would like to introduce this change on aarch64: take the length of live registers into consideration in ZGC C2 load barrier stub.

In a floating point case on 2048 bits SVE machine, the following ZLoadBarrierStubC2 

```
  ......
  0x0000ffff684cfad8:   stp     x15, x18, [sp, #80]
  0x0000ffff684cfadc:   sub     sp, sp, #0x100
  0x0000ffff684cfae0:   str     z16, [sp]
  0x0000ffff684cfae4:   add     x1, x13, #0x10
  0x0000ffff684cfae8:   mov     x0, x16
 ;; 0xFFFF803F5414
  0x0000ffff684cfaec:   mov     x8, #0x5414                     // #21524
  0x0000ffff684cfaf0:   movk    x8, #0x803f, lsl #16
  0x0000ffff684cfaf4:   movk    x8, #0xffff, lsl #32
  0x0000ffff684cfaf8:   blr     x8
  0x0000ffff684cfafc:   mov     x16, x0
  0x0000ffff684cfb00:   ldr     z16, [sp]
  0x0000ffff684cfb04:   add     sp, sp, #0x100
  0x0000ffff684cfb08:   ptrue   p7.b
  0x0000ffff684cfb0c:   ldp     x4, x5, [sp, #16]
  ......
```

could be optimized into:

```
  ......  
  0x0000ffff684cfa50:   stp     x15, x18, [sp, #80]
  0x0000ffff684cfa54:   str     d16, [sp, #-16]!                   // extra 8 bytes to align 16 bytes in push_fp()
  0x0000ffff684cfa58:   add     x1, x13, #0x10
  0x0000ffff684cfa5c:   mov     x0, x16
 ;; 0xFFFF7FA942A8
  0x0000ffff684cfa60:   mov     x8, #0x42a8                     // #17064
  0x0000ffff684cfa64:   movk    x8, #0x7fa9, lsl #16
  0x0000ffff684cfa68:   movk    x8, #0xffff, lsl #32
  0x0000ffff684cfa6c:   blr     x8
  0x0000ffff684cfa70:   mov     x16, x0
  0x0000ffff684cfa74:   ldr     d16, [sp], #16
  0x0000ffff684cfa78:   ptrue   p7.b
  0x0000ffff684cfa7c:   ldp     x4, x5, [sp, #16]
  ......
```

Besides the above benefit, when we know what size of register is live,
we could remove the unnecessary caller save in ZGC C2 load barrier stub when we meet C-ABI SOE fp registers.

Passed jtreg with option "-XX:+UseZGC -XX:+ZGenerational" with no failures introduced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326541](https://bugs.openjdk.org/browse/JDK-8326541): [AArch64] ZGC C2 load barrier stub considers the length of live registers when spilling registers (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17974/head:pull/17974` \
`$ git checkout pull/17974`

Update a local copy of the PR: \
`$ git checkout pull/17974` \
`$ git pull https://git.openjdk.org/jdk.git pull/17974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17974`

View PR using the GUI difftool: \
`$ git pr show -t 17974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17974.diff">https://git.openjdk.org/jdk/pull/17974.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17974#issuecomment-1960704159)