### PR TITLE
8326685: Linux builds not reproducible if two builds configured in different build folders

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -122,6 +122,8 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
             # Add debug prefix map gcc system include paths, as they cause
             # non-deterministic debug paths depending on gcc path location.
             DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS
+            DEBUG_PREFIX_CFLAGS="$DEBUG_PREFIX_CFLAGS -fdebug-prefix-map=\$(SUPPORT_OUTPUTDIR)/="
+            DEBUG_PREFIX_CFLAGS="$DEBUG_PREFIX_CFLAGS -fdebug-prefix-map=\$(HOTSPOT_OUTPUTDIR)/="
         ]
       )
     fi


### PR DESCRIPTION
Adds Linux -fdebug-prefix-map'ing for SUPPORT_OUTPUTDIR and HOTSPOT_OUTPUTDIR when absolute paths are not allowed in the binaries, thus making the building of a JDK identically reproducible from different build directories.
