### PR TITLE
8327361: Update some comments after JDK-8139457

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.hpp
@@ -94,12 +94,12 @@ using MacroAssembler::null_check;
   };
 
   // allocation of arrays
-  // obj        : will contain pointer to allocated object
-  // len        : array length in number of elements
-  // t          : scratch register - contents destroyed
-  // header_size: size of object header in words
-  // f          : element scale factor
-  // slow_case  : exit to slow case implementation if fast allocation fails
+  // obj                 : will contain pointer to allocated object
+  // len                 : array length in number of elements
+  // t                   : scratch register - contents destroyed
+  // base_offset_in_bytes: offset of first array element, in bytes
+  // f                   : element scale factor
+  // slow_case           : exit to slow case implementation if fast allocation fails
   void allocate_array(Register obj, Register len, Register t, Register t2, int base_offset_in_bytes, int f, Register klass, Label& slow_case);
 
   int  rsp_offset() const { return _rsp_offset; }

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.hpp
@@ -95,12 +95,12 @@ using MacroAssembler::null_check;
   };
 
   // allocation of arrays
-  // obj        : will contain pointer to allocated object
-  // len        : array length in number of elements
-  // t          : temp register - contents destroyed
-  // header_size: size of object header in words
-  // f          : element scale factor
-  // slow_case  : exit to slow case implementation if fast allocation fails
+  // obj                 : will contain pointer to allocated object
+  // len                 : array length in number of elements
+  // t                   : temp register - contents destroyed
+  // base_offset_in_bytes: offset of first array element, in bytes
+  // f                   : element scale factor
+  // slow_case           : exit to slow case implementation if fast allocation fails
   void allocate_array(Register obj, Register len, Register tmp1, Register tmp2, int base_offset_in_bytes, int f, Register klass, Label& slow_case);
 
   int  rsp_offset() const { return _rsp_offset; }

--- a/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c1_MacroAssembler_x86.hpp
@@ -83,12 +83,12 @@
   };
 
   // allocation of arrays
-  // obj        : must be rax, will contain pointer to allocated object
-  // len        : array length in number of elements
-  // t          : scratch register - contents destroyed
-  // header_size: size of object header in words
-  // f          : element scale factor
-  // slow_case  : exit to slow case implementation if fast allocation fails
+  // obj                 : must be rax, will contain pointer to allocated object
+  // len                 : array length in number of elements
+  // t                   : scratch register - contents destroyed
+  // base_offset_in_bytes: offset of the first array element, in bytes
+  // f                   : element scale factor
+  // slow_case           : exit to slow case implementation if fast allocation fails
   void allocate_array(Register obj, Register len, Register t, Register t2, int base_offset_in_bytes, Address::ScaleFactor f, Register klass, Label& slow_case);
 
   int  rsp_offset() const { return _rsp_offset; }


### PR DESCRIPTION
A follow-up to [8139457: Relax alignment of array elements](https://bugs.openjdk.org/browse/JDK-8139457) ([PR](https://git.openjdk.org/jdk/pull/11044)), some comments need an update.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327361](https://bugs.openjdk.org/browse/JDK-8327361): Update some comments after JDK-8139457 (**Enhancement** - P4)


### Reviewers
 * [Galder Zamarreño](https://openjdk.org/census#galder) (@galderz - Author)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18120/head:pull/18120` \
`$ git checkout pull/18120`

Update a local copy of the PR: \
`$ git checkout pull/18120` \
`$ git pull https://git.openjdk.org/jdk.git pull/18120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18120`

View PR using the GUI difftool: \
`$ git pr show -t 18120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18120.diff">https://git.openjdk.org/jdk/pull/18120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18120#issuecomment-1978520662)