### PR TITLE
8327173: HotSpot Style Guide needs update regarding nullptr vs NULL

### DIFF
--- a/doc/hotspot-style.html
+++ b/doc/hotspot-style.html
@@ -748,12 +748,17 @@ cases where dynamic initialization or destruction are essential. See <a
 href="https://bugs.openjdk.org/browse/JDK-8282469">JDK-8282469</a> for
 further discussion.</p>
 <h3 id="nullptr">nullptr</h3>
-<p>Prefer <code>nullptr</code> (<a
+<p>Use <code>nullptr</code> (<a
 href="http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf">n2431</a>)
-to <code>NULL</code>. Don't use (constexpr or literal) 0 for
-pointers.</p>
-<p>For historical reasons there are widespread uses of both
-<code>NULL</code> and of integer 0 as a pointer value.</p>
+rather than <code>NULL</code>. Don't use (constant expression or
+literal) 0 for pointers.</p>
+<p>For historical reasons there may be some lingering uses of 0 as a
+pointer. These should be fixed when discovered.</p>
+<p>The C++11 definition of <em>null pointer constant</em> included
+integral constant expressions with value zero. C++14 replaced that with
+integer literals with value zero. Some compilers continue to treat a
+zero-valued integral constant expressions as a <em>null pointer
+constant</em> even in C++14 mode.</p>
 <h3 id="atomic">&lt;atomic&gt;</h3>
 <p>Do not use facilities provided by the <code>&lt;atomic&gt;</code>
 header (<a

--- a/doc/hotspot-style.md
+++ b/doc/hotspot-style.md
@@ -725,12 +725,17 @@ for further discussion.
 
 ### nullptr
 
-Prefer `nullptr`
+Use `nullptr`
 ([n2431](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2431.pdf))
-to `NULL`.  Don't use (constexpr or literal) 0 for pointers.
+rather than `NULL`.  Don't use (constant expression or literal) 0 for pointers.
 
-For historical reasons there are widespread uses of both `NULL` and of
-integer 0 as a pointer value.
+For historical reasons there may be some lingering uses of 0 as a pointer.
+These should be fixed when discovered.
+
+The C++11 definition of _null pointer constant_ included integral constant
+expressions with value zero.  C++14 replaced that with integer literals with
+value zero.  Some compilers continue to treat a zero-valued integral constant
+expressions as a _null pointer constant_ even in C++14 mode.
 
 ### &lt;atomic&gt;
 


### PR DESCRIPTION
Please review this change to update the HotSpot Style Guide's discussion of
nullptr and its use.

I suggest this is an editorial rather than substantive change to the style
guide.  As such, the normal HotSpot PR process can be used for this change.
