### PR TITLE
8327839: Crash with unboxing and widening primitive conversion in switch

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -468,22 +468,23 @@ public class SwitchBootstraps {
                             Label notNumber = cb.newLabel();
                             cb.aload(SELECTOR_OBJ);
                             cb.instanceof_(ConstantDescs.CD_Number);
-                            if (selectorType == long.class || selectorType == float.class || selectorType == double.class) {
+                            if (selectorType == long.class || selectorType == float.class || selectorType == double.class ||
+                                selectorType == Long.class || selectorType == Float.class || selectorType == Double.class) {
                                 cb.ifeq(next);
                             } else {
                                 cb.ifeq(notNumber);
                             }
                             cb.aload(SELECTOR_OBJ);
                             cb.checkcast(ConstantDescs.CD_Number);
-                            if (selectorType == long.class) {
+                            if (selectorType == long.class || selectorType == Long.class) {
                                 cb.invokevirtual(ConstantDescs.CD_Number,
                                         "longValue",
                                         MethodTypeDesc.of(ConstantDescs.CD_long));
-                            } else if (selectorType == float.class) {
+                            } else if (selectorType == float.class || selectorType == Float.class) {
                                 cb.invokevirtual(ConstantDescs.CD_Number,
                                         "floatValue",
                                         MethodTypeDesc.of(ConstantDescs.CD_float));
-                            } else if (selectorType == double.class) {
+                            } else if (selectorType == double.class || selectorType == Double.class) {
                                 cb.invokevirtual(ConstantDescs.CD_Number,
                                         "doubleValue",
                                         MethodTypeDesc.of(ConstantDescs.CD_double));

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitch.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitch.java
@@ -113,6 +113,13 @@ public class PrimitivePatternsSwitch {
         assertEquals(1, testByteWrapperToIntUnconditionallyExact());
         assertEquals(1, testIntegerWrapperToFloat());
         assertEquals(-1, testIntegerWrapperToFloatInexact());
+        assertEquals(Character.MAX_VALUE, testUnboxingAndWideningCharacter1(Character.MAX_VALUE));
+        assertEquals(Character.MAX_VALUE, testUnboxingAndWideningCharacter2(Character.MAX_VALUE));
+        assertEquals(Character.MAX_VALUE, testUnboxingAndWideningCharacter3(Character.MAX_VALUE));
+        assertEquals(Float.MAX_VALUE, testUnboxingAndWideningFloat(Float.MAX_VALUE));
+        assertEquals(Float.MAX_VALUE, testUnboxingAndWideningFloatExplicitCast(Float.MAX_VALUE));
+        assertEquals(42f, testUnboxingAndWideningLong(42l));
+        assertEquals(2, testUnboxingAndWideningLong(Long.MAX_VALUE));
     }
 
     public static int primitiveSwitch(int i) {
@@ -565,6 +572,43 @@ public class PrimitivePatternsSwitch {
         };
     }
 
+    public static char testUnboxingAndWideningCharacter1(Character test) {
+        return switch (test) {
+            case char c -> c;
+        };
+    }
+
+    public static int testUnboxingAndWideningCharacter2(Character test) {
+        return switch (test) {
+            case int c -> c;
+        };
+    }
+
+    public static float testUnboxingAndWideningCharacter3(Character test) {
+        return switch (test) {
+            case float f -> f;
+        };
+    }
+    public static float testUnboxingAndWideningLong(Long test) {
+        return switch (test) {
+            case float y -> y;
+            default -> 2;
+        };
+    }
+
+    public static double testUnboxingAndWideningFloat(Float test) {
+        return switch (test) {
+            case double y -> y;
+            default -> 2;
+        };
+    }
+
+    public static double testUnboxingAndWideningFloatExplicitCast(Object test) {
+        return switch ((Float) test) {
+            case double y -> y;
+            default -> 2;
+        };
+    }
 
     record R_Integer(Integer x) {}
     record R_int(int x) {}

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitch.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitch.java
@@ -118,7 +118,7 @@ public class PrimitivePatternsSwitch {
         assertEquals(Character.MAX_VALUE, testUnboxingAndWideningCharacter3(Character.MAX_VALUE));
         assertEquals(Float.MAX_VALUE, testUnboxingAndWideningFloat(Float.MAX_VALUE));
         assertEquals(Float.MAX_VALUE, testUnboxingAndWideningFloatExplicitCast(Float.MAX_VALUE));
-        assertEquals(42f, testUnboxingAndWideningLong(42l));
+        assertEquals(42f, testUnboxingAndWideningLong(42L));
         assertEquals(2, testUnboxingAndWideningLong(Long.MAX_VALUE));
     }
 

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
@@ -241,4 +241,24 @@ public class PrimitivePatternsSwitchErrors {
             case int b -> -2 ;
         };
     }
+
+    public static int disallowedUnboxingAndNarrowing1() {
+        Long n = 42l;
+        return switch (n) { // Error - not exhaustive and not allowed
+            case char c -> -1 ;
+        };
+    }
+
+    public static int disallowedUnboxingAndNarrowing2() {
+        Long n = 42l;
+        return switch (n) { // Error - not exhaustive and not allowed
+            case int c -> -1 ;
+        };
+    }
+
+    public static char disallowedUnboxingAndWidening(Short test) {
+        return switch (test) {
+            case char c -> c; // Error - not exhaustive and not allowed
+        };
+    }
 }

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
@@ -26,6 +26,9 @@ PrimitivePatternsSwitchErrors.java:179:18: compiler.err.prob.found.req: (compile
 PrimitivePatternsSwitchErrors.java:189:18: compiler.err.unconditional.pattern.and.both.boolean.values
 PrimitivePatternsSwitchErrors.java:196:18: compiler.err.duplicate.unconditional.pattern
 PrimitivePatternsSwitchErrors.java:216:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: compiler.misc.type.null, int)
+PrimitivePatternsSwitchErrors.java:248:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Long, char)
+PrimitivePatternsSwitchErrors.java:255:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Long, int)
+PrimitivePatternsSwitchErrors.java:261:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Short, char)
 PrimitivePatternsSwitchErrors.java:30:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:37:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:44:16: compiler.err.not.exhaustive
