### PR TITLE
8327105: compiler.compilercontrol.share.scenario.Executor should listen on loopback address only

### DIFF
--- a/test/hotspot/jtreg/compiler/compilercontrol/share/actions/BaseAction.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/actions/BaseAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class BaseAction {
         System.out.println("INFO: Client connection port = " + port);
         List<String> lines;
         try (
-                Socket socket = new Socket(InetAddress.getLocalHost(), port);
+                Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
                 BufferedReader in = new BufferedReader(
                         new InputStreamReader(socket.getInputStream()));
                 PrintWriter out = new PrintWriter(

--- a/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
+++ b/test/hotspot/jtreg/compiler/compilercontrol/share/scenario/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.lang.reflect.Executable;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.ArrayList;
@@ -80,8 +82,9 @@ public class Executor {
         // Add class name that would be executed in a separate VM
         vmOptions.add(execClass);
         OutputAnalyzer output;
-        try (ServerSocket serverSocket = new ServerSocket(0)) {
+        try (ServerSocket serverSocket = new ServerSocket()) {
             {
+                serverSocket.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
                 // Get port test VM will connect to
                 int port = serverSocket.getLocalPort();
                 if (port == -1) {


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to address https://bugs.openjdk.org/browse/JDK-8327105?

The commit here changes the internal test class `compiler.compilercontrol.share.scenario.Executor` to bind to a loopback address to prevent other hosts on the network to unexpected communicate on the `ServerSocket`.

The original interference was noticed in some `tier7` tests which use this `Executor` class. With the change proposed in this PR, `tier1`, `tier2`, `tier3` and `tier7`, `tier8` have been run and that issue hasn't been noticed in this class anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327105](https://bugs.openjdk.org/browse/JDK-8327105): compiler.compilercontrol.share.scenario.Executor should listen on loopback address only (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18079/head:pull/18079` \
`$ git checkout pull/18079`

Update a local copy of the PR: \
`$ git checkout pull/18079` \
`$ git pull https://git.openjdk.org/jdk.git pull/18079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18079`

View PR using the GUI difftool: \
`$ git pr show -t 18079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18079.diff">https://git.openjdk.org/jdk/pull/18079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18079#issuecomment-1973173898)