### PR TITLE
8310351: Typo in ImmutableCollections

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -161,7 +161,7 @@ class ImmutableCollections {
      * Null argument or null elements in the argument will result in NPE.
      *
      * @param <E> the List's element type
-     * @param coll the input array
+     * @param coll the input collection
      * @return the new list
      */
     @SuppressWarnings("unchecked")

--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -161,7 +161,7 @@ class ImmutableCollections {
      * Null argument or null elements in the argument will result in NPE.
      *
      * @param <E> the List's element type
-     * @param input the input array
+     * @param coll the input array
      * @return the new list
      */
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Fix the @param name

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310351](https://bugs.openjdk.org/browse/JDK-8310351): Typo in ImmutableCollections (**Enhancement** - P5)


### Reviewers
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**) ⚠️ Review applies to [d7b20743](https://git.openjdk.org/jdk/pull/17996/files/d7b207435294559edf0562675d769a142c5f8470)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17996/head:pull/17996` \
`$ git checkout pull/17996`

Update a local copy of the PR: \
`$ git checkout pull/17996` \
`$ git pull https://git.openjdk.org/jdk.git pull/17996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17996`

View PR using the GUI difftool: \
`$ git pr show -t 17996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17996.diff">https://git.openjdk.org/jdk/pull/17996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17996#issuecomment-1962852795)