### PR TITLE
8326953: Race in creation of win-exports.def with static-libs

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -125,7 +125,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
 $(BUILD_GTEST_LIBJVM) : $(BUILD_GTEST_LIBGTEST)
 
 ifeq ($(call isTargetOs, windows), true)
-  $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS))
+   $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
 
   $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
 endif

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -122,6 +122,7 @@ ifeq ($(call isTargetOs, windows), true)
   $(BUILD_GTEST_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif
 
+
 TARGETS += $(BUILD_GTEST_LIBJVM)
 
 ################################################################################

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -74,6 +74,12 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
 
 TARGETS += $(BUILD_GTEST_LIBGTEST)
 
+ifeq ($(call isTargetOs, windows), true)
+  GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/win-exports.def
+
+  JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
+endif
+
 ################################################################################
 # Additional disabled warnings are due to code in the test source.
 
@@ -119,9 +125,10 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
 $(BUILD_GTEST_LIBJVM) : $(BUILD_GTEST_LIBGTEST)
 
 ifeq ($(call isTargetOs, windows), true)
-  $(BUILD_GTEST_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
-endif
+  $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS))
 
+  $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
+endif
 
 TARGETS += $(BUILD_GTEST_LIBJVM)
 

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -74,15 +74,6 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
 
 TARGETS += $(BUILD_GTEST_LIBGTEST)
 
-ifeq ($(call isTargetOs, windows), true)
-  ifeq ($(STATIC_LIBS), true)
-    GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/static-win-exports.def
-  else
-    GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/win-exports.def
-  endif
-  JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
-endif
-
 ################################################################################
 # Additional disabled warnings are due to code in the test source.
 
@@ -128,9 +119,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
 $(BUILD_GTEST_LIBJVM) : $(BUILD_GTEST_LIBGTEST)
 
 ifeq ($(call isTargetOs, windows), true)
-    $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
-
-  $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
+  $(BUILD_GTEST_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif
 
 TARGETS += $(BUILD_GTEST_LIBJVM)

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -74,12 +74,13 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
 
 TARGETS += $(BUILD_GTEST_LIBGTEST)
 
-ifneq ($(STATIC_LIBS), true)
-  ifeq ($(call isTargetOs, windows), true)
+ifeq ($(call isTargetOs, windows), true)
+  ifeq ($(STATIC_LIBS), true)
+    GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/static-win-exports.def
+  else
     GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/win-exports.def
-
-    JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
   endif
+  JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
 endif
 
 ################################################################################
@@ -126,12 +127,10 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
 
 $(BUILD_GTEST_LIBJVM) : $(BUILD_GTEST_LIBGTEST)
 
-ifneq ($(STATIC_LIBS), true)
-  ifeq ($(call isTargetOs, windows), true)
-     $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
+ifeq ($(call isTargetOs, windows), true)
+    $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
 
-    $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
-  endif
+  $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
 endif
 
 TARGETS += $(BUILD_GTEST_LIBJVM)

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -74,10 +74,12 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
 
 TARGETS += $(BUILD_GTEST_LIBGTEST)
 
-ifeq ($(call isTargetOs, windows), true)
-  GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/win-exports.def
+ifneq ($(STATIC_LIBS), true)
+  ifeq ($(call isTargetOs, windows), true)
+    GTEST_WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/gtest/win-exports.def
 
-  JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
+    JVM_LDFLAGS += -def:$(GTEST_WIN_EXPORT_FILE)
+  endif
 endif
 
 ################################################################################
@@ -124,10 +126,12 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
 
 $(BUILD_GTEST_LIBJVM) : $(BUILD_GTEST_LIBGTEST)
 
-ifeq ($(call isTargetOs, windows), true)
-   $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
+ifneq ($(STATIC_LIBS), true)
+  ifeq ($(call isTargetOs, windows), true)
+     $(eval $(call CreateWinExportFile, $(GTEST_WIN_EXPORT_FILE), $(BUILD_GTEST_LIBJVM_ALL_OBJS)))
 
-  $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
+    $(BUILD_GTEST_LIBJVM_TARGET): $(GTEST_WIN_EXPORT_FILE)
+  endif
 endif
 
 TARGETS += $(BUILD_GTEST_LIBJVM)

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -145,12 +145,14 @@ $(call FillFindCache, $(JVM_SRC_DIRS))
 # operator new.
 LIBJVM_STATIC_EXCLUDE_OBJS := operator_new.o
 
-ifneq ($(STATIC_LIBS), true)
-  ifeq ($(call isTargetOs, windows), true)
+ifeq ($(call isTargetOs, windows), true)
+  ifeq ($(STATIC_LIBS), true)
+    WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/static-win-exports.def
+  else
     WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/win-exports.def
-
-    JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
   endif
+
+  JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
 endif
 
 ifeq ($(call isTargetOs, linux), true)
@@ -216,36 +218,35 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     STATIC_LIB_EXCLUDE_OBJS := $(LIBJVM_STATIC_EXCLUDE_OBJS), \
 ))
 
