### PR TITLE
JDK-8327487: Further augment WorstCaseTests with more cases

### DIFF
--- a/test/jdk/java/lang/Math/WorstCaseTests.java
+++ b/test/jdk/java/lang/Math/WorstCaseTests.java
@@ -500,7 +500,6 @@ public class WorstCaseTests {
         return failures;
     }
 
-
     private static int testAtan2Case(double input1, double input2, double expected) {
         int failures = 0;
          // Cannot represent exact result, allow 1 additional ulp on top of documented bound.
@@ -616,7 +615,6 @@ public class WorstCaseTests {
 
         return failures;
     }
-
 
     private static int testHypotCase(double input1, double input2, double expected) {
         int failures = 0;

--- a/test/jdk/java/lang/Math/WorstCaseTests.java
+++ b/test/jdk/java/lang/Math/WorstCaseTests.java
@@ -89,9 +89,11 @@ public class WorstCaseTests {
         failures += testWorstAcos();
         failures += testWorstTan();
         failures += testWorstAtan();
+        failures += testWorstAtan2();
         failures += testWorstPow2();
         failures += testWorstSinh();
         failures += testWorstCosh();
+        failures += testWorstHypot();
 
         if (failures > 0) {
             System.err.printf("Testing worst cases incurred %d failures.%n", failures);
@@ -482,6 +484,33 @@ public class WorstCaseTests {
     }
 
     /*
+     * 2 ulp stated error bound
+     */
+    private static int testWorstAtan2() {
+        int failures = 0;
+        double [][] testCases = {
+            // Input with large worst-case observed error for another math library
+            {-0x0.00000000039a2p-1022, 0x0.000fdf02p-1022, -0x1.d0ce6fac85de8p-27},
+        };
+
+        for(double[] testCase: testCases) {
+            failures += testAtan2Case(testCase[0], testCase[1], testCase[2]);
+        }
+
+        return failures;
+    }
+
+
+    private static int testAtan2Case(double input1, double input2, double expected) {
+        int failures = 0;
+         // Cannot represent exact result, allow 1 additional ulp on top of documented bound.
+        double ulps = 2.0 + 1.0;
+        failures += Tests.testUlpDiff("Math.atan2",       input1, input2, Math::atan2,       expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.atan2", input1, input2, StrictMath::atan2, expected, ulps);
+        return failures;
+    }
+
+    /*
      * 1 ulp stated error bound
      */
     private static int testWorstPow2() {
@@ -568,6 +597,33 @@ public class WorstCaseTests {
         double out = Tests.nextOut(expected);
         failures += Tests.testBounds("Math.cosh",       input, Math::cosh,       expected, out);
         failures += Tests.testBounds("StrictMath.cosh", input, StrictMath::cosh, expected, out);
+        return failures;
+    }
+
+    /*
+     * 1.5 ulp stated error bound
+     */
+    private static int testWorstHypot() {
+        int failures = 0;
+        double [][] testCases = {
+            // Input with large worst-case observed error for another math library
+            {-0x0.fffffffffffffp-1022, 0x0.0000000000001p-1022, 0x0.fffffffffffffp-1022},
+        };
+
+        for(double[] testCase: testCases) {
+            failures += testHypotCase(testCase[0], testCase[1], testCase[2]);
+        }
+
+        return failures;
+    }
+
+
+    private static int testHypotCase(double input1, double input2, double expected) {
+        int failures = 0;
+         // Cannot represent exact result, allow 1 additional ulp on top of documented bound, rounding up.
+        double ulps = 3.0;
+        failures += Tests.testUlpDiff("Math.hypot",       input1, input2, Math::hypot,       expected, ulps);
+        failures += Tests.testUlpDiff("StrictMath.hypot", input1, input2, StrictMath::hypot, expected, ulps);
         return failures;
     }
 }

--- a/test/jdk/java/lang/Math/WorstCaseTests.java
+++ b/test/jdk/java/lang/Math/WorstCaseTests.java
@@ -619,7 +619,7 @@ public class WorstCaseTests {
     private static int testHypotCase(double input1, double input2, double expected) {
         int failures = 0;
          // Cannot represent exact result, allow 1 additional ulp on top of documented bound, rounding up.
-        double ulps = 3.0;
+        double ulps = 3.0; // 1.5 + 1.0, rounded up
         failures += Tests.testUlpDiff("Math.hypot",       input1, input2, Math::hypot,       expected, ulps);
         failures += Tests.testUlpDiff("StrictMath.hypot", input1, input2, StrictMath::hypot, expected, ulps);
         return failures;


### PR DESCRIPTION
The atan2 and hypot cases added would fail for a particular test library that has errors in the millions of ulps for those inputs, rather than the small number of ulps specified for the error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327487](https://bugs.openjdk.org/browse/JDK-8327487): Further augment WorstCaseTests with more cases (**Enhancement** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18140/head:pull/18140` \
`$ git checkout pull/18140`

Update a local copy of the PR: \
`$ git checkout pull/18140` \
`$ git pull https://git.openjdk.org/jdk.git pull/18140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18140`

View PR using the GUI difftool: \
`$ git pr show -t 18140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18140.diff">https://git.openjdk.org/jdk/pull/18140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18140#issuecomment-1981481438)