### PR TITLE
8297879: javadoc link to preview JEP 1000 has grouping character comma

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public @interface PreviewFeature {
         /**
          * A key for testing.
          */
-        @JEP(number=0, title="Test Feature")
+        @JEP(number=2_147_483_647, title="Test Feature")
         TEST,
         ;
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PreviewListWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/PreviewListWriter.java
@@ -83,7 +83,7 @@ public class PreviewListWriter extends SummaryListWriter<PreviewAPIListBuilder> 
             target.add(HtmlTree.P(contents.getContent("doclet.Preview_API_Checkbox_Label")));
             Content list = HtmlTree.UL(HtmlStyle.previewFeatureList).addStyle(HtmlStyle.checkboxes);
             for (var jep : jeps) {
-                String jepUrl = resources.getText("doclet.Preview_JEP_URL", jep.number());
+                String jepUrl = resources.getText("doclet.Preview_JEP_URL", String.valueOf(jep.number()));
                 Content label = new ContentBuilder(Text.of(jep.number() + ": "))
                         .add(HtmlTree.A(jepUrl, Text.of(jep.title() + " (" + jep.status() + ")")));
                 list.add(HtmlTree.LI(getCheckbox(label, String.valueOf(index++), "feature-")));

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      8250768 8261976 8277300 8282452 8287597 8325325 8325874
+ * @bug      8250768 8261976 8277300 8282452 8287597 8325325 8325874 8297879
  * @summary  test generated docs for items declared using preview
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -81,7 +81,7 @@ public class TestPreview extends JavadocTester {
                     <ul class="preview-feature-list checkboxes">
                     <li><label for="feature-1">
                     <input type="checkbox" id="feature-1" disabled checked onclick="toggleGlobal(this, '1', 3)">
-                    <span>0: <a href="https://openjdk.org/jeps/0">Test Feature (Preview)</a></span></label></li>
+                    <span>2147483647: <a href="https://openjdk.org/jeps/2147483647">Test Feature (Preview)</a></span></label></li>
                     <li><label for="feature-all">
                     <input type="checkbox" id="feature-all" disabled checked onclick="toggleGlobal(this, 'all', 3)">
                     <span>Toggle all</span></label></li>


### PR DESCRIPTION
Please review this simple bugfix to properly construct links to preview JEPs.

The most straightforward fix I could think of was to pass `String` rather than `int` (`Integer`) to a method, which eventually calls `java.text.MessageFormat.format(String, Object...)`.

For the test, I decided to be ~lazy~ practical and piggyback on the existing infrastructure. The alternatives were:

 1. slap `noreg-hard` on the JBS bug and skip testing
 2. create a sophisticated test that dynamically adds a constant into the `PreviewFeature.Feature` enum, annotates some class with `PreviewFeature` with that constant, and finally documents that class with `PreviewFeature` patched into `java.base`

While (1) is insufficient, (2) seems overkill in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297879](https://bugs.openjdk.org/browse/JDK-8297879): javadoc link to preview JEP 1000 has grouping character comma (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18350/head:pull/18350` \
`$ git checkout pull/18350`

Update a local copy of the PR: \
`$ git checkout pull/18350` \
`$ git pull https://git.openjdk.org/jdk.git pull/18350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18350`

View PR using the GUI difftool: \
`$ git pr show -t 18350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18350.diff">https://git.openjdk.org/jdk/pull/18350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18350#issuecomment-2004147111)