### PR TITLE
8327997: G1: Move G1ScanClosureBase::reference_iteration_mode to subclass

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -54,8 +54,6 @@ protected:
   template <class T>
   inline void handle_non_cset_obj_common(G1HeapRegionAttr const region_attr, T* p, oop const obj);
 public:
-  virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
-
   inline void trim_queue_partially();
 };
 
@@ -67,6 +65,16 @@ public:
                     G1ParScanThreadState* pss,
                     size_t& heap_roots_found) :
     G1ScanClosureBase(g1h, pss), _heap_roots_found(heap_roots_found) { }
+
+  // Because this closure is applied on pointers residing outside the
+  // collection set, we shouldn't do discovery, which is why this closure has
+  // its reference-processor being null.
+  // Strictly speaking, one can use the same iteration mode from the superclass
+  // BasicOopIterateClosure, and the null reference-processor will treat fields
+  // as strong references anyway, equivalent to DO_FIELDS. Here we override the
+  // iteration mode to skip the known null-check in
+  // InstanceRefKlass::try_discover.
+  virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
 
   template <class T> void do_oop_work(T* p);
   virtual void do_oop(narrowOop* p) { do_oop_work(p); }

--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -66,14 +66,6 @@ public:
                     size_t& heap_roots_found) :
     G1ScanClosureBase(g1h, pss), _heap_roots_found(heap_roots_found) { }
 
-  // Because this closure is applied on pointers residing outside the
-  // collection set, we shouldn't do discovery, which is why this closure has
-  // its reference-processor being null.
-  // Strictly speaking, one can use the same iteration mode from the superclass
-  // BasicOopIterateClosure, and the null reference-processor will treat fields
-  // as strong references anyway, equivalent to DO_FIELDS. Here we override the
-  // iteration mode to skip the known null-check in
-  // InstanceRefKlass::try_discover.
   virtual ReferenceIterationMode reference_iteration_mode() { return DO_FIELDS; }
 
   template <class T> void do_oop_work(T* p);


### PR DESCRIPTION
Simple moving a method from super class to sub class and some documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327997](https://bugs.openjdk.org/browse/JDK-8327997): G1: Move G1ScanClosureBase::reference_iteration_mode to subclass (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [5513c4a6](https://git.openjdk.org/jdk/pull/18244/files/5513c4a64f4dcc6fdd21ab0cf5d8b5accf2d23d4)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18244/head:pull/18244` \
`$ git checkout pull/18244`

Update a local copy of the PR: \
`$ git checkout pull/18244` \
`$ git pull https://git.openjdk.org/jdk.git pull/18244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18244`

View PR using the GUI difftool: \
`$ git pr show -t 18244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18244.diff">https://git.openjdk.org/jdk/pull/18244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18244#issuecomment-1992103618)