### PR TITLE
8326404: Assertion error when trying to compile switch with fallthrough with pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -459,7 +459,9 @@ public class TransPatterns extends TreeTranslator {
                 newCases.add(c.head);
                 appendBreakIfNeeded(tree, cases, c.head);
             }
-            cases = processCases(tree, newCases.toList());
+            cases = newCases.toList();
+            patchCompletingNormallyCases(cases);
+            cases = processCases(tree, cases);
             ListBuffer<JCStatement> statements = new ListBuffer<>();
             VarSymbol temp = new VarSymbol(Flags.SYNTHETIC,
                     names.fromString("selector" + variableIndex++ + target.syntheticNameChar() + "temp"),
@@ -525,8 +527,6 @@ public class TransPatterns extends TreeTranslator {
             int i = 0;
             boolean previousCompletesNormally = false;
             boolean hasDefault = false;
-
-            patchCompletingNormallyCases(cases);
 
             for (var c : cases) {
                 List<JCCaseLabel> clearedPatterns = c.labels;
@@ -688,7 +688,7 @@ public class TransPatterns extends TreeTranslator {
             if (currentCase.caseKind == CaseKind.STATEMENT &&
                 currentCase.completesNormally &&
                 cases.tail.nonEmpty() &&
-                cases.tail.head.guard != null) {
+                (cases.tail.head.guard != null || cases.tail.head.labels.stream().anyMatch(cl -> cl instanceof JCPatternCaseLabel p && p.syntheticGuard != null))) {
                 ListBuffer<JCStatement> newStatements = new ListBuffer<>();
                 List<JCCase> copyFrom = cases;
 
@@ -703,6 +703,7 @@ public class TransPatterns extends TreeTranslator {
                 };
 
                 currentCase.stats = newStatements.toList();
+                currentCase.completesNormally = false;
             }
 
             cases = cases.tail;
@@ -951,10 +952,12 @@ public class TransPatterns extends TreeTranslator {
         JCExpression commonNestedExpression = null;
         VarSymbol commonNestedBinding = null;
         boolean previousNullable = false;
+        boolean previousCompletesNormally = false;
 
         for (List<JCCase> c = inputCases; c.nonEmpty(); c = c.tail) {
             VarSymbol currentBinding = null;
             boolean currentNullable = false;
+            boolean currentCompletesNormally = c.head.completesNormally;
             JCExpression currentNestedExpression = null;
             VarSymbol currentNestedBinding = null;
 
@@ -989,6 +992,8 @@ public class TransPatterns extends TreeTranslator {
                        commonBinding.isUnnamedVariable() == currentBinding.isUnnamedVariable() &&
                        !previousNullable &&
                        !currentNullable &&
+                       !previousCompletesNormally &&
+                       !currentCompletesNormally &&
                        new TreeDiffer(List.of(commonBinding), List.of(currentBinding))
                                .scan(commonNestedExpression, currentNestedExpression)) {
                 accummulator.add(c.head);
@@ -1004,6 +1009,7 @@ public class TransPatterns extends TreeTranslator {
                 commonNestedBinding = currentNestedBinding;
             }
             previousNullable = currentNullable;
+            previousCompletesNormally = currentCompletesNormally;
         }
         resolveAccummulator.resolve(commonBinding, commonNestedExpression, commonNestedBinding);
         return result.toList();
@@ -1476,8 +1482,8 @@ public class TransPatterns extends TreeTranslator {
             ListBuffer<JCStatement> stats = new ListBuffer<>();
             for (Entry<BindingSymbol, VarSymbol> e : hoistedVarMap.entrySet()) {
                 JCVariableDecl decl = makeHoistedVarDecl(diagPos, e.getValue());
-                if (!e.getKey().isPreserved() ||
-                    !parent.tryPrepend(e.getKey(), decl)) {
+                if (!e.getValue().isUnnamedVariable() &&
+                        (!e.getKey().isPreserved() || !parent.tryPrepend(e.getKey(), decl))) {
                     stats.add(decl);
                 }
             }

--- a/test/langtools/tools/javac/patterns/T8326404.java
+++ b/test/langtools/tools/javac/patterns/T8326404.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8326404
+ * @summary Assertion error when trying to compile switch with fallthrough with pattern
+ * @compile T8326404.java
+ * @run main T8326404
+ */
+public class T8326404 {
+    private static final record R<T>(T a) {}
+
+    public static void main(String[] args) {
+        assertEquals(4, run1(""));
+        assertEquals(3, run1(new R("")));
+        assertEquals(2, run1(new R(42)));
+
+        assertEquals(2, run1_break1(""));
+        assertEquals(1, run1_break1(new R("")));
+        assertEquals(2, run1_break1(new R(42)));
+
+        assertEquals(3, run2(""));
+        assertEquals(4, run2(new R("")));
+        assertEquals(2, run2(new R(42)));
+
+        assertEquals(1, run2_break1(""));
+        assertEquals(2, run2_break1(new R("")));
+        assertEquals(2, run2_break1(new R(42)));
+
+        assertEquals(2, run3(""));
+        assertEquals(4, run3(new R("")));
+        assertEquals(3, run3(new R(42)));
+
+        assertEquals(2, run3_break1(""));
+        assertEquals(2, run3_break1(new R("")));
+        assertEquals(1, run3_break1(new R(42)));
+    }
+
+    private static int run1(Object o) {
+        int i = 0;
+        switch (o) {
+            case String _:
+                i++;
+            case R(String _):
+                i++;
+            case R(Integer _):
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    private static int run1_break1(Object o) {
+        int i = 0;
+        switch (o) {
+            case String s:
+                i++;
+            case R(String _):
+                i++;
+                break;
+            case R(Integer _):
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    private static int run2(Object o) {
+        int i = 0;
+        switch (o) {
+            case R(String _):
+                i++;
+            case String _:
+                i++;
+            case R(Integer _):
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    private static int run2_break1(Object o) {
+        int i = 0;
+        switch (o) {
+            case R(String _):
+                i++;
+            case String _:
+                i++;
+                break;
+            case R(Integer _):
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    private static int run3(Object o) {
+        int i = 0;
+        switch (o) {
+            case R(String _):
+                i++;
+            case R(Integer _):
+                i++;
+            case String _:
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    private static int run3_break1(Object o) {
+        int i = 0;
+        switch (o) {
+            case R(String _):
+                i++;
+            case R(Integer _):
+                i++;
+                break;
+            case String _:
+                i++;
+            default:
+                i++;
+        }
+        return i;
+    }
+
+    static void assertEquals(int expected, int actual) {
+        if (expected != actual) {
+            throw new AssertionError("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+}


### PR DESCRIPTION
The assertion error that was raised in the bug report is a result of local variables not being defined in the case of switches that mix type patterns and record patterns with fall-through. e.g., a print after the `TransPatterns` phase:

```java
private static int run(Object o) {
  int i = 0;
  /*synthetic*/ Object selector2$temp = <*nullchk*>(o);
  /*synthetic*/ int index$3 = 0;
  switch (java.lang.runtime.SwitchBootstraps.typeSwitch(selector2$temp, index$3)) {
    case 0:
      String s;
      if (!(let s = (String)selector2$temp; in true)) {
        index$3 = 1;
        continue;
      }
      i++;
    case 1:
      {
      /*synthetic*/ Object selector4$temp = $b$O.a(); // $b$O appears undefined here 
      ...
      }
    ...
  }
}
```

The code for unrolling a case label into local variable declaration statements appears in `handleSwitch` here: https://github.com/openjdk/jdk/pull/17981/files#diff-e50bbfa8783f3bc8f5542452740b78f3167bee19be7365a87da2298c6333cca6L593-L606

`patchCompletingNormallyCases` takes care of statement block propagation for code that completes normally. Unfortunately this code is called late (after the optimization that merges common type tests together e.g., `case R(...): .... case R(...): ....`). 

The fix bails out of this optimization in the presence of fall-through. For example in the `run3_break1` included, the optimization is triggered. In the rest, not.

Additionally, this patch elides the unnecessary binding generation of unnamed pattern variables from the binding context.

Thanks @lahodaj for contributing this solution 🥇

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326404](https://bugs.openjdk.org/browse/JDK-8326404): Assertion error when trying to compile switch with fallthrough with pattern (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Contributors
 * Jan Lahoda `<jlahoda@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17981/head:pull/17981` \
`$ git checkout pull/17981`

Update a local copy of the PR: \
`$ git checkout pull/17981` \
`$ git pull https://git.openjdk.org/jdk.git pull/17981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17981`

View PR using the GUI difftool: \
`$ git pr show -t 17981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17981.diff">https://git.openjdk.org/jdk/pull/17981.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17981#issuecomment-1961364197)