### PR TITLE
8321299: runtime/logging/ClassLoadUnloadTest.java doesn't reliably trigger class unloading

### DIFF
--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -49,8 +49,7 @@ public class ClassLoadUnloadTest {
     private static class ClassUnloadTestMain {
         public static void main(String... args) throws Exception {
             String className = "test.Empty";
-            String classPath = args[0];
-            ClassLoader cl = ClassUnloadCommon.newClassLoader(classPath);
+            ClassLoader cl = ClassUnloadCommon.newClassLoader();
             Class<?> c = cl.loadClass(className);
             cl = null; c = null;
             ClassUnloadCommon.triggerUnloading();
@@ -73,11 +72,12 @@ public class ClassLoadUnloadTest {
     static OutputAnalyzer exec(String... args) throws Exception {
         String classPath = System.getProperty("test.class.path", ".");
 
+        // Sub-process does not get all the properties automatically, so the test class path needs to be passed explicitly
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m", "-Xbootclasspath/a:.", "-XX:+UnlockDiagnosticVMOptions",
-                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName(), classPath);
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(argsList);
+                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", "-Dtest.class.path=" + classPath, ClassUnloadTestMain.class.getName());
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(argsList);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         return output;

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -49,7 +49,8 @@ public class ClassLoadUnloadTest {
     private static class ClassUnloadTestMain {
         public static void main(String... args) throws Exception {
             String className = "test.Empty";
-            ClassLoader cl = ClassUnloadCommon.newClassLoader();
+            String classPath = args[0];
+            ClassLoader cl = ClassUnloadCommon.newClassLoader(classPath);
             Class<?> c = cl.loadClass(className);
             cl = null; c = null;
             ClassUnloadCommon.triggerUnloading();
@@ -70,10 +71,12 @@ public class ClassLoadUnloadTest {
 
     // Use the same command-line heap size setting as ../ClassUnload/UnloadTest.java
     static OutputAnalyzer exec(String... args) throws Exception {
+        String classPath = System.getProperty("test.class.path", ".");
+
         List<String> argsList = new ArrayList<>();
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m", "-Xbootclasspath/a:.", "-XX:+UnlockDiagnosticVMOptions",
-                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName());
+                           "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", ClassUnloadTestMain.class.getName(), classPath);
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(argsList);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
@@ -86,7 +89,7 @@ public class ClassLoadUnloadTest {
 
         //  -Xlog:class+unload=info
         output = exec("-Xlog:class+unload=info");
-        checkFor(output, "[class,unload]", "unloading class");
+        checkFor(output, "[class,unload]", "unloading class test.Empty");
 
         //  -Xlog:class+unload=off
         output = exec("-Xlog:class+unload=off");

--- a/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
+++ b/test/hotspot/jtreg/runtime/logging/ClassLoadUnloadTest.java
@@ -77,7 +77,7 @@ public class ClassLoadUnloadTest {
         Collections.addAll(argsList, args);
         Collections.addAll(argsList, "-Xmn8m", "-Xbootclasspath/a:.", "-XX:+UnlockDiagnosticVMOptions",
                            "-XX:+WhiteBoxAPI", "-XX:+ClassUnloading", "-Dtest.class.path=" + classPath, ClassUnloadTestMain.class.getName());
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(argsList);
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(argsList);
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
         return output;

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -73,6 +73,14 @@ public class ClassUnloadCommon {
      */
     public static ClassLoader newClassLoader() {
         String cp = System.getProperty("test.class.path", ".");
+        return newClassLoader(cp);
+    }
+
+    /**
+     * Creates a class loader that loads classes from the provided class path
+     * before delegating to the system class loader.
+     */
+    public static ClassLoader newClassLoader(String cp) {
         URL[] urls = Stream.of(cp.split(File.pathSeparator))
                 .map(Paths::get)
                 .map(ClassUnloadCommon::toURL)

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -29,6 +29,8 @@
 
 
 package jdk.test.lib.classloader;
+import jdk.test.whitebox.WhiteBox;
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -37,8 +39,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.stream.Stream;
-
-import jdk.test.whitebox.WhiteBox;
 
 public class ClassUnloadCommon {
     public static class TestFailure extends RuntimeException {

--- a/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
+++ b/test/lib/jdk/test/lib/classloader/ClassUnloadCommon.java
@@ -29,8 +29,6 @@
 
 
 package jdk.test.lib.classloader;
-import jdk.test.whitebox.WhiteBox;
-
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -39,6 +37,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.stream.Stream;
+
+import jdk.test.whitebox.WhiteBox;
 
 public class ClassUnloadCommon {
     public static class TestFailure extends RuntimeException {
@@ -73,14 +73,6 @@ public class ClassUnloadCommon {
      */
     public static ClassLoader newClassLoader() {
         String cp = System.getProperty("test.class.path", ".");
-        return newClassLoader(cp);
-    }
-
-    /**
-     * Creates a class loader that loads classes from the provided class path
-     * before delegating to the system class loader.
-     */
-    public static ClassLoader newClassLoader(String cp) {
         URL[] urls = Stream.of(cp.split(File.pathSeparator))
                 .map(Paths::get)
                 .map(ClassUnloadCommon::toURL)


### PR DESCRIPTION
ClassLoadUnloadTest.java passes by accident because an unrelated LambdaForm is being unloaded. The test class, `test.Empty` should be loaded by a custom class loader and then subsequently unloaded, however this is not actually occurring due to the sub-process not receiving the class path. This patch modifies `ClassUnloadCommon`, so it may accept a string containing the classlist, and `ClassLoadUnloadTest.java` so it checks specifically for `test.Empty` to be unloaded. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321299](https://bugs.openjdk.org/browse/JDK-8321299): runtime/logging/ClassLoadUnloadTest.java doesn't reliably trigger class unloading (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [efa6b5e2](https://git.openjdk.org/jdk/pull/18207/files/efa6b5e2645abef70194e0e36278fad73e050938)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18207/head:pull/18207` \
`$ git checkout pull/18207`

Update a local copy of the PR: \
`$ git checkout pull/18207` \
`$ git pull https://git.openjdk.org/jdk.git pull/18207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18207`

View PR using the GUI difftool: \
`$ git pr show -t 18207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18207.diff">https://git.openjdk.org/jdk/pull/18207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18207#issuecomment-1989474075)