### PR TITLE
8321278: C2: Partial peeling fails with assert "last_peel <- first_not_peeled"

### DIFF
--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -384,6 +384,25 @@ struct NTarjan {
 #endif
 };
 
+void remove_single_entry_region(NTarjan* t, NTarjan*& tdom, Node*& dom, PhaseIterGVN& igvn) {
+  // remove phis:
+  for (DUIterator_Fast jmax, j = dom->fast_outs(jmax); j < jmax; j++) {
+    Node* use = dom->fast_out(j);
+    if (use->is_Phi()) {
+      igvn.replace_node(use, use->in(1));
+      --j; --jmax;
+    }
+  }
+  // Disconnect region from dominator tree
+  assert(dom->unique_ctrl_out() == t->_control, "expect a single dominated node");
+  tdom = tdom->_dom;
+  t->_dom = tdom;
+  assert(tdom->_control == dom->in(1), "dominator of region with single input should be that input");
+  // and remove it
+  igvn.replace_node(dom, dom->in(1));
+  dom = tdom->_control;
+}
+
 // Compute the dominator tree of the sea of nodes.  This version walks all CFG
 // nodes (using the is_CFG() call) and places them in a dominator tree.  Thus,
 // it needs a count of the CFG nodes for the mapping table. This is the
@@ -486,7 +505,11 @@ void PhaseIdealLoop::Dominators() {
     assert(t->_control != nullptr,"Bad DFS walk");
     NTarjan *tdom = t->_dom;           // Handy access to immediate dominator
     if( tdom )  {                      // Root has no immediate dominator
-      _idom[t->_control->_idx] = tdom->_control; // Set immediate dominator
+      Node* dom = tdom->_control;
+      if (dom != C->root() && dom->is_Region() && dom->req() == 2) {
+        remove_single_entry_region(t, tdom, dom, _igvn);
+      }
+      _idom[t->_control->_idx] = dom; // Set immediate dominator
       t->_dom_next = tdom->_dom_child; // Make me a sibling of parent's child
       tdom->_dom_child = t;            // Make me a child of my parent
     } else

--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -506,6 +506,9 @@ void PhaseIdealLoop::Dominators() {
     NTarjan *tdom = t->_dom;           // Handy access to immediate dominator
     if( tdom )  {                      // Root has no immediate dominator
       Node* dom = tdom->_control;
+      // The code that removes unreachable loops above could have left a region with a single input. Remove it. Do it
+      // now that we iterate over cfg nodes for the last time (doing it earlier would have left a dead cfg node behind
+      // that code that goes over the dfs list would have had to handle).
       if (dom != C->root() && dom->is_Region() && dom->req() == 2) {
         remove_single_entry_region(t, tdom, dom, _igvn);
       }

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8321278
+ * @summary C2: Partial peeling fails with assert "last_peel <- first_not_peeled"
+ * @run main/othervm -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,TestPartialPeelingAtSingleInputRegion::test
+ *                   -XX:-TieredCompilation -Xbatch -XX:PerMethodTrapLimit=0 TestPartialPeelingAtSingleInputRegion
+ *
+ */
+
+public class TestPartialPeelingAtSingleInputRegion {
+
+    static void test() {
+        for (int i = 100; i > 10; --i) {
+            for (int j = i; j < 10; ++j) {
+                switch (j) {
+                case 1:
+                    if (j != 0) {
+                        return;
+                    }
+                }
+             }
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 50_000; ++i) {
+            test();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelingAtSingleInputRegion.java
@@ -48,7 +48,7 @@ public class TestPartialPeelingAtSingleInputRegion {
     }
 
     public static void main(String[] args) {
-        for (int i = 0; i < 50_000; ++i) {
+        for (int i = 0; i < 10_000; ++i) {
             test();
         }
     }


### PR DESCRIPTION
The assert fails because peeling happens at a single entry
`Region`. That `Region` only has a single input because other inputs
were found unreachable and removed by
`PhaseIdealLoop::Dominators()`. The fix I propose is to have
`PhaseIdealLoop::Dominators()` remove the `Region` and its `Phi`s
entirely in this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321278](https://bugs.openjdk.org/browse/JDK-8321278): C2: Partial peeling fails with assert "last_peel &lt;- first_not_peeled" (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [d201aee2](https://git.openjdk.org/jdk/pull/18353/files/d201aee2f44a67ad0b214bbaab94a09df741f95b)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18353/head:pull/18353` \
`$ git checkout pull/18353`

Update a local copy of the PR: \
`$ git checkout pull/18353` \
`$ git pull https://git.openjdk.org/jdk.git pull/18353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18353`

View PR using the GUI difftool: \
`$ git pr show -t 18353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18353.diff">https://git.openjdk.org/jdk/pull/18353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18353#issuecomment-2004507479)