### PR TITLE
8326446: The User and System of jdk.CPULoad on Apple M1 are inaccurate

### DIFF
--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/bsd/os_perf_bsd.cpp
+++ b/src/hotspot/os/bsd/os_perf_bsd.cpp
@@ -39,6 +39,7 @@
   #include <net/if.h>
   #include <net/if_dl.h>
   #include <net/route.h>
+  #include <sys/times.h>
 #endif
 
 static const double NANOS_PER_SEC = 1000000000.0;
@@ -47,10 +48,10 @@ class CPUPerformanceInterface::CPUPerformance : public CHeapObj<mtInternal> {
    friend class CPUPerformanceInterface;
  private:
 #ifdef __APPLE__
-  uint64_t _total_cpu_nanos;
+  uint64_t _jvm_real;
   uint64_t _total_csr_nanos;
-  uint64_t _jvm_user_nanos;
-  uint64_t _jvm_system_nanos;
+  uint64_t _jvm_user;
+  uint64_t _jvm_system;
   long _jvm_context_switches;
   long _used_ticks;
   long _total_ticks;
@@ -86,11 +87,11 @@ class CPUPerformanceInterface::CPUPerformance : public CHeapObj<mtInternal> {
 
 CPUPerformanceInterface::CPUPerformance::CPUPerformance() {
 #ifdef __APPLE__
-  _total_cpu_nanos= 0;
+  _jvm_real = 0;
   _total_csr_nanos= 0;
   _jvm_context_switches = 0;
-  _jvm_user_nanos = 0;
-  _jvm_system_nanos = 0;
+  _jvm_user = 0;
+  _jvm_system = 0;
   _used_ticks = 0;
   _total_ticks = 0;
   _active_processor_count = 0;
@@ -152,42 +153,35 @@ int CPUPerformanceInterface::CPUPerformance::cpu_load_total_process(double* cpu_
 int CPUPerformanceInterface::CPUPerformance::cpu_loads_process(double* pjvmUserLoad, double* pjvmKernelLoad, double* psystemTotalLoad) {
 #ifdef __APPLE__
   int result = cpu_load_total_process(psystemTotalLoad);
-  mach_port_t task = mach_task_self();
-  mach_msg_type_number_t task_info_count = TASK_INFO_MAX;
-  task_info_data_t task_info_data;
-  kern_return_t kr = task_info(task, TASK_ABSOLUTETIME_INFO, (task_info_t)task_info_data, &task_info_count);
-  if (kr != KERN_SUCCESS) {
+
+  struct tms buf;
+  clock_t jvm_real = times(&buf);
+  if (jvm_real == (clock_t) (-1)) {
     return OS_ERR;
   }
-  task_absolutetime_info_t absolutetime_info = (task_absolutetime_info_t)task_info_data;
 
   int active_processor_count = os::active_processor_count();
-  uint64_t jvm_user_nanos = absolutetime_info->total_user;
-  uint64_t jvm_system_nanos = absolutetime_info->total_system;
+  uint64_t jvm_user = buf.tms_utime;
+  uint64_t jvm_system = buf.tms_stime;
 
-  uint64_t total_cpu_nanos;
-  if(!now_in_nanos(&total_cpu_nanos)) {
-    return OS_ERR;
-  }
-
-  if (_total_cpu_nanos == 0 || active_processor_count != _active_processor_count) {
-    // First call or change in active processor count
+  if (active_processor_count != _active_processor_count) {
+    // Change in active processor count
     result = OS_ERR;
   } else {
-    uint64_t delta_nanos = active_processor_count * (total_cpu_nanos - _total_cpu_nanos);
-    if (delta_nanos == 0) {
+    uint64_t delta = active_processor_count * (jvm_real - _jvm_real);
+    if (delta == 0) {
       // Avoid division by zero
       return OS_ERR;
     }
 
-    *pjvmUserLoad = normalize((double)(jvm_user_nanos - _jvm_user_nanos)/delta_nanos);
-    *pjvmKernelLoad = normalize((double)(jvm_system_nanos - _jvm_system_nanos)/delta_nanos);
+    *pjvmUserLoad = normalize((double)(jvm_user - _jvm_user) / delta);
+    *pjvmKernelLoad = normalize((double)(jvm_system - _jvm_system) / delta);
   }
 
   _active_processor_count = active_processor_count;
-  _total_cpu_nanos = total_cpu_nanos;
-  _jvm_user_nanos = jvm_user_nanos;
-  _jvm_system_nanos = jvm_system_nanos;
+  _jvm_real = jvm_real;
+  _jvm_user = jvm_user;
+  _jvm_system = jvm_system;
 
   return result;
 #else


### PR DESCRIPTION
hi

I would like to fix this.

As the description in [JDK-8326446](https://bugs.openjdk.org/browse/JDK-8326446).
JFR uses task_info() with flavor TASK_ABSOLUTETIME_INFO to read User and System time. it is not reliable on Apple m1.

Libc provides the [times](https://man7.org/linux/man-pages/man2/times.2.html) function, which uses TASK_BASIC_INFO_COUNT and TASK_THREAD_TIMES_INFO_COUNT. It will also return the real time of the process, and the time unit is the same, which is suitable for solving this problem.

I ran test/jdk/jdk/jfr/event/os/TestCPULoad.java and passed.

I would appreciate it if you could review this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326446](https://bugs.openjdk.org/browse/JDK-8326446): The User and System of jdk.CPULoad on Apple M1 are inaccurate (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17976/head:pull/17976` \
`$ git checkout pull/17976`

Update a local copy of the PR: \
`$ git checkout pull/17976` \
`$ git pull https://git.openjdk.org/jdk.git pull/17976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17976`

View PR using the GUI difftool: \
`$ git pr show -t 17976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17976.diff">https://git.openjdk.org/jdk/pull/17976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17976#issuecomment-1960873600)