### PR TITLE
8327056: Remove unused static char array in JvmtiAgentList::lookup

### DIFF
--- a/src/hotspot/share/prims/jvmtiAgentList.cpp
+++ b/src/hotspot/share/prims/jvmtiAgentList.cpp
@@ -258,7 +258,6 @@ static bool match(JvmtiEnv* env, const JvmtiAgent* agent, const void* os_module_
 JvmtiAgent* JvmtiAgentList::lookup(JvmtiEnv* env, void* f_ptr) {
   assert(env != nullptr, "invariant");
   assert(f_ptr != nullptr, "invariant");
-  static char ebuf[1024];
   static char buffer[JVM_MAXPATHLEN];
   int offset;
   if (!os::dll_address_to_library_name(reinterpret_cast<address>(f_ptr), &buffer[0], JVM_MAXPATHLEN, &offset)) {


### PR DESCRIPTION
Hi,

Please help review this trivial change that removed an unused static char array in JvmtiAgentList::lookup.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327056](https://bugs.openjdk.org/browse/JDK-8327056): Remove unused static char array in JvmtiAgentList::lookup (**Enhancement** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18066/head:pull/18066` \
`$ git checkout pull/18066`

Update a local copy of the PR: \
`$ git checkout pull/18066` \
`$ git pull https://git.openjdk.org/jdk.git pull/18066/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18066`

View PR using the GUI difftool: \
`$ git pr show -t 18066`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18066.diff">https://git.openjdk.org/jdk/pull/18066.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18066#issuecomment-1971338857)