### PR TITLE
8327049: Only export debug.cpp functions on Windows

### DIFF
--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -67,6 +67,13 @@
 #include <stdio.h>
 #include <stdarg.h>
 
+// These functions needs to be exported on Windows only
+#if defined(TARGET_COMPILER_visCPP)
+#define DEBUGEXPORT JNIEXPORT
+#else
+#define DEBUGEXPORT
+#endif
+
 // Support for showing register content on asserts/guarantees.
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT
 static char g_dummy;
@@ -303,20 +310,20 @@ class Command : public StackObj {
 
 int Command::level = 0;
 
-extern "C" JNIEXPORT void blob(CodeBlob* cb) {
+extern "C" DEBUGEXPORT void blob(CodeBlob* cb) {
   Command c("blob");
   cb->print();
 }
 
 
-extern "C" JNIEXPORT void dump_vtable(address p) {
+extern "C" DEBUGEXPORT void dump_vtable(address p) {
   Command c("dump_vtable");
   Klass* k = (Klass*)p;
   k->vtable().print();
 }
 
 
-extern "C" JNIEXPORT void nm(intptr_t p) {
+extern "C" DEBUGEXPORT void nm(intptr_t p) {
   // Actually we look through all CodeBlobs (the nm name has been kept for backwards compatibility)
   Command c("nm");
   CodeBlob* cb = CodeCache::find_blob((address)p);
@@ -328,7 +335,7 @@ extern "C" JNIEXPORT void nm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void disnm(intptr_t p) {
+extern "C" DEBUGEXPORT void disnm(intptr_t p) {
   Command c("disnm");
   CodeBlob* cb = CodeCache::find_blob((address) p);
   if (cb != nullptr) {
@@ -343,7 +350,7 @@ extern "C" JNIEXPORT void disnm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void printnm(intptr_t p) {
+extern "C" DEBUGEXPORT void printnm(intptr_t p) {
   char buffer[256];
   os::snprintf_checked(buffer, sizeof(buffer), "printnm: " INTPTR_FORMAT, p);
   Command c(buffer);
@@ -357,13 +364,13 @@ extern "C" JNIEXPORT void printnm(intptr_t p) {
 }
 
 
-extern "C" JNIEXPORT void universe() {
+extern "C" DEBUGEXPORT void universe() {
   Command c("universe");
   Universe::print_on(tty);
 }
 
 
-extern "C" JNIEXPORT void verify() {
+extern "C" DEBUGEXPORT void verify() {
   // try to run a verify on the entire system
   // note: this may not be safe if we're not at a safepoint; for debugging,
   // this manipulates the safepoint settings to avoid assertion failures
@@ -380,7 +387,7 @@ extern "C" JNIEXPORT void verify() {
 }
 
 
-extern "C" JNIEXPORT void pp(void* p) {
+extern "C" DEBUGEXPORT void pp(void* p) {
   Command c("pp");
   FlagSetting fl(DisplayVMOutput, true);
   if (p == nullptr) {
@@ -405,9 +412,9 @@ extern "C" JNIEXPORT void pp(void* p) {
 }
 
 
-extern "C" JNIEXPORT void findpc(intptr_t x);
+extern "C" DEBUGEXPORT void findpc(intptr_t x);
 
-extern "C" JNIEXPORT void ps() { // print stack
+extern "C" DEBUGEXPORT void ps() { // print stack
   if (Thread::current_or_null() == nullptr) return;
   Command c("ps");
 
@@ -436,7 +443,7 @@ extern "C" JNIEXPORT void ps() { // print stack
   }
 }
 
-extern "C" JNIEXPORT void pfl() {
+extern "C" DEBUGEXPORT void pfl() {
   // print frame layout
   Command c("pfl");
   JavaThread* p = JavaThread::active();
@@ -448,7 +455,7 @@ extern "C" JNIEXPORT void pfl() {
   }
 }
 
-extern "C" JNIEXPORT void psf() { // print stack frames
+extern "C" DEBUGEXPORT void psf() { // print stack frames
   {
     Command c("psf");
     JavaThread* p = JavaThread::active();
@@ -462,19 +469,19 @@ extern "C" JNIEXPORT void psf() { // print stack frames
 }
 
 
-extern "C" JNIEXPORT void threads() {
+extern "C" DEBUGEXPORT void threads() {
   Command c("threads");
   Threads::print(false, true);
 }
 
 
-extern "C" JNIEXPORT void psd() {
+extern "C" DEBUGEXPORT void psd() {
   Command c("psd");
   SystemDictionary::print();
 }
 
 
-extern "C" JNIEXPORT void pss() { // print all stacks
+extern "C" DEBUGEXPORT void pss() { // print all stacks
   if (Thread::current_or_null() == nullptr) return;
   Command c("pss");
   Threads::print(true, PRODUCT_ONLY(false) NOT_PRODUCT(true));
@@ -482,7 +489,7 @@ extern "C" JNIEXPORT void pss() { // print all stacks
 
 // #ifndef PRODUCT
 
-extern "C" JNIEXPORT void debug() {               // to set things up for compiler debugging
+extern "C" DEBUGEXPORT void debug() {               // to set things up for compiler debugging
   Command c("debug");
   NOT_PRODUCT(WizardMode = true;)
   PrintCompilation = true;
@@ -491,7 +498,7 @@ extern "C" JNIEXPORT void debug() {               // to set things up for compil
 }
 
 
-extern "C" JNIEXPORT void ndebug() {              // undo debug()
+extern "C" DEBUGEXPORT void ndebug() {              // undo debug()
   Command c("ndebug");
   PrintCompilation = false;
   PrintInlining = PrintAssembly = false;
@@ -499,35 +506,35 @@ extern "C" JNIEXPORT void ndebug() {              // undo debug()
 }
 
 
-extern "C" JNIEXPORT void flush()  {
+extern "C" DEBUGEXPORT void flush()  {
   Command c("flush");
   tty->flush();
 }
 
-extern "C" JNIEXPORT void events() {
+extern "C" DEBUGEXPORT void events() {
   Command c("events");
   Events::print();
 }
 
-extern "C" JNIEXPORT Method* findm(intptr_t pc) {
+extern "C" DEBUGEXPORT Method* findm(intptr_t pc) {
   Command c("findm");
   nmethod* nm = CodeCache::find_nmethod((address)pc);
   return (nm == nullptr) ? (Method*)nullptr : nm->method();
 }
 
 
-extern "C" JNIEXPORT nmethod* findnm(intptr_t addr) {
+extern "C" DEBUGEXPORT nmethod* findnm(intptr_t addr) {
   Command c("findnm");
   return  CodeCache::find_nmethod((address)addr);
 }
 
-extern "C" JNIEXPORT void find(intptr_t x) {
+extern "C" DEBUGEXPORT void find(intptr_t x) {
   Command c("find");
   os::print_location(tty, x, false);
 }
 
 
-extern "C" JNIEXPORT void findpc(intptr_t x) {
+extern "C" DEBUGEXPORT void findpc(intptr_t x) {
   Command c("findpc");
   os::print_location(tty, x, true);
 }
@@ -538,13 +545,13 @@ extern "C" JNIEXPORT void findpc(intptr_t x) {
 //   call findclass("java/lang/Object", 0x3)             -> find j.l.Object and disasm all of its methods
 //   call findmethod("*ang/Object*", "wait", 0xff)       -> detailed disasm of all "wait" methods in j.l.Object
 //   call findmethod("*ang/Object*", "wait:(*J*)V", 0x1) -> list all "wait" methods in j.l.Object that have a long parameter
-extern "C" JNIEXPORT void findclass(const char* class_name_pattern, int flags) {
+extern "C" DEBUGEXPORT void findclass(const char* class_name_pattern, int flags) {
   Command c("findclass");
   ClassPrinter::print_flags_help(tty);
   ClassPrinter::print_classes(class_name_pattern, flags, tty);
 }
 
-extern "C" JNIEXPORT void findmethod(const char* class_name_pattern,
+extern "C" DEBUGEXPORT void findmethod(const char* class_name_pattern,
                                      const char* method_pattern, int flags) {
   Command c("findmethod");
   ClassPrinter::print_flags_help(tty);
@@ -552,7 +559,7 @@ extern "C" JNIEXPORT void findmethod(const char* class_name_pattern,
 }
 
 // Need method pointer to find bcp
-extern "C" JNIEXPORT void findbcp(intptr_t method, intptr_t bcp) {
+extern "C" DEBUGEXPORT void findbcp(intptr_t method, intptr_t bcp) {
   Command c("findbcp");
   Method* mh = (Method*)method;
   if (!mh->is_native()) {
@@ -563,7 +570,7 @@ extern "C" JNIEXPORT void findbcp(intptr_t method, intptr_t bcp) {
 }
 
 // check and decode a single u5 value
-extern "C" JNIEXPORT u4 u5decode(intptr_t addr) {
+extern "C" DEBUGEXPORT u4 u5decode(intptr_t addr) {
   Command c("u5decode");
   u1* arr = (u1*)addr;
   size_t off = 0, lim = 5;
@@ -580,7 +587,7 @@ extern "C" JNIEXPORT u4 u5decode(intptr_t addr) {
 // there is no limit on the count of items printed; the
 // printing stops when an null is printed or at limit.
 // See documentation for UNSIGNED5::Reader::print(count).
-extern "C" JNIEXPORT intptr_t u5p(intptr_t addr,
+extern "C" DEBUGEXPORT intptr_t u5p(intptr_t addr,
                                   intptr_t limit,
                                   int count) {
   Command c("u5p");
@@ -630,7 +637,7 @@ void help() {
 }
 
 #ifndef PRODUCT
-extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native stack
+extern "C" DEBUGEXPORT void pns(void* sp, void* fp, void* pc) { // print native stack
   Command c("pns");
   static char buf[O_BUFLEN];
   Thread* t = Thread::current_or_null();
@@ -647,7 +654,7 @@ extern "C" JNIEXPORT void pns(void* sp, void* fp, void* pc) { // print native st
 // WARNING: Only intended for use when debugging. Do not leave calls to
 // pns2() in committed source (product or debug).
 //
-extern "C" JNIEXPORT void pns2() { // print native stack
+extern "C" DEBUGEXPORT void pns2() { // print native stack
   Command c("pns2");
   static char buf[O_BUFLEN];
   address lastpc = nullptr;

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -68,11 +68,7 @@
 #include <stdarg.h>
 
 // These functions needs to be exported on Windows only
-#if defined(TARGET_COMPILER_visCPP)
-#define DEBUGEXPORT JNIEXPORT
-#else
-#define DEBUGEXPORT
-#endif
+#define DEBUGEXPORT WINDOWS_ONLY(JNIEXPORT)
 
 // Support for showing register content on asserts/guarantees.
 #ifdef CAN_SHOW_REGISTERS_ON_ASSERT


### PR DESCRIPTION
This is a partial backout of [JDK-8326509](https://bugs.openjdk.org/browse/JDK-8326509). It turned out that starting to export the functions from debug.cpp could have unintended consequences in certain circumstances, so revert back to the original situation where these functions were only exported on Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327049](https://bugs.openjdk.org/browse/JDK-8327049): Only export debug.cpp functions on Windows (**Bug** - P2)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18062/head:pull/18062` \
`$ git checkout pull/18062`

Update a local copy of the PR: \
`$ git checkout pull/18062` \
`$ git pull https://git.openjdk.org/jdk.git pull/18062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18062`

View PR using the GUI difftool: \
`$ git pr show -t 18062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18062.diff">https://git.openjdk.org/jdk/pull/18062.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18062#issuecomment-1971140418)