### PR TITLE
JDK-8327474 Review use of java.io.tmpdir in jdk tests

### DIFF
--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
@@ -41,6 +41,7 @@ import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
 import java.util.Map;
 import jdk.test.lib.process.ProcessTools;
 import sun.tools.attach.HotSpotVirtualMachine;
@@ -53,8 +54,7 @@ public class CheckOrigin {
         if (args.length == 0) {
             // start a process that has options set in a number of different ways
 
-            File flagsFile = File.createTempFile("CheckOriginFlags", null);
-            flagsFile.deleteOnExit();
+            File flagsFile = File.createTempFile("CheckOriginFlags", null, Path.of(".").toFile());
             try (PrintWriter pw =
                    new PrintWriter(new FileWriter(flagsFile))) {
                 pw.println("+PrintCodeCache");

--- a/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
+++ b/test/jdk/com/sun/management/HotSpotDiagnosticMXBean/CheckOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ public class CheckOrigin {
             // start a process that has options set in a number of different ways
 
             File flagsFile = File.createTempFile("CheckOriginFlags", null);
+            flagsFile.deleteOnExit();
             try (PrintWriter pw =
                    new PrintWriter(new FileWriter(flagsFile))) {
                 pw.println("+PrintCodeCache");

--- a/test/jdk/java/io/File/CheckPermission.java
+++ b/test/jdk/java/io/File/CheckPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -362,13 +362,13 @@ public class CheckPermission {
                 "getFileSystemAttributes");
 
         prepare();
-        File tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null);
+        File tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, new File("."));
         assertOnlyCheckOperation(tmpFile, EnumSet.of(FileOperation.WRITE));
         tmpFile.delete();
         assertCheckOperation(tmpFile, EnumSet.of(FileOperation.DELETE));
 
         prepare();
-        tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, null);
+        tmpFile = File.createTempFile(CHECK_PERMISSION_TEST, null, new File("."));
         assertOnlyCheckOperation(tmpFile, EnumSet.of(FileOperation.WRITE));
         tmpFile.delete();
         assertCheckOperation(tmpFile, EnumSet.of(FileOperation.DELETE));

--- a/test/jdk/java/io/FileInputStream/NegativeAvailable.java
+++ b/test/jdk/java/io/FileInputStream/NegativeAvailable.java
@@ -27,7 +27,6 @@
  * @summary Test if available returns correct value when skipping beyond
  *          the end of a file.
  * @author Dan Xu
- * @library /test/lib
  */
 
 import java.io.BufferedWriter;
@@ -38,8 +37,6 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import jdk.test.lib.Utils;
-
 public class NegativeAvailable {
 
     public static void main(String[] args) throws IOException {
@@ -48,29 +45,32 @@ public class NegativeAvailable {
         final int NEGATIVE_SKIP = -5;
 
         // Create a temporary file with size of 10 bytes.
-        Path tmp = Utils.createTempFile(null, null);
-        try (BufferedWriter writer =
-            Files.newBufferedWriter(tmp, Charset.defaultCharset())) {
-            for (int i = 0; i < SIZE; i++) {
-                writer.write('1');
+        Path tmp = Files.createTempFile(null, null);
+        try {
+            try (BufferedWriter writer =
+                         Files.newBufferedWriter(tmp, Charset.defaultCharset())) {
+                for (int i = 0; i < SIZE; i++) {
+                    writer.write('1');
+                }
             }
-        }
 
-        File tempFile = tmp.toFile();
-        try (FileInputStream fis = new FileInputStream(tempFile)) {
-            if (tempFile.length() != SIZE) {
-                throw new RuntimeException("unexpected file size = "
-                                           + tempFile.length());
+            File tempFile = tmp.toFile();
+            try (FileInputStream fis = new FileInputStream(tempFile)) {
+                if (tempFile.length() != SIZE) {
+                    throw new RuntimeException("unexpected file size = "
+                            + tempFile.length());
+                }
+                long space = skipBytes(fis, SKIP, SIZE);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, SKIP, space);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
+                space = skipBytes(fis, NEGATIVE_SKIP, space);
             }
-            long space = skipBytes(fis, SKIP, SIZE);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, SKIP, space);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
-            space = skipBytes(fis, NEGATIVE_SKIP, space);
+        } finally {
+            Files.deleteIfExists(tmp);
         }
-        Files.deleteIfExists(tmp);
     }
 
     /**

--- a/test/jdk/java/io/FileInputStream/NegativeAvailable.java
+++ b/test/jdk/java/io/FileInputStream/NegativeAvailable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test if available returns correct value when skipping beyond
  *          the end of a file.
  * @author Dan Xu
+ * @library /test/lib
  */
 
 import java.io.BufferedWriter;
@@ -37,6 +38,8 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import jdk.test.lib.Utils;
+
 public class NegativeAvailable {
 
     public static void main(String[] args) throws IOException {
@@ -45,7 +48,7 @@ public class NegativeAvailable {
         final int NEGATIVE_SKIP = -5;
 
         // Create a temporary file with size of 10 bytes.
-        Path tmp = Files.createTempFile(null, null);
+        Path tmp = Utils.createTempFile(null, null);
         try (BufferedWriter writer =
             Files.newBufferedWriter(tmp, Charset.defaultCharset())) {
             for (int i = 0; i < SIZE; i++) {

--- a/test/jdk/java/nio/channels/unixdomain/Bind.java
+++ b/test/jdk/java/nio/channels/unixdomain/Bind.java
@@ -159,7 +159,7 @@ public class Bind {
         });
         // address with space should work
         checkNormal(() -> {
-            UnixDomainSocketAddress usa =  UnixDomainSocketAddress.of("with space");
+            UnixDomainSocketAddress usa = UnixDomainSocketAddress.of("with space");
             Files.deleteIfExists(usa.getPath());
             try {
                 server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);

--- a/test/jdk/java/nio/channels/unixdomain/Bind.java
+++ b/test/jdk/java/nio/channels/unixdomain/Bind.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,6 +188,7 @@ public class Bind {
             server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
             server.bind(null);
             UnixDomainSocketAddress usa = (UnixDomainSocketAddress)server.getLocalAddress();
+            usa.getPath().toFile().deleteOnExit();
             if (usa.getPath().toString().isEmpty())
                 throw new RuntimeException("expected non zero address length");
             System.out.println("Null server address: " + server.getLocalAddress());
@@ -320,6 +321,7 @@ public class Bind {
             server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
             server.bind(null);
             UnixDomainSocketAddress usa = (UnixDomainSocketAddress)server.getLocalAddress();
+            usa.getPath().toFile().deleteOnExit();
             client = SocketChannel.open(usa);
             accept1 = server.accept();
             assertAddress(client.getRemoteAddress(), usa, "server");

--- a/test/jdk/java/nio/channels/unixdomain/Bind.java
+++ b/test/jdk/java/nio/channels/unixdomain/Bind.java
@@ -198,7 +198,9 @@ public class Bind {
                     throw new RuntimeException("expected non zero address length");
                 System.out.println("Null server address: " + server.getLocalAddress());
             } finally {
-                Files.deleteIfExists(usa.getPath());
+                if (usa != null) {
+                    Files.deleteIfExists(usa.getPath());
+                }
             }
         });
         // server no bind : not allowed
@@ -338,7 +340,9 @@ public class Bind {
                 accept1 = server.accept();
                 assertAddress(client.getRemoteAddress(), usa, "server");
             } finally {
-                Files.deleteIfExists(usa.getPath());
+                if (usa != null) {
+                    Files.deleteIfExists(usa.getPath());
+                }
             }
         });
     }

--- a/test/jdk/java/nio/channels/unixdomain/Bind.java
+++ b/test/jdk/java/nio/channels/unixdomain/Bind.java
@@ -159,13 +159,17 @@ public class Bind {
         });
         // address with space should work
         checkNormal(() -> {
-            server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-            UnixDomainSocketAddress usa =  UnixDomainSocketAddress.of("with space"); // relative to CWD
+            UnixDomainSocketAddress usa =  UnixDomainSocketAddress.of("with space");
             Files.deleteIfExists(usa.getPath());
-            server.bind(usa);
-            client = SocketChannel.open(usa);
-            Files.delete(usa.getPath());
-            assertAddress(client.getRemoteAddress(), usa, "address");
+            try {
+                server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+                // relative to CWD
+                server.bind(usa);
+                client = SocketChannel.open(usa);
+                assertAddress(client.getRemoteAddress(), usa, "address");
+            } finally {
+                Files.deleteIfExists(usa.getPath());
+            }
         });
         // client bind to null: allowed
         checkNormal(() -> {
@@ -185,13 +189,17 @@ public class Bind {
         });
         // server bind to null: should bind to a local address
         checkNormal(() -> {
-            server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-            server.bind(null);
-            UnixDomainSocketAddress usa = (UnixDomainSocketAddress)server.getLocalAddress();
-            usa.getPath().toFile().deleteOnExit();
-            if (usa.getPath().toString().isEmpty())
-                throw new RuntimeException("expected non zero address length");
-            System.out.println("Null server address: " + server.getLocalAddress());
+            UnixDomainSocketAddress usa = null;
+            try {
+                server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+                server.bind(null);
+                usa = (UnixDomainSocketAddress) server.getLocalAddress();
+                if (usa.getPath().toString().isEmpty())
+                    throw new RuntimeException("expected non zero address length");
+                System.out.println("Null server address: " + server.getLocalAddress());
+            } finally {
+                Files.deleteIfExists(usa.getPath());
+            }
         });
         // server no bind : not allowed
         checkException(
@@ -308,24 +316,30 @@ public class Bind {
             Arrays.fill(chars, 'x');
             String name = new String(chars);
             UnixDomainSocketAddress address = UnixDomainSocketAddress.of(name);
-            ServerSocketChannel server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-            server.bind(address);
-            SocketChannel client = SocketChannel.open(address);
-            assertAddress(server.getLocalAddress(), address, "server");
-            assertAddress(client.getRemoteAddress(), address, "client");
-            Files.delete(address.getPath());
+            try {
+                ServerSocketChannel server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+                server.bind(address);
+                SocketChannel client = SocketChannel.open(address);
+                assertAddress(server.getLocalAddress(), address, "server");
+                assertAddress(client.getRemoteAddress(), address, "client");
+            } finally {
+                Files.deleteIfExists(address.getPath());
+            }
         });
 
         // implicit server bind
         checkNormal(() -> {
-            server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-            server.bind(null);
-            UnixDomainSocketAddress usa = (UnixDomainSocketAddress)server.getLocalAddress();
-            usa.getPath().toFile().deleteOnExit();
-            client = SocketChannel.open(usa);
-            accept1 = server.accept();
-            assertAddress(client.getRemoteAddress(), usa, "server");
-            Files.delete(usa.getPath());
+            UnixDomainSocketAddress usa = null;
+            try {
+                server = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+                server.bind(null);
+                usa = (UnixDomainSocketAddress) server.getLocalAddress();
+                client = SocketChannel.open(usa);
+                accept1 = server.accept();
+                assertAddress(client.getRemoteAddress(), usa, "server");
+            } finally {
+                Files.deleteIfExists(usa.getPath());
+            }
         });
     }
 }

--- a/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
+++ b/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
  */
 
 import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import jtreg.SkippedException;
@@ -54,6 +55,9 @@ public class NonBlockingAccept {
             //non blocking mode
             serverSocketChannel.configureBlocking(false);
             serverSocketChannel.bind(null);
+            UnixDomainSocketAddress addr =
+                    (UnixDomainSocketAddress) serverSocketChannel.getLocalAddress();
+            addr.getPath().toFile().deleteOnExit();
             SocketChannel socketChannel = serverSocketChannel.accept();
             System.out.println("The socketChannel is : expected Null " + socketChannel);
             if (socketChannel != null)

--- a/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
+++ b/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
@@ -32,6 +32,8 @@ import java.net.StandardProtocolFamily;
 import java.net.UnixDomainSocketAddress;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+
 import jtreg.SkippedException;
 
 public class NonBlockingAccept {
@@ -49,20 +51,21 @@ public class NonBlockingAccept {
     public static void main(String[] args) throws Exception {
 
         checkSupported();
+        UnixDomainSocketAddress addr = null;
 
         try (ServerSocketChannel serverSocketChannel =
                                  ServerSocketChannel.open(StandardProtocolFamily.UNIX)) {
             //non blocking mode
             serverSocketChannel.configureBlocking(false);
             serverSocketChannel.bind(null);
-            UnixDomainSocketAddress addr =
-                    (UnixDomainSocketAddress) serverSocketChannel.getLocalAddress();
-            addr.getPath().toFile().deleteOnExit();
+            addr = (UnixDomainSocketAddress) serverSocketChannel.getLocalAddress();
             SocketChannel socketChannel = serverSocketChannel.accept();
             System.out.println("The socketChannel is : expected Null " + socketChannel);
             if (socketChannel != null)
                 throw new RuntimeException("expected null");
             // or exception could be thrown otherwise
+        } finally {
+            Files.deleteIfExists(addr.getPath());
         }
     }
 }

--- a/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
+++ b/test/jdk/java/nio/channels/unixdomain/NonBlockingAccept.java
@@ -65,7 +65,9 @@ public class NonBlockingAccept {
                 throw new RuntimeException("expected null");
             // or exception could be thrown otherwise
         } finally {
-            Files.deleteIfExists(addr.getPath());
+            if (addr != null) {
+                Files.deleteIfExists(addr.getPath());
+            }
         }
     }
 }

--- a/test/jdk/java/util/zip/ZipFile/ZeroDate.java
+++ b/test/jdk/java/util/zip/ZipFile/ZeroDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,17 +40,20 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import jdk.test.lib.Utils;
+
 /* @test
  * @bug 8184940 8188869
  * @summary JDK 9 rejects zip files where the modified day or month is 0
  *          or otherwise represent an invalid date, such as 1980-02-30 24:60:60
  * @author Liam Miller-Cushon
+ * @library /test/lib
  */
 public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Files.createTempFile("bad", ".zip");
+        Path path = Utils.createTempFile("bad", ".zip");
         try (OutputStream os = Files.newOutputStream(path);
                 ZipOutputStream zos = new ZipOutputStream(os)) {
             ZipEntry e = new ZipEntry("x");
@@ -86,7 +89,7 @@ public class ZeroDate {
         writeU32(data, locpos + LOCTIM, date);
 
         // ensure that the archive is still readable, and the date is 1979-11-30
-        Path path = Files.createTempFile("out", ".zip");
+        Path path = Utils.createTempFile("out", ".zip");
         try (OutputStream os = Files.newOutputStream(path)) {
             os.write(data);
         }

--- a/test/jdk/java/util/zip/ZipFile/ZeroDate.java
+++ b/test/jdk/java/util/zip/ZipFile/ZeroDate.java
@@ -53,31 +53,34 @@ public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Utils.createTempFile("bad", ".zip");
-        try (OutputStream os = Files.newOutputStream(path);
-                ZipOutputStream zos = new ZipOutputStream(os)) {
-            ZipEntry e = new ZipEntry("x");
-            zos.putNextEntry(e);
-            zos.write((int) 'x');
-        }
-        int len = (int) Files.size(path);
-        byte[] data = new byte[len];
-        try (InputStream is = Files.newInputStream(path)) {
-            is.read(data);
-        }
-        Files.delete(path);
+        Path path = Files.createTempFile("bad", ".zip");
+        try {
+            try (OutputStream os = Files.newOutputStream(path);
+                 ZipOutputStream zos = new ZipOutputStream(os)) {
+                ZipEntry e = new ZipEntry("x");
+                zos.putNextEntry(e);
+                zos.write((int) 'x');
+            }
+            int len = (int) Files.size(path);
+            byte[] data = new byte[len];
+            try (InputStream is = Files.newInputStream(path)) {
+                is.read(data);
+            }
 
-        // year, month, day are zero
-        testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
-        // only year is zero
-        testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
-        // month is greater than 12
-        testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
-        // 30th of February
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
-        // 30th of February, 24:60:60
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
-                LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+            // year, month, day are zero
+            testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
+            // only year is zero
+            testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
+            // month is greater than 12
+            testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
+            // 30th of February
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
+            // 30th of February, 24:60:60
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
+                    LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+        } finally {
+            Files.delete(path);
+        }
     }
 
     private static void testDate(byte[] data, int date, LocalDateTime expected) throws IOException {

--- a/test/jdk/java/util/zip/ZipFile/ZeroDate.java
+++ b/test/jdk/java/util/zip/ZipFile/ZeroDate.java
@@ -53,7 +53,7 @@ public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Files.createTempFile("bad", ".zip");
+        Path path = Utils.createTempFile("bad", ".zip");
         try {
             try (OutputStream os = Files.newOutputStream(path);
                  ZipOutputStream zos = new ZipOutputStream(os)) {

--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,6 @@
 
 package jdk.jfr.api.consumer.filestream;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.EventStream;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -148,7 +148,7 @@ public class TestOrdered {
                 e.join();
             }
             r.stop();
-            Path p = Files.createTempFile("recording", ".jfr");
+            Path p = Utils.createTempFile("recording", ".jfr");
             r.dump(p);
             return p;
         }

--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestReuse.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestReuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import jdk.jfr.Event;
 import jdk.jfr.Recording;
 import jdk.jfr.consumer.EventStream;
 import jdk.jfr.consumer.RecordedEvent;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -118,7 +119,7 @@ public class TestReuse {
             }
             r.stop();
             rotation.close();
-            Path p = Files.createTempFile("recording", ".jfr");
+            Path p = Utils.createTempFile("recording", ".jfr");
             r.dump(p);
             return p;
         }

--- a/test/jdk/jdk/jfr/threading/TestManyVirtualThreads.java
+++ b/test/jdk/jdk/jfr/threading/TestManyVirtualThreads.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import jdk.jfr.consumer.RecordedEvent;
 import jdk.jfr.consumer.RecordedThread;
 import jdk.jfr.consumer.RecordingFile;
 import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
 
 /**
  * @test
@@ -78,7 +79,7 @@ public class TestManyVirtualThreads {
             }
 
             r.stop();
-            Path p = Files.createTempFile("test", ".jfr");
+            Path p = Utils.createTempFile("test", ".jfr");
             r.dump(p);
             long size = Files.size(p);
             Asserts.assertLessThan(size, 100_000_000L, "Size of recording looks suspiciously large");

--- a/test/jdk/jdk/nio/zipfs/ZeroDate.java
+++ b/test/jdk/jdk/nio/zipfs/ZeroDate.java
@@ -58,31 +58,34 @@ public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Utils.createTempFile("bad", ".zip");
-        try (OutputStream os = Files.newOutputStream(path);
-                ZipOutputStream zos = new ZipOutputStream(os)) {
-            ZipEntry e = new ZipEntry("x");
-            zos.putNextEntry(e);
-            zos.write((int) 'x');
-        }
-        int len = (int) Files.size(path);
-        byte[] data = new byte[len];
-        try (InputStream is = Files.newInputStream(path)) {
-            is.read(data);
-        }
-        Files.delete(path);
+        Path path = Files.createTempFile("bad", ".zip");
+        try {
+            try (OutputStream os = Files.newOutputStream(path);
+                 ZipOutputStream zos = new ZipOutputStream(os)) {
+                ZipEntry e = new ZipEntry("x");
+                zos.putNextEntry(e);
+                zos.write((int) 'x');
+            }
+            int len = (int) Files.size(path);
+            byte[] data = new byte[len];
+            try (InputStream is = Files.newInputStream(path)) {
+                is.read(data);
+            }
 
-        // year, month, day are zero
-        testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
-        // only year is zero
-        testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
-        // month is greater than 12
-        testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
-        // 30th of February
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
-        // 30th of February, 24:60:60
-        testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
-                LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+            // year, month, day are zero
+            testDate(data.clone(), 0, LocalDate.of(1979, 11, 30).atStartOfDay());
+            // only year is zero
+            testDate(data.clone(), 0 << 25 | 4 << 21 | 5 << 16, LocalDate.of(1980, 4, 5).atStartOfDay());
+            // month is greater than 12
+            testDate(data.clone(), 0 << 25 | 13 << 21 | 1 << 16, LocalDate.of(1981, 1, 1).atStartOfDay());
+            // 30th of February
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16, LocalDate.of(1980, 3, 1).atStartOfDay());
+            // 30th of February, 24:60:60
+            testDate(data.clone(), 0 << 25 | 2 << 21 | 30 << 16 | 24 << 11 | 60 << 5 | 60 >> 1,
+                    LocalDateTime.of(1980, 3, 2, 1, 1, 0));
+        } finally {
+            Files.delete(path);
+        }
     }
 
     private static void testDate(byte[] data, int date, LocalDateTime expected) throws IOException {

--- a/test/jdk/jdk/nio/zipfs/ZeroDate.java
+++ b/test/jdk/jdk/nio/zipfs/ZeroDate.java
@@ -58,7 +58,7 @@ public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Files.createTempFile("bad", ".zip");
+        Path path = Utils.createTempFile("bad", ".zip");
         try {
             try (OutputStream os = Files.newOutputStream(path);
                  ZipOutputStream zos = new ZipOutputStream(os)) {

--- a/test/jdk/jdk/nio/zipfs/ZeroDate.java
+++ b/test/jdk/jdk/nio/zipfs/ZeroDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,18 +44,21 @@ import java.util.Collections;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
+import jdk.test.lib.Utils;
+
 /* @test
  * @bug 8184940 8186227 8188869
  * @summary JDK 9 rejects zip files where the modified day or month is 0
  *          or otherwise represent an invalid date, such as 1980-02-30 24:60:60
  * @author Liam Miller-Cushon
  * @modules jdk.zipfs
+ * @library /test/lib
  */
 public class ZeroDate {
 
     public static void main(String[] args) throws Exception {
         // create a zip file, and read it in as a byte array
-        Path path = Files.createTempFile("bad", ".zip");
+        Path path = Utils.createTempFile("bad", ".zip");
         try (OutputStream os = Files.newOutputStream(path);
                 ZipOutputStream zos = new ZipOutputStream(os)) {
             ZipEntry e = new ZipEntry("x");
@@ -91,7 +94,7 @@ public class ZeroDate {
         writeU32(data, locpos + LOCTIM, date);
 
         // ensure that the archive is still readable, and the date is 1979-11-30
-        Path path = Files.createTempFile("out", ".zip");
+        Path path = Utils.createTempFile("out", ".zip");
         try (OutputStream os = Files.newOutputStream(path)) {
             os.write(data);
         }

--- a/test/jdk/sun/security/pkcs12/P12SecretKey.java
+++ b/test/jdk/sun/security/pkcs12/P12SecretKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,7 @@ public class P12SecretKey {
         ks.setEntry(ALIAS, ske, kspp);
 
         File ksFile = File.createTempFile("test", ".test");
+        ksFile.deleteOnExit();
         try (FileOutputStream fos = new FileOutputStream(ksFile)) {
             ks.store(fos, pw);
             fos.flush();


### PR DESCRIPTION
This task addresses an essential aspect of our testing infrastructure: the proper handling and cleanup of temporary files and socket files created during test execution. The motivation behind these changes is to prevent the accumulation of unnecessary files in the default temporary directory, which can affect the system's storage and potentially influence subsequent test runs.

Our review identified that several tests create temporary files or socket files without ensuring their removal post-execution. 
- Direct calls to java.io.File.createTempFile and java.nio.file.Files.createTempFile without adequate cleanup.
- Tests using NIO socket channels with StandardProtocolFamily.UNIX, not explicitly removing socket files post-use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327474](https://bugs.openjdk.org/browse/JDK-8327474): Review use of java.io.tmpdir in jdk tests (**Bug** - P4)


### Reviewers
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [2517f756](https://git.openjdk.org/jdk/pull/18352/files/2517f7569c8f1fffb711cf88959f4b231d578de9)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18352/head:pull/18352` \
`$ git checkout pull/18352`

Update a local copy of the PR: \
`$ git checkout pull/18352` \
`$ git pull https://git.openjdk.org/jdk.git pull/18352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18352`

View PR using the GUI difftool: \
`$ git pr show -t 18352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18352.diff">https://git.openjdk.org/jdk/pull/18352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18352#issuecomment-2004443450)