### PR TITLE
8325680: Uninitialised memory in deleteGSSCB of GSSLibStub.c:179

### DIFF
--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,12 +195,14 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
   if (jcb == NULL) {
     return GSS_C_NO_CHANNEL_BINDINGS;
   }
-
-  cb = malloc(sizeof(struct gss_channel_bindings_struct));
+  size_t size = sizeof(struct gss_channel_bindings_struct);
+  cb = malloc(size);
   if (cb == NULL) {
     gssThrowOutOfMemoryError(env, NULL);
     return NULL;
   }
+
+  memset(cb, 0, size);
 
   // initialize addrtype in CB first
   // LDAP TLS Channel Binding requires GSS_C_AF_UNSPEC address type

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -195,14 +195,12 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
   if (jcb == NULL) {
     return GSS_C_NO_CHANNEL_BINDINGS;
   }
-  size_t size = sizeof(struct gss_channel_bindings_struct);
-  cb = malloc(size);
+
+  cb = calloc(1, sizeof(struct gss_channel_bindings_struct));
   if (cb == NULL) {
     gssThrowOutOfMemoryError(env, NULL);
     return NULL;
   }
-
-  memset(cb, 0, size);
 
   // initialize addrtype in CB first
   // LDAP TLS Channel Binding requires GSS_C_AF_UNSPEC address type

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -196,7 +196,10 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
     return GSS_C_NO_CHANNEL_BINDINGS;
   }
 
+  // initialize cb as zeroes to avoid uninitialized pointer being
+  // freed when deleteGSSCB is called at cleanup.
   cb = calloc(1, sizeof(struct gss_channel_bindings_struct));
+
   if (cb == NULL) {
     gssThrowOutOfMemoryError(env, NULL);
     return NULL;
@@ -210,15 +213,10 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
 
   if ((*env)->IsInstanceOf(env, jcb, tlsCBCl)) {
       // TLS Channel Binding requires unspecified addrtype=0
-      cb->initiator_addrtype = GSS_C_AF_UNSPEC;
-      cb->acceptor_addrtype = GSS_C_AF_UNSPEC;
   } else {
       cb->initiator_addrtype = GSS_C_AF_NULLADDR;
       cb->acceptor_addrtype = GSS_C_AF_NULLADDR;
   }
-  // addresses needs to be initialized to empty
-  memset(&cb->initiator_address, 0, sizeof(cb->initiator_address));
-  memset(&cb->acceptor_address, 0, sizeof(cb->acceptor_address));
 
   /* set up initiator address */
   jinetAddr = (*env)->CallObjectMethod(env, jcb,

--- a/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
+++ b/src/java.security.jgss/share/native/libj2gss/GSSLibStub.c
@@ -213,6 +213,8 @@ gss_channel_bindings_t newGSSCB(JNIEnv *env, jobject jcb) {
 
   if ((*env)->IsInstanceOf(env, jcb, tlsCBCl)) {
       // TLS Channel Binding requires unspecified addrtype=0
+      cb->initiator_addrtype = GSS_C_AF_UNSPEC;
+      cb->acceptor_addrtype = GSS_C_AF_UNSPEC;
   } else {
       cb->initiator_addrtype = GSS_C_AF_NULLADDR;
       cb->acceptor_addrtype = GSS_C_AF_NULLADDR;


### PR DESCRIPTION
Add a `memset` after memory is successfully allocated.

No regression test, hard to write without a KDC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325680](https://bugs.openjdk.org/browse/JDK-8325680): Uninitialised memory in deleteGSSCB of GSSLibStub.c:179 (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**) ⚠️ Review applies to [9983d06b](https://git.openjdk.org/jdk/pull/18015/files/9983d06b70471490bc59125930103e2a86c39524)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) ⚠️ Review applies to [9983d06b](https://git.openjdk.org/jdk/pull/18015/files/9983d06b70471490bc59125930103e2a86c39524)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18015/head:pull/18015` \
`$ git checkout pull/18015`

Update a local copy of the PR: \
`$ git checkout pull/18015` \
`$ git pull https://git.openjdk.org/jdk.git pull/18015/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18015`

View PR using the GUI difftool: \
`$ git pr show -t 18015`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18015.diff">https://git.openjdk.org/jdk/pull/18015.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18015#issuecomment-1966677217)