### PR TITLE
8326578: Clean up networking properties documentation

### DIFF
--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -94,8 +94,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 	        The value of this property is a list of hosts,
 		separated by the '|' character. In addition, the wildcard
 	        character '*' can be used for pattern matching. For example,
-		{@code -Dhttp.nonProxyHosts="*.foo.com|localhost"}
-		will indicate that every host in the foo.com domain (including sub-domains)
+		{@code -Dhttp.nonProxyHosts="*.example.com|localhost"}
+		will indicate that every host in the example.com domain (including sub-domains)
 		and the localhost should be accessed directly even if a proxy server is
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
@@ -129,8 +129,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 	        The value of this property is a list of hosts, separated by
 	        the '|' character. In addition, the wildcard character
 		'*' can be used for pattern matching. For example,
-		{@code -Dftp.nonProxyHosts="*.foo.com|localhost"}
-		will indicate that every host in the foo.com domain (including sub-domains)
+		{@code -Dftp.nonProxyHosts="*.example.com|localhost"}
+		will indicate that every host in the example.com domain (including sub-domains)
 		and the localhost should be accessed directly even if a proxy server is
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
@@ -151,8 +151,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 			The value of this property is a list of hosts, separated by
 			the '|' character. In addition, the wildcard character
 			'*' can be used for pattern matching. For example,
-			{@code -DsocksNonProxyHosts="*.foo.com|localhost"}
-			will indicate that every host in the foo.com domain (including sub-domains)
+			{@code -DsocksNonProxyHosts="*.example.com|localhost"}
+			will indicate that every host in the example.com domain (including sub-domains)
 			and the localhost should be accessed directly even if a proxy server is
 			specified.</P>
 			<P>The default value excludes all common variations of the loopback address.</P>

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -95,8 +95,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 		separated by the '|' character. In addition, the wildcard
 	        character '*' can be used for pattern matching. For example,
 		{@code -Dhttp.nonProxyHosts="*.foo.com|localhost"}
-		will indicate that every host in the foo.com domain and the
-		localhost should be accessed directly even if a proxy server is
+		will indicate that every host in the foo.com domain (including sub-domains)
+		and the localhost should be accessed directly even if a proxy server is
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
         </UL>
@@ -130,8 +130,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 	        the '|' character. In addition, the wildcard character
 		'*' can be used for pattern matching. For example,
 		{@code -Dftp.nonProxyHosts="*.foo.com|localhost"}
-		will indicate that every host in the foo.com domain and the
-		localhost should be accessed directly even if a proxy server is
+		will indicate that every host in the foo.com domain (including sub-domains)
+		and the localhost should be accessed directly even if a proxy server is
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
 	</UL>
@@ -152,8 +152,8 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 			the '|' character. In addition, the wildcard character
 			'*' can be used for pattern matching. For example,
 			{@code -DsocksNonProxyHosts="*.foo.com|localhost"}
-			will indicate that every host in the foo.com domain and the
-			localhost should be accessed directly even if a proxy server is
+			will indicate that every host in the foo.com domain (including sub-domains)
+			and the localhost should be accessed directly even if a proxy server is
 			specified.</P>
 			<P>The default value excludes all common variations of the loopback address.</P>
 		<LI><P><B>{@systemProperty socksProxyVersion}</B> (default: {@code 5})<BR>

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -68,12 +68,14 @@ If there is no special note, a property value is checked every time it is used.<
 <H2>Proxies</H2>
 <P>A proxy server allows indirect connection to network services and
 is used mainly for security (to get through firewalls) and
