### PR TITLE
JDK-8327988: When running ASAN, disable dangerous NMT test

### DIFF
--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2017, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -288,15 +288,16 @@ void Metachunk::verify() const {
 
   // Test accessing the committed area. But not for ASAN. We don't know which portions
   // of the chunk are still poisoned.
-  const bool check_committed = NOT_ASAN(true) ASAN_ONLY(false);
+#if !INCLUDE_ASAN
   SOMETIMES(
-    if (check_committed && _committed_words > 0) {
+    if (_committed_words > 0) {
       for (const MetaWord* p = _base; p < _base + _committed_words; p += os::vm_page_size()) {
         dummy = *p;
       }
       dummy = *(_base + _committed_words - 1);
     }
   )
+#endif // !INCLUDE_ASAN
 }
 #endif // ASSERT
 

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -435,16 +435,15 @@ void VirtualSpaceNode::verify_locked() const {
   // Verify memory against commit mask.
   // Down here, from ASAN's view, this memory may be poisoned, since we only unpoison
   // way up at the ChunkManager level.
-  const bool check_committed = NOT_ASAN(true) ASAN_ONLY(false);
+#if !INCLUDE_ASAN
   SOMETIMES(
-    if (check_committed) {
-      for (MetaWord* p = base(); p < base() + used_words(); p += os::vm_page_size()) {
-        if (_commit_mask.is_committed_address(p)) {
-          test_access += *(uint*)p;
-        }
+    for (MetaWord* p = base(); p < base() + used_words(); p += os::vm_page_size()) {
+      if (_commit_mask.is_committed_address(p)) {
+        test_access += *(uint*)p;
       }
     }
   )
+#endif // !INCLUDE_ASAN
 
   assert(committed_words() <= word_size(), "Sanity");
   assert_is_aligned(committed_words(), Settings::commit_granule_words());

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -55,13 +55,15 @@
 // which preserves the arguments, ensuring they still compile, but ensures they are stripped due to
 // being unreachable. This helps ensure developers do not accidently break ASan builds.
 #ifdef ADDRESS_SANITIZER
-// ASAN_POISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
-// ASAN_UNPOISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
+#define INCLUDE_ASAN 1
 #define ASAN_ONLY(code) code
 #define NOT_ASAN(code)
 #else
+#define INCLUDE_ASAN 0
 #define ASAN_ONLY(code)
 #define NOT_ASAN(code)  code
+// ASAN_POISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
+// ASAN_UNPOISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
 #define ASAN_POISON_MEMORY_REGION(addr, size) \
   do {                                        \
     if (false) {                              \

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2023, Google and/or its affiliates. All rights reserved.
- *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -57,7 +57,11 @@
 #ifdef ADDRESS_SANITIZER
 // ASAN_POISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
 // ASAN_UNPOISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
+#define ASAN_ONLY(code) code
+#define NOT_ASAN(code)
 #else
+#define ASAN_ONLY(code)
+#define NOT_ASAN(code)  code
 #define ASAN_POISON_MEMORY_REGION(addr, size) \
   do {                                        \
     if (false) {                              \

--- a/src/hotspot/share/sanitizers/address.hpp
+++ b/src/hotspot/share/sanitizers/address.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Google and/or its affiliates. All rights reserved.
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,12 +57,8 @@
 // being unreachable. This helps ensure developers do not accidently break ASan builds.
 #ifdef ADDRESS_SANITIZER
 #define INCLUDE_ASAN 1
-#define ASAN_ONLY(code) code
-#define NOT_ASAN(code)
 #else
 #define INCLUDE_ASAN 0
-#define ASAN_ONLY(code)
-#define NOT_ASAN(code)  code
 // ASAN_POISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
 // ASAN_UNPOISON_MEMORY_REGION is defined in <sanitizer/asan_interface.h>
 #define ASAN_POISON_MEMORY_REGION(addr, size) \

--- a/test/hotspot/gtest/compiler/test_directivesParser.cpp
+++ b/test/hotspot/gtest/compiler/test_directivesParser.cpp
@@ -31,15 +31,16 @@
 
 class DirectivesParserTest : public ::testing::Test{
  protected:
-  const char* const _locale;
+  char* const _locale;
   ResourceMark rm;
   stringStream stream;
   // These tests require the "C" locale to correctly parse decimal values
-  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, nullptr)) {
+  DirectivesParserTest() : _locale(os::strdup(setlocale(LC_NUMERIC, nullptr), mtTest)) {
     setlocale(LC_NUMERIC, "C");
   }
   ~DirectivesParserTest() {
     setlocale(LC_NUMERIC, _locale);
+    os::free(_locale);
   }
 
   void test_negative(const char* text) {

--- a/test/hotspot/gtest/compiler/test_directivesParser.cpp
+++ b/test/hotspot/gtest/compiler/test_directivesParser.cpp
@@ -31,16 +31,15 @@
 
 class DirectivesParserTest : public ::testing::Test{
  protected:
-  char* const _locale;
+  const char* const _locale;
   ResourceMark rm;
   stringStream stream;
   // These tests require the "C" locale to correctly parse decimal values
-  DirectivesParserTest() : _locale(os::strdup(setlocale(LC_NUMERIC, nullptr), mtTest)) {
+  DirectivesParserTest() : _locale(setlocale(LC_NUMERIC, nullptr)) {
     setlocale(LC_NUMERIC, "C");
   }
   ~DirectivesParserTest() {
     setlocale(LC_NUMERIC, _locale);
-    os::free(_locale);
   }
 
   void test_negative(const char* text) {

--- a/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
+++ b/test/hotspot/gtest/metaspace/test_virtualspacenode.cpp
@@ -156,6 +156,11 @@ class VirtualSpaceNodeTest {
       // The chunk should be as far committed as was requested
       EXPECT_GE(c->committed_words(), request_commit_words);
 
+      // At the VirtualSpaceNode level, all memory is still poisoned.
+      // Since we bypass the normal way of allocating chunks (ChunkManager::get_chunk), we
+      // need to unpoison this chunk.
+      ASAN_UNPOISON_MEMORY_REGION(c->base(), c->committed_words() * BytesPerWord);
+
       // Zap committed portion.
       DEBUG_ONLY(zap_range(c->base(), c->committed_words());)
 

--- a/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_buffer_overflow_detection.cpp
@@ -26,10 +26,13 @@
 #include "memory/allocation.hpp"
 #include "nmt/memTracker.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/address.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
 #include "unittest.hpp"
 #include "testutils.hpp"
+
+#if !INCLUDE_ASAN
 
 // This prefix shows up on any c heap corruption NMT detects. If unsure which assert will
 // come, just use this one.
@@ -161,3 +164,5 @@ TEST_VM(NMT, test_realloc) {
     }
   }
 }
+
+#endif // !INCLUDE_ASAN

--- a/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_cornercases.cpp
@@ -28,6 +28,7 @@
 #include "nmt/mallocTracker.hpp"
 #include "nmt/memTracker.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/address.hpp"
 #include "testutils.hpp"
 #include "unittest.hpp"
 
@@ -37,6 +38,9 @@ static void check_expected_malloc_header(const void* payload, MEMFLAGS type, siz
   EXPECT_EQ(hdr->size(), size);
   EXPECT_EQ(hdr->flags(), type);
 }
+
+// ASAN complains about allocating very large sizes
+#if !INCLUDE_ASAN
 
 // Check that a malloc with an overflowing size is rejected.
 TEST_VM(NMT, malloc_failure1) {
@@ -85,6 +89,7 @@ TEST_VM(NMT, realloc_failure_overflowing_size) {
 TEST_VM(NMT, realloc_failure_gigantic_size) {
   check_failing_realloc(SIZE_MAX - M);
 }
+#endif // !INCLUDE_ASAN
 
 static void* do_realloc(void* p, size_t old_size, size_t new_size, uint8_t old_content, bool check_nmt_header) {
 

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -27,11 +27,14 @@
 #include "nmt/mallocHeader.inline.hpp"
 #include "nmt/memTracker.hpp"
 #include "runtime/os.hpp"
+#include "sanitizers/address.hpp"
 #include "unittest.hpp"
 
 // Uncomment to get test output
 //#define LOG_PLEASE
 #include "testutils.hpp"
+
+#if !INCLUDE_ASAN
 
 using ::testing::HasSubstr;
 
@@ -123,3 +126,5 @@ static void test_for_mmap(size_t sz, ssize_t offset) {
 
 TEST_VM(NMT, location_printing_mmap_1) { test_for_mmap(os::vm_page_size(), 0);  }
 TEST_VM(NMT, location_printing_mmap_2) { test_for_mmap(os::vm_page_size(), os::vm_page_size() - 1);  }
+
+#endif // !INCLUDE_ASAN


### PR DESCRIPTION
NMT gtests trigger ASAN for several reasons. Issues like printing malloc blocks (which we do, carefully, with SafeFetch), or corner case tests for malloc with sizes ASAN thinks are invalid.

All these tests should just be disabled when building with ASAN support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327988](https://bugs.openjdk.org/browse/JDK-8327988): When running ASAN, disable dangerous NMT test (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18237/head:pull/18237` \
`$ git checkout pull/18237`

Update a local copy of the PR: \
`$ git checkout pull/18237` \
`$ git pull https://git.openjdk.org/jdk.git pull/18237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18237`

View PR using the GUI difftool: \
`$ git pr show -t 18237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18237.diff">https://git.openjdk.org/jdk/pull/18237.diff</a>

</details>
