### PR TITLE
8320794: Emulate rest of vblendvp[sd] on ECore

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4868,7 +4868,7 @@ void C2_MacroAssembler::vector_cast_float_to_int_special_cases_avx(XMMRegister d
   // values are set.
   vpxor(xtmp3, xtmp2, xtmp4, vec_enc);
 
-  vblendvps(dst, dst, xtmp1, xtmp3, vec_enc);
+  vblendvps(dst, dst, xtmp1, xtmp3, vec_enc, true, xtmp4);
   bind(done);
 }
 
@@ -5004,7 +5004,7 @@ void C2_MacroAssembler::vector_cast_double_to_int_special_cases_avx(XMMRegister 
 
   // Shuffle mask vector and pack lower doubles word from each quadword lane.
   vector_crosslane_doubleword_pack_avx(xtmp3, xtmp3, xtmp4, xtmp5, 0x88, src_vec_enc);
-  vblendvps(dst, dst, xtmp4, xtmp3, Assembler::AVX_128bit);
+  vblendvps(dst, dst, xtmp4, xtmp3, Assembler::AVX_128bit, false, xtmp5);
 
   // Recompute the mask for remaining special value.
   pxor(xtmp2, xtmp3);
@@ -5017,7 +5017,7 @@ void C2_MacroAssembler::vector_cast_double_to_int_special_cases_avx(XMMRegister 
 
   // Replace destination lanes holding special value(0x80000000) with max int
   // if corresponding source lane holds a +ve value.
-  vblendvps(dst, dst, xtmp1, xtmp3, Assembler::AVX_128bit);
+  vblendvps(dst, dst, xtmp1, xtmp3, Assembler::AVX_128bit, false, xtmp5);
   bind(done);
 }
 
@@ -6071,7 +6071,7 @@ void C2_MacroAssembler::vector_count_leading_zeros_int_avx(XMMRegister dst, XMMR
   // Replace -ve exponent with zero, exponent is -ve when src
   // lane contains a zero value.
   vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
-  vblendvps(dst, dst, xtmp2, dst, vec_enc);
+  vblendvps(dst, dst, xtmp2, dst, vec_enc, true, xtmp1);
 
   // Rematerialize broadcast 32.
   vpslld(xtmp1, xtmp3, 5, vec_enc);
@@ -6086,7 +6086,7 @@ void C2_MacroAssembler::vector_count_leading_zeros_int_avx(XMMRegister dst, XMMR
 
   // Replace biased_exp with 0 if source lane value is less than zero.
   vpxor(xtmp2, xtmp2, xtmp2, vec_enc);
-  vblendvps(dst, dst, xtmp2, src, vec_enc);
+  vblendvps(dst, dst, xtmp2, src, vec_enc, true, xtmp1);
 }
 
 void C2_MacroAssembler::vector_count_leading_zeros_long_avx(XMMRegister dst, XMMRegister src, XMMRegister xtmp1,

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -3521,7 +3521,7 @@ void MacroAssembler::vblendvps(XMMRegister dst, XMMRegister src1, XMMRegister sr
   // WARN: Allow dst == (src1|src2), mask == scratch
   bool blend_emulation = EnableX86ECoreOpts && UseAVX > 1;
   bool scratch_available = scratch != xnoreg && scratch != src1 && scratch != src2 && scratch != dst;
-  bool dst_available = dst != mask && (dst != src1 || dst != src2);
+  bool dst_available = (dst != mask || compute_mask) && (dst != src1 || dst != src2);
   if (blend_emulation && scratch_available && dst_available) {
     if (compute_mask) {
       vpsrad(scratch, mask, 32, vector_len);
@@ -3536,7 +3536,7 @@ void MacroAssembler::vblendvps(XMMRegister dst, XMMRegister src1, XMMRegister sr
     }
     vpor(dst, dst, scratch, vector_len);
   } else {
-    Assembler::vblendvps(dst, src1, src2, mask, vector_len);
+        Assembler::vblendvps(dst, src1, src2, mask, vector_len);
   }
 }
 

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1114,6 +1114,16 @@ public class IRNode {
         vectorNode(POPCOUNT_VL, "PopCountVL", TYPE_LONG);
     }
 
+    public static final String COUNTTRAILINGZEROS_VI = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VI" + POSTFIX;
+    static {
+        vectorNode(COUNTTRAILINGZEROS_VI, "CountTrailingZerosV", TYPE_INT);
+    }
+
+    public static final String COUNTLEADINGZEROS_VI = VECTOR_PREFIX + "COUNTLEADINGZEROS_VI" + POSTFIX;
+    static {
+        vectorNode(COUNTLEADINGZEROS_VI, "CountLeadingZerosV", TYPE_INT);
+    }
+
     public static final String COUNTTRAILINGZEROS_VL = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VL" + POSTFIX;
     static {
         vectorNode(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV", TYPE_LONG);

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -42,6 +42,7 @@
 package compiler.vectorization.runner;
 
 import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
 
 public class BasicIntOpTest extends VectorizationTestRunner {
 
@@ -57,7 +58,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
         c = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
             a[i] = -25 * i;
-            b[i] = 333 * i + 9999;
+            b[i] = 333 * i - 9999;
             c[i] = -987654321;
         }
     }
@@ -65,56 +66,56 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     // ---------------- Arithmetic ----------------
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_VI, ">0"})
+    counts = {IRNode.SUB_VI, ">0"})
     public int[] vectorNeg() {
-        int[] res = new int[SIZE];
-        for (int i = 0; i < SIZE; i++) {
-            res[i] = -a[i];
-        }
+    int[] res = new int[SIZE];
+    for (int i = 0; i < SIZE; i++) {
+    res[i] = -a[i];
+    }
         return res;
     }
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "ssse3", "true"},
-        counts = {IRNode.ABS_VI, ">0"})
+    counts = {IRNode.ABS_VI, ">0"})
     public int[] vectorAbs() {
-        int[] res = new int[SIZE];
-        for (int i = 0; i < SIZE; i++) {
-            res[i] = Math.abs(a[i]);
-        }
+    int[] res = new int[SIZE];
+    for (int i = 0; i < SIZE; i++) {
+    res[i] = Math.abs(a[i]);
+    }
         return res;
     }
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.ADD_VI, ">0"})
+    counts = {IRNode.ADD_VI, ">0"})
     public int[] vectorAdd() {
-        int[] res = new int[SIZE];
-        for (int i = 0; i < SIZE; i++) {
-            res[i] = a[i] + b[i];
-        }
+    int[] res = new int[SIZE];
+    for (int i = 0; i < SIZE; i++) {
+    res[i] = a[i] + b[i];
+    }
         return res;
     }
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.SUB_VI, ">0"})
+    counts = {IRNode.SUB_VI, ">0"})
     public int[] vectorSub() {
-        int[] res = new int[SIZE];
-        for (int i = 0; i < SIZE; i++) {
-            res[i] = a[i] - b[i];
-        }
+    int[] res = new int[SIZE];
+    for (int i = 0; i < SIZE; i++) {
+    res[i] = a[i] - b[i];
+    }
         return res;
     }
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.MUL_VI, ">0"})
+    counts = {IRNode.MUL_VI, ">0"})
     public int[] vectorMul() {
-        int[] res = new int[SIZE];
-        for (int i = 0; i < SIZE; i++) {
-            res[i] = a[i] * b[i];
-        }
+    int[] res = new int[SIZE];
+    for (int i = 0; i < SIZE; i++) {
+    res[i] = a[i] * b[i];
+    }
         return res;
     }
 