-ifneq ($(STATIC_LIBS), true)
-  ifeq ($(call isTargetOs, windows), true)
-    # The following lines create a list of vftable symbols to be filtered out of
-    # the symbol file. Removing this line causes the linker to complain about too
-    # many (> 64K) symbols, so the _guess_ is that this line is here to keep down
-    # the number of exported symbols below that limit.
-    #
-    # Some usages of C++ lambdas require the vftable symbol of classes that use
-    # the lambda type as a template parameter. The usage of those classes won't
-    # link if their vftable symbols are removed. That's why there's an exception
-    # for vftable symbols containing the string 'lambda'.
-    #
-    # A very simple example of a lambda usage that fails if the lambda vftable
-    # symbols are missing in the symbol file:
-    #
-    # #include <functional>
-    # std::function<void()> f = [](){}
-    FILTER_SYMBOLS_AWK_SCRIPT := \
-        '{ \
-          if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
-        }'
+ifeq ($(call isTargetOs, windows), true)
+  # The following lines create a list of vftable symbols to be filtered out of
+  # the symbol file. Removing this line causes the linker to complain about too
+  # many (> 64K) symbols, so the _guess_ is that this line is here to keep down
+  # the number of exported symbols below that limit.
+  #
+  # Some usages of C++ lambdas require the vftable symbol of classes that use
+  # the lambda type as a template parameter. The usage of those classes won't
+  # link if their vftable symbols are removed. That's why there's an exception
+  # for vftable symbols containing the string 'lambda'.
+  #
+  # A very simple example of a lambda usage that fails if the lambda vftable
+  # symbols are missing in the symbol file:
+  #
+  # #include <functional>
+  # std::function<void()> f = [](){}
+  FILTER_SYMBOLS_AWK_SCRIPT := \
+      '{ \
+        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
+      }'
 
-    # Setup a rule to create a win-exports.def file
-    # $1: the name of the file to create
-    # $2: the object targets to depend on
-    define CreateWinExportFile
-      # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
-      # cd && *.obj, but this will result in very long command lines, which could be
-      # problematic.
-      $1: $2
+  # Setup a rule to create a win-exports.def file
+  # $1: the name of the file to create
+  # $2: the object targets to depend on
+  define CreateWinExportFile
+    # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
+    # cd && *.obj, but this will result in very long command lines, which could be
+    # problematic.
+    $1: $2
 	$$(call LogInfo, Generating list of symbols to export from object files)
 	$$(call MakeDir, $$(@D))
 	$$(ECHO) "EXPORTS" > $$@.tmp
@@ -253,12 +254,11 @@ ifneq ($(STATIC_LIBS), true)
 	    $$(DUMPBIN) -symbols *$$(OBJ_SUFFIX) | $$(AWK) $$(FILTER_SYMBOLS_AWK_SCRIPT) | $$(SORT) -u >> $$@.tmp
 	$$(RM) $$@
 	$$(MV) $$@.tmp $$@
-    endef
+  endef
 
-    $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
+  $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
 
-    $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
-  endif
+  $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif
 
 # Always recompile abstract_vm_version.cpp if libjvm needs to be relinked. This ensures

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -232,7 +232,7 @@ ifeq ($(call isTargetOs, windows), true)
   # std::function<void()> f = [](){}
   FILTER_SYMBOLS_AWK_SCRIPT := \
       '{ \
-        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7; \
+        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
       }'
 
   # Setup a rule to create a win-exports.def file
