### PR TITLE
JDK-8326332: Unclosed inline tags cause misalignment in summary tables

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -113,6 +113,7 @@ import jdk.javadoc.internal.doclets.toolkit.util.Utils.PreviewSummary;
 import jdk.javadoc.internal.doclint.HtmlTag;
 
 import static com.sun.source.doctree.DocTree.Kind.COMMENT;
+import static com.sun.source.doctree.DocTree.Kind.START_ELEMENT;
 import static com.sun.source.doctree.DocTree.Kind.TEXT;
 
 
@@ -1171,21 +1172,28 @@ public abstract class HtmlDocletWriter {
         }
     }
 
-    boolean ignoreNonInlineTag(DocTree dtree) {
+    boolean ignoreNonInlineTag(DocTree dtree, List<Name> openTags) {
         Name name = null;
-        if (dtree.getKind() == Kind.START_ELEMENT) {
-            StartElementTree setree = (StartElementTree)dtree;
-            name = setree.getName();
-        } else if (dtree.getKind() == Kind.END_ELEMENT) {
-            EndElementTree eetree = (EndElementTree)dtree;
-            name = eetree.getName();
+        Kind kind = dtree.getKind();
+        if (kind == Kind.START_ELEMENT) {
+            name = ((StartElementTree)dtree).getName();
+        } else if (kind == Kind.END_ELEMENT) {
+            name = ((EndElementTree)dtree).getName();
         }
 
         if (name != null) {
             HtmlTag htmlTag = HtmlTag.get(name);
-            if (htmlTag != null &&
-                    htmlTag.blockType != jdk.javadoc.internal.doclint.HtmlTag.BlockType.INLINE) {
-                return true;
+            if (htmlTag != null) {
+                if (htmlTag.blockType != HtmlTag.BlockType.INLINE) {
+                    return true;
+                }
+                // Keep track of open inline tags that need to be closed, see 8326332
+                if (kind == START_ELEMENT && htmlTag.endKind == HtmlTag.EndKind.REQUIRED) {
+                    openTags.add(name);
+                } else if (kind == Kind.END_ELEMENT && !openTags.isEmpty()
+                        && openTags.getLast().equals(name)) {
+                    openTags.removeLast();
+                }
             }
         }
         return false;
@@ -1257,6 +1265,7 @@ public abstract class HtmlDocletWriter {
         CommentHelper ch = utils.getCommentHelper(element);
         configuration.tagletManager.checkTags(element, trees);
         commentRemoved = false;
+        ArrayList<Name> openTags = new ArrayList<>();
 
         for (ListIterator<? extends DocTree> iterator = trees.listIterator(); iterator.hasNext();) {
             boolean isFirstNode = !iterator.hasPrevious();
@@ -1265,14 +1274,16 @@ public abstract class HtmlDocletWriter {
 
             if (context.isFirstSentence) {
                 // Ignore block tags
-                if (ignoreNonInlineTag(tag))
+                if (ignoreNonInlineTag(tag, openTags)) {
                     continue;
+                }
 
                 // Ignore any trailing whitespace OR whitespace after removed html comment
                 if ((isLastNode || commentRemoved)
                         && tag.getKind() == TEXT
-                        && ((tag instanceof TextTree tt) && tt.getBody().isBlank()))
+                        && ((tag instanceof TextTree tt) && tt.getBody().isBlank())) {
                     continue;
+                }
 
                 // Ignore any leading html comments
                 if ((isFirstNode || commentRemoved) && tag.getKind() == COMMENT) {
@@ -1465,6 +1476,10 @@ public abstract class HtmlDocletWriter {
 
             if (allDone)
                 break;
+        }
+        // Close any open inline tags
+        while (!openTags.isEmpty()) {
+            result.add(RawHtml.endElement(openTags.removeLast()));
         }
         return result;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1265,7 +1265,7 @@ public abstract class HtmlDocletWriter {
         CommentHelper ch = utils.getCommentHelper(element);
         configuration.tagletManager.checkTags(element, trees);
         commentRemoved = false;
-        ArrayList<Name> openTags = new ArrayList<>();
+        List<Name> openTags = new ArrayList<>();
 
         for (ListIterator<? extends DocTree> iterator = trees.listIterator(); iterator.hasNext();) {
             boolean isFirstNode = !iterator.hasPrevious();

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/TestBreakIterator.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4165985
+ * @bug 4165985 8326332
  * @summary Determine the end of the first sentence using BreakIterator.
  * If the first sentence of "method" is parsed correctly, the test passes.
  * Correct Answer: "This is a class (i.e. it is indeed a class)."
@@ -76,5 +76,10 @@ public class TestBreakIterator extends JavadocTester {
                 """
                     <div class="block">A constant indicating that the keyLocation is indeterminate
                      or not relevant.</div>""");
+
+        checkOutput("pkg/BreakIteratorTest.html", true,
+                """
+                    <div class="block">Inline tags <i><a href="../index-all.html">extending
+                     beyond the first sentence.</a></i></div>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testBreakIterator/pkg/BreakIteratorTest.java
+++ b/test/langtools/jdk/javadoc/doclet/testBreakIterator/pkg/BreakIteratorTest.java
@@ -56,4 +56,9 @@ public class BreakIteratorTest {
      */
     public void fe(){}
 
+    /**
+     * Inline tags <i><a href="{@docRoot}/index-all.html">extending
+     * beyond the first sentence. Tags are closed here.</a></i>
+     */
+    public void meh(){}
 }


### PR DESCRIPTION
Please review a simple fix to make sure inline tags are always closed in summary tables, even when the tags are closed after the first sentence in the original doc comment. 

I decided to colocate the functionality to track open inline tags with the existing `ignoreNonInlineTag` method that filters out non-inline elements because there is a lot of common functionality, such as retrieving the name and kind of an HTML tag. I considered giving the method a name that describes the additional functionality, but couldn't find one that wasn't comically long. Suggestions are welcome of course.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326332](https://bugs.openjdk.org/browse/JDK-8326332): Unclosed inline tags cause misalignment in summary tables (**Bug** - P3)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [9353d1ea](https://git.openjdk.org/jdk/pull/18154/files/9353d1ea12423f6e76b90672f721e79a58e4b04f)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to [9353d1ea](https://git.openjdk.org/jdk/pull/18154/files/9353d1ea12423f6e76b90672f721e79a58e4b04f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18154/head:pull/18154` \
`$ git checkout pull/18154`

Update a local copy of the PR: \
`$ git checkout pull/18154` \
`$ git pull https://git.openjdk.org/jdk.git pull/18154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18154`

View PR using the GUI difftool: \
`$ git pr show -t 18154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18154.diff">https://git.openjdk.org/jdk/pull/18154.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18154#issuecomment-1983636525)