### PR TITLE
8328064: Remove obsolete comments in constantPool and metadataFactory

### DIFF
--- a/src/hotspot/share/memory/metadataFactory.hpp
+++ b/src/hotspot/share/memory/metadataFactory.hpp
@@ -36,8 +36,6 @@ class MetadataFactory : AllStatic {
  public:
   template <typename T>
   static Array<T>* new_array(ClassLoaderData* loader_data, int length, TRAPS) {
-    // The "true" argument is because all metadata arrays are read only when
-    // dumped to the shared archive
     return new (loader_data, length, THREAD) Array<T>(length);
   }
 

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -155,7 +155,7 @@ void ConstantPool::metaspace_pointers_do(MetaspaceClosure* it) {
 
   for (int i = 0; i < length(); i++) {
     // The only MSO's embedded in the CP entries are Symbols:
-    //   JVM_CONSTANT_String (normal and pseudo)
+    //   JVM_CONSTANT_String
     //   JVM_CONSTANT_Utf8
     constantTag ctag = tag_at(i);
     if (ctag.is_string() || ctag.is_utf8()) {


### PR DESCRIPTION
Clean up some obsolete comments:
After 8243287, there is no longer the concept of "pseudo-string";
After 8072061, the "read_only" argument that the comment is referring to is removed.

Cheers

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328064](https://bugs.openjdk.org/browse/JDK-8328064): Remove obsolete comments in constantPool and metadataFactory (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18266/head:pull/18266` \
`$ git checkout pull/18266`

Update a local copy of the PR: \
`$ git checkout pull/18266` \
`$ git pull https://git.openjdk.org/jdk.git pull/18266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18266`

View PR using the GUI difftool: \
`$ git pr show -t 18266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18266.diff">https://git.openjdk.org/jdk/pull/18266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18266#issuecomment-1993930365)