### PR TITLE
8327829: [JVMCI] runtime/ClassUnload/ConstantPoolDependsTest.java fails on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
+++ b/test/hotspot/jtreg/runtime/ClassUnload/ConstantPoolDependsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ import jdk.test.whitebox.WhiteBox;
 import jdk.test.lib.classloader.ClassUnloadCommon;
 
 import java.lang.ref.Reference;
+import java.util.List;
+import java.util.Set;
 public class ConstantPoolDependsTest {
     public static WhiteBox wb = WhiteBox.getWhiteBox();
     public static final String MY_TEST = "ConstantPoolDependsTest$c1c";
@@ -78,10 +80,7 @@ public class ConstantPoolDependsTest {
 
     public static void main(String args[]) throws Throwable {
         test();
-        ClassUnloadCommon.triggerUnloading();  // should unload
-        System.gc();
-        System.out.println("Should unload p2.c2 just now");
-        ClassUnloadCommon.failIf(wb.isClassAlive(MY_TEST), "should be unloaded");
-        ClassUnloadCommon.failIf(wb.isClassAlive("p2.c2"), "should be unloaded");
+        Set<String> aliveClasses = ClassUnloadCommon.triggerUnloading(List.of(MY_TEST, "p2.c2"));
+        ClassUnloadCommon.failIf(!aliveClasses.isEmpty(), "should be unloaded: " + aliveClasses);
     }
 }


### PR DESCRIPTION
This PR fixes failures of `runtime/ClassUnload/ConstantPoolDependsTest.java` for similar reasons to those stated in https://github.com/openjdk/jdk/pull/18044.

The fix is also similar: use a helper that retries class unloading.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327829](https://bugs.openjdk.org/browse/JDK-8327829): [JVMCI] runtime/ClassUnload/ConstantPoolDependsTest.java fails on libgraal (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18202/head:pull/18202` \
`$ git checkout pull/18202`

Update a local copy of the PR: \
`$ git checkout pull/18202` \
`$ git pull https://git.openjdk.org/jdk.git pull/18202/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18202`

View PR using the GUI difftool: \
`$ git pr show -t 18202`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18202.diff">https://git.openjdk.org/jdk/pull/18202.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18202#issuecomment-1989007615)