### PR TITLE
8326936: RISC-V: Shenandoah GC crashes due to incorrect atomic memory operations

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -186,10 +186,12 @@ inline T Atomic::PlatformCmpxchg<byte_size>::operator()(T volatile* dest __attri
                                                         T exchange_value,
                                                         atomic_memory_order order) const {
 
-#if !defined(CORRECT_COMPILER_ATOMIC_SUPPORT)
-  STATIC_ASSERT(byte_size >= 8);
-#elif !defined(FULL_COMPILER_ATOMIC_SUPPORT)
+#ifndef FULL_COMPILER_ATOMIC_SUPPORT
   STATIC_ASSERT(byte_size >= 4);
+#endif
+
+#ifndef CORRECT_COMPILER_ATOMIC_SUPPORT
+  STATIC_ASSERT(byte_size != 4);
 #endif
 
   STATIC_ASSERT(byte_size == sizeof(T));

--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -130,20 +130,19 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest __attribute__((
   STATIC_ASSERT(4 == sizeof(T));
 
   T old_value;
-  long rc;
+  long flag;
 
   if (order != memory_order_relaxed) {
     FULL_MEM_BARRIER;
   }
 
   __asm__ __volatile__ (
-    "1:  sext.w    %1, %3      \n\t" // sign-extend compare_value
-    "    lr.w      %0, %2      \n\t"
-    "    bne       %0, %1, 2f  \n\t"
+    "1:  lr.w      %0, %2      \n\t"
+    "    bne       %0, %3, 2f  \n\t"
     "    sc.w      %1, %4, %2  \n\t"
     "    bnez      %1, 1b      \n\t"
     "2:                        \n\t"
-    : /*%0*/"=&r" (old_value), /*%1*/"=&r" (rc), /*%2*/"+A" (*dest)
+    : /*%0*/"=&r" (old_value), /*%1*/"=&r" (flag), /*%2*/"+A" (*dest)
     : /*%3*/"r" (compare_value), /*%4*/"r" (exchange_value)
     : "memory" );
 

--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -39,6 +39,12 @@
 #define FULL_COMPILER_ATOMIC_SUPPORT
 #endif
 
+#if defined(__clang_major__)
+#define CORRECT_COMPILER_ATOMIC_SUPPORT
+#elif defined(__GNUC__) && __riscv_xlen <= 32
+#define CORRECT_COMPILER_ATOMIC_SUPPORT
+#endif
+
 template<size_t byte_size>
 struct Atomic::PlatformAdd {
   template<typename D, typename I>
@@ -114,6 +120,40 @@ inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest __attribute__((
 }
 #endif
 
+#ifndef CORRECT_COMPILER_ATOMIC_SUPPORT
+template<>
+template<typename T>
+inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest __attribute__((unused)),
+                                                T compare_value,
+                                                T exchange_value,
+                                                atomic_memory_order order) const {
+  STATIC_ASSERT(4 == sizeof(T));
+
+  T old_value;
+  long rc;
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+
+  __asm__ __volatile__ (
+    "1:  sext.w    %1, %3      \n\t" // sign-extend compare_value
+    "    lr.w      %0, %2      \n\t"
+    "    bne       %0, %1, 2f  \n\t"
+    "    sc.w      %1, %4, %2  \n\t"
+    "    bnez      %1, 1b      \n\t"
+    "2:                        \n\t"
+    : /*%0*/"=&r" (old_value), /*%1*/"=&r" (rc), /*%2*/"+A" (*dest)
+    : /*%3*/"r" (compare_value), /*%4*/"r" (exchange_value)
+    : "memory" );
+
+  if (order != memory_order_relaxed) {
+    FULL_MEM_BARRIER;
+  }
+  return old_value;
+}
+#endif
+
 template<size_t byte_size>
 template<typename T>
 inline T Atomic::PlatformXchg<byte_size>::operator()(T volatile* dest,
@@ -147,7 +187,9 @@ inline T Atomic::PlatformCmpxchg<byte_size>::operator()(T volatile* dest __attri
                                                         T exchange_value,
                                                         atomic_memory_order order) const {
 
-#ifndef FULL_COMPILER_ATOMIC_SUPPORT
+#if !defined(CORRECT_COMPILER_ATOMIC_SUPPORT)
+  STATIC_ASSERT(byte_size >= 8);
+#elif !defined(FULL_COMPILER_ATOMIC_SUPPORT)
   STATIC_ASSERT(byte_size >= 4);
 #endif
 
@@ -187,5 +229,6 @@ struct Atomic::PlatformOrderedStore<byte_size, RELEASE_X_FENCE>
 };
 
 #undef FULL_COMPILER_ATOMIC_SUPPORT
+#undef CORRECT_COMPILER_ATOMIC_SUPPORT
 
 #endif // OS_CPU_LINUX_RISCV_ATOMIC_LINUX_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/atomic_linux_riscv.hpp
@@ -154,7 +154,7 @@ inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest __attribute__((
   if (order != memory_order_relaxed) {
     FULL_MEM_BARRIER;
   }
-  return old_value;
+  return (T)old_value;
 }
 #endif
 


### PR DESCRIPTION
With compressed oops enabled, Shenandoah GC crashes in the concurrent marking phase due to some incorrect atomic memory operations. This resulted in the failure of multiple related tests, including `gc/shenandoah/TestSmallHeap.java`, `gc/metaspace/TestMetaspacePerfCounters.java#Shenandoah-64`, and so on, tested on XuanTie C910 and QEMU.

This failure is related to a GCC bug we recently discovered: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=114130.

In detail, there's a pattern in method `ShenandoahHeap::conc_update_with_forwarded`:

```cpp
if (in_collection_set(obj)) {
  // Dereferences `obj` without explicit null check.
  oop fwd = ShenandoahBarrierSet::resolve_forwarded_not_null(obj);
  // Then calls atomic built-in.
  atomic_update_oop(fwd, p, obj);
}
```

`atomic_update_oop` then compresses `obj` into a 32-bit word and calls the built-in `__atomic_compare_exchange`. The latter produces incorrect assembly that comparing this unsigned 32-bit word with the sign-extended result of `lr.w` instructions.

This bug can be bypassed by adding an explicit null check (like `if (obj && in_collection_set(obj))`), or adding compiler flag `-fno-delete-null-pointer-checks`.

In previous commits, JDK-8316186 removed RISC-V's `PlatformCmpxchg<4>` but left the flag `-fno-delete-null-pointer-checks` enabled. Then JDK-8316893 removed the flag and made the bug visible. This patch adds `PlatformCmpxchg<4>` back.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326936](https://bugs.openjdk.org/browse/JDK-8326936): RISC-V: Shenandoah GC crashes due to incorrect atomic memory operations (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [e1a49d85](https://git.openjdk.org/jdk/pull/18039/files/e1a49d8530e4e059ecea28c376d6b9d82eee2b4e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18039/head:pull/18039` \
`$ git checkout pull/18039`

Update a local copy of the PR: \
`$ git checkout pull/18039` \
`$ git pull https://git.openjdk.org/jdk.git pull/18039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18039`

View PR using the GUI difftool: \
`$ git pr show -t 18039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18039.diff">https://git.openjdk.org/jdk/pull/18039.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18039#issuecomment-1968630980)