### PR TITLE
8328236: module_entry in CDS map file has stale value

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1049,7 +1049,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
 #if INCLUDE_CDS_JAVA_HEAP
   static void log_heap_region(ArchiveHeapInfo* heap_info) {
     MemRegion r = heap_info->buffer_region();
-    address start = address(r.start());
+    address start = address(r.start()); // start of the current oop inside the buffer
     address end = address(r.end());
     log_region("heap", start, end, ArchiveHeapWriter::buffered_addr_to_requested_addr(start));
 
@@ -1082,7 +1082,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
       log_as_hex(start, oop_end, requested_start, /*is_heap=*/true);
 
       if (source_oop != nullptr) {
-        log_oop_details(heap_info, source_oop);
+        log_oop_details(heap_info, source_oop, /*buffered_addr=*/start);
       } else if (start == ArchiveHeapWriter::buffered_heap_roots_addr()) {
         log_heap_roots();
       }
@@ -1097,9 +1097,10 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
     ArchiveHeapInfo* _heap_info;
     outputStream* _st;
     oop _source_obj;
+    address _buffered_addr;
   public:
-    ArchivedFieldPrinter(ArchiveHeapInfo* heap_info, outputStream* st, oop src_obj) :
-      _heap_info(heap_info), _st(st), _source_obj(src_obj) {}
+    ArchivedFieldPrinter(ArchiveHeapInfo* heap_info, outputStream* st, oop src_obj, address buffered_addr) :
+      _heap_info(heap_info), _st(st), _source_obj(src_obj), _buffered_addr(buffered_addr) {}
 
     void do_field(fieldDescriptor* fd) {
       _st->print(" - ");
@@ -1114,7 +1115,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         if (ArchiveHeapWriter::is_marked_as_native_pointer(_heap_info, _source_obj, fd->offset())) {
           print_as_native_pointer(fd);
         } else {
-          fd->print_on_for(_st, _source_obj); // name, offset, value
+          fd->print_on_for(_st, cast_to_oop(_buffered_addr)); // name, offset, value
           _st->cr();
         }
       }
@@ -1146,7 +1147,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
   };
 
   // Print the fields of instanceOops, or the elements of arrayOops
-  static void log_oop_details(ArchiveHeapInfo* heap_info, oop source_oop) {
+  static void log_oop_details(ArchiveHeapInfo* heap_info, oop source_oop, address buffered_addr) {
     LogStreamHandle(Trace, cds, map, oops) st;
     if (st.is_enabled()) {
       Klass* source_klass = source_oop->klass();
@@ -1168,7 +1169,7 @@ class ArchiveBuilder::CDSMapLogger : AllStatic {
         }
       } else {
         st.print_cr(" - fields (" SIZE_FORMAT " words):", source_oop->size());
-        ArchivedFieldPrinter print_field(heap_info, &st, source_oop);
+        ArchivedFieldPrinter print_field(heap_info, &st, source_oop, buffered_addr);
         InstanceKlass::cast(source_klass)->print_nonstatic_fields(&print_field);
       }
     }

--- a/test/hotspot/jtreg/runtime/cds/CDSMapReader.java
+++ b/test/hotspot/jtreg/runtime/cds/CDSMapReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -175,6 +175,10 @@ public class CDSMapReader {
     //  - final 'key' 'Ljava/lang/Object;' @16 0x00000007ffc68260 (0xfff8d04c) java.lang.String
     static Pattern oopFieldPattern2 = Pattern.compile(" - [^']* '([^']+)'.*@([0-9]+) 0x([0-9a-f]+) [(]0x([0-9a-f]+)[)] (.*)");
 
+    // (injected module_entry)
+    //  - injected 'module_entry' 'J' @16 0 (0x0000000000000000)
+    static Pattern moduleEntryPattern = Pattern.compile("- injected 'module_entry' 'J' @[0-9]+[ ]+([0-9]+)");
+
     private static Matcher match(String line, Pattern pattern) {
         Matcher m = pattern.matcher(line);
         if (m.find()) {
@@ -218,6 +222,11 @@ public class CDSMapReader {
                         heapObject.addOopField(m.group(1), m.group(2), m.group(3), m.group(4));
                     } else if ((m = match(line, oopFieldPattern1)) != null) {
                         heapObject.addOopField(m.group(1), m.group(2), m.group(3), null);
+                    } else if ((m = match(line, moduleEntryPattern)) != null) {
+                        String value = m.group(1);
+                        if (!value.equals("0")) {
+                            throw new RuntimeException("module_entry should be 0 but found: " + line);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When a `java.lang.Module` object is copied into the CDS archive, we clear its `module_entry` field to 0. However, the information printed in the cds.map file still shows a non-zero value:
```
$ java -Xshare:dump -Xlog:cds+map=debug,cds+map+oops=trace:file=cds.map:none:filesize=0
$ cat cds.map | grep module_entry
...
 - injected 'module_entry' 'J' @16  140166528907408 (0x00007f7b102a3890)
```

The reason is the above is printed using the "original" Module object whose `module_entry` is not cleared. We only clear  this object's "buffered copy", which is the one that gets written into the CDS archive.

The fix is to change the printing code to use the "buffered copy" instead. Now it looks like this:

```
 - injected 'module_entry' 'J' @16  0 (0x0000000000000000)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328236](https://bugs.openjdk.org/browse/JDK-8328236): module_entry in CDS map file has stale value (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18320/head:pull/18320` \
`$ git checkout pull/18320`

Update a local copy of the PR: \
`$ git checkout pull/18320` \
`$ git pull https://git.openjdk.org/jdk.git pull/18320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18320`

View PR using the GUI difftool: \
`$ git pr show -t 18320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18320.diff">https://git.openjdk.org/jdk/pull/18320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18320#issuecomment-1998978937)