### PR TITLE
JDK-8322943: runtime/CompressedOops/CompressedClassPointers.java fails on AIX

### DIFF
--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -516,17 +516,15 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
 
   // The necessary attach point alignment for generated wish addresses.
   // This is needed to increase the chance of attaching for mmap and shmat.
-  const size_t os_attach_point_alignment =
-#ifdef AIX
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t os_attach_point_alignment =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+
   const size_t attach_point_alignment = lcm(alignment, os_attach_point_alignment);
 
   char *aligned_heap_base_min_address = (char *)align_up((void *)HeapBaseMinAddress, alignment);

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -517,8 +517,16 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
   // The necessary attach point alignment for generated wish addresses.
   // This is needed to increase the chance of attaching for mmap and shmat.
   const size_t os_attach_point_alignment =
-    AIX_ONLY(SIZE_256M)  // Known shm boundary alignment.
-    NOT_AIX(os::vm_allocation_granularity());
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
   const size_t attach_point_alignment = lcm(alignment, os_attach_point_alignment);
 
   char *aligned_heap_base_min_address = (char *)align_up((void *)HeapBaseMinAddress, alignment);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1892,17 +1892,15 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   char* const absolute_max = (char*)(NOT_LP64(G * 3) LP64_ONLY(G * 128 * 1024));
   char* const absolute_min = (char*) os::vm_min_address();
 
-  const size_t system_allocation_granularity =
-#ifdef AIX
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t system_allocation_granularity =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+
   const size_t alignment_adjusted = MAX2(alignment, system_allocation_granularity);
 
   // Calculate first and last possible attach points:

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1892,7 +1892,18 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   char* const absolute_max = (char*)(NOT_LP64(G * 3) LP64_ONLY(G * 128 * 1024));
   char* const absolute_min = (char*) os::vm_min_address();
 
-  const size_t alignment_adjusted = MAX2(alignment, os::vm_allocation_granularity());
+  const size_t system_allocation_granularity =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
+  const size_t alignment_adjusted = MAX2(alignment, system_allocation_granularity);
 
   // Calculate first and last possible attach points:
   char* const lo_att = align_up(MAX2(absolute_min, min), alignment_adjusted);

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -51,6 +51,17 @@ static void release_if_needed(char* p, size_t s) {
   }
 }
 
+// AIX is the only platform that uses System V shm for reserving virtual memory.
+// In this case, the required alignment of the allocated size (64K) and the alignment
+// of possible start points of the memory region (256M) differ.
+// This is not reflected by os_allocation_granularity().
+// The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+static size_t allocation_granularity() {
+  return
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+}
+
 #define ERRINFO "addr: " << ((void*)addr) << " min: " << ((void*)min) << " max: " << ((void*)max) \
                  << " bytes: " << bytes << " alignment: " << alignment << " randomized: " << randomized
 
