### PR TITLE
8327152: NMT: use BitMap for committed memory regions in summary mode

### DIFF
--- a/test/hotspot/gtest/nmt/test_nmt_reserved_region.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_reserved_region.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023 SAP SE. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,10 @@
 
 // Tests the assignment operator of ReservedMemoryRegion
 TEST_VM(NMT, ReservedRegionCopy) {
+  if (MemTracker::tracking_level() != NMT_detail) {
+    tty->print_cr("skipped.");
+    return;
+  }
   address dummy1 = (address)0x10000000;
   NativeCallStack stack1(&dummy1, 1);
   ReservedMemoryRegion region1(dummy1, os::vm_page_size(), stack1, mtThreadStack);


### PR DESCRIPTION
In summary mode, we don't show/use the stack traces. So, it is possible to use `BitMap` for sub-regions of a reserved region. A bit is used for every page in the reserved region and is 1 when committed and 0 when uncommitted.
No need to handle split/merge/exclude and any other similar operations on sub-regions. We just set/clear the bits accordingly.

To find the actual amount of committed/uncommitted memory, we just count the 1 bits before the operation and adjust the request size appropriately. For example:
```
                                              1         2
Bit index:                          01234567890123456789012
Current state of a reserved region: 11111000000111110000111
commit sub-region [8,15):                   ^-----^       
already-committed = 4
actual-committed = (15 - 8) - 4 = 3
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327152](https://bugs.openjdk.org/browse/JDK-8327152): NMT: use BitMap for committed memory regions in summary mode (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18090/head:pull/18090` \
`$ git checkout pull/18090`

Update a local copy of the PR: \
`$ git checkout pull/18090` \
`$ git pull https://git.openjdk.org/jdk.git pull/18090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18090`

View PR using the GUI difftool: \
`$ git pr show -t 18090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18090.diff">https://git.openjdk.org/jdk/pull/18090.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18090#issuecomment-1978261676)