### PR TITLE
8326763: Consolidate print methods in ContiguousSpace

### DIFF
--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -99,18 +99,9 @@ void ContiguousSpace::mangle_unused_area_complete() {
 }
 #endif  // NOT_PRODUCT
 
-
-void ContiguousSpace::print_short() const { print_short_on(tty); }
-
-void ContiguousSpace::print_short_on(outputStream* st) const {
-  st->print(" space " SIZE_FORMAT "K, %3d%% used", capacity() / K,
-              (int) ((double) used() * 100 / capacity()));
-}
-
-void ContiguousSpace::print() const { print_on(tty); }
-
 void ContiguousSpace::print_on(outputStream* st) const {
-  print_short_on(st);
+  st->print(" space " SIZE_FORMAT "K, %3d%% used", capacity() / K,
+            (int) ((double) used() * 100 / capacity()));
   st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
                 p2i(bottom()), p2i(top()), p2i(end()));
 }

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -99,6 +99,8 @@ void ContiguousSpace::mangle_unused_area_complete() {
 }
 #endif  // NOT_PRODUCT
 
+void ContiguousSpace::print() const { print_on(tty); }
+
 void ContiguousSpace::print_on(outputStream* st) const {
   st->print(" space " SIZE_FORMAT "K, %3d%% used", capacity() / K,
             (int) ((double) used() * 100 / capacity()));

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -102,10 +102,9 @@ void ContiguousSpace::mangle_unused_area_complete() {
 void ContiguousSpace::print() const { print_on(tty); }
 
 void ContiguousSpace::print_on(outputStream* st) const {
-  st->print(" space " SIZE_FORMAT "K, %3d%% used", capacity() / K,
-            (int) ((double) used() * 100 / capacity()));
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-                p2i(bottom()), p2i(top()), p2i(end()));
+  st->print_cr(" space %zuK, %3d%% used [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+               capacity() / K, (int) ((double) used() * 100 / capacity()),
+               p2i(bottom()), p2i(top()), p2i(end()));
 }
 
 void ContiguousSpace::verify() const {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -126,10 +126,7 @@ public:
   size_t used()     const { return byte_size(bottom(), top()); }
   size_t free()     const { return byte_size(top(),    end()); }
 
-  void print() const;
-  virtual void print_on(outputStream* st) const;
-  void print_short() const;
-  void print_short_on(outputStream* st) const;
+  void print_on(outputStream* st) const;
 
   // Initialization.
   // "initialize" should be called once on a space, before it is used for

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -126,6 +126,7 @@ public:
   size_t used()     const { return byte_size(bottom(), top()); }
   size_t free()     const { return byte_size(top(),    end()); }
 
+  void print() const;
   void print_on(outputStream* st) const;
 
   // Initialization.


### PR DESCRIPTION
Trivial inlining and removing some unused methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326763](https://bugs.openjdk.org/browse/JDK-8326763): Consolidate print methods in ContiguousSpace (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [5f8f543e](https://git.openjdk.org/jdk/pull/18022/files/5f8f543e9d427b01fa4d30fdc45660a229b633ec)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18022/head:pull/18022` \
`$ git checkout pull/18022`

Update a local copy of the PR: \
`$ git checkout pull/18022` \
`$ git pull https://git.openjdk.org/jdk.git pull/18022/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18022`

View PR using the GUI difftool: \
`$ git pr show -t 18022`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18022.diff">https://git.openjdk.org/jdk/pull/18022.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18022#issuecomment-1966172769)