### PR TITLE
8327040: Problemlist ActionListenerCalledTwiceTest.java test failing in macos14

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -689,6 +689,7 @@ javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
 
 # This test fails on macOS 14
 javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
+javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8316151 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java is failing in macos14 due to apple os upgrade. More information in [JDK-8316151](https://bugs.openjdk.org/browse/JDK-8316151)
problemlist the test for now..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327040](https://bugs.openjdk.org/browse/JDK-8327040): Problemlist ActionListenerCalledTwiceTest.java test failing in macos14 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18058/head:pull/18058` \
`$ git checkout pull/18058`

Update a local copy of the PR: \
`$ git checkout pull/18058` \
`$ git pull https://git.openjdk.org/jdk.git pull/18058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18058`

View PR using the GUI difftool: \
`$ git pr show -t 18058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18058.diff">https://git.openjdk.org/jdk/pull/18058.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18058#issuecomment-1970947840)