### PR TITLE
8327477: Parallel: Remove _data_location and _highest_ref in ParallelCompactData

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -255,11 +255,11 @@ print_generic_summary_region(size_t i, const ParallelCompactData::RegionData* c)
   ParallelCompactData& sd = PSParallelCompact::summary_data();
   size_t dci = c->destination() ? sd.addr_to_region_idx(c->destination()) : 0;
   log_develop_trace(gc, compaction)(
-      REGION_IDX_FORMAT " " PTR_FORMAT " "
+      REGION_IDX_FORMAT " "
       REGION_IDX_FORMAT " " PTR_FORMAT " "
       REGION_DATA_FORMAT " " REGION_DATA_FORMAT " "
       REGION_DATA_FORMAT " " REGION_IDX_FORMAT " %d",
-      i, p2i(c->data_location()), dci, p2i(c->destination()),
+      i, dci, p2i(c->destination()),
       c->partial_obj_size(), c->live_obj_size(),
       c->data_size(), c->source_region(), c->destination_count());
 
@@ -540,7 +540,6 @@ ParallelCompactData::summarize_dense_prefix(HeapWord* beg, HeapWord* end)
     _region_data[cur_region].set_destination(addr);
     _region_data[cur_region].set_destination_count(0);
     _region_data[cur_region].set_source_region(cur_region);
-    _region_data[cur_region].set_data_location(addr);
 
     // Update live_obj_size so the region appears completely full.
     size_t live_size = RegionSize - _region_data[cur_region].partial_obj_size();
@@ -734,7 +733,6 @@ bool ParallelCompactData::summarize(SplitInfo& split_info,
       }
 
       _region_data[cur_region].set_destination_count(destination_count);
-      _region_data[cur_region].set_data_location(region_to_addr(cur_region));
       dest_addr += words;
     }
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -367,7 +367,6 @@ public:
     // These enable optimizations that are only partially implemented.  Use
     // debug builds to prevent the code fragments from breaking.
     HeapWord*            _data_location;
-    HeapWord*            _highest_ref;
 #endif  // #ifdef ASSERT
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -279,9 +279,6 @@ public:
     // Number of times the block table was filled.
     DEBUG_ONLY(inline size_t blocks_filled_count() const;)
 
-    // The location of the java heap data that corresponds to this region.
-    inline HeapWord* data_location() const;
-
     // Whether this region is available to be claimed, has been claimed, or has
     // been completed.
     //
@@ -304,7 +301,7 @@ public:
 
     inline void set_destination_count(uint count);
     inline void set_live_obj_size(size_t words);
-    inline void set_data_location(HeapWord* addr);
+
     inline void set_completed();
     inline bool claim_unsafe();
 
@@ -363,10 +360,6 @@ public:
 
 #ifdef ASSERT
     size_t               _blocks_filled_count;   // Number of block table fills.
-
-    // These enable optimizations that are only partially implemented.  Use
-    // debug builds to prevent the code fragments from breaking.
-    HeapWord*            _data_location;
 #endif  // #ifdef ASSERT
 
 #ifdef ASSERT
@@ -535,17 +528,6 @@ inline void ParallelCompactData::RegionData::decrement_destination_count()
   assert(_dc_and_los < dc_claimed, "already claimed");
   assert(_dc_and_los >= dc_one, "count would go negative");
   Atomic::add(&_dc_and_los, dc_mask);
-}
-
-inline HeapWord* ParallelCompactData::RegionData::data_location() const
-{
-  DEBUG_ONLY(return _data_location;)
-  NOT_DEBUG(return nullptr;)
-}
-
-inline void ParallelCompactData::RegionData::set_data_location(HeapWord* addr)
-{
-  DEBUG_ONLY(_data_location = addr;)
 }
 
 inline void ParallelCompactData::RegionData::set_completed()


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327477](https://bugs.openjdk.org/browse/JDK-8327477): Parallel: Remove _data_location and _highest_ref in ParallelCompactData (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18139/head:pull/18139` \
`$ git checkout pull/18139`

Update a local copy of the PR: \
`$ git checkout pull/18139` \
`$ git pull https://git.openjdk.org/jdk.git pull/18139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18139`

View PR using the GUI difftool: \
`$ git pr show -t 18139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18139.diff">https://git.openjdk.org/jdk/pull/18139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18139#issuecomment-1981022721)