### PR TITLE
JDK-8328272: [AIX] Use flag kind "diagnostic" for platform specific flags

### DIFF
--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -55,7 +55,7 @@
   /*  is too small, we might run into resource issues creating many native     */   \
   /*  threads, if it is too large, we reduce our chance of getting a low heap  */   \
   /*  address (needed for compressed Oops).                                    */   \
-  product(uintx, MaxExpectedDataSegmentSize, 8*G, DIAGNOSTIC,                       \
+  product(uintx, MaxExpectedDataSegmentSize, 8*G,                                   \
           "Maximum expected Data Segment Size.")                                    \
                                                                                     \
   /* Use optimized addresses for the polling page.                             */   \

--- a/src/hotspot/os/aix/globals_aix.hpp
+++ b/src/hotspot/os/aix/globals_aix.hpp
@@ -45,7 +45,7 @@
   /* via shmctl). */                                                                \
   /* Per default we quit with an error if that variable is found; for certain */    \
   /* customer scenarios, we may want to be able to run despite that variable. */    \
-  product(bool, AllowExtshm, false,                                                 \
+  product(bool, AllowExtshm, false, DIAGNOSTIC,                                     \
           "Allow VM to run with EXTSHM=ON.")                                        \
                                                                                     \
   /*  Maximum expected size of the data segment. That correlates with the      */   \
@@ -55,21 +55,21 @@
   /*  is too small, we might run into resource issues creating many native     */   \
   /*  threads, if it is too large, we reduce our chance of getting a low heap  */   \
   /*  address (needed for compressed Oops).                                    */   \
-  product(uintx, MaxExpectedDataSegmentSize, 8*G,                                   \
+  product(uintx, MaxExpectedDataSegmentSize, 8*G, DIAGNOSTIC,                       \
           "Maximum expected Data Segment Size.")                                    \
                                                                                     \
   /* Use optimized addresses for the polling page.                             */   \
-  product(bool, OptimizePollingPageLocation, true,                                  \
+  product(bool, OptimizePollingPageLocation, true, DIAGNOSTIC,                      \
              "Optimize the location of the polling page used for Safepoints")       \
                                                                                     \
   /* Use 64K pages for virtual memory (shmat). */                                   \
-  product(bool, Use64KPages, true,                                                  \
+  product(bool, Use64KPages, true, DIAGNOSTIC,                                      \
           "Use 64K pages if available.")                                            \
                                                                                     \
   /* Normally AIX commits memory on touch, but sometimes it is helpful to have */   \
   /* explicit commit behaviour. This flag, if true, causes the VM to touch     */   \
   /* memory on os::commit_memory() (which normally is a noop).                 */   \
-  product(bool, UseExplicitCommit, false,                                           \
+  product(bool, UseExplicitCommit, false, DIAGNOSTIC,                               \
           "Explicit commit for virtual memory.")
 
 // end of RUNTIME_OS_FLAGS


### PR DESCRIPTION
Current platform implementation (globals_aix.hpp) uses regular product flags for almost everything.
Most platform specific flags were never intended for official support. They are only there to diagnose issues and find workarounds.
So flag kind "diagnostic" fits better for them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8328304](https://bugs.openjdk.org/browse/JDK-8328304) to be approved

### Issues
 * [JDK-8328272](https://bugs.openjdk.org/browse/JDK-8328272): [AIX] Use flag kind "diagnostic" for platform specific flags (**Enhancement** - P4)
 * [JDK-8328304](https://bugs.openjdk.org/browse/JDK-8328304): [AIX] Use flag kind "diagnostic" for platform specific flags (**CSR**)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18337/head:pull/18337` \
`$ git checkout pull/18337`

Update a local copy of the PR: \
`$ git checkout pull/18337` \
`$ git pull https://git.openjdk.org/jdk.git pull/18337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18337`

View PR using the GUI difftool: \
`$ git pr show -t 18337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18337.diff">https://git.openjdk.org/jdk/pull/18337.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18337#issuecomment-2002158733)