### PR TITLE
8327796: Add method to java.net.http.HttpRequest to return a GET request in one call

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -343,7 +343,7 @@ public abstract class HttpRequest {
      * @param uristring the URI string to get
      * @return a HttpRequest
      * @throws IllegalArgumentException if the URI scheme is not supported
-     *         or if the uristring is invalid.
+     *         or if the provided {@code uristring} is not a valid URI.
      */
     public static HttpRequest GET(String uristring) {
         URI uri = URI.create(uristring);

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -63,24 +63,34 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * copied and modified many times in order to build multiple related requests
  * that differ in some parameters.
  *
- * <p> The following is an example of a GET request that prints the response
- * body as a String:
- *
+ * <p> The following is an example of an asynchronous POST:
  * {@snippet :
  *   HttpClient client = HttpClient.newHttpClient();
  *
  *   HttpRequest request = HttpRequest.newBuilder()
  *         .uri(URI.create("http://foo.com/"))
+ *         .POST(BodyPublishers.ofString("request body text"))
  *         .build();
  *
  *   client.sendAsync(request, BodyHandlers.ofString())
  *         .thenApply(HttpResponse::body)
  *         .thenAccept(System.out::println)
- *         .join(); }
+ *         .join();
+ *  }
  *
  * <p>The class {@link BodyPublishers BodyPublishers} provides implementations
  * of many common publishers. Alternatively, a custom {@code BodyPublisher}
  * implementation can be used.
+ *
+ * <p> The builder can be avoided for simple GET requests as the following example
+ * shows:
+ * {@snippet :
+ *   HttpClient client = HttpClient.newHttpClient();
+ *
+ *   HttpRequest request = HttpRequest.GET("https://www.foo.com/");
+ *   String response = client.send(request, BodyHandlers.ofString()).body();
+ *   System.out.println(response.body());
+ * }
  *
  * @since 11
  */
@@ -323,6 +333,21 @@ public abstract class HttpRequest {
      */
     public static HttpRequest.Builder newBuilder(URI uri) {
         return new HttpRequestBuilderImpl(uri);
+    }
+
+    /**
+     * Convenience method which returns a GET HttpRequest for the given URI string.
+     *
+     * @param uristring the URI string to get
+     * @return a HttpRequest
+     * @throws IllegalArgumentException if the URI scheme is not supported.
+     */
+    public static HttpRequest GET(String uristring) {
+        URI uri = URI.create(uristring);
+        return HttpRequest.newBuilder()
+            .uri(uri)
+            .GET()
+            .build();
     }
 
     /**

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -340,7 +340,8 @@ public abstract class HttpRequest {
      *
      * @param uristring the URI string to get
      * @return a HttpRequest
-     * @throws IllegalArgumentException if the URI scheme is not supported.
+     * @throws IllegalArgumentException if the URI scheme is not supported
+     *         or is otherwise invalid.
      */
     public static HttpRequest GET(String uristring) {
         URI uri = URI.create(uristring);

--- a/src/java.net.http/share/classes/java/net/http/HttpRequest.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpRequest.java
@@ -88,8 +88,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  *   HttpClient client = HttpClient.newHttpClient();
  *
  *   HttpRequest request = HttpRequest.GET("https://www.foo.com/");
- *   String response = client.send(request, BodyHandlers.ofString()).body();
- *   System.out.println(response.body());
+ *   String response = client.send(request, BodyHandlers.ofString())
+ *                           .bodyWhen(r -> r.statusCode() == 200)
+ *                           .orElse("ERROR");
+ *   System.out.println(response);
  * }
  *
  * @since 11
@@ -341,7 +343,7 @@ public abstract class HttpRequest {
      * @param uristring the URI string to get
      * @return a HttpRequest
      * @throws IllegalArgumentException if the URI scheme is not supported
-     *         or is otherwise invalid.
+     *         or if the uristring is invalid.
      */
     public static HttpRequest GET(String uristring) {
         URI uri = URI.create(uristring);

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -145,8 +145,8 @@ public interface HttpResponse<T> {
     public T body();
 
     /**
-     * Returns the body if the given predicate is satisfied. 
-     * 
+     * Returns the body if the given predicate is satisfied.
+     *
      * @param predicate the Predicate to test
      * @return an Optional containing the response body if the predicate returns true
      */

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -47,6 +47,7 @@ import java.util.concurrent.Flow.Publisher;
 import java.util.concurrent.Flow.Subscription;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLSession;
@@ -142,6 +143,14 @@ public interface HttpResponse<T> {
      * @return the body
      */
     public T body();
+
+    /**
+     * Returns the body if the given predicate is satisfied. 
+     * 
+     * @param predicate the Predicate to test
+     * @return an Optional containing the response body if the predicate returns true
+     */
+    public Optional<T> bodyWhen(Predicate<ResponseInfo> predicate) throws IOException;
 
     /**
      * Returns an {@link Optional} containing the {@link SSLSession} in effect

--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpResponseImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpResponseImpl.java
@@ -30,6 +30,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLSession;
 import java.net.http.HttpClient;
@@ -52,6 +53,7 @@ class HttpResponseImpl<T> implements HttpResponse<T>, RawChannel.Provider {
     final HttpClient.Version version;
     final RawChannelProvider rawChannelProvider;
     final T body;
+    final ResponseInfo rinfo;
 
     public HttpResponseImpl(HttpRequest initialRequest,
                             Response response,
@@ -68,6 +70,7 @@ class HttpResponseImpl<T> implements HttpResponse<T>, RawChannel.Provider {
         this.version = response.version();
         this.rawChannelProvider = RawChannelProvider.create(response, exch);
         this.body = body;
+        this.rinfo = new ResponseInfoImpl(response);
     }
 
     @Override
@@ -93,6 +96,15 @@ class HttpResponseImpl<T> implements HttpResponse<T>, RawChannel.Provider {
     @Override
     public T body() {
         return body;
+    }
+
+    @Override
+    public Optional<T> bodyWhen(Predicate<ResponseInfo> predicate) {
+        if (predicate.test(rinfo)) {
+            return Optional.of(body());
+        } else {
+            return Optional.empty();
+        }
     }
 
     @Override

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8087112
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
+ * @run main/othervm GETTest
+ * @summary GET Test
+ */
+
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.test.lib.net.SimpleSSLContext;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpClient.Version;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import javax.net.ssl.SSLContext;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
+public class GETTest implements HttpServerAdapters {
+
+    static volatile boolean ok;
+    static final String RESPONSE = "Hello world";
+
+    public static void main(String[] args) throws Exception {
+        test(Version.HTTP_1_1, false);
+        test(Version.HTTP_2, false);
+        test(Version.HTTP_1_1, true);
+        test(Version.HTTP_2, true);
+    }
+
+    public static void test(Version version, boolean secure) throws Exception {
+
+        ExecutorService e = Executors.newCachedThreadPool();
+        Handler h = new Handler();
+        SSLContext sslContext = secure ? new SimpleSSLContext().get() : null;
+        HttpTestServer server = HttpTestServer.create(version, sslContext, e);
+        HttpTestContext serverContext = server.addHandler(h,"/test/");
+        server.start();
+
+        var clientBuilder = HttpClient.newBuilder();
+        if (sslContext != null) clientBuilder.sslContext(sslContext);
+        HttpClient client = clientBuilder.build();
+
+        try {
+            String scheme = sslContext == null ? "http" : "https";
+            String uri = scheme + "://" + server.serverAuthority() + "/test/foo/"+version;
+            HttpRequest req = HttpRequest.GET(uri);
+
+            System.out.println("\n\nSending request: " + req);
+            HttpResponse resp = client.send(req, BodyHandlers.ofString());
+            ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
+
+            if (!ok)
+                throw new RuntimeException("Test failed:");
+
+        } finally {
+            server.stop();
+            e.shutdownNow();
+        }
+        System.out.println("OK");
+    }
+
+   static class Handler implements HttpTestHandler {
+        static volatile boolean ok;
+
+        @Override
+        public void handle(HttpTestExchange he) throws IOException {
+            String method = he.getRequestMethod();
+            InputStream is = he.getRequestBody();
+            if (!method.equalsIgnoreCase("GET")) {
+	        he.sendResponseHeaders(500, 0);
+	        ok = false;
+            } else { // GET
+                he.sendResponseHeaders(200, RESPONSE.length());
+                OutputStream os = he.getResponseBody();
+                os.write(RESPONSE.getBytes(US_ASCII));
+                os.close();
+                ok = true;
+            }
+        }
+   }
+}

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -113,8 +113,8 @@ public class GETTest implements HttpServerAdapters {
             String method = he.getRequestMethod();
             InputStream is = he.getRequestBody();
             if (!method.equalsIgnoreCase("GET")) {
-	        he.sendResponseHeaders(500, 0);
-	        ok = false;
+                he.sendResponseHeaders(500, 0);
+                ok = false;
             } else { // GET
                 he.sendResponseHeaders(200, RESPONSE.length());
                 OutputStream os = he.getResponseBody();

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8087112
+ * @bug 8327796
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  * @run main/othervm GETTest

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -67,7 +67,7 @@ public class GETTest implements HttpServerAdapters {
         Handler h = new Handler();
         SSLContext sslContext = secure ? new SimpleSSLContext().get() : null;
         HttpTestServer server = HttpTestServer.create(version, sslContext, e);
-        HttpTestContext serverContext = server.addHandler(h,"/test/");
+        HttpTestContext serverContext = server.addHandler(h, "/test/");
         server.start();
 
         var clientBuilder = HttpClient.newBuilder();

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -80,12 +80,9 @@ public class GETTest implements HttpServerAdapters {
             HttpRequest req = HttpRequest.GET(uri);
 
             System.out.println("\n\nSending request: " + req);
-            HttpResponse resp = client.send(req, BodyHandlers.ofString());
-            ok = resp.statusCode() == 200 && resp.body().equals(RESPONSE);
-
-            if (!ok)
-                throw new RuntimeException("Test failed:");
-
+            String resp = client.send(req, BodyHandlers.ofString())
+                                      .bodyWhen(r -> r.statusCode() == 200)
+                                      .orElseThrow(() -> new RuntimeException("Failed"));
             // try some invalid URIs
             uri = "http!@://foo";
             try {

--- a/test/jdk/java/net/httpclient/GETTest.java
+++ b/test/jdk/java/net/httpclient/GETTest.java
@@ -86,6 +86,18 @@ public class GETTest implements HttpServerAdapters {
             if (!ok)
                 throw new RuntimeException("Test failed:");
 
+            // try some invalid URIs
+            uri = "http!@://foo";
+            try {
+                req = HttpRequest.GET(uri);
+                throw new RuntimeException("Invalid URI accepted");
+            } catch (IllegalArgumentException ex1) {}
+
+            uri = "ftp://foo.com/";
+            try {
+                req = HttpRequest.GET(uri);
+                throw new RuntimeException("Invalid URI accepted");
+            } catch (IllegalArgumentException ex2) {}
         } finally {
             server.stop();
             e.shutdownNow();


### PR DESCRIPTION
Hi,

This PR proposes to add simple utility method which returns a simple GET HttpRequest in one call. The current builder pattern requires 4 (or 3 since GET is the default method) method calls to achieve the same effect.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8328600](https://bugs.openjdk.org/browse/JDK-8328600) to be approved

### Issues
 * [JDK-8327796](https://bugs.openjdk.org/browse/JDK-8327796): Add method to java.net.http.HttpRequest to return a GET request in one call (**Bug** - P4)
 * [JDK-8328600](https://bugs.openjdk.org/browse/JDK-8328600): Add method to java.net.http.HttpRequest to return a GET request in one call (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18227/head:pull/18227` \
`$ git checkout pull/18227`

Update a local copy of the PR: \
`$ git checkout pull/18227` \
`$ git pull https://git.openjdk.org/jdk.git pull/18227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18227`

View PR using the GUI difftool: \
`$ git pr show -t 18227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18227.diff">https://git.openjdk.org/jdk/pull/18227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18227#issuecomment-1991503007)