### PR TITLE
8327224: G1: comment in G1BarrierSetC2::post_barrier() refers to nonexistent new_deferred_store_barrier()

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -389,7 +389,7 @@ void G1BarrierSetC2::post_barrier(GraphKit* kit,
 
   if (use_ReduceInitialCardMarks() && obj == kit->just_allocated_object(kit->control())) {
     // We can skip marks on a freshly-allocated object in Eden.
-    // Keep this code in sync with new_deferred_store_barrier() in runtime.cpp.
+    // Keep this code in sync with CardTableBarrierSet::on_slowpath_allocation_exit.
     // That routine informs GC to take appropriate compensating steps,
     // upon a slow-path allocation, so as to make this card-mark
     // elision safe.


### PR DESCRIPTION
This changeset updates a comment in `G1BarrierSetC2::post_barrier()` to point to the relevant code that must be kept in sync.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327224](https://bugs.openjdk.org/browse/JDK-8327224): G1: comment in G1BarrierSetC2::post_barrier() refers to nonexistent new_deferred_store_barrier() (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18108/head:pull/18108` \
`$ git checkout pull/18108`

Update a local copy of the PR: \
`$ git checkout pull/18108` \
`$ git pull https://git.openjdk.org/jdk.git pull/18108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18108`

View PR using the GUI difftool: \
`$ git pr show -t 18108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18108.diff">https://git.openjdk.org/jdk/pull/18108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18108#issuecomment-1976828235)