### PR TITLE
JDK-8315575: Retransform of record class with record component annotation fails with CFE

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3407,9 +3407,13 @@ u4 ClassFileParser::parse_classfile_record_attribute(const ClassFileStream* cons
                                                              runtime_invisible_type_annotations_length,
                                                              CHECK_0);
 
+    // Some attributes can be ignored. Calculate actual attributes_count.
+    u2 actual_attributes_count = generic_sig_index != 0 ? 1 : 0
+                               + annotations != nullptr ? 1 : 0
+                               + type_annotations != nullptr ? 1 : 0;
     RecordComponent* record_component =
       RecordComponent::allocate(_loader_data, name_index, descriptor_index,
-                                attributes_count, generic_sig_index,
+                                actual_attributes_count, generic_sig_index,
                                 annotations, type_annotations, CHECK_0);
     record_components->at_put(x, record_component);
   }  // End of component processing loop

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -3407,13 +3407,8 @@ u4 ClassFileParser::parse_classfile_record_attribute(const ClassFileStream* cons
                                                              runtime_invisible_type_annotations_length,
                                                              CHECK_0);
 
-    // Some attributes can be ignored. Calculate actual attributes_count.
-    u2 actual_attributes_count = generic_sig_index != 0 ? 1 : 0
-                               + annotations != nullptr ? 1 : 0
-                               + type_annotations != nullptr ? 1 : 0;
     RecordComponent* record_component =
-      RecordComponent::allocate(_loader_data, name_index, descriptor_index,
-                                actual_attributes_count, generic_sig_index,
+      RecordComponent::allocate(_loader_data, name_index, descriptor_index, generic_sig_index,
                                 annotations, type_annotations, CHECK_0);
     record_components->at_put(x, record_component);
   }  // End of component processing loop

