### PR TITLE
8326941: Remove StringUTF16::isBigEndian

### DIFF
--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -32,6 +32,8 @@ import java.util.function.Consumer;
 import java.util.function.IntConsumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.util.DecimalDigits;
 import jdk.internal.vm.annotation.ForceInline;
@@ -1658,12 +1660,10 @@ final class StringUTF16 {
 
     ////////////////////////////////////////////////////////////////
 
-    private static native boolean isBigEndian();
-
     private static final int HI_BYTE_SHIFT;
     private static final int LO_BYTE_SHIFT;
     static {
-        if (isBigEndian()) {
+        if (Unsafe.getUnsafe().isBigEndian()) {
             HI_BYTE_SHIFT = 8;
             LO_BYTE_SHIFT = 0;
         } else {

--- a/src/java.base/share/native/libjava/String.c
+++ b/src/java.base/share/native/libjava/String.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 1998, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjava/String.c
+++ b/src/java.base/share/native/libjava/String.c
@@ -31,14 +31,3 @@ Java_java_lang_String_intern(JNIEnv *env, jobject this)
 {
     return JVM_InternString(env, this);
 }
-
-JNIEXPORT jboolean JNICALL
-Java_java_lang_StringUTF16_isBigEndian(JNIEnv *env, jclass cls)
-{
-  unsigned int endianTest = 0xff000000;
-  if (((char*)(&endianTest))[0] != 0) {
-    return JNI_TRUE;
-  } else {
-    return JNI_FALSE;
-  }
-}


### PR DESCRIPTION
This PR proposes to remove the native method `StringUTF16::isBigEndian` and its corresponding C implementation and instead rely on the `jdk.internal.misc.Unsafe::isBigEndian` method.

This PR passes tier1-3 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326941](https://bugs.openjdk.org/browse/JDK-8326941): Remove StringUTF16::isBigEndian (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18348/head:pull/18348` \
`$ git checkout pull/18348`

Update a local copy of the PR: \
`$ git checkout pull/18348` \
`$ git pull https://git.openjdk.org/jdk.git pull/18348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18348`

View PR using the GUI difftool: \
`$ git pr show -t 18348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18348.diff">https://git.openjdk.org/jdk/pull/18348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18348#issuecomment-2004034644)