-performance reasons (proxies often do provide caching mechanisms).
-The following properties allow for configuration of the various type
-of proxies.</P>
+performance reasons (proxies often do provide caching mechanisms).</P>
+<P>Applications may use the {@link java.net.ProxySelector#select(URI)} method
+to determine the proxy that should be used for connecting to a given URI.</P>
+<P>The following properties allow for configuration of the
+{@linkplain java.net.ProxySelector#getDefault() default proxy selector}.</P>
 <UL>
 	<LI><P>HTTP</P>
-	<P>The following proxy settings are used by the HTTP protocol handler.</P>
+	<P>The following proxy settings are used with the {@code http://} URI scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty http.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
@@ -92,20 +94,19 @@ of proxies.</P>
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
         </UL>
-	<LI><P>HTTPS<BR>This is HTTP over SSL, a secure version of HTTP
-	mainly used when confidentiality (like on payment sites) is needed.</P>
-	<P>The following proxy settings are used by the HTTPS protocol handler.</P>
+	<LI><P>HTTPS</P>
+	<P>The following proxy settings are used with the {@code https://} URI scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty https.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
 		</P>
 		<LI><P><B>{@systemProperty https.proxyPort}</B> (default: {@code 443})<BR>
 	        The port number of the proxy server.</P>
-		<P>The HTTPS protocol handler will use the same nonProxyHosts
+		<P>The HTTPS protocol uses the same nonProxyHosts
 		property as the HTTP protocol.</P>
 	</UL>
 	<LI><P>FTP</P>
-	<P>The following proxy settings are used by the FTP protocol handler.</P>
+	<P>The following proxy settings are used with the {@code ftp://} URI scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty ftp.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
@@ -118,22 +119,32 @@ of proxies.</P>
 	        The value of this property is a list of hosts, separated by
 	        the '|' character. In addition, the wildcard character
 		'*' can be used for pattern matching. For example,
-		{@code -Dhttp.nonProxyHosts="*.foo.com|localhost"}
+		{@code -Dftp.nonProxyHosts="*.foo.com|localhost"}
 		will indicate that every host in the foo.com domain and the
 		localhost should be accessed directly even if a proxy server is
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
 	</UL>
-	<LI><P>SOCKS<BR>The SOCKS proxy enables a lower-level type of tunneling
-	because it works at the TCP level. Specifying a SOCKS proxy server
-	results in all java.net TCP connections going through that proxy server
-	unless other proxies are specified. The following proxy settings
-	are used by the SOCKS protocol handler.</P>
+	<LI><P>SOCKS</P>
+	<P>This is a lower-level proxy that is used with all of the above URI schemes
+		unless a scheme-specific proxy is configured.
+		It is also used with the {@code socket://} URI scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty socksProxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.</P>
 		<LI><P><B>{@systemProperty socksProxyPort}</B> (default: {@code 1080})<BR>
 	        The port number of the proxy server.</P>
+		<LI><P><B>{@systemProperty socksNonProxyHosts}</B> (default: {@code localhost|127.*|[::1]})<BR>
+			Indicates the hosts that should be accessed without going
+			through the proxy. Typically this defines internal hosts.
+			The value of this property is a list of hosts, separated by
+			the '|' character. In addition, the wildcard character
+			'*' can be used for pattern matching. For example,
+			{@code -DsocksNonProxyHosts="*.foo.com|localhost"}
+			will indicate that every host in the foo.com domain and the
+			localhost should be accessed directly even if a proxy server is
+			specified.</P>
+			<P>The default value excludes all common variations of the loopback address.</P>
 		<LI><P><B>{@systemProperty socksProxyVersion}</B> (default: {@code 5})<BR>
                 The version of the SOCKS protocol supported by the server. The
                 default is {@code 5} indicating SOCKS V5. Alternatively,

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -71,8 +71,12 @@ is used mainly for security (to get through firewalls) and
 performance reasons (proxies often do provide caching mechanisms).</P>
 <P>Applications may use the {@link java.net.ProxySelector#select(URI)} method
 to determine the proxy that should be used for connecting to a given URI.</P>
-<P>The following properties allow for configuration of the
-{@linkplain java.net.ProxySelector#getDefault() default proxy selector}.</P>
+<P>The following properties are used to configure the JDK default
+	{@link java.net.ProxySelector} implementation.
+	This is the ProxySelector returned by {@link java.net.ProxySelector#getDefault()}
+	when no default ProxySelector was installed by
+	{@link java.net.ProxySelector#setDefault(ProxySelector)}
+</P>
 <UL>
 	<LI><P>HTTP</P>
 	<P>The following properties are used to configure the proxy

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -75,7 +75,9 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 {@linkplain java.net.ProxySelector#getDefault() default proxy selector}.</P>
 <UL>
 	<LI><P>HTTP</P>
-	<P>The following proxy settings are used with the {@code http://} URI scheme.</P>
+	<P>The following properties are used to configure the proxy
+		that is {@linkplain java.net.ProxySelector#select(URI) selected}
+		for URIs with the {@code http://} scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty http.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
@@ -95,7 +97,9 @@ to determine the proxy that should be used for connecting to a given URI.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
         </UL>
 	<LI><P>HTTPS</P>
-	<P>The following proxy settings are used with the {@code https://} URI scheme.</P>
+	<P>The following properties are used to configure the proxy
+		that is {@linkplain java.net.ProxySelector#select(URI) selected}
+		for URIs with the {@code https://} scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty https.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
@@ -106,7 +110,9 @@ to determine the proxy that should be used for connecting to a given URI.</P>
 		property as the HTTP protocol.</P>
 	</UL>
 	<LI><P>FTP</P>
-	<P>The following proxy settings are used with the {@code ftp://} URI scheme.</P>
+	<P>The following properties are used to configure the proxy
+		that is {@linkplain java.net.ProxySelector#select(URI) selected}
+		for URIs with the {@code ftp://} scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty ftp.proxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.
@@ -126,9 +132,10 @@ to determine the proxy that should be used for connecting to a given URI.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
 	</UL>
 	<LI><P>SOCKS</P>
-	<P>This is a lower-level proxy that is used with all of the above URI schemes
-		unless a scheme-specific proxy is configured.
-		It is also used with the {@code socket://} URI scheme.</P>
+	<P>This is a lower-level proxy that is
+		{@linkplain java.net.ProxySelector#select(URI) selected}
+		for all of the above URI schemes unless a scheme-specific proxy
+		is configured. It is also selected for the {@code socket://} URI scheme.</P>
 	<UL>
 		<LI><P><B>{@systemProperty socksProxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.</P>

--- a/src/java.base/share/classes/java/net/doc-files/net-properties.html
+++ b/src/java.base/share/classes/java/net/doc-files/net-properties.html
@@ -124,31 +124,21 @@ of proxies.</P>
 		specified.</P>
                 <P>The default value excludes all common variations of the loopback address.</P>
 	</UL>
-	<LI><P>SOCKS<BR>This is another type of proxy. It allows for lower-level
-	type of tunneling since it works at the TCP level. In effect,
-	in the Java(tm) platform setting a SOCKS proxy server will result in
-	all TCP connections to go through that proxy, unless other proxies
-	are specified. If SOCKS is supported by a Java SE implementation, the
-	following properties will be used:</P>
+	<LI><P>SOCKS<BR>The SOCKS proxy enables a lower-level type of tunneling
+	because it works at the TCP level. Specifying a SOCKS proxy server
+	results in all java.net TCP connections going through that proxy server
+	unless other proxies are specified. The following proxy settings
+	are used by the SOCKS protocol handler.</P>
 	<UL>
 		<LI><P><B>{@systemProperty socksProxyHost}</B> (default: &lt;none&gt;)<BR>
 	        The hostname, or address, of the proxy server.</P>
 		<LI><P><B>{@systemProperty socksProxyPort}</B> (default: {@code 1080})<BR>
 	        The port number of the proxy server.</P>
-                <LI><P><B>{@systemProperty socksProxyVersion}</B> (default: {@code 5})<BR>
+		<LI><P><B>{@systemProperty socksProxyVersion}</B> (default: {@code 5})<BR>
                 The version of the SOCKS protocol supported by the server. The
                 default is {@code 5} indicating SOCKS V5. Alternatively,
                 {@code 4} can be specified for SOCKS V4. Setting the property
                 to values other than these leads to unspecified behavior.</P>
-		<LI><P><B>{@systemProperty java.net.socks.username}</B> (default: &lt;none&gt;)<BR>
-	        Username to use if the SOCKSv5 server asks for authentication
-	        and no {@link java.net.Authenticator java.net.Authenticator} instance was found.</P>
-		<LI><P><B>{@systemProperty java.net.socks.password}</B> (default: &lt;none&gt;)<BR>
-	        Password to use if the SOCKSv5 server asks for authentication
-	        and no {@code java.net.Authenticator} instance was found.</P>
-		<P>Note that if no authentication is provided with either the above
-		properties or an Authenticator, and the proxy requires one, then
-		the <B>user.name</B> property will be used with no password.</P>
 	</UL>
 	<LI><P><B>{@systemProperty java.net.useSystemProxies}</B> (default: {@code false})<BR>
 	On Windows systems, macOS systems, and Gnome systems it is possible to
@@ -192,20 +182,13 @@ of proxies.</P>
 	protocol handler.</P>
 	<LI><P><B>{@systemProperty http.auth.digest.validateServer}</B> (default: {@code false})</P>
 	<LI><P><B>{@systemProperty http.auth.digest.validateProxy}</B> (default: {@code false})</P>
-	<LI><P><B>{@systemProperty http.auth.digest.cnonceRepeat}</B> (default: {@code 5})</P>
-	<P>These 3 properties modify the behavior of the HTTP digest
+	<P>These properties modify the behavior of the HTTP digest
 	authentication mechanism. Digest authentication provides a limited
 	ability for the server  to authenticate itself to the client (i.e.
 	By proving it knows the user's password). However, not all HTTP
 	servers support this capability and by default it is turned off. The
-	first two properties can be set to true to enforce this check for
+	properties can be set to true to enforce this check for
 	authentication with either an origin or proxy server, respectively.</P>
-	<P>It is usually not necessary to change the third property. It
-	determines how many times a cnonce value is re-used. This can be
-	useful when the MD5-sess algorithm is being used. Increasing this
-	value reduces the computational overhead on both client and server
-	by reducing the amount of material that has to be hashed for each
-	HTTP request.</P>
 	<LI><P><B>{@systemProperty http.auth.ntlm.domain}</B> (default: &lt;none&gt;)<BR>
 	NTLM is another authentication scheme. It uses the
 	{@code java.net.Authenticator} class to acquire usernames and passwords when


### PR DESCRIPTION
Please review this patch that removes the specification of system properties that are no longer used:
- `http.auth.digest.cnonceRepeat` system property was removed in JDK 5
- `java.net.socks.username` and `java.net.socks.password` were never available as system properties; they were available as user preferences. The support for these preferences was removed in JDK 7.

Additionally I updated the SOCKS proxy specification to match the user guide, and added the information that SOCKS proxies are only used by java.net TCP connections; the NIO SocketChannel does not support SOCKS proxies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8327135](https://bugs.openjdk.org/browse/JDK-8327135) to be approved

### Issues
 * [JDK-8326578](https://bugs.openjdk.org/browse/JDK-8326578): Clean up networking properties documentation (**Bug** - P4)
 * [JDK-8327135](https://bugs.openjdk.org/browse/JDK-8327135): Clean up networking properties documentation (**CSR**)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) ⚠️ Review applies to [e8777aaf](https://git.openjdk.org/jdk/pull/17988/files/e8777aaf28d31cef2868d465389fa413ebdf37f3)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [6db8fb92](https://git.openjdk.org/jdk/pull/17988/files/6db8fb92e43096be7884108f9b30b81b84960686)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17988/head:pull/17988` \
`$ git checkout pull/17988`

Update a local copy of the PR: \
`$ git checkout pull/17988` \
`$ git pull https://git.openjdk.org/jdk.git pull/17988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17988`

View PR using the GUI difftool: \
`$ git pr show -t 17988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17988.diff">https://git.openjdk.org/jdk/pull/17988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17988#issuecomment-1961687894)