### PR TITLE
8327501: Common ForkJoinPool prevents class unloading in some cases

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -1140,9 +1140,12 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null)
-                return new ForkJoinWorkerThread(null, pool, true, false);
-            else if (isCommon)
+            if (sm == null) {
+                if (isCommon)
+                    return new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool);
+                else
+                    return new ForkJoinWorkerThread(null, pool, true, false);
+            } else if (isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);


### PR DESCRIPTION
The common ForkJoinPool creating threads as a result of submitting tasks is preventing class unloading when the thread construction is initiated from a class loaded in a separate classloader. This fix avoids that when no SecurityManager is configured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327501](https://bugs.openjdk.org/browse/JDK-8327501): Common ForkJoinPool prevents class unloading in some cases (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18144/head:pull/18144` \
`$ git checkout pull/18144`

Update a local copy of the PR: \
`$ git checkout pull/18144` \
`$ git pull https://git.openjdk.org/jdk.git pull/18144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18144`

View PR using the GUI difftool: \
`$ git pr show -t 18144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18144.diff">https://git.openjdk.org/jdk/pull/18144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18144#issuecomment-1982005309)