### PR TITLE
8325252: C2 SuperWord: refactor the packset

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1045,9 +1045,10 @@ void SuperWord::extend_pairset_with_more_pairs_by_following_use_and_def() {
   bool changed;
   do {
     changed = false;
-    for (PairSetIterator pair(_pairset); !pair.done(); pair.next()) {
-      Node* s1 = pair.left();
-      Node* s2 = pair.right();
+    // Iterate the pairs in insertion order.
+    for (int i =0; i < _pairset.length(); i++) {
+      Node* s1 = _pairset.left_at(i);
+      Node* s2 = _pairset.right_at(i);
       changed |= extend_pairset_with_more_pairs_by_following_def(s1, s2);
       changed |= extend_pairset_with_more_pairs_by_following_use(s1, s2);
     }
@@ -3786,7 +3787,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
 
 #ifndef PRODUCT
 void PairSet::print() const {
-  tty->print_cr("\nPairSet::print: %d pairs", _pair_counter);
+  tty->print_cr("\nPairSet::print: %d pairs", length());
   int chain = 0;
   int chain_index = 0;
   for (PairSetIterator pair(*this); !pair.done(); pair.next()) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1750,22 +1750,10 @@ void SuperWord::filter_packs_for_alignment() {
   }
 }
 
-// Compress packset, such that it has no nullptr entries
-void SuperWord::compress_packset() {
-  int j = 0;
-  for (int i = 0; i < _packset.length(); i++) {
-    Node_List* p = _packset.at(i);
-    if (p != nullptr) {
-      _packset.at_put(j, p);
-      j++;
-    }
-  }
-  _packset.trunc_to(j);
-}
-
 //-----------------------------construct_my_pack_map--------------------------
 // Construct the map from nodes to packs.  Only valid after the
 // point where a node is only in one pack (after combine_pairs_to_longer_packs).
+// TODO remove / integrate to combine?
 void SuperWord::construct_my_pack_map() {
   for (int i = 0; i < _packset.length(); i++) {
     Node_List* p = _packset.at(i);
@@ -2020,6 +2008,7 @@ bool SuperWord::profitable(const Node_List* p) {
 }
 
 #ifdef ASSERT
+// TODO maybe move, and extend, maybe refactor
 void SuperWord::verify_packs() {
   // Verify independence at pack level.
   for (int i = 0; i < _packset.length(); i++) {
@@ -2430,7 +2419,7 @@ bool SuperWord::output() {
   CountedLoopNode *cl = lpt()->_head->as_CountedLoop();
   assert(cl->is_main_loop(), "SLP should only work on main loops");
   Compile* C = phase()->C;
-  if (_packset.length() == 0) {
+  if (_packset.is_empty()) {
     return false;
   }
 
@@ -3419,6 +3408,7 @@ bool VLoopMemorySlices::same_memory_slice(MemNode* m1, MemNode* m2) const {
 
 //------------------------------remove_pack_at---------------------------
 // Remove the pack at position pos in the packset
+// TODO move to packset
 void SuperWord::remove_pack_at(int pos) {
   Node_List* p = _packset.at(pos);
   for (uint i = 0; i < p->size(); i++) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1245,7 +1245,6 @@ void SuperWord::order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node
 //          Therefore, extend_pairset_with_more_pairs_by_following_use cannot extend to MulAddS2I,
 //          but there is a chance that extend_pairset_with_more_pairs_by_following_def can do it.
 //
-// TODO add some IR tests for all these swapping cases.
 SuperWord::PairOrderStatus SuperWord::order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2) {
   assert(_pairset.has_pair(def1, def2), "(def1, def2) must be a pair");
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -469,8 +469,6 @@ bool SuperWord::SLP_extract() {
 
   combine_pairs_to_longer_packs();
 
-  construct_pack_map();
-
   split_packs_at_use_def_boundaries();  // a first time: create natural boundaries
   split_packs_only_implemented_with_smaller_size();
   split_packs_to_break_mutual_dependence();
@@ -1378,7 +1376,7 @@ void SuperWord::combine_pairs_to_longer_packs() {
         pack->push(right);
         left = right;
       }
-      _packset.append(pack);
+      _packset.add_pack(pack);
     }
   }
 
@@ -1747,27 +1745,6 @@ void SuperWord::filter_packs_for_alignment() {
     // Solution is constrained (not trivial)
     // -> must change pre-limit to achieve alignment
     set_align_to_ref(current->as_constrained()->mem_ref());
-  }
-}
-
-// Construct the map from nodes to packs.  Only valid after the
-// point where a node is only in one pack (after combine_pairs_to_longer_packs).
-// TODO remove / integrate to combine?
-void SuperWord::construct_pack_map() {
-  for (int i = 0; i < _packset.length(); i++) {
-    Node_List* p = _packset.at(i);
-    for (uint j = 0; j < p->size(); j++) {
-      Node* s = p->at(j);
-#ifdef ASSERT
-      if (_packset.pack(s) != nullptr) {
-        s->dump(1);
-        tty->print_cr("packs[%d]:", i);
-        _packset.print_pack(p);
-        assert(false, "only in one pack");
-      }
-#endif
-      _packset.set_pack(s, p);
-    }
   }
 }
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -45,7 +45,7 @@ SuperWord::SuperWord(const VLoopAnalyzer &vloop_analyzer) :
   _node_info(arena(), _vloop.estimated_body_length(), 0, SWNodeInfo::initial), // info needed per node
   _clone_map(phase()->C->clone_map()),                      // map of nodes created in cloning
   _align_to_ref(nullptr),                                   // memory reference to align vectors to
-  _pairset(&_arena, _vloop_analyzer.body()),
+  _pairset(&_arena, _vloop_analyzer),
   _packset(&_arena, _vloop_analyzer
            NOT_PRODUCT(COMMA is_trace_superword_packset())
            NOT_PRODUCT(COMMA is_trace_superword_rejections())

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -476,7 +476,6 @@ bool SuperWord::SLP_extract() {
   split_packs_to_break_mutual_dependence();
   split_packs_at_use_def_boundaries();  // again: propagate split of other packs
 
-  // Now we only remove packs:
   filter_packs_for_power_of_2_size();
   filter_packs_for_mutual_independence();
   filter_packs_for_alignment();
@@ -3357,17 +3356,6 @@ const Type* VLoopTypes::container_type(Node* n) const {
 bool VLoopMemorySlices::same_memory_slice(MemNode* m1, MemNode* m2) const {
   return _vloop.phase()->C->get_alias_index(m1->adr_type()) ==
          _vloop.phase()->C->get_alias_index(m2->adr_type());
-}
-
-// Remove the pack at position pos in the packset
-// TODO remove?
-void PackSet::remove_pack_at(int pos) {
-  Node_List* p = _packs.at(pos);
-  for (uint i = 0; i < p->size(); i++) {
-    Node* s = p->at(i);
-    set_pack(s, nullptr);
-  }
-  _packs.at_put(pos, nullptr);
 }
 
 LoadNode::ControlDependency SuperWord::control_dependency(Node_List* p) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -840,7 +840,7 @@ bool SuperWord::stmts_can_pack(Node* s1, Node* s2, int align) {
   // and will still be vectorized by SuperWord::vector_opd.
   if (isomorphic(s1, s2) && !is_populate_index(s1, s2)) {
     if ((independent(s1, s2) && have_similar_inputs(s1, s2)) || reduction(s1, s2)) {
-      if (!_pairset.has_left(s1) && !_pairset.has_right(s2)) {
+      if (!_pairset.is_left(s1) && !_pairset.is_right(s2)) {
         if (!s1->is_Mem() || are_adjacent_refs(s1, s2)) {
           int s1_align = alignment(s1);
           int s2_align = alignment(s2);
@@ -1041,8 +1041,8 @@ void SuperWord::extend_pairset_with_more_pairs_by_following_use_and_def() {
     changed = false;
     // Iterate the pairs in insertion order.
     for (int i = 0; i < _pairset.length(); i++) {
-      Node* left  = _pairset.left_at(i);
-      Node* right = _pairset.right_at(i);
+      Node* left  = _pairset.left_at_in_insertion_order(i);
+      Node* right = _pairset.right_at_in_insertion_order(i);
       changed |= extend_pairset_with_more_pairs_by_following_def(left, right);
       changed |= extend_pairset_with_more_pairs_by_following_use(left, right);
     }
@@ -1086,7 +1086,7 @@ int SuperWord::adjust_alignment_for_type_conversion(Node* s, Node* t, int align)
 }
 
 bool SuperWord::extend_pairset_with_more_pairs_by_following_def(Node* s1, Node* s2) {
-  assert(_pairset.has_pair(s1, s2), "(s1, s2) must be a pair");
+  assert(_pairset.is_pair(s1, s2), "(s1, s2) must be a pair");
   assert(s1->req() == s2->req(), "just checking");
   assert(alignment(s1) + data_size(s1) == alignment(s2), "just checking");
 
@@ -1131,7 +1131,7 @@ bool SuperWord::extend_pairset_with_more_pairs_by_following_def(Node* s1, Node* 
 //       calling this method as long as there are some changes, we will eventually pack all pairs that
 //       can be packed.
 bool SuperWord::extend_pairset_with_more_pairs_by_following_use(Node* s1, Node* s2) {
-  assert(_pairset.has_pair(s1, s2), "(s1, s2) must be a pair");
+  assert(_pairset.is_pair(s1, s2), "(s1, s2) must be a pair");
   assert(s1->req() == s2->req(), "just checking");
   assert(alignment(s1) + data_size(s1) == alignment(s2), "just checking");
 
@@ -1191,7 +1191,7 @@ bool SuperWord::extend_pairset_with_more_pairs_by_following_use(Node* s1, Node* 
 // For a pair (def1, def2), find all use packs (use1, use2), and ensure that their inputs have an order
 // that matches the (def1, def2) pair.
 void SuperWord::order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node* def2) {
-  assert(_pairset.has_pair(def1, def2), "(def1, def2) must be a pair");
+  assert(_pairset.is_pair(def1, def2), "(def1, def2) must be a pair");
 
   if (def1->is_Store()) return;
 
@@ -1249,7 +1249,7 @@ void SuperWord::order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node
 //    use1->in(i) == def1 || use2->in(i) == def2   ->    use1->in(i) == def1 && use2->in(i) == def2
 //
 SuperWord::PairOrderStatus SuperWord::order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2) {
-  assert(_pairset.has_pair(def1, def2), "(def1, def2) must be a pair");
+  assert(_pairset.is_pair(def1, def2), "(def1, def2) must be a pair");
 
   // 1. Reduction
   if (is_marked_reduction(use1) && is_marked_reduction(use2)) {
@@ -1317,7 +1317,7 @@ int SuperWord::estimate_cost_savings_when_packing_as_pair(const Node* s1, const 
     if (x1 != x2) {
       if (are_adjacent_refs(x1, x2)) {
         save_in += adjacent_profit;
-      } else if (!_pairset.has_pair(x1, x2)) {
+      } else if (!_pairset.is_pair(x1, x2)) {
         save_in -= pack_cost(2);
       } else {
         save_in += unpack_cost(2);

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1041,10 +1041,10 @@ void SuperWord::extend_pairset_with_more_pairs_by_following_use_and_def() {
     changed = false;
     // Iterate the pairs in insertion order.
     for (int i = 0; i < _pairset.length(); i++) {
-      Node* s1 = _pairset.left_at(i);
-      Node* s2 = _pairset.right_at(i);
-      changed |= extend_pairset_with_more_pairs_by_following_def(s1, s2);
-      changed |= extend_pairset_with_more_pairs_by_following_use(s1, s2);
+      Node* left  = _pairset.left_at(i);
+      Node* right = _pairset.right_at(i);
+      changed |= extend_pairset_with_more_pairs_by_following_def(left, right);
+      changed |= extend_pairset_with_more_pairs_by_following_use(left, right);
     }
   } while (changed);
 
@@ -1056,9 +1056,9 @@ void SuperWord::extend_pairset_with_more_pairs_by_following_use_and_def() {
   // all pair-chains from left-to-right, we essencially impose the order of the first
   // element on all other elements in the pair-chain.
   for (PairSetIterator pair(_pairset); !pair.done(); pair.next()) {
-    Node* s1 = pair.left();
-    Node* s2 = pair.right();
-    order_inputs_of_all_use_pairs_to_match_def_pair(s1, s2);
+    Node* left  = pair.left();
+    Node* right = pair.right();
+    order_inputs_of_all_use_pairs_to_match_def_pair(left, right);
   }
 
 #ifndef PRODUCT
@@ -1364,16 +1364,16 @@ void SuperWord::combine_pairs_to_longer_packs() {
   // Iterate pair-chain by pair-chain, each from left-most to right-most.
   Node_List* pack = nullptr;
   for (PairSetIterator pair(_pairset); !pair.done(); pair.next()) {
-    Node* s1 = pair.left();
-    Node* s2 = pair.right();
-    if (_pairset.is_left_in_a_left_most_pair(s1)) {
+    Node* left  = pair.left();
+    Node* right = pair.right();
+    if (_pairset.is_left_in_a_left_most_pair(left)) {
       assert(pack == nullptr, "no unfinished pack");
       pack = new (arena()) Node_List(arena());
-      pack->push(s1);
+      pack->push(left);
     }
     assert(pack != nullptr, "must have unfinished pack");
-    pack->push(s2);
-    if (_pairset.is_right_in_a_right_most_pair(s2)) {
+    pack->push(right);
+    if (_pairset.is_right_in_a_right_most_pair(right)) {
       _packset.add_pack(pack);
       pack = nullptr;
     }
@@ -3725,16 +3725,16 @@ void PairSet::print() const {
   int chain = 0;
   int chain_index = 0;
   for (PairSetIterator pair(*this); !pair.done(); pair.next()) {
-    Node* n1 = pair.left();
-    Node* n2 = pair.right();
-    if (is_left_in_a_left_most_pair(n1)) {
+    Node* left  = pair.left();
+    Node* right = pair.right();
+    if (is_left_in_a_left_most_pair(left)) {
       chain_index = 0;
       tty->print_cr(" Pair-chain %d:", chain++);
       tty->print("  %3d: ", chain_index++);
-      n1->dump();
+      left->dump();
     }
     tty->print("  %3d: ", chain_index++);
-    n2->dump();
+    right->dump();
   }
 }
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1212,8 +1212,8 @@ void SuperWord::order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node
   }
 }
 
-// For a def-pair (def1. def2), and their use-nodes (use1, use2):
-// ensure that the input order of (use1, use2) matches the order of (def1, def2).
+// For a def-pair (def1, def2), and their use-nodes (use1, use2):
+// Ensure that the input order of (use1, use2) matches the order of (def1, def2).
 //
 // We have different cases:
 //
@@ -1285,7 +1285,7 @@ SuperWord::PairOrderStatus SuperWord::order_inputs_of_uses_to_match_def_pair(Nod
         }
         return PairOrderStatus::Unknown;
       } else {
-        // The inputs are not ordered, and we can not do anything about it.
+        // The inputs are not ordered, and we cannot do anything about it.
         return PairOrderStatus::Unordered;
       }
     } else if (i1 == i2 && VectorNode::is_muladds2i(use2) && use1 != use2) {
@@ -1300,7 +1300,7 @@ SuperWord::PairOrderStatus SuperWord::order_inputs_of_uses_to_match_def_pair(Nod
   return PairOrderStatus::Ordered;
 }
 
-// Estimate the savings from executing s1 and s2 as a pack
+// Estimate the savings from executing s1 and s2 as a pair.
 int SuperWord::estimate_cost_savings_when_packing_pair(const Node* s1, const Node* s2) const {
   int save_in = 2 - 1; // 2 operations per instruction in packed form
 

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1203,11 +1203,9 @@ void SuperWord::order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node
       break;
     }
 
-    // Check if there is a pair (use1, use2)
-    if (!_pairset.has_left(use1)) {
-      break;
-    }
-    Node* use2 = _pairset.get_right_for(use1);
+    // Find pair (use1, use2)
+    Node* use2 = _pairset.get_right_or_null_for(use1);
+    if (use2 == nullptr) { break; }
 
     order_inputs_of_uses_to_match_def_pair(def1, def2, use1, use2);
   }
@@ -1327,9 +1325,9 @@ int SuperWord::est_savings(Node* s1, Node* s2) const {
   for (DUIterator_Fast imax, i = s1->fast_outs(imax); i < imax; i++) {
     Node* use1 = s1->fast_out(i);
 
-    // Check if we have a pair (use1, use2)
-    if (!_pairset.has_left(use1)) { continue; }
-    Node* use2 = _pairset.get_right_for(use1);
+    // Find pair (use1, use2)
+    Node* use2 = _pairset.get_right_or_null_for(use1);
+    if (use2 == nullptr) { continue; }
 
     for (DUIterator_Fast kmax, k = s2->fast_outs(kmax); k < kmax; k++) {
       if (use2 == s2->fast_out(k)) {

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -1597,7 +1597,7 @@ void SuperWord::filter_packs(const char* filter_name,
       assert(i >= new_packset_length, "only move packs down");
       _packset.at_put(new_packset_length++, pack);
     } else {
-      remove_pack_at(i);
+      _packset.remove_pack_at(i);
 #ifndef PRODUCT
       if (is_trace_superword_rejections()) {
         tty->cr();
@@ -3405,16 +3405,15 @@ bool VLoopMemorySlices::same_memory_slice(MemNode* m1, MemNode* m2) const {
          _vloop.phase()->C->get_alias_index(m2->adr_type());
 }
 
-//------------------------------remove_pack_at---------------------------
 // Remove the pack at position pos in the packset
-// TODO move to packset
-void SuperWord::remove_pack_at(int pos) {
-  Node_List* p = _packset.at(pos);
+// TODO remove?
+void PackSet::remove_pack_at(int pos) {
+  Node_List* p = _packs.at(pos);
   for (uint i = 0; i < p->size(); i++) {
     Node* s = p->at(i);
-    _packset.set_pack(s, nullptr);
+    set_pack(s, nullptr);
   }
-  _packset.at_put(pos, nullptr);
+  _packs.at_put(pos, nullptr);
 }
 
 LoadNode::ControlDependency SuperWord::control_dependency(Node_List* p) {

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -160,6 +160,14 @@ public:
 
   Node_List* pack(const Node* n) const { return !_vloop.in_bb(n) ? nullptr : _node_to_pack.at(_body.bb_idx(n)); }
 
+  void add_pack(Node_List* pack) {
+    _packs.append(pack);
+    for (uint i = 0; i < pack->size(); i++) {
+      Node* n = pack->at(i);
+      assert(this->pack(n) == nullptr, "not yet in a pack");
+      set_pack(n, pack);
+    }
+  }
 
   // TODO remove?
   void at_put(int i, Node_List* pack) { return _packs.at_put(i, pack); }
@@ -519,10 +527,6 @@ private:
 
   // Find the set of alignment solutions for load/store pack.
   const AlignmentSolution* pack_alignment_solution(const Node_List* pack);
-
-  // TODO remove / integrate to combine?
-  // Construct the map from nodes to packs.
-  void construct_pack_map();
 
   // TODO move to packset, and maybe combine with split?
   // Remove packs that are not implemented.

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -391,7 +391,9 @@ private:
   void extend_pairset_with_more_pairs_by_following_use_and_def();
   bool extend_pairset_with_more_pairs_by_following_def(Node* s1, Node* s2);
   bool extend_pairset_with_more_pairs_by_following_use(Node* s1, Node* s2);
-  void order_inputs_of_use_pairs_to_match(Node* def1, Node* def2);
+  void order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node* def2);
+  enum PairOrderStatus { Ordered, Unordered, Unknown };
+  PairOrderStatus order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2);
 
   // Estimate the savings from executing s1 and s2 as a pack
   int est_savings(Node* s1, Node* s2);
@@ -563,10 +565,6 @@ private:
   int memory_alignment(MemNode* s, int iv_adjust);
   // Ensure that the main loop vectors are aligned by adjusting the pre loop limit.
   void adjust_pre_loop_limit_to_align_main_loop_vectors();
-  // Is the use of d1 in u1 at the same operand position as d2 in u2?
-  bool opnd_positions_match(Node* d1, Node* u1, Node* d2, Node* u2);
-
-  void packset_sort(int n);
 };
 
 #endif // SHARE_OPTO_SUPERWORD_HPP

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -90,6 +90,7 @@ public:
   bool has_pair(Node* n1, Node* n2) const { return exists_left(n1) && get_right_for(n1) == n2; }
 
   void add_pair(Node* n1, Node* n2) {
+    assert(n1 != nullptr && n2 != nullptr && n1 != n2, "no nullptr, and different nodes");
     assert(!exists_left(n1) && !exists_right(n2), "cannot be left twice, or right twice");
     int bb_idx_1 = _body.bb_idx(n1);
     int bb_idx_2 = _body.bb_idx(n2);
@@ -385,13 +386,12 @@ private:
   // do s1 and s2 have similar input edges?
   bool have_similar_inputs(Node* s1, Node* s2);
   void set_alignment(Node* s1, Node* s2, int align);
-  // Extend packset by following use->def and def->use links from pack members.
-  void extend_pairset_with_more_pairs_by_following_use_and_def();
   int adjust_alignment_for_type_conversion(Node* s, Node* t, int align);
-  // Extend the packset by visiting operand definitions of nodes in pack p
-  bool follow_use_defs(Node_List* p);
-  // Extend the packset by visiting uses of nodes in pack p
-  bool follow_def_uses(Node_List* p);
+
+  void extend_pairset_with_more_pairs_by_following_use_and_def();
+  bool extend_pairset_with_more_pairs_by_following_def(Node* s1, Node* s2);
+  bool extend_pairset_with_more_pairs_by_following_use(Node* s1, Node* s2);
+
   // For extended packsets, ordinally arrange uses packset by major component
   void order_def_uses(Node_List* p);
   // Estimate the savings from executing s1 and s2 as a pack

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -79,25 +79,25 @@ public:
 
   const VLoopBody& body() const { return _body; }
   bool is_empty() const { return _pair_counter == 0; }
-  bool exists_left(int i)  const { return _left_to_right.at(i) != -1; }
-  bool exists_right(int i) const { return _right_to_left.at(i) != -1; }
-  bool exists_left(Node* n)  const { return exists_left( _body.bb_idx(n)); }
-  bool exists_right(Node* n) const { return exists_right(_body.bb_idx(n)); }
+  bool has_left(int i)  const { return _left_to_right.at(i) != -1; }
+  bool has_right(int i) const { return _right_to_left.at(i) != -1; }
+  bool has_left(Node* n)  const { return has_left( _body.bb_idx(n)); }
+  bool has_right(Node* n) const { return has_right(_body.bb_idx(n)); }
   int get_left_for(int i)  const { return _right_to_left.at(i); }
   int get_right_for(int i) const { return _left_to_right.at(i); }
   Node* get_left_for(Node* n)  const { return _body.body().at(get_left_for( _body.bb_idx(n))); }
   Node* get_right_for(Node* n) const { return _body.body().at(get_right_for(_body.bb_idx(n))); }
-  bool has_pair(Node* n1, Node* n2) const { return exists_left(n1) && get_right_for(n1) == n2; }
+  bool has_pair(Node* n1, Node* n2) const { return has_left(n1) && get_right_for(n1) == n2; }
 
   void add_pair(Node* n1, Node* n2) {
     assert(n1 != nullptr && n2 != nullptr && n1 != n2, "no nullptr, and different nodes");
-    assert(!exists_left(n1) && !exists_right(n2), "cannot be left twice, or right twice");
+    assert(!has_left(n1) && !has_right(n2), "cannot be left twice, or right twice");
     int bb_idx_1 = _body.bb_idx(n1);
     int bb_idx_2 = _body.bb_idx(n2);
     _left_to_right.at_put(bb_idx_1, bb_idx_2);
     _right_to_left.at_put(bb_idx_2, bb_idx_1);
     _pair_counter++;
-    assert(exists_left(n1) && exists_right(n2), "must be set now");
+    assert(has_left(n1) && has_right(n2), "must be set now");
   }
 
   NOT_PRODUCT( void print() const; )
@@ -119,7 +119,7 @@ public:
   void next() {
     do {
       _current_bb_idx++;
-    } while (!done() && !_pairset.exists_left(_current_bb_idx));
+    } while (!done() && !_pairset.has_left(_current_bb_idx));
   }
 
   bool done() const { return _current_bb_idx >= _body.body().length(); }
@@ -391,9 +391,8 @@ private:
   void extend_pairset_with_more_pairs_by_following_use_and_def();
   bool extend_pairset_with_more_pairs_by_following_def(Node* s1, Node* s2);
   bool extend_pairset_with_more_pairs_by_following_use(Node* s1, Node* s2);
+  void order_inputs_of_use_pairs_to_match(Node* def1, Node* def2);
 
-  // For extended packsets, ordinally arrange uses packset by major component
-  void order_def_uses(Node_List* p);
   // Estimate the savings from executing s1 and s2 as a pack
   int est_savings(Node* s1, Node* s2);
   int adjacent_profit(Node* s1, Node* s2);

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -83,19 +83,17 @@ public:
   bool is_empty() const { return _pair_counter == 0; }
   bool has_left(int i)  const { return _left_to_right.at(i) != -1; }
   bool has_right(int i) const { return _right_to_left.at(i) != -1; }
-  bool has_left(Node* n)  const { return _vloop.in_bb(n) && has_left( _body.bb_idx(n)); }
-  bool has_right(Node* n) const { return _vloop.in_bb(n) && has_right(_body.bb_idx(n)); }
+  bool has_left(const Node* n)  const { return _vloop.in_bb(n) && has_left( _body.bb_idx(n)); }
+  bool has_right(const Node* n) const { return _vloop.in_bb(n) && has_right(_body.bb_idx(n)); }
   int get_left_for(int i)  const { return _right_to_left.at(i); }
   int get_right_for(int i) const { return _left_to_right.at(i); }
-  Node* get_left_for(Node* n)  const { return _body.body().at(get_left_for( _body.bb_idx(n))); }
-  Node* get_right_for(Node* n) const { return _body.body().at(get_right_for(_body.bb_idx(n))); }
-  bool has_pair(Node* n1, Node* n2) const { return has_left(n1) && get_right_for(n1) == n2; }
-  bool is_left_in_a_left_most_pair(int i) const { return has_left(i) && !has_right(i); }
+  Node* get_left_for(const Node* n)  const { return _body.body().at(get_left_for( _body.bb_idx(n))); }
+  Node* get_right_for(const Node* n) const { return _body.body().at(get_right_for(_body.bb_idx(n))); }
+  bool has_pair(const Node* n1, const Node* n2) const { return has_left(n1) && get_right_for(n1) == n2; }
+  bool is_left_in_a_left_most_pair(int i)   const { return has_left(i) && !has_right(i); }
   bool is_right_in_a_right_most_pair(int i) const { return !has_left(i) && has_right(i); }
-  bool is_left_in_a_left_most_pair(const Node* n) const { return is_left_in_a_left_most_pair(_body.bb_idx(n)); }
+  bool is_left_in_a_left_most_pair(const Node* n)   const { return is_left_in_a_left_most_pair( _body.bb_idx(n)); }
   bool is_right_in_a_right_most_pair(const Node* n) const { return is_right_in_a_right_most_pair(_body.bb_idx(n)); }
-
-  // TODO figure out if we need all accessors, and make const Node*
 
   void add_pair(Node* n1, Node* n2) {
     assert(n1 != nullptr && n2 != nullptr && n1 != n2, "no nullptr, and different nodes");

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -545,7 +545,7 @@ private:
   void order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node* def2);
   enum PairOrderStatus { Ordered, Unordered, Unknown };
   PairOrderStatus order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2);
-  int estimate_cost_savings_when_packing_pair(const Node* s1, const Node* s2) const;
+  int estimate_cost_savings_when_packing_as_pair(const Node* s1, const Node* s2) const;
 
   void combine_pairs_to_longer_packs();
 

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -510,16 +510,20 @@ private:
   void filter_packs_for_mutual_independence();
   // Ensure all packs are aligned, if AlignVector is on.
   void filter_packs_for_alignment();
+
   // Find the set of alignment solutions for load/store pack.
   const AlignmentSolution* pack_alignment_solution(const Node_List* pack);
-  // Compress packset, such that it has no nullptr entries.
-  void compress_packset();
+
+  // TODO remove / integrate to combine?
   // Construct the map from nodes to packs.
   void construct_my_pack_map();
+
+  // TODO move to packset, and maybe combine with split?
   // Remove packs that are not implemented.
   void filter_packs_for_implemented();
   // Remove packs that are not profitable.
   void filter_packs_for_profitable();
+
   // Verify that for every pack, all nodes are mutually independent.
   // Also verify that packset and my_pack are consistent.
   DEBUG_ONLY(void verify_packs();)
@@ -558,8 +562,11 @@ private:
   BasicType longer_type_for_conversion(Node* n);
   // Find the longest type in def-use chain for packed nodes, and then compute the max vector size.
   int max_vector_size_in_def_use_chain(Node* n);
+
+  // TODO remove?
   // Remove the pack at position pos in the packset
   void remove_pack_at(int pos);
+
   static LoadNode::ControlDependency control_dependency(Node_List* p);
   // Alignment within a vector memory reference
   int memory_alignment(MemNode* s, int iv_adjust);

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -350,7 +350,6 @@ class SuperWord : public ResourceObj {
 
   const PackSet& packset()   const { return _packset; }
  private:
-  bool           _race_possible;   // In cases where SDMU is true
   bool           _do_vector_loop;  // whether to do vectorization/simd style
   int            _num_work_vecs;   // Number of non memory vector operations
   int            _num_reductions;  // Number of reduction expressions applied
@@ -416,7 +415,6 @@ private:
   int pack_cost(int ct)                   const { return ct; }
   int unpack_cost(int ct)                 const { return ct; }
 
-  // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
   void combine_pairs_to_longer_packs();
 
   class SplitTask {

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -85,15 +85,14 @@ public:
   bool has_right(int i) const { return _right_to_left.at(i) != -1; }
   bool has_left(const Node* n)  const { return _vloop.in_bb(n) && has_left( _body.bb_idx(n)); }
   bool has_right(const Node* n) const { return _vloop.in_bb(n) && has_right(_body.bb_idx(n)); }
-  int get_left_for(int i)  const { return _right_to_left.at(i); }
-  int get_right_for(int i) const { return _left_to_right.at(i); }
-  Node* get_left_for(const Node* n)  const { return _body.body().at(get_left_for( _body.bb_idx(n))); }
-  Node* get_right_for(const Node* n) const { return _body.body().at(get_right_for(_body.bb_idx(n))); }
   bool has_pair(const Node* n1, const Node* n2) const { return has_left(n1) && get_right_for(n1) == n2; }
   bool is_left_in_a_left_most_pair(int i)   const { return has_left(i) && !has_right(i); }
   bool is_right_in_a_right_most_pair(int i) const { return !has_left(i) && has_right(i); }
   bool is_left_in_a_left_most_pair(const Node* n)   const { return is_left_in_a_left_most_pair( _body.bb_idx(n)); }
   bool is_right_in_a_right_most_pair(const Node* n) const { return is_right_in_a_right_most_pair(_body.bb_idx(n)); }
+  int get_right_for(int i) const { return _left_to_right.at(i); }
+  Node* get_right_for(const Node* n) const { return _body.body().at(get_right_for(_body.bb_idx(n))); }
+  Node* get_right_or_null_for(const Node* n) const { return has_left(n) ? get_right_for(n) : nullptr; }
 
   void add_pair(Node* n1, Node* n2) {
     assert(n1 != nullptr && n2 != nullptr && n1 != n2, "no nullptr, and different nodes");

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -100,7 +100,7 @@ public:
     assert(has_left(n1) && has_right(n2), "must be set now");
   }
 
-  NOT_PRODUCT( void print() const; )
+  NOT_PRODUCT(void print() const;)
 };
 
 class PairSetIterator : public StackObj {
@@ -143,7 +143,7 @@ private:
   GrowableArray<Node_List*> _packs;
 
   // Mapping from nodes to their pack: bb_idx -> pack
-  GrowableArray<Node_List*> _node_to_pack; // TODO
+  GrowableArray<Node_List*> _node_to_pack;
 
 public:
   // Initialize empty, i.e. no packs, and unmapped (nullptr).
@@ -181,8 +181,9 @@ public:
   // TODO: make private?
   void set_pack(const Node* n, Node_List* pack) { _node_to_pack.at_put(_body.bb_idx(n), pack); }
 
-  NOT_PRODUCT( void print() const; )
-  NOT_PRODUCT( void print_pack(Node_List* pack) const; )
+  DEBUG_ONLY(void verify() const;)
+  NOT_PRODUCT(void print() const;)
+  NOT_PRODUCT(void print_pack(Node_List* pack) const;)
 };
 
 // ========================= SuperWord =====================
@@ -368,13 +369,13 @@ class SuperWord : public ResourceObj {
   bool vectors_should_be_aligned() { return !Matcher::misaligned_vectors_ok() || AlignVector; }
 
   // memory alignment for a node
-  int alignment(Node* n)                     { return _node_info.adr_at(bb_idx(n))->_alignment; }
+  int alignment(Node* n) const               { return _node_info.adr_at(bb_idx(n))->_alignment; }
   void set_alignment(Node* n, int a)         { int i = bb_idx(n); grow_node_info(i); _node_info.adr_at(i)->_alignment = a; }
 
   // is pack good for converting into one vector node replacing bunches of Cmp, Bool, CMov nodes.
   static bool requires_long_to_int_conversion(int opc);
   // For pack p, are all idx operands the same?
-  bool same_inputs(const Node_List* p, int idx);
+  bool same_inputs(const Node_List* p, int idx) const;
   // CloneMap utilities
   bool same_origin_idx(Node* a, Node* b) const;
   bool same_generation(Node* a, Node* b) const;
@@ -534,9 +535,8 @@ private:
   // Remove packs that are not profitable.
   void filter_packs_for_profitable();
 
-  // Verify that for every pack, all nodes are mutually independent.
-  // Also verify that packset and pack are consistent. // TODO move to packset?
-  DEBUG_ONLY(void verify_packs();)
+  DEBUG_ONLY(void verify_packs() const;)
+
   // Adjust the memory graph for the packed operations
   void schedule();
   // Helper function for schedule, that reorders all memops, slice by slice, according to the schedule
@@ -548,12 +548,13 @@ private:
   Node* vector_opd(Node_List* p, int opd_idx);
 
   // Can code be generated for the pack, restricted to size nodes?
-  bool implemented(const Node_List* pack, uint size);
+  bool implemented(const Node_List* pack, uint size) const;
   // Find the maximal implemented size smaller or equal to the packs size
   uint max_implemented_size(const Node_List* pack);
 
   // For pack p, are all operands and all uses (with in the block) vector?
-  bool profitable(const Node_List* p);
+  bool profitable(const Node_List* p) const;
+
   // Verify that all uses of packs are also packs, i.e. we do not need extract operations.
   DEBUG_ONLY(void verify_no_extract();)
 
@@ -561,15 +562,14 @@ private:
   bool has_use_pack_superset(const Node* n1, const Node* n2) const;
   // Find a boundary in the pack, where left and right have different pack uses and defs.
   uint find_use_def_boundary(const Node_List* pack) const;
+
   // Is use->in(u_idx) a vector use?
-  bool is_vector_use(Node* use, int u_idx);
+  bool is_vector_use(Node* use, int u_idx) const;
 
   // Initialize per node info
   void initialize_node_info();
-  // Compute max depth for expressions from beginning of block
-  void compute_max_depth();
   // Return the longer type for vectorizable type-conversion node or illegal type for other nodes.
-  BasicType longer_type_for_conversion(Node* n);
+  BasicType longer_type_for_conversion(Node* n) const;
   // Find the longest type in def-use chain for packed nodes, and then compute the max vector size.
   int max_vector_size_in_def_use_chain(Node* n);
 

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -372,7 +372,7 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.reductions().is_marked_reduction(n);
   }
 
-  bool reduction(Node* n1, Node* n2) const {
+  bool reduction(const Node* n1, const Node* n2) const {
     return _vloop_analyzer.reductions().is_marked_reduction_pair(n1, n2);
   }
 
@@ -539,12 +539,7 @@ private:
   void order_inputs_of_all_use_pairs_to_match_def_pair(Node* def1, Node* def2);
   enum PairOrderStatus { Ordered, Unordered, Unknown };
   PairOrderStatus order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2);
-
-  // Estimate the savings from packing the pair (s1, s2).
-  int est_savings(Node* s1, Node* s2) const;
-  int adjacent_profit(Node* s1, Node* s2) const { return 2; }
-  int pack_cost(int ct)                   const { return ct; }
-  int unpack_cost(int ct)                 const { return ct; }
+  int estimate_cost_savings_when_packing_pair(const Node* s1, const Node* s2) const;
 
   void combine_pairs_to_longer_packs();
 

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -517,7 +517,7 @@ private:
   // Filter out packs with various filter predicates
   template <typename FilterPredicate>
   void filter_packs(const char* filter_name,
-                    const char* error_message,
+                    const char* rejection_message,
                     FilterPredicate filter);
   void filter_packs_for_power_of_2_size();
   void filter_packs_for_mutual_independence();

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -153,10 +153,13 @@ public:
     _packs(arena, 8, 0, nullptr),
     _node_to_pack(arena, _body.body().length(), _body.body().length(), nullptr) {}
 
-  // Delegate to _packs
+  // Accessors to iterate over packs.
   int length() const { return _packs.length(); }
   bool is_empty() const { return _packs.is_empty(); }
   Node_List* at(int i) const { return _packs.at(i); }
+
+  Node_List* pack(const Node* n) const { return !_vloop.in_bb(n) ? nullptr : _node_to_pack.at(_body.bb_idx(n)); }
+
 
   // TODO remove?
   void at_put(int i, Node_List* pack) { return _packs.at_put(i, pack); }
@@ -164,8 +167,10 @@ public:
   void trunc_to(int len) { _packs.trunc_to(len); }
   void clear() { _packs.clear(); }
 
-  Node_List* pack(const Node* n) const { return !_vloop.in_bb(n) ? nullptr : _node_to_pack.at(_body.bb_idx(n)); }
-  // make private?
+  // TODO remove?
+  void remove_pack_at(int pos);
+
+  // TODO: make private?
   void set_pack(const Node* n, Node_List* pack) { _node_to_pack.at_put(_body.bb_idx(n), pack); }
 
   NOT_PRODUCT( void print() const; )
@@ -563,10 +568,6 @@ private:
   BasicType longer_type_for_conversion(Node* n);
   // Find the longest type in def-use chain for packed nodes, and then compute the max vector size.
   int max_vector_size_in_def_use_chain(Node* n);
-
-  // TODO remove?
-  // Remove the pack at position pos in the packset
-  void remove_pack_at(int pos);
 
   static LoadNode::ControlDependency control_dependency(Node_List* p);
   // Alignment within a vector memory reference

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -61,6 +61,7 @@ class VPointer;
 // and stored in the PackSet.
 class PairSet : public StackObj {
 private:
+  const VLoop& _vloop;
   const VLoopBody& _body;
 
   // Doubly-linked pairs. If not linked: -1
@@ -71,18 +72,19 @@ private:
 
 public:
   // Initialize empty, i.e. all not linked (-1).
-  PairSet(Arena* arena, const VLoopBody& body) :
-    _body(body),
-    _left_to_right(arena, body.body().length(), body.body().length(), -1),
-    _right_to_left(arena, body.body().length(), body.body().length(), -1),
+  PairSet(Arena* arena, const VLoopAnalyzer& vloop_analyzer) :
+    _vloop(vloop_analyzer.vloop()),
+    _body(vloop_analyzer.body()),
+    _left_to_right(arena, _body.body().length(), _body.body().length(), -1),
+    _right_to_left(arena, _body.body().length(), _body.body().length(), -1),
     _pair_counter(0) {}
 
   const VLoopBody& body() const { return _body; }
   bool is_empty() const { return _pair_counter == 0; }
   bool has_left(int i)  const { return _left_to_right.at(i) != -1; }
   bool has_right(int i) const { return _right_to_left.at(i) != -1; }
-  bool has_left(Node* n)  const { return has_left( _body.bb_idx(n)); }
-  bool has_right(Node* n) const { return has_right(_body.bb_idx(n)); }
+  bool has_left(Node* n)  const { return _vloop.in_bb(n) && has_left( _body.bb_idx(n)); }
+  bool has_right(Node* n) const { return _vloop.in_bb(n) && has_right(_body.bb_idx(n)); }
   int get_left_for(int i)  const { return _right_to_left.at(i); }
   int get_right_for(int i) const { return _left_to_right.at(i); }
   Node* get_left_for(Node* n)  const { return _body.body().at(get_left_for( _body.bb_idx(n))); }

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -234,12 +234,8 @@ private:
   // Mapping from nodes to their pack: bb_idx -> pack
   GrowableArray<Node_List*> _node_to_pack;
 
-#ifndef PRODUCT
-  const bool _trace_packset;
-  const bool _trace_rejections;
-  bool is_trace_superword_packset() const { return _trace_packset; }
-  bool is_trace_superword_rejections() const { return _trace_rejections; }
-#endif
+  NOT_PRODUCT(const bool _trace_packset;)
+  NOT_PRODUCT(const bool _trace_rejections;)
 
 public:
   // Initialize empty, i.e. no packs, and unmapped (nullptr).
@@ -259,6 +255,9 @@ public:
   bool is_empty() const { return _packs.is_empty(); }
   Node_List* at(int i) const { return _packs.at(i); }
 
+private:
+  void set_pack(const Node* n, Node_List* pack) { _node_to_pack.at_put(_body.bb_idx(n), pack); }
+public:
   Node_List* pack(const Node* n) const { return !_vloop.in_bb(n) ? nullptr : _node_to_pack.at(_body.bb_idx(n)); }
 
   void add_pack(Node_List* pack) {
@@ -270,7 +269,9 @@ public:
     }
   }
 
+private:
   SplitStatus split_pack(const char* split_name, Node_List* pack, SplitTask task);
+public:
   template <typename SplitStrategy>
   void split_packs(const char* split_name, SplitStrategy strategy);
 
@@ -279,18 +280,12 @@ public:
                     const char* rejection_message,
                     FilterPredicate filter);
 
-  // TODO remove?
-  void at_put(int i, Node_List* pack) { return _packs.at_put(i, pack); }
-  void append(Node_List* pack) { _packs.append(pack); }
-  void trunc_to(int len) { _packs.trunc_to(len); }
   void clear() { _packs.clear(); }
 
-  // TODO remove?
-  void remove_pack_at(int pos);
-
-  // TODO: make private?
-  void set_pack(const Node* n, Node_List* pack) { _node_to_pack.at_put(_body.bb_idx(n), pack); }
-
+private:
+  NOT_PRODUCT(bool is_trace_superword_packset() const { return _trace_packset; })
+  NOT_PRODUCT(bool is_trace_superword_rejections() const { return _trace_rejections; })
+public:
   DEBUG_ONLY(void verify() const;)
   NOT_PRODUCT(void print() const;)
   NOT_PRODUCT(void print_pack(Node_List* pack) const;)
@@ -533,16 +528,9 @@ private:
 
   void filter_packs_for_power_of_2_size();
   void filter_packs_for_mutual_independence();
-  // Ensure all packs are aligned, if AlignVector is on.
   void filter_packs_for_alignment();
-
-  // Find the set of alignment solutions for load/store pack.
   const AlignmentSolution* pack_alignment_solution(const Node_List* pack);
-
-  // TODO move to packset, and maybe combine with split?
-  // Remove packs that are not implemented.
   void filter_packs_for_implemented();
-  // Remove packs that are not profitable.
   void filter_packs_for_profitable();
 
   DEBUG_ONLY(void verify_packs() const;)

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -392,7 +392,7 @@ private:
   // Can s1 and s2 be in a pack with s1 immediately preceding s2 and  s1 aligned at "align"
   bool stmts_can_pack(Node* s1, Node* s2, int align);
   // Is s1 immediately before s2 in memory?
-  bool are_adjacent_refs(Node* s1, Node* s2);
+  bool are_adjacent_refs(Node* s1, Node* s2) const;
   // Are s1 and s2 similar?
   bool isomorphic(Node* s1, Node* s2);
   // Do we have pattern n1 = (iv + c) and n2 = (iv + c + 1)?
@@ -410,11 +410,11 @@ private:
   enum PairOrderStatus { Ordered, Unordered, Unknown };
   PairOrderStatus order_inputs_of_uses_to_match_def_pair(Node* def1, Node* def2, Node* use1, Node* use2);
 
-  // Estimate the savings from executing s1 and s2 as a pack
-  int est_savings(Node* s1, Node* s2);
-  int adjacent_profit(Node* s1, Node* s2);
-  int pack_cost(int ct);
-  int unpack_cost(int ct);
+  // Estimate the savings from packing the pair (s1, s2).
+  int est_savings(Node* s1, Node* s2) const;
+  int adjacent_profit(Node* s1, Node* s2) const { return 2; }
+  int pack_cost(int ct)                   const { return ct; }
+  int unpack_cost(int ct)                 const { return ct; }
 
   // Combine packs A and B with A.last == B.first into A.first..,A.last,B.second,..B.last
   void combine_pairs_to_longer_packs();

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -275,7 +275,7 @@ public:
   bool is_marked_reduction_loop() const { return !_loop_reductions.is_empty(); }
 
   // Are s1 and s2 reductions with a data path between them?
-  bool is_marked_reduction_pair(Node* s1, Node* s2) const;
+  bool is_marked_reduction_pair(const Node* s1, const Node* s2) const;
 
 private:
   // Whether n is a standard reduction operator.

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -426,7 +426,7 @@ bool VectorNode::is_type_transition_to_int(Node* n) {
   return is_type_transition_short_to_int(n);
 }
 
-bool VectorNode::is_muladds2i(Node* n) {
+bool VectorNode::is_muladds2i(const Node* n) {
   if (n->Opcode() == Op_MulAddS2I) {
     return true;
   }

--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -102,7 +102,7 @@ class VectorNode : public TypeNode {
   static bool is_vshift_cnt(Node* n);
   static bool is_type_transition_short_to_int(Node* n);
   static bool is_type_transition_to_int(Node* n);
-  static bool is_muladds2i(Node* n);
+  static bool is_muladds2i(const Node* n);
   static bool is_roundopD(Node* n);
   static bool is_scalar_rotate(Node* n);
   static bool is_vector_rotate_supported(int opc, uint vlen, BasicType bt);

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8310886
+ * @bug 8310886 8325252
  * @summary Test MulAddS2I vectorization.
  * @library /test/lib /
  * @run driver compiler.loopopts.superword.TestMulAddS2I

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
@@ -36,14 +36,20 @@ import jdk.test.lib.Asserts;
 import jdk.test.lib.Platform;
 
 public class TestMulAddS2I {
-    static final int RANGE = 1024;
+    static final int RANGE = 1024*16;
     static final int ITER  = RANGE/2 - 1;
 
     static short[] sArr1 = new short[RANGE];
     static short[] sArr2 = new short[RANGE];
+    static int[] ioutArr = new int[RANGE];
     static final int[] GOLDEN_A;
     static final int[] GOLDEN_B;
     static final int[] GOLDEN_C;
+    static final int[] GOLDEN_D;
+    static final int[] GOLDEN_E;
+    static final int[] GOLDEN_F;
+    static final int[] GOLDEN_G;
+    static final int[] GOLDEN_H;
 
     static {
         for (int i = 0; i < RANGE; i++) {
@@ -53,6 +59,11 @@ public class TestMulAddS2I {
         GOLDEN_A = testa();
         GOLDEN_B = testb();
         GOLDEN_C = testc();
+        GOLDEN_D = testd();
+        GOLDEN_E = teste();
+        GOLDEN_F = testf();
+        GOLDEN_G = testg();
+        GOLDEN_H = testh();
     }
 
 
@@ -65,12 +76,17 @@ public class TestMulAddS2I {
         }
     }
 
-    @Run(test = {"testa", "testb", "testc"})
+    @Run(test = {"testa", "testb", "testc", "testd", "teste", "testf", "testg", "testh"})
     @Warmup(0)
     public static void run() {
         compare(testa(), GOLDEN_A, "testa");
         compare(testb(), GOLDEN_B, "testb");
-        compare(testb(), GOLDEN_C, "testc");
+        compare(testc(), GOLDEN_C, "testc");
+        compare(testd(), GOLDEN_D, "testd");
+        compare(teste(), GOLDEN_E, "teste");
+        compare(testf(), GOLDEN_F, "testf");
+        compare(testg(), GOLDEN_G, "testg");
+        compare(testh(), GOLDEN_H, "testh");
     }
 
     public static void compare(int[] out, int[] golden, String name) {
@@ -130,6 +146,101 @@ public class TestMulAddS2I {
         int[] out = new int[ITER];
         for (int i = 0; i < ITER; i++) {
             out[i] += ((sArr1[2*i] * sArr2[2*i]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+        }
+        return out;
+    }
+
+    @Test
+    @IR(applyIfCPUFeature = {"sse2", "true"},
+        applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
+    public static int[] testd() {
+        int[] out = ioutArr;
+        for (int i = 0; i < ITER-2; i+=2) {
+            // Unrolled, with the same structure.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+0]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+            out[i+1] += ((sArr1[2*i+2] * sArr2[2*i+2]) + (sArr1[2*i+3] * sArr2[2*i+3]));
+        }
+        return out;
+    }
+
+    @Test
+    @IR(applyIfCPUFeature = {"sse2", "true"},
+        applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
+    public static int[] teste() {
+        int[] out = ioutArr;
+        for (int i = 0; i < ITER-2; i+=2) {
+            // Unrolled, with some swaps.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+0]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+            out[i+1] += ((sArr2[2*i+2] * sArr1[2*i+2]) + (sArr1[2*i+3] * sArr2[2*i+3])); // swap(1 2)
+        }
+        return out;
+    }
+
+    @Test
+    @IR(applyIfCPUFeature = {"sse2", "true"},
+        applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
+    public static int[] testf() {
+        int[] out = ioutArr;
+        for (int i = 0; i < ITER-2; i+=2) {
+            // Unrolled, with some swaps.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+0]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+            out[i+1] += ((sArr2[2*i+2] * sArr1[2*i+2]) + (sArr2[2*i+3] * sArr1[2*i+3])); // swap(1 2), swap(3 4)
+        }
+        return out;
+    }
+
+    @Test
+    @IR(applyIfCPUFeature = {"sse2", "true"},
+        applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
+    public static int[] testg() {
+        int[] out = ioutArr;
+        for (int i = 0; i < ITER-2; i+=2) {
+            // Unrolled, with some swaps.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+0]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+            out[i+1] += ((sArr1[2*i+3] * sArr2[2*i+3]) + (sArr1[2*i+2] * sArr2[2*i+2])); // swap(1 3), swap(2 4)
+        }
+        return out;
+    }
+
+    @Test
+    @IR(applyIfCPUFeature = {"sse2", "true"},
+        applyIfPlatform = {"64-bit", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"asimd", "true"},
+        applyIf = {"MaxVectorSize", "16"}, // AD file requires vector_length = 16
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI, "> 0"})
+    @IR(applyIfCPUFeature = {"avx512_vnni", "true"},
+        counts = {IRNode.MUL_ADD_S2I, "> 0", IRNode.MUL_ADD_VS2VI_VNNI, "> 0"})
+    public static int[] testh() {
+        int[] out = ioutArr;
+        for (int i = 0; i < ITER-2; i+=2) {
+            // Unrolled, with some swaps.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+0]) + (sArr1[2*i+1] * sArr2[2*i+1]));
+            out[i+1] += ((sArr2[2*i+3] * sArr1[2*i+3]) + (sArr2[2*i+2] * sArr1[2*i+2])); // swap(1 4), swap(2 3)
         }
         return out;
     }


### PR DESCRIPTION
I'm refactoring the packset, separating the details of packset-manupulation from the SuperWord algorithm.

Most importantly: I split it into two classes: `PairSet` and `PackSet`.
`combine_pairs_to_longer_packs` converts the first into the second.

I was able to simplify the combining, and remove the pack-sorting.
I now walk "pair-chains" directly with `PairSetIterator`. One such pair-chain is equivalent to a pack.

I moved all the `filter / split` functionality to the `PackSet`, which allows hiding a lot of packset-manipulation from the SuperWord algorithm.

I ran into some issues when I was extending the pairset in `extend_pairset_with_more_pairs_by_following_use_and_def`:
Using the PairSetIterator changed the order of extension, and that messed with the packing heuristic, and quite a few examples did not vectorize, because we would pack up the wrong 2 nodes out of a choice of 4 (e.g. we would pack `ac bd` instead of `ab cd`). Hence, I now still have to keep the insertion order for the pairs, and this basically means we are extending with a BFS order. Maybe this issue can be removed, if I improve the packing heuristic with some look-ahead expansion approach (but that is for another day [JDK-8309908](https://bugs.openjdk.org/browse/JDK-8309908)).

But since I already spent some time on some of the packing heuristic (reordering and cost estimate), I did a light refactoring, and added extra tests for MulAddS2I.

More details are described in the annotations in the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325252](https://bugs.openjdk.org/browse/JDK-8325252): C2 SuperWord: refactor the packset (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18276/head:pull/18276` \
`$ git checkout pull/18276`

Update a local copy of the PR: \
`$ git checkout pull/18276` \
`$ git pull https://git.openjdk.org/jdk.git pull/18276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18276`

View PR using the GUI difftool: \
`$ git pr show -t 18276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18276.diff">https://git.openjdk.org/jdk/pull/18276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18276#issuecomment-2009802122)