### PR TITLE
8308660: C2 compilation hits 'node must be dead' assert

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1050,6 +1050,10 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
     adjusted_lim = igvn->transform(new SubINode(hi, lo));
   }
   hook->destruct(igvn);
+  
+  if (adjusted_val->is_top() || adjusted_lim->is_top()) {
+    return false;
+  }
 
   if (igvn->type(adjusted_lim)->is_int()->_lo < 0 &&
       !igvn->C->post_loop_opts_phase()) {

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1050,7 +1050,7 @@ bool IfNode::fold_compares_helper(ProjNode* proj, ProjNode* success, ProjNode* f
     adjusted_lim = igvn->transform(new SubINode(hi, lo));
   }
   hook->destruct(igvn);
-  
+
   if (adjusted_val->is_top() || adjusted_lim->is_top()) {
     return false;
   }

--- a/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
+++ b/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
@@ -61,7 +61,7 @@ public class TestFoldIfRemovesTopNode {
     private static void testHelper(int k, boolean flag, int[] array) {
         if (flag) {
             k = new int[k].length;
-            int  j = k + 3;
+            int j = k + 3;
             if (j >= 0 && j <= array.length) {
             }
         }

--- a/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
+++ b/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
@@ -25,8 +25,11 @@
  * @test
  * @bug 8308660
  * @summary C2 compilation hits 'node must be dead' assert
- * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:+StressIGVN -XX:StressSeed=242006623 TestFoldIfRemovesTopNode
- * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:+StressIGVN TestFoldIfRemovesTopNode
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=242006623 TestFoldIfRemovesTopNode
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN TestFoldIfRemovesTopNode
  *
  */
 

--- a/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
+++ b/test/hotspot/jtreg/compiler/c2/TestFoldIfRemovesTopNode.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8308660
+ * @summary C2 compilation hits 'node must be dead' assert
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:+StressIGVN -XX:StressSeed=242006623 TestFoldIfRemovesTopNode
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:+StressIGVN TestFoldIfRemovesTopNode
+ *
+ */
+
+public class TestFoldIfRemovesTopNode {
+
+    public static void main(String[] args) {
+        int[] array = new int[100];
+        for (int i = 0; i < 20_000; i++) {
+            test(false, true, 0, array);
+            test(false, false, 0, array);
+            testHelper2(false, false, 0, array);
+            testHelper(0, true, array);
+        }
+    }
+
+    private static void test(boolean flag, boolean flag2, int k, int[] array) {
+        if (flag2) {
+            testHelper2(flag, flag2, k, array);
+        }
+    }
+
+    private static void testHelper2(boolean flag, boolean flag2, int k, int[] array) {
+        if (flag2) {
+            k = -1;
+        }
+        testHelper(k, flag, array);
+    }
+
+    private static void testHelper(int k, boolean flag, int[] array) {
+        if (flag) {
+            k = new int[k].length;
+            int  j = k + 3;
+            if (j >= 0 && j <= array.length) {
+            }
+        }
+    }
+}


### PR DESCRIPTION
In `IfNode::fold_compares_helper()`, `adjusted_val` is:

```
(SubI (AddI top constant) 0)
```

which is then transformed to the `top` node. The code, next, tries to
destroy the `adjusted_val` node i.e. the `top` node. That results in
the assert failure. Given We're trying to fold 2 ifs in a dying part
of the graph, the fix is straightforward: test `adjusted_val` for top
and bail out from the transformation if that's the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308660](https://bugs.openjdk.org/browse/JDK-8308660): C2 compilation hits 'node must be dead' assert (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [f4703ea7](https://git.openjdk.org/jdk/pull/18305/files/f4703ea7856396594965e9541206bce1850a614a)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [f4703ea7](https://git.openjdk.org/jdk/pull/18305/files/f4703ea7856396594965e9541206bce1850a614a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18305/head:pull/18305` \
`$ git checkout pull/18305`

Update a local copy of the PR: \
`$ git checkout pull/18305` \
`$ git pull https://git.openjdk.org/jdk.git pull/18305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18305`

View PR using the GUI difftool: \
`$ git pr show -t 18305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18305.diff">https://git.openjdk.org/jdk/pull/18305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18305#issuecomment-1997587966)