### PR TITLE
8327002: (fs) java/nio/file/Files/CopyMoveVariations.java should be able to test across file systems

### DIFF
--- a/test/jdk/java/nio/file/Files/CopyMoveVariations.java
+++ b/test/jdk/java/nio/file/Files/CopyMoveVariations.java
@@ -34,6 +34,7 @@ import java.nio.file.AccessDeniedException;
 import java.nio.file.CopyOption;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
+import java.nio.file.FileStore;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
@@ -68,19 +69,21 @@ public class CopyMoveVariations {
     }
 
     private static final boolean SUPPORTS_POSIX_PERMISSIONS;
+    private static final String TMP_DIR =
+        System.getProperty("copymove.tmp.dir", ".");
 
     static {
-        Path currentDir = null;
+        Path tempFile = null;
         try {
-            currentDir = Files.createTempFile(Path.of("."), "this", "that");
+            tempFile = Files.createTempFile(Path.of(TMP_DIR), "this", "that");
             SUPPORTS_POSIX_PERMISSIONS =
-                Files.getFileStore(currentDir).supportsFileAttributeView("posix");
+                Files.getFileStore(tempFile).supportsFileAttributeView("posix");
         } catch (IOException cause) {
             throw new UncheckedIOException(cause);
         } finally {
-            if (currentDir != null) {
+            if (tempFile != null) {
                 try {
-                    Files.delete(currentDir);
+                    Files.delete(tempFile);
                 } catch (IOException ignore)  {
                 }
             }
@@ -89,6 +92,13 @@ public class CopyMoveVariations {
 
     private static boolean supportsPosixPermissions() {
         return SUPPORTS_POSIX_PERMISSIONS;
+    }
+
+    private static boolean isSameFileStore(Path p1, Path p2)
+        throws IOException {
+        FileStore fs1 = p1.getFileSystem().provider().getFileStore(p1);
+        FileStore fs2 = p2.getFileSystem().provider().getFileStore(p2);
+        return fs1.equals(fs2);
     }
 
     private static Stream<Arguments> params() {
@@ -142,15 +152,15 @@ public class CopyMoveVariations {
         Path source = null;
         Path target = null;
         Path linkTarget = null;
-        Path currentDir = Path.of(".");
+        Path tmpDir = Path.of(TMP_DIR);
         try {
             switch (type) {
                 case FILE ->
-                    source = Files.createTempFile(currentDir, "file", "dat");
+                    source = Files.createTempFile(tmpDir, "file", "dat");
                 case DIR ->
-                    source = Files.createTempDirectory(currentDir, "dir");
+                    source = Files.createTempDirectory(tmpDir, "dir");
                 case LINK -> {
-                    linkTarget = Files.createTempFile(currentDir, "link", "target");
+                    linkTarget = Files.createTempFile(tmpDir, "link", "target");
                     Path link = Path.of("link");
                     source = Files.createSymbolicLink(link, linkTarget);
                 }
@@ -164,7 +174,7 @@ public class CopyMoveVariations {
                 Files.setPosixFilePermissions(source, perms);
 
             if (targetExists)
-                target = Files.createTempFile(currentDir, "file", "target");
+                target = Files.createTempFile(tmpDir, "file", "target");
             else
                 target = Path.of("target");
 
@@ -193,7 +203,11 @@ public class CopyMoveVariations {
                     assertThrows(FileAlreadyExistsException.class,
                                  () -> Files.move(src, dst, options));
                 } else {
-                    Files.move(source, target, options);
+                    try {
+                        Files.move(source, target, options);
+                    } catch (AccessDeniedException ade) {
+                        assertTrue(mode.charAt(0) != 'r');
+                    }
                     assert Files.exists(target);
                 }
             } else if (type == PathType.DIR) {
@@ -213,7 +227,20 @@ public class CopyMoveVariations {
                         Files.move(source, target, options);
                         assert Files.exists(target);
                     } catch (AccessDeniedException ade) {
-                        assertTrue(mode.charAt(1) != 'w');
+                        Path other = target.getParent();
+                        if (other == null)
+                            other = Path.of(System.getProperty("user.dir"));
+                        if (isSameFileStore(source, other)) {
+                            // directories on same store should be renamed
+                            assertTrue(mode.charAt(1) != 'w');
+                        } else {
+                            // directories on different stores will likely be
+                            // moved by a copy which requires read permission
+                            if (mode.charAt(1) == 'w')
+                                assertTrue(mode.charAt(0) != 'r');
+                            else
+                                assertTrue(mode.charAt(1) != 'w');
+                        }
                     } catch (FileAlreadyExistsException faee) {
                         assertTrue(targetExists && !replaceExisting);
                     }


### PR DESCRIPTION
1. Modify the test to allow specifying the location of the temporary directory to be distinct from that of the working directory.
2. Correctly handle the responses to `AccessDeniedException`s which occur when a move across different file systems fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327002](https://bugs.openjdk.org/browse/JDK-8327002): (fs) java/nio/file/Files/CopyMoveVariations.java should be able to test across file systems (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18052/head:pull/18052` \
`$ git checkout pull/18052`

Update a local copy of the PR: \
`$ git checkout pull/18052` \
`$ git pull https://git.openjdk.org/jdk.git pull/18052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18052`

View PR using the GUI difftool: \
`$ git pr show -t 18052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18052.diff">https://git.openjdk.org/jdk/pull/18052.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18052#issuecomment-1970211203)