### PR TITLE
8326687: Inconsistent use of "ZIP", "Zip" and "zip" in java.util.zip/jar zipfs javadoc

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -826,7 +826,7 @@ public class JarFile extends ZipFile {
 
     /**
      * Returns an input stream for reading the contents of the specified
-     * zip file entry.
+     * ZIP file entry.
      *
      * @apiNote The {@code InputStream} returned by this method can wrap an
      * {@link java.util.zip.InflaterInputStream InflaterInputStream}, whose
@@ -834,11 +834,11 @@ public class JarFile extends ZipFile {
      * read(byte[], int, int)} method can modify any element of the output
      * buffer.
      *
-     * @param ze the zip file entry
+     * @param ze the ZIP file entry
      * @return an input stream for reading the contents of the specified
-     *         zip file entry or null if the zip file entry does not exist
+     *         ZIP file entry or null if the ZIP file entry does not exist
      *         within the jar file
-     * @throws ZipException if a zip file format error has occurred
+     * @throws ZipException if a ZIP file format error has occurred
      * @throws IOException if an I/O error has occurred
      * @throws SecurityException if any of the jar file entries
      *         are incorrectly signed.

--- a/src/java.base/share/classes/java/util/zip/ZipConstants.java
+++ b/src/java.base/share/classes/java/util/zip/ZipConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -230,7 +230,7 @@ interface ZipConstants {
     static final int ENDOFF = 16;
 
     /**
-     * End of central directory (END) header zip file comment length field offset.
+     * End of central directory (END) header ZIP file comment length field offset.
      */
     static final int ENDCOM = 20;
 }

--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -93,7 +93,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
             128L * 365 * 24 * 60 * 60 * 1000;
 
     /**
-     * Creates a new zip entry with the specified name.
+     * Creates a new ZIP entry with the specified name.
      *
      * @param  name
      *         The entry name
@@ -111,11 +111,11 @@ public class ZipEntry implements ZipConstants, Cloneable {
     }
 
     /**
-     * Creates a new zip entry with fields taken from the specified
-     * zip entry.
+     * Creates a new ZIP entry with fields taken from the specified
+     * ZIP entry.
      *
      * @param  e
-     *         A zip Entry object
+     *         A ZIP Entry object
      *
      * @throws NullPointerException if the entry object is null
      */
@@ -150,7 +150,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * <p> If the entry is output to a ZIP file or ZIP file formatted
      * output stream the last modification time set by this method will
-     * be stored into the {@code date and time fields} of the zip file
+     * be stored into the {@code date and time fields} of the ZIP file
      * entry and encoded in standard {@code MS-DOS date and time format}.
      * The {@link java.util.TimeZone#getDefault() default TimeZone} is
      * used to convert the epoch time to the MS-DOS date and time.
@@ -183,7 +183,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * <p> If the entry is read from a ZIP file or ZIP file formatted
      * input stream, this is the last modification time from the {@code
-     * date and time fields} of the zip file entry. The
+     * date and time fields} of the ZIP file entry. The
      * {@link java.util.TimeZone#getDefault() default TimeZone} is used
      * to convert the standard MS-DOS formatted date and time to the
      * epoch time.
@@ -206,11 +206,11 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * <p> If the entry is output to a ZIP file or ZIP file formatted
      * output stream the last modification time set by this method will
-     * be stored into the {@code date and time fields} of the zip file
+     * be stored into the {@code date and time fields} of the ZIP file
      * entry and encoded in standard {@code MS-DOS date and time format}.
      * If the date-time set is out of the range of the standard {@code
      * MS-DOS date and time format}, the time will also be stored into
-     * zip file entry's extended timestamp fields in {@code optional
+     * ZIP file entry's extended timestamp fields in {@code optional
      * extra data} in UTC time. The {@link java.time.ZoneId#systemDefault()
      * system default TimeZone} is used to convert the local date-time
      * to UTC time.
@@ -285,13 +285,13 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * <p> When output to a ZIP file or ZIP file formatted output stream
      * the last modification time set by this method will be stored into
