### PR TITLE
JDK-8326586: Improve Speed of System.map

### DIFF
--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -88,7 +88,7 @@ class CachedNMTInformation : public VirtualMemoryWalker {
   // of them fit into a cache line.
   Range* _ranges;
   MEMFLAGS* _flags;
-  uintx _count, _capacity;
+  size_t _count, _capacity;
 public:
   CachedNMTInformation() : _ranges(nullptr), _flags(nullptr), _count(0), _capacity(0) {}
 
@@ -107,7 +107,7 @@ public:
     }
     if (_count == _capacity) {
       // Enlarge if needed
-      const uintx new_capacity = MAX2((uintx)4096, 2 * _capacity);
+      const size_t new_capacity = MAX2((size_t)4096, 2 * _capacity);
       // Unfortunately, we need to allocate manually, raw, since we must prevent NMT deadlocks (ThreadCritical).
       ALLOW_C_FUNCTION(realloc, _ranges = (Range*)::realloc(_ranges, new_capacity * sizeof(Range));)
       ALLOW_C_FUNCTION(realloc, _flags = (MEMFLAGS*)::realloc(_flags, new_capacity * sizeof(MEMFLAGS));)

--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -112,7 +112,7 @@ public:
       ALLOW_C_FUNCTION(realloc, _ranges = (Range*)::realloc(_ranges, new_capacity * sizeof(Range));)
       ALLOW_C_FUNCTION(realloc, _flags = (MEMFLAGS*)::realloc(_flags, new_capacity * sizeof(MEMFLAGS));)
       if (_ranges == nullptr || _flags == nullptr) {
-        // In case of OOM lets make no fuzz. Just return.
+        // In case of OOM lets make no fuss. Just return.
         return false;
       }
       _capacity = new_capacity;
@@ -133,7 +133,7 @@ public:
     // are usually sorted in order of addresses, ascending.
     static uintx last = 0;
     if (to <= _ranges[last].from) {
-      // not sequential? restart at 0
+      // the range is to the right of the given section, we need to re-start the search
       last = 0;
     }
     MemFlagBitmap bm;


### PR DESCRIPTION
A small optimization that speeds up `jcmd pid System.map` by orders of magnitude by optimizing NMT cache lookup for sequential accesses. This cache is used to map NMT against System information - and the latter usually comes in sequential form, e.g. scanned from `/proc/<pid>/maps` or via VirtualQuery.

On Linux x64, `System.map`for a JVM with an artificially bloated process space (1 million mappings) takes:

before this patch: 6.3 minutes
with this patch: 4.2 seconds

which is a 87x speed improvement.

Ping @jdksjolen and @gerard-ziemski?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326586](https://bugs.openjdk.org/browse/JDK-8326586): Improve Speed of System.map (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [91ea5966](https://git.openjdk.org/jdk/pull/17984/files/91ea59663026bc80f779f0b8678e543adc670f8a)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17984/head:pull/17984` \
`$ git checkout pull/17984`

Update a local copy of the PR: \
`$ git checkout pull/17984` \
`$ git pull https://git.openjdk.org/jdk.git pull/17984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17984`

View PR using the GUI difftool: \
`$ git pr show -t 17984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17984.diff">https://git.openjdk.org/jdk/pull/17984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17984#issuecomment-1961924498)