### PR TITLE
8327621: Check return value of uname in os::get_host_name

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -611,11 +611,12 @@ void os::print_jni_name_suffix_on(outputStream* st, int args_size) {
 bool os::get_host_name(char* buf, size_t buflen) {
   struct utsname name;
   int retcode = uname(&name);
+  int saved_errno = errno;
   if (retcode != -1) {
     jio_snprintf(buf, buflen, "%s", name.nodename);
     return true;
   }
-  const char* errmsg = os::strerror(retcode);
+  const char* errmsg = os::strerror(saved_errno);
   log_warning(os)("Failed to get host name, error message: %s", errmsg);
   return false;
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -611,12 +611,11 @@ void os::print_jni_name_suffix_on(outputStream* st, int args_size) {
 bool os::get_host_name(char* buf, size_t buflen) {
   struct utsname name;
   int retcode = uname(&name);
-  int saved_errno = errno;
   if (retcode != -1) {
     jio_snprintf(buf, buflen, "%s", name.nodename);
     return true;
   }
-  const char* errmsg = os::strerror(saved_errno);
+  const char* errmsg = os::strerror(errno);
   log_warning(os)("Failed to get host name, error message: %s", errmsg);
   return false;
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -610,10 +610,13 @@ void os::print_jni_name_suffix_on(outputStream* st, int args_size) {
 
 bool os::get_host_name(char* buf, size_t buflen) {
   struct utsname name;
-  if (uname(&name) == 0) {
+  int retcode = uname(&name);
+  if (retcode != -1) {
     jio_snprintf(buf, buflen, "%s", name.nodename);
     return true;
   }
+  const char* errmsg = os::strerror(retcode);
+  log_warning(os)("Failed to get host name, error message: %s", errmsg);
   return false;
 }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -610,9 +610,11 @@ void os::print_jni_name_suffix_on(outputStream* st, int args_size) {
 
 bool os::get_host_name(char* buf, size_t buflen) {
   struct utsname name;
-  uname(&name);
-  jio_snprintf(buf, buflen, "%s", name.nodename);
-  return true;
+  if (uname(&name) == 0) {
+    jio_snprintf(buf, buflen, "%s", name.nodename);
+    return true;
+  }
+  return false;
 }
 
 #ifndef _LP64


### PR DESCRIPTION
Hi,

Trivial bug fix where we didn't check the return value of `uname(2)` on POSIX platforms. I checked callers of `get_host_name` and all wrap the calls in an `if` branch so they already handle failures.

Regards,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327621](https://bugs.openjdk.org/browse/JDK-8327621): Check return value of uname in os::get_host_name (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [9094ac42](https://git.openjdk.org/jdk/pull/18157/files/9094ac42cb6824708c620a64e7b97b14c3783480)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18157/head:pull/18157` \
`$ git checkout pull/18157`

Update a local copy of the PR: \
`$ git checkout pull/18157` \
`$ git pull https://git.openjdk.org/jdk.git pull/18157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18157`

View PR using the GUI difftool: \
`$ git pr show -t 18157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18157.diff">https://git.openjdk.org/jdk/pull/18157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18157#issuecomment-1984177532)