@@ -243,17 +243,16 @@ ifeq ($(call isTargetOs, windows), true)
     # cd && *.obj, but this will result in very long command lines, which could be
     # problematic.
     $1: $2
-	$(call LogInfo, Generating list of symbols to export from object files)
-	$(call MakeDir, $(@D))
-	$(CD) $(JVM_OUTPUTDIR)/objs && \
-	    $(DUMPBIN) -symbols *$(OBJ_SUFFIX) | $(AWK) $(FILTER_SYMBOLS_AWK_SCRIPT) | $(SORT) -u > $@.syms
-	$(ECHO) "EXPORTS" > $@.tmp
-	$(AWK) '{ if ($$0 ~ ".") { print "  " $$0 } }'  < $@.syms >> $@.tmp
-	$(RM) $@
-	$(MV) $@.tmp $@
+	$$(call LogInfo, Generating list of symbols to export from object files)
+	$$(call MakeDir, $$(@D))
+	$$(ECHO) "EXPORTS" > $$@.tmp
+	$$(CD) $$(JVM_OUTPUTDIR)/objs && \
+	    $$(DUMPBIN) -symbols *$$(OBJ_SUFFIX) | $$(AWK) $$(FILTER_SYMBOLS_AWK_SCRIPT) | $$(SORT) -u >> $$@.tmp
+	$$(RM) $$@
+	$$(MV) $$@.tmp $$@
   endef
 
-  $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS))
+  $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
 
   $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -152,7 +152,7 @@ ifeq ($(call isTargetOs, windows), true)
     WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/win-exports.def
   endif
 
-  JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
+  JVM_LDFLAGS += -def:$(WIN_EXPORT_FILE)
 endif
 
 ifeq ($(call isTargetOs, linux), true)
@@ -206,7 +206,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \
-    LDFLAGS := $(JVM_LDFLAGS) $(JVM_LDFLAGS_NO_GTEST), \
+    LDFLAGS := $(JVM_LDFLAGS), \
     LIBS := $(JVM_LIBS), \
     OPTIMIZATION := $(JVM_OPTIMIZATION), \
     OBJECT_DIR := $(JVM_OUTPUTDIR)/objs, \
@@ -239,24 +239,17 @@ ifeq ($(call isTargetOs, windows), true)
         if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
       }'
 
-  # Setup a rule to create a win-exports.def file
-  # $1: the name of the file to create
-  # $2: the object targets to depend on
-  define CreateWinExportFile
-    # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
-    # cd && *.obj, but this will result in very long command lines, which could be
-    # problematic.
-    $1: $2
-	$$(call LogInfo, Generating list of symbols to export from object files)
-	$$(call MakeDir, $$(@D))
-	$$(ECHO) "EXPORTS" > $$@.tmp
-	$$(CD) $$(BUILD_LIBJVM_OBJECT_DIR) && \
-	    $$(DUMPBIN) -symbols *$$(OBJ_SUFFIX) | $$(AWK) $$(FILTER_SYMBOLS_AWK_SCRIPT) | $$(SORT) -u >> $$@.tmp
-	$$(RM) $$@
-	$$(MV) $$@.tmp $$@
-  endef
-
-  $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
+  # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
+  # cd && *.obj, but this will result in very long command lines, which could be
+  # problematic.
+  $(WIN_EXPORT_FILE): $(BUILD_LIBJVM_ALL_OBJS)
+	$(call LogInfo, Generating list of symbols to export from object files)
+	$(call MakeDir, $(@D))
+	$(ECHO) "EXPORTS" > $@.tmp
+	$(CD) $(BUILD_LIBJVM_OBJECT_DIR) && \
+	    $(DUMPBIN) -symbols *$(OBJ_SUFFIX) | $(AWK) $(FILTER_SYMBOLS_AWK_SCRIPT) | $(SORT) -u >> $@.tmp
+	$(RM) $@
+	$(MV) $@.tmp $@
 
   $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -250,7 +250,7 @@ ifeq ($(call isTargetOs, windows), true)
 	$$(call LogInfo, Generating list of symbols to export from object files)
 	$$(call MakeDir, $$(@D))
 	$$(ECHO) "EXPORTS" > $$@.tmp
