### PR TITLE
8325871: Move StringTable and SymbolTable rehashing calls

### DIFF
--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -582,12 +582,10 @@ void StringTable::rehash_table() {
   assert(SafepointSynchronize::is_at_safepoint(), "must be called at safepoint");
 
   _alt_hash_seed = AltHashing::compute_seed();
-  {
-    if (do_rehash()) {
-      _rehashed = true;
-    } else {
-      log_info(stringtable)("Resizes in progress rehashing skipped.");
-    }
+  if (do_rehash()) {
+    _rehashed = true;
+  } else {
+    log_info(stringtable)("Resizes in progress rehashing skipped.");
   }
 }
 

--- a/src/hotspot/share/classfile/stringTable.hpp
+++ b/src/hotspot/share/classfile/stringTable.hpp
@@ -71,8 +71,6 @@ class StringTable : AllStatic {
 
   static void print_table_statistics(outputStream* st);
 
-  static bool do_rehash();
-
  public:
   static size_t table_size();
   static TableStatistics get_table_statistics();

--- a/src/hotspot/share/classfile/stringTable.hpp
+++ b/src/hotspot/share/classfile/stringTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,16 +94,11 @@ class StringTable : AllStatic {
   // Rehash the string table if it gets out of balance
 private:
   static bool should_grow();
-
+  static bool maybe_rehash_table();
 public:
-  static bool rehash_table_expects_safepoint_rehashing();
   static void rehash_table();
   static bool needs_rehashing() { return _needs_rehashing; }
-  static inline void update_needs_rehash(bool rehash) {
-    if (rehash) {
-      _needs_rehashing = true;
-    }
-  }
+  static inline void update_needs_rehash(bool rehash);
 
   // Sharing
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,16 +146,12 @@ public:
   // Rehash the string table if it gets out of balance
 private:
   static bool should_grow();
+  static bool maybe_rehash_table();
 
 public:
-  static bool rehash_table_expects_safepoint_rehashing();
   static void rehash_table();
   static bool needs_rehashing() { return _needs_rehashing; }
-  static inline void update_needs_rehash(bool rehash) {
-    if (rehash) {
-      _needs_rehashing = true;
-    }
-  }
+  static inline void update_needs_rehash(bool rehash);
 
   // Heap dumper and CDS
   static void symbols_do(SymbolClosure *cl);

--- a/src/hotspot/share/classfile/symbolTable.hpp
+++ b/src/hotspot/share/classfile/symbolTable.hpp
@@ -98,7 +98,6 @@ class SymbolTable : public AllStatic {
   static void print_table_statistics(outputStream* st);
 
   static void try_rehash_table();
-  static bool do_rehash();
 
 public:
   // The symbol table
@@ -114,7 +113,7 @@ public:
   static void create_table();
 
   static void do_concurrent_work(JavaThread* jt);
-  static bool has_work() { return _has_work; }
+  static bool has_work();
   static void trigger_cleanup();
 
   // Probing

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,6 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/classLoaderDataGraph.hpp"
-#include "classfile/stringTable.hpp"
 #include "classfile/symbolTable.hpp"
 #include "code/codeCache.hpp"
 #include "code/nmethod.hpp"
@@ -512,7 +510,6 @@ void SafepointSynchronize::end() {
 
 bool SafepointSynchronize::is_cleanup_needed() {
   // Need a safepoint if some inline cache buffers is non-empty
-  if (StringTable::needs_rehashing()) return true;
   if (SymbolTable::needs_rehashing()) return true;
   return false;
 }
@@ -552,10 +549,6 @@ public:
       workers++;
     }
 
-    if (StringTable::rehash_table_expects_safepoint_rehashing()) {
-      workers++;
-    }
-
     if (_do_lazy_roots) {
       workers++;
     }
@@ -569,13 +562,6 @@ public:
       if (SymbolTable::needs_rehashing()) {
         Tracer t("rehashing symbol table");
         SymbolTable::rehash_table();
-      }
-    }
-
-    if (_subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_STRING_TABLE_REHASH)) {
-      if (StringTable::needs_rehashing()) {
-        Tracer t("rehashing string table");
-        StringTable::rehash_table();
       }
     }
 

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -71,7 +71,6 @@ class SafepointSynchronize : AllStatic {
   // The enums are listed in the order of the tasks when done serially.
   enum SafepointCleanupTasks {
     SAFEPOINT_CLEANUP_LAZY_ROOT_PROCESSING,
-    SAFEPOINT_CLEANUP_SYMBOL_TABLE_REHASH,
     SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP,
     // Leave this one last.
     SAFEPOINT_CLEANUP_NUM_TASKS
@@ -157,7 +156,6 @@ public:
   // Exception handling for page polling
   static void handle_polling_page_exception(JavaThread *thread);
 
-  static bool is_cleanup_needed();
   static void do_cleanup_tasks();
 
   static void set_is_at_safepoint()             { _state = _synchronized; }

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,6 @@ class SafepointSynchronize : AllStatic {
   enum SafepointCleanupTasks {
     SAFEPOINT_CLEANUP_LAZY_ROOT_PROCESSING,
     SAFEPOINT_CLEANUP_SYMBOL_TABLE_REHASH,
-    SAFEPOINT_CLEANUP_STRING_TABLE_REHASH,
     SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP,
     // Leave this one last.
     SAFEPOINT_CLEANUP_NUM_TASKS

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,6 +106,7 @@
   template(ClassLoaderHierarchyOperation)         \
   template(DumpHashtable)                         \
   template(CleanClassLoaderDataMetaspaces)        \
+  template(RehashStringTable)                     \
   template(PrintCompileQueue)                     \
   template(PrintClassHierarchy)                   \
   template(PrintClasses)                          \

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -37,7 +37,6 @@
 #define VM_OPS_DO(template)                       \
   template(Halt)                                  \
   template(SafepointALot)                         \
-  template(Cleanup)                               \
   template(ThreadDump)                            \
   template(PrintThreads)                          \
   template(FindDeadlocks)                         \

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -107,6 +107,7 @@
   template(DumpHashtable)                         \
   template(CleanClassLoaderDataMetaspaces)        \
   template(RehashStringTable)                     \
+  template(RehashSymbolTable)                     \
   template(PrintCompileQueue)                     \
   template(PrintClassHierarchy)                   \
   template(PrintClasses)                          \

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/stringTable.hpp"
+#include "classfile/symbolTable.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compileBroker.hpp"
@@ -106,6 +107,10 @@ void VM_CleanClassLoaderDataMetaspaces::doit() {
 
 void VM_RehashStringTable::doit() {
   StringTable::rehash_table();
+}
+
+void VM_RehashSymbolTable::doit() {
+  SymbolTable::rehash_table();
 }
 
 VM_DeoptimizeFrame::VM_DeoptimizeFrame(JavaThread* thread, intptr_t* id, int reason) {

--- a/src/hotspot/share/runtime/vmOperations.cpp
+++ b/src/hotspot/share/runtime/vmOperations.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
+#include "classfile/stringTable.hpp"
 #include "classfile/vmSymbols.hpp"
 #include "code/codeCache.hpp"
 #include "compiler/compileBroker.hpp"
@@ -101,6 +102,10 @@ void VM_ClearICs::doit() {
 
 void VM_CleanClassLoaderDataMetaspaces::doit() {
   ClassLoaderDataGraph::walk_metadata_and_clean_metaspaces();
+}
+
+void VM_RehashStringTable::doit() {
+  StringTable::rehash_table();
 }
 
 VM_DeoptimizeFrame::VM_DeoptimizeFrame(JavaThread* thread, intptr_t* id, int reason) {

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -105,6 +105,13 @@ class VM_RehashStringTable : public VM_Operation {
   void doit();
 };
 
+class VM_RehashSymbolTable : public VM_Operation {
+ public:
+  VM_RehashSymbolTable() {}
+  VMOp_Type type() const                         { return VMOp_RehashSymbolTable; }
+  void doit();
+};
+
 // Deopt helper that can deoptimize frames in threads other than the
 // current thread.  Only used through Deoptimization::deoptimize_frame.
 class VM_DeoptimizeFrame: public VM_Operation {

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,13 @@ class VM_CleanClassLoaderDataMetaspaces : public VM_Operation {
  public:
   VM_CleanClassLoaderDataMetaspaces() {}
   VMOp_Type type() const                         { return VMOp_CleanClassLoaderDataMetaspaces; }
+  void doit();
+};
+
+class VM_RehashStringTable : public VM_Operation {
+ public:
+  VM_RehashStringTable() {}
+  VMOp_Type type() const                         { return VMOp_RehashStringTable; }
   void doit();
 };
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -54,11 +54,6 @@ class VM_SafepointALot: public VM_EmptyOperation {
   VMOp_Type type() const { return VMOp_SafepointALot; }
 };
 
-class VM_Cleanup: public VM_EmptyOperation {
- public:
-  VMOp_Type type() const { return VMOp_Cleanup; }
-};
-
 // empty vm op, evaluated just to force a safepoint
 class VM_ForceSafepoint: public VM_EmptyOperation {
  public:

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -337,9 +337,7 @@ void VMThread::setup_periodic_safepoint_if_needed() {
   if (!max_time_exceeded) {
     return;
   }
-  if (SafepointSynchronize::is_cleanup_needed()) {
-    _next_vm_operation = &cleanup_op;
-  } else if (SafepointALot) {
+  if (SafepointALot) {
     _next_vm_operation = &safepointALot_op;
   }
 }

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -98,14 +98,14 @@ void VMOperationTimeoutTask::disarm() {
 // Implementation of VMThread stuff
 
 static VM_SafepointALot safepointALot_op;
-static VM_Cleanup       cleanup_op;
+static VM_ForceSafepoint no_op;
 
 bool              VMThread::_should_terminate   = false;
 bool              VMThread::_terminated         = false;
 Monitor*          VMThread::_terminate_lock     = nullptr;
 VMThread*         VMThread::_vm_thread          = nullptr;
 VM_Operation*     VMThread::_cur_vm_operation   = nullptr;
-VM_Operation*     VMThread::_next_vm_operation  = &cleanup_op; // Prevent any thread from setting an operation until VM thread is ready.
+VM_Operation*     VMThread::_next_vm_operation  = &no_op; // Prevent any thread from setting an operation until VM thread is ready.
 PerfCounter*      VMThread::_perf_accumulated_vm_operation_time = nullptr;
 VMOperationTimeoutTask* VMThread::_timeout_task = nullptr;
 
@@ -497,7 +497,7 @@ void VMThread::loop() {
 
   // Need to set a calling thread for ops not passed
   // via the normal way.
-  cleanup_op.set_calling_thread(_vm_thread);
+  no_op.set_calling_thread(_vm_thread);
   safepointALot_op.set_calling_thread(_vm_thread);
 
   while (true) {

--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -524,8 +524,9 @@ class ConcurrentHashTable : public CHeapObj<F> {
   void statistics_to(Thread* thread, VALUE_SIZE_FUNC& vs_f, outputStream* st,
                      const char* table_name);
 
-  // Moves all nodes from this table to to_cht
-  bool try_move_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, F>* to_cht);
+  // Moves all nodes from this table to to_cht with new hash code.
+  // Must be done at a safepoint.
+  void rehash_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, F>* to_cht);
 
   // Scoped multi getter.
   class MultiGetHandle : private ScopedCS {

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -1288,12 +1288,10 @@ inline void ConcurrentHashTable<CONFIG, F>::
 }
 
 template <typename CONFIG, MEMFLAGS F>
-inline bool ConcurrentHashTable<CONFIG, F>::
-  try_move_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, F>* to_cht)
+inline void ConcurrentHashTable<CONFIG, F>::
+  rehash_nodes_to(Thread* thread, ConcurrentHashTable<CONFIG, F>* to_cht)
 {
-  if (!try_resize_lock(thread)) {
-    return false;
-  }
+  assert(is_safepoint_safe(), "rehashing is at a safepoint - cannot be resizing");
   assert(_new_table == nullptr || _new_table == POISON_PTR, "Must be null");
   for (size_t bucket_it = 0; bucket_it < _table->_size; bucket_it++) {
     Bucket* bucket = _table->get_bucket(bucket_it);
@@ -1313,8 +1311,6 @@ inline bool ConcurrentHashTable<CONFIG, F>::
       }
     }
   }
-  unlock_resize_lock(thread);
-  return true;
 }
 
 #endif // SHARE_UTILITIES_CONCURRENTHASHTABLE_INLINE_HPP

--- a/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
+++ b/test/hotspot/gtest/utilities/test_concurrentHashtable.cpp
@@ -399,7 +399,8 @@ static void cht_move_to(Thread* thr) {
   EXPECT_TRUE(from_cht->insert(thr, stl3, val3)) << "Insert unique value failed.";
 
   SimpleTestTable* to_cht = new SimpleTestTable();
-  EXPECT_TRUE(from_cht->try_move_nodes_to(thr, to_cht)) << "Moving nodes to new table failed";
+  // This is single threaded and not shared
+  from_cht->rehash_nodes_to(thr, to_cht);
 
   ChtCountScan scan_old;
   EXPECT_TRUE(from_cht->try_scan(thr, scan_old)) << "Scanning table should work.";


### PR DESCRIPTION
Move the rehashing calls as a test in the concurrent work - ie. trigger concurrent work and check for the need to do rehashing. 

Tested with tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325871](https://bugs.openjdk.org/browse/JDK-8325871): Move StringTable and SymbolTable rehashing calls (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18240/head:pull/18240` \
`$ git checkout pull/18240`

Update a local copy of the PR: \
`$ git checkout pull/18240` \
`$ git pull https://git.openjdk.org/jdk.git pull/18240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18240`

View PR using the GUI difftool: \
`$ git pr show -t 18240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18240.diff">https://git.openjdk.org/jdk/pull/18240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18240#issuecomment-1994273796)