### PR TITLE
8326983: Unused operands reported after JDK-8326135

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4091,26 +4091,6 @@ operand immI_56()
   interface(CONST_INTER);
 %}
 
-operand immI_63()
-%{
-  predicate(n->get_int() == 63);
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immI_64()
-%{
-  predicate(n->get_int() == 64);
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 operand immI_255()
 %{
   predicate(n->get_int() == 255);
@@ -4240,28 +4220,6 @@ operand immIScale()
   interface(CONST_INTER);
 %}
 
-// 26 bit signed offset -- for pc-relative branches
-operand immI26()
-%{
-  predicate(((-(1 << 25)) <= n->get_int()) && (n->get_int() < (1 << 25)));
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// 19 bit signed offset -- for pc-relative loads
-operand immI19()
-%{
-  predicate(((-(1 << 18)) <= n->get_int()) && (n->get_int() < (1 << 18)));
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // 5 bit signed integer
 operand immI5()
 %{
@@ -4278,27 +4236,6 @@ operand immIU7()
 %{
   predicate(Assembler::is_uimm(n->get_int(), 7));
   match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// 12 bit unsigned offset -- for base plus immediate loads
-operand immIU12()
-%{
-  predicate((0 <= n->get_int()) && (n->get_int() < (1 << 12)));
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immLU12()
-%{
-  predicate((0 <= n->get_long()) && (n->get_long() < (1 << 12)));
-  match(ConL);
 
   op_cost(0);
   format %{ %}
@@ -4569,34 +4506,10 @@ operand immL0()
   interface(CONST_INTER);
 %}
 
-// 64 bit unit increment
-operand immL_1()
-%{
-  predicate(n->get_long() == 1);
-  match(ConL);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // 64 bit unit decrement
 operand immL_M1()
 %{
   predicate(n->get_long() == -1);
-  match(ConL);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// 32 bit offset of pc in thread anchor
-
-operand immL_pc_off()
-%{
-  predicate(n->get_long() == in_bytes(JavaThread::frame_anchor_offset()) +
-                             in_bytes(JavaFrameAnchor::last_Java_pc_offset()));
   match(ConL);
 
   op_cost(0);
@@ -4685,30 +4598,6 @@ operand immByteMapBase()
   // Get base of card map
   predicate(BarrierSet::barrier_set()->is_a(BarrierSet::CardTableBarrierSet) &&
             (CardTable::CardValue*)n->get_ptr() == ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
-  match(ConP);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Pointer Immediate Minus One
-// this is used when we want to write the current PC to the thread anchor
-operand immP_M1()
-%{
-  predicate(n->get_ptr() == -1);
-  match(ConP);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Pointer Immediate Minus Two
-// this is used when we want to write the current PC to the thread anchor
-operand immP_M2()
-%{
-  predicate(n->get_ptr() == -2);
   match(ConP);
 
   op_cost(0);
@@ -4980,45 +4869,12 @@ operand iRegL_R0()
   interface(REG_INTER);
 %}
 
-// Long 64 bit Register R2 only
-operand iRegL_R2()
-%{
-  constraint(ALLOC_IN_RC(r2_reg));
-  match(RegL);
-  match(iRegLNoSp);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-// Long 64 bit Register R3 only
-operand iRegL_R3()
-%{
-  constraint(ALLOC_IN_RC(r3_reg));
-  match(RegL);
-  match(iRegLNoSp);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 // Long 64 bit Register R11 only
 operand iRegL_R11()
 %{
   constraint(ALLOC_IN_RC(r11_reg));
   match(RegL);
   match(iRegLNoSp);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-// Pointer 64 bit Register FP only
-operand iRegP_FP()
-%{
-  constraint(ALLOC_IN_RC(fp_reg));
-  match(RegP);
-  // match(iRegP);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);
@@ -5077,33 +4933,6 @@ operand iRegN()
   constraint(ALLOC_IN_RC(any_reg32));
   match(RegN);
   match(iRegNNoSp);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand iRegN_R0()
-%{
-  constraint(ALLOC_IN_RC(r0_reg));
-  match(iRegN);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand iRegN_R2()
-%{
-  constraint(ALLOC_IN_RC(r2_reg));
-  match(iRegN);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand iRegN_R3()
-%{
-  constraint(ALLOC_IN_RC(r3_reg));
-  match(iRegN);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);
@@ -5259,222 +5088,6 @@ operand vRegD_V7()
   interface(REG_INTER);
 %}
 
-operand vRegD_V8()
-%{
-  constraint(ALLOC_IN_RC(v8_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V9()
-%{
-  constraint(ALLOC_IN_RC(v9_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V10()
-%{
-  constraint(ALLOC_IN_RC(v10_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V11()
-%{
-  constraint(ALLOC_IN_RC(v11_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V12()
-%{
-  constraint(ALLOC_IN_RC(v12_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V13()
-%{
-  constraint(ALLOC_IN_RC(v13_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V14()
-%{
-  constraint(ALLOC_IN_RC(v14_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V15()
-%{
-  constraint(ALLOC_IN_RC(v15_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V16()
-%{
-  constraint(ALLOC_IN_RC(v16_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V17()
-%{
-  constraint(ALLOC_IN_RC(v17_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V18()
-%{
-  constraint(ALLOC_IN_RC(v18_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V19()
-%{
-  constraint(ALLOC_IN_RC(v19_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V20()
-%{
-  constraint(ALLOC_IN_RC(v20_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V21()
-%{
-  constraint(ALLOC_IN_RC(v21_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V22()
-%{
-  constraint(ALLOC_IN_RC(v22_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V23()
-%{
-  constraint(ALLOC_IN_RC(v23_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V24()
-%{
-  constraint(ALLOC_IN_RC(v24_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V25()
-%{
-  constraint(ALLOC_IN_RC(v25_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V26()
-%{
-  constraint(ALLOC_IN_RC(v26_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V27()
-%{
-  constraint(ALLOC_IN_RC(v27_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V28()
-%{
-  constraint(ALLOC_IN_RC(v28_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V29()
-%{
-  constraint(ALLOC_IN_RC(v29_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V30()
-%{
-  constraint(ALLOC_IN_RC(v30_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand vRegD_V31()
-%{
-  constraint(ALLOC_IN_RC(v31_reg));
-  match(RegD);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 operand pReg()
 %{
   constraint(ALLOC_IN_RC(pr_reg));
@@ -5576,15 +5189,6 @@ operand thread_RegP(iRegP reg)
   interface(REG_INTER);
 %}
 
-operand lr_RegP(iRegP reg)
-%{
-  constraint(ALLOC_IN_RC(lr_reg)); // link_reg
-  match(reg);
-  op_cost(0);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 //----------Memory Operands----------------------------------------------------
 
 operand indirect(iRegP reg)
@@ -5659,20 +5263,6 @@ operand indIndex(iRegP reg, iRegL lreg)
   %}
 %}
 
-operand indOffI(iRegP reg, immIOffset off)
-%{
-  constraint(ALLOC_IN_RC(ptr_reg));
-  match(AddP reg off);
-  op_cost(0);
-  format %{ "[$reg, $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0xffffffff);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
 operand indOffI1(iRegP reg, immIOffset1 off)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));
@@ -5730,20 +5320,6 @@ operand indOffI8(iRegP reg, immIOffset8 off)
 %}
 
 operand indOffI16(iRegP reg, immIOffset16 off)
-%{
-  constraint(ALLOC_IN_RC(ptr_reg));
-  match(AddP reg off);
-  op_cost(0);
-  format %{ "[$reg, $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0xffffffff);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
-operand indOffL(iRegP reg, immLoffset off)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));
   match(AddP reg off);
@@ -5932,22 +5508,6 @@ operand indOffLN(iRegN reg, immLoffset off)
   %}
 %}
 
-
-
-// AArch64 opto stubs need to write to the pc slot in the thread anchor
-operand thread_anchor_pc(thread_RegP reg, immL_pc_off off)
-%{
-  constraint(ALLOC_IN_RC(ptr_reg));
-  match(AddP reg off);
-  op_cost(0);
-  format %{ "[$reg, $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0xffffffff);
-    scale(0x0);
-    disp($off);
-  %}
-%}
 
 //----------Special Memory Operands--------------------------------------------
 // Stack Slot Operand - This operand is used for loading and storing temporary

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1737,56 +1737,6 @@ operand immI0() %{
   interface(CONST_INTER);
 %}
 
-// Integer Immediate: the value 1
-operand immI_1() %{
-  predicate(n->get_int() == 1);
-  match(ConI);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: the value 2
-operand immI_2() %{
-  predicate(n->get_int() == 2);
-  match(ConI);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: the value 3
-operand immI_3() %{
-  predicate(n->get_int() == 3);
-  match(ConI);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: the value 4
-operand immI_4() %{
-  predicate(n->get_int() == 4);
-  match(ConI);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: the value 8
-operand immI_8() %{
-  predicate(n->get_int() == 8);
-  match(ConI);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // Int Immediate non-negative
 operand immU31()
 %{
@@ -1917,27 +1867,6 @@ operand limmIn() %{
   interface(CONST_INTER);
 %}
 
-
-// Long Immediate: the value FF
-operand immL_FF() %{
-  predicate( n->get_long() == 0xFFL );
-  match(ConL);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Long Immediate: the value FFFF
-operand immL_FFFF() %{
-  predicate( n->get_long() == 0xFFFFL );
-  match(ConL);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // Pointer Immediate: 32 or 64-bit
 operand immP() %{
   match(ConP);
@@ -1953,36 +1882,6 @@ operand immP0() %{
   match(ConP);
   op_cost(0);
 
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Pointer Immediate
-operand immN()
-%{
-  match(ConN);
-
-  op_cost(10);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immNKlass()
-%{
-  match(ConNKlass);
-
-  op_cost(10);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Null Pointer Immediate
-operand immN0()
-%{
-  predicate(n->get_narrowcon() == 0);
-  match(ConN);
-
-  op_cost(0);
   format %{ %}
   interface(CONST_INTER);
 %}

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -501,31 +501,6 @@ operand immIRotn() %{
   interface(CONST_INTER);
 %}
 
-operand immIRotneg() %{
-  // if AsmOperand::is_rotated_imm() is true for this constant, it is
-  // a immIRot and an optimal instruction combination exists to handle the
-  // constant as an immIRot
-  predicate(!AsmOperand::is_rotated_imm(n->get_int()) && AsmOperand::is_rotated_imm(-n->get_int()));
-  match(ConI);
-
-  op_cost(0);
-  // formats are generated automatically for constants and base registers
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Non-negative integer immediate that is encodable using the rotation scheme,
-// and that when expanded fits in 31 bits.
-operand immU31Rot() %{
-  predicate((0 <= n->get_int()) && AsmOperand::is_rotated_imm(n->get_int()));
-  match(ConI);
-
-  op_cost(0);
-  // formats are generated automatically for constants and base registers
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 operand immPRot() %{
   predicate(n->get_ptr() == 0 || (AsmOperand::is_rotated_imm(n->get_ptr()) && ((ConPNode*)n)->type()->reloc() == relocInfo::none));
 

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -521,15 +521,15 @@ operand immLlowRot() %{
   interface(CONST_INTER);
 %}
 
-#operand immLRot2() %{
-#  predicate(AsmOperand::is_rotated_imm((int)(n->get_long() >> 32)) &&
-#            AsmOperand::is_rotated_imm((int)(n->get_long())));
-#  match(ConL);
-#  op_cost(0);
-#
-#  format %{ %}
-#  interface(CONST_INTER);
-#%}
+//operand immLRot2() %{
+//  predicate(AsmOperand::is_rotated_imm((int)(n->get_long() >> 32)) &&
+//            AsmOperand::is_rotated_imm((int)(n->get_long())));
+//  match(ConL);
+//  op_cost(0);
+//
+//  format %{ %}
+//  interface(CONST_INTER);
+//%}
 
 // Integer Immediate: 12-bit - for addressing mode
 operand immI12() %{

--- a/src/hotspot/cpu/arm/arm_32.ad
+++ b/src/hotspot/cpu/arm/arm_32.ad
@@ -521,15 +521,15 @@ operand immLlowRot() %{
   interface(CONST_INTER);
 %}
 
-operand immLRot2() %{
-  predicate(AsmOperand::is_rotated_imm((int)(n->get_long() >> 32)) &&
-            AsmOperand::is_rotated_imm((int)(n->get_long())));
-  match(ConL);
-  op_cost(0);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
+#operand immLRot2() %{
+#  predicate(AsmOperand::is_rotated_imm((int)(n->get_long() >> 32)) &&
+#            AsmOperand::is_rotated_imm((int)(n->get_long())));
+#  match(ConL);
+#  op_cost(0);
+#
+#  format %{ %}
+#  interface(CONST_INTER);
+#%}
 
 // Integer Immediate: 12-bit - for addressing mode
 operand immI12() %{

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -4388,27 +4388,6 @@ operand rarg1RegL() %{
   interface(REG_INTER);
 %}
 
-operand rarg2RegL() %{
-  constraint(ALLOC_IN_RC(rarg2_bits64_reg));
-  match(iRegLdst);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand rarg3RegL() %{
-  constraint(ALLOC_IN_RC(rarg3_bits64_reg));
-  match(iRegLdst);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand rarg4RegL() %{
-  constraint(ALLOC_IN_RC(rarg4_bits64_reg));
-  match(iRegLdst);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 // Pointer Destination Register
 // See definition of reg_class bits64_reg_rw.
 operand iRegPdst() %{

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2966,19 +2966,6 @@ operand immL_M1()
 %}
 
 
-// 32 bit offset of pc in thread anchor
-
-operand immL_pc_off()
-%{
-  predicate(n->get_long() == in_bytes(JavaThread::frame_anchor_offset()) +
-                             in_bytes(JavaFrameAnchor::last_Java_pc_offset()));
-  match(ConL);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // 64 bit integer valid for add immediate
 operand immLAdd()
 %{
@@ -3182,17 +3169,6 @@ operand iRegLNoSp()
   constraint(ALLOC_IN_RC(no_special_reg));
   match(RegL);
   match(iRegL_R10);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-// Long 64 bit Register R28 only
-operand iRegL_R28()
-%{
-  constraint(ALLOC_IN_RC(r28_reg));
-  match(RegL);
-  match(iRegLNoSp);
-  op_cost(0);
   format %{ %}
   interface(REG_INTER);
 %}
@@ -3693,22 +3669,6 @@ operand indOffLN(iRegN reg, immLOffset off)
     disp($off);
   %}
 %}
-
-// RISCV opto stubs need to write to the pc slot in the thread anchor
-operand thread_anchor_pc(javaThread_RegP reg, immL_pc_off off)
-%{
-  constraint(ALLOC_IN_RC(ptr_reg));
-  match(AddP reg off);
-  op_cost(0);
-  format %{ "[$reg, $off]" %}
-  interface(MEMORY_INTER) %{
-    base($reg);
-    index(0xffffffff);
-    scale(0x0);
-    disp($off);
-  %}
-%}
-
 
 //----------Special Memory Operands--------------------------------------------
 // Stack Slot Operand - This operand is used for loading and storing temporary

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2578,24 +2578,6 @@ operand uimmI8() %{
   interface(CONST_INTER);
 %}
 
-// Integer Immediate: 6-bit
-operand uimmI6() %{
-  predicate(Immediate::is_uimm(n->get_int(), 6));
-  match(ConI);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: 5-bit
-operand uimmI5() %{
-  predicate(Immediate::is_uimm(n->get_int(), 5));
-  match(ConI);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // Length for SS instructions, given in DWs,
 //   possible range [1..512], i.e. [8..4096] Bytes
 //   used     range [1..256], i.e. [8..2048] Bytes
@@ -2634,15 +2616,6 @@ operand immI_16() %{
 // Integer Immediate: the value 24.
 operand immI_24() %{
   predicate(n->get_int() == 24);
-  match(ConI);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Integer Immediate: the value 255
-operand immI_255() %{
-  predicate(n->get_int() == 255);
   match(ConI);
   op_cost(1);
   format %{ %}
@@ -2753,36 +2726,9 @@ operand uimmL12() %{
   interface(CONST_INTER);
 %}
 
-// Unsigned Long Immediate: 8-bit
-operand uimmL8() %{
-  predicate(Immediate::is_uimm8(n->get_long()));
-  match(ConL);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 //-------------------------------------------
 // (UN)SIGNED LONG specific values
 //-------------------------------------------
-
-// Long Immediate: the value FF
-operand immL_FF() %{
-  predicate(n->get_long() == 0xFFL);
-  match(ConL);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Long Immediate: the value FFFF
-operand immL_FFFF() %{
-  predicate(n->get_long() == 0xFFFFL);
-  match(ConL);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
 
 // Long Immediate: the value FFFFFFFF
 operand immL_FFFFFFFF() %{
@@ -2852,15 +2798,6 @@ operand immL_32bits() %{
 
 // Pointer Immediate: 64-bit
 operand immP() %{
-  match(ConP);
-  op_cost(1);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Pointer Immediate: 32-bit
-operand immP32() %{
-  predicate(Immediate::is_uimm32(n->get_ptr()));
   match(ConP);
   op_cost(1);
   format %{ %}
@@ -3166,20 +3103,6 @@ operand roddRegP() %{
   interface(REG_INTER);
 %}
 
-operand lock_ptr_RegP() %{
-  constraint(ALLOC_IN_RC(z_lock_ptr_reg));
-  match(RegP);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand rscratch2RegP() %{
-  constraint(ALLOC_IN_RC(z_rscratch2_bits64_reg));
-  match(RegP);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 operand iRegN() %{
   constraint(ALLOC_IN_RC(z_int_reg));
   match(RegN);
@@ -3294,14 +3217,6 @@ operand flagsReg() %{
   interface(REG_INTER);
 %}
 
-// Condition Code Flag Registers for rules with result tuples
-operand TD_flagsReg() %{
-  constraint(ALLOC_IN_RC(z_condition_reg));
-  match(RegFlags);
-  format %{ "CR" %}
-  interface(REG_TUPLE_DEST_INTER);
-%}
-
 operand regD() %{
   constraint(ALLOC_IN_RC(z_dbl_reg));
   match(RegD);
@@ -3309,22 +3224,8 @@ operand regD() %{
   interface(REG_INTER);
 %}
 
-operand rscratchRegD() %{
-  constraint(ALLOC_IN_RC(z_rscratch1_dbl_reg));
-  match(RegD);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 operand regF() %{
   constraint(ALLOC_IN_RC(z_flt_reg));
-  match(RegF);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand rscratchRegF() %{
-  constraint(ALLOC_IN_RC(z_rscratch1_flt_reg));
   match(RegF);
   format %{ %}
   interface(REG_INTER);
@@ -3339,26 +3240,6 @@ operand inline_cache_regP(iRegP reg) %{
   format %{ %}
   interface(REG_INTER);
 %}
-
-// Operands to remove register moves in unscaled mode.
-// Match read/write registers with an EncodeP node if neither shift nor add are required.
-operand iRegP2N(iRegP reg) %{
-  predicate(CompressedOops::shift() == 0 && _leaf->as_EncodeP()->in(0) == nullptr);
-  constraint(ALLOC_IN_RC(z_memory_ptr_reg));
-  match(EncodeP reg);
-  format %{ "$reg" %}
-  interface(REG_INTER)
-%}
-
-operand iRegN2P(iRegN reg) %{
-  predicate(CompressedOops::base() == nullptr && CompressedOops::shift() == 0 &&
-            _leaf->as_DecodeN()->in(0) == nullptr);
-  constraint(ALLOC_IN_RC(z_memory_ptr_reg));
-  match(DecodeN reg);
-  format %{ "$reg" %}
-  interface(REG_INTER)
-%}
-
 
 //----------Complex Operands---------------------------------------------------
 

--- a/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
+++ b/src/hotspot/cpu/x86/gc/z/z_x86_64.ad
@@ -99,6 +99,18 @@ static void z_store_barrier(MacroAssembler& _masm, const MachNode* node, Address
 
 %}
 
+operand no_rax_RegP()
+%{
+  constraint(ALLOC_IN_RC(ptr_no_rax_reg));
+  match(RegP);
+  match(rbx_RegP);
+  match(rsi_RegP);
+  match(rdi_RegP);
+
+  format %{ %}
+  interface(REG_INTER);
+%}
+
 // Load Pointer
 instruct zLoadP(rRegP dst, memory mem, rFlagsReg cr)
 %{

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -3602,64 +3602,6 @@ operand kReg()
   interface(REG_INTER);
 %}
 
-operand kReg_K1()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K1));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K2()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K2));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-// Special Registers
-operand kReg_K3()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K3));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K4()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K4));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K5()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K5));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K6()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K6));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-// Special Registers
-operand kReg_K7()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K7));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
 // Register Operands
 // Integer Register
 operand rRegI() %{
@@ -3734,18 +3676,6 @@ operand eDIRegI(xRegI reg) %{
   match(rRegI);
 
   format %{ "EDI" %}
-  interface(REG_INTER);
-%}
-
-operand naxRegI() %{
-  constraint(ALLOC_IN_RC(nax_reg));
-  match(RegI);
-  match(eCXRegI);
-  match(eDXRegI);
-  match(eSIRegI);
-  match(eDIRegI);
-
-  format %{ %}
   interface(REG_INTER);
 %}
 
@@ -3832,31 +3762,6 @@ operand eRegP_no_EBP() %{
   match(eDIRegP);
 
   op_cost(100);
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand naxRegP() %{
-  constraint(ALLOC_IN_RC(nax_reg));
-  match(RegP);
-  match(eBXRegP);
-  match(eDXRegP);
-  match(eCXRegP);
-  match(eSIRegP);
-  match(eDIRegP);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand nabxRegP() %{
-  constraint(ALLOC_IN_RC(nabx_reg));
-  match(RegP);
-  match(eCXRegP);
-  match(eDXRegP);
-  match(eSIRegP);
-  match(eDIRegP);
-
   format %{ %}
   interface(REG_INTER);
 %}

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2561,18 +2561,6 @@ operand rRegN() %{
 // the RBP is used as a proper frame pointer and is not included in ptr_reg. As a
 // result, RBP is not included in the output of the instruction either.
 
-operand no_rax_RegP()
-%{
-  constraint(ALLOC_IN_RC(ptr_no_rax_reg));
-  match(RegP);
-  match(rbx_RegP);
-  match(rsi_RegP);
-  match(rdi_RegP);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
 // This operand is not allowed to use RBP even if
 // RBP is not used to hold the frame pointer.
 operand no_rbp_RegP()

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -2126,28 +2126,6 @@ operand immU31()
   interface(CONST_INTER);
 %}
 
-// Constant for long shifts
-operand immI_32()
-%{
-  predicate( n->get_int() == 32 );
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Constant for long shifts
-operand immI_64()
-%{
-  predicate( n->get_int() == 64 );
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // Pointer Immediate
 operand immP()
 %{
@@ -2302,28 +2280,6 @@ operand immL_M1()
   interface(CONST_INTER);
 %}
 
-// Long Immediate: the value 10
-operand immL10()
-%{
-  predicate(n->get_long() == 10);
-  match(ConL);
-
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Long immediate from 0 to 127.
-// Used for a shorter form of long mul by 10.
-operand immL_127()
-%{
-  predicate(0 <= n->get_long() && n->get_long() < 0x80);
-  match(ConL);
-
-  op_cost(10);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 // Long Immediate: low 32-bit mask
 operand immL_32bits()
 %{
@@ -2453,64 +2409,6 @@ operand immL_65535()
 operand kReg()
 %{
   constraint(ALLOC_IN_RC(vectmask_reg));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K1()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K1));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K2()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K2));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-// Special Registers
-operand kReg_K3()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K3));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K4()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K4));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K5()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K5));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-operand kReg_K6()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K6));
-  match(RegVectMask);
-  format %{%}
-  interface(REG_INTER);
-%}
-
-// Special Registers
-operand kReg_K7()
-%{
-  constraint(ALLOC_IN_RC(vectmask_reg_K7));
   match(RegVectMask);
   format %{%}
   interface(REG_INTER);
@@ -2682,17 +2580,6 @@ operand no_rbp_RegP()
   constraint(ALLOC_IN_RC(ptr_reg_no_rbp));
   match(RegP);
   match(rbx_RegP);
-  match(rsi_RegP);
-  match(rdi_RegP);
-
-  format %{ %}
-  interface(REG_INTER);
-%}
-
-operand no_rax_rbx_RegP()
-%{
-  constraint(ALLOC_IN_RC(ptr_no_rax_rbx_reg));
-  match(RegP);
   match(rsi_RegP);
   match(rdi_RegP);
 

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -720,6 +720,10 @@ public:
 
 // check unused operands
 bool ArchDesc::check_usage() {
+  if (_disable_warnings) {
+    return true;
+  }
+
   std::unordered_set<Form*> visited;
   MarkUsageFormClosure callback(this, &visited);
   _instructions.reset();

--- a/src/hotspot/share/adlc/archDesc.cpp
+++ b/src/hotspot/share/adlc/archDesc.cpp
@@ -747,11 +747,12 @@ bool ArchDesc::check_usage() {
   callback.do_form_by_name("sRegL");
 
   // special generic vector operands only used in Matcher::pd_specialize_generic_vector_operand
+  // x86_32 combine x86.ad and x86_32.ad, the vec*/legVec* can not be cleaned from IA32
 #if defined(AARCH64)
   callback.do_form_by_name("vecA");
   callback.do_form_by_name("vecD");
   callback.do_form_by_name("vecX");
-#elif defined(AMD64)
+#elif defined(IA32) || defined(AMD64)
   callback.do_form_by_name("vecS");
   callback.do_form_by_name("vecD");
   callback.do_form_by_name("vecX");


### PR DESCRIPTION
Remove all unused operands reported by adlc. I'm testing x86_64 and aarch64. So far no failure found in tier1.
I tried to clean unused operands for all platform. A special case is immLRot2 in arm, it's not used, but appeared in many todo comments. So I keep it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326983](https://bugs.openjdk.org/browse/JDK-8326983): Unused operands reported after JDK-8326135 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18075/head:pull/18075` \
`$ git checkout pull/18075`

Update a local copy of the PR: \
`$ git checkout pull/18075` \
`$ git pull https://git.openjdk.org/jdk.git pull/18075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18075`

View PR using the GUI difftool: \
`$ git pr show -t 18075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18075.diff">https://git.openjdk.org/jdk/pull/18075.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18075#issuecomment-1972557234)