### PR TITLE
8327864: Support segmented heap dump for HotSpotDiagnosticMXBean

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2660,7 +2660,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
 
   DumpMerger merger(path, &writer, dumper.dump_seq());
   Thread* current_thread = Thread::current();
-  if (current_thread->is_AttachListener_thread()) {
+  if (current_thread->is_AttachListener_thread() || !_oome) {
     // perform heapdump file merge operation in the current thread prevents us
     // from occupying the VM Thread, which in turn affects the occurrence of
     // GC and other VM operations.

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1949,7 +1949,7 @@ JVM_ENTRY(jint, jmm_DumpHeap0(JNIEnv *env, jstring outputfile, jboolean live))
                "Output file name cannot be null.", -1);
   }
   HeapDumper dumper(live ? true : false);
-  if (dumper.dump(name) != 0) {
+  if (dumper.dump(name, nullptr, -1, false, HeapDumper::default_num_of_dump_threads()) != 0) {
     const char* errmsg = dumper.error_as_C_string();
     THROW_MSG_(vmSymbols::java_io_IOException(), errmsg, -1);
   }


### PR DESCRIPTION
We've received feedback from users of cloud APM platform wanting the new version of the JDK to allow the HotSpotDiagnosticMXBean.dumpHeap underpinnings to reduce STW time using sgemented heapdump. Supporting segmented heapdump for mxbean is a reasonable requirement and adds little additional complexity, both in terms of maintainability and understanding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327864](https://bugs.openjdk.org/browse/JDK-8327864): Support segmented heap dump for HotSpotDiagnosticMXBean (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18221/head:pull/18221` \
`$ git checkout pull/18221`

Update a local copy of the PR: \
`$ git checkout pull/18221` \
`$ git pull https://git.openjdk.org/jdk.git pull/18221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18221`

View PR using the GUI difftool: \
`$ git pr show -t 18221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18221.diff">https://git.openjdk.org/jdk/pull/18221.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18221#issuecomment-1990991290)