### PR TITLE
8320404: Double whitespace in SubTypeCheckNode::dump_spec output

### DIFF
--- a/src/hotspot/share/opto/subtypenode.cpp
+++ b/src/hotspot/share/opto/subtypenode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ uint SubTypeCheckNode::hash() const {
 #ifndef PRODUCT
 void SubTypeCheckNode::dump_spec(outputStream* st) const {
   if (_method != nullptr) {
-    st->print(" profiled at: ");
+    st->print(" profiled at:");
     _method->print_short_name(st);
     st->print(":%d", _bci);
   }


### PR DESCRIPTION
This is a trivial change to remove an extra whitespace.

A double whitespace is printed because method->print_short_name already adds a whitespace before the name.

### Test

For testing, I modified the ProfileAtTypeCheck class to fail a test case and display the message. Specifically, I changed the number of the count element in the IR annotation below.

```java
    @Test
    @IR(phase = { CompilePhase.AFTER_PARSING }, counts = { IRNode.SUBTYPE_CHECK, "1" })
    @IR(phase = { CompilePhase.AFTER_MACRO_EXPANSION }, counts = { IRNode.CMP_P, "5", IRNode.LOAD_KLASS_OR_NKLASS, "2", IRNode.PARTIAL_SUBTYPE_CHECK, "1" })
    public static void test15(Object o) {
```

This change was only for testing, so I reverted back to the original code after the test.

#### Execution Result

Before the change: 
```
$ make test TEST="test/hotspot/jtreg/compiler/c2/irTests/ProfileAtTypeCheck.java"
...
Failed IR Rules (1) of Methods (1)
----------------------------------
1) Method "public static void compiler.c2.irTests.ProfileAtTypeCheck.test15(java.lang.Object)" - [Failed IR rules: 1]:
   * @IR rule 1: "@compiler.lib.ir_framework.IR(phase={AFTER_PARSING}, applyIfPlatformAnd={}, applyIfCPUFeatureOr={}, counts={"_#SUBTYPE_CHECK#_", "11"}, applyIfPlatform={}, applyIfPlatformOr={}, failOn={}, applyIfOr={}, applyIfCPUFeatureAnd={}, applyIf={}, applyIfCPUFeature={}, ap
plyIfAnd={}, applyIfNot={})"
     > Phase "After Parsing":
       - counts: Graph contains wrong number of nodes:
         * Constraint 1: "(\d+(\s){2}(SubTypeCheck.*)+(\s){2}===.*)"
           - Failed comparison: [found] 1 = 11 [given]
             - Matched node:
               * 53  SubTypeCheck  === _ 44 35  [[ 58 ]]  profiled at:  compiler.c2.irTests.ProfileAtTypeCheck::test15:5 !jvms: ProfileAtTypeCheck::test15 @ bci:5 (line 399)
```

After the change:
```
$ make test TEST="test/hotspot/jtreg/compiler/c2/irTests/ProfileAtTypeCheck.java"
...
Failed IR Rules (1) of Methods (1)
----------------------------------
1) Method "public static void compiler.c2.irTests.ProfileAtTypeCheck.test15(java.lang.Object)" - [Failed IR rules: 1]:
   * @IR rule 1: "@compiler.lib.ir_framework.IR(phase={AFTER_PARSING}, applyIfPlatformAnd={}, applyIfCPUFeatureOr={}, counts={"_#SUBTYPE_CHECK#_", "11"}, applyIfPlatform={}, applyIfPlatformOr={}, failOn={}, applyIfOr={}, applyIfCPUFeatureAnd={}, applyIf={}, applyIfCPUFeature={}, ap
plyIfAnd={}, applyIfNot={})"
     > Phase "After Parsing":
       - counts: Graph contains wrong number of nodes:
         * Constraint 1: "(\d+(\s){2}(SubTypeCheck.*)+(\s){2}===.*)"
           - Failed comparison: [found] 1 = 11 [given]
             - Matched node:
               * 53  SubTypeCheck  === _ 44 35  [[ 58 ]]  profiled at: compiler.c2.irTests.ProfileAtTypeCheck::test15:5 !jvms: ProfileAtTypeCheck::test15 @ bci:5 (line 399)
```

I was able confirm that the thing has been corrected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320404](https://bugs.openjdk.org/browse/JDK-8320404): Double whitespace in SubTypeCheckNode::dump_spec output (**Enhancement** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18181/head:pull/18181` \
`$ git checkout pull/18181`

Update a local copy of the PR: \
`$ git checkout pull/18181` \
`$ git pull https://git.openjdk.org/jdk.git pull/18181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18181`

View PR using the GUI difftool: \
`$ git pr show -t 18181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18181.diff">https://git.openjdk.org/jdk/pull/18181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18181#issuecomment-1989769331)