### PR TITLE
8328228: Missing comma in copyright year for a few JColorChooser tests

### DIFF
--- a/test/jdk/javax/swing/JColorChooser/Test4222508.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4222508.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JColorChooser/Test4319113.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4319113.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JColorChooser/Test4759306.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4759306.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JColorChooser/Test4759306.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4759306.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2008, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JColorChooser/Test4759934.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4759934.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JColorChooser/Test4759934.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4759934.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2008, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Adding comma to copyright years

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328228](https://bugs.openjdk.org/browse/JDK-8328228): Missing comma in copyright year for a few JColorChooser tests (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18317/head:pull/18317` \
`$ git checkout pull/18317`

Update a local copy of the PR: \
`$ git checkout pull/18317` \
`$ git pull https://git.openjdk.org/jdk.git pull/18317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18317`

View PR using the GUI difftool: \
`$ git pr show -t 18317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18317.diff">https://git.openjdk.org/jdk/pull/18317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18317#issuecomment-1998653924)