### PR TITLE
8327108: compiler.lib.ir_framework.shared.TestFrameworkSocket should listen on loopback address only

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/shared/TestFrameworkSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutionException;
@@ -47,7 +49,6 @@ public class TestFrameworkSocket implements AutoCloseable {
     private static final int SERVER_PORT = Integer.getInteger(SERVER_PORT_PROPERTY, -1);
 
     private static final boolean REPRODUCE = Boolean.getBoolean("Reproduce");
-    private static final String HOSTNAME = null;
     private static Socket clientSocket = null;
     private static PrintWriter clientWriter = null;
 
@@ -58,7 +59,8 @@ public class TestFrameworkSocket implements AutoCloseable {
 
     public TestFrameworkSocket() {
         try {
-            serverSocket = new ServerSocket(0);
+            serverSocket = new ServerSocket();
+            serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
         } catch (IOException e) {
             throw new TestFrameworkException("Failed to create TestFramework server socket", e);
         }
@@ -132,7 +134,7 @@ public class TestFrameworkSocket implements AutoCloseable {
         try {
             // Keep the client socket open until the test VM terminates (calls closeClientSocket before exiting main()).
             if (clientSocket == null) {
-                clientSocket = new Socket(HOSTNAME, SERVER_PORT);
+                clientSocket = new Socket(InetAddress.getLoopbackAddress(), SERVER_PORT);
                 clientWriter = new PrintWriter(clientSocket.getOutputStream(), true);
             }
             if (stdout) {


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to address https://bugs.openjdk.org/browse/JDK-8327108?

As noted in the JBS issue, before this proposed change, the internal test framework code in `compiler.lib.ir_framework.shared.TestFrameworkSocket` was binding a `java.net.ServerSocket` to "any address". This can lead to interference  from other hosts on the network, when the tests are run. The change here proposes to bind this `ServerSocket` to loopback address and reduce the chances of such interference.

Originally, the interference issues were noticed in CI when `tier3` was run. With the change proposed in this PR, I've run `tier1`, `tier2` and `tier3` in our CI environment and they all passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327108](https://bugs.openjdk.org/browse/JDK-8327108): compiler.lib.ir_framework.shared.TestFrameworkSocket should listen on loopback address only (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18078/head:pull/18078` \
`$ git checkout pull/18078`

Update a local copy of the PR: \
`$ git checkout pull/18078` \
`$ git pull https://git.openjdk.org/jdk.git pull/18078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18078`

View PR using the GUI difftool: \
`$ git pr show -t 18078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18078.diff">https://git.openjdk.org/jdk/pull/18078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18078#issuecomment-1973149181)