@@ -35,6 +38,9 @@ PrimitivePatternsSwitchErrors.java:207:9: compiler.err.not.exhaustive.statement
 PrimitivePatternsSwitchErrors.java:223:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:231:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:239:16: compiler.err.not.exhaustive
+PrimitivePatternsSwitchErrors.java:247:16: compiler.err.not.exhaustive
+PrimitivePatternsSwitchErrors.java:254:16: compiler.err.not.exhaustive
+PrimitivePatternsSwitchErrors.java:260:16: compiler.err.not.exhaustive
 - compiler.note.preview.filename: PrimitivePatternsSwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-37 errors
+43 errors


### PR DESCRIPTION
In cases where the compiler needs to unbox a `long`, `float`, `double` and then run the exactness check, we were getting a crash. While the selector value is always boxed, the type (which controls the execution flow) was not, because the `selectorType` was wrong. This PR addresses this bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327839](https://bugs.openjdk.org/browse/JDK-8327839): Crash with unboxing and widening primitive conversion in switch (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [ecf909d0](https://git.openjdk.org/jdk/pull/18236/files/ecf909d02ee46c733b76297704bf12e0685fa4eb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18236/head:pull/18236` \
`$ git checkout pull/18236`

Update a local copy of the PR: \
`$ git checkout pull/18236` \
`$ git pull https://git.openjdk.org/jdk.git pull/18236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18236`

View PR using the GUI difftool: \
`$ git pr show -t 18236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18236.diff">https://git.openjdk.org/jdk/pull/18236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18236#issuecomment-1991745497)