### PR TITLE
8325857: G1 Full GC flushes mark stats cache too early

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -312,6 +312,13 @@ void G1FullCollector::phase1_mark_live_objects() {
     reference_processor()->set_active_mt_degree(old_active_mt_degree);
   }
 
+  {
+    GCTraceTime(Debug, gc, phases) debug("Phase 1: Flush Mark Stats Cache", scope()->timer());
+    for (uint i = 0; i < workers(); i++) {
+      marker(i)->flush_mark_stats_cache();
+    }
+  }
+
   // Weak oops cleanup.
   {
     GCTraceTime(Debug, gc, phases) debug("Phase 1: Weak Processing", scope()->timer());

--- a/src/hotspot/share/gc/g1/g1FullGCMarkTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCMarkTask.cpp
@@ -56,7 +56,6 @@ void G1FullGCMarkTask::work(uint worker_id) {
 
   // Mark stack is populated, now process and drain it.
   marker->complete_marking(collector()->oop_queue_set(), collector()->array_queue_set(), &_terminator);
-  marker->flush_mark_stats_cache();
 
   // This is the point where the entire marking should have completed.
   assert(marker->oop_stack()->is_empty(), "Marking should have completed");


### PR DESCRIPTION
Hi all,

  please review this fix that flushes mark stats cache after reference processing because that phase can mark some objects. Apart from a minor performance issue (the amount live data is used to determine whether a region is considered for the dead-wood optimization only, so at most g1 full gc compacted too much) there has been no correctness issue.

In this patch the work is performed serially because even on not-so-current processors this phase takes < 1ms for up to 256 threads (~0.004ms per parallel gc thread).

There is a prototype for a parallel version at https://github.com/openjdk/jdk/compare/master...tschatzl:jdk:submit/8325857-wrong-mark-cache-flush?expand=1 (ugly code) that costs, depending on the machine <= 0,1ms (slightly older machine, 36 threads) or <= 0.03ms (current machine, 256 threads), but introducing like 30 LOC + some magic constant.

I assume that one does not use/force such large #threads to run tiny applications where the other part of g1 full gc only takes time where even that 1ms matter, so saving a bit on code complexity. If somebody disagrees with that analysis, I can change the code to use the parallel version.
Additionally g1 full gc is kind of an error condition anyway.

Testing: gha

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325857](https://bugs.openjdk.org/browse/JDK-8325857): G1 Full GC flushes mark stats cache too early (**Bug** - P3)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17979/head:pull/17979` \
`$ git checkout pull/17979`

Update a local copy of the PR: \
`$ git checkout pull/17979` \
`$ git pull https://git.openjdk.org/jdk.git pull/17979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17979`

View PR using the GUI difftool: \
`$ git pr show -t 17979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17979.diff">https://git.openjdk.org/jdk/pull/17979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17979#issuecomment-1961087875)