### PR TITLE
8327225: Revert DataInputStream.readUTF to static final

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -571,7 +571,7 @@ loop:   while (true) {
      *               valid modified UTF-8 encoding of a Unicode string.
      * @see        java.io.DataInputStream#readUnsignedShort()
      */
-    public static String readUTF(DataInput in) throws IOException {
+    public static final String readUTF(DataInput in) throws IOException {
         int utflen = in.readUnsignedShort();
         byte[] bytearr;
         char[] chararr;


### PR DESCRIPTION
[JDK-8325340](https://bugs.openjdk.org/browse/JDK-8325340) accidentally removed `final` from the `static final DataInputStream.readUTF` method. This has a minor compatibility impact (allows hiding the method in a subclass, while before that would throw an exception at compile time) and since it was not the intent of the prior change to alter any behavioral semantics here I want to revert that change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327225](https://bugs.openjdk.org/browse/JDK-8327225): Revert DataInputStream.readUTF to static final (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18107/head:pull/18107` \
`$ git checkout pull/18107`

Update a local copy of the PR: \
`$ git checkout pull/18107` \
`$ git pull https://git.openjdk.org/jdk.git pull/18107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18107`

View PR using the GUI difftool: \
`$ git pr show -t 18107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18107.diff">https://git.openjdk.org/jdk/pull/18107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18107#issuecomment-1976643597)