### PR TITLE
8327423: C2 remove_main_post_loops: check if main-loop belongs to pre-loop, not just assert

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3260,7 +3260,6 @@ void IdealLoopTree::adjust_loop_exit_prob(PhaseIdealLoop *phase) {
   }
 }
 
-#ifdef ASSERT
 static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(!main_loop->is_main_no_pre_loop(), "Does not have a pre loop");
   Node* ctrl = main_loop->skip_assertion_predicates_with_halt();
@@ -3273,7 +3272,6 @@ static CountedLoopNode* locate_pre_from_main(CountedLoopNode* main_loop) {
   assert(pre_loop->is_pre_loop(), "No pre loop found");
   return pre_loop;
 }
-#endif
 
 // Remove the main and post loops and make the pre loop execute all
 // iterations. Useful when the pre loop is found empty.
@@ -3301,7 +3299,11 @@ void IdealLoopTree::remove_main_post_loops(CountedLoopNode *cl, PhaseIdealLoop *
     return;
   }
 
-  assert(locate_pre_from_main(main_head) == cl, "bad main loop");
+  // We found a main-loop after this pre-loop, but they might not belong together.
+  if (locate_pre_from_main(main_head) != cl) {
+    return;
+  }
+
   Node* main_iff = main_head->skip_assertion_predicates_with_halt()->in(0);
 
   // Remove the Opaque1Node of the pre loop and make it execute all iterations

--- a/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8327423
+ * @summary Test empty loop removal of pre-loop, with different main-loop after it.
+ * @run main/othervm -Xcomp
+ *      -XX:CompileCommand=compileonly,compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop::test
+ *      compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
+ * @run main/othervm compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
+ */
+
+package compiler.loopopts;
+
+public class TestEmptyPreLoopForDifferentMainLoop {
+    static int sink;
+
+    public static void main(String args[]) {
+        test(false);
+    }
+
+    static void test(boolean flag) {
+        int x = 8;
+        for (int j = 0; j < 100; j++) {
+            for (int k = 0; k < 100; k++) {
+                if (flag) {
+                    x += k;
+                    sink = 42;
+                }
+            }
+            if (flag) {
+                break;
+            }
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestEmptyPreLoopForDifferentMainLoop.java
@@ -28,7 +28,7 @@
  * @run main/othervm -Xcomp
  *      -XX:CompileCommand=compileonly,compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop::test
  *      compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
- * @run main/othervm compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
+ * @run main compiler.loopopts.TestEmptyPreLoopForDifferentMainLoop
  */
 
 package compiler.loopopts;


### PR DESCRIPTION
The assert was added in [JDK-8085832](https://bugs.openjdk.org/browse/JDK-8085832) (JDK9), by @rwestrel . And in [JDK-8297724](https://bugs.openjdk.org/browse/JDK-8297724) (JDK21), he made more empty loops be removed, and since then the attached regression test fails.

----------

**Problem**

By the time we get to the assert, we already have had a series of Pre-Main-Post, unroll and empty-loop removal:
the PURPLE main and post loops are already previously removed as empty-loops.

At the time of the assert, the graph looks like this:
![image](https://github.com/openjdk/jdk/assets/32593061/cb36eda4-0684-4b79-8557-0fdd5973ab50)

We are in `IdealLoopTree::remove_main_post_loops` with the PURPLE `298 CountedLoop` as the `cl` pre-loop.

The loop-tree looks essencially like this:
```
(rr) p _ltree_root->dump()
Loop: N0/N0 has_sfpt
Loop: N425/N431 limit_check profile_predicated predicated counted [0,int),+1 (4 iters) pre sfpts={ 429 }
Loop: N298/N301 profile_predicated predicated counted [0,int),+1 (4 iters) pre
Loop: N200/N179 counted [int,100),+1 (2147483648 iters) main sfpts={ 171 }
Loop: N398/N404 counted [int,100),+1 (4 iters) post sfpts={ 402 }
```

This is basically:
```
415 pre orange
298 pre PURPLE
200 main orange
398 post orange
```

From `298 pre PURPLE`, we try to find its main-loop, by looking at the `_next` info in the loop-tree.
There, we find `200 main orange`, it is a main-loop that still is has a pre-loop...
...but not the same pre-loop as `cl` -> the `assert` fires.

It seems that we assume in the code, that we can check the `_next->_head`, and if:
1) it is a main-loop and
2) that main-loop still has a pre-loop
then the current pre-loop "cl" must be the pre-loop of that found main-loop locate `_pre_from_main(main_head)`.
But this is NOT generally guaranteed by "PhaseIdealLoop::build_loop_tree".

The loop-tree is correct here, and this is how it was arrived at:
"415 CountedLoop" (pre orange) is visited, and its body traversed. "427 If" is traversed. Now the path splits.
If we first took the "428 IfFalse" path, then we would visit "200 CountedLoop" (main orange), and "398 CountedLoop" (post orange) first.
But we instead take "432 IfTrue" first, and hence visit "298 CountedLoop" (pre PURPLE) first.

So depending on what turn we take at this "427 If", we either get the order:

```
415 pre orange
298 pre PURPLE
200 main orange
398 post orange
```
(the one we get, and assert with)

OR

```
415 pre orange
200 main orange
398 post orange
298 pre PURPLE
```
(assert woud not trigger, since we would have "_next == nullptr" and return)

--------

**Solution**

We need to convert the `assert` into a condition. If the condition fails, we have no main-loop, and can just return from `remove_main_post_loops`.

Note: if we have an empty pre-loop that still has a main-loop, then the loop-tree must have the pre-loop and main-loop adjacent, i.e. you can get from the pre-loop to its main-loop via `_next`. That is because the `build_loop_tree` traversal cannot take any other path.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327423](https://bugs.openjdk.org/browse/JDK-8327423): C2 remove_main_post_loops: check if main-loop belongs to pre-loop, not just assert (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [96116022](https://git.openjdk.org/jdk/pull/18200/files/96116022d22dc9fb5d5cd3f0e4a2c85808e64706)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [96116022](https://git.openjdk.org/jdk/pull/18200/files/96116022d22dc9fb5d5cd3f0e4a2c85808e64706)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18200/head:pull/18200` \
`$ git checkout pull/18200`

Update a local copy of the PR: \
`$ git checkout pull/18200` \
`$ git pull https://git.openjdk.org/jdk.git pull/18200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18200`

View PR using the GUI difftool: \
`$ git pr show -t 18200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18200.diff">https://git.openjdk.org/jdk/pull/18200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18200#issuecomment-1988916950)