### PR TITLE
8326897: (fs) The utility TestUtil.supportsLinks is wrongly used to check for hard link support

### DIFF
--- a/test/jdk/java/nio/file/Files/CheckPermissions.java
+++ b/test/jdk/java/nio/file/Files/CheckPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -311,7 +311,7 @@ public class CheckPermissions {
 
             // -- createLink --
 
-            if (TestUtil.supportsLinks(testdir)) {
+            if (TestUtil.supportsHardLinks(testdir)) {
                 prepare();
                 Path link = testdir.resolve("entry234");
                 createLink(link, file);

--- a/test/jdk/java/nio/file/Files/Misc.java
+++ b/test/jdk/java/nio/file/Files/Misc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,6 +222,10 @@ public class Misc {
                 } finally {
                     delete(link);
                 }
+            }
+
+            if (TestUtil.supportsHardLinks(tmpdir)) {
+                Path link = tmpdir.resolve("hardlink");
 
                 createLink(link, file);
                 try {
@@ -234,7 +238,6 @@ public class Misc {
                     delete(link);
                 }
             }
-
         } finally {
             delete(file);
         }

--- a/test/jdk/java/nio/file/TestUtil.java
+++ b/test/jdk/java/nio/file/TestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,6 +107,23 @@ public class TestUtil {
         Path target = dir.resolve("testtarget");
         try {
             Files.createSymbolicLink(link, target);
+            Files.delete(link);
+            return true;
+        } catch (UnsupportedOperationException x) {
+            return false;
+        } catch (IOException x) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns true if hard links are supported
+     */
+    static boolean supportsHardLinks(Path dir) {
+        Path link = dir.resolve("testlink");
+        Path target = dir.resolve("testtarget");
+        try {
+            Files.createLink(link, target);
             Files.delete(link);
             return true;
         } catch (UnsupportedOperationException x) {


### PR DESCRIPTION
Add to `test/jdk/java/nio/file/TestUtil.java` the method `TestUtil.supportsHardLinks` and use it to conditionally test `Files.createLink` where appropriate in the `java/nio/file` tests.