### PR TITLE
8326722: Cleanup unnecessary forward declaration in collectedHeap.hpp

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -46,9 +46,6 @@
 // class defines the functions that a heap must implement, and contains
 // infrastructure common to all heaps.
 
-class WorkerTask;
-class AdaptiveSizePolicy;
-class BarrierSet;
 class GCHeapLog;
 class GCHeapSummary;
 class GCTimer;


### PR DESCRIPTION
Trivial cleanup

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326722](https://bugs.openjdk.org/browse/JDK-8326722): Cleanup unnecessary forward declaration in collectedHeap.hpp (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18018/head:pull/18018` \
`$ git checkout pull/18018`

Update a local copy of the PR: \
`$ git checkout pull/18018` \
`$ git pull https://git.openjdk.org/jdk.git pull/18018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18018`

View PR using the GUI difftool: \
`$ git pr show -t 18018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18018.diff">https://git.openjdk.org/jdk/pull/18018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18018#issuecomment-1966586319)