### PR TITLE
8326744: Class-File API transition to Second Preview

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -77,7 +77,7 @@ public @interface PreviewFeature {
         SCOPED_VALUES,
         @JEP(number=462, title="Structured Concurrency", status="Second Preview")
         STRUCTURED_CONCURRENCY,
-        @JEP(number=457, title="ClassFile API", status="Preview")
+        @JEP(number=466, title="ClassFile API", status="Second Preview")
         CLASSFILE_API,
         @JEP(number=461, title="Stream Gatherers", status="Preview")
         STREAM_GATHERERS,


### PR DESCRIPTION
Task providing Class-File API transition to Second Preview.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8326748](https://bugs.openjdk.org/browse/JDK-8326748) to be approved

### Issues
 * [JDK-8326744](https://bugs.openjdk.org/browse/JDK-8326744): Class-File API transition to Second Preview (**Sub-task** - P2)
 * [JDK-8326748](https://bugs.openjdk.org/browse/JDK-8326748): Class-File API transition to Second Preview (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18021/head:pull/18021` \
`$ git checkout pull/18021`

Update a local copy of the PR: \
`$ git checkout pull/18021` \
`$ git pull https://git.openjdk.org/jdk.git pull/18021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18021`

View PR using the GUI difftool: \
`$ git pr show -t 18021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18021.diff">https://git.openjdk.org/jdk/pull/18021.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18021#issuecomment-1966059039)