### PR TITLE
JDK-8327986: ASAN reports use-after-free in DirectivesParserTest.empty_object_vm

### DIFF
--- a/test/hotspot/gtest/compiler/test_directivesParser.cpp
+++ b/test/hotspot/gtest/compiler/test_directivesParser.cpp
@@ -31,15 +31,16 @@
 
 class DirectivesParserTest : public ::testing::Test{
  protected:
-  const char* const _locale;
+  char* const _locale;
   ResourceMark rm;
   stringStream stream;
   // These tests require the "C" locale to correctly parse decimal values
-  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, nullptr)) {
+  DirectivesParserTest() : _locale(os::strdup(setlocale(LC_NUMERIC, nullptr), mtTest)) {
     setlocale(LC_NUMERIC, "C");
   }
   ~DirectivesParserTest() {
     setlocale(LC_NUMERIC, _locale);
+    os::free(_locale);
   }
 
   void test_negative(const char* text) {


### PR DESCRIPTION
ASAN reports a use-after-free, because we feed the string we got from `setlocale` back to `setlocale`, but the libc owns this string, and the libc decided to free it in the meantime.

According to POSIX, it should be valid to pass into setlocale output from setlocale.

However, glibc seems to delete the old string when calling setlocale again:

https://codebrowser.dev/glibc/glibc/locale/setlocale.c.html#198

Best to make a copy, and pass in the copy to setlocale.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327986](https://bugs.openjdk.org/browse/JDK-8327986): ASAN reports use-after-free in DirectivesParserTest.empty_object_vm (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18235/head:pull/18235` \
`$ git checkout pull/18235`

Update a local copy of the PR: \
`$ git checkout pull/18235` \
`$ git pull https://git.openjdk.org/jdk.git pull/18235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18235`

View PR using the GUI difftool: \
`$ git pr show -t 18235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18235.diff">https://git.openjdk.org/jdk/pull/18235.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18235#issuecomment-1993719634)