### PR TITLE
JDK-8326974: ODR violation in macroAssembler_aarch64.cpp

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -148,6 +148,8 @@ extern "C" void disnm(intptr_t p);
 //                 strictly should be 64 bit movz #imm16<<0
 //       110___10100 (i.e. requires insn[31:21] == 11010010100)
 //
+namespace { // All have internal linkage in this file
+
 class RelocActions {
 protected:
   typedef int (*reloc_insn)(address insn_addr, address &target);
@@ -492,6 +494,7 @@ public:
   virtual void verify(address insn_addr, address &target) {
   }
 };
+}
 
 address MacroAssembler::target_addr_for_insn(address insn_addr, uint32_t insn) {
   Decoder decoder(insn_addr, insn);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -148,7 +148,6 @@ extern "C" void disnm(intptr_t p);
 //                 strictly should be 64 bit movz #imm16<<0
 //       110___10100 (i.e. requires insn[31:21] == 11010010100)
 //
-
 class RelocActions {
 protected:
   typedef int (*reloc_insn)(address insn_addr, address &target);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -148,7 +148,6 @@ extern "C" void disnm(intptr_t p);
 //                 strictly should be 64 bit movz #imm16<<0
 //       110___10100 (i.e. requires insn[31:21] == 11010010100)
 //
-namespace { // All have internal linkage in this file
 
 class RelocActions {
 protected:
@@ -394,13 +393,13 @@ static bool offset_for(uint32_t insn1, uint32_t insn2, ptrdiff_t &byte_offset) {
   return false;
 }
 
-class Decoder : public RelocActions {
-  virtual reloc_insn adrpMem() { return &Decoder::adrpMem_impl; }
-  virtual reloc_insn adrpAdd() { return &Decoder::adrpAdd_impl; }
-  virtual reloc_insn adrpMovk() { return &Decoder::adrpMovk_impl; }
+class AArch64Decoder : public RelocActions {
+  virtual reloc_insn adrpMem() { return &AArch64Decoder::adrpMem_impl; }
+  virtual reloc_insn adrpAdd() { return &AArch64Decoder::adrpAdd_impl; }
+  virtual reloc_insn adrpMovk() { return &AArch64Decoder::adrpMovk_impl; }
 
 public:
-  Decoder(address insn_addr, uint32_t insn) : RelocActions(insn_addr, insn) {}
+  AArch64Decoder(address insn_addr, uint32_t insn) : RelocActions(insn_addr, insn) {}
 
   virtual int loadStore(address insn_addr, address &target) {
     intptr_t offset = Instruction_aarch64::sextract(_insn, 23, 5);
@@ -494,10 +493,9 @@ public:
   virtual void verify(address insn_addr, address &target) {
   }
 };
-}
 
 address MacroAssembler::target_addr_for_insn(address insn_addr, uint32_t insn) {
-  Decoder decoder(insn_addr, insn);
+  AArch64Decoder decoder(insn_addr, insn);
   address target;
   decoder.run(insn_addr, target);
   return target;


### PR DESCRIPTION
This is a slightly different patch from the one suggested by the bug reporter. It doesn't make any sense to export those classes globally, so I've given them internal linkage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326974](https://bugs.openjdk.org/browse/JDK-8326974): ODR violation in macroAssembler_aarch64.cpp (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) ⚠️ Review applies to [a3fc57b5](https://git.openjdk.org/jdk/pull/18056/files/a3fc57b5cc497f34380092394617a98b79b4f2b0)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [7f38d070](https://git.openjdk.org/jdk/pull/18056/files/7f38d070ff3ca651ac74a48bf592ab1cc170e6fb)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18056/head:pull/18056` \
`$ git checkout pull/18056`

Update a local copy of the PR: \
`$ git checkout pull/18056` \
`$ git pull https://git.openjdk.org/jdk.git pull/18056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18056`

View PR using the GUI difftool: \
`$ git pr show -t 18056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18056.diff">https://git.openjdk.org/jdk/pull/18056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18056#issuecomment-1970777231)