### PR TITLE
8328242: Add a log area to the PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -54,7 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.imageio.ImageIO;
-import javax.swing.BoxLayout;
+import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -481,9 +481,7 @@ public final class PassFailJFrame {
             logArea = new JTextArea(logAreaRows, columns);
             logArea.setEditable(false);
 
-            JPanel buttonsLogPanel = new JPanel();
-            BoxLayout layout = new BoxLayout(buttonsLogPanel, BoxLayout.Y_AXIS);
-            buttonsLogPanel.setLayout(layout);
+            Box buttonsLogPanel = Box.createVerticalBox();
 
             buttonsLogPanel.add(buttonsPanel);
             buttonsLogPanel.add(new JScrollPane(logArea));
@@ -1084,11 +1082,7 @@ public final class PassFailJFrame {
      * @param message to log
      */
     public static void log(String message) {
-        invokeOnEDTUncheckedException(() -> {
-            if (logArea != null) {
-                logArea.append(message + System.lineSeparator());
-            }
-        });
+        invokeOnEDTUncheckedException(() -> logArea.append(message + "\n"));
     }
 
     /**
@@ -1096,24 +1090,16 @@ public final class PassFailJFrame {
      * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
      */
     public static void logClear() {
-        invokeOnEDTUncheckedException(() -> {
-            if (logArea != null) {
-                logArea.setText("");
-            }
-        });
+        invokeOnEDTUncheckedException(() -> logArea.setText(""));
     }
 
     /**
      * Replaces the log area content with provided {@code text}, if enabled by
      * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
-     * @param text replacement
+     * @param text new text for the log area
      */
     public static void logSet(String text) {
-        invokeOnEDTUncheckedException(() -> {
-            if (logArea != null) {
-                logArea.setText(text);
-            }
-        });
+        invokeOnEDTUncheckedException(() -> logArea.setText(text));
     }
 
     public static final class Builder {
@@ -1176,7 +1162,8 @@ public final class PassFailJFrame {
 
         /**
          * Adds a log area below the "Pass", "Fail" buttons.
-         * <p> The log area can be controlled by {@link #log(String)},
+         * <p>
+         * The log area can be controlled by {@link #log(String)},
          * {@link #logClear()} and {@link #logSet(String)}.
          *
          * @return this builder
@@ -1188,10 +1175,11 @@ public final class PassFailJFrame {
 
         /**
          * Adds a log area below the "Pass", "Fail" buttons.
-         * <p> The log area can be controlled by {@link #log(String)},
+         * <p>
+         * The log area can be controlled by {@link #log(String)},
          * {@link #logClear()} and {@link #logSet(String)}.
-         *
-         * <p> The number of columns is taken from the number of
+         * <p>
+         * The number of columns is taken from the number of
          * columns in the instructional JTextArea.
          *
          * @param rows of the log area

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -157,6 +157,7 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *     <li>the title of the instruction UI,</li>
  *     <li>the timeout of the test,</li>
  *     <li>the size of the instruction UI via rows and columns, and</li>
+ *     <li>to add a log area</li>,
  *     <li>to enable screenshots.</li>
  * </ul>
  */

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -207,6 +207,7 @@ public final class PassFailJFrame {
     private static Robot robot;
 
     private static JTextArea logArea;
+    private static boolean isLogAreaFirstAppend = true;
 
     public enum Position {HORIZONTAL, VERTICAL, TOP_LEFT_CORNER}
 
@@ -478,7 +479,8 @@ public final class PassFailJFrame {
         }
 
         if (addLogArea) {
-            logArea = new JTextArea(logAreaRows, columns);
+            logArea = new JTextArea("(the test log will be here)",
+                                    logAreaRows, columns);
             logArea.setEditable(false);
 
             Box buttonsLogPanel = Box.createVerticalBox();
@@ -1082,7 +1084,14 @@ public final class PassFailJFrame {
      * @param message to log
      */
     public static void log(String message) {
-        invokeOnEDTUncheckedException(() -> logArea.append(message + "\n"));
+        invokeOnEDTUncheckedException(() -> {
+            if (isLogAreaFirstAppend) {
+                logArea.setText(message + "\n");
+                isLogAreaFirstAppend = false;
+            } else {
+                logArea.append(message + "\n");
+            }
+        });
     }
 
     /**

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.imageio.ImageIO;
+import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -204,6 +205,8 @@ public final class PassFailJFrame {
     private static JFrame frame;
 
     private static Robot robot;
+
+    private static JTextArea logArea;
 
     public enum Position {HORIZONTAL, VERTICAL, TOP_LEFT_CORNER}
 
@@ -374,6 +377,20 @@ public final class PassFailJFrame {
         }
     }
 
+    /**
+     * Does the same as {@link #invokeOnEDT(Runnable)}, but does not throw
+     * any checked exceptions.
+     *
+     * @param doRun an operation to run on EDT
+     */
+    private static void invokeOnEDTUncheckedException(Runnable doRun) {
+        try {
+            invokeOnEDT(doRun);
+        } catch (InterruptedException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private static void createUI(String title, String instructions,
                                  long testTimeOut, int rows, int columns,
                                  boolean enableScreenCapture) {
@@ -385,7 +402,8 @@ public final class PassFailJFrame {
         frame.add(createInstructionUIPanel(instructions,
                                            testTimeOut,
                                            rows, columns,
-                                           enableScreenCapture),
+                                           enableScreenCapture,
+                                           false, 0),
                   BorderLayout.CENTER);
         frame.pack();
         frame.setLocationRelativeTo(null);
@@ -402,8 +420,9 @@ public final class PassFailJFrame {
                 createInstructionUIPanel(builder.instructions,
                                          builder.testTimeOut,
                                          builder.rows, builder.columns,
-                                         builder.screenCapture);
-
+                                         builder.screenCapture,
+                                         builder.addLogArea,
+                                         builder.logAreaRows);
         if (builder.splitUI) {
             JSplitPane splitPane = new JSplitPane(
                     builder.splitUIOrientation,
@@ -422,7 +441,9 @@ public final class PassFailJFrame {
     private static JComponent createInstructionUIPanel(String instructions,
                                                        long testTimeOut,
                                                        int rows, int columns,
-                                                       boolean enableScreenCapture) {
+                                                       boolean enableScreenCapture,
+                                                       boolean addLogArea,
+                                                       int logAreaRows) {
         JPanel main = new JPanel(new BorderLayout());
 
         JLabel testTimeoutLabel = new JLabel("", JLabel.CENTER);
@@ -456,7 +477,22 @@ public final class PassFailJFrame {
             buttonsPanel.add(createCapturePanel());
         }
 
-        main.add(buttonsPanel, BorderLayout.SOUTH);
+        if (addLogArea) {
+            logArea = new JTextArea(logAreaRows, columns);
+            logArea.setEditable(false);
+
+            JPanel buttonsLogPanel = new JPanel();
+            BoxLayout layout = new BoxLayout(buttonsLogPanel, BoxLayout.Y_AXIS);
+            buttonsLogPanel.setLayout(layout);
+
+            buttonsLogPanel.add(buttonsPanel);
+            buttonsLogPanel.add(new JScrollPane(logArea));
+
+            main.add(buttonsLogPanel, BorderLayout.SOUTH);
+        } else {
+            main.add(buttonsPanel, BorderLayout.SOUTH);
+        }
+
         main.setMinimumSize(main.getPreferredSize());
 
         return main;
@@ -1041,6 +1077,45 @@ public final class PassFailJFrame {
         latch.countDown();
     }
 
+    /**
+     * Adds a {@code message} to the log area, if enabled by
+     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     *
+     * @param message to log
+     */
+    public static void log(String message) {
+        invokeOnEDTUncheckedException(() -> {
+            if (logArea != null) {
+                logArea.append(message + System.lineSeparator());
+            }
+        });
+    }
+
+    /**
+     * Clears the log area, if enabled by
+     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     */
+    public static void logClear() {
+        invokeOnEDTUncheckedException(() -> {
+            if (logArea != null) {
+                logArea.setText("");
+            }
+        });
+    }
+
+    /**
+     * Replaces the log area content with provided {@code text}, if enabled by
+     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * @param text replacement
+     */
+    public static void logSet(String text) {
+        invokeOnEDTUncheckedException(() -> {
+            if (logArea != null) {
+                logArea.setText(text);
+            }
+        });
+    }
+
     public static final class Builder {
         private String title;
         private String instructions;
@@ -1048,6 +1123,8 @@ public final class PassFailJFrame {
         private int rows;
         private int columns;
         private boolean screenCapture;
+        private boolean addLogArea;
+        private int logAreaRows = 10;
 
         private List<? extends Window> testWindows;
         private WindowListCreator windowListCreator;
@@ -1094,6 +1171,35 @@ public final class PassFailJFrame {
 
         public Builder screenCapture() {
             this.screenCapture = true;
+            return this;
+        }
+
+        /**
+         * Adds a log area below the "Pass", "Fail" buttons.
+         * <p> The log area can be controlled by {@link #log(String)},
+         * {@link #logClear()} and {@link #logSet(String)}.
+         *
+         * @return this builder
+         */
+        public Builder logArea() {
+            this.addLogArea = true;
+            return this;
+        }
+
+        /**
+         * Adds a log area below the "Pass", "Fail" buttons.
+         * <p> The log area can be controlled by {@link #log(String)},
+         * {@link #logClear()} and {@link #logSet(String)}.
+         *
+         * <p> The number of columns is taken from the number of
+         * columns in the instructional JTextArea.
+         *
+         * @param rows of the log area
+         * @return this builder
+         */
+        public Builder logArea(int rows) {
+            this.addLogArea = true;
+            this.logAreaRows = rows;
             return this;
         }
 

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -207,7 +207,6 @@ public final class PassFailJFrame {
     private static Robot robot;
 
     private static JTextArea logArea;
-    private static boolean isLogAreaFirstAppend = true;
 
     public enum Position {HORIZONTAL, VERTICAL, TOP_LEFT_CORNER}
 
@@ -479,8 +478,7 @@ public final class PassFailJFrame {
         }
 
         if (addLogArea) {
-            logArea = new JTextArea("(the test log will be here)",
-                                    logAreaRows, columns);
+            logArea = new JTextArea(logAreaRows, columns);
             logArea.setEditable(false);
 
             Box buttonsLogPanel = Box.createVerticalBox();
@@ -1084,14 +1082,7 @@ public final class PassFailJFrame {
      * @param message to log
      */
     public static void log(String message) {
-        invokeOnEDTUncheckedException(() -> {
-            if (isLogAreaFirstAppend) {
-                logArea.setText(message + "\n");
-                isLogAreaFirstAppend = false;
-            } else {
-                logArea.append(message + "\n");
-            }
-        });
+        invokeOnEDTUncheckedException(() -> logArea.append(message + "\n"));
     }
 
     /**

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1082,6 +1082,7 @@ public final class PassFailJFrame {
      * @param message to log
      */
     public static void log(String message) {
+        System.out.println("PassFailJFrame: " + message);
         invokeOnEDTUncheckedException(() -> logArea.append(message + "\n"));
     }
 
@@ -1090,6 +1091,7 @@ public final class PassFailJFrame {
      * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
      */
     public static void logClear() {
+        System.out.println("\nPassFailJFrame: log cleared\n");
         invokeOnEDTUncheckedException(() -> logArea.setText(""));
     }
 
@@ -1099,6 +1101,7 @@ public final class PassFailJFrame {
      * @param text new text for the log area
      */
     public static void logSet(String text) {
+        System.out.println("\nPassFailJFrame: log set to:\n" + text + "\n");
         invokeOnEDTUncheckedException(() -> logArea.setText(text));
     }
 


### PR DESCRIPTION
Often manual tests have a text area in the instruction window to print feedback from the test to be evaluated by a tester.
I stumbled across another test that needed this, so I decided to make these changes a standard feature.

List of changes:
* The log text area can be added below the `Pass` and `Fail` buttons panel.
To do this, use the builder methods `logArea()`, `logArea(int rows)`.
* `PassFailJFrame.log(message)`, `PassFailJFrame.logClear()` and `PassFailJFrame.logSet()` are added to control this text area. (maybe I missed something?)
* added `invokeOnEDTUncheckedException` for easier use of logging methods

So typical usage would be like:
```java
        PassFailJFrame
                .builder()
                .title("GetBoundsResizeTest Instructions")
                .instructions(INSTRUCTIONS)
                .rows(20)
                .columns(70)
                .logArea()
                .build()
                .awaitAndCheck();

```
----
```java
//somewhere in event handlers:
PassFailJFrame.log("Very important message");
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328242](https://bugs.openjdk.org/browse/JDK-8328242): Add a log area to the PassFailJFrame (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [a0fc617c](https://git.openjdk.org/jdk/pull/18319/files/a0fc617c1c804f8695ea14d2942eb302955fd5f9)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18319/head:pull/18319` \
`$ git checkout pull/18319`

Update a local copy of the PR: \
`$ git checkout pull/18319` \
`$ git pull https://git.openjdk.org/jdk.git pull/18319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18319`

View PR using the GUI difftool: \
`$ git pr show -t 18319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18319.diff">https://git.openjdk.org/jdk/pull/18319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18319#issuecomment-1998928414)