### PR TITLE
8327991: Improve HttpClient documentation with regard to reclaiming resources

### DIFF
--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -135,8 +135,8 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  *
  * @implNote
  *  <p id="streaming">
- *  The HttpClient {@link BodyHandlers} and {@link BodySubscribers}
- *  API provide some {@linkplain BodySubscribers##streaming-body streaming
+ *  The {@link BodyHandlers} and {@link BodySubscribers}
+ *  classes provide some {@linkplain BodySubscribers##streaming-body streaming
  *  or publishing {@code BodyHandler} and {@code BodySubscriber}
  *  implementations} which allow to stream body data back to the caller.
  *  In order for the resources associated with these streams to be

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -714,7 +714,7 @@ public abstract class HttpClient implements AutoCloseable {
      *          information.</li>
      * </ul>
      *
-     * <p> The default {@code HttpClient} implementation returns
+     * <p id="cancel"> The default {@code HttpClient} implementation returns
      * {@code CompletableFuture} objects that are <em>cancelable</em>.
      * {@code CompletableFuture} objects {@linkplain CompletableFuture#newIncompleteFuture()
      * derived} from cancelable futures are themselves <em>cancelable</em>.

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -140,8 +140,9 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  *  or publishing {@code BodyHandler} and {@code BodySubscriber}
  *  implementations} which allow to stream body data back to the caller.
  *  In order for the resources associated with these streams to be
- *  reclaimed, a caller must eventually {@linkplain  HttpResponse#body()
- *  obtain these streaming response body} and close, cancel, or
+ *  reclaimed, and for the HTTP request to be considered completed,
+ *  a caller must eventually {@linkplain  HttpResponse#body()
+ *  obtain the streaming response body} and close, cancel, or
  *  read the returned streams to exhaustion. Likewise, a custom
  *  {@link BodySubscriber} implementation should either {@linkplain
  *  Subscription#request(long) request} all data until {@link
@@ -156,7 +157,9 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * provide a best effort implementation. Failing to close, cancel, or
  * read {@link ##streaming streaming bodies} to exhaustion may stop
  * delivery of data and {@linkplain #awaitTermination(Duration) stall an
- * orderly shutdown}.
+ * orderly shutdown}. The {@link #shutdownNow()} method will attempt
+ * to cancel any such non-completed requests, but may cause
+ * abrupt termination of any on going operation.
  *
  * <p id="gc">
  * If not {@linkplain ##closing explicitly closed}, the JDK

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetAddress;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse.BodySubscribers;
 import java.nio.channels.Selector;
 import java.net.Authenticator;
 import java.net.CookieHandler;
@@ -132,21 +134,43 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * reclaimed early by {@linkplain #close() closing} the client.
  *
  * @implNote
- *  <p id="closing">
- *  The JDK built-in implementation of the {@code HttpClient} overrides
+ *  <p id="streaming">
+ *  The HttpClient {@link BodyHandlers} and {@link BodySubscribers}
+ *  API provide some {@linkplain BodySubscribers##streaming-body streaming
+ *  or publishing {@code BodyHandler} and {@code BodySubscriber}
+ *  implementations} which allow to stream body data back to the caller.
+ *  In order for the resources associated with these streams to be
+ *  reclaimed, a caller must eventually {@linkplain  HttpResponse#body()
+ *  obtain these streaming response body} and close, cancel, or
+ *  read the returned streams to exhaustion. Likewise, a custom
+ *  {@link BodySubscriber} implementation should either {@linkplain
+ *  Subscription#request(long) request} all data until {@link
+ *  BodySubscriber#onComplete() onComplete} or {@link
+ *  BodySubscriber#onError(Throwable) onError} is signalled, or eventually
+ *  {@linkplain Subscription#cancel() cancel} its subscription.
+ *
+ * <p id="closing">
+ * The JDK built-in implementation of the {@code HttpClient} overrides
  * {@link #close()}, {@link #shutdown()}, {@link #shutdownNow()},
  * {@link #awaitTermination(Duration)}, and {@link #isTerminated()} to
  * provide a best effort implementation. Failing to close, cancel, or
- * read returned streams to exhaustion, such as streams provided when using
- * {@link BodyHandlers#ofInputStream()}, {@link BodyHandlers#ofLines()}, or
- * {@link BodyHandlers#ofPublisher()}, may prevent requests submitted
- * before an {@linkplain #shutdown() orderly shutdown}
- * to run to completion. Likewise, failing to
- * {@linkplain Subscription#request(long) request data} or {@linkplain
- * Subscription#cancel() cancel subscriptions} from a custom {@linkplain
- * java.net.http.HttpResponse.BodySubscriber BodySubscriber} may stop
+ * read {@link ##streaming streaming bodies} to exhaustion may stop
  * delivery of data and {@linkplain #awaitTermination(Duration) stall an
  * orderly shutdown}.
+ *
+ * <p id="gc">
+ * If not {@linkplain ##closing explicitly closed}, the JDK
+ * built-in implementation of the {@code HttpClient} releases
+ * its resources when an {@code HttpClient} instance is no longer
+ * strongly reachable, and all operations started on that instance have
+ * eventually completed. This relies both on the garbage collector
+ * to notice that the instance is no longer reachable, and on all
+ * requests started on the client to eventually complete. Failure
+ * to properly close {@linkplain ##streaming streaming bodies} may
+ * prevent the associated requests from running to completion, and
+ * prevent the resources allocated by the associated client from
+ * being reclaimed by the garbage collector.
+ *
  *
  * <p>
  * If an explicit {@linkplain HttpClient.Builder#executor(Executor)
@@ -155,7 +179,7 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * dependent tasks in a context that is granted no permissions. Custom
  * {@linkplain HttpRequest.BodyPublisher request body publishers}, {@linkplain
  * HttpResponse.BodyHandler response body handlers}, {@linkplain
- * HttpResponse.BodySubscriber response body subscribers}, and {@linkplain
+ * BodySubscriber response body subscribers}, and {@linkplain
  * WebSocket.Listener WebSocket Listeners}, if executing operations that require
  * privileges, should do so within an appropriate {@linkplain
  * AccessController#doPrivileged(PrivilegedAction) privileged context}.

--- a/src/java.net.http/share/classes/java/net/http/HttpClient.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpClient.java
@@ -155,10 +155,11 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * {@link #close()}, {@link #shutdown()}, {@link #shutdownNow()},
  * {@link #awaitTermination(Duration)}, and {@link #isTerminated()} to
  * provide a best effort implementation. Failing to close, cancel, or
- * read {@link ##streaming streaming bodies} to exhaustion may stop
- * delivery of data and {@linkplain #awaitTermination(Duration) stall an
- * orderly shutdown}. The {@link #shutdownNow()} method will attempt
- * to cancel any such non-completed requests, but may cause
+ * read {@link ##streaming streaming or publishing bodies} to exhaustion
+ * may stop delivery of data while leaving the request open, and
+ * {@linkplain #awaitTermination(Duration) stall an
+ * orderly shutdown}. The {@link #shutdownNow()} method, if called, will
+ * attempt to cancel any such non-completed requests, but may cause
  * abrupt termination of any on going operation.
  *
  * <p id="gc">
@@ -169,8 +170,8 @@ import jdk.internal.net.http.HttpClientBuilderImpl;
  * eventually completed. This relies both on the garbage collector
  * to notice that the instance is no longer reachable, and on all
  * requests started on the client to eventually complete. Failure
- * to properly close {@linkplain ##streaming streaming bodies} may
- * prevent the associated requests from running to completion, and
+ * to properly close {@linkplain ##streaming streaming or publishing bodies}
+ * may prevent the associated requests from running to completion, and
  * prevent the resources allocated by the associated client from
  * being reclaimed by the garbage collector.
  *

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1266,7 +1266,7 @@ public interface HttpResponse<T> {
          * from being reused for subsequent operations.
          *
          * @param charset the character set to use when converting bytes to characters
-         * @return a {@linkplain HttpClient##streaming streaming body subscriber} that streams
+         * @return a {@linkplain HttpClient##streaming streaming body subscriber} which streams
          *          the response body as a {@link Stream Stream}{@code <String>}.
          *
          * @see BufferedReader#lines()

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -295,6 +295,13 @@ public interface HttpResponse<T> {
      *   // Discards the response body
      *   HttpResponse<Void> response = client
      *     .send(request, BodyHandlers.discarding());  }
+     *
+     *  @apiNote
+     *  Some {@linkplain HttpResponse#body() body implementations} created by
+     *  {@linkplain BodySubscribers##streaming-body body subscribers} may need to be
+     *  properly closed, read, or cancelled for the associated resources to
+     *  be reclaimed and for the associated request to {@linkplain HttpClient##closing
+     *  run to completion}.
      *
      * @since 11
      */
@@ -633,8 +640,14 @@ public interface HttpResponse<T> {
          *
          * @apiNote See {@link BodySubscribers#ofInputStream()} for more
          * information.
+         * <p>
+         * To ensure that all resources associated with the
+         * corresponding exchange are properly released the caller must
+         * eventually obtain and close the {@linkplain BodySubscribers#ofInputStream()
+         * returned stream}.
          *
-         * @return a response body handler
+         * @return a {@linkplain HttpClient##streaming streaming} response body handler
+         *
          */
         public static BodyHandler<InputStream> ofInputStream() {
             return (responseInfo) -> BodySubscribers.ofInputStream();
@@ -651,7 +664,14 @@ public interface HttpResponse<T> {
          * <p> When the {@code HttpResponse} object is returned, the body may
          * not have been completely received.
          *
-         * @return a response body handler
+         * @apiNote
+         * To ensure that all resources associated with the
+         * corresponding exchange are properly released the caller must
+         * eventually obtain and close the {@linkplain BodySubscribers#ofLines(Charset)
+         * returned stream}.
+         *
+         * @return a {@linkplain HttpClient##streaming streaming} response body handler
+         *
          */
         public static BodyHandler<Stream<String>> ofLines() {
             return (responseInfo) ->
@@ -726,10 +746,17 @@ public interface HttpResponse<T> {
          * response bytes can be obtained as they are received. The publisher
          * can and must be subscribed to only once.
          *
-         * @apiNote See {@link BodySubscribers#ofPublisher()} for more
+         * @apiNote
+         * See {@link BodySubscribers#ofPublisher()} for more
          * information.
+         * <p>
+         * To ensure that all resources associated with the
+         * corresponding exchange are properly released the caller must
+         * subscribe to the publisher and conform to the rules outlined in
+         * {@linkplain BodySubscribers#ofPublisher()}
          *
-         * @return a response body handler
+         * @return a {@linkplain HttpClient##streaming publishing} response body handler
+         *
          */
         public static BodyHandler<Publisher<List<ByteBuffer>>> ofPublisher() {
             return (responseInfo) -> BodySubscribers.ofPublisher();
@@ -840,7 +867,7 @@ public interface HttpResponse<T> {
          * already be completed at this point.
          *
          * @param <T> the push promise response body type
-         * @param pushPromiseHandler t he body handler to use for push promises
+         * @param pushPromiseHandler the body handler to use for push promises
          * @param pushPromisesMap a map to accumulate push promises into
          * @return a push promise handler
          */
@@ -936,6 +963,20 @@ public interface HttpResponse<T> {
      *   HttpResponse<byte[]> response = client
      *     .send(request, responseInfo ->
      *        BodySubscribers.mapping(BodySubscribers.ofString(UTF_8), String::getBytes)); }
+     *
+     *  @apiNote
+     *  <p id="streaming-body">
+     *  Some {@linkplain HttpResponse#body() body implementations} created by
+     *  {@linkplain BodySubscriber#getBody() body subscribers} may allow response bytes
+     *  to be streamed to the caller. These implementations are typically
+     *  {@link AutoCloseable} and may need to be explicitly closed in order for
+     *  the resources associated with the request and the client to be {@linkplain
+     *  HttpClient##closing eventually reclaimed}.
+     *  Some other implementations are {@linkplain  Publisher publishers} which need to be
+     *  {@link BodySubscribers#ofPublisher() subscribed} in order for their associated
+     *  resources to be released and for the associated request to {@linkplain
+     *  HttpClient##closing run to completion}.
+     *
      *
      * @since 11
      */
@@ -1168,7 +1209,7 @@ public interface HttpResponse<T> {
          * amount of data is delivered in a timely fashion.
          *
          * @param consumer a Consumer of byte arrays
-         * @return a BodySubscriber
+         * @return a body subscriber
          */
         public static BodySubscriber<Void>
         ofByteArrayConsumer(Consumer<Optional<byte[]>> consumer) {
@@ -1199,8 +1240,8 @@ public interface HttpResponse<T> {
          * while blocking on read. In that case, the request will also be
          * cancelled and the {@code InputStream} will be closed.
          *
-         * @return a body subscriber that streams the response body as an
-         *         {@link InputStream}.
+         * @return a {@linkplain HttpClient##streaming streaming body subscriber}
+         *         that streams the response body as an {@link InputStream}.
          */
         public static BodySubscriber<InputStream> ofInputStream() {
             return new ResponseSubscribers.HttpResponseInputStream();
@@ -1225,8 +1266,8 @@ public interface HttpResponse<T> {
          * from being reused for subsequent operations.
          *
          * @param charset the character set to use when converting bytes to characters
-         * @return a body subscriber that streams the response body as a
-         *         {@link Stream Stream}{@code <String>}.
+         * @return a {@linkplain HttpClient##streaming streaming body subscriber} that streams
+         *          the response body as a {@link Stream Stream}{@code <String>}.
          *
          * @see BufferedReader#lines()
          */
@@ -1268,8 +1309,10 @@ public interface HttpResponse<T> {
          * HTTP connection to be closed and prevent it from being reused for
          * subsequent operations.
          *
-         * @return A {@code BodySubscriber} which publishes the response body
+         * @return A {@linkplain HttpClient##streaming publishing body subscriber}
+         *         which publishes the response body
          *         through a {@code Publisher<List<ByteBuffer>>}.
+         *
          */
         public static BodySubscriber<Publisher<List<ByteBuffer>>> ofPublisher() {
             return ResponseSubscribers.createPublisher();
@@ -1282,7 +1325,7 @@ public interface HttpResponse<T> {
          *
          * @param <U> the type of the response body
          * @param value the value to return from HttpResponse.body(), may be {@code null}
-         * @return a {@code BodySubscriber}
+         * @return a body subscriber
          */
         public static <U> BodySubscriber<U> replacing(U value) {
             return new ResponseSubscribers.NullSubscriber<>(Optional.ofNullable(value));

--- a/src/java.net.http/share/classes/java/net/http/HttpResponse.java
+++ b/src/java.net.http/share/classes/java/net/http/HttpResponse.java
@@ -1241,7 +1241,7 @@ public interface HttpResponse<T> {
          * cancelled and the {@code InputStream} will be closed.
          *
          * @return a {@linkplain HttpClient##streaming streaming body subscriber}
-         *         that streams the response body as an {@link InputStream}.
+         *         which streams the response body as an {@link InputStream}.
          */
         public static BodySubscriber<InputStream> ofInputStream() {
             return new ResponseSubscribers.HttpResponseInputStream();

--- a/src/java.net.http/share/classes/java/net/http/package-info.java
+++ b/src/java.net.http/share/classes/java/net/http/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.net.http/share/classes/java/net/http/package-info.java
+++ b/src/java.net.http/share/classes/java/net/http/package-info.java
@@ -56,8 +56,10 @@
  * UnsupportedOperationException} for their {@link
  * CompletableFuture#obtrudeValue(Object) obtrudeValue}
  * and {@link CompletableFuture#obtrudeException(Throwable)
- * obtrudeException} methods. Invoking the {@link CompletableFuture#cancel
- * cancel} method on a {@code CompletableFuture} returned by this API may not
+ * obtrudeException} methods. Unless {@linkplain
+ * HttpClient##cancel otherwise specified}, invoking
+ * the {@link CompletableFuture#cancel cancel} method on a
+ * {@code CompletableFuture} returned by this API may not
  * interrupt the underlying operation, but may be useful to complete,
  * exceptionally, dependent stages that have not already completed.
  *


### PR DESCRIPTION
Please find here a doc-only change that tries to better document how resources allocated by the HttpClient are reclaimed.
The `@implNote` in the HttpClient class level API documentation is extended to document what happens if you don't explicitly close the HttpClient. The note is refactored to introduce the notion of streaming or publishing bodies. BodySubscribers and BodyHandlers now have links that link back to the HttpClient API note, as well as identifying methods that return publishing or streaming body implementations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8328100](https://bugs.openjdk.org/browse/JDK-8328100) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8327991](https://bugs.openjdk.org/browse/JDK-8327991): Improve HttpClient documentation with regard to reclaiming resources (**Enhancement** - P3)
 * [JDK-8328100](https://bugs.openjdk.org/browse/JDK-8328100): Improve HttpClient documentation with regard to reclaiming resources (**CSR**)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [4f830897](https://git.openjdk.org/jdk/pull/18270/files/4f830897f8763c8e4641373b5d277df683adb878)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18270/head:pull/18270` \
`$ git checkout pull/18270`

Update a local copy of the PR: \
`$ git checkout pull/18270` \
`$ git pull https://git.openjdk.org/jdk.git pull/18270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18270`

View PR using the GUI difftool: \
`$ git pr show -t 18270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18270.diff">https://git.openjdk.org/jdk/pull/18270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18270#issuecomment-1994552543)