### PR TITLE
8325433: Type annotations on primitive types are not linked

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -28,6 +28,7 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -37,6 +38,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
@@ -96,7 +98,8 @@ public class HtmlLinkFactory {
                 // handles primitives, no types and error types
                 @Override
                 protected Content defaultAction(TypeMirror type, HtmlLinkInfo linkInfo) {
-                    link.add(utils.getTypeName(type, false));
+                    link.add(getTypeAnnotationLinks(linkInfo));
+                    link.add(utils.getTypeSignature(type, false, false));
                     return link;
                 }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlLinkFactory.java
@@ -28,7 +28,6 @@ package jdk.javadoc.internal.doclets.formats.html;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Set;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -38,7 +37,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/TestTypeAnnotations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      8005091 8009686 8025633 8026567 6469562 8071982 8071984 8162363 8175200 8186332 8182765
- *           8187288 8241969 8259216
+ *           8187288 8241969 8259216 8325433
  * @summary  Make sure that type annotations are displayed correctly
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -144,7 +144,17 @@ public class TestTypeAnnotations extends JavadocTester {
                     le="annotation interface in typeannos">@FldB</a> [] <a href="FldC.html" title="a\
                     nnotation interface in typeannos">@FldC</a> <a href="FldA.html" title="annotatio\
                     n interface in typeannos">@FldA</a> []</span>&nbsp;<span class="element-name">ar\
-                    ray2Deep</span></div>""");
+                    ray2Deep</span></div>""",
+
+                """
+                    <div class="member-signature"><span class="return-type"><a href="FldA.html" titl\
+                    e="annotation interface in typeannos">@FldA</a> int</span>&nbsp;<span cl\
+                    ass="element-name">primitive</span></div>""",
+                """
+                    <div class="member-signature"><span class="return-type"><a href="FldA.html" titl\
+                    e="annotation interface in typeannos">@FldA</a> int <a href="FldB.h\
+                    tml" title="annotation interface in typeannos">@FldB</a> []</span>&nbsp;<span cl\
+                    ass="element-name">primitiveArray1Deep</span></div>""");
 
         checkOutput("typeannos/ModifiedScoped.html", true,
                 """
@@ -182,7 +192,18 @@ public class TestTypeAnnotations extends JavadocTester {
                 """
                     <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
                     le="annotation interface in typeannos">@MRtnA</a> java.lang.String[][]</span>&nb\
-                    sp;<span class="element-name">array2</span>()</div>""");
+                    sp;<span class="element-name">array2</span>()</div>""",
+
+                """
+                    <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
+                    le="annotation interface in typeannos">@MRtnA</a> int</span>&nbsp;\
+                    <span class="element-name">primitive</span>()</div>""",
+
+                """
+                    <div class="member-signature"><span class="return-type"><a href="MRtnA.html" tit\
+                    le="annotation interface in typeannos">@MRtnA</a> int <a href="MRtn\
+                    B.html" title="annotation interface in typeannos">@MRtnB</a> []</span>&nbsp;<spa\
+                    n class="element-name">primitiveArray1Deep</span>()</div>""");
 
         checkOutput("typeannos/MtdModifiedScoped.html", true,
                 """
@@ -255,7 +276,20 @@ public class TestTypeAnnotations extends JavadocTester {
                     amA.html" title="annotation interface in typeannos">@ParamA</a> java.lang.String\
                      <a href="ParamB.html" title="annotation interface in typeannos">@ParamB</a> [] \
                     <a href="ParamA.html" title="annotation interface in typeannos">@ParamA</a> []&n\
-                    bsp;a)</span></div>""");
+                    bsp;a)</span></div>""",
+
+                """
+                    <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
+                    lass="element-name">primitive</span><wbr><span class="parameters">(<a href="Par\
+                    amA.html" title="annotation interface in typeannos">@ParamA</a> int&nbsp;a)</sp\
+                    an></div>""",
+
+                """
+                    <div class="member-signature"><span class="return-type">void</span>&nbsp;<span c\
+                    lass="element-name">primitiveArray1Deep</span><wbr><span class="parameters">(<a \
+                    href="ParamA.html" title="annotation interface in typeannos">@ParamA</a> int <a \
+                    href="ParamB.html" title="annotation interface in typeannos">@ParamB</a> []&nbsp\
+                    ;a)</span></div>""");
 
         // Test for type annotations on throws (Throws.java).
         checkOutput("typeannos/ThrDefaultUnmodified.html", true,

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Fields.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Fields.java
@@ -67,9 +67,6 @@ class ModifiedScoped {
     public final @FldA String @FldA [] @FldB [] array2Deep = null;
     public final String @FldA [] [] array2First = null;
     public final String [] @FldB [] array2Second = null;
-
-    public final @FldA int primitive = 0;
-    public final @FldA int @FldB [] primitiveArray1Deep = null;
 }
 
 class Parameterized<K, V> { }

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Fields.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Fields.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,9 @@ class DefaultScope {
     // Old-style array syntax
     String array2FirstOld @FldA [];
     String array2SecondOld [] @FldB [];
+
+    @FldA int primitive;
+    @FldA int @FldB [] primitiveArray1Deep;
 }
 
 class ModifiedScoped {
@@ -64,6 +67,9 @@ class ModifiedScoped {
     public final @FldA String @FldA [] @FldB [] array2Deep = null;
     public final String @FldA [] [] array2First = null;
     public final String [] @FldB [] array2Second = null;
+
+    public final @FldA int primitive = 0;
+    public final @FldA int @FldB [] primitiveArray1Deep = null;
 }
 
 class Parameterized<K, V> { }

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/MethodReturnType.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/MethodReturnType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,9 @@ class MtdDefaultScope {
     // Old-style array syntax
     String array2FirstOld() @MRtnA [] { return null; }
     String array2SecondOld() [] @MRtnB [] { return null; }
+
+    @MRtnA int primitive() { return 0; }
+    @MRtnA int @MRtnB [] primitiveArray1Deep() { return null; }
 }
 
 class MtdModifiedScoped {
@@ -66,6 +69,9 @@ class MtdModifiedScoped {
     public final @MRtnA String @MRtnA [] @MRtnB [] array2Deep() { return null; }
     public final String @MRtnA [] [] array2First() { return null; }
     public final String [] @MRtnB [] array2Second() { return null; }
+
+    public final @MRtnA int primitive() { return 0; }
+    public final @MRtnA int @MRtnB [] primitiveArray1Deep() { return null; }
 }
 
 class MtdParameterized<K, V> { }

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/MethodReturnType.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/MethodReturnType.java
@@ -69,9 +69,6 @@ class MtdModifiedScoped {
     public final @MRtnA String @MRtnA [] @MRtnB [] array2Deep() { return null; }
     public final String @MRtnA [] [] array2First() { return null; }
     public final String [] @MRtnB [] array2Second() { return null; }
-
-    public final @MRtnA int primitive() { return 0; }
-    public final @MRtnA int @MRtnB [] primitiveArray1Deep() { return null; }
 }
 
 class MtdParameterized<K, V> { }

--- a/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Parameters.java
+++ b/test/langtools/jdk/javadoc/doclet/testTypeAnnotations/typeannos/Parameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@ class Parameters {
     void array2Deep(@ParamA String @ParamA [] @ParamB [] a) {}
     void array2First(String @ParamA [] [] a) {}
     void array2Second(String [] @ParamB [] a) {}
+
+    void primitive(@ParamA int a) {}
+    void primitiveArray1Deep(@ParamA int @ParamB [] a) {}
 }
 
 class ParaParameterized<K, V> { }


### PR DESCRIPTION
Please review this patch that fixes the issue where type annotations on primitive types are not linked.

Tested with file https://cr.openjdk.org/~liach/8325433-arrayanno/ArrayAnno.java
```java
import java.lang.annotation.*;

public class ArrayAnno {
	@Retention(RetentionPolicy.RUNTIME)
	@Target(ElementType.TYPE_USE)
	@Documented
	public @interface Anno { int value(); }

	public void method(@Anno(1) int @Anno(2) [] @Anno(3) [] arg) {}
	public void method(@Anno(1) String @Anno(2) [] @Anno(3) [] arg) {}
}
```
JDK 21: https://cr.openjdk.org/~liach/8325433-arrayanno/old/ArrayAnno.html
This patch: https://cr.openjdk.org/~liach/8325433-arrayanno/new/ArrayAnno.html

Note that a bug within javac (reported in https://bugs.openjdk.org/browse/JDK-8327824) causes the annotations to become `@Anno(1) String @Anno(3) [] @Anno(2) []` in the output files; this bug also affects output class files so I assume this is a bug within javac's tree building. (Intersting, the buggy javadoc output was copied wholesale in the original `TestTypeAnnotations` output for `array2Deep` cases, but no one paid attention to it)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325433](https://bugs.openjdk.org/browse/JDK-8325433): Type annotations on primitive types are not linked (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18179/head:pull/18179` \
`$ git checkout pull/18179`

Update a local copy of the PR: \
`$ git checkout pull/18179` \
`$ git pull https://git.openjdk.org/jdk.git pull/18179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18179`

View PR using the GUI difftool: \
`$ git pr show -t 18179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18179.diff">https://git.openjdk.org/jdk/pull/18179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18179#issuecomment-1987352209)