### PR TITLE
8328075: Shenandoah: Avoid forwarding when objects don't move in full-GC

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -364,7 +364,7 @@ public:
       _compact_point = _to_region->bottom();
     }
 
-    // Object fits into current region, record new location:
+    // Object fits into current region, record new location, if object does not move:
     assert(_compact_point + obj_size <= _to_region->end(), "must fit");
     shenandoah_assert_not_forwarded(nullptr, p);
     if (_compact_point != cast_from_oop<HeapWord*>(p)) {
@@ -866,7 +866,7 @@ public:
     if (p->is_forwarded()) {
       HeapWord* compact_from = cast_from_oop<HeapWord*>(p);
       HeapWord* compact_to = cast_from_oop<HeapWord*>(p->forwardee());
-      assert(compact_from != compact_to, "forwarded object doesn't move");
+      assert(compact_from != compact_to, "Forwarded object should move");
       Copy::aligned_conjoint_words(compact_from, compact_to, size);
       oop new_obj = cast_to_oop(compact_to);
 


### PR DESCRIPTION
Currently, in Shenandoah's full-GC, we forward all marked objects (and preserve their headers), even if they don't move. This typically happens for a certain amount of 'sediment' that accumulates at the bottom of the heap. This results in wasted CPU cycles and memory accesses and usage. It can easily be avoided by not forwarding objects that don't move.

The fix is to simply not forward objects when they don't move.

Testing:
 - [x] hotspot_gc_shenandoah
 - [x] tier1 +UseShenandoahGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328075](https://bugs.openjdk.org/browse/JDK-8328075): Shenandoah: Avoid forwarding when objects don't move in full-GC (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer) ⚠️ Review applies to [079fe89d](https://git.openjdk.org/jdk/pull/18280/files/079fe89d08d45614f88996511294a4a1ff556e67)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [079fe89d](https://git.openjdk.org/jdk/pull/18280/files/079fe89d08d45614f88996511294a4a1ff556e67)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [079fe89d](https://git.openjdk.org/jdk/pull/18280/files/079fe89d08d45614f88996511294a4a1ff556e67)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18280/head:pull/18280` \
`$ git checkout pull/18280`

Update a local copy of the PR: \
`$ git checkout pull/18280` \
`$ git pull https://git.openjdk.org/jdk.git pull/18280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18280`

View PR using the GUI difftool: \
`$ git pr show -t 18280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18280.diff">https://git.openjdk.org/jdk/pull/18280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18280#issuecomment-1996837026)