### PR TITLE
8327522: Shenandoah: Remove unused references to satb_mark_queue_active_offset

### DIFF
--- a/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shenandoah/shenandoahBarrierSetAssembler_x86.cpp
@@ -219,7 +219,6 @@ void ShenandoahBarrierSetAssembler::satb_write_barrier_pre(MacroAssembler* masm,
     assert(pre_val != rax, "check this code");
   }
 
-  Address in_progress(thread, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_active_offset()));
   Address index(thread, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_index_offset()));
   Address buffer(thread, in_bytes(ShenandoahThreadLocalData::satb_mark_queue_buffer_offset()));
 


### PR DESCRIPTION
Removed an unused variable (trivial)

Also, there is another place that uses satb_mark_queue_active_offset which is ShenandoahBarrierSetC2::verify_gc_barriers
The current barrier pattern is different from what this code is expecting:
If->Bool->CmpI->AndI->LoadUB->AddP->ConL(gc_state_offset)
rather than
If->Bool->CmpI->LoadB->AddP->ConL(marking_offset)
However, this code isn't doing as much checking as its counterpart in G1 anyway (so I'm thinking removing the incorrect matching code altogether?) Looking forward to your suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327522](https://bugs.openjdk.org/browse/JDK-8327522): Shenandoah: Remove unused references to satb_mark_queue_active_offset (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18148/head:pull/18148` \
`$ git checkout pull/18148`

Update a local copy of the PR: \
`$ git checkout pull/18148` \
`$ git pull https://git.openjdk.org/jdk.git pull/18148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18148`

View PR using the GUI difftool: \
`$ git pr show -t 18148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18148.diff">https://git.openjdk.org/jdk/pull/18148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18148#issuecomment-1982850990)