-     * zip file entry's {@code date and time fields} in {@code standard
+     * ZIP file entry's {@code date and time fields} in {@code standard
      * MS-DOS date and time format}), and the extended timestamp fields
      * in {@code optional extra data} in UTC time.
      *
      * @param  time
      *         The last modification time of the entry
-     * @return This zip entry
+     * @return This ZIP entry
      *
      * @throws NullPointerException if the {@code time} is null
      *
@@ -337,7 +337,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * @param  time
      *         The last access time of the entry
-     * @return This zip entry
+     * @return This ZIP entry
      *
      * @throws NullPointerException if the {@code time} is null
      *
@@ -373,7 +373,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * @param  time
      *         The creation time of the entry
-     * @return This zip entry
+     * @return This ZIP entry
      *
      * @throws NullPointerException if the {@code time} is null
      *

--- a/src/java.base/share/classes/java/util/zip/ZipException.java
+++ b/src/java.base/share/classes/java/util/zip/ZipException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ package java.util.zip;
 import java.io.IOException;
 
 /**
- * Signals that a Zip exception of some sort has occurred.
+ * Signals that a ZIP exception of some sort has occurred.
  *
  * @see     java.io.IOException
  * @since   1.1

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -76,7 +76,7 @@ import static java.util.zip.ZipConstants64.*;
 import static java.util.zip.ZipUtils.*;
 
 /**
- * This class is used to read entries from a zip file.
+ * This class is used to read entries from a ZIP file.
  *
  * <p> Unless otherwise noted, passing a {@code null} argument to a constructor
  * or method in this class will cause a {@link NullPointerException} to be
@@ -95,27 +95,27 @@ import static java.util.zip.ZipUtils.*;
  */
 public class ZipFile implements ZipConstants, Closeable {
 
-    private final String filePath;     // zip file path
+    private final String filePath;     // ZIP file path
     private final String fileName;     // name of the file
     private volatile boolean closeRequested;
 
-    // The "resource" used by this zip file that needs to be
+    // The "resource" used by this ZIP file that needs to be
     // cleaned after use.
     // a) the input streams that need to be closed
     // b) the list of cached Inflater objects
-    // c) the "native" source of this zip file.
+    // c) the "native" source of this ZIP file.
     private final @Stable CleanableResource res;
 
     private static final int STORED = ZipEntry.STORED;
     private static final int DEFLATED = ZipEntry.DEFLATED;
 
     /**
-     * Mode flag to open a zip file for reading.
+     * Mode flag to open a ZIP file for reading.
      */
     public static final int OPEN_READ = 0x1;
 
     /**
-     * Mode flag to open a zip file and mark it for deletion.  The file will be
+     * Mode flag to open a ZIP file and mark it for deletion.  The file will be
      * deleted some time between the moment that it is opened and the moment
      * that it is closed, but its contents will remain accessible via the
      * {@code ZipFile} object until either the close method is invoked or the
@@ -131,7 +131,7 @@ public class ZipFile implements ZipConstants, Closeable {
             getDisableZip64ExtraFieldValidation();
 
     /**
-     * Opens a zip file for reading.
+     * Opens a ZIP file for reading.
      *
      * <p>First, if there is a security manager, its {@code checkRead}
      * method is called with the {@code name} argument as its argument
@@ -140,7 +140,7 @@ public class ZipFile implements ZipConstants, Closeable {
      * <p>The UTF-8 {@link java.nio.charset.Charset charset} is used to
      * decode the entry names and comments.
      *
-     * @param name the name of the zip file
+     * @param name the name of the ZIP file
      * @throws ZipException if a ZIP format error has occurred
      * @throws IOException if an I/O error has occurred
      * @throws SecurityException if a security manager exists and its
@@ -258,13 +258,13 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     /**
-     * Opens a zip file for reading.
+     * Opens a ZIP file for reading.
      *
      * <p>First, if there is a security manager, its {@code checkRead}
      * method is called with the {@code name} argument as its argument
      * to ensure the read is allowed.
      *
-     * @param name the name of the zip file
+     * @param name the name of the ZIP file
      * @param charset
      *        the {@linkplain java.nio.charset.Charset charset} to
      *        be used to decode the ZIP entry name and comment that are not
@@ -308,13 +308,13 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     /**
-     * Returns the zip file comment. If a comment does not exist or an error is
+     * Returns the ZIP file comment. If a comment does not exist or an error is
      * encountered decoding the comment using the charset specified
-     * when opening the Zip file, then {@code null} is returned.
+     * when opening the ZIP file, then {@code null} is returned.
      *
-     * @return the comment string for the zip file, or null if none
+     * @return the comment string for the ZIP file, or null if none
      *
-     * @throws IllegalStateException if the zip file has been closed
+     * @throws IllegalStateException if the ZIP file has been closed
      *
      * @since 1.7
      */
@@ -325,7 +325,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 return null;
             }
             // If there is a problem decoding the byte array which represents
