### PR TITLE
8327130: Serial: Remove Generation::record_spaces_top

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -234,7 +234,7 @@ class DefNewGeneration: public Generation {
   void gc_epilogue(bool full);
 
   // Save the tops for eden, from, and to
-  virtual void record_spaces_top();
+  void record_spaces_top();
 
   // Accessing marks
   void save_marks();

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -168,9 +168,6 @@ class Generation: public CHeapObj<mtGC> {
   // still unsuccessful, return "null".
   virtual HeapWord* expand_and_allocate(size_t word_size, bool is_tlab) = 0;
 
-  // Save the high water marks for the used space in a generation.
-  virtual void record_spaces_top() {}
-
   // Generations may keep statistics about collection. This method
   // updates those statistics. current_generation is the generation
   // that was most recently collected. This allows the generation to

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -154,7 +154,7 @@ class TenuredGeneration: public Generation {
   // Performance Counter support
   void update_counters();
 
-  virtual void record_spaces_top();
+  void record_spaces_top();
 
   // Statistics
 


### PR DESCRIPTION
Trivial removing effectively dead code in the super class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327130](https://bugs.openjdk.org/browse/JDK-8327130): Serial: Remove Generation::record_spaces_top (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18082/head:pull/18082` \
`$ git checkout pull/18082`

Update a local copy of the PR: \
`$ git checkout pull/18082` \
`$ git pull https://git.openjdk.org/jdk.git pull/18082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18082`

View PR using the GUI difftool: \
`$ git pr show -t 18082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18082.diff">https://git.openjdk.org/jdk/pull/18082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18082#issuecomment-1973323793)