### PR TITLE
8327095: (ch) java/nio/channels/AsyncCloseAndInterrupt.java: improve error message when mkfifo fails

### DIFF
--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -138,15 +138,13 @@ public class AsyncCloseAndInterrupt {
                 throw new IOException("Cannot delete existing fifo " + fifoFile);
         }
 
-        OutputAnalyzer oa = ProcessTools.executeCommand("mkfifo",
-                                                        fifoFile.toString());
+        ProcessBuilder pb = new ProcessBuilder("mkfifo", fifoFile.toString());
+        OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         oa.waitFor();
-        if (oa.pid() != 0) {
-            StringBuilder sb = new StringBuilder();
-            oa.asLines().stream().forEach(s -> sb.append(s));
+        if (oa.pid() != 0)
             throw new IOException("Error creating fifo \"" +
-                fifoFile.getAbsolutePath() + "\" - " + sb);
-        }
+                fifoFile.getAbsolutePath() + "\"\n" +
+                ProcessTools.getProcessLog(pb, oa));
         new RandomAccessFile(fifoFile, "rw").close();
     }
 

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4460583 4470470 4840199 6419424 6710579 6596323 6824135 6395224 7142919
  *      8151582 8068693 8153209
+ * @library /test/lib
  * @run main/othervm AsyncCloseAndInterrupt
  * @key intermittent
  * @summary Comprehensive test of asynchronous closing and interruption
@@ -42,6 +43,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class AsyncCloseAndInterrupt {
 
@@ -133,12 +137,13 @@ public class AsyncCloseAndInterrupt {
             if (!fifoFile.delete())
                 throw new IOException("Cannot delete existing fifo " + fifoFile);
         }
-        Process p = Runtime.getRuntime().exec("mkfifo " + fifoFile);
-        if (p.waitFor() != 0) {
+
+        OutputAnalyzer oa = ProcessTools.executeCommand("mkfifo",
+                                                        fifoFile.toString());
+        oa.waitFor();
+        if (oa.pid() != 0) {
             StringBuilder sb = new StringBuilder();
-            try (BufferedReader errorReader = p.errorReader()) {
-                errorReader.lines().forEach(o -> sb.append((String)o));
-            }
+            oa.asLines().stream().forEach(s -> sb.append(s));
             throw new IOException("Error creating fifo \"" +
                 fifoFile.getAbsolutePath() + "\" - " + sb);
         }

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -141,7 +141,7 @@ public class AsyncCloseAndInterrupt {
         ProcessBuilder pb = new ProcessBuilder("mkfifo", fifoFile.toString());
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         oa.waitFor();
-        if (oa.pid() != 0)
+        if (oa.getExitValue() != 0)
             throw new IOException("Error creating fifo \"" +
                 fifoFile.getAbsolutePath() + "\"\n" +
                 ProcessTools.getProcessLog(pb, oa));

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -141,10 +141,19 @@ public class AsyncCloseAndInterrupt {
         ProcessBuilder pb = new ProcessBuilder("mkfifo", fifoFile.toString());
         OutputAnalyzer oa = ProcessTools.executeProcess(pb);
         oa.waitFor();
-        if (oa.getExitValue() != 0)
-            throw new IOException("Error creating fifo \"" +
-                fifoFile.getAbsolutePath() + "\"\n" +
-                ProcessTools.getProcessLog(pb, oa));
+        if (oa.getExitValue() != 0) {
+            String stderr = oa.getStderr();
+            if (stderr.contains("mkfifo") &&
+                stderr.contains("Operation not supported")) {
+                fifoFile = null;
+                log.println("WARNING: mkfifo failed - cannot completely test FileChannels");
+                return;
+            } else {
+                throw new IOException("Error creating fifo \"" +
+                    fifoFile.getAbsolutePath() + "\"\n" +
+                    ProcessTools.getProcessLog(pb, oa));
+            }
+        }
         new RandomAccessFile(fifoFile, "rw").close();
     }
 

--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,10 +134,15 @@ public class AsyncCloseAndInterrupt {
                 throw new IOException("Cannot delete existing fifo " + fifoFile);
         }
         Process p = Runtime.getRuntime().exec("mkfifo " + fifoFile);
-        if (p.waitFor() != 0)
-            throw new IOException("Error creating fifo");
+        if (p.waitFor() != 0) {
+            StringBuilder sb = new StringBuilder();
+            try (BufferedReader errorReader = p.errorReader()) {
+                errorReader.lines().forEach(o -> sb.append((String)o));
+            }
+            throw new IOException("Error creating fifo \"" +
+                fifoFile.getAbsolutePath() + "\" - " + sb);
+        }
         new RandomAccessFile(fifoFile, "rw").close();
-
     }
 
 


### PR DESCRIPTION
Add to the error message of the `IOException` thrown when the `mkfifo` command fails:

1. the absolute path of the FIFO which was to have been created;
2. the text read from the standard error stream of the process in which `mkfifo` was executed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327095](https://bugs.openjdk.org/browse/JDK-8327095): (ch) java/nio/channels/AsyncCloseAndInterrupt.java: improve error message when mkfifo fails (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18072/head:pull/18072` \
`$ git checkout pull/18072`

Update a local copy of the PR: \
`$ git checkout pull/18072` \
`$ git pull https://git.openjdk.org/jdk.git pull/18072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18072`

View PR using the GUI difftool: \
`$ git pr show -t 18072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18072.diff">https://git.openjdk.org/jdk/pull/18072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18072#issuecomment-1972167881)