@@ -149,6 +150,24 @@ public class BasicIntOpTest extends VectorizationTestRunner {
             res[i] = Integer.bitCount(a[i]);
         }
         return res;
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNTLEADINGZEROS_VI, ">0"})
+    public int[] vectorizeNumberOfLeadingZeros() {
+        int[] res = new int[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = Integer.numberOfLeadingZeros(b[i]);
+        }
+        return res;
+    }
+
+    @Run(test = {"vectorizeNumberOfLeadingZeros"})
+    public void checkResult() {
+        int[] res = vectorizeNumberOfLeadingZeros();
+        for (int i = 0; i < SIZE; ++i) {
+            Asserts.assertEquals(res[i], Integer.numberOfLeadingZeros(b[i]));
+        }
     }
 
     // ---------------- Logic ----------------

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
@@ -64,6 +64,14 @@ public abstract class VectorBitCount {
     }
 
     @Benchmark
+    public int[] intLeadingZeroCount() {
+        for (int i = 0; i < SIZE; i++) {
+            bitCounts[i] = Integer.numberOfLeadingZeros(bufferRandInts[i]);
+        }
+        return bitCounts;
+    }
+
+    @Benchmark
     public int[] longBitCount() {
         for (int i = 0; i < SIZE; i++) {
             bitCounts[i] = Long.bitCount(bufferRandLongs[i]);


### PR DESCRIPTION
Replace vpblendvp[sd] with macro assembler call and test in:
- C2_MacroAssembler::vector_cast_float_to_int_special_cases_avx (insufficient registers for 1 of 2 blends)
- C2_MacroAssembler::vector_cast_double_to_int_special_cases_avx 
- C2_MacroAssembler::vector_count_leading_zeros_int_avx

Functional testing with existing and new tests:
`make test TEST="test/hotspot/jtreg/compiler/vectorapi/reshape test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java"`

Benchmarking with existing and new tests:
make test TEST="micro:org.openjdk.bench.jdk.incubator.vector.VectorFPtoIntCastOperations"

Performance before:
```
Benchmark                                               (SIZE)   Mode  Cnt      Score     Error   Units
VectorFPtoIntCastOperations.microDouble256ToInteger256     512  thrpt    5  17514.335 ± 145.342  ops/ms
VectorFPtoIntCastOperations.microDouble256ToInteger256    1024  thrpt    5   9525.645 ±  72.152  ops/ms
VectorFPtoIntCastOperations.microFloat256ToInteger256      512  thrpt    5  11684.992 ±  10.260  ops/ms
VectorFPtoIntCastOperations.microFloat256ToInteger256     1024  thrpt    5   6001.282 ±   7.813  ops/ms
VectorBitCount.WithSuperword.intLeadingZeroCount    1024       0  avgt    4  1002.290 ± 1.959  ns/op
```

Performance after:
```
Benchmark                                               (SIZE)   Mode  Cnt      Score     Error   Units
VectorFPtoIntCastOperations.microDouble256ToInteger256     512  thrpt    5  18241.190 ± 115.320  ops/ms
VectorFPtoIntCastOperations.microDouble256ToInteger256    1024  thrpt    5   9233.245 ± 123.493  ops/ms
VectorFPtoIntCastOperations.microFloat256ToInteger256      512  thrpt    5  11682.371 ±   5.806  ops/ms
VectorFPtoIntCastOperations.microFloat256ToInteger256     1024  thrpt    5   6006.308 ±   2.190  ops/ms
VectorBitCount.WithSuperword.intLeadingZeroCount    1024       0  avgt    4  957.081 ± 4.049  ns/op
```