### PR TITLE
8286759: TextComponentPrintable: consequent -> consecutive positions

### DIFF
--- a/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
+++ b/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -781,7 +781,7 @@ public class TextComponentPrintable implements CountingPrintable {
                             && (y != previousY || height != previousHeight)) {
                         /*
                          * we do not store the same value as previous. in our
-                         * documents it is often for consequent positions to have
+                         * documents it is often for consecutive positions to have
                          * the same modelToView y and height.
                          */
                         previousY = y;

--- a/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
+++ b/src/java.desktop/share/classes/sun/swing/text/TextComponentPrintable.java
@@ -780,9 +780,9 @@ public class TextComponentPrintable implements CountingPrintable {
                     if (height != 0
                             && (y != previousY || height != previousHeight)) {
                         /*
-                         * we do not store the same value as previous. in our
-                         * documents it is often for consecutive positions to have
-                         * the same modelToView y and height.
+                         * We do not store the same value as previous.
+                         * In our documents, it is common for consecutive
+                         * positions to have the same modelToView y and height.
                          */
                         previousY = y;
                         previousHeight = height;


### PR DESCRIPTION
A trivial change in a comment: consequent → _consecutive_ positions.

This was found in [a code review](https://github.com/openjdk/jdk/pull/8328#discussion_r872596373) for [JDK-8285306](https://bugs.openjdk.org/browse/JDK-8285306).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286759](https://bugs.openjdk.org/browse/JDK-8286759): TextComponentPrintable: consequent -&gt; consecutive positions (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [310a0855](https://git.openjdk.org/jdk/pull/18067/files/310a085593584b4815f81e928f1114f1fbc1a52d)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18067/head:pull/18067` \
`$ git checkout pull/18067`

Update a local copy of the PR: \
`$ git checkout pull/18067` \
`$ git pull https://git.openjdk.org/jdk.git pull/18067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18067`

View PR using the GUI difftool: \
`$ git pr show -t 18067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18067.diff">https://git.openjdk.org/jdk/pull/18067.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18067#issuecomment-1971363866)