### PR TITLE
8326638: Crash in PhaseIdealLoop::remix_address_expressions due to unexpected Region instead of Loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -571,8 +571,8 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
   }
 
   // Replace ((I1 +p V) +p I2) with ((I1 +p I2) +p V),
-  // but not if I2 is a constant.
-  if (n_op == Op_AddP) {
+  // but not if I2 is a constant. Skip for irreducible loops.
+  if (n_op == Op_AddP && n_loop->_head->is_Loop()) {
     if (n2_loop == n_loop && n3_loop != n_loop) {
       if (n->in(2)->Opcode() == Op_AddP && !n->in(3)->is_Con()) {
         Node* n22_ctrl = get_ctrl(n->in(2)->in(2));
@@ -583,9 +583,7 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
             n23_loop == n_loop) {
           Node* add1 = new AddPNode(n->in(1), n->in(2)->in(2), n->in(3));
           // Stuff new AddP in the loop preheader
-          Node* entry = n_loop->_head->is_Loop() ? n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl)
-                                                 : n_loop->_head->in(LoopNode::EntryControl);
-          register_new_node(add1, entry);
+          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
           Node* add2 = new AddPNode(n->in(1), add1, n->in(2)->in(3));
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);
@@ -606,9 +604,7 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
         if (!is_member(n_loop,get_ctrl(I))) {
           Node* add1 = new AddPNode(n->in(1), n->in(2), I);
           // Stuff new AddP in the loop preheader
-          Node* entry = n_loop->_head->is_Loop() ? n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl)
-                                                 : n_loop->_head->in(LoopNode::EntryControl);
-          register_new_node(add1, entry);
+          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
           Node* add2 = new AddPNode(n->in(1), add1, V);
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -583,7 +583,9 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
             n23_loop == n_loop) {
           Node* add1 = new AddPNode(n->in(1), n->in(2)->in(2), n->in(3));
           // Stuff new AddP in the loop preheader
-          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
+          Node* entry = n_loop->_head->is_Loop() ? n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl)
+                                                 : n_loop->_head->in(LoopNode::EntryControl);
+          register_new_node(add1, entry);
           Node* add2 = new AddPNode(n->in(1), add1, n->in(2)->in(3));
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);
@@ -604,7 +606,9 @@ Node* PhaseIdealLoop::remix_address_expressions(Node* n) {
         if (!is_member(n_loop,get_ctrl(I))) {
           Node* add1 = new AddPNode(n->in(1), n->in(2), I);
           // Stuff new AddP in the loop preheader
-          register_new_node(add1, n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl));
+          Node* entry = n_loop->_head->is_Loop() ? n_loop->_head->as_Loop()->skip_strip_mined(1)->in(LoopNode::EntryControl)
+                                                 : n_loop->_head->in(LoopNode::EntryControl);
+          register_new_node(add1, entry);
           Node* add2 = new AddPNode(n->in(1), add1, V);
           register_new_node(add2, n_ctrl);
           _igvn.replace_node(n, add2);

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @bug 8326638
- * @summary TODO
+ * @summary Test handling of irreducible loops in PhaseIdealLoop::remix_address_expressions.
  * @run main/othervm -XX:-TieredCompilation -Xbatch 
  *                   -XX:CompileCommand=compileonly,TestRemixAddressExpressionsWithIrreducibleLoop::test
  *                   TestRemixAddressExpressionsWithIrreducibleLoop

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8326638
  * @summary Test handling of irreducible loops in PhaseIdealLoop::remix_address_expressions.
- * @run main/othervm -XX:-TieredCompilation -Xbatch 
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
  *                   -XX:CompileCommand=compileonly,TestRemixAddressExpressionsWithIrreducibleLoop::test
  *                   TestRemixAddressExpressionsWithIrreducibleLoop
  */

--- a/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestRemixAddressExpressionsWithIrreducibleLoop.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8326638
+ * @summary TODO
+ * @run main/othervm -XX:-TieredCompilation -Xbatch 
+ *                   -XX:CompileCommand=compileonly,TestRemixAddressExpressionsWithIrreducibleLoop::test
+ *                   TestRemixAddressExpressionsWithIrreducibleLoop
+ */
+
+public class TestRemixAddressExpressionsWithIrreducibleLoop {
+
+    public static void main(String[] args) {
+        test("4");
+    }
+
+    public static void test(String arg) {
+        for (int i = 0; i < 100_000; ++i) {
+            int j = 0;
+            while (true) {
+                boolean tmp = "1\ufff0".startsWith(arg, 2 - arg.length());
+                if (j++ > 100)
+                    break;
+            }
+        loop:
+            while (i >= 100) {
+                for (int i2 = 0; i2 < 1; i2 = 1)
+                    if (j > 300)
+                        break loop;
+                j++;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a missing `_head->is_Loop()` check to handle the case when the loop head is not a `LoopNode` but a `RegionNode` because the loop is irreducible:

```
(rr) p n_loop->_head->dump(1)
  412 IfTrue === 411 [[ 345 ]] #1 !jvms: Test$Class1::Class1_method0 @ bci:286 (line 119)
  339 SafePoint === 336 1 340 1 1 344 290 1 1 1 1 291 1 1 293 294 295 1 320 297 1 298 299 300 301 302 1 303 1 [[ 345 ]] SafePoint !jvms: Test$Class1::Class1_method0 @ bci:307 (line 122)
  345 Region === 345 339 412 [[ 345 456 416 417 418 419 420 421 422 423 424 425 426 427 428 429 430 431 1861 1863 1865 1867 1882 1888 ]] #irreducible !jvms: Test$Class1::Class1_method0 @ bci:138 (line 101)
```

We then crash when invoking `LoopNode::skip_strip_mined` on a RegionNode or assert in debug. Unfortunately, I was not able to simply the test any further.

This is a regression from [JDK-8303511](https://bugs.openjdk.org/browse/JDK-8303511) in JDK 21 b13

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326638](https://bugs.openjdk.org/browse/JDK-8326638): Crash in PhaseIdealLoop::remix_address_expressions due to unexpected Region instead of Loop (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18002/head:pull/18002` \
`$ git checkout pull/18002`

Update a local copy of the PR: \
`$ git checkout pull/18002` \
`$ git pull https://git.openjdk.org/jdk.git pull/18002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18002`

View PR using the GUI difftool: \
`$ git pr show -t 18002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18002.diff">https://git.openjdk.org/jdk/pull/18002.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18002#issuecomment-1963582823)