### PR TITLE
8327046: (fs) Files.walk should be clear that depth-first traversal is pre-order

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -3836,7 +3836,7 @@ public final class Files {
     /**
      * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed in <em>post-order</em>, <em>depth-first</em>
+     * file tree is traversed in <em>pre-order</em>, <em>depth-first</em>
      * fashion, the elements in the stream are {@link Path} objects that are
      * obtained as if by {@link Path#resolve(Path) resolving} the relative
      * path against {@code start}.
@@ -3936,7 +3936,7 @@ public final class Files {
     /**
      * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed in <em>post-order</em>, <em>depth-first</em>
+     * file tree is traversed in <em>pre-order</em>, <em>depth-first</em>
      * fashion, the elements in the stream are {@link Path} objects that are
      * obtained as if by {@link Path#resolve(Path) resolving} the relative
      * path against {@code start}.

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -3836,10 +3836,10 @@ public final class Files {
     /**
      * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed in <em>pre-order</em>, <em>depth-first</em>
-     * fashion, the elements in the stream are {@link Path} objects that are
-     * obtained as if by {@link Path#resolve(Path) resolving} the relative
-     * path against {@code start}.
+     * file tree is traversed <em>depth-first</em> with a directory visited
+     * before the entries in that directory. The elements in the stream are
+     * {@link Path} objects that are obtained as if by {@link Path#resolve(Path)
+     * resolving} the relative path against {@code start}.
      *
      * <p> The {@code stream} walks the file tree as elements are consumed.
      * The {@code Stream} returned is guaranteed to have at least one
@@ -3936,10 +3936,10 @@ public final class Files {
     /**
      * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed in <em>pre-order</em>, <em>depth-first</em>
-     * fashion, the elements in the stream are {@link Path} objects that are
-     * obtained as if by {@link Path#resolve(Path) resolving} the relative
-     * path against {@code start}.
+     * file tree is traversed <em>depth-first</em> with a directory visited
+     * before the entries in that directory. The elements in the stream are
+     * {@link Path} objects that are obtained as if by {@link Path#resolve(Path)
+     * resolving} the relative path against {@code start}.
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3743,7 +3743,7 @@ public final class Files {
     // -- Stream APIs --
 
     /**
-     * Return a lazily populated {@code Stream}, the elements of
+     * Returns a lazily populated {@code Stream}, the elements of
      * which are the entries in the directory.  The listing is not recursive.
      *
      * <p> The elements of the stream are {@link Path} objects that are
@@ -3834,11 +3834,12 @@ public final class Files {
     }
 
     /**
-     * Return a {@code Stream} that is lazily populated with {@code
+     * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed <em>depth-first</em>, the elements in the stream
-     * are {@link Path} objects that are obtained as if by {@link
-     * Path#resolve(Path) resolving} the relative path against {@code start}.
+     * file tree is traversed in <em>post-order</em>, <em>depth-first</em>
+     * fashion, the elements in the stream are {@link Path} objects that are
+     * obtained as if by {@link Path#resolve(Path) resolving} the relative
+     * path against {@code start}.
      *
      * <p> The {@code stream} walks the file tree as elements are consumed.
      * The {@code Stream} returned is guaranteed to have at least one
@@ -3933,11 +3934,12 @@ public final class Files {
     }
 
     /**
-     * Return a {@code Stream} that is lazily populated with {@code
+     * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by walking the file tree rooted at a given starting file.  The
-     * file tree is traversed <em>depth-first</em>, the elements in the stream
-     * are {@link Path} objects that are obtained as if by {@link
-     * Path#resolve(Path) resolving} the relative path against {@code start}.
+     * file tree is traversed in <em>post-order</em>, <em>depth-first</em>
+     * fashion, the elements in the stream are {@link Path} objects that are
+     * obtained as if by {@link Path#resolve(Path) resolving} the relative
+     * path against {@code start}.
      *
      * <p> This method works as if invoking it were equivalent to evaluating the
      * expression:
@@ -3978,7 +3980,7 @@ public final class Files {
     }
 
     /**
-     * Return a {@code Stream} that is lazily populated with {@code
+     * Returns a {@code Stream} that is lazily populated with {@code
      * Path} by searching for files in a file tree rooted at a given starting
      * file.
      *

--- a/test/jdk/java/nio/file/Files/StreamTest.java
+++ b/test/jdk/java/nio/file/Files/StreamTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class StreamTest {
     static boolean supportsLinks;
     static Path[] level1;
     static Path[] all;
-    static Path[] all_folowLinks;
+    static Path[] all_followLinks;
 
     @BeforeClass
     void setupTestFolder() throws IOException {
@@ -130,7 +130,7 @@ public class StreamTest {
             tmp = tmp.resolve("lnDir2");
             set.add(tmp);
         }
-        all_folowLinks = set.toArray(new Path[0]);
+        all_followLinks = set.toArray(new Path[0]);
     }
 
     @AfterClass
@@ -179,7 +179,7 @@ public class StreamTest {
         // We still want to test the behavior with FOLLOW_LINKS option.
         try (Stream<Path> s = Files.walk(testFolder, FileVisitOption.FOLLOW_LINKS)) {
             Object[] actual = s.sorted().toArray();
-            assertEquals(actual, all_folowLinks);
+            assertEquals(actual, all_followLinks);
         } catch (IOException ioe) {
             fail("Unexpected IOException");
         }

--- a/test/jdk/java/nio/file/Files/StreamTest.java
+++ b/test/jdk/java/nio/file/Files/StreamTest.java
@@ -75,7 +75,7 @@ public class StreamTest {
     static boolean supportsLinks;
     static Path[] level1;
     static Path[] all;
-    static Path[] all_followLinks;
+    static Path[] allFollowLinks;
 
     @BeforeClass
     void setupTestFolder() throws IOException {
@@ -130,7 +130,7 @@ public class StreamTest {
             tmp = tmp.resolve("lnDir2");
             set.add(tmp);
         }
-        all_followLinks = set.toArray(new Path[0]);
+        allFollowLinks = set.toArray(new Path[0]);
     }
 
     @AfterClass
@@ -179,7 +179,7 @@ public class StreamTest {
         // We still want to test the behavior with FOLLOW_LINKS option.
         try (Stream<Path> s = Files.walk(testFolder, FileVisitOption.FOLLOW_LINKS)) {
             Object[] actual = s.sorted().toArray();
-            assertEquals(actual, all_followLinks);
+            assertEquals(actual, allFollowLinks);
         } catch (IOException ioe) {
             fail("Unexpected IOException");
         }


### PR DESCRIPTION
Please review this clarification to the specification of the two overloads of `java.nio.file.Files.walk`. No tests are added, as I believe the existing `StreamTest.testWalk*` methods already test the order sufficiently. I also took this opportunity to fix a few minor typos.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327046](https://bugs.openjdk.org/browse/JDK-8327046): (fs) Files.walk should be clear that depth-first traversal is pre-order (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [5ffccf38](https://git.openjdk.org/jdk/pull/18063/files/5ffccf3867827ea606cdd90048c639f4a231a1a2)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18063/head:pull/18063` \
`$ git checkout pull/18063`

Update a local copy of the PR: \
`$ git checkout pull/18063` \
`$ git pull https://git.openjdk.org/jdk.git pull/18063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18063`

View PR using the GUI difftool: \
`$ git pr show -t 18063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18063.diff">https://git.openjdk.org/jdk/pull/18063.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18063#issuecomment-1971093834)