### PR TITLE
8327261: Parsing test for Double/Float succeeds w/o testing all bad cases

### DIFF
--- a/test/jdk/java/lang/Double/ParseDouble.java
+++ b/test/jdk/java/lang/Double/ParseDouble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -557,10 +557,8 @@ public class ParseDouble {
     private static void testParsing(String [] input,
                                     boolean exceptionalInput) {
         for(int i = 0; i < input.length; i++) {
-            double d;
-
             try {
-                d = Double.parseDouble(input[i]);
+                Double.parseDouble(input[i]);
                 check(input[i]);
             }
             catch (NumberFormatException e) {
@@ -569,7 +567,7 @@ public class ParseDouble {
                                                "good string `" + input[i] +
                                                "'.");
                 }
-                break;
+                continue;
             }
             if (exceptionalInput) {
                 throw new RuntimeException("Double.parseDouble accepted " +

--- a/test/jdk/java/lang/Double/ParseDouble.java
+++ b/test/jdk/java/lang/Double/ParseDouble.java
@@ -556,22 +556,21 @@ public class ParseDouble {
      */
     private static void testParsing(String [] input,
                                     boolean exceptionalInput) {
-        for(int i = 0; i < input.length; i++) {
+        for (String s : input) {
             try {
-                Double.parseDouble(input[i]);
-                check(input[i]);
-            }
-            catch (NumberFormatException e) {
-                if (! exceptionalInput) {
+                Double.parseDouble(s);
+                check(s);
+            } catch (NumberFormatException e) {
+                if (!exceptionalInput) {
                     throw new RuntimeException("Double.parseDouble rejected " +
-                                               "good string `" + input[i] +
+                                               "good string `" + s +
                                                "'.");
                 }
                 continue;
             }
             if (exceptionalInput) {
                 throw new RuntimeException("Double.parseDouble accepted " +
-                                           "bad string `" + input[i] +
+                                           "bad string `" + s +
                                            "'.");
             }
         }

--- a/test/jdk/java/lang/Float/ParseFloat.java
+++ b/test/jdk/java/lang/Float/ParseFloat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,10 +277,8 @@ public class ParseFloat {
     private static void testParsing(String [] input,
                                     boolean exceptionalInput) {
         for(int i = 0; i < input.length; i++) {
-            double d;
-
             try {
-                d = Float.parseFloat(input[i]);
+                Float.parseFloat(input[i]);
                 check(input[i]);
             }
             catch (NumberFormatException e) {
@@ -289,7 +287,7 @@ public class ParseFloat {
                                                "good string `" + input[i] +
                                                "'.");
                 }
-                break;
+                continue;
             }
             if (exceptionalInput) {
                 throw new RuntimeException("Float.parseFloat accepted " +

--- a/test/jdk/java/lang/Float/ParseFloat.java
+++ b/test/jdk/java/lang/Float/ParseFloat.java
@@ -276,22 +276,21 @@ public class ParseFloat {
      */
     private static void testParsing(String [] input,
                                     boolean exceptionalInput) {
-        for(int i = 0; i < input.length; i++) {
+        for (String s : input) {
             try {
-                Float.parseFloat(input[i]);
-                check(input[i]);
-            }
-            catch (NumberFormatException e) {
-                if (! exceptionalInput) {
+                Float.parseFloat(s);
+                check(s);
+            } catch (NumberFormatException e) {
+                if (!exceptionalInput) {
                     throw new RuntimeException("Float.parseFloat rejected " +
-                                               "good string `" + input[i] +
+                                               "good string `" + s +
                                                "'.");
                 }
                 continue;
             }
             if (exceptionalInput) {
                 throw new RuntimeException("Float.parseFloat accepted " +
-                                           "bad string `" + input[i] +
+                                           "bad string `" + s +
                                            "'.");
             }
         }


### PR DESCRIPTION
Fixing test cases. For bad test cases, only the first case was run, and the rest were ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327261](https://bugs.openjdk.org/browse/JDK-8327261): Parsing test for Double/Float succeeds w/o testing all bad cases (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [4c80fe5c](https://git.openjdk.org/jdk/pull/18113/files/4c80fe5c8f1e934e0b65d08b681c56b69427ed31)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [4c80fe5c](https://git.openjdk.org/jdk/pull/18113/files/4c80fe5c8f1e934e0b65d08b681c56b69427ed31)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18113/head:pull/18113` \
`$ git checkout pull/18113`

Update a local copy of the PR: \
`$ git checkout pull/18113` \
`$ git pull https://git.openjdk.org/jdk.git pull/18113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18113`

View PR using the GUI difftool: \
`$ git pr show -t 18113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18113.diff">https://git.openjdk.org/jdk/pull/18113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18113#issuecomment-1977750580)