### PR TITLE
8325851: Hide PassFailJFrame.Builder constructor

### DIFF
--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -44,7 +44,7 @@ public class DefaultSizeTest {
 
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("DefaultSizeTest Instructions Frame")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -44,25 +44,15 @@ public class DefaultSizeTest {
 
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("DefaultSizeTest Instructions Frame")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(10)
                 .columns(45)
+                .testUI(() -> new Frame("DefaultSize"))
                 .screenCapture()
-                .build();
-
-        EventQueue.invokeAndWait(() -> {
-            Frame frame = new Frame("DefaultSize");
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame
-                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .build()
+                .awaitAndCheck();
     }
 }

--- a/test/jdk/java/awt/Frame/DefaultSizeTest.java
+++ b/test/jdk/java/awt/Frame/DefaultSizeTest.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import java.awt.EventQueue;
 import java.awt.Frame;
 
 /*

--- a/test/jdk/java/awt/Frame/FrameRepackTest.java
+++ b/test/jdk/java/awt/Frame/FrameRepackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Frame/FrameRepackTest.java
+++ b/test/jdk/java/awt/Frame/FrameRepackTest.java
@@ -77,7 +77,7 @@ public class FrameRepackTest {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("FrameRepackTest Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/Frame/FrameRepackTest.java
+++ b/test/jdk/java/awt/Frame/FrameRepackTest.java
@@ -77,25 +77,15 @@ public class FrameRepackTest {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("FrameRepackTest Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(30)
                 .columns(45)
-                .build();
-
-        EventQueue.invokeAndWait(() -> {
-            FrameRepack frame = new FrameRepack();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(FrameRepack::new)
+                .build()
+                .awaitAndCheck();
     }
 
 }

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
@@ -24,7 +24,6 @@
 import java.awt.BorderLayout;
 import java.awt.Canvas;
 import java.awt.Color;
-import java.awt.EventQueue;
 import java.awt.Frame;
 
 /*

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
@@ -53,7 +53,7 @@ public class FrameResizeTest_1 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("FrameResizeTest_1 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_1.java
@@ -53,25 +53,15 @@ public class FrameResizeTest_1 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("FrameResizeTest_1 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(12)
                 .columns(45)
-                .build();
-
-        EventQueue.invokeAndWait(() -> {
-            FrameResize_1 frame = new FrameResize_1();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(FrameResize_1::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
@@ -26,7 +26,6 @@ import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.GridBagConstraints;

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
@@ -57,7 +57,7 @@ public class FrameResizeTest_2 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("FrameResizeTest_2 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
+++ b/test/jdk/java/awt/Frame/FrameResizeTest/FrameResizeTest_2.java
@@ -57,25 +57,15 @@ public class FrameResizeTest_2 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("FrameResizeTest_2 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(10)
                 .columns(45)
-                .build();
-
-        EventQueue.invokeAndWait(() -> {
-            FrameResize_2 frame = new FrameResize_2();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(FrameResize_2::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
@@ -25,7 +25,6 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
-import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.Graphics;
@@ -49,32 +48,28 @@ public class LightweightCliprect {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("LightweightCliprect Instructions Frame")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(10)
                 .columns(45)
-                .build();
+                .testUI(LightweightCliprect::createUI)
+                .build()
+                .awaitAndCheck();
+    }
 
-        EventQueue.invokeAndWait(() -> {
-            Frame frame = new Frame("DefaultSize");
+    private static Frame createUI() {
+        Frame frame = new Frame("DefaultSize");
 
-            Container panel = new MyContainer();
-            MyComponent c = new MyComponent();
-            panel.add(c);
+        Container panel = new MyContainer();
+        MyComponent c = new MyComponent();
+        panel.add(c);
 
-            frame.add(panel);
-            frame.setSize(400, 300);
+        frame.add(panel);
+        frame.setSize(400, 300);
 
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame
-                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+        return frame;
     }
 }
 

--- a/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
+++ b/test/jdk/java/awt/LightweightComponent/LightweightCliprect.java
@@ -49,7 +49,7 @@ public class LightweightCliprect {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("LightweightCliprect Instructions Frame")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
@@ -58,7 +58,7 @@ public class AddRemoveMenuBarTest_1 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_1 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_1.java
@@ -26,7 +26,6 @@ import java.awt.Menu;
 import java.awt.MenuBar;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -58,25 +57,15 @@ public class AddRemoveMenuBarTest_1 {
         """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_1 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(18)
                 .columns(45)
-                .build();
-
-        SwingUtilities.invokeAndWait(() -> {
-            AddRemoveMenuBar_1 frame = new AddRemoveMenuBar_1();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(AddRemoveMenuBar_1::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
@@ -26,7 +26,6 @@ import java.awt.Menu;
 import java.awt.MenuBar;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -54,25 +53,15 @@ public class AddRemoveMenuBarTest_2 {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_2 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(15)
                 .columns(45)
-                .build();
-
-        SwingUtilities.invokeAndWait(() -> {
-            AddRemoveMenuBar_2 frame = new AddRemoveMenuBar_2();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(AddRemoveMenuBar_2::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_2.java
@@ -54,7 +54,7 @@ public class AddRemoveMenuBarTest_2 {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_2 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
@@ -76,7 +76,7 @@ public class AddRemoveMenuBarTest_3  {
             Upon test completion, click Pass or Fail appropriately.
             """;
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_3 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_3.java
@@ -34,7 +34,6 @@ import java.awt.TextField;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -76,25 +75,15 @@ public class AddRemoveMenuBarTest_3  {
             Upon test completion, click Pass or Fail appropriately.
             """;
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_3 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(30)
                 .columns(38)
-                .build();
-
-        SwingUtilities.invokeAndWait(() -> {
-            AddRemoveMenuBar_3 frame = new AddRemoveMenuBar_3();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(null,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(AddRemoveMenuBar_3::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
@@ -61,7 +61,7 @@ public class AddRemoveMenuBarTest_4 {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_4 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
+++ b/test/jdk/java/awt/MenuBar/AddRemoveMenuBarTests/AddRemoveMenuBarTest_4.java
@@ -27,7 +27,6 @@ import java.awt.Frame;
 import java.awt.Menu;
 import java.awt.MenuBar;
 import java.awt.MenuItem;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -61,25 +60,15 @@ public class AddRemoveMenuBarTest_4 {
             """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("AddRemoveMenuBarTest_4 Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(18)
                 .columns(45)
-                .build();
-
-        SwingUtilities.invokeAndWait(() -> {
-            AddRemoveMenuBar_4 frame = new AddRemoveMenuBar_4();
-
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(AddRemoveMenuBar_4::new)
+                .build()
+                .awaitAndCheck();
     }
 }
 

--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
+++ b/test/jdk/java/awt/TrayIcon/TrayIconScalingTest.java
@@ -85,7 +85,7 @@ public class TrayIconScalingTest {
             System.out.println("SystemTray is not supported");
             return;
         }
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("TrayIcon Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(8)

--- a/test/jdk/java/awt/event/KeyEvent/AcceleratorTest/AcceleratorTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/AcceleratorTest/AcceleratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/event/KeyEvent/AcceleratorTest/AcceleratorTest.java
+++ b/test/jdk/java/awt/event/KeyEvent/AcceleratorTest/AcceleratorTest.java
@@ -79,7 +79,7 @@ public class AcceleratorTest {
             cmdHash.put(CMD[i], 0);
         }
 
-        PassFailJFrame testFrame = new PassFailJFrame.Builder()
+        PassFailJFrame testFrame = PassFailJFrame.builder()
                 .title("Test Instructions Frame")
                 .instructions(instructions)
                 .testTimeOut(10)

--- a/test/jdk/java/awt/geom/HitTest/PathHitTest.java
+++ b/test/jdk/java/awt/geom/HitTest/PathHitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/geom/HitTest/PathHitTest.java
+++ b/test/jdk/java/awt/geom/HitTest/PathHitTest.java
@@ -372,7 +372,7 @@ public class PathHitTest {
         }
 
         public static void doManual() throws Exception {
-            PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+            PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                     .title("PathHitTestManual Instructions")
                     .instructions(INSTRUCTIONS)
                     .testTimeOut(5)

--- a/test/jdk/java/awt/print/PageFormat/CustomPaper.java
+++ b/test/jdk/java/awt/print/PageFormat/CustomPaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/awt/print/PageFormat/CustomPaper.java
+++ b/test/jdk/java/awt/print/PageFormat/CustomPaper.java
@@ -167,7 +167,7 @@ public class CustomPaper implements Pageable, Printable {
                     + "Valid values: 4355514 or 4385157");
         };
 
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("CustomPaper Test Instructions")
                 .instructions(instructions)
                 .testTimeOut(5)

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1059,6 +1059,14 @@ public final class PassFailJFrame {
 
         private Position position;
 
+        /**
+         * A private constructor for the builder,
+         * it should not be created directly.
+         * Use {@code PassFailJFrame.builder()} method instead.
+         */
+        private Builder() {
+        }
+
         public Builder title(String title) {
             this.title = title;
             return this;

--- a/test/jdk/javax/accessibility/JComboBox/TestJComboBoxScreenMagnifier.java
+++ b/test/jdk/javax/accessibility/JComboBox/TestJComboBoxScreenMagnifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/accessibility/JComboBox/TestJComboBoxScreenMagnifier.java
+++ b/test/jdk/javax/accessibility/JComboBox/TestJComboBoxScreenMagnifier.java
@@ -54,7 +54,7 @@ public class TestJComboBoxScreenMagnifier {
 
     public static void main(String[] args) throws InterruptedException,
              InvocationTargetException {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("JComboBox Screen Magnifier Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -66,18 +66,18 @@ public class ComboPopupBug {
         cb.addItem("test");
         cb.addItem("test2");
         cb.addItem("test3");
-        frame.getContentPane().add(cb, "North");
 
         JButton b = new JButton("Close");
         b.addActionListener(
                 (e)->{
                     try {
                         Thread.sleep(3000);
-                    }
-                    catch (Exception ex) {
+                    } catch (Exception ignored) {
                     }
                     frame.setVisible(false);
                 });
+
+        frame.getContentPane().add(cb, "North");
         frame.getContentPane().add(b, "South");
         frame.setSize(200, 200);
 

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -48,7 +48,7 @@ public class ComboPopupBug {
             otherwise click Pass.  """;
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("ComboPopup Instructions")
                 .instructions(instructionsText)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
+++ b/test/jdk/javax/swing/JComboBox/ComboPopupBug.java
@@ -24,7 +24,6 @@
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
 
 /*
  * @test
@@ -45,29 +44,32 @@ public class ComboPopupBug {
             Click on Close and then click on JComboBox arrow button
             to try to show combobox popup.
             If IllegalStateException is thrown, test will automatically Fail
-            otherwise click Pass.  """;
+            otherwise click Pass.""";
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("ComboPopup Instructions")
                 .instructions(instructionsText)
                 .testTimeOut(5)
                 .rows(10)
                 .columns(35)
-                .build();
+                .testUI(ComboPopupBug::createUI)
+                .build()
+                .awaitAndCheck();
+    }
 
-        SwingUtilities.invokeAndWait(() -> {
-            JFrame frame = new JFrame("ComboPopup");
+    private static JFrame createUI() {
+        JFrame frame = new JFrame("ComboPopup");
 
-            JComboBox cb = new JComboBox();
-            cb.setEditable(true);
-            cb.addItem("test");
-            cb.addItem("test2");
-            cb.addItem("test3");
-            frame.getContentPane().add(cb, "North");
+        JComboBox<String> cb = new JComboBox<>();
+        cb.setEditable(true);
+        cb.addItem("test");
+        cb.addItem("test2");
+        cb.addItem("test3");
+        frame.getContentPane().add(cb, "North");
 
-            JButton b = new JButton("Close");
-            b.addActionListener(
+        JButton b = new JButton("Close");
+        b.addActionListener(
                 (e)->{
                     try {
                         Thread.sleep(3000);
@@ -75,18 +77,10 @@ public class ComboPopupBug {
                     catch (Exception ex) {
                     }
                     frame.setVisible(false);
-
                 });
-            frame.getContentPane().add(b, "South");
-            frame.setSize(200, 200);
+        frame.getContentPane().add(b, "South");
+        frame.setSize(200, 200);
 
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame.positionTestWindow(frame,
-                    PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+        return frame;
     }
 }

--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -32,7 +32,6 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 
 /*
@@ -73,31 +72,26 @@ public class DefaultCloseOperation extends JPanel {
     JComboBox<String> dialogCloseOp;
 
     public static void main(String[] args) throws Exception {
-
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("DefaultCloseOperation Manual Test")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)
                 .rows(20)
-                .columns(70)
-                .build();
+                .columns(50)
+                .testUI(DefaultCloseOperation::createUI)
+                .build()
+                .awaitAndCheck();
+    }
 
-        SwingUtilities.invokeAndWait(() -> {
-            DefaultCloseOperation dco = new DefaultCloseOperation();
-            dco.init();
+    private static JFrame createUI() {
+        DefaultCloseOperation dco = new DefaultCloseOperation();
+        dco.init();
 
-            JFrame frame = new JFrame("DefaultCloseOperation");
-            frame.add(dco);
-            frame.setSize(500,200);
+        JFrame frame = new JFrame("DefaultCloseOperation");
+        frame.add(dco);
+        frame.setSize(500,200);
 
-            PassFailJFrame.addTestWindow(frame);
-            PassFailJFrame
-                    .positionTestWindow(frame, PassFailJFrame.Position.HORIZONTAL);
-
-            frame.setVisible(true);
-        });
-
-        passFailJFrame.awaitAndCheck();
+        return frame;
     }
 
     public void init() {

--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -74,7 +74,7 @@ public class DefaultCloseOperation extends JPanel {
 
     public static void main(String[] args) throws Exception {
 
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("DefaultCloseOperation Manual Test")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
@@ -57,7 +57,7 @@ public class TestJTabbedPaneArrowDirection {
 
     public static void main(String[] args) throws Exception {
         UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("JTabbedPane Arrow Direction Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestJTabbedPaneArrowDirection.java
@@ -49,7 +49,7 @@ public class TestJTabbedPaneArrowDirection {
     private static JFrame frame;
     private static JTabbedPane tabPane;
     private static final String INSTRUCTIONS =
-            "1. Observe the arrows are ponting to left and right direction\n" +
+            "1. Observe the arrows are pointing to left and right direction\n" +
                " for tab placement set to TOP. Default tab placement is TOP.\n\n" +
             "2. Press BOTTOM to change the tab placement to bottom.\n\n" +
             "3. Observe arrows are pointing to the left and right direction.\n\n" +

--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JToolBar/bug4203039.java
+++ b/test/jdk/javax/swing/JToolBar/bug4203039.java
@@ -49,7 +49,7 @@ public class bug4203039 {
             locations but can dock on the NORTH and WEST""";
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("bug4203039 Instructions")
                 .instructions(instructionsText)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -64,7 +64,7 @@ public class MultimonVImage {
             "    issue, try to use the same or similar video cards for each monitor.";
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                 .title("MultimonVImage Instructions")
                 .instructions(instructionsText)
                 .testTimeOut(5)

--- a/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
+++ b/test/jdk/javax/swing/MultiMonitor/MultimonVImage.java
@@ -38,9 +38,8 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import javax.swing.JViewport;
 import javax.swing.JFrame;
-import javax.swing.SwingUtilities;
+import javax.swing.JViewport;
 
 public class MultimonVImage {
     private static final String instructionsText =
@@ -64,25 +63,20 @@ public class MultimonVImage {
             "    issue, try to use the same or similar video cards for each monitor.";
 
     public static void main(String[] args) throws Exception {
-        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+        PassFailJFrame.builder()
                 .title("MultimonVImage Instructions")
                 .instructions(instructionsText)
                 .testTimeOut(5)
                 .rows(25)
                 .columns(50)
-                .build();
-
-        SwingUtilities.invokeAndWait(() -> {
-            AnimatingFrame af = new AnimatingFrame();
-            af.test();
-            af.run();
-
-            PassFailJFrame.addTestWindow(af);
-            PassFailJFrame.positionTestWindow(af,
-                    PassFailJFrame.Position.HORIZONTAL);
-        });
-
-        passFailJFrame.awaitAndCheck();
+                .testUI(() -> {
+                    AnimatingFrame af = new AnimatingFrame();
+                    af.test();
+                    af.run();
+                    return af;
+                })
+                .build()
+                .awaitAndCheck();
     }
 }
 
@@ -164,9 +158,7 @@ class AnimatingFrame extends JFrame implements Runnable {
         setContentPane(component);
         component.setVisible(true);
 
-        setLocationRelativeTo(null);
         pack();
-        setVisible(true);
     }
 
     public void test() {

--- a/test/jdk/sun/awt/PaletteTester.java
+++ b/test/jdk/sun/awt/PaletteTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/awt/PaletteTester.java
+++ b/test/jdk/sun/awt/PaletteTester.java
@@ -90,7 +90,7 @@ public class PaletteTester {
 
     public static void main( String args[] ) throws Exception {
 
-        PassFailJFrame passFailJFrame = new PassFailJFrame.Builder()
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
                                         .title("PaletteTester Instructions")
                                         .instructions(INSTRUCTIONS)
                                         .testTimeOut(5)


### PR DESCRIPTION
The `Builder` class in `PassFailJFrame` is public and has a public constructor. At the same time, a better design would be to hide all the Builder constructors and rely on the `builder()` method which returns an instance of the `Builder` class.

This PR makes the constructor of the `Builder` class private so that it's not accessible directly.

Use `PassFailJFrame.builder()` to get an instance of the builder and configure parameters of `PassFailJFrame`.

I updated all the tests which used the constructor directly by calling `new PassFailJFrame.Builder()`.

I converted a few tests to use the `testUI`, which greatly simplifies the test code. This change also removes flickering of the test UI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325851](https://bugs.openjdk.org/browse/JDK-8325851): Hide PassFailJFrame.Builder constructor (**Bug** - P5)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18206/head:pull/18206` \
`$ git checkout pull/18206`

Update a local copy of the PR: \
`$ git checkout pull/18206` \
`$ git pull https://git.openjdk.org/jdk.git pull/18206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18206`

View PR using the GUI difftool: \
`$ git pr show -t 18206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18206.diff">https://git.openjdk.org/jdk/pull/18206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18206#issuecomment-1989469680)