### PR TITLE
8325361: Make sun.net.www.MessageHeader final

### DIFF
--- a/src/java.base/share/classes/sun/net/www/MessageHeader.java
+++ b/src/java.base/share/classes/sun/net/www/MessageHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,9 @@ import java.util.*;
     the header that don't have a valid key, but do have
     a value (this isn't legal according to the standard,
     but lines like this are everywhere). */
-public
-class MessageHeader {
-    private String keys[];
-    private String values[];
+public final class MessageHeader {
+    private String[] keys;
+    private String[] values;
     private int nkeys;
 
     public MessageHeader () {

--- a/src/java.base/share/classes/sun/net/www/MessageHeader.java
+++ b/src/java.base/share/classes/sun/net/www/MessageHeader.java
@@ -49,7 +49,6 @@ public final class MessageHeader {
         grow();
     }
 
-    @SuppressWarnings("this-escape")
     public MessageHeader (InputStream is) throws java.io.IOException {
         parseHeader(is);
     }


### PR DESCRIPTION
Make sun.net.www.MessageHeader final, and replace C-style array type declaration with Java-style array declaration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325361](https://bugs.openjdk.org/browse/JDK-8325361): Make sun.net.www.MessageHeader final (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17997/head:pull/17997` \
`$ git checkout pull/17997`

Update a local copy of the PR: \
`$ git checkout pull/17997` \
`$ git pull https://git.openjdk.org/jdk.git pull/17997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17997`

View PR using the GUI difftool: \
`$ git pr show -t 17997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17997.diff">https://git.openjdk.org/jdk/pull/17997.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17997#issuecomment-1962957393)