### PR TITLE
8326692: JVMCI Local.endBci is off-by-one

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -632,7 +632,7 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
 
         for (int i = 0; i < localVariableTableLength; i++) {
             final int startBci = UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementStartBciOffset);
-            final int endBci = startBci + UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementLengthOffset);
+            final int endBci = startBci + UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementLengthOffset) - 1;
             final int nameCpIndex = UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementNameCpIndexOffset);
             final int typeCpIndex = UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementDescriptorCpIndexOffset);
             final int slot = UNSAFE.getChar(localVariableTableElement + config.localVariableTableElementSlotOffset);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/Local.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/Local.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,17 @@ public class Local {
         this.type = type;
     }
 
+    /**
+     * Returns the first BCI at which this local has a value (inclusive).
+     */
     public int getStartBCI() {
         return startBci;
     }
 
+
+    /**
+     * Returns the last BCI at which this local has a value (inclusive).
+     */
     public int getEndBCI() {
         return endBci;
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/Local.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/Local.java
@@ -51,6 +51,8 @@ public class Local {
 
     /**
      * Returns the last BCI at which this local has a value (inclusive).
+     * If the value returned is less than {@link #getStartBCI}, this object denotes a local
+     * variable that is never live.
      */
     public int getEndBCI() {
         return endBci;

--- a/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
+++ b/test/hotspot/jtreg/compiler/jvmci/jdk.vm.ci.runtime.test/src/jdk/vm/ci/runtime/test/TestResolvedJavaMethod.java
@@ -95,6 +95,8 @@ import java.lang.classfile.attribute.CodeAttribute;
 
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.ExceptionHandler;
+import jdk.vm.ci.meta.Local;
+import jdk.vm.ci.meta.LocalVariableTable;
 import jdk.vm.ci.meta.ResolvedJavaMethod;
 import jdk.vm.ci.meta.ResolvedJavaMethod.Parameter;
 import jdk.vm.ci.meta.ResolvedJavaType;
@@ -734,6 +736,24 @@ public class TestResolvedJavaMethod extends MethodUniverse {
         Assert.assertTrue(processedMethodWithManyArgs[0]);
     }
 
+    @Test
+    public void getLocalVariableTableTest() {
+        for (ResolvedJavaMethod m : methods.values()) {
+            LocalVariableTable table = m.getLocalVariableTable();
+            if (table == null) {
+                continue;
+            }
+            for (Local l : table.getLocals()) {
+                if (l.getStartBCI() < 0) {
+                    throw new AssertionError(m.format("%H.%n(%p)") + " local " + l.getName() + " starts at " + l.getStartBCI());
+                }
+                if (l.getEndBCI() >= m.getCodeSize()) {
+                    throw new AssertionError(m.format("%H.%n(%p)") + " (" + m.getCodeSize() + "bytes) local " + l.getName() + " ends at " + l.getEndBCI());
+                }
+            }
+        }
+    }
+
     private Method findTestMethod(Method apiMethod) {
         String testName = apiMethod.getName() + "Test";
         for (Method m : getClass().getDeclaredMethods()) {
@@ -756,7 +776,6 @@ public class TestResolvedJavaMethod extends MethodUniverse {
         "canBeInlined",
         "shouldBeInlined",
         "getLineNumberTable",
-        "getLocalVariableTable",
         "isInVirtualMethodTable",
         "toParameterTypes",
         "getParameterAnnotation",


### PR DESCRIPTION
In class files, in the local variable table, local variables have a start BCI and a length. The local variable has a value from BCI (inclusive) until BCI + length (exclusive).
On the other end, JVMCI stores that information in `Local` objects with a start BCI and an end BCI (inclusive).
Currently the parser just uses BCI+length to compute the end BCI, leading to an off-by-one error.

A simple test checking that the start and end BCIs are within the method's bytecode is added. It fails without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326692](https://bugs.openjdk.org/browse/JDK-8326692): JVMCI Local.endBci is off-by-one (**Bug** - P5)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**) ⚠️ Review applies to [90e96b4e](https://git.openjdk.org/jdk/pull/18087/files/90e96b4ee9756b6d030ce3d7b5c75376045fc8f5)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [90e96b4e](https://git.openjdk.org/jdk/pull/18087/files/90e96b4ee9756b6d030ce3d7b5c75376045fc8f5)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18087/head:pull/18087` \
`$ git checkout pull/18087`

Update a local copy of the PR: \
`$ git checkout pull/18087` \
`$ git pull https://git.openjdk.org/jdk.git pull/18087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18087`

View PR using the GUI difftool: \
`$ git pr show -t 18087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18087.diff">https://git.openjdk.org/jdk/pull/18087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18087#issuecomment-1973633363)