### PR TITLE
8327945: Inline HasScavengableOops

### DIFF
--- a/src/hotspot/share/gc/shared/scavengableNMethods.cpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/scavengableNMethods.cpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.cpp
@@ -107,27 +107,25 @@ void ScavengableNMethods::verify_nmethod(nmethod* nm) {
 #endif // PRODUCT
 }
 
-class HasScavengableOops: public OopClosure {
-  BoolObjectClosure* _is_scavengable;
-  bool               _found;
-public:
-  HasScavengableOops(BoolObjectClosure* is_scavengable, nmethod* nm) :
+bool ScavengableNMethods::has_scavengable_oops(nmethod* nm) {
+  struct HasScavengableOops: public OopClosure {
+    BoolObjectClosure* _is_scavengable;
+    bool               _found;
+
+    explicit HasScavengableOops(BoolObjectClosure* is_scavengable) :
       _is_scavengable(is_scavengable),
       _found(false) {}
 
-  bool found() { return _found; }
-  virtual void do_oop(oop* p) {
-    if (!_found && *p != nullptr && _is_scavengable->do_object_b(*p)) {
-      _found = true;
+    virtual void do_oop(oop* p) {
+      if (!_found && *p != nullptr && _is_scavengable->do_object_b(*p)) {
+        _found = true;
+      }
     }
-  }
-  virtual void do_oop(narrowOop* p) { ShouldNotReachHere(); }
-};
+    virtual void do_oop(narrowOop* p) { ShouldNotReachHere(); }
+  } cl {_is_scavengable};
 
-bool ScavengableNMethods::has_scavengable_oops(nmethod* nm) {
-  HasScavengableOops cl(_is_scavengable, nm);
   nm->oops_do(&cl);
-  return cl.found();
+  return cl._found;
 }
 
 // Walk the list of methods which might contain oops to the java heap.


### PR DESCRIPTION
Trivial inlining a class to reduce its visibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327945](https://bugs.openjdk.org/browse/JDK-8327945): Inline HasScavengableOops (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [adbe5478](https://git.openjdk.org/jdk/pull/18223/files/adbe547887d33ca4c2da93a1a7a5d8d6c035a44e)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18223/head:pull/18223` \
`$ git checkout pull/18223`

Update a local copy of the PR: \
`$ git checkout pull/18223` \
`$ git pull https://git.openjdk.org/jdk.git pull/18223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18223`

View PR using the GUI difftool: \
`$ git pr show -t 18223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18223.diff">https://git.openjdk.org/jdk/pull/18223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18223#issuecomment-1991043026)