### PR TITLE
8328350: G1: Remove DO_DISCOVERED_AND_DISCOVERY

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/g1/g1OopClosures.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.hpp
@@ -105,9 +105,6 @@ public:
   virtual void do_oop(oop* p)          { do_oop_work(p); }
   virtual void do_oop(narrowOop* p)    { do_oop_work(p); }
 
-  // We need to do reference discovery while processing evacuated objects.
-  virtual ReferenceIterationMode reference_iteration_mode() { return DO_DISCOVERED_AND_DISCOVERY; }
-
   void set_ref_discoverer(ReferenceDiscoverer* rd) {
     set_ref_discoverer_internal(rd);
   }

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/memory/iterator.hpp
+++ b/src/hotspot/share/memory/iterator.hpp
@@ -84,7 +84,6 @@ class OopIterateClosure : public OopClosure {
   // the below enum describes the different alternatives.
   enum ReferenceIterationMode {
     DO_DISCOVERY,                // Apply closure and discover references
-    DO_DISCOVERED_AND_DISCOVERY, // Apply closure to discovered field and do discovery
     DO_FIELDS,                   // Apply closure to all fields
     DO_FIELDS_EXCEPT_REFERENT    // Apply closure to all fields except the referent field
   };

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/instanceRefKlass.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.hpp
@@ -108,12 +108,6 @@ class InstanceRefKlass: public InstanceKlass {
   template <typename T, class OopClosureType, class Contains>
   static void oop_oop_iterate_discovery(oop obj, ReferenceType type, OopClosureType* closure, Contains& contains);
 
-  // Used for a special case in G1 where the closure needs to be applied
-  // to the discovered field. Reference discovery is also done if the
-  // closure provides a ReferenceProcessor.
-  template <typename T, class OopClosureType, class Contains>
-  static void oop_oop_iterate_discovered_and_discovery(oop obj, ReferenceType type, OopClosureType* closure, Contains& contains);
-
   // Apply the closure to all fields. No reference discovery is done.
   template <typename T, class OopClosureType, class Contains>
   static void oop_oop_iterate_fields(oop obj, OopClosureType* closure, Contains& contains);

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/oops/instanceRefKlass.inline.hpp
+++ b/src/hotspot/share/oops/instanceRefKlass.inline.hpp
@@ -91,14 +91,6 @@ void InstanceRefKlass::oop_oop_iterate_discovery(oop obj, ReferenceType type, Oo
 }
 
 template <typename T, class OopClosureType, class Contains>
-void InstanceRefKlass::oop_oop_iterate_discovered_and_discovery(oop obj, ReferenceType type, OopClosureType* closure, Contains& contains) {
-  // Explicitly apply closure to the discovered field.
-  do_discovered<T>(obj, closure, contains);
-  // Then do normal reference processing with discovery.
-  oop_oop_iterate_discovery<T>(obj, type, closure, contains);
-}
-
-template <typename T, class OopClosureType, class Contains>
 void InstanceRefKlass::oop_oop_iterate_fields(oop obj, OopClosureType* closure, Contains& contains) {
   assert(closure->ref_discoverer() == nullptr, "ReferenceDiscoverer should not be set");
   do_referent<T>(obj, closure, contains);
@@ -117,10 +109,6 @@ void InstanceRefKlass::oop_oop_iterate_ref_processing(oop obj, OopClosureType* c
     case OopIterateClosure::DO_DISCOVERY:
       trace_reference_gc<T>("do_discovery", obj);
       oop_oop_iterate_discovery<T>(obj, reference_type(), closure, contains);
-      break;
-    case OopIterateClosure::DO_DISCOVERED_AND_DISCOVERY:
-      trace_reference_gc<T>("do_discovered_and_discovery", obj);
-      oop_oop_iterate_discovered_and_discovery<T>(obj, reference_type(), closure, contains);
       break;
     case OopIterateClosure::DO_FIELDS:
       trace_reference_gc<T>("do_fields", obj);


### PR DESCRIPTION
Remove a special ref-processing iteration mode for G1, because non-null `_discovered` field and requiring ref-discovery should never occur at the same time.
 
Test: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328350](https://bugs.openjdk.org/browse/JDK-8328350): G1: Remove DO_DISCOVERED_AND_DISCOVERY (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [5dfd1060](https://git.openjdk.org/jdk/pull/18346/files/5dfd1060993a6d50608c04cf2be7e5fda1a99dbc)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18346/head:pull/18346` \
`$ git checkout pull/18346`

Update a local copy of the PR: \
`$ git checkout pull/18346` \
`$ git pull https://git.openjdk.org/jdk.git pull/18346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18346`

View PR using the GUI difftool: \
`$ git pr show -t 18346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18346.diff">https://git.openjdk.org/jdk/pull/18346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18346#issuecomment-2003707558)