### PR TITLE
8327167: Clarify the handling of Leap year by Calendar

### DIFF
--- a/src/java.base/share/classes/java/util/Calendar.java
+++ b/src/java.base/share/classes/java/util/Calendar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -282,7 +282,9 @@ import sun.util.spi.CalendarProvider;
  * {@code DAY_OF_MONTH} to 30, the closest possible value. Although
  * it is a smaller field, {@code DAY_OF_WEEK} is not adjusted by
  * rule 2, since it is expected to change when the month changes in a
- * {@code GregorianCalendar}.</p>
+ * {@code GregorianCalendar}. In leap years, the adjustment accounts
+ * for the leap day in February to ensure the day of month is valid
+ * for the year.</p>
  *
  * <p><strong>{@code roll(f, delta)}</strong> adds
  * {@code delta} to field {@code f} without changing larger


### PR DESCRIPTION
A simple doc update to include a leap day example in the `Calendar` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8327167](https://bugs.openjdk.org/browse/JDK-8327167): Clarify the handling of Leap year by Calendar (**Bug** - P4)
 * [JDK-8327258](https://bugs.openjdk.org/browse/JDK-8327258): Add add() example for Leap Day in Calendar's doc (**CSR**) (Withdrawn)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18158/head:pull/18158` \
`$ git checkout pull/18158`

Update a local copy of the PR: \
`$ git checkout pull/18158` \
`$ git pull https://git.openjdk.org/jdk.git pull/18158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18158`

View PR using the GUI difftool: \
`$ git pr show -t 18158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18158.diff">https://git.openjdk.org/jdk/pull/18158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18158#issuecomment-1984278329)