### PR TITLE
8327769: jcmd GC.heap_dump without options should write to location given by -XX:HeapDumpPath, if set

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -559,13 +559,13 @@ const int ObjectAlignmentInBytes = 8;
           "from JVM")                                                       \
                                                                             \
   product(ccstr, HeapDumpPath, nullptr, MANAGEABLE,                         \
-          "When HeapDumpOnOutOfMemoryError is on, or a heap dump is "       \
+          "When HeapDumpOnOutOfMemoryError is enabled, or a heap dump is "  \
           "triggered by jcmd GC.heap_dump without specifying a path, "      \
           "the path (filename or directory) of the dump file "              \
           "(defaults to java_pid<pid>.hprof in the working directory)")     \
                                                                             \
   product(int, HeapDumpGzipLevel, 0, MANAGEABLE,                            \
-          "When HeapDumpOnOutOfMemoryError is on, the gzip compression "    \
+          "When HeapDumpOnOutOfMemoryError is enabled, the gzip compression " \
           "level of the dump file. 0 (the default) disables gzip "          \
           "compression. Otherwise the level must be between 1 and 9.")      \
           range(0, 9)                                                       \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -561,8 +561,9 @@ const int ObjectAlignmentInBytes = 8;
   product(ccstr, HeapDumpPath, nullptr, MANAGEABLE,                         \
           "When HeapDumpOnOutOfMemoryError is enabled, or a heap dump is "  \
           "triggered by jcmd GC.heap_dump without specifying a path, "      \
-          "the path (filename or directory) of the dump file "              \
-          "(defaults to java_pid<pid>.hprof in the working directory)")     \
+          "the path (filename or directory) of the dump file. "             \
+          "(in case of HeapDumpOnOutOfMemoryError only: "                   \
+          "defaults to java_pid<pid>.hprof in the working directory)")      \
                                                                             \
   product(int, HeapDumpGzipLevel, 0, MANAGEABLE,                            \
           "When HeapDumpOnOutOfMemoryError is enabled, the gzip compression " \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -559,9 +559,10 @@ const int ObjectAlignmentInBytes = 8;
           "from JVM")                                                       \
                                                                             \
   product(ccstr, HeapDumpPath, nullptr, MANAGEABLE,                         \
-          "When HeapDumpOnOutOfMemoryError is on, the path (filename or "   \
-          "directory) of the dump file (defaults to java_pid<pid>.hprof "   \
-          "in the working directory)")                                      \
+          "When HeapDumpOnOutOfMemoryError is on, or a heap dump is "       \
+          "triggered by jcmd GC.heap_dump without specifying a path, "      \
+          "the path (filename or directory) of the dump file "              \
+          "(defaults to java_pid<pid>.hprof in the working directory)")     \
                                                                             \
   product(int, HeapDumpGzipLevel, 0, MANAGEABLE,                            \
           "When HeapDumpOnOutOfMemoryError is on, the gzip compression "    \

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -472,7 +472,7 @@ void FinalizerInfoDCmd::execute(DCmdSource source, TRAPS) {
 #if INCLUDE_SERVICES // Heap dumping/inspection supported
 HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
                            DCmdWithParser(output, heap),
-  _filename("filename","Name of the dump file", "STRING", false, "-XX:HeapDumpPath"),
+  _filename("filename","Name of the dump file", "STRING", false, "if no filename was specified, but -XX:HeapDumpPath=hdp is set, path hdp is taken"),
   _all("-all", "Dump all objects, including unreachable objects",
        "BOOLEAN", false, "false"),
   _gzip("-gz", "If specified, the heap dump is written in gzipped format "

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -535,7 +535,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
 
   if (use_heapdump_path) {
-    dumper.dump_to_heapdump_path(output(), (int)level, _overwrite.value(), (uint)parallel);
+    dumper.dump_to(output(), (int)level, _overwrite.value(), (uint)parallel);
   } else {
     dumper.dump(filename, output(), (int)level, _overwrite.value(), (uint)parallel);
   }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2611,7 +2611,8 @@ void VM_HeapDumper::dump_vthread(oop vt, AbstractDumpWriter* segment_writer) {
 
 static uint dump_file_seq = 0;
 
-// helper function to create the heap dump path name; free the returned pointer
+// helper function to create the heap dump path name
+// the caller must free the returned pointer
 static char* alloc_and_create_heapdump_pathname() {
   static char base_path[JVM_MAXPATHLEN] = {'\0'};
   char* my_path;

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2687,7 +2687,7 @@ static char* alloc_and_create_heapdump_pathname() {
 }
 
 
-int HeapDumper::dump_to_heapdump_path(outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
+int HeapDumper::dump_to(outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
   if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
     return -1;
   }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2609,6 +2609,97 @@ void VM_HeapDumper::dump_vthread(oop vt, AbstractDumpWriter* segment_writer) {
   thread_dumper.dump_stack_refs(segment_writer);
 }
 
+static uint dump_file_seq = 0;
+
+// helper function to create the heap dump path name; free the returned pointer
+static char* alloc_and_create_heapdump_pathname() {
+  static char base_path[JVM_MAXPATHLEN] = {'\0'};
+  char* my_path;
+  const int max_digit_chars = 20;
+
+  const char* dump_file_name = "java_pid";
+  const char* dump_file_ext  = HeapDumpGzipLevel > 0 ? ".hprof.gz" : ".hprof";
+
+  // The dump file defaults to java_pid<pid>.hprof in the current working
+  // directory. HeapDumpPath=<file> can be used to specify an alternative
+  // dump file name or a directory where dump file is created.
+  if (dump_file_seq == 0) { // first time in, we initialize base_path
+    // Calculate potentially longest base path and check if we have enough
+    // allocated statically.
+    const size_t total_length =
+                      (HeapDumpPath == nullptr ? 0 : strlen(HeapDumpPath)) +
+                      strlen(os::file_separator()) + max_digit_chars +
+                      strlen(dump_file_name) + strlen(dump_file_ext) + 1;
+    if (total_length > sizeof(base_path)) {
+      warning("Cannot create heap dump file.  HeapDumpPath is too long.");
+      return nullptr;
+    }
+
+    bool use_default_filename = true;
+    if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
+      // HeapDumpPath=<file> not specified
+    } else {
+      strcpy(base_path, HeapDumpPath);
+      // check if the path is a directory (must exist)
+      DIR* dir = os::opendir(base_path);
+      if (dir == nullptr) {
+        use_default_filename = false;
+      } else {
+        // HeapDumpPath specified a directory. We append a file separator
+        // (if needed).
+        os::closedir(dir);
+        size_t fs_len = strlen(os::file_separator());
+        if (strlen(base_path) >= fs_len) {
+          char* end = base_path;
+          end += (strlen(base_path) - fs_len);
+          if (strcmp(end, os::file_separator()) != 0) {
+            strcat(base_path, os::file_separator());
+          }
+        }
+      }
+    }
+    // If HeapDumpPath wasn't a file name then we append the default name
+    if (use_default_filename) {
+      const size_t dlen = strlen(base_path);  // if heap dump dir specified
+      jio_snprintf(&base_path[dlen], sizeof(base_path)-dlen, "%s%d%s",
+                   dump_file_name, os::current_process_id(), dump_file_ext);
+    }
+    const size_t len = strlen(base_path) + 1;
+    my_path = (char*)os::malloc(len, mtInternal);
+    if (my_path == nullptr) {
+      warning("Cannot create heap dump file.  Out of system memory.");
+      return nullptr;
+    }
+    strncpy(my_path, base_path, len);
+  } else {
+    // Append a sequence number id for dumps following the first
+    const size_t len = strlen(base_path) + max_digit_chars + 2; // for '.' and \0
+    my_path = (char*)os::malloc(len, mtInternal);
+    if (my_path == nullptr) {
+      warning("Cannot create heap dump file.  Out of system memory.");
+      return nullptr;
+    }
+    jio_snprintf(my_path, len, "%s.%d", base_path, dump_file_seq);
+  }
+  dump_file_seq++;   // increment seq number for next time we dump
+  return my_path;
+}
+
+
+int HeapDumper::dump_to_heapdump_path(outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
+  if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
+    return -1;
+  }
+
+  char* h_path = alloc_and_create_heapdump_pathname();
+  if (h_path != nullptr) {
+    int res = dump(h_path, out, compression, overwrite, num_dump_threads);
+    os::free(h_path);
+    return res;
+  }
+  return -1;
+}
+
 // dump the heap to given path.
 int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
   assert(path != nullptr && strlen(path) > 0, "path missing");
@@ -2753,79 +2844,11 @@ void HeapDumper::dump_heap() {
 }
 
 void HeapDumper::dump_heap(bool oome) {
-  static char base_path[JVM_MAXPATHLEN] = {'\0'};
-  static uint dump_file_seq = 0;
-  char* my_path;
-  const int max_digit_chars = 20;
-
-  const char* dump_file_name = "java_pid";
-  const char* dump_file_ext  = HeapDumpGzipLevel > 0 ? ".hprof.gz" : ".hprof";
-
-  // The dump file defaults to java_pid<pid>.hprof in the current working
-  // directory. HeapDumpPath=<file> can be used to specify an alternative
-  // dump file name or a directory where dump file is created.
-  if (dump_file_seq == 0) { // first time in, we initialize base_path
-    // Calculate potentially longest base path and check if we have enough
-    // allocated statically.
-    const size_t total_length =
-                      (HeapDumpPath == nullptr ? 0 : strlen(HeapDumpPath)) +
-                      strlen(os::file_separator()) + max_digit_chars +
-                      strlen(dump_file_name) + strlen(dump_file_ext) + 1;
-    if (total_length > sizeof(base_path)) {
-      warning("Cannot create heap dump file.  HeapDumpPath is too long.");
-      return;
-    }
-
-    bool use_default_filename = true;
-    if (HeapDumpPath == nullptr || HeapDumpPath[0] == '\0') {
-      // HeapDumpPath=<file> not specified
-    } else {
-      strcpy(base_path, HeapDumpPath);
-      // check if the path is a directory (must exist)
-      DIR* dir = os::opendir(base_path);
-      if (dir == nullptr) {
-        use_default_filename = false;
-      } else {
-        // HeapDumpPath specified a directory. We append a file separator
-        // (if needed).
-        os::closedir(dir);
-        size_t fs_len = strlen(os::file_separator());
-        if (strlen(base_path) >= fs_len) {
-          char* end = base_path;
-          end += (strlen(base_path) - fs_len);
-          if (strcmp(end, os::file_separator()) != 0) {
-            strcat(base_path, os::file_separator());
-          }
-        }
-      }
-    }
-    // If HeapDumpPath wasn't a file name then we append the default name
-    if (use_default_filename) {
-      const size_t dlen = strlen(base_path);  // if heap dump dir specified
-      jio_snprintf(&base_path[dlen], sizeof(base_path)-dlen, "%s%d%s",
-                   dump_file_name, os::current_process_id(), dump_file_ext);
-    }
-    const size_t len = strlen(base_path) + 1;
-    my_path = (char*)os::malloc(len, mtInternal);
-    if (my_path == nullptr) {
-      warning("Cannot create heap dump file.  Out of system memory.");
-      return;
-    }
-    strncpy(my_path, base_path, len);
-  } else {
-    // Append a sequence number id for dumps following the first
-    const size_t len = strlen(base_path) + max_digit_chars + 2; // for '.' and \0
-    my_path = (char*)os::malloc(len, mtInternal);
-    if (my_path == nullptr) {
-      warning("Cannot create heap dump file.  Out of system memory.");
-      return;
-    }
-    jio_snprintf(my_path, len, "%s.%d", base_path, dump_file_seq);
+  char* h_path = alloc_and_create_heapdump_pathname();
+  if (h_path != nullptr) {
+    HeapDumper dumper(false /* no GC before heap dump */,
+                      oome  /* pass along out-of-memory-error flag */);
+    dumper.dump(h_path, tty, HeapDumpGzipLevel);
+    os::free(h_path);
   }
-  dump_file_seq++;   // increment seq number for next time we dump
-
-  HeapDumper dumper(false /* no GC before heap dump */,
-                    oome  /* pass along out-of-memory-error flag */);
-  dumper.dump(my_path, tty, HeapDumpGzipLevel);
-  os::free(my_path);
 }

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -64,7 +64,7 @@ class HeapDumper : public StackObj {
   int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, uint parallel_thread_num = 1);
 
   // same as dump with path parameter, but uses the preset HeapDumpPath file or directory
-  int dump_to_heapdump_path(outputStream* out, int compression, bool overwrite, uint parallel_thread_num);
+  int dump_to(outputStream* out, int compression, bool overwrite, uint parallel_thread_num);
 
   // returns error message (resource allocated), or null if no error
   char* error_as_C_string() const;

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,9 @@ class HeapDumper : public StackObj {
   // compression >= 0 creates a gzipped file with the given compression level.
   // parallel_thread_num >= 0 indicates thread numbers of parallel object dump
   int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, uint parallel_thread_num = 1);
+
+  // same as dump with path parameter, but uses the preset HeapDumpPath file or directory
+  int dump_to_heapdump_path(outputStream* out, int compression, bool overwrite, uint parallel_thread_num);
 
   // returns error message (resource allocated), or null if no error
   char* error_as_C_string() const;

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -2833,9 +2833,9 @@ an \f[V]OutOfMemoryError\f[R] exception is thrown.
 \f[V]-XX:HeapDumpPath=\f[R]\f[I]path\f[R]
 Sets the path and file name for writing the heap dump provided by the
 heap profiler (HPROF) when the \f[V]-XX:+HeapDumpOnOutOfMemoryError\f[R]
-option is set.
-By default, the file is created in the current working directory, and
-it\[aq]s named \f[V]java_pid<pid>.hprof\f[R] where \f[V]<pid>\f[R] is
+option is set or a heap dump is triggered by \f[V]jcmd GC.heap_dump\f[R] without specifying a path.
+In case of HeapDumpOnOutOfMemoryError, by default, the file is created in the current
+working directory, and it\[aq]s named \f[V]java_pid<pid>.hprof\f[R] where \f[V]<pid>\f[R] is
 the identifier of the process that caused the error.
 The following example shows how to set the default file explicitly
 (\f[V]%p\f[R] represents the current process identifier):

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -335,7 +335,9 @@ fewer.
 .PP
 \f[I]arguments\f[R]:
 .IP \[bu] 2
-\f[I]filename\f[R]: The name of the dump file (STRING, no default value)
+\f[I]filename\f[R]: The name of the dump file; in case no file is specified
+but -XX:HeapDumpPath=path is set, the path provided by HeapDumpPath is used
+(STRING, no default value)
 .RE
 .TP
 \f[V]GC.heap_info\f[R]

--- a/test/hotspot/jtreg/serviceability/HeapDump/HeapDumpJcmdPresetPathTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/HeapDumpJcmdPresetPathTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/HeapDump/HeapDumpJcmdPresetPathTest.java
+++ b/test/hotspot/jtreg/serviceability/HeapDump/HeapDumpJcmdPresetPathTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test jcmd GC.heap_dump without path option; path is set via HeapDumpPath
+ * @library /test/lib
+ * @run main/othervm -XX:HeapDumpPath=testjcmd.hprof HeapDumpJcmdPresetPathTest
+ */
+
+import java.io.File;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class HeapDumpJcmdPresetPathTest {
+
+    public static void main(String[] args) throws Exception {
+        PidJcmdExecutor executor = new PidJcmdExecutor();
+        OutputAnalyzer output = executor.execute("GC.heap_dump");
+        output.shouldContain("Dumping heap to testjcmd.hprof");
+        output.shouldContain("Heap dump file created");
+
+        Asserts.assertTrue(new File("testjcmd.hprof").exists());
+    }
+}


### PR DESCRIPTION
Currently jcmd command GC.heap_dump only works with an additionally provided file name.
Syntax : GC.heap_dump [options] <filename>

In case the JVM has the XX - flag HeapDumpPath set, we should support an additional mode where the <filename> is optional.
In case the filename is NOT set, we take the HeapDumpPath (file or directory);

new syntax :
GC.heap_dump [options] <filename> .. has precedence over second option
GC.heap_dump [options] …in case -XX: HeapDumpPath=p is set

This would be a simplification e.g. for support cases where a filename or directory is set at JVM startup with -XX: HeapDumpPath=p and writing to the path is intended/recommended for usage also in the jcmd case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8327769: jcmd GC.heap_dump without options should write to location given by -XX:HeapDumpPath, if set`

### Issue
 * [JDK-8327769](https://bugs.openjdk.org/browse/JDK-8327769): jcmd GC.heap_dump without options should write to location given by -XX:HeapDumpPath, if set (**Bug** - P4)


### Reviewers
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author) ⚠️ Review applies to [61165f55](https://git.openjdk.org/jdk/pull/18190/files/61165f55463db908d57175f2bea20afbe53e040e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18190/head:pull/18190` \
`$ git checkout pull/18190`

Update a local copy of the PR: \
`$ git checkout pull/18190` \
`$ git pull https://git.openjdk.org/jdk.git pull/18190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18190`

View PR using the GUI difftool: \
`$ git pr show -t 18190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18190.diff">https://git.openjdk.org/jdk/pull/18190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18190#issuecomment-1988279717)