### PR TITLE
8327125: SpinYield.report should report microseconds

### DIFF
--- a/src/hotspot/share/utilities/spinYield.cpp
+++ b/src/hotspot/share/utilities/spinYield.cpp
@@ -66,7 +66,7 @@ void SpinYield::report(outputStream* s) const {
   if (_sleep_time.value() != 0) { // Report sleep duration, if slept.
     separator = print_separator(s, separator);
     s->print("sleep = " UINT64_FORMAT " usecs",
-             _sleep_time.milliseconds());
+             _sleep_time.microseconds());
   }
   if (separator == initial_separator) {
     s->print("no waiting");


### PR DESCRIPTION
Changes to report microseconds instead of milliseconds.
GHA tested and also ran tier 2 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327125](https://bugs.openjdk.org/browse/JDK-8327125): SpinYield.report should report microseconds (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18099/head:pull/18099` \
`$ git checkout pull/18099`

Update a local copy of the PR: \
`$ git checkout pull/18099` \
`$ git pull https://git.openjdk.org/jdk.git pull/18099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18099`

View PR using the GUI difftool: \
`$ git pr show -t 18099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18099.diff">https://git.openjdk.org/jdk/pull/18099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18099#issuecomment-1975310908)