### PR TITLE
8328110: Allow simultaneous use of PassFailJFrame with split UI and additional windows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1333,14 +1333,6 @@ public final class PassFailJFrame {
                 position = Position.HORIZONTAL;
             }
 
-            if (panelCreator != null) {
-                if (splitUI && (testWindows != null || windowListCreator != null)) {
-                    // TODO Is it required? We can support both
-                    throw new IllegalStateException("Split UI is not allowed "
-                                                    + "with additional windows");
-                }
-            }
-
             if (positionWindows != null) {
                 if (testWindows == null && windowListCreator == null) {
                     throw new IllegalStateException("To position windows, "


### PR DESCRIPTION
It is currently blocked with an artificial check:

```java
if (panelCreator != null) {
    if (splitUI && (testWindows != null || windowListCreator != null)) {
        // TODO Is it required? We can support both
        throw new IllegalStateException("Split UI is not allowed "
                                        + "with additional windows");
    }
}
```

We have a number of manual tests, which has some text area in the instruction window to print a feedback from the test to be evaluated by a tester.

Removing this check allows us to implement this.
We can consider making a special methods for this later.

This is required for the #18250

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328110](https://bugs.openjdk.org/browse/JDK-8328110): Allow simultaneous use of PassFailJFrame with split UI and additional windows (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18281/head:pull/18281` \
`$ git checkout pull/18281`

Update a local copy of the PR: \
`$ git checkout pull/18281` \
`$ git pull https://git.openjdk.org/jdk.git pull/18281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18281`

View PR using the GUI difftool: \
`$ git pr show -t 18281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18281.diff">https://git.openjdk.org/jdk/pull/18281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18281#issuecomment-1995002576)