### PR TITLE
8280392: java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java failed with "RuntimeException: Test failed."

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -131,7 +131,6 @@ java/awt/Focus/ClearLwQueueBreakTest/ClearLwQueueBreakTest.java 8198618 macosx-a
 java/awt/Focus/ConsumeNextKeyTypedOnModalShowTest/ConsumeNextKeyTypedOnModalShowTest.java 6986252 macosx-all
 java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.java 8194753 linux-all,macosx-all
 java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java 7152980 macosx-all
-java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java 8280392 windows-x64
 java/awt/Focus/ToFrontFocusTest/ToFrontFocus.java 7156130 linux-all
 java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java 8169096 macosx-all
 java/awt/EventQueue/6980209/bug6980209.java 8198615 macosx-all

--- a/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
+++ b/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,20 +21,29 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug       6182359
-  @summary   Tests that Window having non-focusable owner can't be a focus owner.
-  @library   ../../regtesthelpers
-  @build     Util
-  @run       main NonfocusableOwnerTest
-*/
-
-import java.awt.*;
-import java.awt.event.*;
 import test.java.awt.regtesthelpers.Util;
 
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.WindowEvent;
+
+/*
+ ( @test
+ * @key headful
+ * @bug 6182359
+ * @summary Tests that Window having non-focusable owner can't be a focus owner.
+ * @library ../../regtesthelpers
+ * @build Util
+ * @run main NonfocusableOwnerTest
+ */
 public class NonfocusableOwnerTest {
     Robot robot = Util.createRobot();
     Frame frame;
@@ -55,7 +64,7 @@ public class NonfocusableOwnerTest {
                 }
             }, FocusEvent.FOCUS_EVENT_MASK | WindowEvent.WINDOW_FOCUS_EVENT_MASK | WindowEvent.WINDOW_EVENT_MASK);
 
-        frame = new Frame("Frame");
+        frame = new Frame("NonfocusableOwnerTest");
         frame.setName("Frame-owner");
         frame.setBounds(100, 0, 100, 100);
         dialog = new Dialog(frame, "Dialog");

--- a/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
+++ b/test/jdk/java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java
@@ -92,9 +92,11 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(false);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child.add(button);
         child.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child);
 
@@ -111,12 +113,15 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(false);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child1.setFocusableWindowState(true);
         child1.setVisible(true);
+        robot.waitForIdle();
 
         child2.add(button);
         child2.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child2);
 
@@ -134,13 +139,16 @@ public class NonfocusableOwnerTest {
 
         owner.setFocusableWindowState(true);
         owner.setVisible(true);
+        robot.waitForIdle();
 
         child1.setFocusableWindowState(false);
         child1.setVisible(true);
+        robot.waitForIdle();
 
         child2.setFocusableWindowState(true);
         child2.add(button);
         child2.setVisible(true);
+        robot.waitForIdle();
 
         Util.waitTillShown(child2);
 


### PR DESCRIPTION
Introduce delays in test to stabilize. Test passes 50x after fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280392](https://bugs.openjdk.org/browse/JDK-8280392): java/awt/Focus/NonFocusableWindowTest/NonfocusableOwnerTest.java failed with "RuntimeException: Test failed." (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [25008b78](https://git.openjdk.org/jdk/pull/18091/files/25008b78a923fa6ba8d2c44cbb683b606cae579e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18091/head:pull/18091` \
`$ git checkout pull/18091`

Update a local copy of the PR: \
`$ git checkout pull/18091` \
`$ git pull https://git.openjdk.org/jdk.git pull/18091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18091`

View PR using the GUI difftool: \
`$ git pr show -t 18091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18091.diff">https://git.openjdk.org/jdk/pull/18091.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18091#issuecomment-1974040289)