### PR TITLE
8327007: javax/swing/JSpinner/8008657/bug8008657.java fails

### DIFF
--- a/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
+++ b/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import javax.swing.UnsupportedLookAndFeelException;
  * @test
  * @key headful
  * @bug 8008657
- * @author Alexander Scherbatiy
  * @summary JSpinner setComponentOrientation doesn't affect on text orientation
  * @run main bug8008657
  */
@@ -134,20 +133,10 @@ public class bug8008657 {
     static void createDateSpinner() {
         Calendar calendar = Calendar.getInstance();
         Date initDate = calendar.getTime();
-        int year = calendar.get(Calendar.YEAR);
-        boolean isLeapYear = ((year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0));
-        int curDay = 0;
-        int curMonth = 0;
-        if (isLeapYear) {
-            curMonth = calendar.get(Calendar.MONTH);
-            curDay = calendar.get(Calendar.DAY_OF_MONTH);
-        }
         calendar.add(Calendar.YEAR, -1);
         Date earliestDate = calendar.getTime();
         calendar.add(Calendar.YEAR, 1);
-        if (isLeapYear && curMonth == 1 && curDay == 29) {
-            calendar.add(Calendar.DAY_OF_MONTH, 1);
-        }
+        calendar.add(Calendar.DAY_OF_MONTH, 1);
         Date latestDate = calendar.getTime();
         SpinnerModel dateModel = new SpinnerDateModel(initDate,
                 earliestDate,

--- a/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
+++ b/test/jdk/javax/swing/JSpinner/8008657/bug8008657.java
@@ -134,9 +134,20 @@ public class bug8008657 {
     static void createDateSpinner() {
         Calendar calendar = Calendar.getInstance();
         Date initDate = calendar.getTime();
+        int year = calendar.get(Calendar.YEAR);
+        boolean isLeapYear = ((year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0));
+        int curDay = 0;
+        int curMonth = 0;
+        if (isLeapYear) {
+            curMonth = calendar.get(Calendar.MONTH);
+            curDay = calendar.get(Calendar.DAY_OF_MONTH);
+        }
         calendar.add(Calendar.YEAR, -1);
         Date earliestDate = calendar.getTime();
         calendar.add(Calendar.YEAR, 1);
+        if (isLeapYear && curMonth == 1 && curDay == 29) {
+            calendar.add(Calendar.DAY_OF_MONTH, 1);
+        }
         Date latestDate = calendar.getTime();
         SpinnerModel dateModel = new SpinnerDateModel(initDate,
                 earliestDate,


### PR DESCRIPTION
Test failed with the exception java.lang.IllegalArgumentException: (start <= value <= end) with no history of failing till date.
Investigation shows SpinnerDateModel constructor condition is not satisfied because
It seems it's a leap year problem that is being manifested..

As per test,
initDate Thu Feb 29 13:49:08 IST 2024 [ obtained by calendar.getTime();]
earliestDate Tue Feb 28 13:49:08 IST 2023 [obtained by calendar.add(Calendar.YEAR, -1);]
latestDate Wed Feb 28 13:49:08 IST 2024 [obtained by calendar.add(Calendar.YEAR, 1);]

Now, as per SpinnerDateModel constructor
earliestDate <= initDate condition is satisfied
but
latestDate >= initDate is not
so [start <= value <= end](https://github.com/openjdk/jdk/blob/998d0baab0fd051c38d9fd6021628eb863b80554/src/java.desktop/share/classes/javax/swing/SpinnerDateModel.java#L185) condition fails

Not sure it anything can be done in Calendar class for this but fix is done in test taking leapyear into account so that we add a day if it's a leapyear when we consecutively do Calendar.add(YEAR, -1) and Calendar.add(YEAR,1) on leapyear date of 29Feb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327007](https://bugs.openjdk.org/browse/JDK-8327007): javax/swing/JSpinner/8008657/bug8008657.java fails (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18054/head:pull/18054` \
`$ git checkout pull/18054`

Update a local copy of the PR: \
`$ git checkout pull/18054` \
`$ git pull https://git.openjdk.org/jdk.git pull/18054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18054`

View PR using the GUI difftool: \
`$ git pr show -t 18054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18054.diff">https://git.openjdk.org/jdk/pull/18054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18054#issuecomment-1970758013)