### PR TITLE
8326172: Dubious claim on long[]/double[] alignment in MemorySegment javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -305,8 +305,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * and/or garbage collection behavior).
  * <p>
  * In practice, the Java runtime lays out arrays in memory so that each n-byte element
- * occurs at an n-byte aligned physical address (except for {@code long[]} and
- * {@code double[]}, where alignment is platform-dependent, as explained below). The
+ * occurs at an n-byte aligned physical address. The
  * runtime preserves this invariant even if the array is relocated during garbage
  * collection. Access operations rely on this invariant to determine if the specified
  * offset in a heap segment refers to an aligned address in physical memory.
@@ -335,7 +334,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *     1000, 1002, 1004, 1006) are 2-byte aligned.</li>
  * </ul>
  * <p>
- * In other words, heap segments feature a (platform-dependent) <em>maximum</em>
+ * In other words, heap segments feature a <em>maximum</em>
  * alignment which is derived from the size of the elements of the Java array backing the
  * segment, as shown in the following table:
  *

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -325,24 +325,14 @@ import jdk.internal.vm.annotation.ForceInline;
  *     would correspond to physical address 1008 but offset 4 would correspond to
  *     physical address 1010.</li>
  * <li>The starting physical address of a {@code long[]} array will be 8-byte aligned
- *     (e.g. 1000) on 64-bit platforms, so that successive long elements occur at
- *     8-byte aligned addresses (e.g., 1000, 1008, 1016, 1024, etc.) On 64-bit platforms,
- *     a heap segment backed by a {@code long[]} array can be accessed at offsets
- *     0, 8, 16, 24, etc under an 8-byte alignment constraint. In addition, the segment
- *     can be accessed at offsets 0, 4, 8, 12, etc under a 4-byte alignment constraint,
- *     because the target addresses (1000, 1004, 1008, 1012) are 4-byte aligned. And,
- *     the segment can be accessed at offsets 0, 2, 4, 6, etc under a 2-byte alignment
- *     constraint, because the target addresses (e.g. 1000, 1002, 1004, 1006) are
- *     2-byte aligned.</li>
- * <li>The starting physical address of a {@code long[]} array will be 4-byte aligned
- *     (e.g. 1004) on 32-bit platforms, so that successive long elements occur at 4-byte
- *     aligned addresses (e.g., 1004, 1008, 1012, 1016, etc.) On 32-bit platforms, a heap
- *     segment backed by a {@code long[]} array can be accessed at offsets
- *     0, 4, 8, 12, etc under a 4-byte alignment constraint, because the target addresses
- *     (1004, 1008, 1012, 1016) are 4-byte aligned. And, the segment can be accessed at
- *     offsets 0, 2, 4, 6, etc under a 2-byte alignment constraint, because the target
- *     addresses (e.g. 1000, 1002, 1004, 1006) are 2-byte aligned.</li>
- * </ul>
+ *     (e.g. 1000), so that successive long elements occur at 8-byte aligned addresses
+ *     (e.g., 1000, 1008, 1016, 1024, etc.) A heap segment backed by a {@code long[]}
+ *     array can be accessed at offsets 0, 8, 16, 24, etc under an 8-byte alignment
+ *     constraint. In addition, the segment can be accessed at offsets 0, 4, 8, 12,
+ *     etc under a 4-byte alignment constraint, because the target addresses (1000, 1004,
+ *     1008, 1012) are 4-byte aligned. And, the segment can be accessed at offsets 0, 2,
+ *     4, 6, etc under a 2-byte alignment constraint, because the target addresses (e.g.
+ *     1000, 1002, 1004, 1006) are 2-byte aligned.</li>
  * <p>
  * In other words, heap segments feature a (platform-dependent) <em>maximum</em>
  * alignment which is derived from the size of the elements of the Java array backing the
@@ -389,10 +379,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * In such circumstances, clients have two options. They can use a heap segment backed
  * by a different array type (e.g. {@code long[]}), capable of supporting greater maximum
  * alignment. More specifically, the maximum alignment associated with {@code long[]} is
