### PR TITLE
8327218: Add an ability to specify modules which should have native access enabled

### DIFF
--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -91,3 +91,6 @@ PLATFORM_MODULES= \
 PLATFORM_MODULES_windows= \
     jdk.crypto.mscapi \
     #
+
+NATIVE_ACCESS_MODULES= \
+    jdk.internal.le

--- a/make/conf/module-loader-map.conf
+++ b/make/conf/module-loader-map.conf
@@ -93,4 +93,48 @@ PLATFORM_MODULES_windows= \
     #
 
 NATIVE_ACCESS_MODULES= \
-    jdk.internal.le
+    java.base \
+    java.datatransfer \
+    java.desktop \
+    java.instrument \
+    java.logging \
+    java.management \
+    java.management.rmi \
+    java.naming \
+    java.net.http \
+    java.prefs \
+    java.rmi \
+    java.scripting \
+    java.se \
+    java.security.jgss \
+    java.security.sasl \
+    java.smartcardio \
+    java.sql \
+    java.sql.rowset \
+    java.transaction.xa \
+    java.xml \
+    java.xml.crypto \
+    jdk.accessibility \
+    jdk.charsets \
+    jdk.crypto.cryptoki \
+    jdk.dynalink \
+    jdk.httpserver \
+    jdk.incubator.vector \
+    jdk.internal.vm.ci \
+    jdk.jfr \
+    jdk.jsobject \
+    jdk.localedata \
+    jdk.management \
+    jdk.management.agent \
+    jdk.management.jfr \
+    jdk.naming.dns \
+    jdk.naming.rmi \
+    jdk.net \
+    jdk.nio.mapmode \
+    jdk.sctp \
+    jdk.security.auth \
+    jdk.security.jgss \
+    jdk.unsupported \
+    jdk.xml.dom \
+    jdk.zipfs \
+    #

--- a/make/jdk/src/classes/build/tools/module/GenModuleLoaderMap.java
+++ b/make/jdk/src/classes/build/tools/module/GenModuleLoaderMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/module/GenModuleLoaderMap.java
+++ b/make/jdk/src/classes/build/tools/module/GenModuleLoaderMap.java
@@ -48,6 +48,7 @@ public class GenModuleLoaderMap {
         // default set of boot modules and ext modules
         Stream<String> bootModules = Stream.empty();
         Stream<String> platformModules = Stream.empty();
+        Stream<String> nativeAccessModules = Stream.empty();
         Path outfile = null;
         Path source = null;
         for (int i=0; i < args.length; i++) {
@@ -60,6 +61,9 @@ public class GenModuleLoaderMap {
                 } else if (option.equals("-platform")) {
                     String[] mns = arg.split(",");
                     platformModules = Stream.concat(platformModules, Arrays.stream(mns));
+                } else if (option.equals("-native-access")) {
+                    String[] mns = arg.split(",");
+                    nativeAccessModules = Stream.concat(nativeAccessModules, Arrays.stream(mns));
                 } else if (option.equals("-o")) {
                     outfile = Paths.get(arg);
                 } else {
@@ -84,6 +88,8 @@ public class GenModuleLoaderMap {
                     line = patch(line, "@@BOOT_MODULE_NAMES@@", bootModules);
                 } else if (line.contains("@@PLATFORM_MODULE_NAMES@@")) {
                     line = patch(line, "@@PLATFORM_MODULE_NAMES@@", platformModules);
+                } else if (line.contains("@@NATIVE_ACCESS_MODULE_NAMES@@")) {
+                    line = patch(line, "@@NATIVE_ACCESS_MODULE_NAMES@@", nativeAccessModules);
                 }
                 writer.println(line);
             }

--- a/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
+++ b/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
+++ b/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
@@ -39,7 +39,7 @@ BOOT_MODULES_LIST := $(call SubstComma, $(BOOT_MODULES))
 PLATFORM_MODULES_LIST := $(call SubstComma, $(PLATFORM_MODULES))
 NATIVE_ACCESS_MODULES_LIST := $(call SubstComma, $(NATIVE_ACCESS_MODULES))
 
-VARDEPS_VALUE := $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST) $(JDK_MODULES_LIST)
+VARDEPS_VALUE := $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST) $(NATIVE_ACCESS_MODULES_LIST)
 VARDEPS_FILE := $(call DependOnVariable, VARDEPS_VALUE)
 
 ############################################################################
