### PR TITLE
8327486: java/util/Properties/PropertiesStoreTest.java fails "Text 'xxx' could not be parsed at index 20" after 8174269

### DIFF
--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -57,7 +57,7 @@ public class PropertiesStoreTest {
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
     // use a neutral locale, since when the date comment was written by Properties.store(...),
     // it internally calls the Date.toString() which always writes in a locale insensitive manner
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.ROOT);
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.US);
     private static final Locale PREV_LOCALE = Locale.getDefault();
 
     @DataProvider(name = "propsProvider")

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,8 +55,6 @@ import java.util.stream.Collectors;
 public class PropertiesStoreTest {
 
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
-    // use a neutral locale, since when the date comment was written by Properties.store(...),
-    // it internally calls the Date.toString() which always writes in a locale insensitive manner
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.US);
     private static final Locale PREV_LOCALE = Locale.getDefault();
 

--- a/test/jdk/java/util/Properties/PropertiesStoreTest.java
+++ b/test/jdk/java/util/Properties/PropertiesStoreTest.java
@@ -55,6 +55,8 @@ import java.util.stream.Collectors;
 public class PropertiesStoreTest {
 
     private static final String DATE_FORMAT_PATTERN = "EEE MMM dd HH:mm:ss zzz uuuu";
+    // use Locale.US, since when the date comment was written by Properties.store(...),
+    // it internally calls the Date.toString() which uses Locale.US for time zone names
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN, Locale.US);
     private static final Locale PREV_LOCALE = Locale.getDefault();
 


### PR DESCRIPTION
Date.toString() uses Locale.US explicitly for printing the time zone, so replace Locale.ROOT to Locale.US in this testcase for fix the test failure.

This testcase fixed has been verified.

Only change the testcase, risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327486](https://bugs.openjdk.org/browse/JDK-8327486): java/util/Properties/PropertiesStoreTest.java fails "Text 'xxx' could not be parsed at index 20" after 8174269 (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18155/head:pull/18155` \
`$ git checkout pull/18155`

Update a local copy of the PR: \
`$ git checkout pull/18155` \
`$ git pull https://git.openjdk.org/jdk.git pull/18155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18155`

View PR using the GUI difftool: \
`$ git pr show -t 18155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18155.diff">https://git.openjdk.org/jdk/pull/18155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18155#issuecomment-1983991539)