- * set to {@code ValueLayout.JAVA_LONG.byteAlignment()} which is a platform-dependent
- * value (set to {@code ValueLayout.ADDRESS.byteSize()}). That is, {@code long[]}) is
- * guaranteed to provide at least 8-byte alignment in 64-bit platforms, but only 4-byte
- * alignment in 32-bit platforms:
+ * set to {@code ValueLayout.JAVA_LONG.byteAlignment()}, which is 8 bytes:
  *
  * {@snippet lang=java :
  * MemorySegment longSegment = MemorySegment.ofArray(new long[10]);

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -333,6 +333,7 @@ import jdk.internal.vm.annotation.ForceInline;
  *     1008, 1012) are 4-byte aligned. And, the segment can be accessed at offsets 0, 2,
  *     4, 6, etc under a 2-byte alignment constraint, because the target addresses (e.g.
  *     1000, 1002, 1004, 1006) are 2-byte aligned.</li>
+ * </ul>
  * <p>
  * In other words, heap segments feature a (platform-dependent) <em>maximum</em>
  * alignment which is derived from the size of the elements of the Java array backing the

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -47,9 +47,6 @@ import jdk.internal.foreign.layout.ValueLayouts;
  *          For instance, the byte order of these constants is set to the
  *          {@linkplain ByteOrder#nativeOrder() native byte order}, thus making it easy
  *          to work with other APIs, such as arrays and {@link java.nio.ByteBuffer}.
- *          Moreover, the alignment constraint of {@link ValueLayout#JAVA_LONG} and
- *          {@link ValueLayout#JAVA_DOUBLE} is set to 8 bytes on 64-bit platforms,
- *          but only to 4 bytes on 32-bit platforms.
  *
  * @implSpec implementing classes and subclasses are immutable, thread-safe and
  * <a href="{@docRoot}/java.base/java/lang/doc-files/ValueBased.html">value-based</a>.

--- a/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/HeapMemorySegmentImpl.java
@@ -49,9 +49,6 @@ import jdk.internal.vm.annotation.ForceInline;
 abstract sealed class HeapMemorySegmentImpl extends AbstractMemorySegmentImpl {
 
     // Constants defining the maximum alignment supported by various kinds of heap arrays.
-    // While for most arrays, the maximum alignment is constant (the size, in bytes, of the array elements),
-    // note that the alignment of a long[]/double[] depends on the platform: it's 4-byte on x86, but 8 bytes on x64
-    // (as specified by the JAVA_LONG layout constant).
 
     private static final long MAX_ALIGN_BYTE_ARRAY = ValueLayout.JAVA_BYTE.byteAlignment();
     private static final long MAX_ALIGN_SHORT_ARRAY = ValueLayout.JAVA_SHORT.byteAlignment();

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -307,8 +307,8 @@ public final class FallbackLinker extends AbstractLinker {
                     Map.entry("bool", JAVA_BOOLEAN),
                     Map.entry("char", JAVA_BYTE),
                     Map.entry("float", JAVA_FLOAT),
-                    Map.entry("long long", JAVA_LONG),
-                    Map.entry("double", JAVA_DOUBLE),
+                    Map.entry("long long", JAVA_LONG.withByteAlignment(LibFallback.longLongAlign())),
+                    Map.entry("double", JAVA_DOUBLE.withByteAlignment(LibFallback.doubleAlign())),
                     Map.entry("void*", ADDRESS),
                     // platform-dependent sizes
                     Map.entry("size_t", FFIType.SIZE_T),

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/LibFallback.java
@@ -73,6 +73,8 @@ final class LibFallback {
     static int intSize() { return NativeConstants.SIZEOF_INT; }
     static int longSize() {return NativeConstants.SIZEOF_LONG; }
     static int wcharSize() {return NativeConstants.SIZEOF_WCHAR; }
+    static int longLongAlign() { return NativeConstants.ALIGNOF_LONG_LONG; }
+    static int doubleAlign() { return NativeConstants.ALIGNOF_DOUBLE; }
 
     static short structTag() { return NativeConstants.STRUCT_TAG; }
 
@@ -242,6 +244,9 @@ final class LibFallback {
     private static native int ffi_sizeof_long();
     private static native int ffi_sizeof_wchar();
 
+    private static native int alignof_long_long();
+    private static native int alignof_double();
+
     // put these in a separate class to avoid an UnsatisfiedLinkError
     // when LibFallback is initialized but the library is not present
     private static final class NativeConstants {
@@ -263,6 +268,8 @@ final class LibFallback {
         static final int SIZEOF_LONG = ffi_sizeof_long();
         static final int SIZEOF_WCHAR = ffi_sizeof_wchar();
 
+        static final int ALIGNOF_LONG_LONG = alignof_long_long();
+        static final int ALIGNOF_DOUBLE = alignof_double();
 
         static final MemorySegment VOID_TYPE = MemorySegment.ofAddress(ffi_type_void());
         static final short STRUCT_TAG = ffi_type_struct();

--- a/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/layout/ValueLayouts.java
@@ -278,7 +278,7 @@ public final class ValueLayouts {
         }
 
         public static OfLong of(ByteOrder order) {
-            return new OfLongImpl(order, ADDRESS_SIZE_BYTES, Optional.empty());
+            return new OfLongImpl(order, Long.BYTES, Optional.empty());
         }
     }
 
@@ -294,7 +294,7 @@ public final class ValueLayouts {
         }
 
         public static OfDouble of(ByteOrder order) {
-            return new OfDoubleImpl(order, ADDRESS_SIZE_BYTES, Optional.empty());
+            return new OfDoubleImpl(order, Double.BYTES, Optional.empty());
         }
 
     }

--- a/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
+++ b/src/java.base/share/native/libfallbackLinker/fallbackLinker.c
@@ -28,6 +28,7 @@
 #include <ffi.h>
 
 #include <errno.h>
+#include <stdalign.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <wchar.h>
@@ -274,4 +275,14 @@ Java_jdk_internal_foreign_abi_fallback_LibFallback_ffi_1sizeof_1long(JNIEnv* env
 JNIEXPORT jint JNICALL
 Java_jdk_internal_foreign_abi_fallback_LibFallback_ffi_1sizeof_1wchar(JNIEnv* env, jclass cls) {
   return sizeof(wchar_t);
+}
+
+JNIEXPORT jint JNICALL
+Java_jdk_internal_foreign_abi_fallback_LibFallback_alignof_1long_1long(JNIEnv* env, jclass cls) {
+  return alignof(long long);
+}
+
+JNIEXPORT jint JNICALL
+Java_jdk_internal_foreign_abi_fallback_LibFallback_alignof_1double(JNIEnv* env, jclass cls) {
+  return alignof(double);
 }

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -477,24 +477,24 @@ public class TestLayouts {
         List<Object[]> layoutsAndAlignments = new ArrayList<>();
         int i = 0;
         //add basic layouts
-        for (MemoryLayout l : basicLayoutsNoLongDouble) {
+        for (MemoryLayout l : basicLayouts) {
             layoutsAndAlignments.add(new Object[] { l, l.byteAlignment() });
         }
         //add basic layouts wrapped in a sequence with given size
-        for (MemoryLayout l : basicLayoutsNoLongDouble) {
+        for (MemoryLayout l : basicLayouts) {
             layoutsAndAlignments.add(new Object[] { MemoryLayout.sequenceLayout(4, l), l.byteAlignment() });
         }
         //add basic layouts wrapped in a struct
-        for (MemoryLayout l1 : basicLayoutsNoLongDouble) {
-            for (MemoryLayout l2 : basicLayoutsNoLongDouble) {
+        for (MemoryLayout l1 : basicLayouts) {
+            for (MemoryLayout l2 : basicLayouts) {
                 if (l1.byteSize() % l2.byteAlignment() != 0) continue; // second element is not aligned, skip
                 long align = Math.max(l1.byteAlignment(), l2.byteAlignment());
                 layoutsAndAlignments.add(new Object[]{MemoryLayout.structLayout(l1, l2), align});
             }
         }
         //add basic layouts wrapped in a union
-        for (MemoryLayout l1 : basicLayoutsNoLongDouble) {
-            for (MemoryLayout l2 : basicLayoutsNoLongDouble) {
+        for (MemoryLayout l1 : basicLayouts) {
+            for (MemoryLayout l2 : basicLayouts) {
                 long align = Math.max(l1.byteAlignment(), l2.byteAlignment());
                 layoutsAndAlignments.add(new Object[]{MemoryLayout.unionLayout(l1, l2), align});
             }
@@ -543,8 +543,4 @@ public class TestLayouts {
             ValueLayout.JAVA_LONG,
             ValueLayout.JAVA_DOUBLE,
     };
-
-    static MemoryLayout[] basicLayoutsNoLongDouble = Stream.of(basicLayouts)
-            .filter(l -> l.carrier() != long.class && l.carrier() != double.class)
-            .toArray(MemoryLayout[]::new);
 }

--- a/test/jdk/java/foreign/TestLayouts.java
+++ b/test/jdk/java/foreign/TestLayouts.java
@@ -161,7 +161,7 @@ public class TestLayouts {
                 ValueLayout.JAVA_LONG
         );
         assertEquals(struct.byteSize(), 1 + 1 + 2 + 4 + 8);
-        assertEquals(struct.byteAlignment(), ADDRESS.byteSize());
+        assertEquals(struct.byteAlignment(), 8);
     }
 
     @Test(dataProvider="basicLayouts")
@@ -192,7 +192,7 @@ public class TestLayouts {
                 ValueLayout.JAVA_LONG
         );
         assertEquals(struct.byteSize(), 8);
-        assertEquals(struct.byteAlignment(), ADDRESS.byteSize());
+        assertEquals(struct.byteAlignment(), 8);
     }
 
     @Test

--- a/test/jdk/java/foreign/TestValueLayouts.java
+++ b/test/jdk/java/foreign/TestValueLayouts.java
@@ -70,7 +70,7 @@ public class TestValueLayouts {
 
     @Test
     public void testLong() {
-        testAligned(JAVA_LONG, long.class, Long.BYTES, ADDRESS.byteSize());
+        testAligned(JAVA_LONG, long.class, Long.BYTES, Long.BYTES);
     }
 
     @Test
@@ -90,7 +90,7 @@ public class TestValueLayouts {
 
     @Test
     public void testDouble() {
-        testAligned(JAVA_DOUBLE, double.class, Double.BYTES, ADDRESS.byteSize());
+        testAligned(JAVA_DOUBLE, double.class, Double.BYTES, Double.BYTES);
     }
 
     @Test

--- a/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
+++ b/test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java
@@ -76,7 +76,7 @@ public class TestReentrantUpcalls extends NativeTestHelper {
     }
 
     static void m(int depth, MemorySegment thisStub, MethodHandle downcallHandle) throws Throwable {
-        if (depth < 100) {
+        if (depth < 50) {
             downcallHandle.invokeExact(depth + 1, thisStub);
         } else {
             WB.verifyFrames(/*log=*/true, /*updateRegisterMap=*/true);


### PR DESCRIPTION
This patch changes the alignment for `JAVA_LONG` and `JAVA_DOUBLE` to 8, regardless of the underlying platform. This means that atomic access modes work on memory segments wrapping `long[]` or `double[]`, as they already do when using `MethodHandless::arrayAccessVarHandle`.

After discussion, we came to the conclusion that it is reasonable for the JDK to require the elements of a `long[]` and `double[]` to be 8 byte aligned. It is ultimately up to the JDK to set these requirements, which are for the VM to implement.

I was seeing a stack overflow when running test/jdk/java/foreign/stackwalk/TestReentrantUpcalls.java on x86, so I've lowered the recursion to 50 (which is still more than enough I think).

Testing: `jdk_foreign` on x64 Windows, x64 Windows + fallback linker, and x86 Linux (uses fallback linker)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8326711](https://bugs.openjdk.org/browse/JDK-8326711) to be approved

### Issues
 * [JDK-8326172](https://bugs.openjdk.org/browse/JDK-8326172): Dubious claim on long[]/double[] alignment in MemorySegment javadoc (**Bug** - P4)
 * [JDK-8326711](https://bugs.openjdk.org/browse/JDK-8326711): Dubious claim on long[]/double[] alignment in MemorySegment javadoc (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18007/head:pull/18007` \
`$ git checkout pull/18007`

Update a local copy of the PR: \
`$ git checkout pull/18007` \
`$ git pull https://git.openjdk.org/jdk.git pull/18007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18007`

View PR using the GUI difftool: \
`$ git pr show -t 18007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18007.diff">https://git.openjdk.org/jdk/pull/18007.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18007#issuecomment-1964274757)