### PR TITLE
8327999: Remove copy of unused registers for cpu features check in x86_64 AVX2 Poly1305 implementation

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -309,9 +309,6 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ cpuid();
     __ lea(rsi, Address(rbp, in_bytes(VM_Version::sef_cpuid7_ecx1_offset())));
     __ movl(Address(rsi, 0), rax);
-    __ movl(Address(rsi, 4), rbx);
-    __ movl(Address(rsi, 8), rcx);
-    __ movl(Address(rsi, 12), rdx);
 
     //
     // Extended cpuid(0x80000000)


### PR DESCRIPTION
The goal of this PR is to fix the bug reported in #17881 where data from unused registers (rbx, rcx, rdx) is being copied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327999](https://bugs.openjdk.org/browse/JDK-8327999): Remove copy of unused registers for cpu features check in x86_64 AVX2 Poly1305 implementation (**Bug** - P4)


### Reviewers
 * @teshull (no known openjdk.org user name / role)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18248/head:pull/18248` \
`$ git checkout pull/18248`

Update a local copy of the PR: \
`$ git checkout pull/18248` \
`$ git pull https://git.openjdk.org/jdk.git pull/18248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18248`

View PR using the GUI difftool: \
`$ git pr show -t 18248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18248.diff">https://git.openjdk.org/jdk/pull/18248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18248#issuecomment-1992368443)