### PR TITLE
8328331: Rename files 'blockOffsetTable.[h|c]pp' to 'BOTConstants.[h|c]pp'

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #define SHARE_GC_G1_G1BLOCKOFFSETTABLE_HPP
 
 #include "gc/g1/g1RegionToSpaceMapper.hpp"
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "memory/memRegion.hpp"
 #include "memory/virtualspace.hpp"
 #include "utilities/globalDefinitions.hpp"

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #define SHARE_GC_PARALLEL_OBJECTSTARTARRAY_HPP
 
 #include "gc/parallel/psVirtualspace.hpp"
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "memory/allocation.hpp"
 #include "memory/memRegion.hpp"
 #include "oops/oop.hpp"

--- a/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/serial/serialBlockOffsetTable.inline.hpp"
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "logging/log.hpp"
 #include "memory/iterator.hpp"

--- a/src/hotspot/share/gc/serial/serialBlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/serial/serialBlockOffsetTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SERIAL_SERIALBLOCKOFFSETTABLE_HPP
 #define SHARE_GC_SERIAL_SERIALBLOCKOFFSETTABLE_HPP
 
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shared/memset_with_concurrent_readers.hpp"

--- a/src/hotspot/share/gc/shared/BOTConstants.cpp
+++ b/src/hotspot/share/gc/shared/BOTConstants.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 uint BOTConstants::_log_card_size = 0;

--- a/src/hotspot/share/gc/shared/BOTConstants.hpp
+++ b/src/hotspot/share/gc/shared/BOTConstants.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -25,7 +25,7 @@
 #ifndef SHARE_GC_SHARED_SPACE_HPP
 #define SHARE_GC_SHARED_SPACE_HPP
 
-#include "gc/shared/blockOffsetTable.hpp"
+#include "gc/shared/BOTConstants.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "memory/allocation.hpp"


### PR DESCRIPTION
Hi all,

This path renames the files `gc/shared/blockOffsetTable.[h|c]pp` to `BOTConstants.[h|c]pp`. Becuase these two files only have one class `BOTConstants`. Thanks for taking the time to review.

Best Regrads,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328331](https://bugs.openjdk.org/browse/JDK-8328331): Rename files 'blockOffsetTable.[h|c]pp' to 'BOTConstants.[h|c]pp' (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18342/head:pull/18342` \
`$ git checkout pull/18342`

Update a local copy of the PR: \
`$ git checkout pull/18342` \
`$ git pull https://git.openjdk.org/jdk.git pull/18342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18342`

View PR using the GUI difftool: \
`$ git pr show -t 18342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18342.diff">https://git.openjdk.org/jdk/pull/18342.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18342#issuecomment-2003187433)