@@ -58,15 +69,7 @@ static char* call_attempt_reserve_memory_between(char* min, char* max, size_t by
   char* const  addr = os::attempt_reserve_memory_between(min, max, bytes, alignment, randomized);
   if (addr != nullptr) {
     EXPECT_TRUE(is_aligned(addr, alignment)) << ERRINFO;
-
-    // AIX is the only platform that uses System V shm for reserving virtual memory.
-    // In this case, the required alignment of the allocated size (64K) and the alignment
-    // of possible start points of the memory region (256M) differ.
-    // This is not reflected by os_allocation_granularity().
-    // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-    AIX_ONLY(EXPECT_TRUE(is_aligned(addr, os::vm_page_size() == 4*K ? 4*K : 256*M)) << ERRINFO)
-    NOT_AIX(EXPECT_TRUE(is_aligned(addr, os::vm_allocation_granularity())) << ERRINFO);
-
+    EXPECT_TRUE(is_aligned(addr, allocation_granularity())) << ERRINFO;
     EXPECT_LE(addr, max - bytes) << ERRINFO;
     EXPECT_LE(addr, (char*)ARMB_constants::absolute_max - bytes) << ERRINFO;
     EXPECT_GE(addr, min) << ERRINFO;
@@ -182,14 +185,7 @@ public:
 // Test that, when reserving in a range randomly, we get random results
 static void test_attempt_reserve_memory_between_random_distribution(unsigned num_possible_attach_points) {
 
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-  const size_t ag =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
+  const size_t ag = allocation_granularity();
 
   // Create a space that is mostly a hole bordered by two small stripes of reserved memory, with
   // as many attach points as we need.
@@ -268,15 +264,7 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 
   constexpr int threshold = ARMB_constants::min_random_value_range;
   const size_t ps = os::vm_page_size();
-
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-  const size_t ag =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
+  const size_t ag = allocation_granularity();
 
   SpaceWithHole space(ag * (threshold + 2), ag, ag * threshold);
   if (!space.reserve()) {
@@ -294,22 +282,12 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 // Test all possible combos
 TEST_VM(os, attempt_reserve_memory_between_combos) {
   const size_t large_end = NOT_LP64(G) LP64_ONLY(64 * G);
-
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-  const size_t system_allocation_granularity =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
-
-  for (size_t range_size = system_allocation_granularity; range_size <= large_end; range_size *= 2) {
+  for (size_t range_size = allocation_granularity(); range_size <= large_end; range_size *= 2) {
     for (size_t start_offset = 0; start_offset <= large_end; start_offset += (large_end / 2)) {
       char* const min = (char*)(uintptr_t)start_offset;
       char* const max = min + range_size;
       for (size_t bytes = os::vm_page_size(); bytes < large_end; bytes *= 2) {
-        for (size_t alignment = system_allocation_granularity; alignment < large_end; alignment *= 2) {
+        for (size_t alignment = allocation_granularity(); alignment < large_end; alignment *= 2) {
           test_attempt_reserve_memory_between(min, max, bytes, alignment, true, Expect::dontcare(), __LINE__);
           test_attempt_reserve_memory_between(min, max, bytes, alignment, false, Expect::dontcare(), __LINE__);
         }
@@ -320,16 +298,7 @@ TEST_VM(os, attempt_reserve_memory_between_combos) {
 
 TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
   const size_t ps = os::vm_page_size();
-
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-  const size_t ag =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
-
+  const size_t ag = allocation_granularity();
   constexpr size_t quarter_address_space = NOT_LP64(nth_bit(30)) LP64_ONLY(nth_bit(62));
 
   // Zero-sized range
@@ -369,16 +338,7 @@ TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
 // as long as the range size is smaller than the number of probe attempts
 TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
   const size_t ps = os::vm_page_size();
-
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-  const size_t ag =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
-
+  const size_t ag = allocation_granularity();
   constexpr int num = ARMB_constants::max_attempts;
   for (int i = 0; i < num; i ++) {
     SpaceWithHole space(ag * (num + 2), ag * (i + 1), ag);

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -58,16 +58,15 @@ static char* call_attempt_reserve_memory_between(char* min, char* max, size_t by
   char* const  addr = os::attempt_reserve_memory_between(min, max, bytes, alignment, randomized);
   if (addr != nullptr) {
     EXPECT_TRUE(is_aligned(addr, alignment)) << ERRINFO;
-#ifdef AIX
-  // AIX is the only platform that uses System V shm for reserving virtual memory.
-  // In this case, the required alignment of the allocated size (64K) and the alignment
-  // of possible start points of the memory region (256M) differ.
-  // This is not reflected by os_allocation_granularity().
-  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      EXPECT_TRUE(is_aligned(addr, os::vm_page_size() == 4*K ? 4*K : 256*M)) << ERRINFO;
-#else
-      EXPECT_TRUE(is_aligned(addr, os::vm_allocation_granularity())) << ERRINFO;
-#endif
+
+    // AIX is the only platform that uses System V shm for reserving virtual memory.
+    // In this case, the required alignment of the allocated size (64K) and the alignment
+    // of possible start points of the memory region (256M) differ.
+    // This is not reflected by os_allocation_granularity().
+    // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+    AIX_ONLY(EXPECT_TRUE(is_aligned(addr, os::vm_page_size() == 4*K ? 4*K : 256*M)) << ERRINFO)
+    NOT_AIX(EXPECT_TRUE(is_aligned(addr, os::vm_allocation_granularity())) << ERRINFO);
+
     EXPECT_LE(addr, max - bytes) << ERRINFO;
     EXPECT_LE(addr, (char*)ARMB_constants::absolute_max - bytes) << ERRINFO;
     EXPECT_GE(addr, min) << ERRINFO;
@@ -183,17 +182,14 @@ public:
 // Test that, when reserving in a range randomly, we get random results
 static void test_attempt_reserve_memory_between_random_distribution(unsigned num_possible_attach_points) {
 
-  const size_t ag =
-#ifdef AIX
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t ag =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
 
   // Create a space that is mostly a hole bordered by two small stripes of reserved memory, with
   // as many attach points as we need.
@@ -272,17 +268,15 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 
   constexpr int threshold = ARMB_constants::min_random_value_range;
   const size_t ps = os::vm_page_size();
-  const size_t ag =
-#ifdef AIX
+
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t ag =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
 
   SpaceWithHole space(ag * (threshold + 2), ag, ag * threshold);
   if (!space.reserve()) {
@@ -300,17 +294,16 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 // Test all possible combos
 TEST_VM(os, attempt_reserve_memory_between_combos) {
   const size_t large_end = NOT_LP64(G) LP64_ONLY(64 * G);
-  const size_t system_allocation_granularity =
-#ifdef AIX
+
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t system_allocation_granularity =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+
   for (size_t range_size = system_allocation_granularity; range_size <= large_end; range_size *= 2) {
     for (size_t start_offset = 0; start_offset <= large_end; start_offset += (large_end / 2)) {
       char* const min = (char*)(uintptr_t)start_offset;
@@ -327,17 +320,16 @@ TEST_VM(os, attempt_reserve_memory_between_combos) {
 
 TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
   const size_t ps = os::vm_page_size();
-  const size_t ag =
-#ifdef AIX
+
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t ag =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+
   constexpr size_t quarter_address_space = NOT_LP64(nth_bit(30)) LP64_ONLY(nth_bit(62));
 
   // Zero-sized range
@@ -377,17 +369,16 @@ TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
 // as long as the range size is smaller than the number of probe attempts
 TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
   const size_t ps = os::vm_page_size();
-  const size_t ag =
-#ifdef AIX
+
   // AIX is the only platform that uses System V shm for reserving virtual memory.
   // In this case, the required alignment of the allocated size (64K) and the alignment
   // of possible start points of the memory region (256M) differ.
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
-      os::vm_page_size() == 4*K ? 4*K : 256*M;
-#else
-      os::vm_allocation_granularity();
-#endif
+  const size_t ag =
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    NOT_AIX(os::vm_allocation_granularity());
+
   constexpr int num = ARMB_constants::max_attempts;
   for (int i = 0; i < num; i ++) {
     SpaceWithHole space(ag * (num + 2), ag * (i + 1), ag);

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -35,10 +35,6 @@
 #include "testutils.hpp"
 #include "unittest.hpp"
 
-// On AIX, these tests make no sense as long as JDK-8315321 remains unfixed since the attach
-// addresses are not predictable.
-#ifndef AIX
-
 // Must be the same as in os::attempt_reserve_memory_between()
 struct ARMB_constants {
   static constexpr uintptr_t absolute_max = NOT_LP64(G * 3) LP64_ONLY(G * 128 * 1024);
@@ -62,7 +58,16 @@ static char* call_attempt_reserve_memory_between(char* min, char* max, size_t by
   char* const  addr = os::attempt_reserve_memory_between(min, max, bytes, alignment, randomized);
   if (addr != nullptr) {
     EXPECT_TRUE(is_aligned(addr, alignment)) << ERRINFO;
-    EXPECT_TRUE(is_aligned(addr, os::vm_allocation_granularity())) << ERRINFO;
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      EXPECT_TRUE(is_aligned(addr, os::vm_page_size() == 4*K ? 4*K : 256*M)) << ERRINFO;
+#else
+      EXPECT_TRUE(is_aligned(addr, os::vm_allocation_granularity())) << ERRINFO;
+#endif
     EXPECT_LE(addr, max - bytes) << ERRINFO;
     EXPECT_LE(addr, (char*)ARMB_constants::absolute_max - bytes) << ERRINFO;
     EXPECT_GE(addr, min) << ERRINFO;
@@ -178,7 +183,17 @@ public:
 // Test that, when reserving in a range randomly, we get random results
 static void test_attempt_reserve_memory_between_random_distribution(unsigned num_possible_attach_points) {
 
-  const size_t ag = os::vm_allocation_granularity();
+  const size_t ag =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
 
   // Create a space that is mostly a hole bordered by two small stripes of reserved memory, with
   // as many attach points as we need.
@@ -257,7 +272,17 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 
   constexpr int threshold = ARMB_constants::min_random_value_range;
   const size_t ps = os::vm_page_size();
-  const size_t ag = os::vm_allocation_granularity();
+  const size_t ag =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
 
   SpaceWithHole space(ag * (threshold + 2), ag, ag * threshold);
   if (!space.reserve()) {
@@ -275,12 +300,23 @@ TEST_VM(os, attempt_reserve_memory_randomization_threshold) {
 // Test all possible combos
 TEST_VM(os, attempt_reserve_memory_between_combos) {
   const size_t large_end = NOT_LP64(G) LP64_ONLY(64 * G);
-  for (size_t range_size = os::vm_allocation_granularity(); range_size <= large_end; range_size *= 2) {
+  const size_t system_allocation_granularity =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
+  for (size_t range_size = system_allocation_granularity; range_size <= large_end; range_size *= 2) {
     for (size_t start_offset = 0; start_offset <= large_end; start_offset += (large_end / 2)) {
       char* const min = (char*)(uintptr_t)start_offset;
       char* const max = min + range_size;
       for (size_t bytes = os::vm_page_size(); bytes < large_end; bytes *= 2) {
-        for (size_t alignment = os::vm_allocation_granularity(); alignment < large_end; alignment *= 2) {
+        for (size_t alignment = system_allocation_granularity; alignment < large_end; alignment *= 2) {
           test_attempt_reserve_memory_between(min, max, bytes, alignment, true, Expect::dontcare(), __LINE__);
           test_attempt_reserve_memory_between(min, max, bytes, alignment, false, Expect::dontcare(), __LINE__);
         }
@@ -291,7 +327,17 @@ TEST_VM(os, attempt_reserve_memory_between_combos) {
 
 TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
   const size_t ps = os::vm_page_size();
-  const size_t ag = os::vm_allocation_granularity();
+  const size_t ag =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
   constexpr size_t quarter_address_space = NOT_LP64(nth_bit(30)) LP64_ONLY(nth_bit(62));
 
   // Zero-sized range
@@ -331,7 +377,17 @@ TEST_VM(os, attempt_reserve_memory_randomization_cornercases) {
 // as long as the range size is smaller than the number of probe attempts
 TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
   const size_t ps = os::vm_page_size();
-  const size_t ag = os::vm_allocation_granularity();
+  const size_t ag =
+#ifdef AIX
+  // AIX is the only platform that uses System V shm for reserving virtual memory.
+  // In this case, the required alignment of the allocated size (64K) and the alignment
+  // of possible start points of the memory region (256M) differ.
+  // This is not reflected by os_allocation_granularity().
+  // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
+      os::vm_page_size() == 4*K ? 4*K : 256*M;
+#else
+      os::vm_allocation_granularity();
+#endif
   constexpr int num = ARMB_constants::max_attempts;
   for (int i = 0; i < num; i ++) {
     SpaceWithHole space(ag * (num + 2), ag * (i + 1), ag);
@@ -342,5 +398,3 @@ TEST_VM(os, attempt_reserve_memory_between_small_range_fill_hole) {
     }
   }
 }
-
-#endif // AIX

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -107,7 +107,6 @@ runtime/os/TestTracePageSizes.java#G1 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
-runtime/CompressedOops/CompressedClassPointers.java 8322943 aix-ppc64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le


### PR DESCRIPTION
Even after recent fixes like
https://bugs.openjdk.org/browse/JDK-8305765
the test runtime/CompressedOops/CompressedClassPointers.java fails on AIX.

This error results from the fact, that on AIX the shmat() allocation granularity is 256MB instead of the standard Pagesize (4KB or 64KB).

Because my first proposal (PR 17708) of introducing a new method os::vm_shm_allocation_granularity() in the shared hotspot code was rejected I now encapsulate the difference in ifdef AIX brackets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322943](https://bugs.openjdk.org/browse/JDK-8322943): runtime/CompressedOops/CompressedClassPointers.java fails on AIX (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [0aa55745](https://git.openjdk.org/jdk/pull/18105/files/0aa55745a0323ccad9141eacb0bd3b5cc9d7ed2c)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18105/head:pull/18105` \
`$ git checkout pull/18105`

Update a local copy of the PR: \
`$ git checkout pull/18105` \
`$ git pull https://git.openjdk.org/jdk.git pull/18105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18105`

View PR using the GUI difftool: \
`$ git pr show -t 18105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18105.diff">https://git.openjdk.org/jdk/pull/18105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18105#issuecomment-1976238932)