### PR TITLE
8328112: Remove CardTable::_guard_region

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -77,8 +77,7 @@ CardTable::CardTable(MemRegion whole_heap) :
 void CardTable::initialize(void* region0_start, void* region1_start) {
   size_t num_cards = cards_required(_whole_heap.word_size());
 
-  // each card takes 1 byte
-  size_t num_bytes = num_cards;
+  size_t num_bytes = num_cards * sizeof(CardValue);
   _byte_map_size = compute_byte_map_size(num_bytes);
 
   HeapWord* low_bound  = _whole_heap.start();

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,8 +68,7 @@ CardTable::CardTable(MemRegion whole_heap) :
   _page_size(os::vm_page_size()),
   _byte_map_size(0),
   _byte_map(nullptr),
-  _byte_map_base(nullptr),
-  _guard_region()
+  _byte_map_base(nullptr)
 {
   assert((uintptr_t(_whole_heap.start())  & (_card_size - 1))  == 0, "heap must start at card boundary");
   assert((uintptr_t(_whole_heap.end()) & (_card_size - 1))  == 0, "heap must end at card boundary");
@@ -106,10 +105,6 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
   _byte_map_base = _byte_map - (uintptr_t(low_bound) >> _card_shift);
   assert(byte_for(low_bound) == &_byte_map[0], "Checking start of map");
   assert(byte_for(high_bound-1) <= &_byte_map[last_valid_index()], "Checking end of map");
-
-  CardValue* guard_card = &_byte_map[num_cards];
-  assert(is_aligned(guard_card, _page_size), "must be on its own OS page");
-  _guard_region = MemRegion((HeapWord*)guard_card, _page_size);
 
   initialize_covered_region(region0_start, region1_start);
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -77,9 +77,8 @@ CardTable::CardTable(MemRegion whole_heap) :
 void CardTable::initialize(void* region0_start, void* region1_start) {
   size_t num_cards = cards_required(_whole_heap.word_size());
 
-  // each card takes 1 byte; + 1 for the guard card
-  size_t num_bytes = num_cards + 1;
-  _byte_map_size = compute_byte_map_size(num_bytes);
+  // each card takes 1 byte
+  _byte_map_size = compute_byte_map_size(num_cards);
 
   HeapWord* low_bound  = _whole_heap.start();
   HeapWord* high_bound = _whole_heap.end();
@@ -90,7 +89,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
 
   MemTracker::record_virtual_memory_type((address)heap_rs.base(), mtGC);
 
-  os::trace_page_sizes("Card Table", num_bytes, num_bytes,
+  os::trace_page_sizes("Card Table", num_cards, num_cards,
                        heap_rs.base(), heap_rs.size(), _page_size);
   if (!heap_rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for the "

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -78,7 +78,8 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
   size_t num_cards = cards_required(_whole_heap.word_size());
 
   // each card takes 1 byte
-  _byte_map_size = compute_byte_map_size(num_cards);
+  size_t num_bytes = num_cards;
+  _byte_map_size = compute_byte_map_size(num_bytes);
 
   HeapWord* low_bound  = _whole_heap.start();
   HeapWord* high_bound = _whole_heap.end();
@@ -89,7 +90,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
 
   MemTracker::record_virtual_memory_type((address)heap_rs.base(), mtGC);
 
-  os::trace_page_sizes("Card Table", num_cards, num_cards,
+  os::trace_page_sizes("Card Table", num_bytes, num_bytes,
                        heap_rs.base(), heap_rs.size(), _page_size);
   if (!heap_rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for the "

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,9 +58,6 @@ protected:
 
   // The covered regions should be in address order.
   MemRegion _covered[max_covered_regions];
-
-  // The last card is a guard card; never committed.
-  MemRegion _guard_region;
 
   inline size_t compute_byte_map_size(size_t num_bytes);
 

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -89,7 +89,6 @@
   nonstatic_field(CardTable,                   _page_size,                                    const size_t)                          \
   nonstatic_field(CardTable,                   _byte_map_size,                                const size_t)                          \
   nonstatic_field(CardTable,                   _byte_map,                                     CardTable::CardValue*)                 \
-  nonstatic_field(CardTable,                   _guard_region,                                 MemRegion)                             \
   nonstatic_field(CardTable,                   _byte_map_base,                                CardTable::CardValue*)                 \
   nonstatic_field(CardTableBarrierSet,         _defer_initial_card_mark,                      bool)                                  \
   nonstatic_field(CardTableBarrierSet,         _card_table,                                   CardTable*)                            \


### PR DESCRIPTION
Hi all,

This patch removes the `CardTable::_guard_region`. Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328112](https://bugs.openjdk.org/browse/JDK-8328112): Remove CardTable::_guard_region (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [393c2e38](https://git.openjdk.org/jdk/pull/18324/files/393c2e3847c84ac0d2d2e056c9e7e987077cdd90)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18324/head:pull/18324` \
`$ git checkout pull/18324`

Update a local copy of the PR: \
`$ git checkout pull/18324` \
`$ git pull https://git.openjdk.org/jdk.git pull/18324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18324`

View PR using the GUI difftool: \
`$ git pr show -t 18324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18324.diff">https://git.openjdk.org/jdk/pull/18324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18324#issuecomment-1999134073)