@@ -51,7 +51,7 @@ $(SUPPORT_OUTPUTDIR)/gensrc/java.base/jdk/internal/module/ModuleLoaderMap.java: 
 	$(RM) $@ $@.tmp
 	$(TOOL_GENCLASSLOADERMAP) -boot $(BOOT_MODULES_LIST) \
 	     -platform $(PLATFORM_MODULES_LIST) \
-	     -native-access $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST) $(NATIVE_ACCESS_MODULES_LIST) \
+	     -native-access $(NATIVE_ACCESS_MODULES_LIST) \
 	     -o $@.tmp $<
 	$(MV) $@.tmp $@
 

--- a/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
+++ b/make/modules/java.base/gensrc/GensrcModuleLoaderMap.gmk
@@ -37,8 +37,9 @@ $(strip \
 endef
 BOOT_MODULES_LIST := $(call SubstComma, $(BOOT_MODULES))
 PLATFORM_MODULES_LIST := $(call SubstComma, $(PLATFORM_MODULES))
+NATIVE_ACCESS_MODULES_LIST := $(call SubstComma, $(NATIVE_ACCESS_MODULES))
 
-VARDEPS_VALUE := $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST)
+VARDEPS_VALUE := $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST) $(JDK_MODULES_LIST)
 VARDEPS_FILE := $(call DependOnVariable, VARDEPS_VALUE)
 
 ############################################################################
@@ -49,7 +50,9 @@ $(SUPPORT_OUTPUTDIR)/gensrc/java.base/jdk/internal/module/ModuleLoaderMap.java: 
 	$(call MakeTargetDir)
 	$(RM) $@ $@.tmp
 	$(TOOL_GENCLASSLOADERMAP) -boot $(BOOT_MODULES_LIST) \
-	     -platform $(PLATFORM_MODULES_LIST) -o $@.tmp $<
+	     -platform $(PLATFORM_MODULES_LIST) \
+	     -native-access $(BOOT_MODULES_LIST) $(PLATFORM_MODULES_LIST) $(NATIVE_ACCESS_MODULES_LIST) \
+	     -o $@.tmp $<
 	$(MV) $@.tmp $@
 
 TARGETS += $(SUPPORT_OUTPUTDIR)/gensrc/java.base/jdk/internal/module/ModuleLoaderMap.java

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -143,10 +143,6 @@ public final class Module implements AnnotatedElement {
         String loc = Objects.toString(uri, null);
         Object[] packages = descriptor.packages().toArray();
         defineModule0(this, isOpen, vs, loc, packages);
-        if (loader == null || loader == ClassLoaders.platformClassLoader()) {
-            // boot/builtin modules are always native
-            implAddEnableNativeAccess();
-        }
     }
 
 

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -882,18 +882,21 @@ public final class ModuleLayer {
     }
 
     /**
-     * Returns the module with the given name in this later only.
+     * Update module named {@code name} to allow access to restricted methods.
      *
-     * @param  name
-     *         The name of the module to find
-     *
-     * @return The module with the given name or {@code null}
-     *         if there isn't a module with this name in this layer
+     * @param name the name of the module for which the native access should be enabled
+     * @return {@code true} iff the module was present in this layer,
+     *         {@code false} otherwise
      */
