### PR TITLE
8327242: Document supported CLDR versions in the javadoc

### DIFF
--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -122,13 +122,13 @@ import java.util.Locale;
  * {@link System#setProperty(String, String)} is discouraged and it may not affect
  * the order.
  * JDK Reference Implementation provides the following three
- * locale providers:
+ * locale data providers:
  * <ul>
- * <li> "CLDR": A provider based on Unicode Consortium's
- * <a href="http://cldr.unicode.org/">CLDR Project</a>.
+ * <li> "CLDR": A locale data provider based on the Unicode Consortium's
+ * <a href="http://cldr.unicode.org/">Common Locale Data Repository (CLDR)</a>.
  * <li> "SPI": represents the locale sensitive services implementing the subclasses of
  * this {@code LocaleServiceProvider} class.
- * <li> "HOST": A provider that reflects the user's custom settings in the
+ * <li> "HOST": A locale data provider that reflects the user's custom settings in the
  * underlying operating system. This provider may not be available, depending
  * on the JDK Reference Implementation.
  * </ul>
@@ -140,18 +140,19 @@ import java.util.Locale;
  * the locale sensitive services in the SPI providers are looked up first. If the
  * desired locale sensitive service is not available, then the runtime looks for CLDR.
  * <p>
- * The default value for looking up the preferred locale providers is "CLDR",
+ * The default value for looking up the preferred locale data providers is "CLDR",
  * so specifying "CLDR" is identical to the default behavior. Applications which
  * require implementations of the locale sensitive services must explicitly specify
  * "SPI" in order for the Java runtime to load them from the classpath.
  *
- * @implNote The JDK uses locale data from the Unicode Common Locale Data Repository
- * (CLDR) to implement locale-sensitive APIs in the {@code java.util} and
+ * @implNote The JDK uses locale data from the Unicode Consortium's
+ * <a href="http://cldr.unicode.org/">Common Locale Data Repository (CLDR)</a>
+ * to implement locale-sensitive APIs in the {@code java.util} and
  * {@code java.text} packages. This locale data makes the set of locales
  * supported by the Java runtime environment. The following table lists the
  * version of CLDR used in each JDK release.
  * <table class="striped">
- * <caption style="display:none">Shows JDK releases and supported CLDR versions</caption>
+ * <caption style="display:none">JDK releases and supported CLDR versions</caption>
  * <thead>
  * <tr><th scope="col">JDK release</th>
  *     <th scope="col">CLDR version</th></tr>

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -141,14 +141,14 @@ import java.util.Locale;
  * desired locale sensitive service is not available, then the runtime looks for CLDR.
  * <p>
  * The default value for looking up the preferred locale data providers is "CLDR",
- * so specifying "CLDR" is identical to the default behavior. Applications which
+ * so specifying only "CLDR" is identical to the default behavior. Applications which
  * require implementations of the locale sensitive services must explicitly specify
  * "SPI" in order for the Java runtime to load them from the classpath.
  *
  * @implNote The JDK uses locale data from the Unicode Consortium's
  * <a href="http://cldr.unicode.org/">Common Locale Data Repository (CLDR)</a>
  * to implement locale-sensitive APIs in the {@code java.util} and
- * {@code java.text} packages. This locale data makes the set of locales
+ * {@code java.text} packages. This locale data derives the set of locales
  * supported by the Java runtime environment. The following table lists the
  * version of CLDR used in each JDK release.
  * <table class="striped">

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -32,9 +32,10 @@ import java.util.Locale;
  * This is the super class of all the locale sensitive service provider
  * interfaces (SPIs).
  * <p>
- * Locale sensitive  service provider interfaces are interfaces that
+ * Locale sensitive service provider interfaces are interfaces that
  * correspond to locale sensitive classes in the {@code java.text}
- * and {@code java.util} packages. The interfaces enable the
+ * and {@code java.util} packages in order to provide the locale
+ * data used for each service. The interfaces enable the
  * construction of locale sensitive objects and the retrieval of
  * localized names for these packages. Locale sensitive factory methods
  * and methods for name retrieval in the {@code java.text} and
@@ -143,6 +144,51 @@ import java.util.Locale;
  * so specifying "CLDR" is identical to the default behavior. Applications which
  * require implementations of the locale sensitive services must explicitly specify
  * "SPI" in order for the Java runtime to load them from the classpath.
+ *
+ * @implNote The JDK uses locale data from the Unicode Common Locale Data Repository
+ * (CLDR) to implement locale-sensitive APIs in the {@code java.util} and
+ * {@code java.text} packages. This locale data makes the set of locales
+ * supported by the Java runtime environment. The following table lists the
+ * version of CLDR used in each JDK release.
+ * <table class="striped">
+ * <caption style="display:none">Shows JDK releases and supported CLDR versions</caption>
+ * <thead>
+ * <tr><th scope="col">JDK release</th>
+ *     <th scope="col">CLDR version</th></tr>
+ * </thead>
+ * <tbody>
+ * <tr><th scope="row" style="text-align:left">JDK 22</th>
+ *     <td>CLDR 44</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 21</th>
+ *     <td>CLDR 43</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 20</th>
+ *     <td>CLDR 42</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 19</th>
+ *     <td>CLDR 41</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 18</th>
+ *     <td>CLDR 39</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 17</th>
+ *     <td>CLDR 39</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 16</th>
+ *     <td>CLDR 38</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 15</th>
+ *     <td>CLDR 37</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 14</th>
+ *     <td>CLDR 36</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 13</th>
+ *     <td>CLDR 35.1</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 12</th>
+ *     <td>CLDR 33</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 11</th>
+ *     <td>CLDR 33</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 10</th>
+ *     <td>CLDR 29</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 9</th>
+ *     <td>CLDR 29</td></tr>
+ * <tr><th scope="row" style="text-align:left">JDK 8</th>
+ *     <td>CLDR 21.0.1</td></tr>
+ * </tbody>
+ * </table>
  *
  * @since        1.6
  */

--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -150,7 +150,8 @@ import java.util.Locale;
  * to implement locale-sensitive APIs in the {@code java.util} and
  * {@code java.text} packages. This locale data derives the set of locales
  * supported by the Java runtime environment. The following table lists the
- * version of CLDR used in each JDK release.
+ * version of CLDR used in each JDK release. Unless otherwise specified, all
+ * update releases in a given JDK release family use the same CLDR version.
  * <table class="striped">
  * <caption style="display:none">JDK releases and supported CLDR versions</caption>
  * <thead>


### PR DESCRIPTION
Adding a table that maps JDK versions and corresponding CLDR releases as an implNote. A draft CSR has also been created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8327259](https://bugs.openjdk.org/browse/JDK-8327259) to be approved

### Issues
 * [JDK-8327242](https://bugs.openjdk.org/browse/JDK-8327242): Document supported CLDR versions in the javadoc (**Bug** - P4)
 * [JDK-8327259](https://bugs.openjdk.org/browse/JDK-8327259): Document supported CLDR versions in the javadoc (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [98b40f95](https://git.openjdk.org/jdk/pull/18243/files/98b40f956fb4f0953b69825a8bdc939bd1843747)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [98b40f95](https://git.openjdk.org/jdk/pull/18243/files/98b40f956fb4f0953b69825a8bdc939bd1843747)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18243/head:pull/18243` \
`$ git checkout pull/18243`

Update a local copy of the PR: \
`$ git checkout pull/18243` \
`$ git pull https://git.openjdk.org/jdk.git pull/18243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18243`

View PR using the GUI difftool: \
`$ git pr show -t 18243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18243.diff">https://git.openjdk.org/jdk/pull/18243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18243#issuecomment-1992078921)