### PR TITLE
8326718: Test java/util/Formatter/Padding.java should timeout on large inputs before fix in JDK-8299677

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -40,8 +40,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
 
-    private static final String tenMillionZeros = "0".repeat(10000000);
-    private static final String tenMillionBlanks = " ".repeat(10000000);
+    private static final String tenMillionZeros = "0".repeat(10_000_000);
+    private static final String tenMillionBlanks = " ".repeat(10_000_000);
 
     static Arguments[] padding() {
         return new Arguments[] {

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4906370
  * @summary Tests to excercise padding on int and double values,
  *      with various flag combinations.
- * @run junit Padding
+ * @run junit/timeout=10 Padding
  */
 
 import java.util.Locale;
@@ -40,6 +40,9 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
 
+    static String tenMillionZeros = "0".repeat(10000000);
+    static String tenMillionBlanks = " ".repeat(10000000);
+
     static Arguments[] padding() {
         return new Arguments[] {
                 /* blank padding, right adjusted, optional plus sign */
@@ -49,6 +52,7 @@ public class Padding {
                 arguments("  12", "%4d", 12),
                 arguments("   12", "%5d", 12),
                 arguments("        12", "%10d", 12),
+                arguments(tenMillionBlanks + "12", "%10000002d", 12),
 
                 arguments("-12", "%1d", -12),
                 arguments("-12", "%2d", -12),
@@ -56,6 +60,7 @@ public class Padding {
                 arguments(" -12", "%4d", -12),
                 arguments("  -12", "%5d", -12),
                 arguments("       -12", "%10d", -12),
+                arguments(tenMillionBlanks + "-12", "%10000003d", -12),
 
                 arguments("1.2", "%1.1f", 1.2),
                 arguments("1.2", "%2.1f", 1.2),
@@ -63,6 +68,7 @@ public class Padding {
                 arguments(" 1.2", "%4.1f", 1.2),
                 arguments("  1.2", "%5.1f", 1.2),
                 arguments("       1.2", "%10.1f", 1.2),
+                arguments(tenMillionBlanks + "1.2", "%10000003.1f", 1.2),
 
                 arguments("-1.2", "%1.1f", -1.2),
                 arguments("-1.2", "%2.1f", -1.2),
@@ -70,6 +76,7 @@ public class Padding {
                 arguments("-1.2", "%4.1f", -1.2),
                 arguments(" -1.2", "%5.1f", -1.2),
                 arguments("      -1.2", "%10.1f", -1.2),
+                arguments(tenMillionBlanks + "-1.2", "%10000004.1f", -1.2),
 
                 /* blank padding, right adjusted, mandatory plus sign */
                 arguments("+12", "%+1d", 12),
@@ -78,6 +85,7 @@ public class Padding {
                 arguments(" +12", "%+4d", 12),
                 arguments("  +12", "%+5d", 12),
                 arguments("       +12", "%+10d", 12),
+                arguments(tenMillionBlanks + "+12", "%+10000003d", 12),
 
                 arguments("-12", "%+1d", -12),
                 arguments("-12", "%+2d", -12),
@@ -85,6 +93,7 @@ public class Padding {
                 arguments(" -12", "%+4d", -12),
                 arguments("  -12", "%+5d", -12),
                 arguments("       -12", "%+10d", -12),
+                arguments(tenMillionBlanks + "-12", "%+10000003d", -12),
 
                 arguments("+1.2", "%+1.1f", 1.2),
                 arguments("+1.2", "%+2.1f", 1.2),
@@ -92,6 +101,7 @@ public class Padding {
                 arguments("+1.2", "%+4.1f", 1.2),
                 arguments(" +1.2", "%+5.1f", 1.2),
                 arguments("      +1.2", "%+10.1f", 1.2),
+                arguments(tenMillionBlanks + "+1.2", "%+10000004.1f", 1.2),
 
                 arguments("-1.2", "%+1.1f", -1.2),
                 arguments("-1.2", "%+2.1f", -1.2),
@@ -99,6 +109,7 @@ public class Padding {
                 arguments("-1.2", "%+4.1f", -1.2),
                 arguments(" -1.2", "%+5.1f", -1.2),
                 arguments("      -1.2", "%+10.1f", -1.2),
+                arguments(tenMillionBlanks + "-1.2", "%+10000004.1f", -1.2),
 
                 /* blank padding, right adjusted, mandatory blank sign */
                 arguments(" 12", "% 1d", 12),
@@ -107,6 +118,7 @@ public class Padding {
                 arguments("  12", "% 4d", 12),
                 arguments("   12", "% 5d", 12),
                 arguments("        12", "% 10d", 12),
+                arguments(tenMillionBlanks + "12", "% 10000002d", 12),
 
                 arguments("-12", "% 1d", -12),
                 arguments("-12", "% 2d", -12),
@@ -114,6 +126,7 @@ public class Padding {
                 arguments(" -12", "% 4d", -12),
                 arguments("  -12", "% 5d", -12),
                 arguments("       -12", "% 10d", -12),
+                arguments(tenMillionBlanks + "-12", "% 10000003d", -12),
 
                 arguments(" 1.2", "% 1.1f", 1.2),
                 arguments(" 1.2", "% 2.1f", 1.2),
@@ -121,6 +134,7 @@ public class Padding {
                 arguments(" 1.2", "% 4.1f", 1.2),
                 arguments("  1.2", "% 5.1f", 1.2),
                 arguments("       1.2", "% 10.1f", 1.2),
+                arguments(tenMillionBlanks + "1.2", "% 10000003.1f", 1.2),
 
                 arguments("-1.2", "% 1.1f", -1.2),
                 arguments("-1.2", "% 2.1f", -1.2),
@@ -128,6 +142,7 @@ public class Padding {
                 arguments("-1.2", "% 4.1f", -1.2),
                 arguments(" -1.2", "% 5.1f", -1.2),
                 arguments("      -1.2", "% 10.1f", -1.2),
+                arguments(tenMillionBlanks + "-1.2", "% 10000004.1f", -1.2),
 
                 /* blank padding, left adjusted, optional sign */
                 arguments("12", "%-1d", 12),
@@ -136,6 +151,7 @@ public class Padding {
                 arguments("12  ", "%-4d", 12),
                 arguments("12   ", "%-5d", 12),
                 arguments("12        ", "%-10d", 12),
+                arguments("12" + tenMillionBlanks, "%-10000002d", 12),
 
                 arguments("-12", "%-1d", -12),
                 arguments("-12", "%-2d", -12),
@@ -143,6 +159,7 @@ public class Padding {
                 arguments("-12 ", "%-4d", -12),
                 arguments("-12  ", "%-5d", -12),
                 arguments("-12       ", "%-10d", -12),
+                arguments("-12" + tenMillionBlanks, "%-10000003d", -12),
 
                 arguments("1.2", "%-1.1f", 1.2),
                 arguments("1.2", "%-2.1f", 1.2),
@@ -150,6 +167,7 @@ public class Padding {
                 arguments("1.2 ", "%-4.1f", 1.2),
                 arguments("1.2  ", "%-5.1f", 1.2),
                 arguments("1.2       ", "%-10.1f", 1.2),
+                arguments("1.2" + tenMillionBlanks, "%-10000003.1f", 1.2),
 
                 arguments("-1.2", "%-1.1f", -1.2),
                 arguments("-1.2", "%-2.1f", -1.2),
@@ -157,6 +175,7 @@ public class Padding {
                 arguments("-1.2", "%-4.1f", -1.2),
                 arguments("-1.2 ", "%-5.1f", -1.2),
                 arguments("-1.2      ", "%-10.1f", -1.2),
+                arguments("-1.2" + tenMillionBlanks, "%-10000004.1f", -1.2),
 
                 /* blank padding, left adjusted, mandatory plus sign */
                 arguments("+12", "%-+1d", 12),
@@ -165,6 +184,7 @@ public class Padding {
                 arguments("+12 ", "%-+4d", 12),
                 arguments("+12  ", "%-+5d", 12),
                 arguments("+12       ", "%-+10d", 12),
+                arguments("+12" + tenMillionBlanks, "%-+10000003d", 12),
 
                 arguments("-12", "%-+1d", -12),
                 arguments("-12", "%-+2d", -12),
@@ -172,6 +192,7 @@ public class Padding {
                 arguments("-12 ", "%-+4d", -12),
                 arguments("-12  ", "%-+5d", -12),
                 arguments("-12       ", "%-+10d", -12),
+                arguments("-12" + tenMillionBlanks, "%-+10000003d", -12),
 
                 arguments("+1.2", "%-+1.1f", 1.2),
                 arguments("+1.2", "%-+2.1f", 1.2),
@@ -179,6 +200,7 @@ public class Padding {
                 arguments("+1.2", "%-+4.1f", 1.2),
                 arguments("+1.2 ", "%-+5.1f", 1.2),
                 arguments("+1.2      ", "%-+10.1f", 1.2),
+                arguments("+1.2" + tenMillionBlanks, "%-+10000004.1f", 1.2),
 
                 arguments("-1.2", "%-+1.1f", -1.2),
                 arguments("-1.2", "%-+2.1f", -1.2),
@@ -186,6 +208,7 @@ public class Padding {
                 arguments("-1.2", "%-+4.1f", -1.2),
                 arguments("-1.2 ", "%-+5.1f", -1.2),
                 arguments("-1.2      ", "%-+10.1f", -1.2),
+                arguments("-1.2" + tenMillionBlanks, "%-+10000004.1f", -1.2),
 
                 /* blank padding, left adjusted, mandatory blank sign */
                 arguments(" 12", "%- 1d", 12),
@@ -194,6 +217,7 @@ public class Padding {
                 arguments(" 12 ", "%- 4d", 12),
                 arguments(" 12  ", "%- 5d", 12),
                 arguments(" 12       ", "%- 10d", 12),
+                arguments(" 12" + tenMillionBlanks, "%- 10000003d", 12),
 
                 arguments("-12", "%- 1d", -12),
                 arguments("-12", "%- 2d", -12),
@@ -201,6 +225,7 @@ public class Padding {
                 arguments("-12 ", "%- 4d", -12),
                 arguments("-12  ", "%- 5d", -12),
                 arguments("-12       ", "%- 10d", -12),
+                arguments("-12" + tenMillionBlanks, "%- 10000003d", -12),
 
                 arguments(" 1.2", "%- 1.1f", 1.2),
                 arguments(" 1.2", "%- 2.1f", 1.2),
@@ -208,6 +233,7 @@ public class Padding {
                 arguments(" 1.2", "%- 4.1f", 1.2),
                 arguments(" 1.2 ", "%- 5.1f", 1.2),
                 arguments(" 1.2      ", "%- 10.1f", 1.2),
+                arguments(" 1.2" + tenMillionBlanks, "%- 10000004.1f", 1.2),
 
                 arguments("-1.2", "%- 1.1f", -1.2),
                 arguments("-1.2", "%- 2.1f", -1.2),
@@ -215,6 +241,7 @@ public class Padding {
                 arguments("-1.2", "%- 4.1f", -1.2),
                 arguments("-1.2 ", "%- 5.1f", -1.2),
                 arguments("-1.2      ", "%- 10.1f", -1.2),
+                arguments("-1.2" + tenMillionBlanks, "%- 10000004.1f", -1.2),
 
                 /* zero padding, right adjusted, optional sign */
                 arguments("12", "%01d", 12),
@@ -223,6 +250,7 @@ public class Padding {
                 arguments("0012", "%04d", 12),
                 arguments("00012", "%05d", 12),
                 arguments("0000000012", "%010d", 12),
+                arguments(tenMillionZeros + "12", "%010000002d", 12),
 
                 arguments("-12", "%01d", -12),
                 arguments("-12", "%02d", -12),
@@ -230,6 +258,7 @@ public class Padding {
                 arguments("-012", "%04d", -12),
                 arguments("-0012", "%05d", -12),
                 arguments("-000000012", "%010d", -12),
+                arguments("-" + tenMillionZeros + "12", "%010000003d", -12),
 
                 arguments("1.2", "%01.1f", 1.2),
                 arguments("1.2", "%02.1f", 1.2),
@@ -237,6 +266,7 @@ public class Padding {
                 arguments("01.2", "%04.1f", 1.2),
                 arguments("001.2", "%05.1f", 1.2),
                 arguments("00000001.2", "%010.1f", 1.2),
+                arguments(tenMillionZeros + "1.2", "%010000003.1f", 1.2),
 
                 arguments("-1.2", "%01.1f", -1.2),
                 arguments("-1.2", "%02.1f", -1.2),
@@ -244,6 +274,7 @@ public class Padding {
                 arguments("-1.2", "%04.1f", -1.2),
                 arguments("-01.2", "%05.1f", -1.2),
                 arguments("-0000001.2", "%010.1f", -1.2),
+                arguments("-" + tenMillionZeros + "1.2", "%010000004.1f", -1.2),
 
                 /* zero padding, right adjusted, mandatory plus sign */
                 arguments("+12", "%+01d", 12),
@@ -252,6 +283,7 @@ public class Padding {
                 arguments("+012", "%+04d", 12),
                 arguments("+0012", "%+05d", 12),
                 arguments("+000000012", "%+010d", 12),
+                arguments("+" + tenMillionZeros + "12", "%+010000003d", 12),
 
                 arguments("-12", "%+01d", -12),
                 arguments("-12", "%+02d", -12),
@@ -259,6 +291,7 @@ public class Padding {
                 arguments("-012", "%+04d", -12),
                 arguments("-0012", "%+05d", -12),
                 arguments("-000000012", "%+010d", -12),
+                arguments("-" + tenMillionZeros + "12", "%+010000003d", -12),
 
                 arguments("+1.2", "%+01.1f", 1.2),
                 arguments("+1.2", "%+02.1f", 1.2),
@@ -266,6 +299,7 @@ public class Padding {
                 arguments("+1.2", "%+04.1f", 1.2),
                 arguments("+01.2", "%+05.1f", 1.2),
                 arguments("+0000001.2", "%+010.1f", 1.2),
+                arguments("+" + tenMillionZeros + "1.2", "%+010000004.1f", 1.2),
 
                 arguments("-1.2", "%+01.1f", -1.2),
                 arguments("-1.2", "%+02.1f", -1.2),
@@ -273,6 +307,7 @@ public class Padding {
                 arguments("-1.2", "%+04.1f", -1.2),
                 arguments("-01.2", "%+05.1f", -1.2),
                 arguments("-0000001.2", "%+010.1f", -1.2),
+                arguments("-" + tenMillionZeros + "1.2", "%+010000004.1f", -1.2),
 
                 /* zero padding, right adjusted, mandatory blank sign */
                 arguments(" 12", "% 01d", 12),
@@ -281,6 +316,7 @@ public class Padding {
                 arguments(" 012", "% 04d", 12),
                 arguments(" 0012", "% 05d", 12),
                 arguments(" 000000012", "% 010d", 12),
+                arguments(" " + tenMillionZeros + "12", "% 010000003d", 12),
 
                 arguments("-12", "% 01d", -12),
                 arguments("-12", "% 02d", -12),
@@ -288,6 +324,7 @@ public class Padding {
                 arguments("-012", "% 04d", -12),
                 arguments("-0012", "% 05d", -12),
                 arguments("-000000012", "% 010d", -12),
+                arguments("-" + tenMillionZeros + "12", "% 010000003d", -12),
 
                 arguments(" 1.2", "% 01.1f", 1.2),
                 arguments(" 1.2", "% 02.1f", 1.2),
@@ -295,6 +332,7 @@ public class Padding {
                 arguments(" 1.2", "% 04.1f", 1.2),
                 arguments(" 01.2", "% 05.1f", 1.2),
                 arguments(" 0000001.2", "% 010.1f", 1.2),
+                arguments(" " + tenMillionZeros + "1.2", "% 010000004.1f", 1.2),
 
                 arguments("-1.2", "% 01.1f", -1.2),
                 arguments("-1.2", "% 02.1f", -1.2),
@@ -302,6 +340,7 @@ public class Padding {
                 arguments("-1.2", "% 04.1f", -1.2),
                 arguments("-01.2", "% 05.1f", -1.2),
                 arguments("-0000001.2", "% 010.1f", -1.2),
+                arguments("-" + tenMillionZeros + "1.2", "% 010000004.1f", -1.2),
 
         };
     }

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 4906370
+ * @bug 4906370 8299677 8326718
  * @summary Tests to excercise padding on int and double values,
  *      with various flag combinations.
- * @run junit/timeout=10 Padding
+ * @run junit Padding
  */
 
 import java.util.Locale;
@@ -40,8 +40,8 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
 
-    static String tenMillionZeros = "0".repeat(10000000);
-    static String tenMillionBlanks = " ".repeat(10000000);
+    private static final String tenMillionZeros = "0".repeat(10000000);
+    private static final String tenMillionBlanks = " ".repeat(10000000);
 
     static Arguments[] padding() {
         return new Arguments[] {


### PR DESCRIPTION
[JDK-8299677](https://bugs.openjdk.java.net/browse/JDK-8299677) fixes a bug with Formatter.format taking a long time when there is a lot of padding. This test runs Formatter.format with very large padding. Test fails before [JDK-8299677](https://bugs.openjdk.java.net/browse/JDK-8299677) and passes after.

Timeout for the test was set to 10 seconds. Test passes locally with as low as 1 (after [JDK-8299677](https://bugs.openjdk.java.net/browse/JDK-8299677)) and fails as high as 120 (before [JDK-8299677](https://bugs.openjdk.java.net/browse/JDK-8299677)) so it should be consistent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326718](https://bugs.openjdk.org/browse/JDK-8326718): Test java/util/Formatter/Padding.java should timeout on large inputs before fix in JDK-8299677 (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18033/head:pull/18033` \
`$ git checkout pull/18033`

Update a local copy of the PR: \
`$ git checkout pull/18033` \
`$ git pull https://git.openjdk.org/jdk.git pull/18033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18033`

View PR using the GUI difftool: \
`$ git pr show -t 18033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18033.diff">https://git.openjdk.org/jdk/pull/18033.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18033#issuecomment-1967256794)