### PR TITLE
8326824: Test: remove redundant test in compiler/vectorapi/reshape/utils/TestCastMethods.java

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/utils/TestCastMethods.java
@@ -62,7 +62,6 @@ public class TestCastMethods {
             makePair(FSPEC128, ISPEC128),
             makePair(FSPEC64, DSPEC128),
             makePair(FSPEC128, DSPEC256),
-            makePair(FSPEC128, ISPEC128),
             makePair(FSPEC128, SSPEC64),
             makePair(DSPEC128, FSPEC64),
             makePair(DSPEC256, FSPEC128),


### PR DESCRIPTION
Hi,
Can you review this simple patch to remove redundant test?
Thanks.

FYI: `makePair(FSPEC128, ISPEC128),` is tested twice unnecessarily, so this is to remove the redundant one.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326824](https://bugs.openjdk.org/browse/JDK-8326824): Test: remove redundant test in compiler/vectorapi/reshape/utils/TestCastMethods.java (**Enhancement** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18027/head:pull/18027` \
`$ git checkout pull/18027`

Update a local copy of the PR: \
`$ git checkout pull/18027` \
`$ git pull https://git.openjdk.org/jdk.git pull/18027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18027`

View PR using the GUI difftool: \
`$ git pr show -t 18027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18027.diff">https://git.openjdk.org/jdk/pull/18027.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18027#issuecomment-1966318534)