### PR TITLE
8326948: Force English locale for timeout formatting

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -639,7 +640,8 @@ public final class PassFailJFrame {
             long hours = leftTime / 3_600_000;
             long minutes = (leftTime - hours * 3_600_000) / 60_000;
             long seconds = (leftTime - hours * 3_600_000 - minutes * 60_000) / 1_000;
-            label.setText(String.format("Test timeout: %02d:%02d:%02d",
+            label.setText(String.format(Locale.ENGLISH,
+                                        "Test timeout: %02d:%02d:%02d",
                                         hours, minutes, seconds));
         }
 


### PR DESCRIPTION
If a test runs in non-English locale, the digits displayed in the timeout could be locale-specific, which may be confusing.

For example, in the Arabic locale `-Duser.language=ar`, the timeout is displayed like this:

Test timeout: ٠٠:٠٤:٥٨

The fix explicitly sets English locale for formatting, which ensures the timeout is always displayed with the Western Arabic numerals, see [Numerals in most popular systems](https://en.wikipedia.org/wiki/Numerical_digit#Numerals_in_most_popular_systems).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326948](https://bugs.openjdk.org/browse/JDK-8326948): Force English locale for timeout formatting (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18042/head:pull/18042` \
`$ git checkout pull/18042`

Update a local copy of the PR: \
`$ git checkout pull/18042` \
`$ git pull https://git.openjdk.org/jdk.git pull/18042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18042`

View PR using the GUI difftool: \
`$ git pr show -t 18042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18042.diff">https://git.openjdk.org/jdk/pull/18042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18042#issuecomment-1968875294)