### PR TITLE
8325897: Parallel: Remove PSYoungGen::is_maximal_no_gc

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,8 @@ size_t ParallelScavengeHeap::used() const {
 }
 
 bool ParallelScavengeHeap::is_maximal_no_gc() const {
-  return old_gen()->is_maximal_no_gc() && young_gen()->is_maximal_no_gc();
+  // We don't expand young-gen except at a GC.
+  return old_gen()->is_maximal_no_gc();
 }
 
 

--- a/src/hotspot/share/gc/parallel/psYoungGen.hpp
+++ b/src/hotspot/share/gc/parallel/psYoungGen.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,10 +122,6 @@ class PSYoungGen : public CHeapObj<mtGC> {
 
   size_t min_gen_size() const { return _min_gen_size; }
   size_t max_gen_size() const { return _max_gen_size; }
-
-  bool is_maximal_no_gc() const {
-    return true;  // Never expands except at a GC
-  }
 
   // Allocation
   HeapWord* allocate(size_t word_size) {


### PR DESCRIPTION
Hi all,

This trivial patch removes the unnecessary method `PSYoungGen::is_maximal_no_gc`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325897](https://bugs.openjdk.org/browse/JDK-8325897): Parallel: Remove PSYoungGen::is_maximal_no_gc (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18277/head:pull/18277` \
`$ git checkout pull/18277`

Update a local copy of the PR: \
`$ git checkout pull/18277` \
`$ git pull https://git.openjdk.org/jdk.git pull/18277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18277`

View PR using the GUI difftool: \
`$ git pr show -t 18277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18277.diff">https://git.openjdk.org/jdk/pull/18277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18277#issuecomment-1994588537)