### PR TITLE
8327799: JFR view: the "Park Until" field of jdk.ThreadPark is invalid if the parking method is not absolute

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -343,6 +343,9 @@ public final class ValueFormatter {
     }
 
     public static String formatTimestamp(Instant instant) {
+        if (Instant.MIN.equals(instant)) {
+            return "N/A";
+        }
         return LocalTime.ofInstant(instant, ZoneId.systemDefault()).format(DATE_FORMAT);
     }
 }


### PR DESCRIPTION
Hi all

Could I have a review of this patch for [JDK-8327799](https://bugs.openjdk.org/browse/JDK-8327799)?

```java
UNSAFE.park(true, System.currentTimeMillis() + 1000);
UNSAFE.park(false, 2000L * 1000 * 1000);
```

```bash
jfr view jdk.ThreadPark test.jfr

                                                    Java Thread Park
Start Time Duration Event Thread Stack Trace             Class Parked On Park Timeout Park Until Address of Object Pa...
---------- -------- ------------ ----------------------- --------------- ------------ ---------- -----------------------
20:13:21     1.00 s main         jdk.internal.misc.Un... N/A                      N/A 20:13:22   0x00000000
20:13:22     2.00 s main         jdk.internal.misc.Un... N/A                   2.00 s 08:05:43   0x00000000
```

If the parking method is not absolute (the second event), the real value of "until" in JFR event is `Long.MIN_VALUE`, which will be convert back to `java.time.Instant.MIN`, but `JFR view` displays this value as '08:05:43' of my timezone. This is somewhat misleading, better to show as `N/A`, just like what `jfr print --events` does.

Testing:
test/jdk/jdk/jfr/tool/TestView.java
test/jdk/jdk/jfr/jcmd/TestJcmdView.java

All passed.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327799](https://bugs.openjdk.org/browse/JDK-8327799): JFR view: the "Park Until" field of jdk.ThreadPark is invalid if the parking method is not absolute (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18214/head:pull/18214` \
`$ git checkout pull/18214`

Update a local copy of the PR: \
`$ git checkout pull/18214` \
`$ git pull https://git.openjdk.org/jdk.git pull/18214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18214`

View PR using the GUI difftool: \
`$ git pr show -t 18214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18214.diff">https://git.openjdk.org/jdk/pull/18214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18214#issuecomment-1990843197)