### PR TITLE
8327675: jspawnhelper should be built on all unix platforms

### DIFF
--- a/make/modules/java.base/Launcher.gmk
+++ b/make/modules/java.base/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ endif
 
 ################################################################################
 
-ifeq ($(call isTargetOs, macosx aix linux), true)
+ifeq ($(call isTargetOsType, unix), true)
   $(eval $(call SetupJdkExecutable, BUILD_JSPAWNHELPER, \
       NAME := jspawnhelper, \
       SRC := $(TOPDIR)/src/$(MODULE)/unix/native/jspawnhelper, \


### PR DESCRIPTION
We should match the building of jspawnhelper in make/modules/java.base/Launcher.gmk with the usage for all unix platforms in src/java.base/unix/classes/java/lang/ProcessImpl.java.

Granted, the list of OSes in the makefile amounts to the current list of all Unix OSes in the JDK, but there is no need to have this logical disparity. 

This was inspired by the discovery in https://github.com/openjdk/jdk/pull/18112#discussion_r1517455696.