### PR TITLE
8326659: Serial: Remove redundant TenuredSpace::print_on

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -115,14 +115,6 @@ void ContiguousSpace::print_on(outputStream* st) const {
                 p2i(bottom()), p2i(top()), p2i(end()));
 }
 
-#if INCLUDE_SERIALGC
-void TenuredSpace::print_on(outputStream* st) const {
-  print_short_on(st);
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-              p2i(bottom()), p2i(top()), p2i(end()));
-}
-#endif
-
 void ContiguousSpace::verify() const {
   HeapWord* p = bottom();
   HeapWord* t = top();

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -243,8 +243,6 @@ class TenuredSpace: public ContiguousSpace {
   inline HeapWord* par_allocate(size_t word_size) override;
 
   inline void update_for_block(HeapWord* start, HeapWord* end);
-
-  void print_on(outputStream* st) const override;
 };
 #endif //INCLUDE_SERIALGC
 


### PR DESCRIPTION
Trivial removing effectively dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326659](https://bugs.openjdk.org/browse/JDK-8326659): Serial: Remove redundant TenuredSpace::print_on (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18005/head:pull/18005` \
`$ git checkout pull/18005`

Update a local copy of the PR: \
`$ git checkout pull/18005` \
`$ git pull https://git.openjdk.org/jdk.git pull/18005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18005`

View PR using the GUI difftool: \
`$ git pr show -t 18005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18005.diff">https://git.openjdk.org/jdk/pull/18005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18005#issuecomment-1963869138)