### PR TITLE
8327208: Remove unused method java.util.jar.Manifest.make72Safe

### DIFF
--- a/src/java.base/share/classes/java/util/jar/Manifest.java
+++ b/src/java.base/share/classes/java/util/jar/Manifest.java
@@ -220,22 +220,6 @@ public class Manifest implements Cloneable {
     }
 
     /**
-     * Adds line breaks to enforce a maximum of 72 bytes per line.
-     *
-     * @deprecation Replaced with {@link #println72}.
-     */
-    @Deprecated(since = "13")
-    static void make72Safe(StringBuffer line) {
-        int length = line.length();
-        int index = 72;
-        while (index < length) {
-            line.insert(index, "\r\n ");
-            index += 74; // + line width + line break ("\r\n")
-            length += 3; // + line break ("\r\n") and space
-        }
-    }
-
-    /**
      * Writes {@code line} to {@code out} with line breaks and continuation
      * spaces within the limits of 72 bytes of contents per line followed
      * by a line break.

--- a/test/jdk/java/util/jar/Manifest/LineBreakLineWidth.java
+++ b/test/jdk/java/util/jar/Manifest/LineBreakLineWidth.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/jar/Manifest/LineBreakLineWidth.java
+++ b/test/jdk/java/util/jar/Manifest/LineBreakLineWidth.java
@@ -26,6 +26,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.jar.Manifest;
 import java.util.jar.Attributes;
 import java.util.jar.Attributes.Name;
@@ -171,7 +172,7 @@ public class LineBreakLineWidth {
          * if the header name is 69 or 70 bytes and in that case the name/value
          * delimiter ": " was broken on a new line.
          *
-         * changing the line width in Manifest#make72Safe(StringBuffer),
+         * changing the line width in {@link Manifest#println72(OutputStream, String)},
          * however, also affects at which positions values are broken across
          * lines (should always have affected values only and never header
          * names or the delimiter) which is tested here.

--- a/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
@@ -22,12 +22,9 @@
  */
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.FilterOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -46,7 +43,6 @@ import java.util.zip.ZipFile;
 import java.util.zip.ZipEntry;
 import jdk.security.jarsigner.JarSigner;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.Platform;
 import jdk.test.lib.SecurityTools;
 import jdk.test.lib.util.JarUtils;
 import org.testng.annotations.BeforeTest;
@@ -467,14 +463,14 @@ public class PreserveRawManifestEntryAndDigest {
     }
 
     /**
-     * Breaks {@code line} at 70 bytes even though the name says 72 but when
-     * also counting the line delimiter ("{@code \r\n}") the line totals to 72
-     * bytes.
-     * Borrowed from {@link Manifest#make72Safe} before JDK 11
+     * Pre JDK 11, {@link Manifest#write(OutputStream)} would inject
+     * line breaks after 70 bytes instead of 72 bytes as mandated by
+     * the JAR File Specification.
      *
-     * @see Manifest#make72Safe
+     * This method injects line breaks after 70 bytes to simulate pre
+     * JDK 11 manifests.
      */
-    static void make72Safe(StringBuffer line) {
+    static void injectLineBreaksAt70Bytes(StringBuffer line) {
         int length = line.length();
         if (length > 72) {
             int index = 70;
@@ -516,7 +512,7 @@ public class PreserveRawManifestEntryAndDigest {
                     buf[0].append(line.substring(1));
                 } else {
                     if (buf[0] != null) {
-                        make72Safe(buf[0]);
+                        injectLineBreaksAt70Bytes(buf[0]);
                         sb.append(buf[0].toString());
                         sb.append("\r\n");
                     }
@@ -524,7 +520,7 @@ public class PreserveRawManifestEntryAndDigest {
                     buf[0].append(line);
                 }
             });
-            make72Safe(buf[0]);
+            injectLineBreaksAt70Bytes(buf[0]);
             sb.append(buf[0].toString());
             sb.append("\r\n");
             return sb.toString().getBytes(UTF_8);


### PR DESCRIPTION
Please review this cleanup PR which suggests we remove the package-private, unused and deprecated method `java.util.jar.Manifest.make72Safe`.

This method was marked deprecated after a cleanup/refactoring in [JDK-8066619](https://bugs.openjdk.org/browse/JDK-8066619) caused it to fall out of use. It should rather be removed.

Some tests reference the `make72Safe` methods in comment, or implement the legacy versions of the same logic to simulate pre JDK 11 line break behavior of `Manifest.write`. These comments and method names are adjusted to not reference the now removed method.

This change was initially discussed here: https://mail.openjdk.org/pipermail/core-libs-dev/2024-February/119819.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327208](https://bugs.openjdk.org/browse/JDK-8327208): Remove unused method java.util.jar.Manifest.make72Safe (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18104/head:pull/18104` \
`$ git checkout pull/18104`

Update a local copy of the PR: \
`$ git checkout pull/18104` \
`$ git pull https://git.openjdk.org/jdk.git pull/18104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18104`

View PR using the GUI difftool: \
`$ git pr show -t 18104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18104.diff">https://git.openjdk.org/jdk/pull/18104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18104#issuecomment-1976209663)