### PR TITLE
8325532: serviceability/dcmd/compiler/PerfMapTest.java leaves created files in the /tmp dir.

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -65,7 +65,13 @@ public class PerfMapTest {
         output.stderrShouldBeEmpty();
         output.stdoutShouldBeEmpty();
 
-        Assert.assertTrue(Files.exists(path), "File must exist: " + path);
+        try {
+            Assert.assertTrue(Files.exists(path), "File must exist: " + path);
+            Assert.assertTrue(Files.size(path) > 0,
+                              "File must not be empty. Possible file permission issue: " + path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
         // Sanity check the file contents
         try {
@@ -79,10 +85,11 @@ public class PerfMapTest {
     }
 
     @Test
-    public void defaultMapFile() {
+    public void defaultMapFile() throws IOException {
         final long pid = ProcessHandle.current().pid();
         final Path path = Paths.get(String.format("/tmp/perf-%d.map", pid));
         run(new JMXExecutor(), "Compiler.perfmap", path);
+        Files.deleteIfExists(path);
     }
 
     @Test
@@ -96,7 +103,7 @@ public class PerfMapTest {
     }
 
     @Test
-    public void specifiedDefaultMapFile() {
+    public void specifiedDefaultMapFile() throws IOException {
         // This is a special case of specifiedMapFile() where the filename specified
         // is the same as the default filename as given in the help output. The dcmd
         // should treat this literally as the filename and not expand <pid> into
@@ -104,5 +111,6 @@ public class PerfMapTest {
         String test_dir = System.getProperty("test.dir", ".");
         Path path = Paths.get("/tmp/perf-<pid>.map");
         run(new JMXExecutor(), "Compiler.perfmap " + path.toString(), path);
+        Files.deleteIfExists(path);
     }
 }


### PR DESCRIPTION
PerfMapTest.java issues the Compiler.perfmap jcmd with a filename argument to write the perfmap to. It does this in 3 different modes. 2 of the modes result in a perfmap file being left in the tmp directory that is not removed after the test executes (and should be removed). The 3rd mode creates the perfmap file in the directory specified by the test.dir property, and is ok to leave the file there. I've added code to delete the /tmp files that are created.

I did a bit of extra testing by hand. I created `/tmp/perf-<pid>.map` as root. As expected the Files.deleteIfExists() call threw an exception due to the lack of permissions to delete the file. However, I then realized the file had a size of 0, which means the test was not even doing a proper job of testing that the perfrmap jcmd was working. In other words, the test should have failed long before getting to the Files.deleteIfExists(), so I added a size check to make sure it fails when the file is not written to.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325532](https://bugs.openjdk.org/browse/JDK-8325532): serviceability/dcmd/compiler/PerfMapTest.java leaves created files in the /tmp dir. (**Bug** - P5)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17992/head:pull/17992` \
`$ git checkout pull/17992`

Update a local copy of the PR: \
`$ git checkout pull/17992` \
`$ git pull https://git.openjdk.org/jdk.git pull/17992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17992`

View PR using the GUI difftool: \
`$ git pr show -t 17992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17992.diff">https://git.openjdk.org/jdk/pull/17992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17992#issuecomment-1967447361)