### PR TITLE
JDK-8326496: [test] checkHsErrFileContent support printing hserr in error case

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2022 SAP SE. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,12 +63,10 @@ public class HsErrFileUtils {
      * if patterns are missing, or if the END marker is missing.
      * @param f Input file
      * @param patterns An array of patterns that need to match, in that order
-     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
-     *                are printed.
      * @throws RuntimeException, {@link IOException}
      */
     public static void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {
-        checkHsErrFileContent(f, patterns, null, true, verbose);
+        checkHsErrFileContent(f, patterns, null, true, verbose, false);
     }
 
     /**
@@ -85,6 +83,38 @@ public class HsErrFileUtils {
      * @throws RuntimeException, {@link IOException}
      */
     public static void checkHsErrFileContent(File f, Pattern[] positivePatterns, Pattern[] negativePatterns, boolean checkEndMarker, boolean verbose) throws IOException {
+        checkHsErrFileContent(f, positivePatterns, negativePatterns, checkEndMarker, verbose, false);
+    }
+
+    /**
+     * Given an open hs-err file, read it line by line and check for existence of a set of patterns. Will fail
+     * if patterns are missing, or if the END marker is missing.
+     * @param f Input file
+     * @param patterns An array of patterns that need to match, in that order
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
+     *                are printed.
+     * @param printHserrOnError If true, the content of the hs-err file is printed in case of a failing check
+     * @throws RuntimeException, {@link IOException}
+     */
+    public static void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose, boolean printHserrOnError) throws IOException {
+        checkHsErrFileContent(f, patterns, null, true, verbose, printHserrOnError);
+    }
+
+    /**
+     * Given an open hs-err file, read it line by line and check for various conditions.
+     * @param f input file
+     * @param positivePatterns Optional array of patterns that need to appear, in given order, in the file. Missing
+     *                        patterns cause the test to fail.
+     * @param negativePatterns Optional array of patterns that must not appear in the file; test fails if they do.
+     *                        Order is irrelevant.
+     * @param checkEndMarker If true, we check for the final "END" in an hs-err file; if it is missing it indicates
+     *                        that hs-err file printing did not complete successfully.
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
+     *               information are printed.
+     * @param printHserrOnError If true, the content of the hs-err file is printed in case of a failing check
+     * @throws RuntimeException, {@link IOException}
+     */
+    public static void checkHsErrFileContent(File f, Pattern[] positivePatterns, Pattern[] negativePatterns, boolean checkEndMarker, boolean verbose, boolean printHserrOnError) throws IOException {
         try (
                 FileInputStream fis = new FileInputStream(f);
                 BufferedReader br = new BufferedReader(new InputStreamReader(fis));
@@ -123,6 +153,9 @@ public class HsErrFileUtils {
                                 System.out.println(line);
                             }
                             System.out.println("^^^ Forbidden pattern found at line " + lineNo + ": " + negativePattern + "^^^");
+                            if (printHserrOnError) {
+                                printHsErrFile(f);
+                            }
                             throw new RuntimeException("Forbidden pattern found at line " + lineNo + ": " + negativePattern);
                         }
                     }
@@ -132,12 +165,32 @@ public class HsErrFileUtils {
             }
             // If the current pattern is not null then it didn't match
             if (currentPositivePattern != null) {
+                if (printHserrOnError) {
+                    printHsErrFile(f);
+                }
                 throw new RuntimeException("hs-err file incomplete (first missing pattern: " + currentPositivePattern.pattern() + ")");
             }
             if (checkEndMarker && !lastLine.equals("END.")) {
+                if (printHserrOnError) {
+                    printHsErrFile(f);
+                }
                 throw new RuntimeException("hs-err file incomplete (missing END marker.)");
             }
             System.out.println("hs-err file " + f.getAbsolutePath() + " scanned successfully.");
+        }
+    }
+
+    private static void printHsErrFile(File f) throws IOException {
+        try (
+                FileInputStream fis = new FileInputStream(f);
+                BufferedReader br = new BufferedReader(new InputStreamReader(fis));
+        ) {
+            String line;
+            System.out.println("------------------------ hs error file ------------------------");
+            while ((line = br.readLine()) != null) {
+                System.out.println(line);
+            }
+            System.out.println("---------------------------------------------------------------");
         }
     }
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -63,6 +63,8 @@ public class HsErrFileUtils {
      * if patterns are missing, or if the END marker is missing.
      * @param f Input file
      * @param patterns An array of patterns that need to match, in that order
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
+     *               information are printed.
      * @throws RuntimeException, {@link IOException}
      */
     public static void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {

--- a/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/HsErrFileUtils.java
@@ -63,8 +63,8 @@ public class HsErrFileUtils {
      * if patterns are missing, or if the END marker is missing.
      * @param f Input file
      * @param patterns An array of patterns that need to match, in that order
-     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
-     *               information are printed.
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
+     *                are printed.
      * @throws RuntimeException, {@link IOException}
      */
     public static void checkHsErrFileContent(File f, Pattern[] patterns, boolean verbose) throws IOException {
@@ -80,8 +80,8 @@ public class HsErrFileUtils {
      *                        Order is irrelevant.
      * @param checkEndMarker If true, we check for the final "END" in an hs-err file; if it is missing it indicates
      *                        that hs-err file printing did not complete successfully.
-     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
-     *               information are printed.
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
+     *                are printed.
      * @throws RuntimeException, {@link IOException}
      */
     public static void checkHsErrFileContent(File f, Pattern[] positivePatterns, Pattern[] negativePatterns, boolean checkEndMarker, boolean verbose) throws IOException {
@@ -111,8 +111,8 @@ public class HsErrFileUtils {
      *                        Order is irrelevant.
      * @param checkEndMarker If true, we check for the final "END" in an hs-err file; if it is missing it indicates
      *                        that hs-err file printing did not complete successfully.
-     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only important
-     *               information are printed.
+     * @param verbose If true, the content of the hs-err file is printed while matching. If false, only the matched patterns
+     *                are printed.
      * @param printHserrOnError If true, the content of the hs-err file is printed in case of a failing check
      * @throws RuntimeException, {@link IOException}
      */
@@ -188,11 +188,11 @@ public class HsErrFileUtils {
                 BufferedReader br = new BufferedReader(new InputStreamReader(fis));
         ) {
             String line;
-            System.out.println("------------------------ hs error file ------------------------");
+            System.out.println("------------------------ hs-err file ------------------------");
             while ((line = br.readLine()) != null) {
                 System.out.println(line);
             }
-            System.out.println("---------------------------------------------------------------");
+            System.out.println("-------------------------------------------------------------");
         }
     }
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/SecondaryErrorTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2014, 2022 SAP SE. All rights reserved.
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ public class SecondaryErrorTest {
     }
     Pattern[] pattern = patternlist.toArray(new Pattern[] {});
 
-    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
+    HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false, true);
 
     System.out.println("OK.");
 


### PR DESCRIPTION
checkHsErrFileContent checks hs error files for existance and non-existance of some user provided patterns. However it should also have an option to print the hs_err file in case of a failing check, this would make error analysis easier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326496](https://bugs.openjdk.org/browse/JDK-8326496): [test] checkHsErrFileContent  support printing hserr in error case (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17978/head:pull/17978` \
`$ git checkout pull/17978`

Update a local copy of the PR: \
`$ git checkout pull/17978` \
`$ git pull https://git.openjdk.org/jdk.git pull/17978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17978`

View PR using the GUI difftool: \
`$ git pr show -t 17978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17978.diff">https://git.openjdk.org/jdk/pull/17978.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17978#issuecomment-1960989207)