### PR TITLE
8326714: Make file-local functions static in src/java.base/unix/native/libjava/childproc.c

### DIFF
--- a/src/java.base/unix/native/libjava/childproc.c
+++ b/src/java.base/unix/native/libjava/childproc.c
@@ -36,7 +36,7 @@
 
 const char * const *parentPathv;
 
-int
+static int
 restartableDup2(int fd_from, int fd_to)
 {
     int err;
@@ -50,7 +50,7 @@ closeSafely(int fd)
     return (fd == -1) ? 0 : close(fd);
 }
 
-int
+static int
 isAsciiDigit(char c)
 {
   return c >= '0' && c <= '9';
@@ -65,7 +65,7 @@ isAsciiDigit(char c)
   #define FD_DIR "/proc/self/fd"
 #endif
 
-int
+static int
 closeDescriptors(void)
 {
     DIR *dp;
@@ -103,7 +103,7 @@ closeDescriptors(void)
     return 1;
 }
 
-int
+static int
 moveDescriptor(int fd_from, int fd_to)
 {
     if (fd_from != fd_to) {
@@ -209,7 +209,7 @@ initVectorFromBlock(const char**vector, const char* block, int count)
  * misfeature, but compatibility wins over sanity.  The original support for
  * this was imported accidentally from execvp().
  */
-void
+static void
 execve_as_traditional_shell_script(const char *file,
                                    const char *argv[],
                                    const char *const envp[])
@@ -232,7 +232,7 @@ execve_as_traditional_shell_script(const char *file,
  * Like execve(2), except that in case of ENOEXEC, FILE is assumed to
  * be a shell script and the system default shell is invoked to run it.
  */
-void
+static void
 execve_with_shell_fallback(int mode, const char *file,
                            const char *argv[],
                            const char *const envp[])
@@ -256,7 +256,7 @@ execve_with_shell_fallback(int mode, const char *file,
  * JDK_execvpe is identical to execvp, except that the child environment is
  * specified via the 3rd argument instead of being inherited from environ.
  */
-void
+static void
 JDK_execvpe(int mode, const char *file,
             const char *argv[],
             const char *const envp[])

--- a/src/java.base/unix/native/libjava/childproc.h
+++ b/src/java.base/unix/native/libjava/childproc.h
@@ -128,24 +128,11 @@ typedef struct _SpawnInfo {
 extern const char * const *parentPathv;
 
 ssize_t writeFully(int fd, const void *buf, size_t count);
-int restartableDup2(int fd_from, int fd_to);
 int closeSafely(int fd);
-int isAsciiDigit(char c);
-int closeDescriptors(void);
-int moveDescriptor(int fd_from, int fd_to);
 
 int magicNumber();
 ssize_t readFully(int fd, void *buf, size_t nbyte);
 void initVectorFromBlock(const char**vector, const char* block, int count);
-void execve_as_traditional_shell_script(const char *file,
-                                        const char *argv[],
-                                        const char *const envp[]);
-void execve_with_shell_fallback(int mode, const char *file,
-                                const char *argv[],
-                                const char *const envp[]);
-void JDK_execvpe(int mode, const char *file,
-                 const char *argv[],
-                 const char *const envp[]);
 int childProcess(void *arg);
 
 #ifdef DEBUG


### PR DESCRIPTION
Please help review this trivial change. This was branched from https://github.com/openjdk/jdk/pull/18013, based on discussion with @plummercj in https://github.com/openjdk/jdk/pull/18013 comments. Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326714](https://bugs.openjdk.org/browse/JDK-8326714): Make file-local functions static in src/java.base/unix/native/libjava/childproc.c (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18019/head:pull/18019` \
`$ git checkout pull/18019`

Update a local copy of the PR: \
`$ git checkout pull/18019` \
`$ git pull https://git.openjdk.org/jdk.git pull/18019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18019`

View PR using the GUI difftool: \
`$ git pr show -t 18019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18019.diff">https://git.openjdk.org/jdk/pull/18019.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18019#issuecomment-1965713027)