### PR TITLE
8326975: Parallel: Remove redundant PSOldGen::is_allocated

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -122,7 +122,7 @@ jint ParallelScavengeHeap::initialize() {
   _gc_policy_counters =
     new PSGCAdaptivePolicyCounters("ParScav:MSC", 2, 2, _size_policy);
 
-  if (!PSParallelCompact::initialize()) {
+  if (!PSParallelCompact::initialize_aux_data()) {
     return JNI_ENOMEM;
   }
 

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -121,12 +121,6 @@ void PSOldGen::initialize_performance_counters(const char* perf_data_name, int l
                                       _object_space, _gen_counters);
 }
 
-// Assume that the generation has been allocated if its
-// reserved size is not 0.
-bool  PSOldGen::is_allocated() {
-  return virtual_space()->reserved_size() != 0;
-}
-
 size_t PSOldGen::num_iterable_blocks() const {
   return (object_space()->used_in_bytes() + IterateBlockSize - 1) / IterateBlockSize;
 }

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -105,9 +105,6 @@ class PSOldGen : public CHeapObj<mtGC> {
   ObjectStartArray*     start_array()             { return &_start_array; }
   PSVirtualSpace*       virtual_space() const     { return _virtual_space;}
 
-  // Has the generation been successfully allocated?
-  bool is_allocated();
-
   // Size info
   size_t capacity_in_bytes() const        { return object_space()->capacity_in_bytes(); }
   size_t used_in_bytes() const            { return object_space()->used_in_bytes(); }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -866,11 +866,6 @@ bool PSParallelCompact::initialize() {
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
   MemRegion mr = heap->reserved_region();
 
-  // Was the old gen get allocated successfully?
-  if (!heap->old_gen()->is_allocated()) {
-    return false;
-  }
-
   initialize_space_info();
   initialize_dead_wood_limiter();
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -862,9 +862,10 @@ void PSParallelCompact::post_initialize() {
   ParCompactionManager::initialize(mark_bitmap());
 }
 
-bool PSParallelCompact::initialize() {
+bool PSParallelCompact::initialize_aux_data() {
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
   MemRegion mr = heap->reserved_region();
+  assert(mr.byte_size() != 0, "heap should be reserved");
 
   initialize_space_info();
   initialize_dead_wood_limiter();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -1069,7 +1069,7 @@ class PSParallelCompact : AllStatic {
   // allocations.  This should be called during the VM initialization
   // at a pointer where it would be appropriate to return a JNI_ENOMEM
   // in the event of a failure.
-  static bool initialize();
+  static bool initialize_aux_data();
 
   // Closure accessors
   static BoolObjectClosure* is_alive_closure()     { return &_is_alive_closure; }


### PR DESCRIPTION
Simple removing redundant code, since old-gen should have been allocated in the caller context.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326975](https://bugs.openjdk.org/browse/JDK-8326975): Parallel: Remove redundant PSOldGen::is_allocated (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18047/head:pull/18047` \
`$ git checkout pull/18047`

Update a local copy of the PR: \
`$ git checkout pull/18047` \
`$ git pull https://git.openjdk.org/jdk.git pull/18047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18047`

View PR using the GUI difftool: \
`$ git pr show -t 18047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18047.diff">https://git.openjdk.org/jdk/pull/18047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18047#issuecomment-1969380511)