### PR TITLE
8328194: Add a test to check default rendering engine

### DIFF
--- a/test/jdk/sun/java2d/marlin/DefaultRenderingEngine.java
+++ b/test/jdk/sun/java2d/marlin/DefaultRenderingEngine.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import sun.java2d.pipe.RenderingEngine;
+
+/**
+ * @test
+ * @bug 8241307
+ * @summary Verifies that the Marlin renderer is the default RenderingEngine
+ * @modules java.desktop/sun.java2d.pipe
+ */
+public final class DefaultRenderingEngine {
+
+    public static void main(String[] argv) {
+
+        final RenderingEngine engine = RenderingEngine.getInstance();
+
+        if (!engine.getClass().getSimpleName().contains("Marlin")) {
+            throw new RuntimeException("Marlin must be the default RenderingEngine");
+        }
+    }
+}


### PR DESCRIPTION
This is a request to forward port the test added by the [JDK-8241307](https://bugs.openjdk.org/browse/JDK-8241307) with inverted condition - jdk jdk11 the marlin should be used by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328194](https://bugs.openjdk.org/browse/JDK-8328194): Add a test to check default rendering engine (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18313/head:pull/18313` \
`$ git checkout pull/18313`

Update a local copy of the PR: \
`$ git checkout pull/18313` \
`$ git pull https://git.openjdk.org/jdk.git pull/18313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18313`

View PR using the GUI difftool: \
`$ git pr show -t 18313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18313.diff">https://git.openjdk.org/jdk/pull/18313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18313#issuecomment-2002158558)