### PR TITLE
8327201: C2: Uninitialized VLoop::_pre_loop_end after JDK-8324890

### DIFF
--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -99,7 +99,8 @@ public:
     _allow_cfg (allow_cfg),
     _cl        (nullptr),
     _cl_exit   (nullptr),
-    _iv        (nullptr) {}
+    _iv        (nullptr),
+    _pre_loop_end (nullptr) {}
   NONCOPYABLE(VLoop);
 
   IdealLoopTree* lpt()        const { return _lpt; };


### PR DESCRIPTION
As Aleksey pointed out, the issue seems innocuous. It seems that all code that uses `pre_loop_end` are called from the main loop, and the field is always initialized for main loops. But we should still avoid uninitialized fields.

Passing hotspot tier1 locally on my Linux machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327201](https://bugs.openjdk.org/browse/JDK-8327201): C2: Uninitialized VLoop::_pre_loop_end after JDK-8324890 (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18130/head:pull/18130` \
`$ git checkout pull/18130`

Update a local copy of the PR: \
`$ git checkout pull/18130` \
`$ git pull https://git.openjdk.org/jdk.git pull/18130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18130`

View PR using the GUI difftool: \
`$ git pr show -t 18130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18130.diff">https://git.openjdk.org/jdk/pull/18130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18130#issuecomment-1979963145)