### PR TITLE
8326612: Parallel: remove redundant assertion from ScavengeRootsTask

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -298,8 +298,6 @@ public:
       _active_workers(active_workers),
       _is_old_gen_empty(old_gen->object_space()->is_empty()),
       _terminator(active_workers, PSPromotionManager::vm_thread_promotion_manager()->stack_array_depth()) {
-    assert(_old_gen != nullptr, "Sanity");
-
     if (!_is_old_gen_empty) {
       PSCardTable* card_table = ParallelScavengeHeap::heap()->card_table();
       card_table->pre_scavenge(active_workers);


### PR DESCRIPTION
This change removes a redundant assertion from `ScavengeRootsTask`.
The assertion is redundant because `_old_gen` is initialized to `old_gen` at L296 which is dereferenced at L297 before the assertion is reached.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326612](https://bugs.openjdk.org/browse/JDK-8326612): Parallel: remove redundant assertion from ScavengeRootsTask (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17994/head:pull/17994` \
`$ git checkout pull/17994`

Update a local copy of the PR: \
`$ git checkout pull/17994` \
`$ git pull https://git.openjdk.org/jdk.git pull/17994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17994`

View PR using the GUI difftool: \
`$ git pr show -t 17994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17994.diff">https://git.openjdk.org/jdk/pull/17994.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17994#issuecomment-1970643882)