### PR TITLE
JDK-8327210: AIX: Delete obsolete parameter Use64KPagesThreshold

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -66,12 +66,6 @@
   product(bool, Use64KPages, true,                                                  \
           "Use 64K pages if available.")                                            \
                                                                                     \
-  /*  If VM uses 64K paged memory (shmat) for virtual memory: threshold below  */   \
-  /*  which virtual memory allocations are done with 4K memory (mmap). This is */   \
-  /*  mainly for test purposes.                                                */   \
-  develop(uintx, Use64KPagesThreshold, 0,                                           \
-          "4K/64K page allocation threshold.")                                      \
-                                                                                    \
   /* Normally AIX commits memory on touch, but sometimes it is helpful to have */   \
   /* explicit commit behaviour. This flag, if true, causes the VM to touch     */   \
   /* memory on os::commit_memory() (which normally is a noop).                 */   \

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1972,11 +1972,7 @@ char* os::pd_reserve_memory(size_t bytes, bool exec) {
   if (os::vm_page_size() == 4*K) {
     return reserve_mmaped_memory(bytes, nullptr /* requested_addr */);
   } else {
-    if (bytes >= Use64KPagesThreshold) {
-      return reserve_shmated_memory(bytes, nullptr /* requested_addr */);
-    } else {
-      return reserve_mmaped_memory(bytes, nullptr /* requested_addr */);
-    }
+    return reserve_shmated_memory(bytes, nullptr /* requested_addr */);
   }
 }
 
@@ -2185,11 +2181,7 @@ char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool 
   if (os::vm_page_size() == 4*K) {
     return reserve_mmaped_memory(bytes, requested_addr);
   } else {
-    if (bytes >= Use64KPagesThreshold) {
-      return reserve_shmated_memory(bytes, requested_addr);
-    } else {
-      return reserve_mmaped_memory(bytes, requested_addr);
-    }
+    return reserve_shmated_memory(bytes, requested_addr);
   }
 
   return addr;

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -957,7 +957,7 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
 #ifdef AIX
 // On Aix, we should fail attach attempts not aligned to segment boundaries (256m)
 TEST_VM(os, aix_reserve_at_non_shmlba_aligned_address) {
-  if (Use64KPages && Use64KPagesThreshold == 0) {
+  if (Use64KPages) {
     char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
     ASSERT_EQ(p, nullptr); // should have failed
     p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);


### PR DESCRIPTION
As the configuration parameter Use64KPagesThreshold on AIX is not needed anymore, we remove it from the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327210](https://bugs.openjdk.org/browse/JDK-8327210): AIX: Delete obsolete parameter Use64KPagesThreshold (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18171/head:pull/18171` \
`$ git checkout pull/18171`

Update a local copy of the PR: \
`$ git checkout pull/18171` \
`$ git pull https://git.openjdk.org/jdk.git pull/18171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18171`

View PR using the GUI difftool: \
`$ git pr show -t 18171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18171.diff">https://git.openjdk.org/jdk/pull/18171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18171#issuecomment-1985790004)