--- a/src/hotspot/share/oops/recordComponent.cpp
+++ b/src/hotspot/share/oops/recordComponent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,11 @@
 
 RecordComponent* RecordComponent::allocate(ClassLoaderData* loader_data,
                                            u2 name_index, u2 descriptor_index,
-                                           u2 attributes_count,
                                            u2 generic_signature_index,
                                            AnnotationArray* annotations,
                                            AnnotationArray* type_annotations, TRAPS) {
   return new (loader_data, size(), MetaspaceObj::RecordComponentType, THREAD)
-         RecordComponent(name_index, descriptor_index, attributes_count,
+         RecordComponent(name_index, descriptor_index,
                          generic_signature_index, annotations, type_annotations);
 }
 
@@ -65,7 +64,6 @@ void RecordComponent::print_value_on(outputStream* st) const {
 void RecordComponent::print_on(outputStream* st) const {
   st->print("name_index: %d", _name_index);
   st->print(" - descriptor_index: %d", _descriptor_index);
-  st->print(" - attributes_count: %d", _attributes_count);
   if (_generic_signature_index != 0) {
     st->print(" - generic_signature_index: %d", _generic_signature_index);
   }

--- a/src/hotspot/share/oops/recordComponent.hpp
+++ b/src/hotspot/share/oops/recordComponent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,25 +36,21 @@ class RecordComponent: public MetaspaceObj {
     AnnotationArray* _type_annotations;
     u2 _name_index;
     u2 _descriptor_index;
-    u2 _attributes_count;
 
     // generic_signature_index gets set if the Record component has a Signature
     // attribute.  A zero value indicates that there was no Signature attribute.
     u2 _generic_signature_index;
 
   public:
-    RecordComponent(u2 name_index, u2 descriptor_index, u2 attributes_count,
-                    u2 generic_signature_index, AnnotationArray* annotations,
-                    AnnotationArray* type_annotations):
+    RecordComponent(u2 name_index, u2 descriptor_index, u2 generic_signature_index,
+                    AnnotationArray* annotations, AnnotationArray* type_annotations):
                     _annotations(annotations), _type_annotations(type_annotations),
                     _name_index(name_index), _descriptor_index(descriptor_index),
-                    _attributes_count(attributes_count),
                     _generic_signature_index(generic_signature_index) { }
 
     // Allocate instance of this class
     static RecordComponent* allocate(ClassLoaderData* loader_data,
                                      u2 name_index, u2 descriptor_index,
-                                     u2 attributes_count,
                                      u2 generic_signature_index,
                                      AnnotationArray* annotations,
                                      AnnotationArray* type_annotations, TRAPS);
@@ -68,8 +64,6 @@ class RecordComponent: public MetaspaceObj {
     void set_descriptor_index(u2 descriptor_index) {
       _descriptor_index = descriptor_index;
     }
-
-    u2 attributes_count() const { return _attributes_count; }
 
     u2 generic_signature_index() const { return _generic_signature_index; }
     void set_generic_signature_index(u2 generic_signature_index) {

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -494,7 +494,6 @@ void JvmtiClassFileReconstituter::write_record_attribute() {
     RecordComponent* component = components->at(x);
     if (component->generic_signature_index() != 0) {
       length += 8; // Signature attribute size
-      assert(component->attributes_count() > 0, "Bad component attributes count");
     }
     if (component->annotations() != nullptr) {
       length += 6 + component->annotations()->length();
@@ -511,7 +510,10 @@ void JvmtiClassFileReconstituter::write_record_attribute() {
     RecordComponent* component = components->at(i);
     write_u2(component->name_index());
     write_u2(component->descriptor_index());
-    write_u2(component->attributes_count());
+    u2 attributes_count = component->generic_signature_index() != 0 ? 1 : 0
+                        + component->annotations() != nullptr ? 1 : 0
+                        + component->type_annotations() != nullptr ? 1 : 0;
+    write_u2(attributes_count);
     if (component->generic_signature_index() != 0) {
       write_signature_attribute(component->generic_signature_index());
     }

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -510,9 +510,10 @@ void JvmtiClassFileReconstituter::write_record_attribute() {
     RecordComponent* component = components->at(i);
     write_u2(component->name_index());
     write_u2(component->descriptor_index());
-    u2 attributes_count = component->generic_signature_index() != 0 ? 1 : 0
-                        + component->annotations() != nullptr ? 1 : 0
-                        + component->type_annotations() != nullptr ? 1 : 0;
+    u2 attributes_count = (component->generic_signature_index() != 0 ? 1 : 0)
+                        + (component->annotations() != nullptr ? 1 : 0)
+                        + (component->type_annotations() != nullptr ? 1 : 0);
+
     write_u2(attributes_count);
     if (component->generic_signature_index() != 0) {
       write_signature_attribute(component->generic_signature_index());

--- a/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
+++ b/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8315575
- * @summary test that records with invisible annotation can be retfansformed
+ * @summary test that records with invisible annotation can be retransformed
  *
  * @library /test/lib
  * @run shell MakeJAR.sh retransformAgent

--- a/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
+++ b/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
@@ -93,6 +93,7 @@ public class RetransformRecordAnnotation extends AInstrumentationTestCase {
 
         {
             log("Test: retransform to null");
+            // Ensure retransformation does not fail with ClassFormatError.
             retransform(null);
             log("");
         }

--- a/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
+++ b/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
@@ -112,6 +112,9 @@ public class RetransformRecordAnnotation extends AInstrumentationTestCase {
             log("");
         }
 
+        // The following testcases use null as new class bytes (i.e. no transform is performed).
+        // However, it is enough for testing purposes as the JvmtiClassFileReconstituter is still involved
+        // in preparation of the initial class bytes.
         {
             log("Test: retransform VisibleAnnos to null");
             retransform(VisibleAnnos.class, null);

--- a/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
+++ b/test/jdk/java/lang/instrument/RetransformRecordAnnotation.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8315575
+ * @summary test that records with invisible annotation can be retfansformed
+ *
+ * @library /test/lib
+ * @run shell MakeJAR.sh retransformAgent
+ * @run main/othervm -javaagent:retransformAgent.jar -Xlog:redefine+class=trace RetransformRecordAnnotation
+ */
+
+import java.io.File;
+import java.lang.instrument.ClassFileTransformer;
+import java.nio.file.Files;
+import java.security.ProtectionDomain;
+
+public class RetransformRecordAnnotation extends AInstrumentationTestCase {
+
+    // RetentionPolicy.CLASS by default
+    @interface MyAnnotation{}
+    public record MyRecord(@MyAnnotation Object o, Object other) {}
+
+    public static void main (String[] args) throws Throwable {
+        ATestCaseScaffold test = new RetransformRecordAnnotation();
+        test.beVerbose();
+        test.runTest();
+    }
+
+    private String targetClassName = "RetransformRecordAnnotation$MyRecord";
+    private String classFileName = targetClassName + ".class";
+    private Class targetClass;
+    private byte[] originalClassBytes;
+
+    private byte[] seenClassBytes;
+    private byte[] newClassBytes;
+
+    public RetransformRecordAnnotation() throws Throwable {
+        super("RetransformRecordAnnotation");
+
+        File origClassFile = new File(System.getProperty("test.classes", "."), classFileName);
+        log("Reading test class from " + origClassFile);
+        originalClassBytes = Files.readAllBytes(origClassFile.toPath());
+        log("Read " + originalClassBytes.length + " bytes.");
+    }
+
+    private void log(Object o) {
+        System.out.println(String.valueOf(o));
+    }
+
+    // Retransforms target class using provided class bytes;
+    // Returns class bytes passed to the transformer.
+    private byte[] retransform(byte[] classBytes) throws Throwable {
+        seenClassBytes = null;
+        newClassBytes = classBytes;
+        fInst.retransformClasses(targetClass);
+        assertTrue(targetClassName + " was not seen by transform()", seenClassBytes != null);
+        return seenClassBytes;
+    }
+
+    protected final void doRunTest() throws Throwable {
+        ClassLoader loader = getClass().getClassLoader();
+        targetClass = loader.loadClass(targetClassName);
+
+        fInst.addTransformer(new Transformer(), true);
+
+        {
+            log("Sanity: retransform to original class bytes");
+            retransform(originalClassBytes);
+            log("");
+        }
+
+        {
+            log("Test: retransform to null");
+            retransform(null);
+            log("");
+        }
+    }
+
+
+    public class Transformer implements ClassFileTransformer {
+        public Transformer() {
+        }
+
+        public String toString() {
+            return Transformer.this.getClass().getName();
+        }
+
+        public byte[] transform(ClassLoader loader, String className,
+            Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) {
+
+            if (className.equals(targetClassName)) {
+                log(this + ".transform() sees '" + className
+                        + "' of " + classfileBuffer.length + " bytes.");
+                seenClassBytes = classfileBuffer;
+                if (newClassBytes != null) {
+                    log(this + ".transform() sets new classbytes for '" + className
+                            + "' of " + newClassBytes.length + " bytes.");
+                }
+                return newClassBytes;
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
RecordComponent class has _attributes_count field.
The only user of the field is JvmtiClassFileReconstituter. Incorrect value of the field causes producing incorrect data for Record attribute.
Parsing Record attribute ClassFileParser skips unknown attributes and may skip RuntimeInvisibleAnnotations/RuntimeInvisibleTypeAnnotations.
Also annotations can be changed (added/removed) by class redefinition.
The fix removes attributes_count from RecordComponent; JvmtiClassFileReconstituter calculates correct attributes_count generating class bytes.

Testing: 
- tier1,tier2,hs-tier5-svc;
 - redefineClasses/retransformClasses tests:
   - test/jdk/java/lang/instrument
   - test/hotspot/jtreg/serviceability/jvmti/RedefineClasses
   - test/hotspot/jtreg/vmTestbase/nsk/jvmti/RedefineClasses
   - test/hotspot/jtreg/vmTestbase/nsk/jvmti/RetransformClasses

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315575](https://bugs.openjdk.org/browse/JDK-8315575): Retransform of record class with record component annotation fails with CFE (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18161/head:pull/18161` \
`$ git checkout pull/18161`

Update a local copy of the PR: \
`$ git checkout pull/18161` \
`$ git pull https://git.openjdk.org/jdk.git pull/18161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18161`

View PR using the GUI difftool: \
`$ git pr show -t 18161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18161.diff">https://git.openjdk.org/jdk/pull/18161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18161#issuecomment-1984959472)