### PR TITLE
8327812: JFR: Remove debug message in Function.Maximum

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Function.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -275,9 +275,6 @@ abstract class Function {
 
         @Override
         public Object result() {
-            if (maximum == null) {
-                System.out.println("Why");
-            }
             return maximum;
         }
     }


### PR DESCRIPTION
Could I have a review of a change that removes a debug message that was accidentally checked in.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327812](https://bugs.openjdk.org/browse/JDK-8327812): JFR: Remove debug message in Function.Maximum (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18193/head:pull/18193` \
`$ git checkout pull/18193`

Update a local copy of the PR: \
`$ git checkout pull/18193` \
`$ git pull https://git.openjdk.org/jdk.git pull/18193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18193`

View PR using the GUI difftool: \
`$ git pr show -t 18193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18193.diff">https://git.openjdk.org/jdk/pull/18193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18193#issuecomment-1988554722)