### PR TITLE
8325567: jspawnhelper without args fails with segfault

### DIFF
--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
+++ b/src/java.base/unix/native/jspawnhelper/jspawnhelper.c
@@ -140,6 +140,11 @@ int main(int argc, char *argv[]) {
     int r, fdinr, fdinw, fdout;
     sigset_t unblock_signals;
 
+    if (argc == 1) {
+        fprintf(stdout, "An earlier version of Java is trying to call jspawnhelper.\n");
+        fprintf(stdout, "Please restart Java process.\n");
+        exit(1);
+    }
 #ifdef DEBUG
     jtregSimulateCrash(0, 4);
 #endif

--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
@@ -35,6 +35,7 @@
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -84,6 +85,40 @@ public class JspawnhelperProtocol {
                                                               "normalExec");
         pb.inheritIO();
         Process p = pb.start();
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            throw new Exception("Parent process timed out");
+        }
+        if (p.exitValue() != 0) {
+            throw new Exception("Parent process exited with " + p.exitValue());
+        }
+    }
+
+    private static void jspawnhelperWithNoArgs() throws Exception {
+        System.out.println("Running jspawnhelper without args");
+        Process p = null;
+        try {
+            p = Runtime.getRuntime().exec(Paths.get(System.getProperty("java.home"), "lib", "jspawnhelper").toString());
+        } catch (Exception e) {
+            e.printStackTrace(System.out);
+            System.exit(ERROR);
+        }
+        if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
+            System.out.println("Child process timed out");
+            System.exit(ERROR + 1);
+        }
+        if (p.exitValue() != 1)
+            System.exit(ERROR + 2);
+        System.exit(0);
+    }
+
+    private static void simulateJspawnhelperWithoutArgs() throws Exception {
+        ProcessBuilder pb;
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Djdk.lang.Process.launchMechanism=posix_spawn",
+                                                              "JspawnhelperProtocol",
+                                                              "noargs");
+        pb.inheritIO();
+        Process p = pb.start();
+
         if (!p.waitFor(TIMEOUT, TimeUnit.SECONDS)) {
             throw new Exception("Parent process timed out");
         }
@@ -222,10 +257,14 @@ public class JspawnhelperProtocol {
         //    don't lead to deadlocks or zombie processes.
         if (args.length > 0) {
             // Entry point for recursive execution in the "parent" process
-            parentCode(args[0]);
+            if ("noargs".equals(args[0]))
+                jspawnhelperWithNoArgs();
+            else
+                parentCode(args[0]);
         } else {
             // Main test entry for execution from jtreg
             normalExec();
+            simulateJspawnhelperWithoutArgs();
             simulateCrashInParent(1);
             simulateCrashInParent(2);
             simulateCrashInParent(3);


### PR DESCRIPTION
This MR fixes segsegv in jspawnhelper when it is called without args. 
This scenario happens when a long running Java process is not restarted during upgrade. 

It updates test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java to check that jspawnhelper exits with code 1:

After test update:
```
$ make CONF=linux-x86_64-server-fastdebug test TEST=test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
...
Running jspawnhelper without args
STDERR:
java.lang.Exception: Parent process exited with 12
        at JspawnhelperProtocol.simulateJspawnhelperWithoutArgs(JspawnhelperProtocol.java:126)
        at JspawnhelperProtocol.main(JspawnhelperProtocol.java:267)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1575)
...
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
>>                                                       1     0     1     0 <<
==============================
TEST FAILURE
```
After jspawnhelper change the test passes:
```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
   jtreg:test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
                                                         1     1     0     0   
==============================
TEST SUCCESS
```

The user will see the following output in the logs:
```
An earlier version of Java is trying to call jspawnhelper.
Please restart Java process.
Exception in thread "main" java.io.IOException: Cannot run program "ls": error=0, Failed to exec spawn helper: pid: 2168121, exit value: 1
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1143)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1073)
        at Test.main(Test.java:3)
Caused by: java.io.IOException: error=0, Failed to exec spawn helper: pid: 2168121, exit value: 1
        at java.base/java.lang.ProcessImpl.forkAndExec(Native Method)
        at java.base/java.lang.ProcessImpl.<init>(ProcessImpl.java:314)
        at java.base/java.lang.ProcessImpl.start(ProcessImpl.java:244)
        at java.base/java.lang.ProcessBuilder.start(ProcessBuilder.java:1110)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325567](https://bugs.openjdk.org/browse/JDK-8325567): jspawnhelper without args fails with segfault (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18074/head:pull/18074` \
`$ git checkout pull/18074`

Update a local copy of the PR: \
`$ git checkout pull/18074` \
`$ git pull https://git.openjdk.org/jdk.git pull/18074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18074`

View PR using the GUI difftool: \
`$ git pr show -t 18074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18074.diff">https://git.openjdk.org/jdk/pull/18074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18074#issuecomment-1972400553)