### PR TITLE
8326979: (jdeps) improve the error message for FindException caused by InvalidModuleDescriptorException

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/jdeps/JdepsTask.java
@@ -536,7 +536,8 @@ class JdepsTask {
             }
             return EXIT_CMDERR;
         } catch (ResolutionException | FindException e) {
-            reportError("err.exception.message", e.getMessage());
+            Throwable cause = e.getCause();
+            reportError("err.exception.message", cause != null ? cause.getMessage() : e.getMessage());
             return EXIT_CMDERR;
         } catch (IOException e) {
             e.printStackTrace();

--- a/test/langtools/tools/jdeps/modules/InvalidModuleDescriptor.java
+++ b/test/langtools/tools/jdeps/modules/InvalidModuleDescriptor.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8326979
+ * @run main InvalidModuleDescriptor
+ * @summary jdeps should print the exception message of the cause of FindException
+ *          instead of FindException
+ */
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.spi.ToolProvider;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+public class InvalidModuleDescriptor {
+    private static final Path TEST_CLASSES = Paths.get(System.getProperty("test.classes"));
+    private static final ToolProvider JDEPS = ToolProvider.findFirst("jdeps").orElseThrow();
+    private static final ToolProvider JAR = ToolProvider.findFirst("jar").orElseThrow();
+
+    public static void main(String... args) throws IOException {
+        // create an automatic module with an invalid module descriptor (containing unnamed package)
+        Path jarFile = Paths.get("hi.jar");
+        String moduleName = "hi";
+        int rc = createAutomaticModule(jarFile, moduleName);
+        if (rc != 0) {
+            throw new RuntimeException("Fail to create automatic module");
+        }
+
+        // jdeps should fail with an error without stack trace
+        String expectedError = "Error: InvalidModuleDescriptor.class found in top-level directory (unnamed package not allowed in module)";
+        rc = runJdeps(expectedError, "--module-path", jarFile.toString(), "-m", moduleName);
+        if (rc == 0) {
+            throw new RuntimeException("Expected jdeps to fail");
+        }
+    }
+
+    // create an automatic module with an invalid module descriptor
+    static int createAutomaticModule(Path jarFile, String moduleName) throws IOException {
+        Path manifest = Paths.get("manifest");
+        Files.writeString(manifest, "Automatic-Module-Name: " + moduleName, CREATE_NEW);
+        return JAR.run(System.out, System.out, "--create", "--file", jarFile.toString(),
+                       "-m", manifest.toString(),
+                       "-C", TEST_CLASSES.toString(), "InvalidModuleDescriptor.class");
+    }
+
+    static int runJdeps(String expected, String... args) {
+        StringWriter output = new StringWriter();
+        StringWriter error = new StringWriter();
+        try (PrintWriter pwout = new PrintWriter(output);
+             PrintWriter pwerr = new PrintWriter(error)) {
+            int rc = JDEPS.run(pwout, pwerr, args);
+            if (!output.toString().contains(expected)) {
+                System.out.println(output);
+                System.out.println(error);
+                throw new RuntimeException("Mismatched output");
+            }
+            return rc;
+        }
+    }
+}


### PR DESCRIPTION
Trivial fix.  Improve the error message to print the cause of the module resolution failure if present.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326979](https://bugs.openjdk.org/browse/JDK-8326979): (jdeps) improve the error message for FindException caused by InvalidModuleDescriptorException (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18308/head:pull/18308` \
`$ git checkout pull/18308`

Update a local copy of the PR: \
`$ git checkout pull/18308` \
`$ git pull https://git.openjdk.org/jdk.git pull/18308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18308`

View PR using the GUI difftool: \
`$ git pr show -t 18308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18308.diff">https://git.openjdk.org/jdk/pull/18308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18308#issuecomment-1997996254)