### PR TITLE
8327390: JitTester: Implement temporary folder functionality

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/Makefile
+++ b/test/hotspot/jtreg/testlibrary/jittester/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,7 @@ TESTLIBRARY_SRC_FILES = $(TESTLIBRARY_SRC_DIR)/Asserts.java \
                         $(TESTLIBRARY_SRC_DIR)/process/OutputBuffer.java \
                         $(TESTLIBRARY_SRC_DIR)/process/ProcessTools.java \
                         $(TESTLIBRARY_SRC_DIR)/process/StreamPumper.java \
+                        $(TESTLIBRARY_SRC_DIR)/util/FileUtils.java \
                         $(TESTLIBRARY_SRC_DIR)/util/Pair.java
 
 .PHONY: cleantmp

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/JavaCodeGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/JavaCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,13 +64,13 @@ public class JavaCodeGenerator extends TestsGenerator {
     }
 
     private void compileJavaFile(String mainClassName) {
-        String classPath = tmpDir.toString();
+        String classPath = tmpDir.path.toString();
         ProcessBuilder pb = new ProcessBuilder(JAVAC,
                 "-d", classPath,
                 "-cp", classPath,
                 generatorDir.resolve(mainClassName + ".java").toString());
         try {
-            int r = runProcess(pb, tmpDir.resolve(mainClassName + ".javac").toString());
+            int r = runProcess(pb, tmpDir.path.resolve(mainClassName + ".javac").toString());
             if (r != 0) {
                 throw new Error("Can't compile sources, exit code = " + r);
             }

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TempDir.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jdk.test.lib.util.FileUtils;
+
+/**
+  * A temporary directory wrapper.
+  * Makes sure that the directory gets deleted after usage.
+  */
+public class TempDir {
+    public final Path path;
+
+    /**
+     * Creates a temporary directory with a given suffix.
+     * The directory is deep deleted on VM shutdown using a ShutdownHook.
+     */
+    public TempDir(String suffix) {
+        try {
+            path = Files.createTempDirectory(suffix).toAbsolutePath();
+            Runtime.getRuntime().addShutdownHook(new Thread(this::delete));
+        } catch (IOException e) {
+            throw new Error("Can't create a tmp dir for " + suffix, e);
+        }
+
+        System.out.println("DBG: Temp folder created: '" + path + "'");
+    }
+
+    private void delete() {
+        try {
+            FileUtils.deleteFileTreeWithRetry(path);
+            System.out.println("DBG: Temp folder deleted: '" + path + "'");
+        } catch (IOException exc) {
+            throw new Error("Could not deep delete '" + path + "'", exc);
+        }
+    }
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public abstract class TestsGenerator implements BiConsumer<IRNode, IRNode> {
     protected static final String JAVAC = Paths.get(JAVA_BIN, "javac").toString();
     protected static final String JAVA = Paths.get(JAVA_BIN, "java").toString();
     protected final Path generatorDir;
-    protected final Path tmpDir;
+    protected final TempDir tmpDir;
     protected final Function<String, String[]> preRunActions;
     protected final String jtDriverOptions;
     private static final String DISABLE_WARNINGS = "-XX:-PrintWarnings";
@@ -54,17 +54,13 @@ public abstract class TestsGenerator implements BiConsumer<IRNode, IRNode> {
     protected TestsGenerator(String suffix, Function<String, String[]> preRunActions,
             String jtDriverOptions) {
         generatorDir = getRoot().resolve(suffix).toAbsolutePath();
-        try {
-            tmpDir = Files.createTempDirectory(suffix).toAbsolutePath();
-        } catch (IOException e) {
-            throw new Error("Can't get a tmp dir for " + suffix, e);
-        }
+        tmpDir = new TempDir(suffix);
         this.preRunActions = preRunActions;
         this.jtDriverOptions = jtDriverOptions;
     }
 
     protected void generateGoldenOut(String mainClassName) {
-        String classPath = tmpDir.toString() + File.pathSeparator
+        String classPath = tmpDir.path.toString() + File.pathSeparator
                 + generatorDir.toString();
         ProcessBuilder pb = new ProcessBuilder(JAVA, "-Xint", DISABLE_WARNINGS, "-Xverify",
                 "-cp", classPath, mainClassName);
@@ -97,7 +93,7 @@ public abstract class TestsGenerator implements BiConsumer<IRNode, IRNode> {
     protected void compilePrinter() {
         Path root = getRoot();
         ProcessBuilder pbPrinter = new ProcessBuilder(JAVAC,
-                "-d", tmpDir.toString(),
+                "-d", tmpDir.path.toString(),
                 root.resolve("jdk")
                     .resolve("test")
                     .resolve("lib")


### PR DESCRIPTION
The JITTester relies on standard OS / Java library functionality to create temporary folders and never cleans them.

This creates problems in CI machines and also complicates problems investigation. We need to have a dedicated TempDir entity that we could adjust during problems investigations and development. It can also be a good place for various file-related activities, like executing FailureHandler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327390](https://bugs.openjdk.org/browse/JDK-8327390): JitTester: Implement temporary folder functionality (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18128/head:pull/18128` \
`$ git checkout pull/18128`

Update a local copy of the PR: \
`$ git checkout pull/18128` \
`$ git pull https://git.openjdk.org/jdk.git pull/18128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18128`

View PR using the GUI difftool: \
`$ git pr show -t 18128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18128.diff">https://git.openjdk.org/jdk/pull/18128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18128#issuecomment-1983420096)