-	$$(CD) $$(JVM_OUTPUTDIR)/objs && \
+	$$(CD) $$(BUILD_LIBJVM_OBJECT_DIR) && \
 	    $$(DUMPBIN) -symbols *$$(OBJ_SUFFIX) | $$(AWK) $$(FILTER_SYMBOLS_AWK_SCRIPT) | $$(SORT) -u >> $$@.tmp
 	$$(RM) $$@
 	$$(MV) $$@.tmp $$@

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -145,10 +145,12 @@ $(call FillFindCache, $(JVM_SRC_DIRS))
 # operator new.
 LIBJVM_STATIC_EXCLUDE_OBJS := operator_new.o
 
-ifeq ($(call isTargetOs, windows), true)
-  WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/win-exports.def
+ifneq ($(STATIC_LIBS), true)
+  ifeq ($(call isTargetOs, windows), true)
+    WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/win-exports.def
 
-  JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
+    JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
+  endif
 endif
 
 ifeq ($(call isTargetOs, linux), true)
@@ -214,35 +216,36 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     STATIC_LIB_EXCLUDE_OBJS := $(LIBJVM_STATIC_EXCLUDE_OBJS), \
 ))
 
-ifeq ($(call isTargetOs, windows), true)
-  # The following lines create a list of vftable symbols to be filtered out of
-  # the symbol file. Removing this line causes the linker to complain about too
-  # many (> 64K) symbols, so the _guess_ is that this line is here to keep down
-  # the number of exported symbols below that limit.
-  #
-  # Some usages of C++ lambdas require the vftable symbol of classes that use
-  # the lambda type as a template parameter. The usage of those classes won't
-  # link if their vftable symbols are removed. That's why there's an exception
-  # for vftable symbols containing the string 'lambda'.
-  #
-  # A very simple example of a lambda usage that fails if the lambda vftable
-  # symbols are missing in the symbol file:
-  #
-  # #include <functional>
-  # std::function<void()> f = [](){}
-  FILTER_SYMBOLS_AWK_SCRIPT := \
-      '{ \
-        if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
-      }'
+ifneq ($(STATIC_LIBS), true)
+  ifeq ($(call isTargetOs, windows), true)
+    # The following lines create a list of vftable symbols to be filtered out of
+    # the symbol file. Removing this line causes the linker to complain about too
+    # many (> 64K) symbols, so the _guess_ is that this line is here to keep down
+    # the number of exported symbols below that limit.
+    #
+    # Some usages of C++ lambdas require the vftable symbol of classes that use
+    # the lambda type as a template parameter. The usage of those classes won't
+    # link if their vftable symbols are removed. That's why there's an exception
+    # for vftable symbols containing the string 'lambda'.
+    #
+    # A very simple example of a lambda usage that fails if the lambda vftable
+    # symbols are missing in the symbol file:
+    #
+    # #include <functional>
+    # std::function<void()> f = [](){}
+    FILTER_SYMBOLS_AWK_SCRIPT := \
+        '{ \
+          if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print "  " $$7; \
+        }'
 
-  # Setup a rule to create a win-exports.def file
-  # $1: the name of the file to create
-  # $2: the object targets to depend on
-  define CreateWinExportFile
-    # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
-    # cd && *.obj, but this will result in very long command lines, which could be
-    # problematic.
-    $1: $2
+    # Setup a rule to create a win-exports.def file
+    # $1: the name of the file to create
+    # $2: the object targets to depend on
+    define CreateWinExportFile
+      # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
+      # cd && *.obj, but this will result in very long command lines, which could be
+      # problematic.
+      $1: $2
 	$$(call LogInfo, Generating list of symbols to export from object files)
 	$$(call MakeDir, $$(@D))
 	$$(ECHO) "EXPORTS" > $$@.tmp
