### PR TITLE
8269428: java/util/concurrent/ConcurrentHashMap/ToArray.java timed out

### DIFF
--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/ToArray.java
@@ -31,6 +31,7 @@
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -45,57 +46,59 @@ public class ToArray {
     }
 
     static void executeTest() throws Throwable {
-        final ConcurrentHashMap<Integer, Integer> m = new ConcurrentHashMap<>();
-        final ThreadLocalRandom rnd = ThreadLocalRandom.current();
-        final int nCPU = Runtime.getRuntime().availableProcessors();
-        final int minWorkers = 2;
-        final int maxWorkers = Math.max(minWorkers, Math.min(32, nCPU));
-        final int nWorkers = rnd.nextInt(minWorkers, maxWorkers + 1);
-        final int sizePerWorker = 1024;
-        final int maxSize = nWorkers * sizePerWorker;
+        try (var executor = Executors.newCachedThreadPool()) {
+            final ConcurrentHashMap<Integer, Integer> m = new ConcurrentHashMap<>();
+            final ThreadLocalRandom rnd = ThreadLocalRandom.current();
+            final int nCPU = Runtime.getRuntime().availableProcessors();
+            final int minWorkers = 2;
+            final int maxWorkers = Math.max(minWorkers, Math.min(32, nCPU));
+            final int nWorkers = rnd.nextInt(minWorkers, maxWorkers + 1);
+            final int sizePerWorker = 1024;
+            final int maxSize = nWorkers * sizePerWorker;
 
-        // The foreman busy-checks that the size of the arrays obtained
-        // from the keys and values views grows monotonically until it
-        // reaches the maximum size.
+            // The foreman busy-checks that the size of the arrays obtained
+            // from the keys and values views grows monotonically until it
+            // reaches the maximum size.
 
-        // NOTE: these size constraints are not specific to toArray and are
-        // applicable to any form of traversal of the collection views
-        CompletableFuture<?> foreman = CompletableFuture.runAsync(new Runnable() {
-            private int prevSize = 0;
+            // NOTE: these size constraints are not specific to toArray and are
+            // applicable to any form of traversal of the collection views
+            CompletableFuture<?> foreman = CompletableFuture.runAsync(new Runnable() {
+                private int prevSize = 0;
 
-            private boolean checkProgress(Object[] a) {
-                int size = a.length;
-                if (size < prevSize || size > maxSize)
-                    throw new AssertionError(
-                        String.format("prevSize=%d size=%d maxSize=%d",
-                                      prevSize, size, maxSize));
-                prevSize = size;
-                return size == maxSize;
-            }
+                private boolean checkProgress(Object[] a) {
+                    int size = a.length;
+                    if (size < prevSize || size > maxSize)
+                        throw new AssertionError(
+                                String.format("prevSize=%d size=%d maxSize=%d",
+                                        prevSize, size, maxSize));
+                    prevSize = size;
+                    return size == maxSize;
+                }
 
-            public void run() {
-                Integer[] empty = new Integer[0];
-                for (;;)
-                    if (checkProgress(m.values().toArray())
-                        & checkProgress(m.keySet().toArray())
-                        & checkProgress(m.values().toArray(empty))
-                        & checkProgress(m.keySet().toArray(empty)))
-                        return;
-            }
-        });
+                public void run() {
+                    Integer[] empty = new Integer[0];
+                    for (; ; )
+                        if (checkProgress(m.values().toArray())
+                                & checkProgress(m.keySet().toArray())
+                                & checkProgress(m.values().toArray(empty))
+                                & checkProgress(m.keySet().toArray(empty)))
+                            return;
+                }
+            }, executor);
 
-        // Each worker puts globally unique keys into the map
-        List<CompletableFuture<?>> workers =
-            IntStream.range(0, nWorkers)
-            .mapToObj(w -> (Runnable) () -> {
-                for (int i = 0, o = w * sizePerWorker; i < sizePerWorker; i++)
-                    m.put(o + i, i);
-            })
-            .map(CompletableFuture::runAsync)
-            .collect(Collectors.toList());
+            // Each worker puts globally unique keys into the map
+            List<CompletableFuture<?>> workers =
+                    IntStream.range(0, nWorkers)
+                            .mapToObj(w -> (Runnable) () -> {
+                                for (int i = 0, o = w * sizePerWorker; i < sizePerWorker; i++)
+                                    m.put(o + i, i);
+                            })
+                            .map(r -> CompletableFuture.runAsync(r, executor))
+                            .collect(Collectors.toList());
 
-        // Wait for workers and foreman to complete
-        workers.forEach(CompletableFuture<?>::join);
-        foreman.join();
+            // Wait for workers and foreman to complete
+            workers.forEach(CompletableFuture<?>::join);
+            foreman.join();
+        }
     }
 }


### PR DESCRIPTION
As an intermediate fix to the test, switching to explicit usage of an ExecutorService seems to do the trick to make this test reliably pass.

With that said, this test (CHM::ToArray.java) seems to trigger an issue in ForkJoinPool, so that would need to be fixed separately.

Tagging @DougLea as an FYI. :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269428](https://bugs.openjdk.org/browse/JDK-8269428): java/util/concurrent/ConcurrentHashMap/ToArray.java timed out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18023/head:pull/18023` \
`$ git checkout pull/18023`

Update a local copy of the PR: \
`$ git checkout pull/18023` \
`$ git pull https://git.openjdk.org/jdk.git pull/18023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18023`

View PR using the GUI difftool: \
`$ git pr show -t 18023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18023.diff">https://git.openjdk.org/jdk/pull/18023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18023#issuecomment-1966256843)