### PR TITLE
8326891: Prefer RPATH over RUNPATH for $ORIGIN rpaths in internal JDK binaries

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -39,7 +39,7 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
     SHARED_LIBRARY_FLAGS='-shared'
     # --disable-new-dtags forces use of RPATH instead of RUNPATH for rpaths.
     # This protects internal library dependencies within the JDK from being
-    # overridden using LD_LIBRARY_PATH.
+    # overridden using LD_LIBRARY_PATH. See JDK-8326891 for more information.
     SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1 -Wl,--disable-new-dtags'
     SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
     SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -37,7 +37,7 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Default works for linux, might work on other platforms as well.
     SHARED_LIBRARY_FLAGS='-shared'
-    SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1'
+    SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1 -Wl,--disable-new-dtags'
     SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
     SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'
 
@@ -60,6 +60,9 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
       # Default works for linux, might work on other platforms as well.
       SHARED_LIBRARY_FLAGS='-shared'
       SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1'
+      if test "x$OPENJDK_TARGET_OS" = xlinux; then
+        SET_EXECUTABLE_ORIGIN="$SET_EXECUTABLE_ORIGIN -Wl,--disable-new-dtags"
+      fi
       SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'
 
       # arm specific settings

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -28,7 +28,7 @@
 # Setup flags for C/C++ compiler
 #
 
-###############################################################################
+################################################################################
 #
 # How to compile shared libraries.
 #
@@ -37,6 +37,9 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Default works for linux, might work on other platforms as well.
     SHARED_LIBRARY_FLAGS='-shared'
+    # --disable-new-dtags forces use of RPATH instead of RUNPATH for rpaths.
+    # This protects internal library dependencies within the JDK from being
+    # overridden using LD_LIBRARY_PATH.
     SET_EXECUTABLE_ORIGIN='-Wl,-rpath,\$$ORIGIN[$]1 -Wl,--disable-new-dtags'
     SET_SHARED_LIBRARY_ORIGIN="-Wl,-z,origin $SET_EXECUTABLE_ORIGIN"
     SET_SHARED_LIBRARY_NAME='-Wl,-soname=[$]1'

--- a/test/jdk/tools/launcher/RunpathTest.java
+++ b/test/jdk/tools/launcher/RunpathTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 7190813 8022719
  * @summary Check for extended RPATHs on Linux
+ * @requires os.family == "linux"
  * @compile -XDignore.symbol.file RunpathTest.java
  * @run main RunpathTest
  * @author ksrini
@@ -69,13 +70,11 @@ public class RunpathTest extends TestHelper {
     }
 
     public static void main(String... args) throws Exception {
-        if (isLinux) {
-            RunpathTest rp = new RunpathTest();
-            if (rp.elfreaderCmd == null) {
-                System.err.println("Warning: test passes vacuously");
-                return;
-            }
-            rp.testRpath();
+        RunpathTest rp = new RunpathTest();
+        if (rp.elfreaderCmd == null) {
+            System.err.println("Warning: test passes vacuously");
+            return;
         }
+        rp.testRpath();
     }
 }

--- a/test/jdk/tools/launcher/RunpathTest.java
+++ b/test/jdk/tools/launcher/RunpathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 7190813 8022719
- * @summary Check for extended  RPATHs on *nixes
+ * @summary Check for extended RPATHs on Linux
  * @compile -XDignore.symbol.file RunpathTest.java
  * @run main RunpathTest
  * @author ksrini
@@ -57,14 +57,14 @@ public class RunpathTest extends TestHelper {
         final TestResult tr = doExec(elfreaderCmd, "-d", javacmd);
         if (!tr.matches(expectedRpath)) {
             System.out.println(tr);
-            throw new RuntimeException("FAILED: RPATH/RUNPATH strings " +
+            throw new RuntimeException("FAILED: RPATH strings " +
                     expectedRpath + " not found in " + javaCmd);
         }
-        System.out.println(javacmd + " contains expected RPATHS/RUNPATH");
+        System.out.println(javacmd + " contains expected RPATHS");
     }
 
     void testRpath() {
-        String expectedRpath = ".*R(UN)?PATH.*\\$ORIGIN/../lib.*";
+        String expectedRpath = ".*RPATH.*\\$ORIGIN/../lib.*";
         elfCheck(javaCmd, expectedRpath);
     }
 


### PR DESCRIPTION
Executables and dynamic libraries on Linux can encode a search path that the dynamic linker will use when looking up library dependencies, generally referred to as an "rpath". In the JDK we use this with the $ORIGIN feature to set search paths relative to the location of the binary itself. Typically executables in the bin/ directory have the rpath "$ORIGIN/../lib" to find libjli.so. Most of the libraries in lib/ have rpath set to just "$ORIGIN" to find each other.

There are two different types of such rpaths, RPATH and RUNPATH. The former is the earlier incantation but RUNPATH has been around since about 2003 and has been default in prominent Linux distros for a long time, and now also seems to be default in the linker directly from binutils. The toolchain used by Oracle defaulted to RPATH until at least JDK 11, but since then with some toolchain upgrade, the default was flipped to RUNPATH.

The main (relevant in this case) difference between the two is that RPATH is considered before the LD_LIBRARY_PATH environment variable, while RUNPATH is only considered after LD_LIBRARY_PATH. For libraries that are part of a Linux distribution, letting users, or the system, control and override builtin rpaths with LD_LIBRARY_PATH seems like a reasonable thing to prefer. However, for the JDK, there really is no usecase for having an externally configured LD_LIBRARY_PATH potentially getting in the way of the JDK libraries finding each other correctly. If a user environment sets LD_LIBRARY_PATH, and there is a library in that path with the same name as a JDK library (e.g. libnet.so or some other generically named library) that external library will be loaded instead of the JDK internal library and that is basically guaranteed to break the JDK. There is no supported usecase that I can think of for injecting other versions of such libraries in a JDK distribution.

I propose that we explicitly configure the JDK build to set RPATH instead of RUNPATH for Linux binaries. This is done with the linker flag "--disable-new-dtags".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326891](https://bugs.openjdk.org/browse/JDK-8326891): Prefer RPATH over RUNPATH for $ORIGIN rpaths in internal JDK binaries (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [faafef8a](https://git.openjdk.org/jdk/pull/18050/files/faafef8a46834ab0f8efc94e49324ad216d9271e)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18050/head:pull/18050` \
`$ git checkout pull/18050`

Update a local copy of the PR: \
`$ git checkout pull/18050` \
`$ git pull https://git.openjdk.org/jdk.git pull/18050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18050`

View PR using the GUI difftool: \
`$ git pr show -t 18050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18050.diff">https://git.openjdk.org/jdk/pull/18050.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18050#issuecomment-1969705264)