### PR TITLE
8327172: C2 SuperWord: data node in loop has no input in loop: replace assert with bailout

### DIFF
--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -323,6 +323,7 @@ public:
 class VLoopBody : public StackObj {
 private:
   static constexpr char const* FAILURE_NODE_NOT_ALLOWED = "encontered unhandled node";
+  static constexpr char const* FAILURE_UNEXPECTED_CTRL  = "data node in loop has no input in loop";
 
   const VLoop& _vloop;
 

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestNoInputInLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestNoInputInLoop.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.loopopts.superword;
+
+/*
+ * @test id=Vanilla
+ * @bug 8327172
+ * @summary Test bad loop ctrl: a node is in the loop, but has no input in the loop
+ * @run main/othervm compiler.loopopts.superword.TestNoInputInLoop
+ */
+
+/*
+ * @test id=WithFlags
+ * @bug 8327172
+ * @summary Test bad loop ctrl: a node is in the loop, but has no input in the loop
+ * @run main/othervm -Xbatch -XX:PerMethodTrapLimit=0
+ *                   compiler.loopopts.superword.TestNoInputInLoop
+ */
+
+/*
+ * @test id=WithMoreFlags
+ * @bug 8327172
+ * @summary Test bad loop ctrl: a node is in the loop, but has no input in the loop
+ * @run main/othervm -Xbatch -XX:PerMethodTrapLimit=0
+ *                   -XX:CompileCommand=compileonly,compiler.loopopts.superword.TestNoInputInLoop::test*
+ *                   compiler.loopopts.superword.TestNoInputInLoop
+ */
+
+public class TestNoInputInLoop {
+    static long lFld;
+    static float fFld;
+    static int iArr[] = new int[400];
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 100; i++) {
+            test1();
+        }
+        for (int i = 0; i < 1_000; i++) {
+            test2(0);
+        }
+    }
+
+    // It specifically reproduced with UseAVX=2
+    // 1. PhaseIdealLoop::build_loop_early
+    //    We have a Store in a loop, with a Load after it.
+    //    Both have ctrl as the CountedLoopNode.
+    // 2. split_if_with_blocks -> PhaseIdealLoop::try_move_store_before_loop
+    //    The Store is moved out of the loop, and its ctrl updated accordingly.
+    //    But the Load has its ctrl not updated, even though it has now no input in the loop.
+    // 3. SuperWord (VLoopBody::construct)
+    //    We detect a data node in the loop that has no input in the loop.
+    //    This is not expected.
+
+    // OSR failure
+    static void test1() {
+        for (int i = 0; i < 200; i++) {
+            fFld *= iArr[0] - lFld;
+            iArr[1] = (int) lFld;
+            for (int j = 0; j < 100_000; j++) {} // empty loop, trigger OSR
+        }
+    }
+
+    // Normal compilation
+    static void test2(int start) {
+        for (int i = start; i < 200; i++) {
+            fFld *= iArr[0] - lFld;
+            iArr[1] = (int) lFld;
+        }
+    }
+}


### PR DESCRIPTION
This is a regression fix from https://github.com/openjdk/jdk/pull/17657.

I had never encountered an example where a data node in the loop body did not have any input node in the loop.
My assumption was that this should never happen, such a node should move out of the loop itself.

I now encountered such an example. But I think it shows that there are cases where we compute the ctrl wrong.

https://github.com/openjdk/jdk/blob/8835f786b8dc7db1ebff07bbb3dbb61a6c42f6c8/test/hotspot/jtreg/compiler/loopopts/superword/TestNoInputInLoop.java#L65-L73

I now had a few options:
1. Revert to the code before https://github.com/openjdk/jdk/pull/17657: handle such cases with the extra `data_entry` logic. But this would just be extra complexity for patterns that shoud not exist in the first place.
2. Fix the computation of ctrl. But we know that there are many edge cases that are currently wrong, and I am working on verification and fixing these issues in https://github.com/openjdk/jdk/pull/16558. So I would rather fix those pre-existing issues separately.
3. Just create a silent bailout from vectorization, with `VStatus::make_failure`.

I chose option 3, since it allows simple logic, and only prevents vectorization in cases that are already otherwise broken.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327172](https://bugs.openjdk.org/browse/JDK-8327172): C2 SuperWord: data node in loop has no input in loop: replace assert with bailout (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18123/head:pull/18123` \
`$ git checkout pull/18123`

Update a local copy of the PR: \
`$ git checkout pull/18123` \
`$ git pull https://git.openjdk.org/jdk.git pull/18123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18123`

View PR using the GUI difftool: \
`$ git pr show -t 18123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18123.diff">https://git.openjdk.org/jdk/pull/18123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18123#issuecomment-1979206506)