### PR TITLE
8327701: Remove the xlc toolchain

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -68,7 +68,8 @@ id="toc-native-compiler-toolchain-requirements">Native Compiler
 <li><a href="#apple-xcode" id="toc-apple-xcode">Apple Xcode</a></li>
 <li><a href="#microsoft-visual-studio"
 id="toc-microsoft-visual-studio">Microsoft Visual Studio</a></li>
-<li><a href="#ibm-xl-cc" id="toc-ibm-xl-cc">IBM XL C/C++</a></li>
+<li><a href="#ibm-open-xl-cc" id="toc-ibm-open-xl-cc">IBM Open XL
+C/C++</a></li>
 </ul></li>
 <li><a href="#boot-jdk-requirements" id="toc-boot-jdk-requirements">Boot
 JDK Requirements</a>
@@ -673,11 +674,10 @@ the following line: (note that the " characters are essential)</p>
 version number accordingly. If you have not installed the
 <code>BuildTools</code>, but e.g. <code>Professional</code>, adjust the
 product ID accordingly.</p>
-<h3 id="ibm-xl-cc">IBM XL C/C++</h3>
-<p>Please consult the AIX section of the <a
-href="https://wiki.openjdk.org/display/Build/Supported+Build+Platforms">Supported
-Build Platforms</a> OpenJDK Build Wiki page for details about which
-versions of XLC are supported.</p>
+<h3 id="ibm-open-xl-cc">IBM Open XL C/C++</h3>
+<p>The minimum accepted version of Open XL is 17.1.1.4. This is in
+essence clang 13, and will be treated as such by the OpenJDK build
+system.</p>
 <h2 id="boot-jdk-requirements">Boot JDK Requirements</h2>
 <p>Paradoxically, building the JDK requires a pre-existing JDK. This is
 called the "boot JDK". The boot JDK does not, however, have to be a JDK

--- a/doc/building.html
+++ b/doc/building.html
@@ -676,7 +676,7 @@ version number accordingly. If you have not installed the
 product ID accordingly.</p>
 <h3 id="ibm-open-xl-cc">IBM Open XL C/C++</h3>
 <p>The minimum accepted version of Open XL is 17.1.1.4. This is in
-essence clang 13, and will be treated as such by the OpenJDK build
+essence clang 15, and will be treated as such by the OpenJDK build
 system.</p>
 <h2 id="boot-jdk-requirements">Boot JDK Requirements</h2>
 <p>Paradoxically, building the JDK requires a pre-existing JDK. This is

--- a/doc/building.md
+++ b/doc/building.md
@@ -487,11 +487,10 @@ that the " characters are essential)
 accordingly. If you have not installed the `BuildTools`, but e.g.
 `Professional`, adjust the product ID accordingly.
 
-### IBM XL C/C++
+### IBM Open XL C/C++
 
-Please consult the AIX section of the [Supported Build Platforms](
-https://wiki.openjdk.org/display/Build/Supported+Build+Platforms) OpenJDK Build
-Wiki page for details about which versions of XLC are supported.
+The minimum accepted version of Open XL is 17.1.1.4. This is in essence clang
+13, and will be treated as such by the OpenJDK build system.
 
 ## Boot JDK Requirements
 

--- a/doc/building.md
+++ b/doc/building.md
@@ -490,7 +490,7 @@ accordingly. If you have not installed the `BuildTools`, but e.g.
 ### IBM Open XL C/C++
 
 The minimum accepted version of Open XL is 17.1.1.4. This is in essence clang
-13, and will be treated as such by the OpenJDK build system.
+15, and will be treated as such by the OpenJDK build system.
 
 ## Boot JDK Requirements
 

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -358,9 +358,6 @@ AC_DEFUN_ONCE([BPERF_SETUP_PRECOMPILED_HEADERS],
   AC_MSG_CHECKING([if precompiled headers are available])
   if test "x$ICECC" != "x"; then
     AC_MSG_RESULT([no, does not work effectively with icecc])
-    PRECOMPILED_HEADERS_AVAILABLE=false
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    AC_MSG_RESULT([no, does not work with xlc])
     PRECOMPILED_HEADERS_AVAILABLE=false
   elif test "x$TOOLCHAIN_TYPE" = xgcc; then
     # Check that the compiler actually supports precomp headers.

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -77,12 +77,6 @@ AC_DEFUN([FLAGS_SETUP_SHARED_LIBS],
       fi
     fi
 
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    SHARED_LIBRARY_FLAGS="-qmkshrobj -bM:SRE -bnoentry"
-    SET_EXECUTABLE_ORIGIN=""
-    SET_SHARED_LIBRARY_ORIGIN=''
-    SET_SHARED_LIBRARY_NAME=''
-
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     SHARED_LIBRARY_FLAGS="-dll"
     SET_EXECUTABLE_ORIGIN=''
@@ -152,8 +146,6 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
 
     CFLAGS_DEBUG_SYMBOLS="-g ${GDWARF_FLAGS}"
     ASFLAGS_DEBUG_SYMBOLS="-g"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    CFLAGS_DEBUG_SYMBOLS="-g1"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CFLAGS_DEBUG_SYMBOLS="-Z7"
   fi
@@ -219,11 +211,7 @@ AC_DEFUN([DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS],
 AC_DEFUN([FLAGS_SETUP_WARNINGS],
 [
   # Set default value.
-  if test "x$TOOLCHAIN_TYPE" != xxlc; then
-    WARNINGS_AS_ERRORS_DEFAULT=true
-  else
-    WARNINGS_AS_ERRORS_DEFAULT=false
-  fi
+  WARNINGS_AS_ERRORS_DEFAULT=true
 
   UTIL_ARG_ENABLE(NAME: warnings-as-errors, DEFAULT: $WARNINGS_AS_ERRORS_DEFAULT,
       RESULT: WARNINGS_AS_ERRORS,
@@ -272,15 +260,6 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       WARNINGS_ENABLE_ALL="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
 
       DISABLED_WARNINGS="unknown-warning-option unused-parameter unused"
-      ;;
-
-    xlc)
-      DISABLE_WARNING_PREFIX="-Wno-"
-      CFLAGS_WARNINGS_ARE_ERRORS="-qhalt=w"
-
-      # Possibly a better subset than "all" is "lan:trx:ret:zea:cmp:ret"
-      WARNINGS_ENABLE_ALL="-qinfo=all -qformat=all"
-      DISABLED_WARNINGS=""
       ;;
   esac
   AC_SUBST(DISABLE_WARNING_PREFIX)
@@ -363,15 +342,6 @@ AC_DEFUN([FLAGS_SETUP_OPTIMIZATION],
     C_O_FLAG_SIZE="-Os"
     C_O_FLAG_DEBUG="-O0"
     C_O_FLAG_NONE="-O0"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    C_O_FLAG_HIGHEST_JVM="-O3 -qhot=level=1 -qinline -qinlglue"
-    C_O_FLAG_HIGHEST="-O3 -qhot=level=1 -qinline -qinlglue"
-    C_O_FLAG_HI="-O3 -qinline -qinlglue"
-    C_O_FLAG_NORM="-O2"
-    C_O_FLAG_DEBUG="-qnoopt"
-    # FIXME: Value below not verified.
-    C_O_FLAG_DEBUG_JVM=""
-    C_O_FLAG_NONE="-qnoopt"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     C_O_FLAG_HIGHEST_JVM="-O2 -Oy-"
     C_O_FLAG_HIGHEST="-O2"
@@ -524,12 +494,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   else
     DEBUG_CFLAGS_JDK="-DDEBUG"
 
-    if test "x$TOOLCHAIN_TYPE" = xxlc; then
-      # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
-      # Hotspot now overflows its 64K TOC (currently only for debug),
-      # so for debug we build with '-qpic=large -bbigtoc'.
-      DEBUG_CFLAGS_JVM="-qpic=large"
-    fi
     if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
       DEBUG_CFLAGS_JVM="-fpic -mcmodel=large"
     fi
@@ -546,9 +510,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE -D_REENTRANT"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     ALWAYS_DEFINES_JVM="-D_GNU_SOURCE"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    ALWAYS_DEFINES_JVM="-D_REENTRANT"
-    ALWAYS_DEFINES_JDK="-D_GNU_SOURCE -D_REENTRANT -DSTDC"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # Access APIs for Windows 8 and above
     # see https://docs.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt?view=msvc-170
@@ -612,12 +573,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
       TOOLCHAIN_CFLAGS_JDK_CONLY="-fno-strict-aliasing" # technically NOT for CXX
     fi
 
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # Suggested additions: -qsrcmsg to get improved error reporting
-    # set -qtbtable=full for a better traceback table/better stacks in hs_err when xlc16 is used
-    TOOLCHAIN_CFLAGS_JDK="-qtbtable=full -qchars=signed -qfullpath -qsaveopt -qstackprotect"  # add on both CFLAGS
-    TOOLCHAIN_CFLAGS_JVM="-qtbtable=full -qtune=balanced -fno-exceptions \
-        -qalias=noansi -qstrict -qtls=default -qnortti -qnoeh -qignerrno -qstackprotect"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # The -utf-8 option sets source and execution character sets to UTF-8 to enable correct
     # compilation of all source files regardless of the active code page on Windows.
@@ -626,7 +581,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   fi
 
   # CFLAGS C language level for JDK sources (hotspot only uses C++)
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     LANGSTD_CFLAGS="-std=c11"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CFLAGS="-std:c11"
@@ -634,12 +589,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   TOOLCHAIN_CFLAGS_JDK_CONLY="$LANGSTD_CFLAGS $TOOLCHAIN_CFLAGS_JDK_CONLY"
 
   # CXXFLAGS C++ language level for all of JDK, including Hotspot.
-  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xxlc; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     LANGSTD_CXXFLAGS="-std=c++14"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     LANGSTD_CXXFLAGS="-std:c++14"
   else
-    AC_MSG_ERROR([Don't know how to enable C++14 for this toolchain])
+    AC_MSG_ERROR([Cannot enable C++14 for this toolchain])
   fi
   TOOLCHAIN_CFLAGS_JDK_CXXONLY="$TOOLCHAIN_CFLAGS_JDK_CXXONLY $LANGSTD_CXXFLAGS"
   TOOLCHAIN_CFLAGS_JVM="$TOOLCHAIN_CFLAGS_JVM $LANGSTD_CXXFLAGS"
@@ -658,8 +613,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     WARNING_CFLAGS="$WARNINGS_ENABLE_ALL"
 
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    WARNING_CFLAGS=""  # currently left empty
   fi
 
   # Set some additional per-OS defines.
@@ -684,31 +637,12 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
   if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     PICFLAG="-fPIC"
     PIEFLAG="-fPIE"
-  elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
-    JVM_PICFLAG="-fpic -mcmodel=large -Wl,-bbigtoc
-    JDK_PICFLAG="-fpic
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # '-qpic' defaults to 'qpic=small'. This means that the compiler generates only
-    # one instruction for accessing the TOC. If the TOC grows larger than 64K, the linker
-    # will have to patch this single instruction with a call to some out-of-order code which
-    # does the load from the TOC. This is of course slower, and we also would have
-    # to use '-bbigtoc' for linking anyway so we could also change the PICFLAG to 'qpic=large'.
-    # With 'qpic=large' the compiler will by default generate a two-instruction sequence which
-    # can be patched directly by the linker and does not require a jump to out-of-order code.
-    #
-    # Since large TOC causes perf. overhead, only pay it where we must. Currently this is
-    # for all libjvm variants (both gtest and normal) but no other binaries. So, build
-    # libjvm with -qpic=large and link with -bbigtoc.
-    JVM_PICFLAG="-qpic=large"
-    JDK_PICFLAG="-qpic"
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     PICFLAG=""
   fi
 
-  if test "x$TOOLCHAIN_TYPE" != xxlc; then
-    JVM_PICFLAG="$PICFLAG"
-    JDK_PICFLAG="$PICFLAG"
-  fi
+  JVM_PICFLAG="$PICFLAG"
+  JDK_PICFLAG="$PICFLAG"
 
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then
     # Linking is different on MacOSX
@@ -758,8 +692,7 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
   $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -DARCH='\"$FLAGS_CPU_LEGACY\"' \
       -D$FLAGS_CPU_LEGACY"
 
-  if test "x$FLAGS_CPU_BITS" = x64 && test "x$FLAGS_OS" != xaix; then
-    # xlc on AIX defines _LP64=1 by default and issues a warning if we redefine it.
+  if test "x$FLAGS_CPU_BITS" = x64; then
     $1_DEFINES_CPU_JDK="${$1_DEFINES_CPU_JDK} -D_LP64=1"
     $1_DEFINES_CPU_JVM="${$1_DEFINES_CPU_JVM} -D_LP64=1"
   fi
@@ -834,11 +767,6 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_CPU_DEP],
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       $1_CFLAGS_CPU="-mcpu=pwr8"
-    fi
-
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    if test "x$FLAGS_CPU" = xppc64; then
-      $1_CFLAGS_CPU_JVM="-qarch=ppc64"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -641,7 +641,11 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
     PICFLAG=""
   fi
 
-  JVM_PICFLAG="$PICFLAG"
+  if test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then
+    JVM_PICFLAG="-fpic -mcmodel=large"
+  else
+    JVM_PICFLAG="$PICFLAG"
+  fi
   JDK_PICFLAG="$PICFLAG"
 
   if test "x$OPENJDK_TARGET_OS" = xmacosx; then

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -86,11 +86,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
         -Wl,-bernotok -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    BASIC_LDFLAGS="-b64 -brtl -bnorwexec -bnolibpath -bnoexpall -bernotok -btextpsize:64K \
-        -bdatapsize:64K -bstackpsize:64K"
-    # libjvm.so has gotten too large for normal TOC size; compile with qpic=large and link with bigtoc
-    BASIC_LDFLAGS_JVM_ONLY="-Wl,-lC_r -bbigtoc"
 
   elif test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     BASIC_LDFLAGS="-opt:ref"
@@ -118,14 +113,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       if test x$DEBUG_LEVEL = xrelease; then
         DEBUGLEVEL_LDFLAGS_JDK_ONLY="$DEBUGLEVEL_LDFLAGS_JDK_ONLY -Wl,-O1"
       fi
-    fi
-
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    # We need '-qminimaltoc' or '-qpic=large -bbigtoc' if the TOC overflows.
-    # Hotspot now overflows its 64K TOC (currently only for debug),
-    # so we build with '-qpic=large -bbigtoc'.
-    if test "x$DEBUG_LEVEL" != xrelease; then
-      DEBUGLEVEL_LDFLAGS_JVM_ONLY="$DEBUGLEVEL_LDFLAGS_JVM_ONLY -bbigtoc"
     fi
 
   elif test "x$TOOLCHAIN_TYPE" = xclang && test "x$OPENJDK_TARGET_OS" = xaix; then

--- a/make/autoconf/flags.m4
+++ b/make/autoconf/flags.m4
@@ -261,12 +261,9 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
   # The sysroot flags are needed for configure to be able to run the compilers
   FLAGS_SETUP_SYSROOT_FLAGS
 
-  # For xlc, the word size flag is required for correct behavior.
   # For clang/gcc, the flag is only strictly required for reduced builds, but
   # set it always where possible (x86 and ppc).
-  if test "x$TOOLCHAIN_TYPE" = xxlc; then
-    MACHINE_FLAG="-q${OPENJDK_TARGET_CPU_BITS}"
-  elif test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
+  if test "x$TOOLCHAIN_TYPE" = xgcc || test "x$TOOLCHAIN_TYPE" = xclang; then
     if test "x$OPENJDK_TARGET_CPU_ARCH" = xx86 &&
         test "x$OPENJDK_TARGET_CPU" != xx32 ||
         test "x$OPENJDK_TARGET_CPU_ARCH" = xppc; then
@@ -321,47 +318,6 @@ AC_DEFUN_ONCE([FLAGS_PRE_TOOLCHAIN],
 
 AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
 [
-  # COMPILER_TARGET_BITS_FLAG  : option for selecting 32- or 64-bit output
-  # COMPILER_COMMAND_FILE_FLAG : option for passing a command file to the compiler
-  # COMPILER_BINDCMD_FILE_FLAG : option for specifying a file which saves the binder
-  #                              commands produced by the link step (currently AIX only)
-  if test "x$TOOLCHAIN_TYPE" = xxlc; then
-    COMPILER_TARGET_BITS_FLAG="-q"
-    COMPILER_COMMAND_FILE_FLAG="-f"
-    COMPILER_BINDCMD_FILE_FLAG="-bloadmap:"
-  else
-    COMPILER_TARGET_BITS_FLAG="-m"
-    COMPILER_COMMAND_FILE_FLAG="@"
-    COMPILER_BINDCMD_FILE_FLAG=""
-
-    # Check if @file is supported by gcc
-    if test "x$TOOLCHAIN_TYPE" = xgcc; then
-      AC_MSG_CHECKING([if @file is supported by gcc])
-      # Extra empty "" to prevent ECHO from interpreting '--version' as argument
-      $ECHO "" "--version" > command.file
-      # Redirect stderr and stdout to config.log (AS_MESSAGE_LOG_FD) via merge
-      if $CXX @command.file 2>&AS_MESSAGE_LOG_FD >&AS_MESSAGE_LOG_FD; then
-        AC_MSG_RESULT(yes)
-        COMPILER_COMMAND_FILE_FLAG="@"
-      else
-        AC_MSG_RESULT(no)
-        COMPILER_COMMAND_FILE_FLAG=
-      fi
-      $RM command.file
-    fi
-  fi
-
-  AC_SUBST(COMPILER_TARGET_BITS_FLAG)
-  AC_SUBST(COMPILER_COMMAND_FILE_FLAG)
-  AC_SUBST(COMPILER_BINDCMD_FILE_FLAG)
-
-  # Check that the compiler supports -mX (or -qX on AIX) flags
-  # Set COMPILER_SUPPORTS_TARGET_BITS_FLAG to 'true' if it does
-  FLAGS_COMPILER_CHECK_ARGUMENTS(ARGUMENT: [${COMPILER_TARGET_BITS_FLAG}${OPENJDK_TARGET_CPU_BITS}],
-      IF_TRUE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=true],
-      IF_FALSE: [COMPILER_SUPPORTS_TARGET_BITS_FLAG=false])
-  AC_SUBST(COMPILER_SUPPORTS_TARGET_BITS_FLAG)
-
   if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     CC_OUT_OPTION=-Fo
   else
@@ -376,8 +332,6 @@ AC_DEFUN([FLAGS_SETUP_TOOLCHAIN_CONTROL],
     GENDEPS_FLAGS="-MMD -MF"
   elif test "x$TOOLCHAIN_TYPE" = xclang; then
     GENDEPS_FLAGS="-MMD -MF"
-  elif test "x$TOOLCHAIN_TYPE" = xxlc; then
-    GENDEPS_FLAGS="-qmakedep=gcc -MF"
   fi
   AC_SUBST(GENDEPS_FLAGS)
 ])

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -477,7 +477,7 @@ MACOSX_VERSION_MAX := @MACOSX_VERSION_MAX@
 MACOSX_CODESIGN_MODE := @MACOSX_CODESIGN_MODE@
 MACOSX_CODESIGN_IDENTITY := @MACOSX_CODESIGN_IDENTITY@
 
-# Toolchain type: gcc, clang, xlc, microsoft...
+# Toolchain type: gcc, clang, microsoft...
 TOOLCHAIN_TYPE := @TOOLCHAIN_TYPE@
 TOOLCHAIN_VERSION := @TOOLCHAIN_VERSION@
 CC_VERSION_NUMBER := @CC_VERSION_NUMBER@
@@ -485,17 +485,6 @@ CXX_VERSION_NUMBER := @CXX_VERSION_NUMBER@
 
 # Legacy support
 HOTSPOT_TOOLCHAIN_TYPE := @HOTSPOT_TOOLCHAIN_TYPE@
-
-# Option used to tell the compiler whether to create 32- or 64-bit executables
-COMPILER_TARGET_BITS_FLAG := @COMPILER_TARGET_BITS_FLAG@
-COMPILER_SUPPORTS_TARGET_BITS_FLAG := @COMPILER_SUPPORTS_TARGET_BITS_FLAG@
-
-# Option used to pass a command file to the compiler
-COMPILER_COMMAND_FILE_FLAG := @COMPILER_COMMAND_FILE_FLAG@
-
-# Option for specifying a file which saves the binder commands
-# produced by the link step (for debugging, currently AIX only)
-COMPILER_BINDCMD_FILE_FLAG := @COMPILER_BINDCMD_FILE_FLAG@
 
 CC_OUT_OPTION := @CC_OUT_OPTION@
 

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -441,11 +441,6 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
 [
   COMPILER_NAME=$2
   SEARCH_LIST="$3"
-  SEARCH_PATH="$PATH"
-  if test "x$OPENJDK_TARGET_OS" = xaix && test "x$TOOLCHAIN_PATH" != x; then
-    # On AIX, we search the toolchain path first, if it is provided
-    SEARCH_PATH="$TOOLCHAIN_PATH:$PATH"
-  fi
 
   if test "x[$]$1" != x; then
     # User has supplied compiler name already, always let that override.
@@ -453,7 +448,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
     if test "x`basename [$]$1`" = "x[$]$1"; then
       # A command without a complete path is provided, search $PATH.
 
-      UTIL_LOOKUP_PROGS(POTENTIAL_$1, [$]$1, $SEARCH_PATH)
+      UTIL_LOOKUP_PROGS(POTENTIAL_$1, [$]$1)
       if test "x$POTENTIAL_$1" != x; then
         $1=$POTENTIAL_$1
       else
@@ -475,7 +470,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
     # If we are not cross compiling, then the default compiler name will be
     # used.
 
-    UTIL_LOOKUP_TOOLCHAIN_PROGS(POTENTIAL_$1, $SEARCH_LIST, $SEARCH_PATH)
+    UTIL_LOOKUP_TOOLCHAIN_PROGS(POTENTIAL_$1, $SEARCH_LIST)
     if test "x$POTENTIAL_$1" != x; then
       $1=$POTENTIAL_$1
     else

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -937,9 +937,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_MISC_CHECKS],
   fi
   if test "x$OPENJDK_TARGET_OS" = xaix; then
     # Make sure we have the Open XL version of clang on AIX
-    CC_VERSION_OUTPUT=`$CC --version 2>&1 | $HEAD -n 1`
 
-    $ECHO "$CC_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
+    $ECHO "$CC_VERSION_STRING" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
     if test $? -ne 0; then
       AC_MSG_ERROR([ibm-clang_r version output check failed, output: $CC_VERSION_OUTPUT])
     fi

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -937,6 +937,8 @@ AC_DEFUN_ONCE([TOOLCHAIN_MISC_CHECKS],
   fi
   if test "x$OPENJDK_TARGET_OS" = xaix; then
     # Make sure we have the Open XL version of clang on AIX
+    CC_VERSION_OUTPUT=`$CC --version 2>&1 | $HEAD -n 1`
+
     $ECHO "$CC_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
     if test $? -ne 0; then
       AC_MSG_ERROR([ibm-clang_r version output check failed, output: $CC_VERSION_OUTPUT])

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -35,25 +35,23 @@
 m4_include([toolchain_microsoft.m4])
 
 # All valid toolchains, regardless of platform (used by help.m4)
-VALID_TOOLCHAINS_all="gcc clang xlc microsoft"
+VALID_TOOLCHAINS_all="gcc clang microsoft"
 
 # These toolchains are valid on different platforms
 VALID_TOOLCHAINS_linux="gcc clang"
 VALID_TOOLCHAINS_macosx="clang"
-VALID_TOOLCHAINS_aix="xlc clang"
+VALID_TOOLCHAINS_aix="clang"
 VALID_TOOLCHAINS_windows="microsoft"
 
 # Toolchain descriptions
 TOOLCHAIN_DESCRIPTION_clang="clang/LLVM"
 TOOLCHAIN_DESCRIPTION_gcc="GNU Compiler Collection"
 TOOLCHAIN_DESCRIPTION_microsoft="Microsoft Visual Studio"
-TOOLCHAIN_DESCRIPTION_xlc="IBM XL C/C++"
 
 # Minimum supported versions, empty means unspecified
 TOOLCHAIN_MINIMUM_VERSION_clang="13.0"
 TOOLCHAIN_MINIMUM_VERSION_gcc="10.0"
 TOOLCHAIN_MINIMUM_VERSION_microsoft="19.28.0.0" # VS2019 16.8, aka MSVC 14.28
-TOOLCHAIN_MINIMUM_VERSION_xlc="17.1.1.4"
 
 # Minimum supported linker versions, empty means unspecified
 TOOLCHAIN_MINIMUM_LD_VERSION_gcc="2.18"
@@ -234,25 +232,6 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   # First toolchain type in the list is the default
   DEFAULT_TOOLCHAIN=${VALID_TOOLCHAINS%% *}
 
-  # On AIX the default toolchain depends on the installed (found) compiler
-  #   xlclang++     -> xlc toolchain
-  #   ibm-clang++_r -> clang toolchain
-  # The compiler is searched on the PATH and TOOLCHAIN_PATH
-  # xlclang++ has precedence over ibm-clang++_r if both are installed
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    DEFAULT_TOOLCHAIN="clang"
-    if test "x$TOOLCHAIN_PATH" != x; then
-      if test -e ${TOOLCHAIN_PATH}/xlclang++; then
-        DEFAULT_TOOLCHAIN="xlc"
-      fi
-    else
-      UTIL_LOOKUP_PROGS(XLCLANG_TEST_PATH, xlclang++)
-      if test "x$XLCLANG_TEST_PATH" != x; then
-        DEFAULT_TOOLCHAIN="xlc"
-      fi
-    fi
-  fi
-
   if test "x$with_toolchain_type" = xlist; then
     # List all toolchains
     AC_MSG_NOTICE([The following toolchains are valid on this platform:])
@@ -277,48 +256,13 @@ AC_DEFUN_ONCE([TOOLCHAIN_DETERMINE_TOOLCHAIN_TYPE],
   fi
   AC_SUBST(TOOLCHAIN_TYPE)
 
-  # on AIX, check for xlclang++ on the PATH and TOOLCHAIN_PATH and use it if it is available
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    if test "x$TOOLCHAIN_PATH" != x; then
-      XLC_TEST_PATH=${TOOLCHAIN_PATH}/
-    fi
-    if test "x$TOOLCHAIN_TYPE" = xclang; then
-      TOOLCHAIN_DESCRIPTION_clang="IBM Open XL C/C++"
-      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}ibm-clang++_r --version 2>&1 | $HEAD -n 1`
-      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
-      if test $? -eq 0; then
-        AC_MSG_NOTICE([ibm-clang++_r output: $XLCLANG_VERSION_OUTPUT])
-      else
-        AC_MSG_ERROR([ibm-clang++_r version output check failed, output: $XLCLANG_VERSION_OUTPUT])
-      fi
-    else
-      XLCLANG_VERSION_OUTPUT=`${XLC_TEST_PATH}xlclang++ -qversion 2>&1 | $HEAD -n 1`
-      $ECHO "$XLCLANG_VERSION_OUTPUT" | $GREP "IBM XL C/C++ for AIX" > /dev/null
-      if test $? -eq 0; then
-        AC_MSG_NOTICE([xlclang++ output: $XLCLANG_VERSION_OUTPUT])
-      else
-        AC_MSG_ERROR([xlclang++ version output check failed, output: $XLCLANG_VERSION_OUTPUT])
-      fi
-    fi
-  fi
-
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    TOOLCHAIN_CC_BINARY_clang="ibm-clang_r"
-  else
-    TOOLCHAIN_CC_BINARY_clang="clang"
-  fi
+  TOOLCHAIN_CC_BINARY_clang="ibm-clang_r clang"
   TOOLCHAIN_CC_BINARY_gcc="gcc"
   TOOLCHAIN_CC_BINARY_microsoft="cl"
-  TOOLCHAIN_CC_BINARY_xlc="xlclang"
 
-  if test "x$OPENJDK_TARGET_OS" = xaix; then
-    TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r"
-  else
-    TOOLCHAIN_CXX_BINARY_clang="clang++"
-  fi
+  TOOLCHAIN_CXX_BINARY_clang="ibm-clang++_r clang++"
   TOOLCHAIN_CXX_BINARY_gcc="g++"
   TOOLCHAIN_CXX_BINARY_microsoft="cl"
-  TOOLCHAIN_CXX_BINARY_xlc="xlclang++"
 
   # Use indirect variable referencing
   toolchain_var_name=TOOLCHAIN_DESCRIPTION_$TOOLCHAIN_TYPE
@@ -408,25 +352,7 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
   COMPILER=[$]$1
   COMPILER_NAME=$2
 
-  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
-    # xlc -qversion output typically looks like
-    #     IBM XL C/C++ for AIX, V11.1 (5724-X13)
-    #     Version: 11.01.0000.0015
-    COMPILER_VERSION_OUTPUT=`$COMPILER -qversion 2>&1`
-    # Check that this is likely to be the IBM XL C compiler.
-    $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "IBM XL C" > /dev/null
-    if test $? -ne 0; then
-      ALT_VERSION_OUTPUT=`$COMPILER --version 2>&1`
-      AC_MSG_NOTICE([The $COMPILER_NAME compiler (located as $COMPILER) does not seem to be the required $TOOLCHAIN_TYPE compiler.])
-      AC_MSG_NOTICE([The result from running with -qversion was: "$COMPILER_VERSION_OUTPUT"])
-      AC_MSG_NOTICE([The result from running with --version was: "$ALT_VERSION_OUTPUT"])
-      AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
-    fi
-    # Collapse compiler output into a single line
-    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
-    COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.*Version: \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
-  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     # Microsoft (R) 32-bit C/C++ Optimizing Compiler Version 16.00.40219.01 for 80x86
@@ -465,12 +391,22 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
         $SED -e 's/^.* \(@<:@1-9@:>@<:@0-9@:>@*\.@<:@0-9.@:>@*\)@<:@^0-9.@:>@.*$/\1/'`
   elif test  "x$TOOLCHAIN_TYPE" = xclang; then
     # clang --version output typically looks like
-    #    Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
-    #    clang version 3.3 (tags/RELEASE_33/final)
+    #    Apple clang version 15.0.0 (clang-1500.3.9.4)
+    #    Target: arm64-apple-darwin23.2.0
+    #    Thread model: posix
+    #    InstalledDir: /Library/Developer/CommandLineTools/usr/bin
     # or
-    #    Debian clang version 3.2-7ubuntu1 (tags/RELEASE_32/final) (based on LLVM 3.2)
+    #    clang version 10.0.0-4ubuntu1
     #    Target: x86_64-pc-linux-gnu
     #    Thread model: posix
+    #    InstalledDir: /usr/bin
+    #    Target: x86_64-pc-linux-gnu
+    #    Thread model: posix
+    # or
+    #    IBM Open XL C/C++ for AIX 17.1.0 (5725-C72, 5765-J18), clang version 13.0.0
+    #    Target: powerpc-ibm-aix7.2.0.0
+    #    Thread model: posix
+    #    InstalledDir: /opt/IBM/openxlC/17.1.0/bin
     COMPILER_VERSION_OUTPUT=`$COMPILER --version 2>&1`
     # Check that this is likely to be clang
     $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "clang" > /dev/null
@@ -479,10 +415,12 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
       AC_MSG_NOTICE([The result from running with --version was: "$COMPILER_VERSION_OUTPUT"])
       AC_MSG_ERROR([A $TOOLCHAIN_TYPE compiler is required. Try setting --with-tools-dir.])
     fi
-    # Collapse compiler output into a single line
-    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT`
+    # Remove "Thread model:" and further details from the version string, and
+    # collapse into a single line
+    COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT | \
+        $SED -e 's/ *Thread model: .*//'`
     COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.* version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
+        $SED -e 's/^.*clang version \(@<:@1-9@:>@@<:@0-9.@:>@*\).*$/\1/'`
   else
       AC_MSG_ERROR([Unknown toolchain type $TOOLCHAIN_TYPE.])
   fi
@@ -503,6 +441,11 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
 [
   COMPILER_NAME=$2
   SEARCH_LIST="$3"
+  SEARCH_PATH="$PATH"
+  if test "x$OPENJDK_TARGET_OS" = xaix && test "x$TOOLCHAIN_PATH" != x; then
+    # On AIX, we search the toolchain path first, if it is provided
+    SEARCH_PATH="$TOOLCHAIN_PATH:$PATH"
+  fi
 
   if test "x[$]$1" != x; then
     # User has supplied compiler name already, always let that override.
@@ -510,7 +453,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
     if test "x`basename [$]$1`" = "x[$]$1"; then
       # A command without a complete path is provided, search $PATH.
 
-      UTIL_LOOKUP_PROGS(POTENTIAL_$1, [$]$1)
+      UTIL_LOOKUP_PROGS(POTENTIAL_$1, [$]$1, $SEARCH_PATH)
       if test "x$POTENTIAL_$1" != x; then
         $1=$POTENTIAL_$1
       else
@@ -532,7 +475,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
     # If we are not cross compiling, then the default compiler name will be
     # used.
 
-    UTIL_LOOKUP_TOOLCHAIN_PROGS(POTENTIAL_$1, $SEARCH_LIST)
+    UTIL_LOOKUP_TOOLCHAIN_PROGS(POTENTIAL_$1, $SEARCH_LIST, $SEARCH_PATH)
     if test "x$POTENTIAL_$1" != x; then
       $1=$POTENTIAL_$1
     else
@@ -575,10 +518,7 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_LD_VERSION],
   LINKER=[$]$1
   LINKER_NAME="$2"
 
-  if test  "x$TOOLCHAIN_TYPE" = xxlc; then
-    LINKER_VERSION_STRING="Unknown"
-    LINKER_VERSION_NUMBER="0.0"
-  elif test  "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+  if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
     # There is no specific version flag, but all output starts with a version string.
     # First line typically looks something like:
     #   Microsoft (R) Incremental Linker Version 12.00.31101.0
@@ -998,6 +938,13 @@ AC_DEFUN_ONCE([TOOLCHAIN_MISC_CHECKS],
       if test "x$COMPILER_CPU_TEST" != "xARM64"; then
         AC_MSG_ERROR([Target CPU mismatch. We are building for $OPENJDK_TARGET_CPU but CL is for "$COMPILER_CPU_TEST"; expected "arm64".])
       fi
+    fi
+  fi
+  if test "x$OPENJDK_TARGET_OS" = xaix; then
+    # Make sure we have the Open XL version of clang on AIX
+    $ECHO "$CC_VERSION_OUTPUT" | $GREP "IBM Open XL C/C++ for AIX" > /dev/null
+    if test $? -ne 0; then
+      AC_MSG_ERROR([ibm-clang_r version output check failed, output: $CC_VERSION_OUTPUT])
     fi
   fi
 

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,6 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
   LDFLAGS_JDKEXE += -Wl,--exclude-libs,ALL
 else ifeq ($(TOOLCHAIN_TYPE), clang)
   LAUNCHER_CFLAGS += -fvisibility=hidden
-else ifeq ($(TOOLCHAIN_TYPE), xlc)
-  LAUNCHER_CFLAGS += -qvisibility=hidden
 endif
 
 LAUNCHER_SRC := $(TOPDIR)/src/java.base/share/native/launcher

--- a/make/common/modules/LibCommon.gmk
+++ b/make/common/modules/LibCommon.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,6 @@ ifeq ($(TOOLCHAIN_TYPE), gcc)
 else ifeq ($(TOOLCHAIN_TYPE), clang)
   CFLAGS_JDKLIB += -fvisibility=hidden
   CXXFLAGS_JDKLIB += -fvisibility=hidden
-else ifeq ($(TOOLCHAIN_TYPE), xlc)
-  CFLAGS_JDKLIB += -qvisibility=hidden
-  CXXFLAGS_JDKLIB += -qvisibility=hidden
 endif
 
 # Put the libraries here.

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -133,11 +133,6 @@ define CreateDynamicLibraryOrExecutable
   ifeq ($$($1_TYPE), LIBRARY)
     # Generating a dynamic library.
     $1_EXTRA_LDFLAGS += $$(call SET_SHARED_LIBRARY_NAME,$$($1_BASENAME))
-
-    # Create loadmap on AIX. Helps in diagnosing some problems.
-    ifneq ($(COMPILER_BINDCMD_FILE_FLAG), )
-      $1_EXTRA_LDFLAGS += $(COMPILER_BINDCMD_FILE_FLAG)$$($1_OBJECT_DIR)/$$($1_NOSUFFIX).loadmap
-    endif
   endif
 
   $1_VARDEPS := $$($1_LD) $$($1_SYSROOT_LDFLAGS) $$($1_LDFLAGS) \

--- a/make/common/native/Paths.gmk
+++ b/make/common/native/Paths.gmk
@@ -209,12 +209,7 @@ define SetupObjectFileList
   # If there are many object files, use an @-file...
   ifneq ($$(word 17, $$($1_ALL_OBJS)), )
     $1_OBJ_FILE_LIST := $$($1_OBJECT_DIR)/_$1_objectfilenames.txt
-    ifneq ($(COMPILER_COMMAND_FILE_FLAG), )
-      $1_LD_OBJ_ARG := $(COMPILER_COMMAND_FILE_FLAG)$$($1_OBJ_FILE_LIST)
-    else
-      # ...except for toolchains which don't support them.
-      $1_LD_OBJ_ARG := `cat $$($1_OBJ_FILE_LIST)`
-    endif
+    $1_LD_OBJ_ARG := @$$($1_OBJ_FILE_LIST)
 
     # If we are building static library, 'AR' on macosx/aix may not support @-file.
     ifeq ($$($1_TYPE), STATIC_LIBRARY)

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -97,8 +97,6 @@ ifneq ($(DEBUG_LEVEL), release)
   DISABLED_WARNINGS_gcc += strict-overflow
 endif
 
-DISABLED_WARNINGS_xlc := tautological-compare shift-negative-value
-
 DISABLED_WARNINGS_microsoft := 4624 4244 4291 4146 4127 4722
 
 ################################################################################
@@ -203,7 +201,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_clang_aix_debug.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_jvm.cpp := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_osThread_aix.cpp := tautological-undefined-compare, \
-    DISABLED_WARNINGS_xlc := $(DISABLED_WARNINGS_xlc), \
     DISABLED_WARNINGS_microsoft := $(DISABLED_WARNINGS_microsoft), \
     ASFLAGS := $(JVM_ASFLAGS), \
     LDFLAGS := $(JVM_LDFLAGS), \

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -72,7 +72,6 @@ TARGETS += $(BUILD_LIBNET)
 $(eval $(call SetupJdkLibrary, BUILD_LIBNIO, \
     NAME := nio, \
     OPTIMIZATION := HIGH, \
-    WARNINGS_AS_ERRORS_xlc := false, \
     CFLAGS := $(CFLAGS_JDKLIB), \
     EXTRA_HEADER_DIRS := \
         libnio/ch \

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -59,7 +59,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVA, \
     CFLAGS := $(CFLAGS_JDKLIB) \
         $(LIBJAVA_CFLAGS), \
     jdk_util.c_CFLAGS := $(VERSION_CFLAGS), \
-    WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc_ProcessImpl_md.c := unused-result, \
     LDFLAGS := $(LDFLAGS_JDKLIB) \
         $(call SET_SHARED_LIBRARY_ORIGIN), \

--- a/make/modules/java.desktop/lib/Awt2dLibraries.gmk
+++ b/make/modules/java.desktop/lib/Awt2dLibraries.gmk
@@ -238,7 +238,6 @@ ifeq ($(call isTargetOs, windows macosx), false)
         OPTIMIZATION := LOW, \
         CFLAGS := $(CFLAGS_JDKLIB) $(LIBAWT_XAWT_CFLAGS) \
             $(X_CFLAGS), \
-        WARNINGS_AS_ERRORS_xlc := false, \
         DISABLED_WARNINGS_gcc := int-to-pointer-cast, \
         DISABLED_WARNINGS_gcc_awt_Taskbar.c := parentheses, \
         DISABLED_WARNINGS_gcc_GLXSurfaceData.c := unused-function, \
@@ -482,14 +481,6 @@ else
      HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
    endif
 
-   # Early re-canonizing has to be disabled to workaround an internal XlC compiler error
-   # when building libharfbuzz
-   ifeq ($(call isTargetOs, aix), true)
-    ifneq ($(TOOLCHAIN_TYPE), clang)
-     HARFBUZZ_CFLAGS += -qdebug=necan
-    endif
-   endif
-
    # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
    # hb-subset and hb-style APIs are not needed, excluded to cut on compilation time.
    LIBFONTMANAGER_EXCLUDE_FILES += hb-ft.cc hb-subset-cff-common.cc \
@@ -571,7 +562,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBFONTMANAGER, \
     CFLAGS_windows = -DCC_NOEX, \
     EXTRA_HEADER_DIRS := $(LIBFONTMANAGER_EXTRA_HEADER_DIRS), \
     EXTRA_SRC := $(LIBFONTMANAGER_EXTRA_SRC), \
-    WARNINGS_AS_ERRORS_xlc := false, \
     DISABLED_WARNINGS_gcc := $(HARFBUZZ_DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_CXX_gcc := $(HARFBUZZ_DISABLED_WARNINGS_CXX_gcc), \
     DISABLED_WARNINGS_clang := $(HARFBUZZ_DISABLED_WARNINGS_clang), \

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -84,9 +84,7 @@
 #endif
 
 // put OS-includes here (sorted alphabetically)
-#ifdef AIX_XLC_GE_17
 #include <alloca.h>
-#endif
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,9 +108,8 @@ public:
 // constant evaluation.
 #if defined(TARGET_COMPILER_gcc) || defined(TARGET_COMPILER_xlc)
 
-// gcc10 added both __has_builtin and __builtin_is_constant_evaluated.
-// clang has had __has_builtin for a long time, so likely also in xlclang++.
-// Similarly, clang has had __builtin_is_constant_evaluated for a long time.
+// Both __has_builtin and __builtin_is_constant_evaluated are available in our
+// minimum required versions of gcc and clang.
 
 #ifdef __has_builtin
 #if __has_builtin(__builtin_is_constant_evaluated)

--- a/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_xlc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,26 +61,16 @@
 
 #include <stdint.h>
 
-// check for xlc16 or higher
-#ifdef __ibmxl_version__
-  #if __ibmxl_version__ < 16
-  #error "xlc < 16 not supported"
-  #endif
-#elif defined(__open_xl_version__)
+#if defined(__open_xl_version__)
   #if __open_xl_version__ < 17
   #error "open xlc < 17 not supported"
   #endif
 #else
-  #error "xlc version not supported, macro __ibmxl_version__ or __open_xl_version__ not found"
+  #error "xlc version not supported, macro __open_xl_version__ not found"
 #endif
 
 #ifndef _AIX
 #error "missing AIX-specific definition _AIX"
-#endif
-
-// Shortcut for the new xlc 17 compiler
-#if defined(AIX) && defined(__open_xl_version__) && __open_xl_version__ >= 17
-#define AIX_XLC_GE_17
 #endif
 
 // Use XLC compiler builtins instead of inline assembler


### PR DESCRIPTION
As of [JDK-8325880](https://bugs.openjdk.org/browse/JDK-8325880), building the JDK requires version 17 of IBM Open XL C/C++ (xlc). This is in effect clang by another name, and it uses the clang toolchain in the JDK build. Thus the old xlc toolchain is no longer supported, and should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327701](https://bugs.openjdk.org/browse/JDK-8327701): Remove the xlc toolchain (**Bug** - P3)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) ⚠️ Review applies to [53a05019](https://git.openjdk.org/jdk/pull/18172/files/53a050192e2e641196813216741a284ebf758f7a)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [53a05019](https://git.openjdk.org/jdk/pull/18172/files/53a050192e2e641196813216741a284ebf758f7a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18172/head:pull/18172` \
`$ git checkout pull/18172`

Update a local copy of the PR: \
`$ git checkout pull/18172` \
`$ git pull https://git.openjdk.org/jdk.git pull/18172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18172`

View PR using the GUI difftool: \
`$ git pr show -t 18172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18172.diff">https://git.openjdk.org/jdk/pull/18172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18172#issuecomment-1985910720)