### PR TITLE
JDK-8326615: Problem-list compiler/startup/StartupCode

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -76,6 +76,8 @@ compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
+compiler/startup/StartupOutput.java 8326615 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Let's problem-list this test until [JDK-8326615](https://bugs.openjdk.org/browse/JDK-8326615) is figured out.