### PR TITLE
8327689: RISC-V: adjust test filters of zfh extension

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16Conversion.java
@@ -26,7 +26,7 @@
  * @bug 8289551 8302976
  * @summary Verify conversion between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
- *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/Binary16ConversionNaN.java
@@ -26,7 +26,7 @@
  * @bug 8289551 8302976
  * @summary Verify NaN sign and significand bits are preserved across conversions
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
- *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @library /test/lib /

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestAllFloat16ToFloat.java
@@ -26,7 +26,7 @@
  * @bug 8302976
  * @summary Verify conversion between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch == "aarch64"
- *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run:

--- a/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/float16/TestConstFloat16ToFloat.java
@@ -26,7 +26,7 @@
  * @bug 8302976
  * @summary Verify conversion cons between float and the binary16 format
  * @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch=="aarch64"
- *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh,.*")
+ *           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
  * @requires vm.compiler1.enabled & vm.compiler2.enabled
  * @requires vm.compMode != "Xcomp"
  * @comment default run:


### PR DESCRIPTION
Hi,
Can you review this simple patch?
Thanks

FYI:
test filter `vm.cpu.features ~= ".*zfh,.*"` could be adjusted to `vm.cpu.features ~= ".*zfh.*"` according to comment at https://github.com/openjdk/jdk/pull/17698#discussion_r1517349407

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327689](https://bugs.openjdk.org/browse/JDK-8327689): RISC-V: adjust test filters of zfh extension (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18169/head:pull/18169` \
`$ git checkout pull/18169`

Update a local copy of the PR: \
`$ git checkout pull/18169` \
`$ git pull https://git.openjdk.org/jdk.git pull/18169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18169`

View PR using the GUI difftool: \
`$ git pr show -t 18169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18169.diff">https://git.openjdk.org/jdk/pull/18169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18169#issuecomment-1985579440)