### PR TITLE
8327171: Fix more NULL usage backsliding

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -278,7 +278,7 @@ julong os::Aix::available_memory() {
 
 jlong os::total_swap_space() {
   perfstat_memory_total_t memory_info;
-  if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
+  if (libperfstat::perfstat_memory_total(nullptr, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
     return -1;
   }
   return (jlong)(memory_info.pgsp_total * 4 * K);
@@ -286,7 +286,7 @@ jlong os::total_swap_space() {
 
 jlong os::free_swap_space() {
   perfstat_memory_total_t memory_info;
-  if (libperfstat::perfstat_memory_total(NULL, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
+  if (libperfstat::perfstat_memory_total(nullptr, &memory_info, sizeof(perfstat_memory_total_t), 1) == -1) {
     return -1;
   }
   return (jlong)(memory_info.pgsp_free * 4 * K);

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -184,7 +184,7 @@ jlong os::total_swap_space() {
 #if defined(__APPLE__)
   struct xsw_usage vmusage;
   size_t size = sizeof(vmusage);
-  if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
+  if (sysctlbyname("vm.swapusage", &vmusage, &size, nullptr, 0) != 0) {
     return -1;
   }
   return (jlong)vmusage.xsu_total;
@@ -197,7 +197,7 @@ jlong os::free_swap_space() {
 #if defined(__APPLE__)
   struct xsw_usage vmusage;
   size_t size = sizeof(vmusage);
-  if (sysctlbyname("vm.swapusage", &vmusage, &size, NULL, 0) != 0) {
+  if (sysctlbyname("vm.swapusage", &vmusage, &size, nullptr, 0) != 0) {
     return -1;
   }
   return (jlong)vmusage.xsu_avail;

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -356,7 +356,7 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   const bool useThp = UseTransparentHugePages;
   UseTransparentHugePages = true;
   char* const heap = os::reserve_memory(size, false, mtInternal);
-  EXPECT_NE(heap, (char*)NULL);
+  EXPECT_NE(heap, nullptr);
   EXPECT_TRUE(os::commit_memory(heap, size, false));
 
   {


### PR DESCRIPTION
Please review this trivial change that replaces some recently introduced uses
of NULL with nullptr.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327171](https://bugs.openjdk.org/browse/JDK-8327171): Fix more NULL usage backsliding (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18096/head:pull/18096` \
`$ git checkout pull/18096`

Update a local copy of the PR: \
`$ git checkout pull/18096` \
`$ git pull https://git.openjdk.org/jdk.git pull/18096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18096`

View PR using the GUI difftool: \
`$ git pr show -t 18096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18096.diff">https://git.openjdk.org/jdk/pull/18096.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18096#issuecomment-1975027043)