### PR TITLE
8326838: JFR: Native mirror events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -203,7 +203,12 @@ public final class MetadataRepository {
         if (pEventType == null) {
             pEventType = (PlatformEventType) TypeLibrary.createType(eventClass, dynamicAnnotations, dynamicFields);
         }
-        // Check for native mirror
+        // Check for native mirror.
+        // Note, defining an event in metadata.xml is not a generic mechanism to emit
+        // native data in Java. For example, calling JVM.getStackTraceId(int, long)
+        // and assign the result to a long field is not enough to always get a proper
+        // stack trace. Purpose of the mechanism is to transfer metadata, such as
+        // native type IDs, without specialized Java logic for each type.
         if (eventClass.getClassLoader() == null) {
             Name name = eventClass.getAnnotation(Name.class);
             if (name != null) {
@@ -214,7 +219,7 @@ public final class MetadataRepository {
                     var eventFields = pEventType.getFields();
                     var comparator = Comparator.comparing(ValueDescriptor::getName);
                     if (!Utils.compareLists(nativeFields, eventFields, comparator)) {
-                        throw new InternalError("Fields for native mirror event " + n + " doesn't match Java event");
+                        throw new InternalError("Field for native mirror event " + n + " doesn't match Java event");
                     }
                     nativeEventTypes.remove(n);
                     nativeControls.remove(n);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,12 +35,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.Event;
 import jdk.jfr.EventType;
+import jdk.jfr.Name;
 import jdk.jfr.Period;
 import jdk.jfr.StackTrace;
 import jdk.jfr.Threshold;
@@ -54,8 +56,8 @@ public final class MetadataRepository {
 
     private static final MetadataRepository instance = new MetadataRepository();
 
-    private final List<EventType> nativeEventTypes = new ArrayList<>(150);
-    private final List<EventControl> nativeControls = new ArrayList<EventControl>(nativeEventTypes.size());
+    private final Map<String, EventType> nativeEventTypes = LinkedHashMap.newHashMap(150);
+    private final Map<String, EventControl> nativeControls = LinkedHashMap.newHashMap(150);
     private final SettingsManager settingsManager = new SettingsManager();
     private Constructor<EventConfiguration> cachedEventConfigurationConstructor;
     private boolean staleMetadata = true;
@@ -83,8 +85,9 @@ public final class MetadataRepository {
                         PeriodicEvents.addJVMEvent(pEventType);
                     }
                 }
-                nativeControls.add(new EventControl(pEventType));
-                nativeEventTypes.add(eventType);
+                String name = eventType.getName();
+                nativeControls.put(name, new EventControl(pEventType));
+                nativeEventTypes.put(name,eventType);
             }
         }
     }
@@ -101,7 +104,7 @@ public final class MetadataRepository {
                 eventTypes.add(ec.getEventType());
             }
         }
-        for (EventType t : nativeEventTypes) {
+        for (EventType t : nativeEventTypes.values()) {
             if (PrivateAccess.getInstance().isVisible(t)) {
                 eventTypes.add(t);
             }
@@ -200,6 +203,27 @@ public final class MetadataRepository {
         if (pEventType == null) {
             pEventType = (PlatformEventType) TypeLibrary.createType(eventClass, dynamicAnnotations, dynamicFields);
         }
+        // Check for native mirror
+        if (eventClass.getClassLoader() == null) {
+            Name name = eventClass.getAnnotation(Name.class);
+            if (name != null) {
+                String n = name.value();
+                EventType nativeType = nativeEventTypes.get(n);
+                if (nativeType != null) {
+                    var nativeFields = nativeType.getFields();
+                    var eventFields = pEventType.getFields();
+                    var comparator = Comparator.comparing(ValueDescriptor::getName);
+                    if (!Utils.compareLists(nativeFields, eventFields, comparator)) {
+                        throw new InternalError("Fields for native mirror event " + n + " doesn't match Java event");
+                    }
+                    nativeEventTypes.remove(n);
+                    nativeControls.remove(n);
+                    TypeLibrary.removeType(nativeType.getId());
+                    pEventType.setAnnotations(nativeType.getAnnotationElements());
+                    pEventType.setFields(nativeType.getFields());
+                }
+            }
+        }
         EventType eventType = PrivateAccess.getInstance().newEventType(pEventType);
         EventControl ec = new EventControl(pEventType, eventClass);
         EventConfiguration configuration = newEventConfiguration(eventType, ec);
@@ -226,7 +250,7 @@ public final class MetadataRepository {
     public synchronized List<EventControl> getEventControls() {
         List<Class<? extends jdk.internal.event.Event>> eventClasses = JVM.getAllEventClasses();
         ArrayList<EventControl> controls = new ArrayList<>(eventClasses.size() + nativeControls.size());
-        controls.addAll(nativeControls);
+        controls.addAll(nativeControls.values());
         for (Class<? extends jdk.internal.event.Event> clazz : eventClasses) {
             EventConfiguration eh = JVMSupport.getConfiguration(clazz);
             if (eh != null) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,6 +220,10 @@ public class Type implements Comparable<Type> {
 
     public boolean isDefinedByJVM() {
         return id < JVM.RESERVED_CLASS_ID_LIMIT;
+    }
+
+    public void setFields(List<ValueDescriptor> fields) {
+        this.fields = List.copyOf(fields);
     }
 
     public void add(ValueDescriptor valueDescriptor) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -322,7 +322,7 @@ public final class TypeLibrary {
             ValueDescriptor vd = dynamicFieldSet.get(field.getName());
             if (vd != null) {
                 if (!vd.getTypeName().equals(field.getType().getName())) {
-                    throw new InternalError("Type expected to match for field " + vd.getName() + " expected "  + field.getName() + " but got " + vd.getName());
+                    throw new InternalError("Type expected to match for field " + vd.getName() + " expected "  + field.getType().getName() + " but got " + vd.getTypeName());
                 }
                 for (AnnotationElement ae : vd.getAnnotationElements()) {
                     newTypes.add(PrivateAccess.getInstance().getType(ae));

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -174,6 +175,19 @@ public final class Utils {
             map.put(key, value);
         }
         return map;
+    }
+
+    public static <T> boolean compareLists(List<T> a, List<T> b, Comparator<T> c) {
+        int size = a.size();
+        if (size != b.size()) {
+            return false;
+        }
+        for (int i = 0; i < size; i++) {
+            if (c.compare(a.get(i), b.get(i)) != 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static <T> List<T> sanitizeNullFreeList(List<T> elements, Class<T> clazz) {


### PR DESCRIPTION
Hi,

Could I have a review of a change that provides infrastructure for emitting JDK events with metadata defined in native, such as structs, enum constants and references to native artefacts. If an event in the JDK has the same name as an event defined in metadata.xml, the metadata for the native event is used.

I also fixed an incorrect exception message in the TypeLibrary class.

Testing: jdk/jdk/jfr  and manual validatation that native metadata is picked up by a JDK event.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326838](https://bugs.openjdk.org/browse/JDK-8326838): JFR: Native mirror events (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18051/head:pull/18051` \
`$ git checkout pull/18051`

Update a local copy of the PR: \
`$ git checkout pull/18051` \
`$ git pull https://git.openjdk.org/jdk.git pull/18051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18051`

View PR using the GUI difftool: \
`$ git pr show -t 18051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18051.diff">https://git.openjdk.org/jdk/pull/18051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18051#issuecomment-1969747117)