### PR TITLE
8326529: JFR: Test for CompilerCompile events fails due to time out

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
@@ -47,6 +47,7 @@ import jdk.test.whitebox.WhiteBox;
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerCompile::dummyMethod,jdk.jfr.event.compiler.TestCompilerCompile::doTest
  *     jdk.jfr.event.compiler.TestCompilerCompile
  */
 public class TestCompilerCompile {


### PR DESCRIPTION
The test `jdk\jfr\event\compiler\TestCompilerCompile.java` times-out waiting for the compilation of the test methods.
```
#-----testresult-----
description=file\:/C\:/cygwin64/home/rtoyonag/jdk8u/jdk/test/jdk/jfr/event/compiler/TestCompilerCompile.java
elapsed=121659 0\:02\:01.659
end=Thu Feb 22 18\:52\:04 UTC 2024
environment=regtest
execStatus=Error. Program `C\:\\cygwin64\\home\\rtoyonag\\jdk8u\\build\\windows-x86-normal-server-release\\images\\j2sdk-image\\bin\\java' timed out (timeout set to 120000ms, elapsed time including timeout handling was 120404ms).
harnessLoaderMode=Classpath Loader
harnessVariety=Full Bundle
hostname=TEST-WIN2016-1.2nnkwmsaofoerpj2hhoaq1ahee.bx.internal.cloudapp.net
javatestOS=Windows Server 2016 10.0 (amd64)
javatestVersion=6.0-ea+b24-2024-02-01-${BUILT_FROM_COMMIT}
jtregVersion=jtreg 7.3.1 dev 0
script=com.sun.javatest.regtest.exec.RegressionScript
sections=script_messages build build main build main
start=Thu Feb 22 18\:50\:02 UTC 2024
test=jdk/jfr/event/compiler/TestCompilerCompile.java
testJDK=C\:\\cygwin64\\home\\rtoyonag\\jdk8u\\build\\windows-x86-normal-server-release\\images\\j2sdk-image
testJDK_OS=[name\:Windows Server 2016,arch\:x86,version\:10.0,family\:windows,simple_arch\:i586,simple_version\:10.0,processors\:2,maxMemory\:8589463552,maxSwap\:13622628352]
testJDK_os.arch=x86
testJDK_os.name=Windows Server 2016
testJDK_os.version=10.0
totalTime=121662
user.name=rtoyonag
work=C\:\\cygwin64\\home\\rtoyonag\\jdk8u\\JTwork\\jdk\\jfr\\event\\compiler
...
Timeout signalled after 120 seconds
result: Error. Program `C:\cygwin64\home\rtoyonag\jdk8u\build\windows-x86-normal-server-release\images\j2sdk-image\bin\java' timed out (timeout set to 120000ms, elapsed time including timeout handling was 120404ms).

```
This PR limits compilation only to the test methods we care about ([similar to what `jdk\jfr\event\compiler\TestCompilerPhases.java` does](https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java#L46)).

This problem is seen in [Adoptium automated tests](https://github.com/adoptium/aqa-tests/issues/3046) for windows 32 bit. I've only been able to reproduce the issue with JDK8, but the test code has not changed since JDK8 so I think it makes sense to make the change here and backport it.  Although I haven't seen the problem in later JDK versions, it shouldn't hurt to limit compilation to the specific test methods we care about.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326529](https://bugs.openjdk.org/browse/JDK-8326529): JFR: Test for CompilerCompile events fails due to time out (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18010/head:pull/18010` \
`$ git checkout pull/18010`

Update a local copy of the PR: \
`$ git checkout pull/18010` \
`$ git pull https://git.openjdk.org/jdk.git pull/18010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18010`

View PR using the GUI difftool: \
`$ git pr show -t 18010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18010.diff">https://git.openjdk.org/jdk/pull/18010.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18010#issuecomment-1964605348)