### PR TITLE
8327790: Improve javadoc for ResolvedJavaType.hasFinalizableSubclass

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/ResolvedJavaType.java
@@ -40,10 +40,12 @@ public interface ResolvedJavaType extends JavaType, ModifiersProvider, Annotated
     boolean hasFinalizer();
 
     /**
-     * Checks whether this type has any finalizable subclasses so far. Any decisions based on this
-     * information require the registration of a dependency, since this information may change.
+     * Checks whether this type might have finalizable subclasses. Any decisions based on a
+     * negative answer require the registration of a dependency, since this information may change.
+     * For example, dynamic class loading can later load a finalizable subclass.
      *
-     * @return {@code true} if this class has any subclasses with finalizers
+     * @return an {@link AssumptionResult} specifying if this class may have any subclasses with
+     *         finalizers along with any assumptions under which this answer holds
      */
     AssumptionResult<Boolean> hasFinalizableSubclass();
 


### PR DESCRIPTION
This PR fixes and clarifies the javadoc for `ResolvedJavaType.hasFinalizableSubclass()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327790](https://bugs.openjdk.org/browse/JDK-8327790): Improve javadoc for ResolvedJavaType.hasFinalizableSubclass (**Enhancement** - P5)


### Reviewers
 * [Gilles Duboscq](https://openjdk.org/census#gdub) (@gilles-duboscq - Committer) ⚠️ Review applies to [0df2978b](https://git.openjdk.org/jdk/pull/18192/files/0df2978b3a21d858cec00bfdc95f4e3ec4d4223d)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) ⚠️ Review applies to [0df2978b](https://git.openjdk.org/jdk/pull/18192/files/0df2978b3a21d858cec00bfdc95f4e3ec4d4223d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18192/head:pull/18192` \
`$ git checkout pull/18192`

Update a local copy of the PR: \
`$ git checkout pull/18192` \
`$ git pull https://git.openjdk.org/jdk.git pull/18192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18192`

View PR using the GUI difftool: \
`$ git pr show -t 18192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18192.diff">https://git.openjdk.org/jdk/pull/18192.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18192#issuecomment-1988407026)