-            // the Zip file comment, return null;
+            // the ZIP file comment, return null;
             try {
                 return res.zsrc.zc.toString(res.zsrc.comment);
             } catch (IllegalArgumentException iae) {
@@ -335,12 +335,12 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     /**
-     * Returns the zip file entry for the specified name, or null
+     * Returns the ZIP file entry for the specified name, or null
      * if not found.
      *
      * @param name the name of the entry
-     * @return the zip file entry, or null if not found
-     * @throws IllegalStateException if the zip file has been closed
+     * @return the ZIP file entry, or null if not found
+     * @throws IllegalStateException if the ZIP file has been closed
      */
     public ZipEntry getEntry(String name) {
         Objects.requireNonNull(name, "name");
@@ -357,7 +357,7 @@ public class ZipFile implements ZipConstants, Closeable {
 
     /**
      * Returns an input stream for reading the contents of the specified
-     * zip file entry.
+     * ZIP file entry.
      * <p>
      * Closing this ZIP file will, in turn, close all input streams that
      * have been returned by invocations of this method.
@@ -368,13 +368,13 @@ public class ZipFile implements ZipConstants, Closeable {
      * read(byte[], int, int)} method can modify any element of the output
      * buffer.
      *
-     * @param entry the zip file entry
+     * @param entry the ZIP file entry
      * @return the input stream for reading the contents of the specified
-     * zip file entry or null if the zip file entry does not exist
-     * within the zip file.
+     * ZIP file entry or null if the ZIP file entry does not exist
+     * within the ZIP file.
      * @throws ZipException if a ZIP format error has occurred
      * @throws IOException if an I/O error has occurred
-     * @throws IllegalStateException if the zip file has been closed
+     * @throws IllegalStateException if the ZIP file has been closed
      */
     public InputStream getInputStream(ZipEntry entry) throws IOException {
         Objects.requireNonNull(entry, "entry");
@@ -553,7 +553,7 @@ public class ZipFile implements ZipConstants, Closeable {
     /**
      * Returns an enumeration of the ZIP file entries.
      * @return an enumeration of the ZIP file entries
-     * @throws IllegalStateException if the zip file has been closed
+     * @throws IllegalStateException if the ZIP file has been closed
      */
     public Enumeration<? extends ZipEntry> entries() {
         synchronized (this) {
@@ -605,7 +605,7 @@ public class ZipFile implements ZipConstants, Closeable {
      * the central directory of the ZIP file.
      *
      * @return an ordered {@code Stream} of entries in this ZIP file
-     * @throws IllegalStateException if the zip file has been closed
+     * @throws IllegalStateException if the ZIP file has been closed
      * @since 1.8
      */
     public Stream<? extends ZipEntry> stream() {
@@ -624,13 +624,13 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     /*
-     * Returns an ordered {@code Stream} over the zip file entry names.
+     * Returns an ordered {@code Stream} over the ZIP file entry names.
      *
      * Entry names appear in the {@code Stream} in the order they appear in
      * the central directory of the ZIP file.
      *
-     * @return an ordered {@code Stream} of entry names in this zip file
-     * @throws IllegalStateException if the zip file has been closed
+     * @return an ordered {@code Stream} of entry names in this ZIP file
+     * @throws IllegalStateException if the ZIP file has been closed
      * @since 10
      */
     private Stream<String> entryNameStream() {
@@ -642,13 +642,13 @@ public class ZipFile implements ZipConstants, Closeable {
     }
 
     /*
-     * Returns an ordered {@code Stream} over the zip file entries.
+     * Returns an ordered {@code Stream} over the ZIP file entries.
      *
      * Entries appear in the {@code Stream} in the order they appear in
      * the central directory of the jar file.
      *
-     * @return an ordered {@code Stream} of entries in this zip file
-     * @throws IllegalStateException if the zip file has been closed
+     * @return an ordered {@code Stream} of entries in this ZIP file
+     * @throws IllegalStateException if the ZIP file has been closed
      * @since 10
      */
     private Stream<JarEntry> jarStream() {
@@ -717,7 +717,7 @@ public class ZipFile implements ZipConstants, Closeable {
      * Returns the number of entries in the ZIP file.
      *
      * @return the number of entries in the ZIP file
-     * @throws IllegalStateException if the zip file has been closed
+     * @throws IllegalStateException if the ZIP file has been closed
      */
     public int size() {
         synchronized (this) {
@@ -817,7 +817,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 }
             }
 
-            // Release zip src
+            // Release ZIP src
             if (zsrc != null) {
                 synchronized (zsrc) {
                     try {
@@ -852,7 +852,7 @@ public class ZipFile implements ZipConstants, Closeable {
 
         synchronized (this) {
             // Close streams, release their inflaters, release cached inflaters
-            // and release zip source
+            // and release ZIP source
             try {
                 res.clean();
             } catch (UncheckedIOException ioe) {
@@ -878,7 +878,7 @@ public class ZipFile implements ZipConstants, Closeable {
 
     /*
      * Inner class implementing the input stream used to read a
-     * (possibly compressed) zip file entry.
+     * (possibly compressed) ZIP file entry.
      */
     private class ZipFileInputStream extends InputStream {
         private volatile boolean closeRequested;
@@ -891,7 +891,7 @@ public class ZipFile implements ZipConstants, Closeable {
             rem = CENSIZ(cen, cenpos);
             size = CENLEN(cen, cenpos);
             pos = CENOFF(cen, cenpos);
-            // zip64
+            // ZIP64
             if (rem == ZIP64_MAGICVAL || size == ZIP64_MAGICVAL ||
                 pos == ZIP64_MAGICVAL) {
                 checkZIP64(cen, cenpos);
@@ -938,7 +938,7 @@ public class ZipFile implements ZipConstants, Closeable {
         }
 
         /*
-         * The Zip file spec explicitly allows the LOC extra data size to
+         * The ZIP file spec explicitly allows the LOC extra data size to
          * be different from the CEN extra data size. Since we cannot trust
          * the CEN extra data size, we need to read the LOC to determine
          * the entry data offset.
@@ -1186,20 +1186,20 @@ public class ZipFile implements ZipConstants, Closeable {
         private static final int[] EMPTY_META_VERSIONS = new int[0];
 
         private final Key key;               // the key in files
-        private final @Stable ZipCoder zc;   // zip coder used to decode/encode
+        private final @Stable ZipCoder zc;   // ZIP coder used to decode/encode
 
         private int refs = 1;
 
-        private RandomAccessFile zfile;      // zfile of the underlying zip file
+        private RandomAccessFile zfile;      // zfile of the underlying ZIP file
         private byte[] cen;                  // CEN & ENDHDR
         private long locpos;                 // position of first LOC header (usually 0)
-        private byte[] comment;              // zip file comment
+        private byte[] comment;              // ZIP file comment
                                              // list of meta entries in META-INF dir
         private int   manifestPos = -1;      // position of the META-INF/MANIFEST.MF, if exists
         private int   manifestNum = 0;       // number of META-INF/MANIFEST.MF, case insensitive
         private int[] signatureMetaNames;    // positions of signature related entries, if such exist
         private int[] metaVersions;          // list of unique versions found in META-INF/versions/
-        private final boolean startsWithLoc; // true, if zip file starts with LOCSIG (usually true)
+        private final boolean startsWithLoc; // true, if ZIP file starts with LOCSIG (usually true)
 
         // A Hashmap for all entries.
         //
@@ -1454,10 +1454,10 @@ public class ZipFile implements ZipConstants, Closeable {
         private int tablelen;                // number of hash heads
 
         /**
-         * A class representing a key to a zip file. A key is based
+         * A class representing a key to a ZIP file. A key is based
          * on the file key if available, or the path value if the
          * file key is not available. The key is also based on the
-         * file's last modified time to allow for cases where a zip
+         * file's last modified time to allow for cases where a ZIP
          * file is re-opened after it has been modified.
          */
         private static class Key {
@@ -1679,7 +1679,7 @@ public class ZipFile implements ZipConstants, Closeable {
                                 zerror("zip comment read failed");
                             }
                         }
-                        // must check for a zip64 end record; it is always permitted to be present
+                        // must check for a ZIP64 end record; it is always permitted to be present
                         try {
                             byte[] loc64 = new byte[ZIP64_LOCHDR];
                             if (end.endpos < ZIP64_LOCHDR ||
@@ -1708,7 +1708,7 @@ public class ZipFile implements ZipConstants, Closeable {
                             end.cenoff = cenoff64;
                             end.centot = (int)centot64; // assume total < 2g
                             end.endpos = end64pos;
-                        } catch (IOException x) {}    // no zip64 loc/end
+                        } catch (IOException x) {}    // no ZIP64 loc/end
                         return end;
                     }
                 }
@@ -1716,7 +1716,7 @@ public class ZipFile implements ZipConstants, Closeable {
             throw new ZipException("zip END header not found");
         }
 
-        // Reads zip file central directory.
+        // Reads ZIP file central directory.
         private void initCEN(int knownTotal) throws IOException {
             // Prefer locals for better performance during startup
             byte[] cen;
@@ -1733,7 +1733,7 @@ public class ZipFile implements ZipConstants, Closeable {
                     zerror("invalid END header (bad central directory size)");
                 long cenpos = end.endpos - end.cenlen;     // position of CEN table
                 // Get position of first local file (LOC) header, taking into
-                // account that there may be a stub prefixed to the zip file.
+                // account that there may be a stub prefixed to the ZIP file.
                 locpos = cenpos - end.cenoff;
                 if (locpos < 0) {
                     zerror("invalid END header (bad central directory offset)");
@@ -1776,7 +1776,7 @@ public class ZipFile implements ZipConstants, Closeable {
             manifestNum = 0;
             while (entryPos <= limit) {
                 if (idx >= entriesLength) {
-                    // This will only happen if the zip file has an incorrect
+                    // This will only happen if the ZIP file has an incorrect
                     // ENDTOT field, which usually means it contains more than
                     // 65535 entries.
                     initCEN(countCENHeaders(cen, limit));
@@ -1849,7 +1849,7 @@ public class ZipFile implements ZipConstants, Closeable {
         }
 
         /*
-         * Returns the {@code pos} of the zip cen entry corresponding to the
+         * Returns the {@code pos} of the ZIP cen entry corresponding to the
          * specified entry name, or -1 if not found.
          */
         private int getEntryPos(String name, boolean addSlash) {
@@ -2037,9 +2037,9 @@ public class ZipFile implements ZipConstants, Closeable {
 
         /**
          * Returns the number of CEN headers in a central directory.
-         * Will not throw, even if the zip file is corrupt.
+         * Will not throw, even if the ZIP file is corrupt.
          *
-         * @param cen copy of the bytes in a zip file's central directory
+         * @param cen copy of the bytes in a ZIP file's central directory
          * @param size number of bytes in central directory
          */
         private static int countCENHeaders(byte[] cen, int size) {

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -66,7 +66,7 @@ import static java.util.zip.ZipUtils.*;
  *      }
  *    }
  * @apiNote
- * The LOC header contains metadata about the Zip file entry. {@code ZipInputStream}
+ * The LOC header contains metadata about the ZIP file entry. {@code ZipInputStream}
  * does not read the Central directory (CEN) header for the entry and therefore
  * will not have access to its metadata such as the external file attributes.
  * {@linkplain ZipFile} may be used when the information stored within
@@ -579,7 +579,7 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
      * data descriptor, and that data descriptor may optionally contain a
      * leading signature (EXTSIG).
      *
-     * From the zip spec http://www.pkware.com/documents/casestudies/APPNOTE.TXT
+     * From the ZIP spec http://www.pkware.com/documents/casestudies/APPNOTE.TXT
      *
      * """Although not originally assigned a signature, the value 0x08074b50
      * has commonly been adopted as a signature value for the data descriptor

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -52,7 +52,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * Whether to use ZIP64 for zip files with more than 64k entries.
      * Until ZIP64 support in zip implementations is ubiquitous, this
      * system property allows the creation of zip files which can be
-     * read by legacy zip implementations which tolerate "incorrect"
+     * read by legacy ZIP implementations which tolerate "incorrect"
      * total entry count fields, such as the ones in jdk6, and even
      * some in jdk7.
      */
@@ -233,7 +233,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
             // descriptor immediately following the compressed entry data.
             // Ignore the compressed size of a ZipEntry if it was implcitely set
             // while reading that ZipEntry from a  ZipFile or ZipInputStream because
-            // we can't know the compression level of the source zip file/stream.
+            // we can't know the compression level of the source ZIP file/stream.
             if (e.size  == -1 || e.csize == -1 || e.crc   == -1 || !e.csizeSet) {
                 e.flag = 8;
             }
@@ -734,7 +734,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
         writeShort(count);                // total number of directory entries
         writeInt(xlen);                   // length of central directory
         writeInt(xoff);                   // offset of central directory
-        if (comment != null) {            // zip file comment
+        if (comment != null) {            // ZIP file comment
             writeShort(comment.length);
             writeBytes(comment, 0, comment.length);
         } else {

--- a/src/java.base/share/classes/java/util/zip/package-info.java
+++ b/src/java.base/share/classes/java/util/zip/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,12 +39,12 @@
  *         are based.
  *     <li><a id="zip64">An implementation may optionally support the
  *         ZIP64(tm) format extensions defined by the</a>
- *         <a href="https://support.pkware.com/home/pkzip/developer-tools/appnote">
+ *         <a href="https://support.pkware.com/pkzip/appnote">
  *         PKWARE ZIP File Format Specification</a>. The ZIP64(tm) format
  *         extensions are used to overcome the size limitations of the
  *         original ZIP format.
  *     <li><a id="lang_encoding">APPENDIX D of</a>
- *         <a href="https://support.pkware.com/home/pkzip/developer-tools/appnote">
+ *         <a href="https://support.pkware.com/pkzip/appnote">
  *         PKWARE ZIP File Format Specification</a> - Language Encoding Flag
  *         to encode ZIP entry filename and comment fields using UTF-8.
  *     <li><a href="http://www.ietf.org/rfc/rfc1950.txt">

--- a/src/jdk.zipfs/share/classes/module-info.java
+++ b/src/jdk.zipfs/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,28 +33,28 @@ import java.nio.file.attribute.PosixFileAttributeView;
 import java.util.Set;
 
 /**
- * Provides the implementation of the Zip file system provider.
- * The Zip file system provider treats the contents of a Zip or JAR file as a file system.
+ * Provides the implementation of the ZIP file system provider.
+ * The ZIP file system provider treats the contents of a ZIP or JAR file as a file system.
  *
- * <h2>Accessing a Zip File System</h2>
+ * <h2>Accessing a ZIP File System</h2>
  *
  * The {@linkplain java.nio.file.FileSystems FileSystems} {@code newFileSystem}
  * static factory methods can be used to:
  * <ul>
- *   <li>Create a Zip file system</li>
- *   <li>Open an existing file as a Zip file system</li>
+ *   <li>Create a ZIP file system</li>
+ *   <li>Open an existing file as a ZIP file system</li>
  * </ul>
  *
- * The Zip file system provider does not support opening an existing Zip file
+ * The ZIP file system provider does not support opening an existing ZIP file
  * that contains entries with "." or ".." in its name elements.
  *
- * <h2>URI Scheme Used to Identify the Zip File System</h2>
+ * <h2>URI Scheme Used to Identify the ZIP File System</h2>
  *
  * The URI {@link java.net.URI#getScheme scheme} that identifies the ZIP file system is {@code jar}.
  *
  * <h2>POSIX file attributes</h2>
  *
- * A Zip file system supports a file attribute {@link FileAttributeView view}
+ * A ZIP file system supports a file attribute {@link FileAttributeView view}
  * named "{@code zip}" that defines the following file attribute:
  *
  * <blockquote>
@@ -76,8 +76,8 @@ import java.util.Set;
  * </blockquote>
  *
  * The "permissions" attribute is the set of access permissions that are optionally
- * stored for entries in a Zip file. The value of the attribute is {@code null}
- * for entries that do not have access permissions. Zip file systems do not
+ * stored for entries in a ZIP file. The value of the attribute is {@code null}
+ * for entries that do not have access permissions. ZIP file systems do not
  * enforce access permissions.
  *
  * <p> The "permissions" attribute may be read and set using the
@@ -92,12 +92,12 @@ import java.util.Set;
  *     }
  * } </pre>
  *
- * <p> In addition to the "{@code zip}" view, a Zip file system optionally supports
+ * <p> In addition to the "{@code zip}" view, a ZIP file system optionally supports
  * the {@link PosixFileAttributeView} ("{@code posix}").
  * This view extends the "{@code basic}" view with type safe access to the
  * {@link PosixFileAttributes#owner() owner}, {@link PosixFileAttributes#group() group-owner},
  * and {@link PosixFileAttributes#permissions() permissions} attributes. The
- * "{@code posix}" view is only supported when the Zip file system is created with
+ * "{@code posix}" view is only supported when the ZIP file system is created with
  * the provider property "{@code enablePosixFileAttributes}" set to "{@code true}".
  * The following creates a file system with this property and reads the access
  * permissions of a file:
@@ -110,16 +110,16 @@ import java.util.Set;
  * } </pre>
  *
  * <p> The file owner and group owner attributes are not persisted, meaning they are
- * not stored in the zip file. The "{@code defaultOwner}" and "{@code defaultGroup}"
+ * not stored in the ZIP file. The "{@code defaultOwner}" and "{@code defaultGroup}"
  * provider properties (listed below) can be used to configure the default values
  * for these attributes. If these properties are not set then the file owner
- * defaults to the owner of the zip file, and the group owner defaults to the
- * zip file's group owner (or the file owner on platforms that don't support a
+ * defaults to the owner of the ZIP file, and the group owner defaults to the
+ * ZIP file's group owner (or the file owner on platforms that don't support a
  * group owner).
  *
  * <p> The "{@code permissions}" attribute is not optional in the "{@code posix}"
  * view so a default set of permissions are used for entries that do not have
- * access permissions stored in the Zip file. The default set of permissions
+ * access permissions stored in the ZIP file. The default set of permissions
  * are
  * <ul>
  *   <li>{@link PosixFilePermission#OWNER_READ OWNER_READ}</li>
@@ -129,14 +129,14 @@ import java.util.Set;
  * The default permissions can be configured with the "{@code defaultPermissions}"
  * property described below.
  *
- * <h2>Zip File System Properties</h2>
+ * <h2>ZIP File System Properties</h2>
  *
  * The following properties may be specified when creating a Zip
  * file system:
  * <table class="striped">
  * <caption style="display:none">
  *     Configurable properties that may be specified when creating
- *     a new Zip file system
+ *     a new ZIP file system
  * </caption>
  * <thead>
  *   <tr>
@@ -153,8 +153,8 @@ import java.util.Set;
  *   <td>{@link java.lang.String} or {@link java.lang.Boolean}</td>
  *   <td>false</td>
  *   <td>
- *       If the value is {@code true}, the Zip file system provider
- *       creates a new Zip or JAR file if it does not exist.
+ *       If the value is {@code true}, the ZIP file system provider
+ *       creates a new ZIP or JAR file if it does not exist.
  *   </td>
  * </tr>
  * <tr>
@@ -163,7 +163,7 @@ import java.util.Set;
  *   <td>UTF-8</td>
  *   <td>
  *       The value indicates the encoding scheme for the
- *       names of the entries in the Zip or JAR file.
+ *       names of the entries in the ZIP or JAR file.
  *   </td>
  * </tr>
  * <tr>
@@ -171,7 +171,7 @@ import java.util.Set;
  *   <td>{@link java.lang.String} or {@link java.lang.Boolean}</td>
  *   <td>false</td>
  *   <td>
- *       If the value is {@code true}, the Zip file system will support
+ *       If the value is {@code true}, the ZIP file system will support
  *       the {@link java.nio.file.attribute.PosixFileAttributeView PosixFileAttributeView}.
  *   </td>
  * </tr>
@@ -181,7 +181,7 @@ import java.util.Set;
  *   {@link java.lang.String}</td>
  *   <td>null/unset</td>
  *   <td>
- *       Override the default owner for entries in the Zip file system.<br>
+ *       Override the default owner for entries in the ZIP file system.<br>
  *       The value can be a UserPrincipal or a String value that is used as the UserPrincipal's name.
  *   </td>
  * </tr>
@@ -191,7 +191,7 @@ import java.util.Set;
  *   {@link java.lang.String}</td>
  *   <td>null/unset</td>
  *   <td>
- *       Override the default group for entries in the Zip file system.<br>
+ *       Override the default group for entries in the ZIP file system.<br>
  *       The value can be a GroupPrincipal or a String value that is used as the GroupPrincipal's name.
  *   </td>
  * </tr>
@@ -201,7 +201,7 @@ import java.util.Set;
  *       or {@link java.lang.String}</td>
  *   <td>null/unset</td>
  *   <td>
- *       Override the default Set of permissions for entries in the Zip file system.<br>
+ *       Override the default Set of permissions for entries in the ZIP file system.<br>
  *       The value can be a {@link java.util.Set Set}&lt;{@link java.nio.file.attribute.PosixFilePermission PosixFilePermission}&gt; or<br>
  *       a String that is parsed by {@link java.nio.file.attribute.PosixFilePermissions#fromString PosixFilePermissions::fromString}
  *   </td>
@@ -212,16 +212,16 @@ import java.util.Set;
  *   <td>"DEFLATED"</td>
  *   <td>
  *       The value representing the compression method to use when writing entries
- *       to the Zip file system.
+ *       to the ZIP file system.
  *       <ul>
  *           <li>
- *               If the value is {@code "STORED"}, the Zip file system provider will
- *               not compress entries when writing to the Zip file system.
+ *               If the value is {@code "STORED"}, the ZIP file system provider will
+ *               not compress entries when writing to the ZIP file system.
  *           </li>
  *           <li>
  *               If the value is {@code "DEFLATED"} or the property is not set,
- *               the Zip file system provider will use data compression when
- *               writing entries to the Zip file system.
+ *               the ZIP file system provider will use data compression when
+ *               writing entries to the ZIP file system.
  *           </li>
  *           <li>
  *               If the value is not {@code "STORED"} or {@code "DEFLATED"}, an
@@ -270,7 +270,7 @@ import java.util.Set;
  *
  * <h2>Examples:</h2>
  *
- * Construct a new Zip file system that is identified by a URI.  If the Zip file does not exist,
+ * Construct a new ZIP file system that is identified by a URI.  If the ZIP file does not exist,
  * it will be created:
  * <pre>
  * {@code
@@ -281,7 +281,7 @@ import java.util.Set;
  * }
  * </pre>
  *
- * Construct a new Zip file system that is identified by specifying a path
+ * Construct a new ZIP file system that is identified by specifying a path
  * and using automatic file type detection. Iterate from the root of the JAR displaying each
  * found entry:
  * <pre>


### PR DESCRIPTION
This PR updates the javadoc and comments within java.util.zip/jar and zipfs module summary so that it is consistent with the use of "ZIP".

In addition, open/src/java.base/share/classes/java/util/zip/package-info.java has been updated to point to the higher level location of the PKWARE APPNOTE.TXT has PKWare recently changed the direct path the the latest version of the spec.

It is also worth noting that error messages were not updated as part of the PR and will be updated separately to keep the javadoc changes separate 