### PR TITLE
8327379: Make TimeLinearScan a develop flag

### DIFF
--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/c1/c1_globals.hpp
+++ b/src/hotspot/share/c1/c1_globals.hpp
@@ -210,7 +210,7 @@
   develop(bool, StressLinearScan, false,                                    \
           "scramble block order used by LinearScan (stress test)")          \
                                                                             \
-  product(bool, TimeLinearScan, false,                                      \
+  develop(bool, TimeLinearScan, false,                                      \
           "detailed timing of LinearScan phases")                           \
                                                                             \
   develop(bool, TimeEachLinearScan, false,                                  \


### PR DESCRIPTION
Hi,

Please help review this change that makes TimeLinearScan a develop flag.

Currently, TimeLinearScan is only used in code guarded by '#ifndef PRODUCT'. We should move it to develop or maybe notproduct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8327384](https://bugs.openjdk.org/browse/JDK-8327384) to be approved

### Issues
 * [JDK-8327379](https://bugs.openjdk.org/browse/JDK-8327379): Make TimeLinearScan a develop flag (**Enhancement** - P4)
 * [JDK-8327384](https://bugs.openjdk.org/browse/JDK-8327384): Make TimeLinearScan a develop flag (**CSR**)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18125/head:pull/18125` \
`$ git checkout pull/18125`

Update a local copy of the PR: \
`$ git checkout pull/18125` \
`$ git pull https://git.openjdk.org/jdk.git pull/18125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18125`

View PR using the GUI difftool: \
`$ git pr show -t 18125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18125.diff">https://git.openjdk.org/jdk/pull/18125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18125#issuecomment-1979101711)