### PR TITLE
8327434: Test java/util/PluggableLocale/TimeZoneNameProviderTest.java timed out

### DIFF
--- a/test/jdk/java/util/PluggableLocale/TimeZoneNameProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/TimeZoneNameProviderTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4052440 8003267 8062588 8210406 8174269
+ * @bug 4052440 8003267 8062588 8210406 8174269 8327434
  * @summary TimeZoneNameProvider tests
  * @library providersrc/foobarutils
  *          providersrc/barprovider
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import com.bar.TimeZoneNameProviderImpl;
 
@@ -69,12 +70,12 @@ public class TimeZoneNameProviderTest extends ProviderTest {
     }
 
     void test1() {
-        Locale[] available = Locale.getAvailableLocales();
         List<Locale> jreimplloc = Arrays.asList(LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR).getTimeZoneNameProvider().getAvailableLocales());
         List<Locale> providerLocales = Arrays.asList(tznp.getAvailableLocales());
         String[] ids = TimeZone.getAvailableIDs();
 
-        for (Locale target: available) {
+        // Sampling relevant locales
+        Stream.concat(Stream.of(Locale.ROOT, Locale.US, Locale.JAPAN), providerLocales.stream()).forEach(target -> {
             // pure JRE implementation
             OpenListResourceBundle rb = ((ResourceBundleBasedAdapter)LocaleProviderAdapter.forType(LocaleProviderAdapter.Type.CLDR)).getLocaleData().getTimeZoneNames(target);
             boolean jreSupportsTarget = jreimplloc.contains(target);
@@ -111,7 +112,7 @@ public class TimeZoneNameProviderTest extends ProviderTest {
                         jreSupportsTarget && jresname != null);
                 }
             }
-        }
+        });
     }
 
     final String pattern = "z";


### PR DESCRIPTION
Fixing timeout failures in the test case. Time zone names that are missing (chiefly for minor locales) are now calculated at runtime after the fix to JDK-8174269. This extra calculation time was multiplied in the test case as it iterated over all locales x timezones, which caused timeouts in some configurations. Changed the test case to not iterate all locales, but iterate over relevant ones.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327434](https://bugs.openjdk.org/browse/JDK-8327434): Test java/util/PluggableLocale/TimeZoneNameProviderTest.java timed out (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18143/head:pull/18143` \
`$ git checkout pull/18143`

Update a local copy of the PR: \
`$ git checkout pull/18143` \
`$ git pull https://git.openjdk.org/jdk.git pull/18143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18143`

View PR using the GUI difftool: \
`$ git pr show -t 18143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18143.diff">https://git.openjdk.org/jdk/pull/18143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18143#issuecomment-1981831109)