### PR TITLE
8328066: WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap

### DIFF
--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -56,7 +56,7 @@ import static org.testng.Assert.assertThrows;
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
  * @comment skip running this test on 32 bit VM
- * @requires vm.bits == "64" & os.maxMemory > 2G
+ * @requires vm.bits == "64"
  * @run testng/othervm -Xmx2g WhiteBoxResizeTest
  */
 public class WhiteBoxResizeTest {

--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,9 @@ import static org.testng.Assert.assertThrows;
  * @bug 8186958 8210280 8281631 8285386 8284780
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
+ * @comment skip running this test on 32 bit VM
+ * @requires vm.bits == "64"
+ * @requires os.maxMemory > 2G
  * @run testng/othervm -Xmx2g WhiteBoxResizeTest
  */
 public class WhiteBoxResizeTest {

--- a/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
+++ b/test/jdk/java/util/HashMap/WhiteBoxResizeTest.java
@@ -56,8 +56,7 @@ import static org.testng.Assert.assertThrows;
  * @modules java.base/java.util:open
  * @summary White box tests for HashMap-related internals around table sizing
  * @comment skip running this test on 32 bit VM
- * @requires vm.bits == "64"
- * @requires os.maxMemory > 2G
+ * @requires vm.bits == "64" & os.maxMemory > 2G
  * @run testng/othervm -Xmx2g WhiteBoxResizeTest
  */
 public class WhiteBoxResizeTest {


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to address https://bugs.openjdk.org/browse/JDK-8328066?

The test launches a JVM with 2G heap (`-Xmx2G`) and as noted in that issue, the failure was observed on linux-86 instance on a GitHub jobs run. 

The commit in this PR proposes to add relevant `@requires` so that the test is only run on 64 bit VM and expects the `os.maxMemory` to be > 2G.

The change has been tested on a linux-x86 run in GitHub actions job, plus even on local and CI 64 bit VM environments. No failures have been noticed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328066](https://bugs.openjdk.org/browse/JDK-8328066): WhiteBoxResizeTest failure on linux-x86: Could not reserve enough space for 2097152KB object heap (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [0a66d740](https://git.openjdk.org/jdk/pull/18290/files/0a66d740c768826c1ca58a440de35641a977404d)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18290/head:pull/18290` \
`$ git checkout pull/18290`

Update a local copy of the PR: \
`$ git checkout pull/18290` \
`$ git pull https://git.openjdk.org/jdk.git pull/18290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18290`

View PR using the GUI difftool: \
`$ git pr show -t 18290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18290.diff">https://git.openjdk.org/jdk/pull/18290.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18290#issuecomment-1996369990)