### PR TITLE
8319889: Vector API tests trigger VM crashes with -XX:+StressIncrementalInlining

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -9665,6 +9665,21 @@ instruct vlshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
+instruct vlshift_mem_masked(vec dst, memory src2, kReg mask) %{
+  match(Set dst (LShiftVS (Binary dst (LoadVector src2)) mask));
+  match(Set dst (LShiftVI (Binary dst (LoadVector src2)) mask));
+  match(Set dst (LShiftVL (Binary dst (LoadVector src2)) mask));
+  format %{ "vplshift_masked $dst, $dst, $src2, $mask\t! lshift masked operation" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 instruct vrshift_imm_masked(vec dst, immI8 shift, kReg mask) %{
   match(Set dst (RShiftVS (Binary dst (RShiftCntV shift)) mask));
   match(Set dst (RShiftVI (Binary dst (RShiftCntV shift)) mask));
@@ -9712,6 +9727,20 @@ instruct vrshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
+instruct vrshift_mem_masked(vec dst, memory src2, kReg mask) %{
+  match(Set dst (RShiftVS (Binary dst (LoadVector src2)) mask));
+  match(Set dst (RShiftVI (Binary dst (LoadVector src2)) mask));
+  match(Set dst (RShiftVL (Binary dst (LoadVector src2)) mask));
+  format %{ "vprshift_masked $dst, $dst, $src2, $mask\t! rshift masked operation" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
 instruct vurshift_imm_masked(vec dst, immI8 shift, kReg mask) %{
   match(Set dst (URShiftVS (Binary dst (RShiftCntV shift)) mask));
@@ -9760,6 +9789,20 @@ instruct vurshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
+instruct vurshift_mem_masked(vec dst, memory src2, kReg mask) %{
+  match(Set dst (URShiftVS (Binary dst (LoadVector src2)) mask));
+  match(Set dst (URShiftVI (Binary dst (LoadVector src2)) mask));
+  match(Set dst (URShiftVL (Binary dst (LoadVector src2)) mask));
+  format %{ "vpurshift_masked $dst, $dst, $src2, $mask\t! urshift masked operation" %}
+  ins_encode %{
+    int vlen_enc = vector_length_encoding(this);
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    int opc = this->ideal_Opcode();
+    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
+                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
 instruct vmaxv_reg_masked(vec dst, vec src2, kReg mask) %{
   match(Set dst (MaxV (Binary dst src2) mask));

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -9665,21 +9665,6 @@ instruct vlshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vlshift_mem_masked(vec dst, memory src2, kReg mask) %{
-  match(Set dst (LShiftVS (Binary dst (LoadVector src2)) mask));
-  match(Set dst (LShiftVI (Binary dst (LoadVector src2)) mask));
-  match(Set dst (LShiftVL (Binary dst (LoadVector src2)) mask));
-  format %{ "vplshift_masked $dst, $dst, $src2, $mask\t! lshift masked operation" %}
-  ins_encode %{
-    int vlen_enc = vector_length_encoding(this);
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int opc = this->ideal_Opcode();
-    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
-                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 instruct vrshift_imm_masked(vec dst, immI8 shift, kReg mask) %{
   match(Set dst (RShiftVS (Binary dst (RShiftCntV shift)) mask));
   match(Set dst (RShiftVI (Binary dst (RShiftCntV shift)) mask));
@@ -9727,20 +9712,6 @@ instruct vrshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vrshift_mem_masked(vec dst, memory src2, kReg mask) %{
-  match(Set dst (RShiftVS (Binary dst (LoadVector src2)) mask));
-  match(Set dst (RShiftVI (Binary dst (LoadVector src2)) mask));
-  match(Set dst (RShiftVL (Binary dst (LoadVector src2)) mask));
-  format %{ "vprshift_masked $dst, $dst, $src2, $mask\t! rshift masked operation" %}
-  ins_encode %{
-    int vlen_enc = vector_length_encoding(this);
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int opc = this->ideal_Opcode();
-    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
-                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
-  %}
-  ins_pipe( pipe_slow );
-%}
 
 instruct vurshift_imm_masked(vec dst, immI8 shift, kReg mask) %{
   match(Set dst (URShiftVS (Binary dst (RShiftCntV shift)) mask));
@@ -9789,20 +9760,6 @@ instruct vurshiftv_reg_masked(vec dst, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vurshift_mem_masked(vec dst, memory src2, kReg mask) %{
-  match(Set dst (URShiftVS (Binary dst (LoadVector src2)) mask));
-  match(Set dst (URShiftVI (Binary dst (LoadVector src2)) mask));
-  match(Set dst (URShiftVL (Binary dst (LoadVector src2)) mask));
-  format %{ "vpurshift_masked $dst, $dst, $src2, $mask\t! urshift masked operation" %}
-  ins_encode %{
-    int vlen_enc = vector_length_encoding(this);
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    int opc = this->ideal_Opcode();
-    __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
-                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
-  %}
-  ins_pipe( pipe_slow );
-%}
 
 instruct vmaxv_reg_masked(vec dst, vec src2, kReg mask) %{
   match(Set dst (MaxV (Binary dst src2) mask));

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -161,12 +161,12 @@ Node* GraphKit::box_vector(Node* vector, const TypeInstPtr* vbox_type, BasicType
 
 Node* GraphKit::unbox_vector(Node* v, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem, bool shuffle_to_vector) {
   assert(EnableVectorSupport, "");
-  const TypePtr* vbox_type_v = gvn().type(v)->isa_ptr();
-  if (!vbox_type_v->isa_instptr() || vbox_type_v->maybe_null()) {
-    return nullptr; // no nulls are allowed
-  }
-  if (vbox_type->instance_klass() != vbox_type_v->is_instptr()->instance_klass()) {
+  const TypeInstPtr* vbox_type_v = gvn().type(v)->isa_instptr();
+  if (vbox_type_v == nullptr || vbox_type->instance_klass() != vbox_type_v->instance_klass()) {
     return nullptr; // arguments don't agree on vector shapes
+  }
+  if (vbox_type_v->maybe_null()) {
+    return nullptr; // no nulls are allowed
   }
   assert(check_vbox(vbox_type), "");
   const TypeVect* vt = TypeVect::make(elem_bt, num_elem, is_vector_mask(vbox_type->instance_klass()));

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -161,12 +161,12 @@ Node* GraphKit::box_vector(Node* vector, const TypeInstPtr* vbox_type, BasicType
 
 Node* GraphKit::unbox_vector(Node* v, const TypeInstPtr* vbox_type, BasicType elem_bt, int num_elem, bool shuffle_to_vector) {
   assert(EnableVectorSupport, "");
-  const TypeInstPtr* vbox_type_v = gvn().type(v)->is_instptr();
-  if (vbox_type->instance_klass() != vbox_type_v->instance_klass()) {
-    return nullptr; // arguments don't agree on vector shapes
-  }
-  if (vbox_type_v->maybe_null()) {
+  const TypePtr* vbox_type_v = gvn().type(v)->isa_ptr();
+  if (!vbox_type_v->isa_instptr() || vbox_type_v->maybe_null()) {
     return nullptr; // no nulls are allowed
+  }
+  if (vbox_type->instance_klass() != vbox_type_v->is_instptr()->instance_klass()) {
+    return nullptr; // arguments don't agree on vector shapes
   }
   assert(check_vbox(vbox_type), "");
   const TypeVect* vt = TypeVect::make(elem_bt, num_elem, is_vector_mask(vbox_type->instance_klass()));


### PR DESCRIPTION
This bug fix patch fixes a crash occurring due to combined effect of bi-morphic inlining, exception handling, randomized incremental inlining. In this case top level slice API is invoked using concrete 256 bit vector, some of the intermediate APIs within sliceTemplate are marked for lazy inlining due to randomized IncrementalInlining, these APIs returns an abstract vector which when used for virtual dispatch of subsequent APIs results into bi-morphic inlining on account of multiple profile based receiver types. Consider following code snippet.

```
    ByteVector sliceTemplate(int origin, Vector<Byte> v1) {
        ByteVector that = (ByteVector) v1;
        that.check(this);
        Objects.checkIndex(origin, length() + 1);
        VectorShuffle<Byte> iota = iotaShuffle();
        VectorMask<Byte> blendMask = iota.toVector().compare(VectorOperators.LT, (broadcast((byte)(length() - origin))));  [A]
        iota = iotaShuffle(origin, 1, true);     [B]    
        return that.rearrange(iota).blend(this.rearrange(iota), blendMask); [C]
    }
```


Receiver for sliceTemplate is a 256 bit vector, parser defers inlining of toVector() API (see code at line A) and generates a Call IR returning an abstract vector. This abstract vector then virtually dispatches compare API. Compiler observes multiple profile based receiver types (128 and 256 bit byte vectors) for compare API and parser generates a chain of PredictedCallGenerators for bi-morphically inlining it.
      
         PredictedCallGenerators (Vector.compare)
              PredictedCallGenerators (Byte256Vector.compare)
                 ParseGenerator (Byte256Vector.compare)               [D]
                 UncommonTrap (receiver other than Byte256Vector)
              PredictedCallGenerators (Byte128Vector.compare)
                 ParseGenerator (Byte128Vector.compare)               [E]
                 UncommonTrap (receiver other than Byte128Vector)     [F]
              PredictedCallGenerators (UncommonTrap)
         [converged state] = Merge JVM State orginating from C and E  [G]

   Since top level receiver of sliceTemplate is Byte256Vector hence while executing the call generator for Byte128Vector.compare (see code at line E) compiler observes a mismatch b/w incoming argument species i.e. one argument is a 256 bit vector while other is 128 bit vector and throws an exception.
    
At state convergence point (see code at line G), since one of the control path resulted into an exception, compiler propagates the JVM state of other control path comprising of Byte256Mask to downstream graph after  bookkeeping the pending exception state.

Similar to toVector API, iotaShuffle (see code at line B) is also lazily inlined and returns an abstract vector which results into bi-morphic inlining of rearrange. State convergence due to bi-morphic inlining of rearrange results into generation of an abstract ByteVector (Phi Byte128Vector Byte256Vector) which further causes bi-morphic inlining of blend API due to multiple profile based receiver types.
    
Byte128Vector.blend [Java implementation](https://github.com/openjdk/jdk/blob/master/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Byte128Vector.java#L412) explicitly cast incoming mask (Byte256Mask) by Byte128Mask type which results into a[ null reference](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/graphKit.cpp#L1417), this causes a crash while unboxing the mask during inline expansion of blend. To be safe, relaxing the null checking constraint during unboxing to disable intrinsification.

All existing Vector API JTREG tests are passing with -XX:+StressIncrementalInlining at various AVX levels.

Please review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319889](https://bugs.openjdk.org/browse/JDK-8319889): Vector API tests trigger VM crashes with -XX:+StressIncrementalInlining (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18282/head:pull/18282` \
`$ git checkout pull/18282`

Update a local copy of the PR: \
`$ git checkout pull/18282` \
`$ git pull https://git.openjdk.org/jdk.git pull/18282/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18282`

View PR using the GUI difftool: \
`$ git pr show -t 18282`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18282.diff">https://git.openjdk.org/jdk/pull/18282.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18282#issuecomment-1995081719)