### PR TITLE
8325179: Race in BasicDirectoryModel.validateFileCache

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -102,6 +102,8 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
             if (filesLoader != null) {
                 filesLoader.loadThread.interrupt();
                 filesLoader = null;
+                // Increment fetch ID to invalidate pending DoChangeContents
+                fetchID.incrementAndGet();
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -535,8 +535,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                 return;
             }
 
-            int remSize = (remFiles == null) ? 0 : remFiles.size();
-            int addSize = (addFiles == null) ? 0 : addFiles.size();
+            final int remSize = (remFiles == null) ? 0 : remFiles.size();
+            final int addSize = (addFiles == null) ? 0 : addFiles.size();
+            final int cacheSize;
             synchronized (fileCache) {
                 if (remSize > 0) {
                     fileCache.removeAll(remFiles);
@@ -546,10 +547,11 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
                 }
                 files = null;
                 directories = null;
+                cacheSize = fileCache.size();
             }
             if (remSize > 0 && addSize == 0) {
                 fireIntervalRemoved(BasicDirectoryModel.this, remStart, remStart + remSize - 1);
-            } else if (addSize > 0 && remSize == 0 && addStart + addSize <= fileCache.size()) {
+            } else if (addSize > 0 && remSize == 0 && addStart + addSize <= cacheSize) {
                 fireIntervalAdded(BasicDirectoryModel.this, addStart, addStart + addSize - 1);
             } else {
                 fireContentsChanged();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -299,13 +299,11 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         }
 
         private void run0() {
-            FileSystemView fileSystem = fileSystemView;
-
             if (loadThread.isInterrupted()) {
                 return;
             }
 
-            File[] list = fileSystem.getFiles(currentDirectory, useFileHiding);
+            File[] list = fileSystemView.getFiles(currentDirectory, useFileHiding);
 
             if (loadThread.isInterrupted()) {
                 return;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -278,8 +278,6 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         private final File currentDirectory;
         private final Thread loadThread;
 
-        private DoChangeContents runnable;
-
         private FilesLoader(File currentDirectory, int fid) {
             this.currentDirectory = currentDirectory;
             this.fid = fid;
@@ -338,7 +336,7 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
 
             // To avoid loads of synchronizations with Invoker and improve performance we
             // execute the whole block on the COM thread
-            runnable = ShellFolder.invoke(new Callable<DoChangeContents>() {
+            DoChangeContents runnable = ShellFolder.invoke(new Callable<DoChangeContents>() {
                 public DoChangeContents call() {
                     synchronized (fileCache) {
                         int newSize = newFileCache.size();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -97,10 +97,12 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
     /**
      * This method is used to interrupt file loading thread.
      */
-    public synchronized void invalidateFileCache() {
-        if (filesLoader != null) {
-            filesLoader.loadThread.interrupt();
-            filesLoader = null;
+    public void invalidateFileCache() {
+        synchronized (this) {
+            if (filesLoader != null) {
+                filesLoader.loadThread.interrupt();
+                filesLoader = null;
+            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -515,8 +515,8 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         private final List<File> addFiles;
         private final List<File> remFiles;
         private final int fid;
-        private int addStart = 0;
-        private int remStart = 0;
+        private final int addStart;
+        private final int remStart;
 
         DoChangeContents(List<File> addFiles, int addStart, List<File> remFiles,
                          int remStart, int fid) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -527,7 +527,8 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
             this.fid = fid;
         }
 
-        public synchronized void run() {
+        @Override
+        public void run() {
             if (fetchID.get() != fid) {
                 return;
             }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -528,26 +528,28 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         }
 
         public synchronized void run() {
-            if (fetchID.get() == fid) {
-                int remSize = (remFiles == null) ? 0 : remFiles.size();
-                int addSize = (addFiles == null) ? 0 : addFiles.size();
-                synchronized(fileCache) {
-                    if (remSize > 0) {
-                        fileCache.removeAll(remFiles);
-                    }
-                    if (addSize > 0) {
-                        fileCache.addAll(addStart, addFiles);
-                    }
-                    files = null;
-                    directories = null;
+            if (fetchID.get() != fid) {
+                return;
+            }
+
+            int remSize = (remFiles == null) ? 0 : remFiles.size();
+            int addSize = (addFiles == null) ? 0 : addFiles.size();
+            synchronized(fileCache) {
+                if (remSize > 0) {
+                    fileCache.removeAll(remFiles);
                 }
-                if (remSize > 0 && addSize == 0) {
-                    fireIntervalRemoved(BasicDirectoryModel.this, remStart, remStart + remSize - 1);
-                } else if (addSize > 0 && remSize == 0 && addStart + addSize <= fileCache.size()) {
-                    fireIntervalAdded(BasicDirectoryModel.this, addStart, addStart + addSize - 1);
-                } else {
-                    fireContentsChanged();
+                if (addSize > 0) {
+                    fileCache.addAll(addStart, addFiles);
                 }
+                files = null;
+                directories = null;
+            }
+            if (remSize > 0 && addSize == 0) {
+                fireIntervalRemoved(BasicDirectoryModel.this, remStart, remStart + remSize - 1);
+            } else if (addSize > 0 && remSize == 0 && addStart + addSize <= fileCache.size()) {
+                fireIntervalAdded(BasicDirectoryModel.this, addStart, addStart + addSize - 1);
+            } else {
+                fireContentsChanged();
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -276,8 +276,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         private final boolean fileSelectionEnabled;
         private final int fid;
         private final File currentDirectory;
-        private volatile DoChangeContents runnable;
         private final Thread loadThread;
+
+        private DoChangeContents runnable;
 
         private FilesLoader(File currentDirectory, int fid) {
             this.currentDirectory = currentDirectory;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -534,7 +534,7 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
 
             int remSize = (remFiles == null) ? 0 : remFiles.size();
             int addSize = (addFiles == null) ? 0 : addFiles.size();
-            synchronized(fileCache) {
+            synchronized (fileCache) {
                 if (remSize > 0) {
                     fileCache.removeAll(remFiles);
                 }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -156,14 +156,16 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         if (currentDirectory == null) {
             return;
         }
-        if (filesLoader != null) {
-            filesLoader.loadThread.interrupt();
-            filesLoader.cancelRunnables();
-        }
+        synchronized (this) {
+            if (filesLoader != null) {
+                filesLoader.loadThread.interrupt();
+                filesLoader.cancelRunnables();
+            }
 
-        int fid = fetchID.incrementAndGet();
-        setBusy(true, fid);
-        filesLoader = new FilesLoader(currentDirectory, fid);
+            int fid = fetchID.incrementAndGet();
+            setBusy(true, fid);
+            filesLoader = new FilesLoader(currentDirectory, fid);
+        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -517,8 +517,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
         private final int addStart;
         private final int remStart;
 
-        DoChangeContents(List<File> addFiles, int addStart, List<File> remFiles,
-                         int remStart, int fid) {
+        private DoChangeContents(List<File> addFiles, int addStart,
+                                 List<File> remFiles, int remStart,
+                                 int fid) {
             this.addFiles = addFiles;
             this.addStart = addStart;
             this.remFiles = remFiles;

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicDirectoryModel.java
@@ -310,9 +310,9 @@ public class BasicDirectoryModel extends AbstractListModel<Object> implements Pr
             }
 
             final Vector<File> newFileCache = new Vector<File>();
-            Vector<File> newFiles = new Vector<File>();
+            final Vector<File> newFiles = new Vector<File>();
 
-            // run through the file list, add directories and selectable files to fileCache
+            // Run through the file list, add directories and selectable files to fileCache
             // Note that this block must be OUTSIDE of Invoker thread because of
             // deadlock possibility with custom synchronized FileSystemView
             for (File file : list) {


### PR DESCRIPTION
Ensure access to the `filesLoader` field of `BasicDirectoryModel` is synchronized.

Without synchronization, a thread checks if `filesLoader` is not null and creates a new `FilesLoader` thread. If the thread is pre-empted between these two operations, another thread or even several threads can see the `null` value and create new `FilesLoader` threads.

The same way, `BasicDirectoryModel.invalidateFileCache` needs to be synchornized to interrupt the current `filesLoader` and assign `null`.

This bug allows reproducing `ConcurrentModificationException` seen in [JDK-8323670](https://bugs.openjdk.org/browse/JDK-8323670) and [JDK-8307091](https://bugs.openjdk.org/browse/JDK-8307091) using the test in PR #18109.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8325179](https://bugs.openjdk.org/browse/JDK-8325179): Race in BasicDirectoryModel.validateFileCache (**Bug** - P3)
 * [JDK-8238169](https://bugs.openjdk.org/browse/JDK-8238169): BasicDirectoryModel getDirectories and DoChangeContents.run can deadlock (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [a9ec7f64](https://git.openjdk.org/jdk/pull/18111/files/a9ec7f646a073f1ae67806c885a0e7f5b5818442)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [a9ec7f64](https://git.openjdk.org/jdk/pull/18111/files/a9ec7f646a073f1ae67806c885a0e7f5b5818442)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer) ⚠️ Review applies to [a9ec7f64](https://git.openjdk.org/jdk/pull/18111/files/a9ec7f646a073f1ae67806c885a0e7f5b5818442)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18111/head:pull/18111` \
`$ git checkout pull/18111`

Update a local copy of the PR: \
`$ git checkout pull/18111` \
`$ git pull https://git.openjdk.org/jdk.git pull/18111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18111`

View PR using the GUI difftool: \
`$ git pr show -t 18111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18111.diff">https://git.openjdk.org/jdk/pull/18111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18111#issuecomment-1977393905)