### PR TITLE
JDK-8327468: Do not restart close if errno is EINTR [macOS/linux]

### DIFF
--- a/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/linux/native/libattach/VirtualMachineImpl.c
@@ -194,7 +194,10 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_close
 {
     int res;
     shutdown(fd, SHUT_RDWR);
-    RESTARTABLE(close(fd), res);
+    res = close(fd);
+    if (res == -1) {
+        JNU_ThrowIOExceptionWithLastError(env, "close");
+    }
 }
 
 /*


### PR DESCRIPTION
There are a number of places remaining in the linux/macOS native JDK codebase where we use the RESTARTABLE macro with close, but this is unwanted on Linux/macOS.