### PR TITLE
8327180: Failed: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#G1

### DIFF
--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -54,7 +54,7 @@ import static org.testng.Assert.assertTrue;
  * @bug 8277072 8327180
  * @library /test/lib/
  * @summary ObjectStreamClass caches keep ClassLoaders alive (ZGC)
- * @run testng/othervm -Xmx64m -XX:+UseZGC ObjectStreamClassCaching
+ * @run testng/othervm -Xmx64m -XX:+UseZGC -XX:+ZGenerational ObjectStreamClassCaching
  */
 
 /*

--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -49,7 +49,6 @@ import static org.testng.Assert.assertTrue;
  */
 
 /*
- * Disabled for ZGC Generational.
  * @test id=ZGenerational
  * @requires vm.gc.ZGenerational
  * @bug 8277072 8327180

--- a/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
+++ b/test/jdk/java/io/ObjectStreamClass/ObjectStreamClassCaching.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,12 @@ import static org.testng.Assert.assertTrue;
 
 /*
  * Disabled for ZGC Generational.
- * TODO: Find correct appropriate solution to the flakiness of this test.
+ * @test id=ZGenerational
+ * @requires vm.gc.ZGenerational
+ * @bug 8277072 8327180
+ * @library /test/lib/
+ * @summary ObjectStreamClass caches keep ClassLoaders alive (ZGC)
+ * @run testng/othervm -Xmx64m -XX:+UseZGC ObjectStreamClassCaching
  */
 
 /*
@@ -65,40 +70,12 @@ import static org.testng.Assert.assertTrue;
 /*
  * @test id=Serial
  * @requires vm.gc.Serial
- * @bug 8277072
+ * @bug 8277072 8327180
  * @library /test/lib/
  * @summary ObjectStreamClass caches keep ClassLoaders alive (Serial GC)
  * @run testng/othervm -Xmx64m -XX:+UseSerialGC ObjectStreamClassCaching
  */
 public class ObjectStreamClassCaching {
-
-    /**
-     * Test methods execute in same VM and are ordered by name.
-     * We test effectiveness 1st which is sensitive to previous allocations when ZGC is used.
-     */
-    @Test
-    public void test1CacheEffectiveness() throws Exception {
-        var list = new ArrayList<>();
-        var ref1 = lookupObjectStreamClass(TestClass1.class);
-        var ref2 = newWeakRef();
-        boolean oome = false;
-        try {
-            while (!ref2.refersTo(null)) {
-                list.add(new byte[1024 * 1024 * 1]); // 1 MiB chunks
-                System.out.println("1MiB allocated...");
-                Thread.sleep(5L);
-            }
-        } catch (OutOfMemoryError e) {
-            // release
-            list = null;
-            oome = true;
-        }
-        assertFalse(oome, "WeakReference was not cleared although memory was pressed hard");
-        assertFalse(ref1.refersTo(null),
-                    "Cache lost entry together with WeakReference being cleared although memory was not under pressure");
-        System.gc();
-        Thread.sleep(100L);
-    }
 
     @Test
     public void test2CacheReleaseUnderMemoryPressure() throws Exception {


### PR DESCRIPTION
The intermittent failure of ObjectStreamClassCaching is due to an incorrect assumption about GC behavior and a race condition.

Removed test based on incorrect assumptions about simultaneous clearing of WeakReferences.
Added a run of the test using ZGC, (previously omitted)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327180](https://bugs.openjdk.org/browse/JDK-8327180): Failed: java/io/ObjectStreamClass/ObjectStreamClassCaching.java#G1 (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18284/head:pull/18284` \
`$ git checkout pull/18284`

Update a local copy of the PR: \
`$ git checkout pull/18284` \
`$ git pull https://git.openjdk.org/jdk.git pull/18284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18284`

View PR using the GUI difftool: \
`$ git pr show -t 18284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18284.diff">https://git.openjdk.org/jdk/pull/18284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18284#issuecomment-1995216581)