-    Module findModuleInThisLayer(String name) {
-        return nameToModule.get(name);
+    boolean addEnableNativeAccess(String name) {
+        Module m = nameToModule.get(name);
+        if (m != null) {
+            m.implAddEnableNativeAccess();
+            return true;
+        } else {
+            return false;
+        }
     }
-
 
     /**
      * Returns the {@code ClassLoader} for the module with the given name. If

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -882,10 +882,12 @@ public final class ModuleLayer {
     }
 
     /**
-     * Update module named {@code name} to allow access to restricted methods.
+     * Updates the module with the given {@code name} in this layer
+     * to allow access to restricted methods.
      *
-     * @param name the name of the module for which the native access should be enabled
-     * @return {@code true} iff the module was present in this layer,
+     * @param name the name of the module for which the native access
+     *             should be enabled
+     * @return {@code true} iff the module is present in this layer,
      *         {@code false} otherwise
      */
     boolean addEnableNativeAccess(String name) {

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -881,6 +881,19 @@ public final class ModuleLayer {
                 .findAny();
     }
 
+    /**
+     * Returns the module with the given name in this later only.
+     *
+     * @param  name
+     *         The name of the module to find
+     *
+     * @return The module with the given name or {@code null}
+     *         if there isn't a module with this name in this layer
+     */
+    Module findModuleInThisLayer(String name) {
+        return nameToModule.get(name);
+    }
+
 
     /**
      * Returns the {@code ClassLoader} for the module with the given name. If

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2460,13 +2460,7 @@ public final class System {
                 return m.implAddEnableNativeAccess();
             }
             public boolean addEnableNativeAccess(ModuleLayer layer, String name) {
-                Module m = layer.findModuleInThisLayer(name);
-                if (m != null) {
-                    m.implAddEnableNativeAccess();
-                    return true;
-                } else {
-                    return false;
-                }
+                return layer.addEnableNativeAccess(name);
             }
             public void addEnableNativeAccessToAllUnnamed() {
                 Module.implAddEnableNativeAccessToAllUnnamed();

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2459,6 +2459,15 @@ public final class System {
             public Module addEnableNativeAccess(Module m) {
                 return m.implAddEnableNativeAccess();
             }
+            public boolean addEnableNativeAccess(ModuleLayer layer, String name) {
+                Module m = layer.findModuleInThisLayer(name);
+                if (m != null) {
+                    m.implAddEnableNativeAccess();
+                    return true;
+                } else {
+                    return false;
+                }
+            }
             public void addEnableNativeAccessToAllUnnamed() {
                 Module.implAddEnableNativeAccessToAllUnnamed();
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -270,6 +270,12 @@ public interface JavaLangAccess {
     Module addEnableNativeAccess(Module m);
 
     /**
+     * Updates module named name in layer layer to allow access to restricted methods.
+     * Returns true iff the given module exists in the given layer.
+     */
+    boolean addEnableNativeAccess(ModuleLayer layer, String name);
+
+    /**
      * Updates all unnamed modules to allow access to restricted methods.
      */
     void addEnableNativeAccessToAllUnnamed();

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -802,14 +802,18 @@ public final class ModuleBootstrap {
     }
 
     /**
-     * Process the --enable-native-access option to grant access to restricted methods to selected modules.
-     * Also add Enable native access from JDK modules.
+     * Grants native access to modules selected using the --enable-native-access
+     * command line option, and also to JDK modules that need the access.
      */
     private static void addEnableNativeAccess(ModuleLayer layer) {
         addEnableNativeAccess(layer, USER_NATIVE_ACCESS_MODULES, true);
         addEnableNativeAccess(layer, JDK_NATIVE_ACCESS_MODULES, false);
     }
 
+    /**
+     * Grants native access for the given modules in the given layer.
+     * Warns optionally about modules that were specified, but not present in the layer.
+     */
     private static void addEnableNativeAccess(ModuleLayer layer, Set<String> moduleNames, boolean shouldWarn) {
         for (String name : moduleNames) {
             if (name.equals("ALL-UNNAMED")) {

--- a/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleBootstrap.java
@@ -788,31 +788,34 @@ public final class ModuleBootstrap {
     }
 
     private static final boolean HAS_ENABLE_NATIVE_ACCESS_FLAG;
-    private static final Set<String> NATIVE_ACCESS_MODULES;
+    private static final Set<String> USER_NATIVE_ACCESS_MODULES;
+    private static final Set<String> JDK_NATIVE_ACCESS_MODULES;
 
     public static boolean hasEnableNativeAccessFlag() {
         return HAS_ENABLE_NATIVE_ACCESS_FLAG;
     }
 
     static {
-        NATIVE_ACCESS_MODULES = decodeEnableNativeAccess();
-        HAS_ENABLE_NATIVE_ACCESS_FLAG = !NATIVE_ACCESS_MODULES.isEmpty();
+        USER_NATIVE_ACCESS_MODULES = decodeEnableNativeAccess();
+        HAS_ENABLE_NATIVE_ACCESS_FLAG = !USER_NATIVE_ACCESS_MODULES.isEmpty();
+        JDK_NATIVE_ACCESS_MODULES = ModuleLoaderMap.nativeAccessModules();
     }
 
     /**
      * Process the --enable-native-access option to grant access to restricted methods to selected modules.
+     * Also add Enable native access from JDK modules.
      */
     private static void addEnableNativeAccess(ModuleLayer layer) {
-        for (String name : NATIVE_ACCESS_MODULES) {
+        addEnableNativeAccess(layer, USER_NATIVE_ACCESS_MODULES, true);
+        addEnableNativeAccess(layer, JDK_NATIVE_ACCESS_MODULES, false);
+    }
+
+    private static void addEnableNativeAccess(ModuleLayer layer, Set<String> moduleNames, boolean shouldWarn) {
+        for (String name : moduleNames) {
             if (name.equals("ALL-UNNAMED")) {
                 JLA.addEnableNativeAccessToAllUnnamed();
-            } else {
-                Optional<Module> module = layer.findModule(name);
-                if (module.isPresent()) {
-                    JLA.addEnableNativeAccess(module.get());
-                } else {
-                    warnUnknownModule(ENABLE_NATIVE_ACCESS, name);
-                }
+            } else if (!JLA.addEnableNativeAccess(layer, name) && shouldWarn) {
+                warnUnknownModule(ENABLE_NATIVE_ACCESS, name);
             }
         }
     }

--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -110,6 +110,13 @@ public final class ModuleLoaderMap {
         return Modules.platformModules;
     }
 
+    /**
+     * Returns the names of the modules defined to the application loader which perform native access.
+     */
+    public static Set<String> nativeAccessModules() {
+        return Modules.nativeAccessModules;
+    }
+
     private static class Modules {
         // list of boot modules is generated at build time.
         private static final Set<String> bootModules =
@@ -118,6 +125,10 @@ public final class ModuleLoaderMap {
         // list of platform modules is generated at build time.
         private static final Set<String> platformModules =
                 Set.of(new String[] { "@@PLATFORM_MODULE_NAMES@@" });
+
+        // list of jdk modules is generated at build time.
+        private static final Set<String> nativeAccessModules =
+                Set.of(new String[] { "@@NATIVE_ACCESS_MODULE_NAMES@@" });
     }
 
     /**

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -639,7 +640,8 @@ public final class PassFailJFrame {
             long hours = leftTime / 3_600_000;
             long minutes = (leftTime - hours * 3_600_000) / 60_000;
             long seconds = (leftTime - hours * 3_600_000 - minutes * 60_000) / 1_000;
-            label.setText(String.format("Test timeout: %02d:%02d:%02d",
+            label.setText(String.format(Locale.ENGLISH,
+                                        "Test timeout: %02d:%02d:%02d",
                                         hours, minutes, seconds));
         }
 


### PR DESCRIPTION
Currently, JDK modules load by the bootstrap and platform ClassLoaders are automatically granted the native access. I am working on an upgrade of JLine inside the `jdk.internal.le` module, and I would like to replace the current native bindings with FFM-based bindings (which are now somewhat provided by JLine). But, for that, native access is needed for the `jdk.internal.le` module. We could possibly move the module to the platform ClassLoader, but it seems it might be better to have more control over which modules have the native access.

This patch introduces an explicit list of modules that will automatically be granted the native access. Note this patch is not yet intended to change the end behavior - the list of modules granted native access is supposed to be the same as modules in the boot and platform ClassLoaders.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327218](https://bugs.openjdk.org/browse/JDK-8327218): Add an ability to specify modules which should have native access enabled (**Task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [e30e4529](https://git.openjdk.org/jdk/pull/18106/files/e30e452944b5ed57f4c4411ec22f4220ba6f89e0)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [924e1aa0](https://git.openjdk.org/jdk/pull/18106/files/924e1aa010865dca427d769bfbe645ca61e18a4d)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) ⚠️ Review applies to [6127044d](https://git.openjdk.org/jdk/pull/18106/files/6127044dc8bce69e7e580903a32859d6b4acf7ab)


### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18106/head:pull/18106` \
`$ git checkout pull/18106`

Update a local copy of the PR: \
`$ git checkout pull/18106` \
`$ git pull https://git.openjdk.org/jdk.git pull/18106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18106`

View PR using the GUI difftool: \
`$ git pr show -t 18106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18106.diff">https://git.openjdk.org/jdk/pull/18106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18106#issuecomment-1976636232)