### PR TITLE
8328037: Test java/util/Formatter/Padding.java has unnecessary high heap requirement after JDK-8326718

### DIFF
--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -30,325 +30,398 @@
  */
 
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class Padding {
 
-    private static final String tenMillionZeros = "0".repeat(10_000_000);
-    private static final String tenMillionBlanks = " ".repeat(10_000_000);
+    private static final String tenMillionZeros() {
+        return "0".repeat(10_000_000);
+    }
+    private static final String tenMillionBlanks() {
+        return " ".repeat(10_000_000);
+    }
 
-    static Arguments[] padding() {
-        return new Arguments[] {
-                /* blank padding, right adjusted, optional plus sign */
-                arguments("12", "%1d", 12),
-                arguments("12", "%2d", 12),
-                arguments(" 12", "%3d", 12),
-                arguments("  12", "%4d", 12),
-                arguments("   12", "%5d", 12),
-                arguments("        12", "%10d", 12),
-                arguments(tenMillionBlanks + "12", "%10000002d", 12),
+    /* blank padding, right adjusted, optional sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedOptionalSign() {
+        return Stream.of(
+            Arguments.of("12", "%1d", 12),
+            Arguments.of("12", "%2d", 12),
+            Arguments.of(" 12", "%3d", 12),
+            Arguments.of("  12", "%4d", 12),
+            Arguments.of("   12", "%5d", 12),
+            Arguments.of("        12", "%10d", 12),
+            Arguments.of(tenMillionBlanks() + "12", "%10000002d", 12),
 
-                arguments("-12", "%1d", -12),
-                arguments("-12", "%2d", -12),
-                arguments("-12", "%3d", -12),
-                arguments(" -12", "%4d", -12),
-                arguments("  -12", "%5d", -12),
-                arguments("       -12", "%10d", -12),
-                arguments(tenMillionBlanks + "-12", "%10000003d", -12),
+            Arguments.of("-12", "%1d", -12),
+            Arguments.of("-12", "%2d", -12),
+            Arguments.of("-12", "%3d", -12),
+            Arguments.of(" -12", "%4d", -12),
+            Arguments.of("  -12", "%5d", -12),
+            Arguments.of("       -12", "%10d", -12),
+            Arguments.of(tenMillionBlanks() + "-12", "%10000003d", -12),
 
-                arguments("1.2", "%1.1f", 1.2),
-                arguments("1.2", "%2.1f", 1.2),
-                arguments("1.2", "%3.1f", 1.2),
-                arguments(" 1.2", "%4.1f", 1.2),
-                arguments("  1.2", "%5.1f", 1.2),
-                arguments("       1.2", "%10.1f", 1.2),
-                arguments(tenMillionBlanks + "1.2", "%10000003.1f", 1.2),
+            Arguments.of("1.2", "%1.1f", 1.2),
+            Arguments.of("1.2", "%2.1f", 1.2),
+            Arguments.of("1.2", "%3.1f", 1.2),
+            Arguments.of(" 1.2", "%4.1f", 1.2),
+            Arguments.of("  1.2", "%5.1f", 1.2),
+            Arguments.of("       1.2", "%10.1f", 1.2),
+            Arguments.of(tenMillionBlanks() + "1.2", "%10000003.1f", 1.2),
 
-                arguments("-1.2", "%1.1f", -1.2),
-                arguments("-1.2", "%2.1f", -1.2),
-                arguments("-1.2", "%3.1f", -1.2),
-                arguments("-1.2", "%4.1f", -1.2),
-                arguments(" -1.2", "%5.1f", -1.2),
-                arguments("      -1.2", "%10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "%10000004.1f", -1.2),
-
-                /* blank padding, right adjusted, mandatory plus sign */
-                arguments("+12", "%+1d", 12),
-                arguments("+12", "%+2d", 12),
-                arguments("+12", "%+3d", 12),
-                arguments(" +12", "%+4d", 12),
-                arguments("  +12", "%+5d", 12),
-                arguments("       +12", "%+10d", 12),
-                arguments(tenMillionBlanks + "+12", "%+10000003d", 12),
-
-                arguments("-12", "%+1d", -12),
-                arguments("-12", "%+2d", -12),
-                arguments("-12", "%+3d", -12),
-                arguments(" -12", "%+4d", -12),
-                arguments("  -12", "%+5d", -12),
-                arguments("       -12", "%+10d", -12),
-                arguments(tenMillionBlanks + "-12", "%+10000003d", -12),
-
-                arguments("+1.2", "%+1.1f", 1.2),
-                arguments("+1.2", "%+2.1f", 1.2),
-                arguments("+1.2", "%+3.1f", 1.2),
-                arguments("+1.2", "%+4.1f", 1.2),
-                arguments(" +1.2", "%+5.1f", 1.2),
-                arguments("      +1.2", "%+10.1f", 1.2),
-                arguments(tenMillionBlanks + "+1.2", "%+10000004.1f", 1.2),
-
-                arguments("-1.2", "%+1.1f", -1.2),
-                arguments("-1.2", "%+2.1f", -1.2),
-                arguments("-1.2", "%+3.1f", -1.2),
-                arguments("-1.2", "%+4.1f", -1.2),
-                arguments(" -1.2", "%+5.1f", -1.2),
-                arguments("      -1.2", "%+10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "%+10000004.1f", -1.2),
-
-                /* blank padding, right adjusted, mandatory blank sign */
-                arguments(" 12", "% 1d", 12),
-                arguments(" 12", "% 2d", 12),
-                arguments(" 12", "% 3d", 12),
-                arguments("  12", "% 4d", 12),
-                arguments("   12", "% 5d", 12),
-                arguments("        12", "% 10d", 12),
-                arguments(tenMillionBlanks + "12", "% 10000002d", 12),
-
-                arguments("-12", "% 1d", -12),
-                arguments("-12", "% 2d", -12),
-                arguments("-12", "% 3d", -12),
-                arguments(" -12", "% 4d", -12),
-                arguments("  -12", "% 5d", -12),
-                arguments("       -12", "% 10d", -12),
-                arguments(tenMillionBlanks + "-12", "% 10000003d", -12),
-
-                arguments(" 1.2", "% 1.1f", 1.2),
-                arguments(" 1.2", "% 2.1f", 1.2),
-                arguments(" 1.2", "% 3.1f", 1.2),
-                arguments(" 1.2", "% 4.1f", 1.2),
-                arguments("  1.2", "% 5.1f", 1.2),
-                arguments("       1.2", "% 10.1f", 1.2),
-                arguments(tenMillionBlanks + "1.2", "% 10000003.1f", 1.2),
-
-                arguments("-1.2", "% 1.1f", -1.2),
-                arguments("-1.2", "% 2.1f", -1.2),
-                arguments("-1.2", "% 3.1f", -1.2),
-                arguments("-1.2", "% 4.1f", -1.2),
-                arguments(" -1.2", "% 5.1f", -1.2),
-                arguments("      -1.2", "% 10.1f", -1.2),
-                arguments(tenMillionBlanks + "-1.2", "% 10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, optional sign */
-                arguments("12", "%-1d", 12),
-                arguments("12", "%-2d", 12),
-                arguments("12 ", "%-3d", 12),
-                arguments("12  ", "%-4d", 12),
-                arguments("12   ", "%-5d", 12),
-                arguments("12        ", "%-10d", 12),
-                arguments("12" + tenMillionBlanks, "%-10000002d", 12),
-
-                arguments("-12", "%-1d", -12),
-                arguments("-12", "%-2d", -12),
-                arguments("-12", "%-3d", -12),
-                arguments("-12 ", "%-4d", -12),
-                arguments("-12  ", "%-5d", -12),
-                arguments("-12       ", "%-10d", -12),
-                arguments("-12" + tenMillionBlanks, "%-10000003d", -12),
-
-                arguments("1.2", "%-1.1f", 1.2),
-                arguments("1.2", "%-2.1f", 1.2),
-                arguments("1.2", "%-3.1f", 1.2),
-                arguments("1.2 ", "%-4.1f", 1.2),
-                arguments("1.2  ", "%-5.1f", 1.2),
-                arguments("1.2       ", "%-10.1f", 1.2),
-                arguments("1.2" + tenMillionBlanks, "%-10000003.1f", 1.2),
-
-                arguments("-1.2", "%-1.1f", -1.2),
-                arguments("-1.2", "%-2.1f", -1.2),
-                arguments("-1.2", "%-3.1f", -1.2),
-                arguments("-1.2", "%-4.1f", -1.2),
-                arguments("-1.2 ", "%-5.1f", -1.2),
-                arguments("-1.2      ", "%-10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%-10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, mandatory plus sign */
-                arguments("+12", "%-+1d", 12),
-                arguments("+12", "%-+2d", 12),
-                arguments("+12", "%-+3d", 12),
-                arguments("+12 ", "%-+4d", 12),
-                arguments("+12  ", "%-+5d", 12),
-                arguments("+12       ", "%-+10d", 12),
-                arguments("+12" + tenMillionBlanks, "%-+10000003d", 12),
-
-                arguments("-12", "%-+1d", -12),
-                arguments("-12", "%-+2d", -12),
-                arguments("-12", "%-+3d", -12),
-                arguments("-12 ", "%-+4d", -12),
-                arguments("-12  ", "%-+5d", -12),
-                arguments("-12       ", "%-+10d", -12),
-                arguments("-12" + tenMillionBlanks, "%-+10000003d", -12),
-
-                arguments("+1.2", "%-+1.1f", 1.2),
-                arguments("+1.2", "%-+2.1f", 1.2),
-                arguments("+1.2", "%-+3.1f", 1.2),
-                arguments("+1.2", "%-+4.1f", 1.2),
-                arguments("+1.2 ", "%-+5.1f", 1.2),
-                arguments("+1.2      ", "%-+10.1f", 1.2),
-                arguments("+1.2" + tenMillionBlanks, "%-+10000004.1f", 1.2),
-
-                arguments("-1.2", "%-+1.1f", -1.2),
-                arguments("-1.2", "%-+2.1f", -1.2),
-                arguments("-1.2", "%-+3.1f", -1.2),
-                arguments("-1.2", "%-+4.1f", -1.2),
-                arguments("-1.2 ", "%-+5.1f", -1.2),
-                arguments("-1.2      ", "%-+10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%-+10000004.1f", -1.2),
-
-                /* blank padding, left adjusted, mandatory blank sign */
-                arguments(" 12", "%- 1d", 12),
-                arguments(" 12", "%- 2d", 12),
-                arguments(" 12", "%- 3d", 12),
-                arguments(" 12 ", "%- 4d", 12),
-                arguments(" 12  ", "%- 5d", 12),
-                arguments(" 12       ", "%- 10d", 12),
-                arguments(" 12" + tenMillionBlanks, "%- 10000003d", 12),
-
-                arguments("-12", "%- 1d", -12),
-                arguments("-12", "%- 2d", -12),
-                arguments("-12", "%- 3d", -12),
-                arguments("-12 ", "%- 4d", -12),
-                arguments("-12  ", "%- 5d", -12),
-                arguments("-12       ", "%- 10d", -12),
-                arguments("-12" + tenMillionBlanks, "%- 10000003d", -12),
-
-                arguments(" 1.2", "%- 1.1f", 1.2),
-                arguments(" 1.2", "%- 2.1f", 1.2),
-                arguments(" 1.2", "%- 3.1f", 1.2),
-                arguments(" 1.2", "%- 4.1f", 1.2),
-                arguments(" 1.2 ", "%- 5.1f", 1.2),
-                arguments(" 1.2      ", "%- 10.1f", 1.2),
-                arguments(" 1.2" + tenMillionBlanks, "%- 10000004.1f", 1.2),
-
-                arguments("-1.2", "%- 1.1f", -1.2),
-                arguments("-1.2", "%- 2.1f", -1.2),
-                arguments("-1.2", "%- 3.1f", -1.2),
-                arguments("-1.2", "%- 4.1f", -1.2),
-                arguments("-1.2 ", "%- 5.1f", -1.2),
-                arguments("-1.2      ", "%- 10.1f", -1.2),
-                arguments("-1.2" + tenMillionBlanks, "%- 10000004.1f", -1.2),
-
-                /* zero padding, right adjusted, optional sign */
-                arguments("12", "%01d", 12),
-                arguments("12", "%02d", 12),
-                arguments("012", "%03d", 12),
-                arguments("0012", "%04d", 12),
-                arguments("00012", "%05d", 12),
-                arguments("0000000012", "%010d", 12),
-                arguments(tenMillionZeros + "12", "%010000002d", 12),
-
-                arguments("-12", "%01d", -12),
-                arguments("-12", "%02d", -12),
-                arguments("-12", "%03d", -12),
-                arguments("-012", "%04d", -12),
-                arguments("-0012", "%05d", -12),
-                arguments("-000000012", "%010d", -12),
-                arguments("-" + tenMillionZeros + "12", "%010000003d", -12),
-
-                arguments("1.2", "%01.1f", 1.2),
-                arguments("1.2", "%02.1f", 1.2),
-                arguments("1.2", "%03.1f", 1.2),
-                arguments("01.2", "%04.1f", 1.2),
-                arguments("001.2", "%05.1f", 1.2),
-                arguments("00000001.2", "%010.1f", 1.2),
-                arguments(tenMillionZeros + "1.2", "%010000003.1f", 1.2),
-
-                arguments("-1.2", "%01.1f", -1.2),
-                arguments("-1.2", "%02.1f", -1.2),
-                arguments("-1.2", "%03.1f", -1.2),
-                arguments("-1.2", "%04.1f", -1.2),
-                arguments("-01.2", "%05.1f", -1.2),
-                arguments("-0000001.2", "%010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "%010000004.1f", -1.2),
-
-                /* zero padding, right adjusted, mandatory plus sign */
-                arguments("+12", "%+01d", 12),
-                arguments("+12", "%+02d", 12),
-                arguments("+12", "%+03d", 12),
-                arguments("+012", "%+04d", 12),
-                arguments("+0012", "%+05d", 12),
-                arguments("+000000012", "%+010d", 12),
-                arguments("+" + tenMillionZeros + "12", "%+010000003d", 12),
-
-                arguments("-12", "%+01d", -12),
-                arguments("-12", "%+02d", -12),
-                arguments("-12", "%+03d", -12),
-                arguments("-012", "%+04d", -12),
-                arguments("-0012", "%+05d", -12),
-                arguments("-000000012", "%+010d", -12),
-                arguments("-" + tenMillionZeros + "12", "%+010000003d", -12),
-
-                arguments("+1.2", "%+01.1f", 1.2),
-                arguments("+1.2", "%+02.1f", 1.2),
-                arguments("+1.2", "%+03.1f", 1.2),
-                arguments("+1.2", "%+04.1f", 1.2),
-                arguments("+01.2", "%+05.1f", 1.2),
-                arguments("+0000001.2", "%+010.1f", 1.2),
-                arguments("+" + tenMillionZeros + "1.2", "%+010000004.1f", 1.2),
-
-                arguments("-1.2", "%+01.1f", -1.2),
-                arguments("-1.2", "%+02.1f", -1.2),
-                arguments("-1.2", "%+03.1f", -1.2),
-                arguments("-1.2", "%+04.1f", -1.2),
-                arguments("-01.2", "%+05.1f", -1.2),
-                arguments("-0000001.2", "%+010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "%+010000004.1f", -1.2),
-
-                /* zero padding, right adjusted, mandatory blank sign */
-                arguments(" 12", "% 01d", 12),
-                arguments(" 12", "% 02d", 12),
-                arguments(" 12", "% 03d", 12),
-                arguments(" 012", "% 04d", 12),
-                arguments(" 0012", "% 05d", 12),
-                arguments(" 000000012", "% 010d", 12),
-                arguments(" " + tenMillionZeros + "12", "% 010000003d", 12),
-
-                arguments("-12", "% 01d", -12),
-                arguments("-12", "% 02d", -12),
-                arguments("-12", "% 03d", -12),
-                arguments("-012", "% 04d", -12),
-                arguments("-0012", "% 05d", -12),
-                arguments("-000000012", "% 010d", -12),
-                arguments("-" + tenMillionZeros + "12", "% 010000003d", -12),
-
-                arguments(" 1.2", "% 01.1f", 1.2),
-                arguments(" 1.2", "% 02.1f", 1.2),
-                arguments(" 1.2", "% 03.1f", 1.2),
-                arguments(" 1.2", "% 04.1f", 1.2),
-                arguments(" 01.2", "% 05.1f", 1.2),
-                arguments(" 0000001.2", "% 010.1f", 1.2),
-                arguments(" " + tenMillionZeros + "1.2", "% 010000004.1f", 1.2),
-
-                arguments("-1.2", "% 01.1f", -1.2),
-                arguments("-1.2", "% 02.1f", -1.2),
-                arguments("-1.2", "% 03.1f", -1.2),
-                arguments("-1.2", "% 04.1f", -1.2),
-                arguments("-01.2", "% 05.1f", -1.2),
-                arguments("-0000001.2", "% 010.1f", -1.2),
-                arguments("-" + tenMillionZeros + "1.2", "% 010000004.1f", -1.2),
-
-        };
+            Arguments.of("-1.2", "%1.1f", -1.2),
+            Arguments.of("-1.2", "%2.1f", -1.2),
+            Arguments.of("-1.2", "%3.1f", -1.2),
+            Arguments.of("-1.2", "%4.1f", -1.2),
+            Arguments.of(" -1.2", "%5.1f", -1.2),
+            Arguments.of("      -1.2", "%10.1f", -1.2),
+            Arguments.of(tenMillionBlanks() + "-1.2", "%10000004.1f", -1.2));
     }
 
     @ParameterizedTest
     @MethodSource
-    void padding(String expected, String format, Object value) {
+    void blankPaddingRightAdjustedOptionalSign(String expected, String format, Object value) {
         assertEquals(expected, String.format(Locale.US, format, value));
     }
 
+    /* blank padding, right adjusted, mandatory sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedMandatorySign() {
+        return Stream.of(
+            Arguments.of("+12", "%+1d", 12),
+            Arguments.of("+12", "%+2d", 12),
+            Arguments.of("+12", "%+3d", 12),
+            Arguments.of(" +12", "%+4d", 12),
+            Arguments.of("  +12", "%+5d", 12),
+            Arguments.of("       +12", "%+10d", 12),
+            Arguments.of(tenMillionBlanks() + "+12", "%+10000003d", 12),
+
+            Arguments.of("-12", "%+1d", -12),
+            Arguments.of("-12", "%+2d", -12),
+            Arguments.of("-12", "%+3d", -12),
+            Arguments.of(" -12", "%+4d", -12),
+            Arguments.of("  -12", "%+5d", -12),
+            Arguments.of("       -12", "%+10d", -12),
+            Arguments.of(tenMillionBlanks() + "-12", "%+10000003d", -12),
+
+            Arguments.of("+1.2", "%+1.1f", 1.2),
+            Arguments.of("+1.2", "%+2.1f", 1.2),
+            Arguments.of("+1.2", "%+3.1f", 1.2),
+            Arguments.of("+1.2", "%+4.1f", 1.2),
+            Arguments.of(" +1.2", "%+5.1f", 1.2),
+            Arguments.of("      +1.2", "%+10.1f", 1.2),
+            Arguments.of(tenMillionBlanks() + "+1.2", "%+10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%+1.1f", -1.2),
+            Arguments.of("-1.2", "%+2.1f", -1.2),
+            Arguments.of("-1.2", "%+3.1f", -1.2),
+            Arguments.of("-1.2", "%+4.1f", -1.2),
+            Arguments.of(" -1.2", "%+5.1f", -1.2),
+            Arguments.of("      -1.2", "%+10.1f", -1.2),
+            Arguments.of(tenMillionBlanks() + "-1.2", "%+10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingRightAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, right adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> blankPaddingRightAdjustedMandatoryBlank() {
+        return Stream.of(
+            Arguments.of(" 12", "% 1d", 12),
+            Arguments.of(" 12", "% 2d", 12),
+            Arguments.of(" 12", "% 3d", 12),
+            Arguments.of("  12", "% 4d", 12),
+            Arguments.of("   12", "% 5d", 12),
+            Arguments.of("        12", "% 10d", 12),
+            Arguments.of(tenMillionBlanks() + "12", "% 10000002d", 12),
+
+            Arguments.of("-12", "% 1d", -12),
+            Arguments.of("-12", "% 2d", -12),
+            Arguments.of("-12", "% 3d", -12),
+            Arguments.of(" -12", "% 4d", -12),
+            Arguments.of("  -12", "% 5d", -12),
+            Arguments.of("       -12", "% 10d", -12),
+            Arguments.of(tenMillionBlanks() + "-12", "% 10000003d", -12),
+
+            Arguments.of(" 1.2", "% 1.1f", 1.2),
+            Arguments.of(" 1.2", "% 2.1f", 1.2),
+            Arguments.of(" 1.2", "% 3.1f", 1.2),
+            Arguments.of(" 1.2", "% 4.1f", 1.2),
+            Arguments.of("  1.2", "% 5.1f", 1.2),
+            Arguments.of("       1.2", "% 10.1f", 1.2),
+            Arguments.of(tenMillionBlanks() + "1.2", "% 10000003.1f", 1.2),
+
+            Arguments.of("-1.2", "% 1.1f", -1.2),
+            Arguments.of("-1.2", "% 2.1f", -1.2),
+            Arguments.of("-1.2", "% 3.1f", -1.2),
+            Arguments.of("-1.2", "% 4.1f", -1.2),
+            Arguments.of(" -1.2", "% 5.1f", -1.2),
+            Arguments.of("      -1.2", "% 10.1f", -1.2),
+            Arguments.of(tenMillionBlanks() + "-1.2", "% 10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingRightAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, optional sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedOptionalSign() {
+        return Stream.of(
+            Arguments.of("12", "%-1d", 12),
+            Arguments.of("12", "%-2d", 12),
+            Arguments.of("12 ", "%-3d", 12),
+            Arguments.of("12  ", "%-4d", 12),
+            Arguments.of("12   ", "%-5d", 12),
+            Arguments.of("12        ", "%-10d", 12),
+            Arguments.of("12" + tenMillionBlanks(), "%-10000002d", 12),
+
+            Arguments.of("-12", "%-1d", -12),
+            Arguments.of("-12", "%-2d", -12),
+            Arguments.of("-12", "%-3d", -12),
+            Arguments.of("-12 ", "%-4d", -12),
+            Arguments.of("-12  ", "%-5d", -12),
+            Arguments.of("-12       ", "%-10d", -12),
+            Arguments.of("-12" + tenMillionBlanks(), "%-10000003d", -12),
+
+            Arguments.of("1.2", "%-1.1f", 1.2),
+            Arguments.of("1.2", "%-2.1f", 1.2),
+            Arguments.of("1.2", "%-3.1f", 1.2),
+            Arguments.of("1.2 ", "%-4.1f", 1.2),
+            Arguments.of("1.2  ", "%-5.1f", 1.2),
+            Arguments.of("1.2       ", "%-10.1f", 1.2),
+            Arguments.of("1.2" + tenMillionBlanks(), "%-10000003.1f", 1.2),
+
+            Arguments.of("-1.2", "%-1.1f", -1.2),
+            Arguments.of("-1.2", "%-2.1f", -1.2),
+            Arguments.of("-1.2", "%-3.1f", -1.2),
+            Arguments.of("-1.2", "%-4.1f", -1.2),
+            Arguments.of("-1.2 ", "%-5.1f", -1.2),
+            Arguments.of("-1.2      ", "%-10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks(), "%-10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedOptionalSign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, mandatory sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatorySign() {
+        return Stream.of(
+            Arguments.of("+12", "%-+1d", 12),
+            Arguments.of("+12", "%-+2d", 12),
+            Arguments.of("+12", "%-+3d", 12),
+            Arguments.of("+12 ", "%-+4d", 12),
+            Arguments.of("+12  ", "%-+5d", 12),
+            Arguments.of("+12       ", "%-+10d", 12),
+            Arguments.of("+12" + tenMillionBlanks(), "%-+10000003d", 12),
+
+            Arguments.of("-12", "%-+1d", -12),
+            Arguments.of("-12", "%-+2d", -12),
+            Arguments.of("-12", "%-+3d", -12),
+            Arguments.of("-12 ", "%-+4d", -12),
+            Arguments.of("-12  ", "%-+5d", -12),
+            Arguments.of("-12       ", "%-+10d", -12),
+            Arguments.of("-12" + tenMillionBlanks(), "%-+10000003d", -12),
+
+            Arguments.of("+1.2", "%-+1.1f", 1.2),
+            Arguments.of("+1.2", "%-+2.1f", 1.2),
+            Arguments.of("+1.2", "%-+3.1f", 1.2),
+            Arguments.of("+1.2", "%-+4.1f", 1.2),
+            Arguments.of("+1.2 ", "%-+5.1f", 1.2),
+            Arguments.of("+1.2      ", "%-+10.1f", 1.2),
+            Arguments.of("+1.2" + tenMillionBlanks(), "%-+10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%-+1.1f", -1.2),
+            Arguments.of("-1.2", "%-+2.1f", -1.2),
+            Arguments.of("-1.2", "%-+3.1f", -1.2),
+            Arguments.of("-1.2", "%-+4.1f", -1.2),
+            Arguments.of("-1.2 ", "%-+5.1f", -1.2),
+            Arguments.of("-1.2      ", "%-+10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks(), "%-+10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* blank padding, left adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatoryBlank() {
+        return Stream.of(
+            Arguments.of(" 12", "%- 1d", 12),
+            Arguments.of(" 12", "%- 2d", 12),
+            Arguments.of(" 12", "%- 3d", 12),
+            Arguments.of(" 12 ", "%- 4d", 12),
+            Arguments.of(" 12  ", "%- 5d", 12),
+            Arguments.of(" 12       ", "%- 10d", 12),
+            Arguments.of(" 12" + tenMillionBlanks(), "%- 10000003d", 12),
+
+            Arguments.of("-12", "%- 1d", -12),
+            Arguments.of("-12", "%- 2d", -12),
+            Arguments.of("-12", "%- 3d", -12),
+            Arguments.of("-12 ", "%- 4d", -12),
+            Arguments.of("-12  ", "%- 5d", -12),
+            Arguments.of("-12       ", "%- 10d", -12),
+            Arguments.of("-12" + tenMillionBlanks(), "%- 10000003d", -12),
+
+            Arguments.of(" 1.2", "%- 1.1f", 1.2),
+            Arguments.of(" 1.2", "%- 2.1f", 1.2),
+            Arguments.of(" 1.2", "%- 3.1f", 1.2),
+            Arguments.of(" 1.2", "%- 4.1f", 1.2),
+            Arguments.of(" 1.2 ", "%- 5.1f", 1.2),
+            Arguments.of(" 1.2      ", "%- 10.1f", 1.2),
+            Arguments.of(" 1.2" + tenMillionBlanks(), "%- 10000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%- 1.1f", -1.2),
+            Arguments.of("-1.2", "%- 2.1f", -1.2),
+            Arguments.of("-1.2", "%- 3.1f", -1.2),
+            Arguments.of("-1.2", "%- 4.1f", -1.2),
+            Arguments.of("-1.2 ", "%- 5.1f", -1.2),
+            Arguments.of("-1.2      ", "%- 10.1f", -1.2),
+            Arguments.of("-1.2" + tenMillionBlanks(), "%- 10000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void blankPaddingLeftAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, optional sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedOptionalSign() {
+        return Stream.of(
+            Arguments.of("12", "%01d", 12),
+            Arguments.of("12", "%02d", 12),
+            Arguments.of("012", "%03d", 12),
+            Arguments.of("0012", "%04d", 12),
+            Arguments.of("00012", "%05d", 12),
+            Arguments.of("0000000012", "%010d", 12),
+            Arguments.of(tenMillionZeros() + "12", "%010000002d", 12),
+
+            Arguments.of("-12", "%01d", -12),
+            Arguments.of("-12", "%02d", -12),
+            Arguments.of("-12", "%03d", -12),
+            Arguments.of("-012", "%04d", -12),
+            Arguments.of("-0012", "%05d", -12),
+            Arguments.of("-000000012", "%010d", -12),
+            Arguments.of("-" + tenMillionZeros() + "12", "%010000003d", -12),
+
+            Arguments.of("1.2", "%01.1f", 1.2),
+            Arguments.of("1.2", "%02.1f", 1.2),
+            Arguments.of("1.2", "%03.1f", 1.2),
+            Arguments.of("01.2", "%04.1f", 1.2),
+            Arguments.of("001.2", "%05.1f", 1.2),
+            Arguments.of("00000001.2", "%010.1f", 1.2),
+            Arguments.of(tenMillionZeros() + "1.2", "%010000003.1f", 1.2),
+
+            Arguments.of("-1.2", "%01.1f", -1.2),
+            Arguments.of("-1.2", "%02.1f", -1.2),
+            Arguments.of("-1.2", "%03.1f", -1.2),
+            Arguments.of("-1.2", "%04.1f", -1.2),
+            Arguments.of("-01.2", "%05.1f", -1.2),
+            Arguments.of("-0000001.2", "%010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros() + "1.2", "%010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedOptionalSign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, mandatory sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatorySign() {
+        return Stream.of(
+            Arguments.of("+12", "%+01d", 12),
+            Arguments.of("+12", "%+02d", 12),
+            Arguments.of("+12", "%+03d", 12),
+            Arguments.of("+012", "%+04d", 12),
+            Arguments.of("+0012", "%+05d", 12),
+            Arguments.of("+000000012", "%+010d", 12),
+            Arguments.of("+" + tenMillionZeros() + "12", "%+010000003d", 12),
+
+            Arguments.of("-12", "%+01d", -12),
+            Arguments.of("-12", "%+02d", -12),
+            Arguments.of("-12", "%+03d", -12),
+            Arguments.of("-012", "%+04d", -12),
+            Arguments.of("-0012", "%+05d", -12),
+            Arguments.of("-000000012", "%+010d", -12),
+            Arguments.of("-" + tenMillionZeros() + "12", "%+010000003d", -12),
+
+            Arguments.of("+1.2", "%+01.1f", 1.2),
+            Arguments.of("+1.2", "%+02.1f", 1.2),
+            Arguments.of("+1.2", "%+03.1f", 1.2),
+            Arguments.of("+1.2", "%+04.1f", 1.2),
+            Arguments.of("+01.2", "%+05.1f", 1.2),
+            Arguments.of("+0000001.2", "%+010.1f", 1.2),
+            Arguments.of("+" + tenMillionZeros() + "1.2", "%+010000004.1f", 1.2),
+
+            Arguments.of("-1.2", "%+01.1f", -1.2),
+            Arguments.of("-1.2", "%+02.1f", -1.2),
+            Arguments.of("-1.2", "%+03.1f", -1.2),
+            Arguments.of("-1.2", "%+04.1f", -1.2),
+            Arguments.of("-01.2", "%+05.1f", -1.2),
+            Arguments.of("-0000001.2", "%+010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros() + "1.2", "%+010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedMandatorySign(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
+
+    /* zero padding, right adjusted, mandatory blank sign */
+    static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatoryBlank() {
+        return Stream.of(
+            Arguments.of(" 12", "% 01d", 12),
+            Arguments.of(" 12", "% 02d", 12),
+            Arguments.of(" 12", "% 03d", 12),
+            Arguments.of(" 012", "% 04d", 12),
+            Arguments.of(" 0012", "% 05d", 12),
+            Arguments.of(" 000000012", "% 010d", 12),
+            Arguments.of(" " + tenMillionZeros() + "12", "% 010000003d", 12),
+
+            Arguments.of("-12", "% 01d", -12),
+            Arguments.of("-12", "% 02d", -12),
+            Arguments.of("-12", "% 03d", -12),
+            Arguments.of("-012", "% 04d", -12),
+            Arguments.of("-0012", "% 05d", -12),
+            Arguments.of("-000000012", "% 010d", -12),
+            Arguments.of("-" + tenMillionZeros() + "12", "% 010000003d", -12),
+
+            Arguments.of(" 1.2", "% 01.1f", 1.2),
+            Arguments.of(" 1.2", "% 02.1f", 1.2),
+            Arguments.of(" 1.2", "% 03.1f", 1.2),
+            Arguments.of(" 1.2", "% 04.1f", 1.2),
+            Arguments.of(" 01.2", "% 05.1f", 1.2),
+            Arguments.of(" 0000001.2", "% 010.1f", 1.2),
+            Arguments.of(" " + tenMillionZeros() + "1.2", "% 010000004.1f", 1.2),
+
+            Arguments.of("-1.2", "% 01.1f", -1.2),
+            Arguments.of("-1.2", "% 02.1f", -1.2),
+            Arguments.of("-1.2", "% 03.1f", -1.2),
+            Arguments.of("-1.2", "% 04.1f", -1.2),
+            Arguments.of("-01.2", "% 05.1f", -1.2),
+            Arguments.of("-0000001.2", "% 010.1f", -1.2),
+            Arguments.of("-" + tenMillionZeros() + "1.2", "% 010000004.1f", -1.2));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void zeroPaddingRightAdjustedMandatoryBlank(String expected, String format, Object value) {
+        assertEquals(expected, String.format(Locale.US, format, value));
+    }
 }

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -39,16 +39,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Padding {
-
-    private static final String tenMillionZeros() {
-        return "0".repeat(10_000_000);
-    }
-    private static final String tenMillionBlanks() {
-        return " ".repeat(10_000_000);
-    }
-
     /* blank padding, right adjusted, optional sign */
     static Stream<? extends Arguments> blankPaddingRightAdjustedOptionalSign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of("12", "%1d", 12),
             Arguments.of("12", "%2d", 12),
@@ -56,7 +49,7 @@ public class Padding {
             Arguments.of("  12", "%4d", 12),
             Arguments.of("   12", "%5d", 12),
             Arguments.of("        12", "%10d", 12),
-            Arguments.of(tenMillionBlanks() + "12", "%10000002d", 12),
+            Arguments.of(tenMillionBlanks + "12", "%10000002d", 12),
 
             Arguments.of("-12", "%1d", -12),
             Arguments.of("-12", "%2d", -12),
@@ -64,7 +57,7 @@ public class Padding {
             Arguments.of(" -12", "%4d", -12),
             Arguments.of("  -12", "%5d", -12),
             Arguments.of("       -12", "%10d", -12),
-            Arguments.of(tenMillionBlanks() + "-12", "%10000003d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "%10000003d", -12),
 
             Arguments.of("1.2", "%1.1f", 1.2),
             Arguments.of("1.2", "%2.1f", 1.2),
@@ -72,7 +65,7 @@ public class Padding {
             Arguments.of(" 1.2", "%4.1f", 1.2),
             Arguments.of("  1.2", "%5.1f", 1.2),
             Arguments.of("       1.2", "%10.1f", 1.2),
-            Arguments.of(tenMillionBlanks() + "1.2", "%10000003.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "1.2", "%10000003.1f", 1.2),
 
             Arguments.of("-1.2", "%1.1f", -1.2),
             Arguments.of("-1.2", "%2.1f", -1.2),
@@ -80,7 +73,7 @@ public class Padding {
             Arguments.of("-1.2", "%4.1f", -1.2),
             Arguments.of(" -1.2", "%5.1f", -1.2),
             Arguments.of("      -1.2", "%10.1f", -1.2),
-            Arguments.of(tenMillionBlanks() + "-1.2", "%10000004.1f", -1.2));
+            Arguments.of(tenMillionBlanks + "-1.2", "%10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -91,6 +84,7 @@ public class Padding {
 
     /* blank padding, right adjusted, mandatory sign */
     static Stream<? extends Arguments> blankPaddingRightAdjustedMandatorySign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of("+12", "%+1d", 12),
             Arguments.of("+12", "%+2d", 12),
@@ -98,7 +92,7 @@ public class Padding {
             Arguments.of(" +12", "%+4d", 12),
             Arguments.of("  +12", "%+5d", 12),
             Arguments.of("       +12", "%+10d", 12),
-            Arguments.of(tenMillionBlanks() + "+12", "%+10000003d", 12),
+            Arguments.of(tenMillionBlanks + "+12", "%+10000003d", 12),
 
             Arguments.of("-12", "%+1d", -12),
             Arguments.of("-12", "%+2d", -12),
@@ -106,7 +100,7 @@ public class Padding {
             Arguments.of(" -12", "%+4d", -12),
             Arguments.of("  -12", "%+5d", -12),
             Arguments.of("       -12", "%+10d", -12),
-            Arguments.of(tenMillionBlanks() + "-12", "%+10000003d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "%+10000003d", -12),
 
             Arguments.of("+1.2", "%+1.1f", 1.2),
             Arguments.of("+1.2", "%+2.1f", 1.2),
@@ -114,7 +108,7 @@ public class Padding {
             Arguments.of("+1.2", "%+4.1f", 1.2),
             Arguments.of(" +1.2", "%+5.1f", 1.2),
             Arguments.of("      +1.2", "%+10.1f", 1.2),
-            Arguments.of(tenMillionBlanks() + "+1.2", "%+10000004.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "+1.2", "%+10000004.1f", 1.2),
 
             Arguments.of("-1.2", "%+1.1f", -1.2),
             Arguments.of("-1.2", "%+2.1f", -1.2),
@@ -122,7 +116,7 @@ public class Padding {
             Arguments.of("-1.2", "%+4.1f", -1.2),
             Arguments.of(" -1.2", "%+5.1f", -1.2),
             Arguments.of("      -1.2", "%+10.1f", -1.2),
-            Arguments.of(tenMillionBlanks() + "-1.2", "%+10000004.1f", -1.2));
+            Arguments.of(tenMillionBlanks + "-1.2", "%+10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -133,6 +127,7 @@ public class Padding {
 
     /* blank padding, right adjusted, mandatory blank sign */
     static Stream<? extends Arguments> blankPaddingRightAdjustedMandatoryBlank() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of(" 12", "% 1d", 12),
             Arguments.of(" 12", "% 2d", 12),
@@ -140,7 +135,7 @@ public class Padding {
             Arguments.of("  12", "% 4d", 12),
             Arguments.of("   12", "% 5d", 12),
             Arguments.of("        12", "% 10d", 12),
-            Arguments.of(tenMillionBlanks() + "12", "% 10000002d", 12),
+            Arguments.of(tenMillionBlanks + "12", "% 10000002d", 12),
 
             Arguments.of("-12", "% 1d", -12),
             Arguments.of("-12", "% 2d", -12),
@@ -148,7 +143,7 @@ public class Padding {
             Arguments.of(" -12", "% 4d", -12),
             Arguments.of("  -12", "% 5d", -12),
             Arguments.of("       -12", "% 10d", -12),
-            Arguments.of(tenMillionBlanks() + "-12", "% 10000003d", -12),
+            Arguments.of(tenMillionBlanks + "-12", "% 10000003d", -12),
 
             Arguments.of(" 1.2", "% 1.1f", 1.2),
             Arguments.of(" 1.2", "% 2.1f", 1.2),
@@ -156,7 +151,7 @@ public class Padding {
             Arguments.of(" 1.2", "% 4.1f", 1.2),
             Arguments.of("  1.2", "% 5.1f", 1.2),
             Arguments.of("       1.2", "% 10.1f", 1.2),
-            Arguments.of(tenMillionBlanks() + "1.2", "% 10000003.1f", 1.2),
+            Arguments.of(tenMillionBlanks + "1.2", "% 10000003.1f", 1.2),
 
             Arguments.of("-1.2", "% 1.1f", -1.2),
             Arguments.of("-1.2", "% 2.1f", -1.2),
@@ -164,7 +159,7 @@ public class Padding {
             Arguments.of("-1.2", "% 4.1f", -1.2),
             Arguments.of(" -1.2", "% 5.1f", -1.2),
             Arguments.of("      -1.2", "% 10.1f", -1.2),
-            Arguments.of(tenMillionBlanks() + "-1.2", "% 10000004.1f", -1.2));
+            Arguments.of(tenMillionBlanks + "-1.2", "% 10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -175,6 +170,7 @@ public class Padding {
 
     /* blank padding, left adjusted, optional sign */
     static Stream<? extends Arguments> blankPaddingLeftAdjustedOptionalSign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of("12", "%-1d", 12),
             Arguments.of("12", "%-2d", 12),
@@ -182,7 +178,7 @@ public class Padding {
             Arguments.of("12  ", "%-4d", 12),
             Arguments.of("12   ", "%-5d", 12),
             Arguments.of("12        ", "%-10d", 12),
-            Arguments.of("12" + tenMillionBlanks(), "%-10000002d", 12),
+            Arguments.of("12" + tenMillionBlanks, "%-10000002d", 12),
 
             Arguments.of("-12", "%-1d", -12),
             Arguments.of("-12", "%-2d", -12),
@@ -190,7 +186,7 @@ public class Padding {
             Arguments.of("-12 ", "%-4d", -12),
             Arguments.of("-12  ", "%-5d", -12),
             Arguments.of("-12       ", "%-10d", -12),
-            Arguments.of("-12" + tenMillionBlanks(), "%-10000003d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%-10000003d", -12),
 
             Arguments.of("1.2", "%-1.1f", 1.2),
             Arguments.of("1.2", "%-2.1f", 1.2),
@@ -198,7 +194,7 @@ public class Padding {
             Arguments.of("1.2 ", "%-4.1f", 1.2),
             Arguments.of("1.2  ", "%-5.1f", 1.2),
             Arguments.of("1.2       ", "%-10.1f", 1.2),
-            Arguments.of("1.2" + tenMillionBlanks(), "%-10000003.1f", 1.2),
+            Arguments.of("1.2" + tenMillionBlanks, "%-10000003.1f", 1.2),
 
             Arguments.of("-1.2", "%-1.1f", -1.2),
             Arguments.of("-1.2", "%-2.1f", -1.2),
@@ -206,7 +202,7 @@ public class Padding {
             Arguments.of("-1.2", "%-4.1f", -1.2),
             Arguments.of("-1.2 ", "%-5.1f", -1.2),
             Arguments.of("-1.2      ", "%-10.1f", -1.2),
-            Arguments.of("-1.2" + tenMillionBlanks(), "%-10000004.1f", -1.2));
+            Arguments.of("-1.2" + tenMillionBlanks, "%-10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -217,6 +213,7 @@ public class Padding {
 
     /* blank padding, left adjusted, mandatory sign */
     static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatorySign() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of("+12", "%-+1d", 12),
             Arguments.of("+12", "%-+2d", 12),
@@ -224,7 +221,7 @@ public class Padding {
             Arguments.of("+12 ", "%-+4d", 12),
             Arguments.of("+12  ", "%-+5d", 12),
             Arguments.of("+12       ", "%-+10d", 12),
-            Arguments.of("+12" + tenMillionBlanks(), "%-+10000003d", 12),
+            Arguments.of("+12" + tenMillionBlanks, "%-+10000003d", 12),
 
             Arguments.of("-12", "%-+1d", -12),
             Arguments.of("-12", "%-+2d", -12),
@@ -232,7 +229,7 @@ public class Padding {
             Arguments.of("-12 ", "%-+4d", -12),
             Arguments.of("-12  ", "%-+5d", -12),
             Arguments.of("-12       ", "%-+10d", -12),
-            Arguments.of("-12" + tenMillionBlanks(), "%-+10000003d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%-+10000003d", -12),
 
             Arguments.of("+1.2", "%-+1.1f", 1.2),
             Arguments.of("+1.2", "%-+2.1f", 1.2),
@@ -240,7 +237,7 @@ public class Padding {
             Arguments.of("+1.2", "%-+4.1f", 1.2),
             Arguments.of("+1.2 ", "%-+5.1f", 1.2),
             Arguments.of("+1.2      ", "%-+10.1f", 1.2),
-            Arguments.of("+1.2" + tenMillionBlanks(), "%-+10000004.1f", 1.2),
+            Arguments.of("+1.2" + tenMillionBlanks, "%-+10000004.1f", 1.2),
 
             Arguments.of("-1.2", "%-+1.1f", -1.2),
             Arguments.of("-1.2", "%-+2.1f", -1.2),
@@ -248,7 +245,7 @@ public class Padding {
             Arguments.of("-1.2", "%-+4.1f", -1.2),
             Arguments.of("-1.2 ", "%-+5.1f", -1.2),
             Arguments.of("-1.2      ", "%-+10.1f", -1.2),
-            Arguments.of("-1.2" + tenMillionBlanks(), "%-+10000004.1f", -1.2));
+            Arguments.of("-1.2" + tenMillionBlanks, "%-+10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -259,6 +256,7 @@ public class Padding {
 
     /* blank padding, left adjusted, mandatory blank sign */
     static Stream<? extends Arguments> blankPaddingLeftAdjustedMandatoryBlank() {
+        var tenMillionBlanks = " ".repeat(10_000_000);
         return Stream.of(
             Arguments.of(" 12", "%- 1d", 12),
             Arguments.of(" 12", "%- 2d", 12),
@@ -266,7 +264,7 @@ public class Padding {
             Arguments.of(" 12 ", "%- 4d", 12),
             Arguments.of(" 12  ", "%- 5d", 12),
             Arguments.of(" 12       ", "%- 10d", 12),
-            Arguments.of(" 12" + tenMillionBlanks(), "%- 10000003d", 12),
+            Arguments.of(" 12" + tenMillionBlanks, "%- 10000003d", 12),
 
             Arguments.of("-12", "%- 1d", -12),
             Arguments.of("-12", "%- 2d", -12),
@@ -274,7 +272,7 @@ public class Padding {
             Arguments.of("-12 ", "%- 4d", -12),
             Arguments.of("-12  ", "%- 5d", -12),
             Arguments.of("-12       ", "%- 10d", -12),
-            Arguments.of("-12" + tenMillionBlanks(), "%- 10000003d", -12),
+            Arguments.of("-12" + tenMillionBlanks, "%- 10000003d", -12),
 
             Arguments.of(" 1.2", "%- 1.1f", 1.2),
             Arguments.of(" 1.2", "%- 2.1f", 1.2),
@@ -282,7 +280,7 @@ public class Padding {
             Arguments.of(" 1.2", "%- 4.1f", 1.2),
             Arguments.of(" 1.2 ", "%- 5.1f", 1.2),
             Arguments.of(" 1.2      ", "%- 10.1f", 1.2),
-            Arguments.of(" 1.2" + tenMillionBlanks(), "%- 10000004.1f", 1.2),
+            Arguments.of(" 1.2" + tenMillionBlanks, "%- 10000004.1f", 1.2),
 
             Arguments.of("-1.2", "%- 1.1f", -1.2),
             Arguments.of("-1.2", "%- 2.1f", -1.2),
@@ -290,7 +288,7 @@ public class Padding {
             Arguments.of("-1.2", "%- 4.1f", -1.2),
             Arguments.of("-1.2 ", "%- 5.1f", -1.2),
             Arguments.of("-1.2      ", "%- 10.1f", -1.2),
-            Arguments.of("-1.2" + tenMillionBlanks(), "%- 10000004.1f", -1.2));
+            Arguments.of("-1.2" + tenMillionBlanks, "%- 10000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -301,6 +299,7 @@ public class Padding {
 
     /* zero padding, right adjusted, optional sign */
     static Stream<? extends Arguments> zeroPaddingRightAdjustedOptionalSign() {
+        var tenMillionZeros = "0".repeat(10_000_000);
         return Stream.of(
             Arguments.of("12", "%01d", 12),
             Arguments.of("12", "%02d", 12),
@@ -308,7 +307,7 @@ public class Padding {
             Arguments.of("0012", "%04d", 12),
             Arguments.of("00012", "%05d", 12),
             Arguments.of("0000000012", "%010d", 12),
-            Arguments.of(tenMillionZeros() + "12", "%010000002d", 12),
+            Arguments.of(tenMillionZeros + "12", "%010000002d", 12),
 
             Arguments.of("-12", "%01d", -12),
             Arguments.of("-12", "%02d", -12),
@@ -316,7 +315,7 @@ public class Padding {
             Arguments.of("-012", "%04d", -12),
             Arguments.of("-0012", "%05d", -12),
             Arguments.of("-000000012", "%010d", -12),
-            Arguments.of("-" + tenMillionZeros() + "12", "%010000003d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "%010000003d", -12),
 
             Arguments.of("1.2", "%01.1f", 1.2),
             Arguments.of("1.2", "%02.1f", 1.2),
@@ -324,7 +323,7 @@ public class Padding {
             Arguments.of("01.2", "%04.1f", 1.2),
             Arguments.of("001.2", "%05.1f", 1.2),
             Arguments.of("00000001.2", "%010.1f", 1.2),
-            Arguments.of(tenMillionZeros() + "1.2", "%010000003.1f", 1.2),
+            Arguments.of(tenMillionZeros + "1.2", "%010000003.1f", 1.2),
 
             Arguments.of("-1.2", "%01.1f", -1.2),
             Arguments.of("-1.2", "%02.1f", -1.2),
@@ -332,7 +331,7 @@ public class Padding {
             Arguments.of("-1.2", "%04.1f", -1.2),
             Arguments.of("-01.2", "%05.1f", -1.2),
             Arguments.of("-0000001.2", "%010.1f", -1.2),
-            Arguments.of("-" + tenMillionZeros() + "1.2", "%010000004.1f", -1.2));
+            Arguments.of("-" + tenMillionZeros + "1.2", "%010000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -343,6 +342,7 @@ public class Padding {
 
     /* zero padding, right adjusted, mandatory sign */
     static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatorySign() {
+        var tenMillionZeros = "0".repeat(10_000_000);
         return Stream.of(
             Arguments.of("+12", "%+01d", 12),
             Arguments.of("+12", "%+02d", 12),
@@ -350,7 +350,7 @@ public class Padding {
             Arguments.of("+012", "%+04d", 12),
             Arguments.of("+0012", "%+05d", 12),
             Arguments.of("+000000012", "%+010d", 12),
-            Arguments.of("+" + tenMillionZeros() + "12", "%+010000003d", 12),
+            Arguments.of("+" + tenMillionZeros + "12", "%+010000003d", 12),
 
             Arguments.of("-12", "%+01d", -12),
             Arguments.of("-12", "%+02d", -12),
@@ -358,7 +358,7 @@ public class Padding {
             Arguments.of("-012", "%+04d", -12),
             Arguments.of("-0012", "%+05d", -12),
             Arguments.of("-000000012", "%+010d", -12),
-            Arguments.of("-" + tenMillionZeros() + "12", "%+010000003d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "%+010000003d", -12),
 
             Arguments.of("+1.2", "%+01.1f", 1.2),
             Arguments.of("+1.2", "%+02.1f", 1.2),
@@ -366,7 +366,7 @@ public class Padding {
             Arguments.of("+1.2", "%+04.1f", 1.2),
             Arguments.of("+01.2", "%+05.1f", 1.2),
             Arguments.of("+0000001.2", "%+010.1f", 1.2),
-            Arguments.of("+" + tenMillionZeros() + "1.2", "%+010000004.1f", 1.2),
+            Arguments.of("+" + tenMillionZeros + "1.2", "%+010000004.1f", 1.2),
 
             Arguments.of("-1.2", "%+01.1f", -1.2),
             Arguments.of("-1.2", "%+02.1f", -1.2),
@@ -374,7 +374,7 @@ public class Padding {
             Arguments.of("-1.2", "%+04.1f", -1.2),
             Arguments.of("-01.2", "%+05.1f", -1.2),
             Arguments.of("-0000001.2", "%+010.1f", -1.2),
-            Arguments.of("-" + tenMillionZeros() + "1.2", "%+010000004.1f", -1.2));
+            Arguments.of("-" + tenMillionZeros + "1.2", "%+010000004.1f", -1.2));
     }
 
     @ParameterizedTest
@@ -385,6 +385,7 @@ public class Padding {
 
     /* zero padding, right adjusted, mandatory blank sign */
     static Stream<? extends Arguments> zeroPaddingRightAdjustedMandatoryBlank() {
+        var tenMillionZeros = "0".repeat(10_000_000);
         return Stream.of(
             Arguments.of(" 12", "% 01d", 12),
             Arguments.of(" 12", "% 02d", 12),
@@ -392,7 +393,7 @@ public class Padding {
             Arguments.of(" 012", "% 04d", 12),
             Arguments.of(" 0012", "% 05d", 12),
             Arguments.of(" 000000012", "% 010d", 12),
-            Arguments.of(" " + tenMillionZeros() + "12", "% 010000003d", 12),
+            Arguments.of(" " + tenMillionZeros + "12", "% 010000003d", 12),
 
             Arguments.of("-12", "% 01d", -12),
             Arguments.of("-12", "% 02d", -12),
@@ -400,7 +401,7 @@ public class Padding {
             Arguments.of("-012", "% 04d", -12),
             Arguments.of("-0012", "% 05d", -12),
             Arguments.of("-000000012", "% 010d", -12),
-            Arguments.of("-" + tenMillionZeros() + "12", "% 010000003d", -12),
+            Arguments.of("-" + tenMillionZeros + "12", "% 010000003d", -12),
 
             Arguments.of(" 1.2", "% 01.1f", 1.2),
             Arguments.of(" 1.2", "% 02.1f", 1.2),
@@ -408,7 +409,7 @@ public class Padding {
             Arguments.of(" 1.2", "% 04.1f", 1.2),
             Arguments.of(" 01.2", "% 05.1f", 1.2),
             Arguments.of(" 0000001.2", "% 010.1f", 1.2),
-            Arguments.of(" " + tenMillionZeros() + "1.2", "% 010000004.1f", 1.2),
+            Arguments.of(" " + tenMillionZeros + "1.2", "% 010000004.1f", 1.2),
 
             Arguments.of("-1.2", "% 01.1f", -1.2),
             Arguments.of("-1.2", "% 02.1f", -1.2),
@@ -416,7 +417,7 @@ public class Padding {
             Arguments.of("-1.2", "% 04.1f", -1.2),
             Arguments.of("-01.2", "% 05.1f", -1.2),
             Arguments.of("-0000001.2", "% 010.1f", -1.2),
-            Arguments.of("-" + tenMillionZeros() + "1.2", "% 010000004.1f", -1.2));
+            Arguments.of("-" + tenMillionZeros + "1.2", "% 010000004.1f", -1.2));
     }
 
     @ParameterizedTest

--- a/test/jdk/java/util/Formatter/Padding.java
+++ b/test/jdk/java/util/Formatter/Padding.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 4906370 8299677 8326718
- * @summary Tests to excercise padding on int and double values,
+ * @bug 4906370 8299677 8326718 8328037
+ * @summary Tests to exercise padding on int and double values,
  *      with various flag combinations.
  * @run junit Padding
  */


### PR DESCRIPTION
4f336085d1098e7fba7b58f0a73c028179a2a13d ([JDK-8326718](https://bugs.openjdk.org/browse/JDK-8326718)) added a few cases to test java/util/Formatter/Padding.java with huge Strings as arguments. Since all possible argument combinations for the test are stored in one array, nothing can be garbage collected while the test is running and the heap requirement is blown up.

In one of our test pipelines we run tier1 tests with VMs that default to 384M of heap and this is not sufficient any longer.

I'm improving this by splitting the one large @ParameterizedTest into multiple ones. With that, I could run the test successfully in a test VM with 96M of heap, e.g. by modifying `@run junit Padding` to `@run junit/othervm -Xmx96m Padding`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328037](https://bugs.openjdk.org/browse/JDK-8328037): Test java/util/Formatter/Padding.java has unnecessary high heap requirement after JDK-8326718 (**Enhancement** - P3)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18264/head:pull/18264` \
`$ git checkout pull/18264`

Update a local copy of the PR: \
`$ git checkout pull/18264` \
`$ git pull https://git.openjdk.org/jdk.git pull/18264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18264`

View PR using the GUI difftool: \
`$ git pr show -t 18264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18264.diff">https://git.openjdk.org/jdk/pull/18264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18264#issuecomment-1993762350)