### PR TITLE
8328269: NonFocusablePopupMenuTest.java should be marked as headful

### DIFF
--- a/test/jdk/java/awt/Choice/NonFocusablePopupMenuTest.java
+++ b/test/jdk/java/awt/Choice/NonFocusablePopupMenuTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 6519005
  * @summary regression: Selection the item on the choice don't work properly in vista ultimate.
+ * @key headful
  * @run main NonFocusablePopupMenuTest
  */
 


### PR DESCRIPTION
Please review this trivial change.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328269](https://bugs.openjdk.org/browse/JDK-8328269): NonFocusablePopupMenuTest.java should be marked as headful (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18326/head:pull/18326` \
`$ git checkout pull/18326`

Update a local copy of the PR: \
`$ git checkout pull/18326` \
`$ git pull https://git.openjdk.org/jdk.git pull/18326/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18326`

View PR using the GUI difftool: \
`$ git pr show -t 18326`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18326.diff">https://git.openjdk.org/jdk/pull/18326.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18326#issuecomment-1999538464)