### PR TITLE
8324829: Uniform use of synchronizations in NMT

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1086,11 +1086,10 @@ static char* mmap_create_shared(size_t size) {
 static void unmap_shared(char* addr, size_t bytes) {
   int res;
   if (MemTracker::enabled()) {
-    // Note: Tracker contains a ThreadCritical.
-    Tracker tkr(Tracker::release);
+    ThreadCritical tc;
     res = ::munmap(addr, bytes);
     if (res == 0) {
-      tkr.record((address)addr, bytes);
+      MemTracker::record_virtual_memory_release((address)addr, bytes);
     }
   } else {
     res = ::munmap(addr, bytes);

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1803,9 +1803,9 @@ void PerfMemory::detach(char* addr, size_t bytes) {
 
   if (MemTracker::enabled()) {
     // it does not go through os api, the operation has to record from here
-    Tracker tkr(Tracker::release);
+    ThreadCritical tc;
     remove_file_mapping(addr);
-    tkr.record((address)addr, bytes);
+    MemTracker::record_virtual_memory_release((address)addr, bytes);
   } else {
     remove_file_mapping(addr);
   }

--- a/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
@@ -283,11 +283,9 @@ void XPhysicalMemoryManager::nmt_commit(uintptr_t offset, size_t size) const {
 }
 
 void XPhysicalMemoryManager::nmt_uncommit(uintptr_t offset, size_t size) const {
-  if (MemTracker::enabled()) {
-    const uintptr_t addr = XAddress::marked0(offset);
-    Tracker tracker(Tracker::uncommit);
-    tracker.record((address)addr, size);
-  }
+  const uintptr_t addr = XAddress::marked0(offset);
+  ThreadCritical tc;
+  MemTracker::record_virtual_memory_uncommit((address)addr, size);
 }
 
 void XPhysicalMemoryManager::alloc(XPhysicalMemory& pmem, size_t size) {

--- a/src/hotspot/share/gc/z/zNMT.cpp
+++ b/src/hotspot/share/gc/z/zNMT.cpp
@@ -73,10 +73,8 @@ void ZNMT::process_fake_mapping(zoffset offset, size_t size, bool commit) {
     if (commit) {
       MemTracker::record_virtual_memory_commit((void*)sub_range_addr, sub_range_size, CALLER_PC);
     } else {
-      if (MemTracker::enabled()) {
-        Tracker tracker(Tracker::uncommit);
-        tracker.record((address)sub_range_addr, sub_range_size);
-      }
+      ThreadCritical tc;
+      MemTracker::record_virtual_memory_uncommit((address)sub_range_addr, sub_range_size);
     }
 
     left_to_process -= sub_range_size;

--- a/src/hotspot/share/nmt/memTracker.cpp
+++ b/src/hotspot/share/nmt/memTracker.cpp
@@ -95,20 +95,6 @@ void MemTracker::initialize() {
   }
 }
 
-void Tracker::record(address addr, size_t size) {
-  if (MemTracker::tracking_level() < NMT_summary) return;
-  switch(_type) {
-    case uncommit:
-      VirtualMemoryTracker::remove_uncommitted_region(addr, size);
-      break;
-    case release:
-      VirtualMemoryTracker::remove_released_region(addr, size);
-        break;
-    default:
-      ShouldNotReachHere();
-  }
-}
-
 // Report during error reporting.
 void MemTracker::error_report(outputStream* output) {
   if (enabled()) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2063,10 +2063,10 @@ bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
-    Tracker tkr(Tracker::uncommit);
+    ThreadCritical tc;
     res = pd_uncommit_memory(addr, bytes, executable);
     if (res) {
-      tkr.record((address)addr, bytes);
+      MemTracker::record_virtual_memory_uncommit((address)addr, bytes);
     }
   } else {
     res = pd_uncommit_memory(addr, bytes, executable);
@@ -2078,11 +2078,10 @@ bool os::release_memory(char* addr, size_t bytes) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
-    // Note: Tracker contains a ThreadCritical.
-    Tracker tkr(Tracker::release);
+    ThreadCritical tc;
     res = pd_release_memory(addr, bytes);
     if (res) {
-      tkr.record((address)addr, bytes);
+      MemTracker::record_virtual_memory_release((address)addr, bytes);
     }
   } else {
     res = pd_release_memory(addr, bytes);
@@ -2169,10 +2168,10 @@ char* os::remap_memory(int fd, const char* file_name, size_t file_offset,
 bool os::unmap_memory(char *addr, size_t bytes) {
   bool result;
   if (MemTracker::enabled()) {
-    Tracker tkr(Tracker::release);
+    ThreadCritical tc;
     result = pd_unmap_memory(addr, bytes);
     if (result) {
-      tkr.record((address)addr, bytes);
+      MemTracker::record_virtual_memory_release((address)addr, bytes);
     }
   } else {
     result = pd_unmap_memory(addr, bytes);
@@ -2205,11 +2204,10 @@ char* os::reserve_memory_special(size_t size, size_t alignment, size_t page_size
 bool os::release_memory_special(char* addr, size_t bytes) {
   bool res;
   if (MemTracker::enabled()) {
-    // Note: Tracker contains a ThreadCritical.
-    Tracker tkr(Tracker::release);
+    ThreadCritical tc;
     res = pd_release_memory_special(addr, bytes);
     if (res) {
-      tkr.record((address)addr, bytes);
+      MemTracker::record_virtual_memory_release((address)addr, bytes);
     }
   } else {
     res = pd_release_memory_special(addr, bytes);


### PR DESCRIPTION
In NMT, both `ThreadCritical` and `Tracker` objects are used to do synchronizations. `Tracker` class uses `ThreadCritical` internally and used only for uncommit and release memory operations.  In this change, `Tracker` class is replaced with explicit use of `ThreadCritical` to be the same as the other instances of sync'ing NMT operations.

tiers1-5 tests passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324829](https://bugs.openjdk.org/browse/JDK-8324829): Uniform use of synchronizations in NMT (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18000/head:pull/18000` \
`$ git checkout pull/18000`

Update a local copy of the PR: \
`$ git checkout pull/18000` \
`$ git pull https://git.openjdk.org/jdk.git pull/18000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18000`

View PR using the GUI difftool: \
`$ git pr show -t 18000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18000.diff">https://git.openjdk.org/jdk/pull/18000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18000#issuecomment-1963496054)