### PR TITLE
JDK-8324682 Remove redefinition of NULL for XLC compiler

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -157,7 +157,6 @@ void basic_types_init() {
   static_assert(is_power_of_2(HeapWordSize), "HeapWordSize must be power of 2");
   static_assert((size_t)HeapWordSize >= sizeof(juint),
                 "HeapWord should be at least as large as juint");
-  static_assert(sizeof(nullptr) == sizeof(char*), "NULL must be same size as pointer");
 #endif
 
   if( JavaPriority1_To_OSPriority != -1 )

--- a/src/hotspot/share/utilities/globalDefinitions.cpp
+++ b/src/hotspot/share/utilities/globalDefinitions.cpp
@@ -157,7 +157,7 @@ void basic_types_init() {
   static_assert(is_power_of_2(HeapWordSize), "HeapWordSize must be power of 2");
   static_assert((size_t)HeapWordSize >= sizeof(juint),
                 "HeapWord should be at least as large as juint");
-  static_assert(sizeof(NULL) == sizeof(char*), "NULL must be same size as pointer");
+  static_assert(sizeof(nullptr) == sizeof(char*), "NULL must be same size as pointer");
 #endif
 
   if( JavaPriority1_To_OSPriority != -1 )

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2024 IBM Corp. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +94,7 @@
 
 // NULL vs NULL_WORD:
 // Some platform/tool-chain combinations can't assign NULL to an integer
-// type so we define NULL_WORD to use in those contexts. For xlc they are the same.
+// type so we define NULL_WORD to use in those contexts.
 #define NULL_WORD  0L
 
 // checking for nanness

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
- * Copyright (c) 2024 IBM Corp. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -94,21 +94,7 @@
 // NULL vs NULL_WORD:
 // Some platform/tool-chain combinations can't assign NULL to an integer
 // type so we define NULL_WORD to use in those contexts. For xlc they are the same.
-#define NULL_WORD  NULL
-
-// AIX also needs a 64 bit NULL to work as a null address pointer.
-// Most system includes on AIX would define it as an int 0 if not already defined with one
-// exception: /usr/include/dirent.h will unconditionally redefine NULL to int 0 again.
-// In this case you need to copy the following defines to a position after #include <dirent.h>
-#include <dirent.h>
-#ifdef _LP64
-  #undef NULL
-  #define NULL 0L
-#else
-  #ifndef NULL
-    #define NULL 0
-  #endif
-#endif
+#define NULL_WORD  0L
 
 // checking for nanness
 inline int g_isnan(float  f) { return isnan(f); }


### PR DESCRIPTION
Remove redefinition of NULL for XLC compiler
In globalDefinitions_xlc.hpp there is a redefinition of NULL to work around an issue with one of the AIX headers (<dirent.h>). 
Once all uses of NULL in HotSpot have been replaced with nullptr, there is no longer any need for this, and it can be removed.


JBS ISSUE : [JDK-8324682](https://bugs.openjdk.org/browse/JDK-8324682)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324682](https://bugs.openjdk.org/browse/JDK-8324682): Remove redefinition of NULL for XLC compiler (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18064/head:pull/18064` \
`$ git checkout pull/18064`

Update a local copy of the PR: \
`$ git checkout pull/18064` \
`$ git pull https://git.openjdk.org/jdk.git pull/18064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18064`

View PR using the GUI difftool: \
`$ git pr show -t 18064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18064.diff">https://git.openjdk.org/jdk/pull/18064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18064#issuecomment-1971226556)