### PR TITLE
8327946: containers/docker/TestJFREvents.java fails when host kernel config vm.swappiness=0 after JDK-8325139

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -221,7 +221,7 @@ public class TestJFREvents {
                                       commonDockerOpts()
                                       .addDockerOpts("--memory=" + memValueToSet)
                                       .addDockerOpts("--memory-swap=" + swapValueToSet)
-                                      //The default memory-swappiness vaule is inherited from the host machine, which maybe 0
+                                      // The default memory-swappiness vaule is inherited from the host machine, which maybe 0
                                       .addDockerOpts("--memory-swappiness=60")
                                       .addClassOptions("jdk.SwapSpace"));
          out.shouldHaveExitValue(0)

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -221,6 +221,8 @@ public class TestJFREvents {
                                       commonDockerOpts()
                                       .addDockerOpts("--memory=" + memValueToSet)
                                       .addDockerOpts("--memory-swap=" + swapValueToSet)
+                                      //The default memory-swappiness vaule is inherited from the host machine, which maybe 0
+                                      .addDockerOpts("--memory-swappiness=60")
                                       .addClassOptions("jdk.SwapSpace"));
          out.shouldHaveExitValue(0)
             .shouldContain("totalSize = " + expectedTotalValue)


### PR DESCRIPTION
Hi,

According to the [docker document](https://docs.docker.com/config/containers/resource_constraints/#--memory-swappiness-details), the default value of --memory-swappiness is inherited from the host machine. So, when the the kernel config vm.swappiness=0 on the host machine, this testcase will fail, because of docker container can not use swap memory, the deafult value of --memory-swappiness is 0.

When the host kernel config "vm.swappiness = 0", In order to run this testcase passed , there are three methods:

1. change `.shouldContain("totalSize = " + expectedTotalValue)` to `.shouldContain("totalSize = "`, which ignored the `expectedTotalValue`, because the `expectedTotalValue` could be 0(swap memroy is disable when --memory-swappiness=0) or could be 104857600(300MB-200MB=100MB), it depends on the host machine config `vm.swappiness`
2. Change the default `--memory-swappiness` 0 to non-zero, such as 60.
3. Change the host kernel config `vm.swappiness=0` to `vm.swappiness=60`. I think it's not a good idea.

Maybe the 2rd method seems more resonable.


Thanks,
-sendao

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327946](https://bugs.openjdk.org/browse/JDK-8327946): containers/docker/TestJFREvents.java fails when host kernel config vm.swappiness=0 after JDK-8325139 (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18225/head:pull/18225` \
`$ git checkout pull/18225`

Update a local copy of the PR: \
`$ git checkout pull/18225` \
`$ git pull https://git.openjdk.org/jdk.git pull/18225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18225`

View PR using the GUI difftool: \
`$ git pr show -t 18225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18225.diff">https://git.openjdk.org/jdk/pull/18225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18225#issuecomment-1991111164)