### PR TITLE
8327096: (fc) java/nio/channels/FileChannel/Size.java fails on partition incapable of creating large files

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/Size.java
+++ b/test/jdk/java/nio/channels/FileChannel/Size.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4563125
  * @summary Test size method of FileChannel
+ * @library /test/lib
  * @run main/othervm Size
  * @key randomness
  */
@@ -34,7 +35,7 @@ import java.nio.channels.*;
 import java.nio.file.FileStore;
 import java.nio.file.Path;
 import java.util.Random;
-
+import jtreg.SkippedException;
 
 /**
  * Testing FileChannel's size method.
@@ -83,8 +84,8 @@ public class Size {
             if ("File too large".equals(ioe.getMessage())) {
                 Path p = largeFile.toPath();
                 FileStore store = p.getFileSystem().provider().getFileStore(p);
-                if ("msdos".equals(store.type())) // FAT32
-                    return; // ignore IOE: file too big for 32 bits
+                if ("msdos".equals(store.type()))
+                    throw new SkippedException("file too big for FAT32");
             }
             throw ioe;
         }

--- a/test/jdk/java/nio/channels/FileChannel/Size.java
+++ b/test/jdk/java/nio/channels/FileChannel/Size.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,8 @@
 import java.io.*;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.*;
+import java.nio.file.FileStore;
+import java.nio.file.Path;
 import java.util.Random;
 
 
@@ -65,6 +67,8 @@ public class Size {
     // Test for bug 4563125
     private static void testLargeFile() throws Exception {
         File largeFile = new File("largeFileTest");
+        largeFile.deleteOnExit();
+
         long testSize = ((long)Integer.MAX_VALUE) * 2;
         initTestFile(largeFile, 10);
         try (FileChannel fc = new RandomAccessFile(largeFile, "rw").getChannel()) {
@@ -75,8 +79,15 @@ public class Size {
                                          + "Expect size " + (testSize + 10)
                                          + ", actual size " + fc.size());
             }
+        } catch (IOException ioe) {
+            if ("File too large".equals(ioe.getMessage())) {
+                Path p = largeFile.toPath();
+                FileStore store = p.getFileSystem().provider().getFileStore(p);
+                if ("msdos".equals(store.type())) // FAT32
+                    return; // ignore IOE: file too big for 32 bits
+            }
+            throw ioe;
         }
-        largeFile.deleteOnExit();
     }
 
     /**


### PR DESCRIPTION
If an `IOException` with message "File too large" is thrown while testing with a large file, then ignore the exception if the type of the `FileStore` where the file would be located is "msdos".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327096](https://bugs.openjdk.org/browse/JDK-8327096): (fc) java/nio/channels/FileChannel/Size.java fails on partition incapable of creating large files (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18073/head:pull/18073` \
`$ git checkout pull/18073`

Update a local copy of the PR: \
`$ git checkout pull/18073` \
`$ git pull https://git.openjdk.org/jdk.git pull/18073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18073`

View PR using the GUI difftool: \
`$ git pr show -t 18073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18073.diff">https://git.openjdk.org/jdk/pull/18073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18073#issuecomment-1972173594)