### PR TITLE
8326688: Parallel: Remove unnecessary BOT update in UpdateOnlyClosure::do_addr

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2551,7 +2551,6 @@ void PSParallelCompact::verify_complete(SpaceId space_id) {
 #endif  // #ifdef ASSERT
 
 inline void UpdateOnlyClosure::do_addr(HeapWord* addr) {
-  _start_array->update_for_block(addr, addr + cast_to_oop(addr)->size());
   compaction_manager()->update_contents(cast_to_oop(addr));
 }
 


### PR DESCRIPTION
Simple removing redundant BOT updates for non-moved objs.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326688](https://bugs.openjdk.org/browse/JDK-8326688): Parallel: Remove unnecessary BOT update in UpdateOnlyClosure::do_addr (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18008/head:pull/18008` \
`$ git checkout pull/18008`

Update a local copy of the PR: \
`$ git checkout pull/18008` \
`$ git pull https://git.openjdk.org/jdk.git pull/18008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18008`

View PR using the GUI difftool: \
`$ git pr show -t 18008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18008.diff">https://git.openjdk.org/jdk/pull/18008.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18008#issuecomment-1964474197)