### PR TITLE
8327058: RISC-V: make Zcb experimental

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -2656,7 +2656,7 @@ public:
   }
 
   bool do_compress_zcb(Register reg1 = noreg, Register reg2 = noreg) const {
-    return do_compress() && VM_Version::ext_Zcb.enabled() &&
+    return do_compress() && UseZcb &&
            (reg1 == noreg || reg1->is_compressed_valid()) && (reg2 == noreg || reg2->is_compressed_valid());
   }
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -105,6 +105,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZba, false, "Use Zba instructions")                           \
   product(bool, UseZbb, false, "Use Zbb instructions")                           \
   product(bool, UseZbs, false, "Use Zbs instructions")                           \
+  product(bool, UseZcb, false, EXPERIMENTAL, "Use Zcb instructions")             \
   product(bool, UseZfh, false, "Use Zfh instructions")                           \
   product(bool, UseZacas, false, EXPERIMENTAL, "Use Zacas instructions")         \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -105,9 +105,9 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZba, false, "Use Zba instructions")                           \
   product(bool, UseZbb, false, "Use Zbb instructions")                           \
   product(bool, UseZbs, false, "Use Zbs instructions")                           \
-  product(bool, UseZcb, false, EXPERIMENTAL, "Use Zcb instructions")             \
   product(bool, UseZfh, false, "Use Zfh instructions")                           \
   product(bool, UseZacas, false, EXPERIMENTAL, "Use Zacas instructions")         \
+  product(bool, UseZcb, false, EXPERIMENTAL, "Use Zcb instructions")             \
   product(bool, UseZic64b, false, EXPERIMENTAL, "Use Zic64b instructions")       \
   product(bool, UseZicbom, false, EXPERIMENTAL, "Use Zicbom instructions")       \
   product(bool, UseZicbop, false, EXPERIMENTAL, "Use Zicbop instructions")       \

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -144,7 +144,7 @@ class VM_Version : public Abstract_VM_Version {
   decl(ext_Zbb         , "Zbb"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZbb))         \
   decl(ext_Zbc         , "Zbc"         , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zbs         , "Zbs"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZbs))         \
-  decl(ext_Zcb         , "Zcb"         , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
+  decl(ext_Zcb         , "Zcb"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZcb))         \
   decl(ext_Zfh         , "Zfh"         , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZfh))         \
   decl(ext_Zicsr       , "Zicsr"       , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \
   decl(ext_Zifencei    , "Zifencei"    , RV_NO_FLAG_BIT, true , NO_UPDATE_DEFAULT)              \


### PR DESCRIPTION
Hi,
Can you review the patch to add a flag for Zcb extension to enable user to control it?
Thanks.

As discussed in [1], it's good to give a flag to control Zcb, and currently it's good to make it experimental.

[1] https://github.com/openjdk/jdk/pull/17698#discussion_r1505364098

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327058](https://bugs.openjdk.org/browse/JDK-8327058): RISC-V: make Zcb experimental (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [500a6ea2](https://git.openjdk.org/jdk/pull/18070/files/500a6ea293fb6ac329bece7764965bbc06049c5e)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [500a6ea2](https://git.openjdk.org/jdk/pull/18070/files/500a6ea293fb6ac329bece7764965bbc06049c5e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18070/head:pull/18070` \
`$ git checkout pull/18070`

Update a local copy of the PR: \
`$ git checkout pull/18070` \
`$ git pull https://git.openjdk.org/jdk.git pull/18070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18070`

View PR using the GUI difftool: \
`$ git pr show -t 18070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18070.diff">https://git.openjdk.org/jdk/pull/18070.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18070#issuecomment-1971634302)