### PR TITLE
8327237: Remove unused PSAdaptiveSizePolicyResizeVirtualSpaceAlot develop flag

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -345,10 +345,6 @@
   product(bool, UseAdaptiveSizePolicyWithSystemGC, false,                   \
           "Include statistics from System.gc() for adaptive size policy")   \
                                                                             \
-  develop(intx, PSAdaptiveSizePolicyResizeVirtualSpaceAlot, -1,             \
-          "Resize the virtual spaces of the young or old generations")      \
-          range(-1, 1)                                                      \
-                                                                            \
   product(uint, AdaptiveSizeThroughPutPolicy, 0,                            \
           "Policy for changing generation size for throughput goals")       \
           range(0, 1)                                                       \


### PR DESCRIPTION
Hi all,

  please review this trivial change to remove the unused debug flag PSAdaptiveSizePolicyResizeVirtualSpaceAlot.

Thanks,
   Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Error
&nbsp;⚠️ This PR only contains changes already present in the target

### Issue
 * [JDK-8327237](https://bugs.openjdk.org/browse/JDK-8327237): Remove unused PSAdaptiveSizePolicyResizeVirtualSpaceAlot develop flag (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18110/head:pull/18110` \
`$ git checkout pull/18110`

Update a local copy of the PR: \
`$ git checkout pull/18110` \
`$ git pull https://git.openjdk.org/jdk.git pull/18110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18110`

View PR using the GUI difftool: \
`$ git pr show -t 18110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18110.diff">https://git.openjdk.org/jdk/pull/18110.diff</a>

</details>
