### PR TITLE
8328361: Use memset() in method CardTable::dirty_MemRegion()

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -207,10 +207,7 @@ void CardTable::dirty_MemRegion(MemRegion mr) {
   assert(align_up  (mr.end(),   HeapWordSize) == mr.end(),   "Unaligned end"  );
   CardValue* cur  = byte_for(mr.start());
   CardValue* last = byte_after(mr.last());
-  while (cur < last) {
-    *cur = dirty_card;
-    cur++;
-  }
+  memset(cur, dirty_card, pointer_delta(last, cur, sizeof(CardValue)));
 }
 
 void CardTable::clear_MemRegion(MemRegion mr) {


### PR DESCRIPTION
Hi all,

This patch uses `memset` instead of explicit loop in method `CardTable::dirty_MemRegion` to simplify the code. Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328361](https://bugs.openjdk.org/browse/JDK-8328361): Use memset() in method CardTable::dirty_MemRegion() (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18349/head:pull/18349` \
`$ git checkout pull/18349`

Update a local copy of the PR: \
`$ git checkout pull/18349` \
`$ git pull https://git.openjdk.org/jdk.git pull/18349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18349`

View PR using the GUI difftool: \
`$ git pr show -t 18349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18349.diff">https://git.openjdk.org/jdk/pull/18349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18349#issuecomment-2004053150)