### PR TITLE
8327779: Remove deprecated internal field sun.security.x509.X509Key.key

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X509Key.java
+++ b/src/java.base/share/classes/sun/security/x509/X509Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,24 +65,6 @@ public class X509Key implements PublicKey, DerEncoder {
     /* The algorithm information (name, parameters, etc). */
     protected AlgorithmId algid;
 
-    /**
-     * The key bytes, without the algorithm information.
-     * @deprecated Use the BitArray form which does not require keys to
-     * be byte aligned.
-     * @see sun.security.x509.X509Key#setKey(BitArray)
-     * @see sun.security.x509.X509Key#getKey()
-     */
-    @Deprecated
-    protected byte[] key = null;
-
-    /*
-     * The number of bits unused in the last byte of the key.
-     * Added to keep the byte[] key form consistent with the BitArray
-     * form. Can de deleted when byte[] key is deleted.
-     */
-    @Deprecated
-    private int unusedBits = 0;
-
     /* BitArray form of key */
     private transient BitArray bitStringKey = null;
 
@@ -112,15 +94,6 @@ public class X509Key implements PublicKey, DerEncoder {
      */
     protected void setKey(BitArray key) {
         this.bitStringKey = (BitArray)key.clone();
-
-        /*
-         * Do this to keep the byte array form consistent with
-         * this. Can delete when byte[] key is deleted.
-         */
-        this.key = key.toByteArray();
-        int remaining = key.length() % 8;
-        this.unusedBits =
-            ((remaining == 0) ? 0 : 8 - remaining);
     }
 
     /**
@@ -128,18 +101,6 @@ public class X509Key implements PublicKey, DerEncoder {
      * @return a BitArray containing the key.
      */
     protected BitArray getKey() {
-        /*
-         * Do this for consistency in case a subclass
-         * modifies byte[] key directly. Remove when
-         * byte[] key is deleted.
-         * Note: the consistency checks fail when the subclass
-         * modifies a non byte-aligned key (into a byte-aligned key)
-         * using the deprecated byte[] key field.
-         */
-        this.bitStringKey = new BitArray(
-                          this.key.length * 8 - this.unusedBits,
-                          this.key);
-
         return (BitArray)bitStringKey.clone();
     }
 
@@ -331,7 +292,7 @@ public class X509Key implements PublicKey, DerEncoder {
         HexDumpEncoder  encoder = new HexDumpEncoder();
 
         return "algorithm = " + algid.toString()
-            + ", unparsed keybits = \n" + encoder.encodeBuffer(key);
+            + ", unparsed keybits = \n" + encoder.encodeBuffer(bitStringKey.toByteArray());
     }
 
     /**


### PR DESCRIPTION
Please review this cleanup PR which removes the protected, deprecated field `X509Key.key` in the internal package `sun.security.x509`.

This field and the associated field `unusedBits` have been marked `@Deprecated` since the initial load. The recommended replacement is to use the `BitArray` representation, which does not require keys to be byte-aligned.

Two use sites of the `key` field were found in subclasses:

* The `ECPublicKeyImpl` constructor was updated to use a `BitArray` instead.
* `ECPublicKeyImpl.parseKeyBits()` was updated to call `getKey().toByteArray()` to produce the byte array.

Somewhat unrelated, the method `ECPublicKeyImpl.getEncodedPublicValue()` was deemed unused and has been removed.

Testing and verification: This PR does not update any tests. GHA runs green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327779](https://bugs.openjdk.org/browse/JDK-8327779): Remove deprecated internal field sun.security.x509.X509Key.key (**Enhancement** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18185/head:pull/18185` \
`$ git checkout pull/18185`

Update a local copy of the PR: \
`$ git checkout pull/18185` \
`$ git pull https://git.openjdk.org/jdk.git pull/18185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18185`

View PR using the GUI difftool: \
`$ git pr show -t 18185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18185.diff">https://git.openjdk.org/jdk/pull/18185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18185#issuecomment-1988234705)