### PR TITLE
8327239: Obsolete unused GCLockerEdenExpansionPercent product option

### DIFF
--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -168,11 +168,6 @@
           "A System.gc() request invokes a concurrent collection; "         \
           "(effective only when using concurrent collectors)")              \
                                                                             \
-  product(uint, GCLockerEdenExpansionPercent, 5,                            \
-          "How much the GC can expand the eden by while the GC locker "     \
-          "is active (as a percentage)")                                    \
-          range(0, 100)                                                     \
-                                                                            \
   product(uintx, GCLockerRetryAllocationCount, 2, DIAGNOSTIC,               \
           "Number of times to retry allocations when "                      \
           "blocked by the GC locker")                                       \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -527,6 +527,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "InitialRAMFraction",           JDK_Version::jdk(10),  JDK_Version::jdk(23), JDK_Version::jdk(24) },
   { "DefaultMaxRAMFraction",        JDK_Version::jdk(8),  JDK_Version::jdk(23), JDK_Version::jdk(24) },
   { "TLABStats",                    JDK_Version::jdk(12), JDK_Version::jdk(23), JDK_Version::jdk(24) },
+  { "GCLockerEdenExpansionPercent", JDK_Version::undefined(), JDK_Version::jdk(23), JDK_Version::jdk(24) },
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif

--- a/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewRatioFlag.java
@@ -73,7 +73,6 @@ public class TestNewRatioFlag {
                 "-Xbootclasspath/a:.",
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",
-                "-XX:GCLockerEdenExpansionPercent=0",
                 "-Xmx" + HEAP_SIZE,
                 "-Xms" + HEAP_SIZE,
                 "-XX:NewRatio=" + ratio,

--- a/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestNewSizeFlags.java
@@ -157,7 +157,6 @@ public class TestNewSizeFlags {
                 (maxNewSize >= 0 ? "-XX:MaxNewSize=" + maxNewSize : ""),
                 "-Xmx" + maxHeapSize,
                 "-Xms" + heapSize,
-                "-XX:GCLockerEdenExpansionPercent=0",
                 "-XX:-UseLargePages",
                 NewSizeVerifier.class.getName(),
                 Long.toString(expectedNewSize),

--- a/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSurvivorRatioFlag.java
@@ -77,7 +77,6 @@ public class TestSurvivorRatioFlag {
                 "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
                 "-XX:+UnlockDiagnosticVMOptions",
                 "-XX:+WhiteBoxAPI",
-                "-XX:GCLockerEdenExpansionPercent=0",
                 "-XX:MaxNewSize=" + NEW_SIZE,
                 "-XX:NewSize=" + NEW_SIZE,
                 "-Xmx" + HEAP_SIZE,


### PR DESCRIPTION
Hi all,

  please review this change to obsolete the unused flag GCLockerEdenExpansionPercent. Please also review the CSR.

Testing: local compilation, grepping sources for occurrences

Thanks,
  Thomas8327239-obsolete-gclockeredenexpansionpercent

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8327293](https://bugs.openjdk.org/browse/JDK-8327293) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8327239](https://bugs.openjdk.org/browse/JDK-8327239): Obsolete unused GCLockerEdenExpansionPercent product option (**Enhancement** - P4)
 * [JDK-8327293](https://bugs.openjdk.org/browse/JDK-8327293): Obsolete unused GCLockerEdenExpansionPercent product option (**CSR**)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18117/head:pull/18117` \
`$ git checkout pull/18117`

Update a local copy of the PR: \
`$ git checkout pull/18117` \
`$ git pull https://git.openjdk.org/jdk.git pull/18117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18117`

View PR using the GUI difftool: \
`$ git pr show -t 18117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18117.diff">https://git.openjdk.org/jdk/pull/18117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18117#issuecomment-1978349974)