### PR TITLE
8327788: G1: Improve concurrent reference processing documentation

### DIFF
--- a/src/hotspot/share/gc/shared/referenceProcessor.cpp
+++ b/src/hotspot/share/gc/shared/referenceProcessor.cpp
@@ -978,10 +978,12 @@ bool ReferenceProcessor::discover_reference(oop obj, ReferenceType rt) {
     log_develop_trace(gc, ref)("Already discovered reference (" PTR_FORMAT ": %s)",
                                p2i(obj), obj->klass()->internal_name());
 
-    // Check assumption that an object is not potentially
-    // discovered twice except by concurrent collectors that potentially
-    // trace the same Reference object twice.
-    assert(UseG1GC, "Only possible with a concurrent marking collector");
+    // Encountering an already-discovered non-strong ref because G1 can restart
+    // concurrent marking on marking-stack overflow. Must continue to treat
+    // this non-strong ref as discovered to avoid keeping the referent
+    // unnecessarily alive.
+    assert(UseG1GC, "inv");
+    assert(_discovery_is_concurrent, "inv");
     return true;
   }
 


### PR DESCRIPTION
Simple doc update re discovered ref in concurrent ref-processing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327788](https://bugs.openjdk.org/browse/JDK-8327788): G1: Improve concurrent reference processing documentation (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18188/head:pull/18188` \
`$ git checkout pull/18188`

Update a local copy of the PR: \
`$ git checkout pull/18188` \
`$ git pull https://git.openjdk.org/jdk.git pull/18188/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18188`

View PR using the GUI difftool: \
`$ git pr show -t 18188`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18188.diff">https://git.openjdk.org/jdk/pull/18188.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18188#issuecomment-1988179139)