### PR TITLE
8292955: Collections.checkedMap Map.merge does not properly check key and value

### DIFF
--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -3921,6 +3921,7 @@ public class Collections {
             Objects.requireNonNull(func);
             return (k, v) -> {
                 V newValue = func.apply(k, v);
+                System.out.println("key:" + k + "value:" + v);
                 typeCheck(k, newValue);
                 return newValue;
             };
@@ -4050,6 +4051,7 @@ public class Collections {
         public V merge(K key, V value,
                 BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
             Objects.requireNonNull(remappingFunction);
+            typeCheck(key, value);
             return m.merge(key, value, (v1, v2) -> {
                 V newValue = remappingFunction.apply(v1, v2);
                 typeCheck(null, newValue);

--- a/src/java.base/share/classes/java/util/Collections.java
+++ b/src/java.base/share/classes/java/util/Collections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3921,7 +3921,6 @@ public class Collections {
             Objects.requireNonNull(func);
             return (k, v) -> {
                 V newValue = func.apply(k, v);
-                System.out.println("key:" + k + "value:" + v);
                 typeCheck(k, newValue);
                 return newValue;
             };

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -30,6 +30,7 @@
  * @key randomness
  */
 
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -185,19 +186,9 @@ public class CheckedMapBash {
     }
 
     @Test(groups = "type_check")
-    public static void testTypeCheck() {
-        try {
-            Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
-            m.merge("key", "value", (v1, v2) -> null);
-            fail("Should throw ClassCastException");
-        } catch (ClassCastException ignore) {
-        }
-
-        try {
-            Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
-            m.merge("key", 3, (v1, v2) -> v2);
-            fail("Should throw ClassCastException");
-        } catch (ClassCastException ignore) {
-        }
+    public static void testCheckedMapMerge() {
+        Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
+        Assert.assertThrows(ClassCastException.class, () -> m.merge("key", "value", (v1, v2) -> null));
+        Assert.assertThrows(ClassCastException.class, () -> m.merge("key", 3, (v1, v2) -> v2));
     }
 }

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -183,4 +183,15 @@ public class CheckedMapBash {
         };
         return Arrays.asList(params);
     }
+
+    @Test(groups = "type_check")
+    public static void testTypeCheck() {
+        try {
+            Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
+            m.merge("key", "value", (v1, v2) -> null);
+            m.merge("key", 3, (v1, v2) -> v2);
+            fail("Should throw ClassCastException");
+        } catch (ClassCastException ignore) {
+        }
+    }
 }

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug     4904067 5023830 7129185 8072015
+ * @bug     4904067 5023830 7129185 8072015 8292955
  * @summary Unit test for Collections.checkedMap
  * @author  Josh Bloch
  * @run testng CheckedMapBash

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -189,6 +189,12 @@ public class CheckedMapBash {
         try {
             Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
             m.merge("key", "value", (v1, v2) -> null);
+            fail("Should throw ClassCastException");
+        } catch (ClassCastException ignore) {
+        }
+
+        try {
+            Map m = Collections.checkedMap(new HashMap<>(), Integer.class, Integer.class);
             m.merge("key", 3, (v1, v2) -> v2);
             fail("Should throw ClassCastException");
         } catch (ClassCastException ignore) {

--- a/test/jdk/java/util/Collections/CheckedMapBash.java
+++ b/test/jdk/java/util/Collections/CheckedMapBash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
When the specified key did not associated with a value, should check the `key` and `value` type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292955](https://bugs.openjdk.org/browse/JDK-8292955): Collections.checkedMap Map.merge does not properly check key and value (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18141/head:pull/18141` \
`$ git checkout pull/18141`

Update a local copy of the PR: \
`$ git checkout pull/18141` \
`$ git pull https://git.openjdk.org/jdk.git pull/18141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18141`

View PR using the GUI difftool: \
`$ git pr show -t 18141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18141.diff">https://git.openjdk.org/jdk/pull/18141.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18141#issuecomment-1981537332)