### PR TITLE
JDK-8327059: os::Linux::print_proc_sys_info add swappiness information

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2270,6 +2270,8 @@ void os::Linux::print_proc_sys_info(outputStream* st) {
                       "/proc/sys/kernel/threads-max", st);
   _print_ascii_file_h("/proc/sys/vm/max_map_count (maximum number of memory map areas a process may have)",
                       "/proc/sys/vm/max_map_count", st);
+  _print_ascii_file_h("/proc/sys/vm/swappiness (control to define how aggressively the kernel swaps out anonymous memory)",
+                      "/proc/sys/vm/swappiness", st);
   _print_ascii_file_h("/proc/sys/kernel/pid_max (system-wide limit on number of process identifiers)",
                       "/proc/sys/kernel/pid_max", st);
 }


### PR DESCRIPTION
The swappiness information is an important reclaim ration metrics on Linux. See https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-tuning-memory.html#cha-tuning-memory-vm .
We should add it to the already existing information about data from /proc/sys .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327059](https://bugs.openjdk.org/browse/JDK-8327059): os::Linux::print_proc_sys_info add swappiness information (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18068/head:pull/18068` \
`$ git checkout pull/18068`

Update a local copy of the PR: \
`$ git checkout pull/18068` \
`$ git pull https://git.openjdk.org/jdk.git pull/18068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18068`

View PR using the GUI difftool: \
`$ git pr show -t 18068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18068.diff">https://git.openjdk.org/jdk/pull/18068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18068#issuecomment-1971428970)