### PR TITLE
Enable java/lang/ProcessBuilder/JspawnhelperProtocol.java on Mac

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @bug 8307990
- * @requires (os.family == "linux") | (os.family == "aix")
+ * @requires (os.family == "linux") | (os.family == "aix") | (os.family == "mac")
  * @requires vm.debug
  * @requires vm.flagless
  * @library /test/lib


### PR DESCRIPTION
This change enables to run JspawnhelperProtocol.java on MacOS.

In addition to GHA , the test has been run on macos and linux.

```
Test report is stored in build/macosx-x86_64-server-fastdebug/test-results/jtreg_test_jdk_java_lang_ProcessBuilder_JspawnhelperProtocol_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
                                                         1     1     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'macosx-x86_64-server-fastdebug'
```


```

Test report is stored in build/linux-x86_64-server-fastdebug/test-results/jtreg_test_jdk_java_lang_ProcessBuilder_JspawnhelperProtocol_java

==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
                                                         1     1     0     0
==============================
TEST SUCCESS

Stopping javac server
[ec2-user@ip-172-16-0-10 jdk]$ make test CONF=linux-x86_64-server-fastdebug TEST=test/jdk/java/lang/ProcessBuilder/JspawnhelperProtocol.java
```