### PR TITLE
8328316: Finisher cannot emit if stream is sequential and integrator returned false

### DIFF
--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/util/stream/GathererShortCircuitTest.java
+++ b/test/jdk/java/util/stream/GathererShortCircuitTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Gatherer;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+/**
+ * @test
+ * @bug 8328316
+ * @summary Testing Gatherer behavior under short circuiting
+ * @enablePreview
+ * @run junit GathererShortCircuitTest
+ */
+
+public class GathererShortCircuitTest {
+    @Test
+    public void mustBeAbleToPushFromFinisher() {
+        Integer expected = 8328316;
+        List<Integer> source = List.of(1,2,3,4,5);
+
+        Gatherer<Integer, ?, Integer> pushOneInFinisher =
+                Gatherer.of(
+                    (unused, element, downstream) -> false,
+                    (unused, downstream) -> downstream.push(expected)
+                );
+
+        var usingCollect =
+            source.stream().gather(pushOneInFinisher).collect(Collectors.toList());
+        var usingBuiltin =
+            source.stream().gather(pushOneInFinisher).toList();
+        var usingCollectPar =
+            source.stream().parallel().gather(pushOneInFinisher).collect(Collectors.toList());
+        var usingBuiltinPar =
+            source.stream().parallel().gather(pushOneInFinisher).toList();
+
+        assertEquals(List.of(expected), usingCollect);
+        assertEquals(List.of(expected), usingBuiltin);
+        assertEquals(List.of(expected), usingCollectPar);
+        assertEquals(List.of(expected), usingBuiltinPar);
+    }
+}

--- a/test/jdk/java/util/stream/GathererShortCircuitTest.java
+++ b/test/jdk/java/util/stream/GathererShortCircuitTest.java
@@ -44,8 +44,8 @@ public class GathererShortCircuitTest {
 
         Gatherer<Integer, ?, Integer> pushOneInFinisher =
                 Gatherer.of(
-                    (unused, element, downstream) -> false,
-                    (unused, downstream) -> downstream.push(expected)
+                    (_, element, downstream) -> false,
+                    (_, downstream) -> downstream.push(expected)
                 );
 
         var usingCollect =


### PR DESCRIPTION
Adds differentiation between direct and transitive short circuiting which could prevent pushing downstream in the finisher for built-ins that were not `collect()`.

Creating this as a draft PR for now, just need to run some benchmarks to validate no significant regressions first.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328316](https://bugs.openjdk.org/browse/JDK-8328316): Finisher cannot emit if stream is sequential and integrator returned false (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [8974d9f9](https://git.openjdk.org/jdk/pull/18351/files/8974d9f9da703f953cc6fee6c989a3b42f484e20)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18351/head:pull/18351` \
`$ git checkout pull/18351`

Update a local copy of the PR: \
`$ git checkout pull/18351` \
`$ git pull https://git.openjdk.org/jdk.git pull/18351/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18351`

View PR using the GUI difftool: \
`$ git pr show -t 18351`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18351.diff">https://git.openjdk.org/jdk/pull/18351.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18351#issuecomment-2010559086)