### PR TITLE
8326333: jshell <TAB> completion on arrays is incomplete

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysisImpl.java
@@ -1032,14 +1032,7 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             case DECLARED: {
                 TypeElement element = (TypeElement) at.getTypes().asElement(site);
                 List<Element> result = new ArrayList<>();
-                at.getElements().getAllMembers(element).forEach(m -> result.add(
-                    element.equals(m.getEnclosingElement())
-                        ? m
-                        : (m instanceof Symbol.MethodSymbol ms)
-                            ? ms.clone((Symbol)element)
-                            : (m instanceof Symbol.VarSymbol vs)
-                                ? vs.clone((Symbol)element)
-                                : m));
+                result.addAll(membersOf(at, element));
                 if (shouldGenerateDotClassItem) {
                     result.add(createDotClassSymbol(at, site));
                 }
@@ -1076,6 +1069,10 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             }
             case ARRAY: {
                 List<Element> result = new ArrayList<>();
+                TypeElement jlObject = at.getElements().getTypeElement("java.lang.Object");
+                if (jlObject != null) {
+                    result.addAll(membersOf(at, jlObject));
+                }
                 result.add(createArrayLengthSymbol(at, site));
                 if (shouldGenerateDotClassItem)
                     result.add(createDotClassSymbol(at, site));
@@ -1084,6 +1081,17 @@ class SourceCodeAnalysisImpl extends SourceCodeAnalysis {
             default:
                 return Collections.emptyList();
         }
+    }
+
+    private List<? extends Element> membersOf(AnalyzeTask at, TypeElement element) {
+        return at.getElements().getAllMembers(element).stream().map(m ->
+            element.equals(m.getEnclosingElement())
+                ? m
+                : (m instanceof Symbol.MethodSymbol ms)
+                    ? ms.clone((Symbol)element)
+                    : (m instanceof Symbol.VarSymbol vs)
+                        ? vs.clone((Symbol)element)
+                        : m).toList();
     }
 
     private List<? extends Element> membersOf(AnalyzeTask at, List<? extends Element> elements) {

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -811,7 +811,7 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertSignature("test(|", "void test(String s)", "void test(Integer i)");
     }
 
-    //JDK-8326333
+    //JDK-8326333: verify completion returns sensible output for arrays:
     public void testArray() {
         assertEval("String[] strs = null;");
         assertCompletion("strs.to|", "toString()");

--- a/test/langtools/jdk/jshell/CompletionSuggestionTest.java
+++ b/test/langtools/jdk/jshell/CompletionSuggestionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206 8296789 8314662
+ * @bug 8131025 8141092 8153761 8145263 8131019 8175886 8176184 8176241 8176110 8177466 8197439 8221759 8234896 8240658 8278039 8286206 8296789 8314662 8326333
  * @summary Test Completion and Documentation
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -86,9 +86,9 @@ public class CompletionSuggestionTest extends KullaTesting {
         assertCompletion("Object[].|", "class");
         assertCompletion("int[].|", "class");
         assertEval("Object[] ao = null;");
-        assertCompletion("int i = ao.|", "length");
+        assertCompletion("int i = ao.le|", "length");
         assertEval("int[] ai = null;");
-        assertCompletion("int i = ai.|", "length");
+        assertCompletion("int i = ai.le|", "length");
         assertCompletionIncludesExcludes("\"\".|",
                 new HashSet<>(Collections.emptyList()),
                 new HashSet<>(Arrays.asList("String(")));
@@ -809,5 +809,16 @@ public class CompletionSuggestionTest extends KullaTesting {
                                      ste(m1, RECOVERABLE_DEFINED, VALID, true, MAIN_SNIPPET),
                                      ste(m2, RECOVERABLE_DEFINED, VALID, true, MAIN_SNIPPET));
         assertSignature("test(|", "void test(String s)", "void test(Integer i)");
+    }
+
+    //JDK-8326333
+    public void testArray() {
+        assertEval("String[] strs = null;");
+        assertCompletion("strs.to|", "toString()");
+        assertCompletion("strs.le|", "length");
+        assertEval("int[] ints = null;");
+        assertCompletion("ints.no|", "notify()", "notifyAll()");
+        assertCompletion("ints.le|", "length");
+        assertCompletion("String[].|", "class");
     }
 }


### PR DESCRIPTION
Inside jshell, arrays don't show `Object` method in array code completion, i.e.:
```
jshell> String[] arr = null;
arr ==> null

jshell> arr.<code-completion-here>
```

will only show `length`. This patch adds `j.l.Object` methods to the suggestions for arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326333](https://bugs.openjdk.org/browse/JDK-8326333): jshell &lt;TAB&gt; completion on arrays is incomplete (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18163/head:pull/18163` \
`$ git checkout pull/18163`

Update a local copy of the PR: \
`$ git checkout pull/18163` \
`$ git pull https://git.openjdk.org/jdk.git pull/18163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18163`

View PR using the GUI difftool: \
`$ git pr show -t 18163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18163.diff">https://git.openjdk.org/jdk/pull/18163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18163#issuecomment-1985284190)