### PR TITLE
8327424: ProblemList serviceability/sa/TestJmapCore.java on all platforms with ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -34,7 +34,7 @@ serviceability/sa/ClhsdbJstackWithConcurrentLock.java         8276539   generic-
 serviceability/sa/jmap-hprof/JMapHProfLargeHeapTest.java      8276539   generic-all
 
 serviceability/sa/ClhsdbFindPC.java#xcomp-core                8284045   generic-all
-serviceability/sa/TestJmapCore.java                           8268283,8270202   linux-aarch64,linux-x64,macosx-aarch64
+serviceability/sa/TestJmapCore.java                           8268283,8270202   generic-all
 serviceability/sa/TestJmapCoreMetaspace.java                  8268636   generic-all
 
 serviceability/sa/TestJhsdbJstackMixed.java                   8248912   generic-all


### PR DESCRIPTION
This test can fail due to [JDK-8270202](https://bugs.openjdk.org/browse/JDK-8270202) on all platforms, but currently is not problem listed for windows-x64 or macosx-x64. It should be problem listed for all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327424](https://bugs.openjdk.org/browse/JDK-8327424): ProblemList serviceability/sa/TestJmapCore.java on all platforms with ZGC (**Sub-task** - P5)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18146/head:pull/18146` \
`$ git checkout pull/18146`

Update a local copy of the PR: \
`$ git checkout pull/18146` \
`$ git pull https://git.openjdk.org/jdk.git pull/18146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18146`

View PR using the GUI difftool: \
`$ git pr show -t 18146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18146.diff">https://git.openjdk.org/jdk/pull/18146.diff</a>

</details>
