### PR TITLE
8327885: runtime/Unsafe/InternalErrorTest.java enters endless loop on Alpine aarch64

### DIFF
--- a/src/hotspot/share/utilities/copy.cpp
+++ b/src/hotspot/share/utilities/copy.cpp
@@ -247,8 +247,10 @@ void Copy::fill_to_memory_atomic(void* to, size_t size, jubyte value) {
     // This code is used by Unsafe and may hit the next page after truncation of mapped memory.
     // Therefore, we use volatile to prevent compilers from replacing the loop by memset which
     // may not trigger SIGBUS as needed (observed on Alpine Linux x86_64)
+    // Also making counter volatile to prevent compilers from generating strb with auto-increment
+    // Otherwise, it may trigger endless loop on Alpine Linux aarch64
     jbyte fill = value;
-    for (uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
+    for (volatile uintptr_t off = 0; off < size; off += sizeof(jbyte)) {
       *(volatile jbyte*)(dst + off) = fill;
     }
 #else


### PR DESCRIPTION
[JDK-8322163](https://bugs.openjdk.org/browse/JDK-8322163) replaced memset with a for loop on Alpine. This fixed the test on Alpine x86_64 but it enters endless loop on Alpine aarch64.

The loop causes SIGBUS to be generated and the signal handler continues to the next instruction. As gcc generates strb with auto-increment on aarch64, the increment will be skipped.

The patch makes the counter volatile to prevent compilers from generating strb with auto-increment. With the patch, the test passes on Alpine aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327885](https://bugs.openjdk.org/browse/JDK-8327885): runtime/Unsafe/InternalErrorTest.java enters endless loop on Alpine aarch64 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18262/head:pull/18262` \
`$ git checkout pull/18262`

Update a local copy of the PR: \
`$ git checkout pull/18262` \
`$ git pull https://git.openjdk.org/jdk.git pull/18262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18262`

View PR using the GUI difftool: \
`$ git pr show -t 18262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18262.diff">https://git.openjdk.org/jdk/pull/18262.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18262#issuecomment-1993736496)