### PR TITLE
8323242: Remove vestigial DONT_USE_REGISTER_DEFINES

### DIFF
--- a/src/hotspot/cpu/zero/register_zero.hpp
+++ b/src/hotspot/cpu/zero/register_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -114,8 +114,6 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
 };
 
 CONSTANT_REGISTER_DECLARATION(Register, noreg, (-1));
-#ifndef DONT_USE_REGISTER_DEFINES
 #define noreg ((Register)(noreg_RegisterEnumValue))
-#endif
 
 #endif // CPU_ZERO_REGISTER_ZERO_HPP


### PR DESCRIPTION
This pull request removes an unnecessary directive.

There is no definition of DONT_USE_REGISTER_DEFINES in HotSpot or the build system, so this `#ifndef`conditional directive is always true. We can remove it. 

I built OpenJDK with Zero VM as a test. It was successful.

```
$ ./configure --with-jvm-variants=zero --enable-debug
$ make images 
$ ./build/macosx-aarch64-zero-fastdebug/jdk/bin/java -version                                                                                                                                         
openjdk version "23-internal" 2024-09-17                                                                                                                                                                                                                                                 
OpenJDK Runtime Environment (fastdebug build 23-internal-adhoc.jyukutyo.jyukutyo-jdk)                                                                                                                                                                                                    
OpenJDK 64-Bit Zero VM (fastdebug build 23-internal-adhoc.jyukutyo.jyukutyo-jdk, interpreted mode)
```

It may be possible to remove the `#define noreg` as well because the CONSTANT_REGISTER_DECLARATION macro creates a variable named noreg, but I can't be sure. When I tried removing the noreg definition and building the OpenJDK, the build was successful.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323242](https://bugs.openjdk.org/browse/JDK-8323242): Remove vestigial DONT_USE_REGISTER_DEFINES (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18115/head:pull/18115` \
`$ git checkout pull/18115`

Update a local copy of the PR: \
`$ git checkout pull/18115` \
`$ git pull https://git.openjdk.org/jdk.git pull/18115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18115`

View PR using the GUI difftool: \
`$ git pr show -t 18115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18115.diff">https://git.openjdk.org/jdk/pull/18115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18115#issuecomment-1979867967)