### PR TITLE
8327238: Remove MetadataAllocationFailALot* develop flags

### DIFF
--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -215,11 +215,9 @@ void VM_CollectForMetadataAllocation::doit() {
   // Check again if the space is available.  Another thread
   // may have similarly failed a metadata allocation and induced
   // a GC that freed space for the allocation.
-  if (!MetadataAllocationFailALot) {
-    _result = _loader_data->metaspace_non_null()->allocate(_size, _mdtype);
-    if (_result != nullptr) {
-      return;
-    }
+  _result = _loader_data->metaspace_non_null()->allocate(_size, _mdtype);
+  if (_result != nullptr) {
+    return;
   }
 
 #if INCLUDE_G1GC

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -284,13 +284,6 @@
           "Number of object array elements to push onto the marking stack " \
           "before pushing a continuation entry")                            \
                                                                             \
-  develop(bool, MetadataAllocationFailALot, false,                          \
-          "Fail metadata allocations at intervals controlled by "           \
-          "MetadataAllocationFailALotInterval")                             \
-                                                                            \
-  develop(uintx, MetadataAllocationFailALotInterval, 1000,                  \
-          "Metadata allocation failure a lot interval")                     \
-                                                                            \
   product_pd(bool, NeverActAsServerClassMachine,                            \
           "Never act like a server-class machine")                          \
                                                                             \


### PR DESCRIPTION
Hi all,

  please review this trivial removal of the `MetadataFailAlot` flags; one of them,
`MetadataAllocationFailALotInterval` is unused anyway, and the other `MetadataAllocationFailALot` only prevents the attempt to retry metadata allocation in the VM operation.

This functionality does not seem to stress metadata allocation failure at all, just execution of the metadata VM operation, so I decided to just drop the second flag as well.

I considered keeping it maybe as `MetadataAllocationFailRetry` or something, but decided against it since it does not seem interesting to test. However I can at reviewer's request do that.

Testing: local compilation, gha, grepping hotspot tests/hotspot sources

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327238](https://bugs.openjdk.org/browse/JDK-8327238): Remove MetadataAllocationFailALot* develop flags (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18133/head:pull/18133` \
`$ git checkout pull/18133`

Update a local copy of the PR: \
`$ git checkout pull/18133` \
`$ git pull https://git.openjdk.org/jdk.git pull/18133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18133`

View PR using the GUI difftool: \
`$ git pr show -t 18133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18133.diff">https://git.openjdk.org/jdk/pull/18133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18133#issuecomment-1980449224)