### PR TITLE
8326585: COMPARE_BUILD=PATCH fails if patch -R fails

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -427,8 +427,9 @@ else # $(HAS_SPEC)=true
 
   # Cleanup after a compare build
   define CleanupCompareBuild
-        # If running with a COMPARE_BUILD patch, reverse-apply it
-	$(if $(COMPARE_BUILD_PATCH), cd $(topdir) && $(PATCH) -R -p1 < $(COMPARE_BUILD_PATCH))
+        # If running with a COMPARE_BUILD patch, reverse-apply it, but continue
+        # even if that fails (can happen with removed files).
+	$(if $(COMPARE_BUILD_PATCH), cd $(topdir) && $(PATCH) -R -p1 < $(COMPARE_BUILD_PATCH) || true)
         # Move this build away and restore the original build
 	$(MKDIR) -p $(topdir)/build/compare-build
 	$(MV) $(OUTPUTDIR) $(COMPARE_BUILD_OUTPUTDIR)


### PR DESCRIPTION
At the end of a COMPARE_BUILD run with a patch file, the build tries to revert the patch to restore the workspace as it was. On some versions of patch, this fails if one or more files were deleted, causing the makefile to abort just before the actual comparison. :-(

Reverting the patch is just a courtesy act for running on a developer workspace, so even if this fails, we should continue with the comparison.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326585](https://bugs.openjdk.org/browse/JDK-8326585): COMPARE_BUILD=PATCH fails if patch -R fails (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17983/head:pull/17983` \
`$ git checkout pull/17983`

Update a local copy of the PR: \
`$ git checkout pull/17983` \
`$ git pull https://git.openjdk.org/jdk.git pull/17983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17983`

View PR using the GUI difftool: \
`$ git pr show -t 17983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17983.diff">https://git.openjdk.org/jdk/pull/17983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17983#issuecomment-1961523780)