### PR TITLE
JDK-8328006: refactor large anonymous inner class in HtmlDocletWriter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1292,184 +1292,7 @@ public abstract class HtmlDocletWriter {
                 }
             }
 
-            var docTreeVisitor = new SimpleDocTreeVisitor<Boolean, Content>() {
-
-                private boolean inAnAtag() {
-                    return (tag instanceof StartElementTree st) && equalsIgnoreCase(st.getName(), "a");
-                }
-
-                @Override
-                public Boolean visitAttribute(AttributeTree node, Content content) {
-                    if (!content.isEmpty()) {
-                        content.add(" ");
-                    }
-                    content.add(node.getName());
-                    if (node.getValueKind() == ValueKind.EMPTY) {
-                        return false;
-                    }
-                    content.add("=");
-                    String quote = switch (node.getValueKind()) {
-                        case DOUBLE -> "\"";
-                        case SINGLE -> "'";
-                        default -> "";
-                    };
-                    content.add(quote);
-
-                    /* In the following code for an attribute value:
-                     * 1. {@docRoot} followed by text beginning "/.." is replaced by the value
-                     *    of the docrootParent option, followed by the remainder of the text
-                     * 2. in the value of an "href" attribute in a <a> tag, an initial text
-                     *    value will have a relative link redirected.
-                     * Note that, realistically, it only makes sense to ever use {@docRoot}
-                     * at the beginning of a URL in an attribute value, but this is not
-                     * required or enforced.
-                     */
-                    boolean isHRef = inAnAtag() && equalsIgnoreCase(node.getName(), "href");
-                    boolean first = true;
-                    DocRootTree pendingDocRoot = null;
-                    for (DocTree dt : node.getValue()) {
-                        if (pendingDocRoot != null) {
-                            if (dt instanceof TextTree tt) {
-                                String text = tt.getBody();
-                                if (text.startsWith("/..") && !options.docrootParent().isEmpty()) {
-                                    content.add(options.docrootParent());
-                                    content.add(textCleanup(text.substring(3), isLastNode));
-                                    pendingDocRoot = null;
-                                    continue;
-                                }
-                            }
-                            pendingDocRoot.accept(this, content);
-                            pendingDocRoot = null;
-                        }
-
-                        if (dt instanceof TextTree tt) {
-                            String text = tt.getBody();
-                            if (first && isHRef) {
-                                text = redirectRelativeLinks(element, tt);
-                            }
-                            content.add(textCleanup(text, isLastNode));
-                        } else if (dt instanceof DocRootTree drt) {
-                            // defer until we see what, if anything, follows this node
-                            pendingDocRoot = drt;
-                        } else {
-                            dt.accept(this, content);
-                        }
-                        first = false;
-                    }
-                    if (pendingDocRoot != null) {
-                        pendingDocRoot.accept(this, content);
-                    }
-
-                    content.add(quote);
-                    return false;
-                }
-
-                @Override
-                public Boolean visitComment(CommentTree node, Content content) {
-                    content.add(RawHtml.comment(node.getBody()));
-                    return false;
-                }
-
-                @Override
-                public Boolean visitEndElement(EndElementTree node, Content content) {
-                    content.add(RawHtml.endElement(node.getName()));
-                    return false;
-                }
-
-                @Override
-                public Boolean visitEntity(EntityTree node, Content content) {
-                    content.add(Entity.of(node.getName()));
-                    return false;
-                }
-
-                @Override
-                public Boolean visitErroneous(ErroneousTree node, Content content) {
-                    DocTreePath dtp = ch.getDocTreePath(node);
-                    if (dtp != null) {
-                        String body = node.getBody();
-                        Matcher m = Pattern.compile("(?i)\\{@([a-z]+).*").matcher(body);
-                        String tagName = m.matches() ? m.group(1) : null;
-                        if (tagName == null) {
-                            if (!configuration.isDocLintSyntaxGroupEnabled()) {
-                                messages.warning(dtp, "doclet.tag.invalid_input", body);
-                            }
-                            content.add(invalidTagOutput(resources.getText("doclet.tag.invalid_input", body),
-                                    Optional.empty()));
-                        } else {
-                            messages.warning(dtp, "doclet.tag.invalid_usage", body);
-                            content.add(invalidTagOutput(resources.getText("doclet.tag.invalid", tagName),
-                                    Optional.of(Text.of(body))));
-                        }
-                    }
-                    return false;
-                }
-
-                @Override
-                public Boolean visitEscape(EscapeTree node, Content content) {
-                    result.add(node.getBody());
-                    return false;
-                }
-
-                @Override
-                public Boolean visitInheritDoc(InheritDocTree node, Content content) {
-                    Content output = getInlineTagOutput(element, node, context);
-                    content.add(output);
-                    // if we obtained the first sentence successfully, nothing more to do
-                    return (context.isFirstSentence && !output.isEmpty());
-                }
-
-                @Override
-                public Boolean visitStartElement(StartElementTree node, Content content) {
-                    Content attrs = new ContentBuilder();
-                    if (node.getName().toString().matches("(?i)h[1-6]")
-                            && isIndexable()) {
-                        createSectionIdAndIndex(node, trees, attrs, element, context);
-                    }
-                    for (DocTree dt : node.getAttributes()) {
-                        dt.accept(this, attrs);
-                    }
-                    content.add(RawHtml.startElement(node.getName(), attrs, node.isSelfClosing()));
-                    return false;
-                }
-
-                private CharSequence textCleanup(String text, boolean isLast) {
-                    return textCleanup(text, isLast, false);
-                }
-
-                private CharSequence textCleanup(String text, boolean isLast, boolean stripLeading) {
-                    boolean stripTrailing = context.isFirstSentence && isLast;
-                    if (stripLeading && stripTrailing) {
-                        text = text.strip();
-                    } else if (stripLeading) {
-                        text = text.stripLeading();
-                    } else if (stripTrailing) {
-                        text = text.stripTrailing();
-                    }
-                    text = utils.replaceTabs(text);
-                    return Text.normalizeNewlines(text);
-                }
-
-                @Override
-                public Boolean visitText(TextTree node, Content content) {
-                    String text = node.getBody();
-                    result.add(text.startsWith("<![CDATA[")
-                            ? RawHtml.cdata(text)
-                            : Text.of(textCleanup(text, isLastNode, commentRemoved)));
-                    return false;
-                }
-
-                @Override
-                protected Boolean defaultAction(DocTree node, Content content) {
-                    if (node instanceof InlineTagTree itt) {
-                        var output = getInlineTagOutput(element, itt, context);
-                        if (output != null) {
-                            content.add(output);
-                        }
-                    }
-                    return false;
-                }
-
-            };
+            var docTreeVisitor = new InlineVisitor(element, tag, isLastNode, context, ch, trees);;
 
             boolean allDone = docTreeVisitor.visit(tag, result);
             commentRemoved = false;
