### PR TITLE
8327147: Improve performance of Math ceil, floor, and rint for x86

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6135,7 +6135,7 @@ void Assembler::smovl() {
 void Assembler::roundsd(XMMRegister dst, XMMRegister src, int32_t rmode) {
   assert(VM_Version::supports_sse4_1(), "");
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
-  int encode = simd_prefix_and_encode(dst, dst, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
+  int encode = simd_prefix_and_encode(dst, src, src, VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int24(0x0B, (0xC0 | encode), (unsigned char)rmode);
 }
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3875,7 +3875,7 @@ instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
   ins_encode %{
     assert(UseSSE >= 4, "required");
     if ((UseAVX == 0) && ($dst$$XMMRegister != $src$$XMMRegister)) {
-    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+      __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
     }
     __ roundsd($dst$$XMMRegister, $src$$XMMRegister, $rmode$$constant);
   %}

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3874,6 +3874,9 @@ instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
   ins_cost(150);
   ins_encode %{
     assert(UseSSE >= 4, "required");
+    if ((UseAVX == 0) && ($dst$$XMMRegister != $src$$XMMRegister)) {
+    __ pxor($dst$$XMMRegister, $dst$$XMMRegister);
+    }
     __ roundsd($dst$$XMMRegister, $src$$XMMRegister, $rmode$$constant);
   %}
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3869,7 +3869,6 @@ instruct reinterpret_shrink(vec dst, legVec src) %{
 
 #ifdef _LP64
 instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
-  predicate(UseAVX == 0);
   match(Set dst (RoundDoubleMode src rmode));
   format %{ "roundsd $dst,$src" %}
   ins_cost(150);
@@ -3879,30 +3878,6 @@ instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
   %}
   ins_pipe(pipe_slow);
 %}
-
-instruct roundD_reg_avx(legRegD dst, legRegD src, immU8 rmode) %{
-  predicate(UseAVX > 0);
-  match(Set dst (RoundDoubleMode src rmode));
-  format %{ "roundsd $dst,$src" %}
-  ins_cost(150);
-  ins_encode %{
-    __ vroundsd($dst$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, $rmode$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-
-/*
-instruct roundD_mem(legRegD dst, memory src, immU8 rmode) %{
-  match(Set dst (RoundDoubleMode (LoadD src) rmode));
-  format %{ "roundsd $dst,$src" %}
-  ins_cost(150);
-  ins_encode %{
-    assert(UseSSE >= 4, "required");
-    __ roundsd($dst$$XMMRegister, $src$$Address, $rmode$$constant);
-  %}
-  ins_pipe(pipe_slow);
-%}
-*/
 
 instruct roundD_imm(legRegD dst, immD con, immU8 rmode) %{
   match(Set dst (RoundDoubleMode con rmode));

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3869,6 +3869,7 @@ instruct reinterpret_shrink(vec dst, legVec src) %{
 
 #ifdef _LP64
 instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
+  predicate(UseAVX == 0);
   match(Set dst (RoundDoubleMode src rmode));
   format %{ "roundsd $dst,$src" %}
   ins_cost(150);
@@ -3879,6 +3880,18 @@ instruct roundD_reg(legRegD dst, legRegD src, immU8 rmode) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct roundD_reg_avx(legRegD dst, legRegD src, immU8 rmode) %{
+  predicate(UseAVX > 0);
+  match(Set dst (RoundDoubleMode src rmode));
+  format %{ "roundsd $dst,$src" %}
+  ins_cost(150);
+  ins_encode %{
+    __ vroundsd($dst$$XMMRegister, $src$$XMMRegister, $src$$XMMRegister, $rmode$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+/*
 instruct roundD_mem(legRegD dst, memory src, immU8 rmode) %{
   match(Set dst (RoundDoubleMode (LoadD src) rmode));
   format %{ "roundsd $dst,$src" %}
@@ -3889,6 +3902,7 @@ instruct roundD_mem(legRegD dst, memory src, immU8 rmode) %{
   %}
   ins_pipe(pipe_slow);
 %}
+*/
 
 instruct roundD_imm(legRegD dst, immD con, immU8 rmode) %{
   match(Set dst (RoundDoubleMode con rmode));

--- a/test/micro/org/openjdk/bench/java/lang/MathBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/MathBench.java
@@ -142,6 +142,11 @@ public class MathBench {
     }
 
     @Benchmark
+    public double  addCeilFloorDouble() {
+        return  Math.ceil(double4Dot1) + Math.floor(double4Dot1);
+    }
+
+    @Benchmark
     public double  copySignDouble() {
         return  Math.copySign(double81, doubleNegative12);
     }


### PR DESCRIPTION
The goal of this PR is to provide ~4x faster implementation of Math.ceil, Math.floor and Math.rint for x86_64 CPUs.

Below is the performance data on an Intel Tiger Lake machine. 

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/sparasa/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/sparasa/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl66
	{mso-number-format:0;
	border:.5pt solid windowtext;}
.xl67
	{mso-number-format:Fixed;
	border:.5pt solid windowtext;}
.xl68
	{vertical-align:middle;
	border:.5pt solid windowtext;}
-->

</head>

<body link="#0563C1" vlink="#954F72">


Benchmark   (UseAVX=3) | Stock JDK   (ops/ms) | This PR (ops/ms) | Speedup
-- | -- | -- | --
MathBench.ceilDouble | 547979 | 2170198 | 3.96
MathBench.floorDouble | 547979 | 2167459 | 3.96
MathBench.rintDouble | 547962 | 2130499 | 3.89
MathBench.addCeilFloorDouble | 501366 | 1754260 | 3.50



</body>

</html>

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/sparasa/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/sparasa/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl66
	{mso-number-format:0;
	border:.5pt solid windowtext;}
.xl67
	{mso-number-format:Fixed;
	border:.5pt solid windowtext;}
.xl68
	{vertical-align:middle;
	border:.5pt solid windowtext;}
-->

</head>

<body link="#0563C1" vlink="#954F72">


Benchmark   (UseAVX=0) | Stock JDK   (ops/ms) | This PR (ops/ms) | Speedup
-- | -- | -- | --
MathBench.ceilDouble | 548492 | 2193497 | 4.00
MathBench.floorDouble | 548485 | 2192813 | 4.00
MathBench.rintDouble | 548488 | 2192578 | 4.00
MathBench.addCeilFloorDouble | 501761 | 1644714 | 3.28



</body>

</html>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327147](https://bugs.openjdk.org/browse/JDK-8327147): Improve performance of Math ceil, floor, and rint for x86 (**Enhancement** - P4)


### Reviewers
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) ⚠️ Review applies to [0401e18e](https://git.openjdk.org/jdk/pull/18089/files/0401e18e380cbecc6a183f220d636406d363260f)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [0401e18e](https://git.openjdk.org/jdk/pull/18089/files/0401e18e380cbecc6a183f220d636406d363260f)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18089/head:pull/18089` \
`$ git checkout pull/18089`

Update a local copy of the PR: \
`$ git checkout pull/18089` \
`$ git pull https://git.openjdk.org/jdk.git pull/18089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18089`

View PR using the GUI difftool: \
`$ git pr show -t 18089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18089.diff">https://git.openjdk.org/jdk/pull/18089.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18089#issuecomment-1973777078)