### PR TITLE
8327383: Clean up _Stalled and _Spinner fields

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -419,7 +419,6 @@ JavaThread::JavaThread() :
   _current_waiting_monitor(nullptr),
   _active_handles(nullptr),
   _free_handle_block(nullptr),
-  _Stalled(0),
 
   _monitor_chunks(nullptr),
 

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -158,8 +158,6 @@ class JavaThread: public Thread {
   JNIHandleBlock* _free_handle_block;
 
  public:
-  volatile intptr_t _Stalled;
-
   // For tracking the heavyweight monitor the thread is pending on.
   ObjectMonitor* current_pending_monitor() {
     // Use Atomic::load() to prevent data race between concurrent modification and

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -269,7 +269,6 @@ ObjectMonitor::ObjectMonitor(oop object) :
   _cxq(nullptr),
   _succ(nullptr),
   _Responsible(nullptr),
-  _Spinner(0),
   _SpinDuration(ObjectMonitor::Knob_SpinLimit),
   _contentions(0),
   _WaitSet(nullptr),
@@ -401,8 +400,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
   }
 
   // We've encountered genuine contention.
-  assert(current->_Stalled == 0, "invariant");
-  current->_Stalled = intptr_t(this);
 
   // Try one round of spinning *before* enqueueing current
   // and before going through the awkward and expensive state
@@ -416,7 +413,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
            "object mark must match encoded this: mark=" INTPTR_FORMAT
            ", encoded this=" INTPTR_FORMAT, object()->mark().value(),
            markWord::encode(this).value());
-    current->_Stalled = 0;
     return true;
   }
 
@@ -437,7 +433,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
       // we only retry once if the deflater thread happens to be slow.
       install_displaced_markword_in_object(l_object);
     }
-    current->_Stalled = 0;
     add_to_contentions(-1);
     return false;
   }
@@ -500,7 +495,6 @@ bool ObjectMonitor::enter(JavaThread* current) {
 
   add_to_contentions(-1);
   assert(contentions() >= 0, "must not be negative: contentions=%d", contentions());
-  current->_Stalled = 0;
 
   // Must either set _recursions = 0 or ASSERT _recursions == 0.
   assert(_recursions == 0, "invariant");
@@ -1511,8 +1505,6 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
     return;
   }
 
-  assert(current->_Stalled == 0, "invariant");
-  current->_Stalled = intptr_t(this);
   current->set_current_waiting_monitor(this);
 
   // create a node to be put into the queue
@@ -1645,9 +1637,6 @@ void ObjectMonitor::wait(jlong millis, bool interruptible, TRAPS) {
     }
 
     OrderAccess::fence();
-
-    assert(current->_Stalled != 0, "invariant");
-    current->_Stalled = 0;
 
     assert(owner_raw() != current, "invariant");
     ObjectWaiter::TStates v = node.TState;
@@ -2190,7 +2179,6 @@ void ObjectMonitor::print() const { print_on(tty); }
 //   _cxq = 0x0000000000000000
 //   _succ = 0x0000000000000000
 //   _Responsible = 0x0000000000000000
-//   _Spinner = 0
 //   _SpinDuration = 5000
 //   _contentions = 0
 //   _WaitSet = 0x0000700009756248
@@ -2220,7 +2208,6 @@ void ObjectMonitor::print_debug_style_on(outputStream* st) const {
   st->print_cr("  _cxq = " INTPTR_FORMAT, p2i(_cxq));
   st->print_cr("  _succ = " INTPTR_FORMAT, p2i(_succ));
   st->print_cr("  _Responsible = " INTPTR_FORMAT, p2i(_Responsible));
-  st->print_cr("  _Spinner = %d", _Spinner);
   st->print_cr("  _SpinDuration = %d", _SpinDuration);
   st->print_cr("  _contentions = %d", contentions());
   st->print_cr("  _WaitSet = " INTPTR_FORMAT, p2i(_WaitSet));

--- a/src/hotspot/share/runtime/objectMonitor.hpp
+++ b/src/hotspot/share/runtime/objectMonitor.hpp
@@ -175,7 +175,6 @@ private:
   JavaThread* volatile _succ;       // Heir presumptive thread - used for futile wakeup throttling
   JavaThread* volatile _Responsible;
 
-  volatile int _Spinner;            // for exit->spinner handoff optimization
   volatile int _SpinDuration;
 
   int _contentions;                 // Number of active contentions in enter(). It is used by is_busy()


### PR DESCRIPTION
Removed the `_Stalled` and the `_Spinner` fields from the object synchronization code, since they are not used anymore.

Passes tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327383](https://bugs.openjdk.org/browse/JDK-8327383): Clean up _Stalled and _Spinner fields (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18306/head:pull/18306` \
`$ git checkout pull/18306`

Update a local copy of the PR: \
`$ git checkout pull/18306` \
`$ git pull https://git.openjdk.org/jdk.git pull/18306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18306`

View PR using the GUI difftool: \
`$ git pr show -t 18306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18306.diff">https://git.openjdk.org/jdk/pull/18306.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18306#issuecomment-1998525031)