@@ -250,11 +253,12 @@ ifeq ($(call isTargetOs, windows), true)
 	    $$(DUMPBIN) -symbols *$$(OBJ_SUFFIX) | $$(AWK) $$(FILTER_SYMBOLS_AWK_SCRIPT) | $$(SORT) -u >> $$@.tmp
 	$$(RM) $$@
 	$$(MV) $$@.tmp $$@
-  endef
+    endef
 
-  $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
+    $(eval $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS)))
 
-  $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
+    $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
+  endif
 endif
 
 # Always recompile abstract_vm_version.cpp if libjvm needs to be relinked. This ensures

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -148,7 +148,7 @@ LIBJVM_STATIC_EXCLUDE_OBJS := operator_new.o
 ifeq ($(call isTargetOs, windows), true)
   WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/win-exports.def
 
-  JVM_LDFLAGS += -def:$(WIN_EXPORT_FILE)
+  JVM_LDFLAGS_NO_GTEST += -def:$(WIN_EXPORT_FILE)
 endif
 
 ifeq ($(call isTargetOs, linux), true)
@@ -202,7 +202,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \
-    LDFLAGS := $(JVM_LDFLAGS), \
+    LDFLAGS := $(JVM_LDFLAGS) $(JVM_LDFLAGS_NO_GTEST), \
     LIBS := $(JVM_LIBS), \
     OPTIMIZATION := $(JVM_OPTIMIZATION), \
     OBJECT_DIR := $(JVM_OUTPUTDIR)/objs, \
@@ -235,10 +235,14 @@ ifeq ($(call isTargetOs, windows), true)
         if ($$7 ~ /\?\?_7.*@@6B@/ && $$7 !~ /type_info/ && $$7 !~ /lambda/) print $$7; \
       }'
 
-  # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
-  # cd && *.obj, but this will result in very long command lines, which could be
-  # problematic.
-  $(WIN_EXPORT_FILE): $(BUILD_LIBJVM_ALL_OBJS)
+  # Setup a rule to create a win-exports.def file
+  # $1: the name of the file to create
+  # $2: the object targets to depend on
+  define CreateWinExportFile
+    # A more correct solution would be to send BUILD_LIBJVM_ALL_OBJS instead of
+    # cd && *.obj, but this will result in very long command lines, which could be
+    # problematic.
+    $1: $2
 	$(call LogInfo, Generating list of symbols to export from object files)
 	$(call MakeDir, $(@D))
 	$(CD) $(JVM_OUTPUTDIR)/objs && \
@@ -247,6 +251,9 @@ ifeq ($(call isTargetOs, windows), true)
 	$(AWK) '{ if ($$0 ~ ".") { print "  " $$0 } }'  < $@.syms >> $@.tmp
 	$(RM) $@
 	$(MV) $@.tmp $@
+  endef
+
+  $(call CreateWinExportFile, $(WIN_EXPORT_FILE), $(BUILD_LIBJVM_ALL_OBJS))
 
   $(BUILD_LIBJVM_TARGET): $(WIN_EXPORT_FILE)
 endif


### PR DESCRIPTION
We have seen a build failure along the lines of:
```
 /usr/bin/mv: cannot move '.../build/windows-x64-open-debug/hotspot/variant-server/libjvm/win-exports.def.tmp' to '.../build/windows-x64-open-debug/hotspot/variant-server/libjvm/win-exports.def': No such file or directory
```
on Windows.

My guess is that this is a race between creating the win-export.def file for the gtest jvm and the product jvm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326953](https://bugs.openjdk.org/browse/JDK-8326953): Race in creation of win-exports.def with static-libs (**Bug** - P2)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) ⚠️ Review applies to [7ccd2766](https://git.openjdk.org/jdk/pull/18043/files/7ccd27669fcb8994ae214b092ced1b85b1bfa808)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18043/head:pull/18043` \
`$ git checkout pull/18043`

Update a local copy of the PR: \
`$ git checkout pull/18043` \
`$ git pull https://git.openjdk.org/jdk.git pull/18043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18043`

View PR using the GUI difftool: \
`$ git pr show -t 18043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18043.diff">https://git.openjdk.org/jdk/pull/18043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18043#issuecomment-1968886559)