### PR TITLE
8328139: Prefer 'override' to 'virtual' in subclasses of 'GCInitLogger'

### DIFF
--- a/src/hotspot/share/gc/epsilon/epsilonInitLogger.hpp
+++ b/src/hotspot/share/gc/epsilon/epsilonInitLogger.hpp
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +30,7 @@
 
 class EpsilonInitLogger : public GCInitLogger {
 protected:
-  virtual void print_gc_specific();
+  void print_gc_specific() override;
 
 public:
   static void print();

--- a/src/hotspot/share/gc/g1/g1InitLogger.hpp
+++ b/src/hotspot/share/gc/g1/g1InitLogger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,9 @@
 
 class G1InitLogger : public GCInitLogger {
  protected:
-  virtual void print_heap();
-  virtual void print_workers();
-  virtual void print_gc_specific();
+  void print_heap() override;
+  void print_workers() override;
+  void print_gc_specific() override;
  public:
   static void print();
 };

--- a/src/hotspot/share/gc/parallel/parallelInitLogger.hpp
+++ b/src/hotspot/share/gc/parallel/parallelInitLogger.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 
 class ParallelInitLogger : public GCInitLogger {
  protected:
-  virtual void print_heap();
+  void print_heap() override;
  public:
   static void print();
 };


### PR DESCRIPTION
Hi all,

This patch adds keyword `override` and removes `virtual` in the subclasses of `GCInitLogger`. 

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328139](https://bugs.openjdk.org/browse/JDK-8328139): Prefer 'override' to 'virtual' in subclasses of 'GCInitLogger' (**Enhancement** - P5)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18291/head:pull/18291` \
`$ git checkout pull/18291`

Update a local copy of the PR: \
`$ git checkout pull/18291` \
`$ git pull https://git.openjdk.org/jdk.git pull/18291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18291`

View PR using the GUI difftool: \
`$ git pr show -t 18291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18291.diff">https://git.openjdk.org/jdk/pull/18291.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18291#issuecomment-1996389391)