### PR TITLE
8327230: Remove redundant null check for TreeMap comparator.

### DIFF
--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -382,13 +382,15 @@ public class TreeMap<K,V>
         @SuppressWarnings("unchecked")
             Comparable<? super K> k = (Comparable<? super K>) key;
         Entry<K,V> p = root;
-        int cmp = k.compareTo(p.key);
-        if (cmp < 0)
-            p = p.left;
-        else if (cmp > 0)
-            p = p.right;
-        else
-            return p;
+        while(p != null) {
+            int cmp = k.compareTo(p.key);
+            if (cmp < 0)
+                p = p.left;
+            else if (cmp > 0)
+                p = p.right;
+            else
+                return p;
+        }
         return null;
     }
 
@@ -402,17 +404,15 @@ public class TreeMap<K,V>
         @SuppressWarnings("unchecked")
             K k = (K) key;
         Comparator<? super K> cpr = comparator;
-        if (cpr != null) {
-            Entry<K,V> p = root;
-            while (p != null) {
-                int cmp = cpr.compare(k, p.key);
-                if (cmp < 0)
-                    p = p.left;
-                else if (cmp > 0)
-                    p = p.right;
-                else
-                    return p;
-            }
+        Entry<K,V> p = root;
+        while (p != null) {
+            int cmp = cpr.compare(k, p.key);
+            if (cmp < 0)
+                p = p.left;
+            else if (cmp > 0)
+                p = p.right;
+            else
+                return p;
         }
         return null;
     }

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -382,7 +382,7 @@ public class TreeMap<K,V>
         @SuppressWarnings("unchecked")
             Comparable<? super K> k = (Comparable<? super K>) key;
         Entry<K,V> p = root;
-        while(p != null) {
+        while (p != null) {
             int cmp = k.compareTo(p.key);
             if (cmp < 0)
                 p = p.left;


### PR DESCRIPTION
The null check for the comparator is redundant. We already check whether comparator is null before calling the function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8327230](https://bugs.openjdk.org/browse/JDK-8327230): Remove redundant null check for TreeMap comparator. (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/17999/head:pull/17999` \
`$ git checkout pull/17999`

Update a local copy of the PR: \
`$ git checkout pull/17999` \
`$ git pull https://git.openjdk.org/jdk.git pull/17999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17999`

View PR using the GUI difftool: \
`$ git pr show -t 17999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/17999.diff">https://git.openjdk.org/jdk/pull/17999.diff</a>

</details>
