### PR TITLE
8326726: Problem list Exhaustiveness.java due to 8326616

### DIFF
--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -66,6 +66,7 @@ tools/javac/annotations/typeAnnotations/referenceinfos/Lambda.java              
 tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         8057687    generic-all    emit correct byte code an attributes for type annotations
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
+tools/javac/patterns/Exhaustiveness.java 					8326616    generic-all    intermittently timeout
 
 ###########################################################################
 #

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @build toolbox.ToolBox toolbox.JavacTask
- * @run main Exhaustiveness
+ * @run main/timeout=6000 Exhaustiveness
 */
 
 import java.io.IOException;

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -30,7 +30,7 @@
  *          jdk.compiler/com.sun.tools.javac.main
  *          jdk.compiler/com.sun.tools.javac.util
  * @build toolbox.ToolBox toolbox.JavacTask
- * @run main/timeout=6000 Exhaustiveness
+ * @run main Exhaustiveness
 */
 
 import java.io.IOException;


### PR DESCRIPTION
The testcase tools/javac/patterns/Exhaustiveness.java intermittently timeout after [8325215](https://bugs.openjdk.org/browse/JDK-8325215).

I change the timeout value from 120(default value) to 300 locally, and set timeoutFactor to 20, then run this testcase 1000 times, use the concurrecy 16(the half of the nproc).
The test result show that, 90% of the test run finish in 20 seconds, but 15 times test exaust more than 5000 seconds.
So, maybe be we should change the timeout value from 120(default value) to 6000.

Mine test command:
```shell
export test=test/langtools/tools/javac/patterns/Exhaustiveness.java
nproc=`nproc` ; dir="tmp-jtreg-"`basename $test .java` ; rm -rf $dir ; mkdir -p $dir ; time seq 1000 | xargs -i -n 1 -P `expr $nproc / 2` bash -c "jtreg -ea -esa -timeoutFactor:20 -v:fail,error,time,nopass -nr -w $dir/index-{} $test &> $dir/{}.log ; grep 'Test results: passed: 1' -L $dir/{}.log"
```

The command statistic the time elapsed testcase run:
```shell
for i in `seq 1000` ; do grep "elapsed time" index-$i/tools/javac/patterns/Exhaustiveness.jtr | tail -n 1 ; done | awk -F ':' '{print $NF}' | sort -n > time-statistics.log
```

[time-statistics.log](https://github.com/openjdk/jdk/files/14396886/time-statistics.log)


The CPU and memory information:
```
[root@iZbp1fauxu0pkmhplfguv6Z ~]# lscpu 
Architecture:        x86_64
CPU op-mode(s):      32-bit, 64-bit
Byte Order:          Little Endian
CPU(s):              32
On-line CPU(s) list: 0-31
Thread(s) per core:  2
Core(s) per socket:  16
Socket(s):           1
NUMA node(s):        1
Vendor ID:           GenuineIntel
BIOS Vendor ID:      Alibaba Cloud
CPU family:          6
Model:               106
Model name:          Intel(R) Xeon(R) Platinum 8369B CPU @ 2.70GHz
BIOS Model name:     pc-i440fx-2.1
Stepping:            6
CPU MHz:             3500.041
BogoMIPS:            5399.99
Hypervisor vendor:   KVM
Virtualization type: full
L1d cache:           48K
L1i cache:           32K
L2 cache:            1280K
L3 cache:            49152K
NUMA node0 CPU(s):   0-31
Flags:               fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc rep_good nopl nonstop_tsc cpuid aperfmperf tsc_known_freq pni pclmulqdq monitor ssse3 fma cx16 pcid sse4_1 sse4_2 x2apic movbe popcnt aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single ibrs_enhanced fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid avx512f avx512dq rdseed adx smap avx512ifma clflushopt clwb avx512cd sha_ni avx512bw avx512vl xsaveopt xsavec xgetbv1 xsaves wbnoinvd arat avx512vbmi pku ospke avx512_vbmi2 gfni vaes vpclmulqdq avx512_vnni avx512_bitalg avx512_vpopcntdq rdpid fsrm arch_capabilities
[root@iZbp1fauxu0pkmhplfguv6Z ~]# free -h
              total        used        free      shared  buff/cache   available
Mem:           60Gi       2.8Gi        37Gi        21Mi        20Gi        57Gi
Swap:            0B          0B          0B
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326726](https://bugs.openjdk.org/browse/JDK-8326726): Problem list Exhaustiveness.java due to 8326616 (**Sub-task** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17998/head:pull/17998` \
`$ git checkout pull/17998`

Update a local copy of the PR: \
`$ git checkout pull/17998` \
`$ git pull https://git.openjdk.org/jdk.git pull/17998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17998`

View PR using the GUI difftool: \
`$ git pr show -t 17998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17998.diff">https://git.openjdk.org/jdk/pull/17998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/17998#issuecomment-1962986381)