@@ -1482,6 +1305,205 @@ public abstract class HtmlDocletWriter {
             result.add(RawHtml.endElement(openTags.removeLast()));
         }
         return result;
+    }
+
+    private class InlineVisitor extends SimpleDocTreeVisitor<Boolean, Content> {
+        private final Element element;
+        private final DocTree tag;
+        private final boolean isLastNode;
+        private final TagletWriter.Context context;
+        private final CommentHelper ch;
+        private final List<? extends DocTree> trees;
+
+        InlineVisitor(Element element,
+                      DocTree tag,
+                      boolean isLastNode,
+                      TagletWriter.Context context,
+                      CommentHelper ch,
+                      List<? extends DocTree> trees) {
+
+            this.element = element;
+            this.tag = tag;
+            this.isLastNode = isLastNode;
+            this.context = context;
+            this.ch = ch;
+            this.trees = trees;
+        }
+
+        private boolean inAnAtag() {
+            return (tag instanceof StartElementTree st) && equalsIgnoreCase(st.getName(), "a");
+        }
+
+        @Override
+        public Boolean visitAttribute(AttributeTree node, Content content) {
+            if (!content.isEmpty()) {
+                content.add(" ");
+            }
+            content.add(node.getName());
+            if (node.getValueKind() == ValueKind.EMPTY) {
+                return false;
+            }
+            content.add("=");
+            String quote = switch (node.getValueKind()) {
+                case DOUBLE -> "\"";
+                case SINGLE -> "'";
+                default -> "";
+            };
+            content.add(quote);
+
+            /* In the following code for an attribute value:
+             * 1. {@docRoot} followed by text beginning "/.." is replaced by the value
+             *    of the docrootParent option, followed by the remainder of the text
+             * 2. in the value of an "href" attribute in a <a> tag, an initial text
+             *    value will have a relative link redirected.
+             * Note that, realistically, it only makes sense to ever use {@docRoot}
+             * at the beginning of a URL in an attribute value, but this is not
+             * required or enforced.
+             */
+            boolean isHRef = inAnAtag() && equalsIgnoreCase(node.getName(), "href");
+            boolean first = true;
+            DocRootTree pendingDocRoot = null;
+            for (DocTree dt : node.getValue()) {
+                if (pendingDocRoot != null) {
+                    if (dt instanceof TextTree tt) {
+                        String text = tt.getBody();
+                        if (text.startsWith("/..") && !options.docrootParent().isEmpty()) {
+                            content.add(options.docrootParent());
+                            content.add(textCleanup(text.substring(3), isLastNode));
+                            pendingDocRoot = null;
+                            continue;
+                        }
+                    }
+                    pendingDocRoot.accept(this, content);
+                    pendingDocRoot = null;
+                }
+
+                if (dt instanceof TextTree tt) {
+                    String text = tt.getBody();
+                    if (first && isHRef) {
+                        text = redirectRelativeLinks(element, tt);
+                    }
+                    content.add(textCleanup(text, isLastNode));
+                } else if (dt instanceof DocRootTree drt) {
+                    // defer until we see what, if anything, follows this node
+                    pendingDocRoot = drt;
+                } else {
+                    dt.accept(this, content);
+                }
+                first = false;
+            }
+            if (pendingDocRoot != null) {
+                pendingDocRoot.accept(this, content);
+            }
+
+            content.add(quote);
+            return false;
+        }
+
+        @Override
+        public Boolean visitComment(CommentTree node, Content content) {
+            content.add(RawHtml.comment(node.getBody()));
+            return false;
+        }
+
+        @Override
+        public Boolean visitEndElement(EndElementTree node, Content content) {
+            content.add(RawHtml.endElement(node.getName()));
+            return false;
+        }
+
+        @Override
+        public Boolean visitEntity(EntityTree node, Content content) {
+            content.add(Entity.of(node.getName()));
+            return false;
+        }
+
+        @Override
+        public Boolean visitErroneous(ErroneousTree node, Content content) {
+            DocTreePath dtp = ch.getDocTreePath(node);
+            if (dtp != null) {
+                String body = node.getBody();
+                Matcher m = Pattern.compile("(?i)\\{@([a-z]+).*").matcher(body);
+                String tagName = m.matches() ? m.group(1) : null;
+                if (tagName == null) {
+                    if (!configuration.isDocLintSyntaxGroupEnabled()) {
+                        messages.warning(dtp, "doclet.tag.invalid_input", body);
+                    }
+                    content.add(invalidTagOutput(resources.getText("doclet.tag.invalid_input", body),
+                            Optional.empty()));
+                } else {
+                    messages.warning(dtp, "doclet.tag.invalid_usage", body);
+                    content.add(invalidTagOutput(resources.getText("doclet.tag.invalid", tagName),
+                            Optional.of(Text.of(body))));
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitEscape(EscapeTree node, Content content) {
+            content.add(node.getBody());
+            return false;
+        }
+
+        @Override
+        public Boolean visitInheritDoc(InheritDocTree node, Content content) {
+            Content output = getInlineTagOutput(element, node, context);
+            content.add(output);
+            // if we obtained the first sentence successfully, nothing more to do
+            return (context.isFirstSentence && !output.isEmpty());
+        }
+
+        @Override
+        public Boolean visitStartElement(StartElementTree node, Content content) {
+            Content attrs = new ContentBuilder();
+            if (node.getName().toString().matches("(?i)h[1-6]")
+                    && isIndexable()) {
+                createSectionIdAndIndex(node, trees, attrs, element, context);
+            }
+            for (DocTree dt : node.getAttributes()) {
+                dt.accept(this, attrs);
+            }
+            content.add(RawHtml.startElement(node.getName(), attrs, node.isSelfClosing()));
+            return false;
+        }
+
+        private CharSequence textCleanup(String text, boolean isLast) {
+            return textCleanup(text, isLast, false);
+        }
+
+        private CharSequence textCleanup(String text, boolean isLast, boolean stripLeading) {
+            boolean stripTrailing = context.isFirstSentence && isLast;
+            if (stripLeading && stripTrailing) {
+                text = text.strip();
+            } else if (stripLeading) {
+                text = text.stripLeading();
+            } else if (stripTrailing) {
+                text = text.stripTrailing();
+            }
+            text = utils.replaceTabs(text);
+            return Text.normalizeNewlines(text);
+        }
+
+        @Override
+        public Boolean visitText(TextTree node, Content content) {
+            String text = node.getBody();
+            content.add(text.startsWith("<![CDATA[")
+                    ? RawHtml.cdata(text)
+                    : Text.of(textCleanup(text, isLastNode, commentRemoved)));
+            return false;
+        }
+
+        @Override
+        protected Boolean defaultAction(DocTree node, Content content) {
+            if (node instanceof InlineTagTree itt) {
+                var output = getInlineTagOutput(element, itt, context);
+                if (output != null) {
+                    content.add(output);
+                }
+            }
+            return false;
+        }
     }
 
     private boolean equalsIgnoreCase(Name name, String s) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -1292,7 +1292,7 @@ public abstract class HtmlDocletWriter {
                 }
             }
 
-            var docTreeVisitor = new InlineVisitor(element, tag, isLastNode, context, ch, trees);;
+            var docTreeVisitor = new InlineVisitor(element, tag, isLastNode, context, ch, trees);
 
             boolean allDone = docTreeVisitor.visit(tag, result);
             commentRemoved = false;


### PR DESCRIPTION
Please review a conceptually simple change, to move a large anonymous inner class to be a named inner class.

While most of the code is simply moved, two simple changes were necessary.  In `visitEscape` and `visitText` the variable `result` from the enclosing lexical scope was accessed directly. The change is simply to use the equivalent value `content` which is passed to each `visit...` call.

No tests needed updating. All javadoc tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328006](https://bugs.openjdk.org/browse/JDK-8328006): refactor large anonymous inner class in HtmlDocletWriter (**Enhancement** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**) ⚠️ Review applies to [b44594c0](https://git.openjdk.org/jdk/pull/18252/files/b44594c041b805b78acf3ac39a61dbcc72f4746b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18252/head:pull/18252` \
`$ git checkout pull/18252`

Update a local copy of the PR: \
`$ git checkout pull/18252` \
`$ git pull https://git.openjdk.org/jdk.git pull/18252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18252`

View PR using the GUI difftool: \
`$ git pr show -t 18252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18252.diff">https://git.openjdk.org/jdk/pull/18252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18252#issuecomment-1992501318)