### PR TITLE
8327693: C1: LIRGenerator::_instruction_for_operand is only read by assertion code

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -205,9 +205,11 @@ void LIRItem::set_result(LIR_Opr opr) {
   assert(value()->operand()->is_illegal() || value()->operand()->is_constant(), "operand should never change");
   value()->set_operand(opr);
 
+#ifdef ASSERT
   if (opr->is_virtual()) {
     _gen->_instruction_for_operand.at_put_grow(opr->vreg_number(), value(), nullptr);
   }
+#endif
 
   _result = opr;
 }
@@ -1494,28 +1496,22 @@ LIR_Opr LIRGenerator::operand_for_instruction(Instruction* x) {
       assert(x->as_Phi() || x->as_Local() != nullptr, "only for Phi and Local");
       // allocate a virtual register for this local or phi
       x->set_operand(rlock(x));
+#ifdef ASSERT
       _instruction_for_operand.at_put_grow(x->operand()->vreg_number(), x, nullptr);
+#endif
     }
   }
   return x->operand();
 }
 
-
-Instruction* LIRGenerator::instruction_for_opr(LIR_Opr opr) {
-  if (opr->is_virtual()) {
-    return instruction_for_vreg(opr->vreg_number());
-  }
-  return nullptr;
-}
-
-
+#ifdef ASSERT
 Instruction* LIRGenerator::instruction_for_vreg(int reg_num) {
   if (reg_num < _instruction_for_operand.length()) {
     return _instruction_for_operand.at(reg_num);
   }
   return nullptr;
 }
-
+#endif
 
 void LIRGenerator::set_vreg_flag(int vreg_num, VregFlag f) {
   if (_vreg_flags.size_in_bits() == 0) {
@@ -2660,7 +2656,9 @@ void LIRGenerator::do_Base(Base* x) {
     assert(as_ValueType(t)->tag() == local->type()->tag(), "check");
 #endif // __SOFTFP__
     local->set_operand(dest);
+#ifdef ASSERT
     _instruction_for_operand.at_put_grow(dest->vreg_number(), local, nullptr);
+#endif
     java_index += type2size[t];
   }
 

--- a/src/hotspot/share/c1/c1_LIRGenerator.hpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,9 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
   PhiResolverState  _resolver_state;
   BlockBegin*   _block;
   int           _virtual_register_number;
+#ifdef ASSERT
   Values        _instruction_for_operand;
+#endif
   BitMap2D      _vreg_flags; // flags which can be set on a per-vreg basis
   LIR_List*     _lir;
 
@@ -223,9 +225,11 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
     assert(!opr->is_register() || opr->is_virtual(), "should never set result to a physical register");
     x->set_operand(opr);
     assert(opr == x->operand(), "must be");
+#ifdef ASSERT
     if (opr->is_virtual()) {
       _instruction_for_operand.at_put_grow(opr->vreg_number(), x, nullptr);
     }
+#endif
   }
   void  set_no_result(Value x)                     { assert(!x->has_uses(), "can't have use"); x->clear_operand(); }
 
@@ -507,9 +511,10 @@ class LIRGenerator: public InstructionVisitor, public BlockClosure {
     , _barrier_set(BarrierSet::barrier_set()->barrier_set_c1()) {
   }
 
+#ifdef ASSERT
   // for virtual registers, maps them back to Phi's or Local's
-  Instruction* instruction_for_opr(LIR_Opr opr);
   Instruction* instruction_for_vreg(int reg_num);
+#endif
 
   void set_vreg_flag   (int vreg_num, VregFlag f);
   bool is_vreg_flag_set(int vreg_num, VregFlag f);


### PR DESCRIPTION
Hi,

Please help review this change that moves _instruction_for_operand into ASSERT block since it is only read by assertion code in c1_LinearScan.cpp.

Thanks