### PR TITLE
8312444: Delete unused parameters and variables in SocketPermission

### DIFF
--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -225,6 +225,8 @@ public final class SocketPermission extends Permission
     // port range on host
     private transient int[] portrange;
 
+    private transient boolean defaultDeny = false;
+
     // true if this SocketPermission represents a hostname
     // that failed our reverse mapping heuristic test
     private transient boolean untrusted;
@@ -296,6 +298,10 @@ public final class SocketPermission extends Permission
         super(getHost(host));
         // name initialized to getHost(host); NPE detected in getHost()
         init(getName(), mask);
+    }
+
+    private void setDeny() {
+        defaultDeny = true;
     }
 
     private static String getHost(String host) {
@@ -605,7 +611,8 @@ public final class SocketPermission extends Permission
         if (trusted) return false;
         if (invalid || untrusted) return true;
         try {
-            if (!trustNameService && sun.net.www.URLConnection.isProxiedHost(hostname)) {
+            if (!trustNameService && (defaultDeny ||
+                    sun.net.www.URLConnection.isProxiedHost(hostname))) {
                 if (this.cname == null) {
                     this.getCanonName();
                 }

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -178,7 +178,7 @@ public final class SocketPermission extends Permission
     /**
      * No actions
      */
-    private static final int NONE               = 0x0;
+    private static final int NONE       = 0x0;
 
     /**
      * All actions
@@ -224,8 +224,6 @@ public final class SocketPermission extends Permission
 
     // port range on host
     private transient int[] portrange;
-
-    private transient boolean defaultDeny = false;
 
     // true if this SocketPermission represents a hostname
     // that failed our reverse mapping heuristic test
@@ -298,10 +296,6 @@ public final class SocketPermission extends Permission
         super(getHost(host));
         // name initialized to getHost(host); NPE detected in getHost()
         init(getName(), mask);
-    }
-
-    private void setDeny() {
-        defaultDeny = true;
     }
 
     private static String getHost(String host) {
@@ -611,14 +605,13 @@ public final class SocketPermission extends Permission
         if (trusted) return false;
         if (invalid || untrusted) return true;
         try {
-            if (!trustNameService && (defaultDeny ||
-                sun.net.www.URLConnection.isProxiedHost(hostname))) {
+            if (!trustNameService && sun.net.www.URLConnection.isProxiedHost(hostname)) {
                 if (this.cname == null) {
                     this.getCanonName();
                 }
                 if (!match(cname, hostname)) {
                     // Last chance
-                    if (!authorized(hostname, addresses[0].getAddress())) {
+                    if (!authorized(addresses[0].getAddress())) {
                         untrusted = true;
                         Debug debug = getDebug();
                         if (debug != null && Debug.isOn("failure")) {
@@ -704,7 +697,7 @@ public final class SocketPermission extends Permission
         return !cdomain.isEmpty() && !hdomain.isEmpty() && cdomain.equals(hdomain);
     }
 
-    private boolean authorized(String cname, byte[] addr) {
+    private boolean authorized(byte[] addr) {
         if (addr.length == 4)
             return authorizedIPv4(addr);
         else if (addr.length == 16)

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -241,8 +241,8 @@ public final class SocketPermission extends Permission
     // lazy initializer
     private static class EphemeralRange {
         static final int low = initEphemeralPorts("low");
-            static final int high = initEphemeralPorts("high");
-    };
+        static final int high = initEphemeralPorts("high");
+    }
 
     private static synchronized Debug getDebug() {
         if (!debugInit) {
@@ -340,10 +340,7 @@ public final class SocketPermission extends Permission
         }
     }
 
-    private int[] parsePort(String port)
-        throws Exception
-    {
-
+    private int[] parsePort(String port) {
         if (port == null || port.isEmpty() || port.equals("*")) {
             return new int[] {PORT_MIN, PORT_MAX};
         }

--- a/src/java.base/share/classes/java/net/SocketPermission.java
+++ b/src/java.base/share/classes/java/net/SocketPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,8 +188,6 @@ public final class SocketPermission extends Permission
     // various port constants
     private static final int PORT_MIN = 0;
     private static final int PORT_MAX = 65535;
-    private static final int PRIV_PORT_MAX = 1023;
-    private static final int DEF_EPH_LOW = 49152;
 
     // the actions mask
     private transient int mask;
@@ -242,8 +240,8 @@ public final class SocketPermission extends Permission
 
     // lazy initializer
     private static class EphemeralRange {
-        static final int low = initEphemeralPorts("low", DEF_EPH_LOW);
-            static final int high = initEphemeralPorts("high", PORT_MAX);
+        static final int low = initEphemeralPorts("low");
+            static final int high = initEphemeralPorts("high");
     };
 
     private static synchronized Debug getDebug() {
@@ -466,7 +464,7 @@ public final class SocketPermission extends Permission
                 // see if we are being initialized with an IP address.
                 char ch = host.charAt(0);
                 if (ch == ':' || IPAddressUtil.digit(ch, 16) != -1) {
-                    byte ip[] = IPAddressUtil.textToNumericFormatV4(host);
+                    byte[] ip = IPAddressUtil.textToNumericFormatV4(host);
                     if (ip == null) {
                         ip = IPAddressUtil.textToNumericFormatV6(host);
                     }
@@ -521,8 +519,6 @@ public final class SocketPermission extends Permission
         char[] a = action.toCharArray();
 
         int i = a.length - 1;
-        if (i < 0)
-            return mask;
 
         while (i != -1) {
             char c;
@@ -713,14 +709,14 @@ public final class SocketPermission extends Permission
 
     private boolean authorized(String cname, byte[] addr) {
         if (addr.length == 4)
-            return authorizedIPv4(cname, addr);
+            return authorizedIPv4(addr);
         else if (addr.length == 16)
-            return authorizedIPv6(cname, addr);
+            return authorizedIPv6(addr);
         else
             return false;
     }
 
-    private boolean authorizedIPv4(String cname, byte[] addr) {
+    private boolean authorizedIPv4(byte[] addr) {
         String authHost = "";
         InetAddress auth;
 
@@ -749,7 +745,7 @@ public final class SocketPermission extends Permission
         return false;
     }
 
-    private boolean authorizedIPv6(String cname, byte[] addr) {
+    private boolean authorizedIPv6(byte[] addr) {
         String authHost = "";
         InetAddress auth;
 
@@ -854,8 +850,6 @@ public final class SocketPermission extends Permission
      */
     @Override
     public boolean implies(Permission p) {
-        int i,j;
-
         if (!(p instanceof SocketPermission that))
             return false;
 
@@ -1221,7 +1215,7 @@ public final class SocketPermission extends Permission
      * for this system. The suffix is either "high" or "low"
      */
     @SuppressWarnings("removal")
-    private static int initEphemeralPorts(String suffix, int defval) {
+    private static int initEphemeralPorts(String suffix) {
         return AccessController.doPrivileged(
             new PrivilegedAction<>(){
                 public Integer run() {


### PR DESCRIPTION
Removing unused parameter `defval` in `SocketPermission.initEphemeralPorts`, so the variable `PRIV_PORT_MAX` and `DEF_EPH_LOW` unused too.

Removing unused parameter `cname` in `SocketPermission.authorizedIPv4` and `SocketPermission.authorizedIPv6`.

Parameter 'action' must be not empty so `a.length > 0`, the check `a.length - 1 < 0` can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312444](https://bugs.openjdk.org/browse/JDK-8312444): Delete unused parameters and variables in SocketPermission (**Enhancement** - P5)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [a07280d4](https://git.openjdk.org/jdk/pull/18086/files/a07280d4960218f2e884cd93462d31fea6db9ede)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer) ⚠️ Review applies to [9ebd6e12](https://git.openjdk.org/jdk/pull/18086/files/9ebd6e1279d7fc23ee1683070453ac1cd43f9868)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18086/head:pull/18086` \
`$ git checkout pull/18086`

Update a local copy of the PR: \
`$ git checkout pull/18086` \
`$ git pull https://git.openjdk.org/jdk.git pull/18086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18086`

View PR using the GUI difftool: \
`$ git pr show -t 18086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18086.diff">https://git.openjdk.org/jdk/pull/18086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18086#issuecomment-1973619485)