### PR TITLE
8327450: The result of jfr view active-settings is invalid if jfr file is created by JDK 11 or JDK 8

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Aggregator.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,10 @@ enum Aggregator {
      * Calculates the number of distinct values determined by invoking Object.equals.
      */
     UNIQUE("UNIQUE"),
+    /**
+     * The last elements, for an event type, that all share the same end timestamp, accurate to the second.
+     */
+    LAST_BATCH_BY_SECONDS("LAST_BATCH_BY_SECONDS"),
     /**
      * The last elements, for an event type, that all share the same end timestamp.
      */

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Field.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Field.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ final class Field {
     // A java.time.Instant
     boolean timestamp;
 
-    // Used by LAST_BATCH aggregator
+    // Used by LAST_BATCH and LAST_BATCH_BY_SECONDS aggregator
     Instant last = Instant.EPOCH;
 
     // The data type, for example, jdk.types.Frame or java.lang.String

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/FieldBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -402,7 +402,7 @@ final class FieldBuilder {
         field.label = switch (aggregator) {
             case COUNT -> "Count";
             case AVERAGE -> "Avg. " + field.label;
-            case FIRST, LAST, LAST_BATCH -> field.label;
+            case FIRST, LAST, LAST_BATCH, LAST_BATCH_BY_SECONDS  -> field.label;
             case MAXIMUM -> "Max. " + field.label;
             case MINIMUM -> "Min. " + field.label;
             case SUM -> "Total " + field.label;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,6 +114,9 @@ abstract class Function {
         }
         if (aggregator == Aggregator.LAST_BATCH) {
             return new LastBatch(field);
+        }
+        if (aggregator == Aggregator.LAST_BATCH_BY_SECONDS) {
+            return new LastBatchBySeconds(field);
         }
         if (aggregator == Aggregator.LAST) {
             return new Last();
@@ -631,10 +634,10 @@ abstract class Function {
         }
     }
 
-    public static final class LastBatch extends Function {
-        private final Field field;
+    public static class LastBatch extends Function {
+        protected final Field field;
         private final Last last = new Last();
-        private Instant timestamp;
+        protected Instant timestamp;
 
         public LastBatch(Field field) {
             this.field = field;
@@ -660,6 +663,18 @@ abstract class Function {
                 return timestamp.equals(field.last);
             }
             return true;
+        }
+    }
+
+    public static final class LastBatchBySeconds extends LastBatch {
+        public LastBatchBySeconds(Field field) {
+            super(field);
+        }
+
+        @Override
+        public void setTime(Instant timestamp) {
+           this.timestamp = timestamp.truncatedTo(ChronoUnit.SECONDS);
+           field.last = this.timestamp;
         }
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Histogram.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Histogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ import jdk.jfr.consumer.RecordedStackTrace;
 import jdk.jfr.consumer.RecordedThread;
 import jdk.jfr.consumer.RecordedThreadGroup;
 import jdk.jfr.internal.query.Function.LastBatch;
+import jdk.jfr.internal.query.Function.LastBatchBySeconds;
 
 /**
  * Class responsible for aggregating values
@@ -140,6 +141,9 @@ final class Histogram {
         for (int i = 0; i < values.length; i++) {
             Function function = fs[sourceFields.get(i).index];
             function.add(values[i]);
+            if (function instanceof LastBatchBySeconds l) {
+                l.setTime(e.getEndTime());
+            }
             if (function instanceof LastBatch l) {
                 l.setTime(e.getEndTime());
             }
@@ -153,6 +157,9 @@ final class Histogram {
             boolean valid = true;
             int index = 0;
             for (Function f : functions) {
+                if (f instanceof LastBatchBySeconds last && !last.valid()) {
+                    valid = false;
+                }
                 if (f instanceof LastBatch last && !last.valid()) {
                     valid = false;
                 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryPrinter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryPrinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,6 +275,7 @@ public final class QueryPrinter {
                     FIRST: The first value
                     LAST: The last value
                     LAST_BATCH: The last set of values with the same end timestamp
+                    LAST_BATCH_BY_SECONDS: The last set of values with the same end timestamp, accurate to the second
                     LIST: All values in a comma-separated list
                     MAX: The numeric maximum
                     MEDIAN: The numeric median

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -1,5 +1,5 @@
 ;
-; Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+; Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
 ; DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 ;
 ; This code is free software; you can redistribute it and/or modify it
@@ -40,9 +40,9 @@ table = "COLUMN 'Event Type', 'Enabled', 'Threshold',
                 'Stack Trace','Period','Cutoff', 'Throttle'
          FORMAT none, missing:whitespace, missing:whitespace, missing:whitespace,
                 missing:whitespace, missing:whitespace, missing:whitespace
-         SELECT E.id, LAST_BATCH(E.value), LAST_BATCH(T.value),
-                LAST_BATCH(S.value), LAST_BATCH(P.value),
-                LAST_BATCH(C.value), LAST_BATCH(U.value)
+         SELECT E.id, LAST_BATCH_BY_SECONDS(E.value), LAST_BATCH_BY_SECONDS(T.value),
+                LAST_BATCH_BY_SECONDS(S.value), LAST_BATCH_BY_SECONDS(P.value),
+                LAST_BATCH_BY_SECONDS(C.value), LAST_BATCH_BY_SECONDS(U.value)
          FROM
                 ActiveSetting AS E,
                 ActiveSetting AS T,


### PR DESCRIPTION
Hi all

Could I have a review of this patch for [JDK-8327450](https://bugs.openjdk.org/browse/JDK-8327450)?

If the jfr file is created by `JDK 8` or `JDK 11`, and use `jfr view `to show the `active-settings` view, the result is invalid, missing many settings.
```
jfr view active-settings j11.jfr

Active Settings

Event Type Enabled Threshold Stack Trace Period Cutoff Throttle
------------- ---------- ------------ -------------- --------- --------- -----------
File Force true 20 ms true
```
```
jfr summary j11.jfr
...
 Event Type Count Size (bytes)
=============================================================
...
 jdk.ActiveSetting 292 9528
...
```

The reason is the `endTime` of `jdk.ActiveSetting` on `JDK 8` or `JDK 11` increases naturally, the time between two consecutive events is approximately a few microseconds, but the `query statement` of `active-settings` view used `LAST_BATCH()`, It assumes that the end time of events are the same.
 For JDK 17 and above, this assumption is correct, but not for JDK 8 and JDK 11.

My solution is to truncate the endTime to the second.

Although `jfr view` was released in `JDK 21`, it would make some sense if it could support JFR files created by `JDK 8` and `11`.

Testing:
test/jdk/jdk/jfr/tool/TestView.java
test/jdk/jdk/jfr/jcmd/TestJcmdView.java

All passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327450](https://bugs.openjdk.org/browse/JDK-8327450): The result of jfr view active-settings is invalid if jfr file is created by JDK 11 or JDK 8 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18137/head:pull/18137` \
`$ git checkout pull/18137`

Update a local copy of the PR: \
`$ git checkout pull/18137` \
`$ git pull https://git.openjdk.org/jdk.git pull/18137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18137`

View PR using the GUI difftool: \
`$ git pr show -t 18137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18137.diff">https://git.openjdk.org/jdk/pull/18137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18137#issuecomment-1980760744)