### PR TITLE
8327884: JFR view: Improve time display accuracy to milliseconds

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueFormatter.java
@@ -57,7 +57,7 @@ public final class ValueFormatter {
         }
     }
 
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss.SSS");
     private static final Duration MICRO_SECOND = Duration.ofNanos(1_000);
     private static final Duration SECOND = Duration.ofSeconds(1);
     private static final Duration MINUTE = Duration.ofMinutes(1);


### PR DESCRIPTION
Could I have a review of this patch for [8327884](https://bugs.openjdk.org/browse/JDK-8327884) ?

Now the time display accuracy is seconds. It's better if we can display milliseconds, especially when printing original events.
This is a break change, consider this is a command line utility, it's acceptable.

Testing:
test/jdk/jdk/jfr/tool/TestView.java
test/jdk/jdk/jfr/jcmd/TestJcmdView.java

All passed.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327884](https://bugs.openjdk.org/browse/JDK-8327884): JFR view: Improve time display accuracy to milliseconds (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18219/head:pull/18219` \
`$ git checkout pull/18219`

Update a local copy of the PR: \
`$ git checkout pull/18219` \
`$ git pull https://git.openjdk.org/jdk.git pull/18219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18219`

View PR using the GUI difftool: \
`$ git pr show -t 18219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18219.diff">https://git.openjdk.org/jdk/pull/18219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18219#issuecomment-1990972411)