### PR TITLE
8326944: (ch) Minor typo in the ScatteringByteChannel.read(ByteBuffer[] dsts,int offset,int length) javadoc

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/ScatteringByteChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/ScatteringByteChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public interface ScatteringByteChannel
      *
      * <p> An invocation of this method attempts to read up to <i>r</i> bytes
      * from this channel, where <i>r</i> is the total number of bytes remaining
-     * the specified subsequence of the given buffer array, that is,
+     * in the specified subsequence of the given buffer array, that is,
      *
      * {@snippet lang=java :
      *     dsts[offset].remaining()


### PR DESCRIPTION
Insert missing `in` in the specification of `ScatteringByteChannel.read`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326944](https://bugs.openjdk.org/browse/JDK-8326944): (ch) Minor typo in the ScatteringByteChannel.read(ByteBuffer[] dsts,int offset,int length) javadoc (**Bug** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18049/head:pull/18049` \
`$ git checkout pull/18049`

Update a local copy of the PR: \
`$ git checkout pull/18049` \
`$ git pull https://git.openjdk.org/jdk.git pull/18049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18049`

View PR using the GUI difftool: \
`$ git pr show -t 18049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18049.diff">https://git.openjdk.org/jdk/pull/18049.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18049#issuecomment-1969545507)