### PR TITLE
8327283: RISC-V: Minimal build failed after JDK-8319716

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3664,6 +3664,9 @@ class StubGenerator: public StubCodeGenerator {
 
 #undef __
 #define __ this->
+
+#if COMPILER2_OR_JVMCI
+
   class Sha2Generator : public MacroAssembler {
     StubCodeGenerator* _cgen;
    public:
@@ -3935,7 +3938,7 @@ class StubGenerator: public StubCodeGenerator {
       // ma: mask agnostic (don't care about those lanes)
       // x0 is not written, we known the number of vector elements.
 
-      if (vset_sew == Assembler::e64 && VM_Version::_initial_vector_length == 16) { // SHA512 and VLEN = 128
+      if (vset_sew == Assembler::e64 && MaxVectorSize == 16) { // SHA512 and VLEN = 128
         __ vsetivli(x0, 4, vset_sew, Assembler::m2, Assembler::ma, Assembler::ta);
       } else {
         __ vsetivli(x0, 4, vset_sew, Assembler::m1, Assembler::ma, Assembler::ta);
@@ -4044,6 +4047,9 @@ class StubGenerator: public StubCodeGenerator {
       return start;
     }
   };
+
+#endif // COMPILER2_OR_JVMCI
+
 #undef __
 #define __ masm->
 
@@ -4423,6 +4429,8 @@ class StubGenerator: public StubCodeGenerator {
     m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
   }
 
+#if COMPILER2_OR_JVMCI
+
   // Arguments:
   //
   // Inputs:
@@ -4673,6 +4681,8 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
+#endif // COMPILER2_OR_JVMCI
+
   /**
    * Perform the quarter round calculations on values contained within four vector registers.
    *
@@ -4704,6 +4714,8 @@ class StubGenerator: public StubCodeGenerator {
     __ vxor_vv(bVec, bVec, cVec);
     __ vrole32_vi(bVec, 7, tmp_vr);
   }
+
+#if COMPILER2_OR_JVMCI
 
   /**
    * int com.sun.crypto.provider.ChaCha20Cipher.implChaCha20Block(int[] initState, byte[] result)
@@ -4808,6 +4820,8 @@ class StubGenerator: public StubCodeGenerator {
 
     return (address) start;
   }
+
+#endif // COMPILER2_OR_JVMCI
 
 
   // ------------------------ SHA-1 intrinsic ------------------------
@@ -5002,6 +5016,8 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(prev_e, e);
   }
 
+#if COMPILER2_OR_JVMCI
+
   // Intrinsic for:
   //   void sun.security.provider.SHA.implCompress0(byte[] buf, int ofs)
   //   void sun.security.provider.DigestBase.implCompressMultiBlock0(byte[] b, int ofs, int limit)
@@ -5148,6 +5164,8 @@ class StubGenerator: public StubCodeGenerator {
 
     return (address) start;
   }
+
+#endif // COMPILER2_OR_JVMCI
 
 
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3664,9 +3664,6 @@ class StubGenerator: public StubCodeGenerator {
 
 #undef __
 #define __ this->
-
-#if COMPILER2_OR_JVMCI
-
   class Sha2Generator : public MacroAssembler {
     StubCodeGenerator* _cgen;
    public:
@@ -4047,9 +4044,6 @@ class StubGenerator: public StubCodeGenerator {
       return start;
     }
   };
-
-#endif // COMPILER2_OR_JVMCI
-
 #undef __
 #define __ masm->
 
@@ -4429,8 +4423,6 @@ class StubGenerator: public StubCodeGenerator {
     m5_FF_GG_HH_II_epilogue(reg_cache, a, b, c, d, k, s, t, rtmp1);
   }
 
-#if COMPILER2_OR_JVMCI
-
   // Arguments:
   //
   // Inputs:
@@ -4681,8 +4673,6 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-#endif // COMPILER2_OR_JVMCI
-
   /**
    * Perform the quarter round calculations on values contained within four vector registers.
    *
@@ -4714,8 +4704,6 @@ class StubGenerator: public StubCodeGenerator {
     __ vxor_vv(bVec, bVec, cVec);
     __ vrole32_vi(bVec, 7, tmp_vr);
   }
-
-#if COMPILER2_OR_JVMCI
 
   /**
    * int com.sun.crypto.provider.ChaCha20Cipher.implChaCha20Block(int[] initState, byte[] result)
@@ -4820,8 +4808,6 @@ class StubGenerator: public StubCodeGenerator {
 
     return (address) start;
   }
-
-#endif // COMPILER2_OR_JVMCI
 
 
   // ------------------------ SHA-1 intrinsic ------------------------
@@ -5016,8 +5002,6 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(prev_e, e);
   }
 
-#if COMPILER2_OR_JVMCI
-
   // Intrinsic for:
   //   void sun.security.provider.SHA.implCompress0(byte[] buf, int ofs)
   //   void sun.security.provider.DigestBase.implCompressMultiBlock0(byte[] b, int ofs, int limit)
@@ -5164,8 +5148,6 @@ class StubGenerator: public StubCodeGenerator {
 
     return (address) start;
   }
-
-#endif // COMPILER2_OR_JVMCI
 
 
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3935,7 +3935,7 @@ class StubGenerator: public StubCodeGenerator {
       // ma: mask agnostic (don't care about those lanes)
       // x0 is not written, we known the number of vector elements.
 
-      if (vset_sew == Assembler::e64 && MaxVectorSize == 16) { // SHA512 and VLEN = 128
+      if (vset_sew == Assembler::e64 && VM_Version::_initial_vector_length == 16) { // SHA512 and VLEN = 128
         __ vsetivli(x0, 4, vset_sew, Assembler::m2, Assembler::ma, Assembler::ta);
       } else {
         __ vsetivli(x0, 4, vset_sew, Assembler::m1, Assembler::ma, Assembler::ta);


### PR DESCRIPTION
Hi, please review this patch that fix the minimal build failed for riscv.

Error log for minimal build:
```
Creating support/modules_libs/java.base/minimal/libjvm.so from 591 file(s)
^@/home/zifeihan/jdk/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp: In member function ‘u_char* StubGenerator::Sha2Generator::generate_sha2_implCompress(Assembler::SEW, bool)’:
/home/zifeihan/jdk/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp:3938:41: error: ‘MaxVectorSize’ was not declared in this scope; did you mean ‘MaxNewSize’?
 3938 |       if (vset_sew == Assembler::e64 && MaxVectorSize == 16) { // SHA512 and VLEN = 128
      |                                         ^~~~~~~~~~~~~
      |                                         MaxNewSize
gmake[3]: *** [lib/CompileJvm.gmk:165: /home/zifeihan/jdk/build/linux-riscv64-minimal-fastdebug/hotspot/variant-minimal/libjvm/objs/stubGenerator_riscv.o] Error 1
gmake[3]: *** Waiting for unfinished jobs....
^@gmake[2]: *** [make/Main.gmk:253: hotspot-minimal-libs] Error 2
gmake[2]: *** Waiting for unfinished jobs....
^@
ERROR: Build failed for target 'images' in configuration 'linux-riscv64-minimal-fastdebug' (exit code 2)

=== Output from failing command(s) repeated here ===
* For target hotspot_variant-minimal_libjvm_objs_stubGenerator_riscv.o:
/home/zifeihan/jdk/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp: In member function ‘u_char* StubGenerator::Sha2Generator::generate_sha2_implCompress(Assembler::SEW, bool)’:
/home/zifeihan/jdk/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp:3938:41: error: ‘MaxVectorSize’ was not declared in this scope; did you mean ‘MaxNewSize’?
 3938 |       if (vset_sew == Assembler::e64 && MaxVectorSize == 16) { // SHA512 and VLEN = 128
      |                                         ^~~~~~~~~~~~~
      |                                         MaxNewSize

* All command lines available in /home/zifeihan/jdk/build/linux-riscv64-minimal-fastdebug/make-support/failure-logs.
=== End of repeated output ===

No indication of failed target found.
HELP: Try searching the build log for '] Error'.
HELP: Run 'make doctor' to diagnose build problems.

make[1]: *** [/home/zifeihan/jdk/make/Init.gmk:323: main] Error 2
make: *** [/home/zifeihan/jdk/make/Init.gmk:189: images] Error 2
```

The root cause is that MaxVectorSize is only defined under COMPILER2 , We should use VM_Version::_initial_vector_length instead of MaxVectorSize.  

Testing:

- [x] linux-riscv minimal fastdebug native build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327283](https://bugs.openjdk.org/browse/JDK-8327283): RISC-V: Minimal build failed after JDK-8319716 (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18114/head:pull/18114` \
`$ git checkout pull/18114`

Update a local copy of the PR: \
`$ git checkout pull/18114` \
`$ git pull https://git.openjdk.org/jdk.git pull/18114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18114`

View PR using the GUI difftool: \
`$ git pr show -t 18114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18114.diff">https://git.openjdk.org/jdk/pull/18114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18114#issuecomment-1978159150)