### PR TITLE
8328106: COMPARE_BUILD improvements

### DIFF
--- a/make/Images.gmk
+++ b/make/Images.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -142,6 +142,14 @@ define CreateCDSArchive
     $1_$2_CDS_ARCHIVE := bin/$1/classes$2.jsa
   else
     $1_$2_CDS_ARCHIVE := lib/$1/classes$2.jsa
+  endif
+
+  ifneq ($(COMPARE_BUILD), )
+    DEBUG_CDS_ARCHIVE := true
+  endif
+
+  ifeq ($(DEBUG_CDS_ARCHIVE), true)
+    $1_$2_CDS_DUMP_FLAGS += -Xlog:cds+map*=trace:file=$$(JDK_IMAGE_DIR)/$$($1_$2_CDS_ARCHIVE).cdsmap:none:filesize=0
   endif
 
   $$(eval $$(call SetupExecute, $1_$2_gen_cds_archive_jdk, \

--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -442,10 +442,10 @@ else # $(HAS_SPEC)=true
         # Compare first and second build. Ignore any error code from compare.sh.
 	$(ECHO) "Comparing between comparison rebuild (this/new) and baseline (other/old)"
 	$(if $(COMPARE_BUILD_COMP_DIR), \
-	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh -vv $(COMPARE_BUILD_COMP_OPTS) \
+	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh --diffs $(COMPARE_BUILD_COMP_OPTS) \
 	      -2dirs $(COMPARE_BUILD_OUTPUTDIR)/$(COMPARE_BUILD_COMP_DIR) \
 	      $(OUTPUTDIR)/$(COMPARE_BUILD_COMP_DIR) $(COMPARE_BUILD_IGNORE_RESULT)), \
-	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh -vv $(COMPARE_BUILD_COMP_OPTS) \
+	  +(cd $(COMPARE_BUILD_OUTPUTDIR) && ./compare.sh --diffs $(COMPARE_BUILD_COMP_OPTS) \
 	      -o $(OUTPUTDIR) $(COMPARE_BUILD_IGNORE_RESULT)) \
 	)
   endef

--- a/make/autoconf/compare.sh.template
+++ b/make/autoconf/compare.sh.template
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -45,11 +45,13 @@ export CP="@CP@"
 export CUT="@CUT@"
 export DIFF="@DIFF@"
 export DUMPBIN="@DUMPBIN@"
+export ECHO="@ECHO@"
 export EXPR="@EXPR@"
 export FILE="@FILE@"
 export FIND="@FIND@"
 export GREP="@GREP@"
 export GUNZIP="@GUNZIP@"
+export HEAD="@HEAD@"
 export LDD="@LDD@"
 export LN="@LN@"
 export MKDIR="@MKDIR@"


### PR DESCRIPTION
This is a collection of various improvements to `COMPARE_BUILD` I have been using lately.

* Introducing `DEBUG_CDS_ARCHIVE` make variable, which is set automatically when using `COMPARE_BUILD`. This will create a detailed log file for the `classes*.jsa` CDS archives creation, to help debug any differences in these files. It is also possible to call `make DEBUG_CDS_ARCHIVE=true` to get this functionality even without running comparisons.

* `otool` on macOS did not include all relevant information.

* We now create modern "unified" diffs using `diff -u` whenever the output is supposed to be seen by the user. For diffs that are processed by the tooling, the traditional style `>`/`<` diffs are still used.

* "Other" files are now getting symlinks as well, to facilitate debugging; and also the diff output is improved.

* Better handling of showing diffs: 

  The `-vv` argument was too verbose. To see diffs, you also were required to see redundant information about unchanged files, which spammed the log.  Now instead you can set `--diffs` to see the diffs but not unchanged files. By default, this is cut after 500 lines, but using `--diffs=full` you can get the whole diffs. Beware that this can cause logs the size of hundereds of MB!

  Now `-vv` is aliased to `-v --diffs`, and `COMPARE_BUILD` is run with `--diffs` instead of `-vv` as default.

* And finally, for some reason (merge error?) the file `compare_exceptions.sh.incl` were not properly removed before, just replaced with an emty file. This is now fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328106](https://bugs.openjdk.org/browse/JDK-8328106): COMPARE_BUILD improvements (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18279/head:pull/18279` \
`$ git checkout pull/18279`

Update a local copy of the PR: \
`$ git checkout pull/18279` \
`$ git pull https://git.openjdk.org/jdk.git pull/18279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18279`

View PR using the GUI difftool: \
`$ git pr show -t 18279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18279.diff">https://git.openjdk.org/jdk/pull/18279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18279#issuecomment-1994752409)