### PR TITLE
8328261: public lookup fails with IllegalAccessException when used while module system is being initialized

### DIFF
--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -201,9 +201,10 @@ public class VerifyAccess {
             Module lookupModule = lookupClass.getModule();
             Module refModule = refc.getModule();
 
-            // early VM startup case, java.base not defined
-            if (lookupModule == null) {
-                assert refModule == null;
+            // early VM startup case, java.base not defined or
+            // module system is not fully initialized and exports are not set up
+            if (lookupModule == null || !jdk.internal.misc.VM.isModuleSystemInited()) {
+                assert lookupModule == refModule;
                 return true;
             }
 
@@ -228,11 +229,6 @@ public class VerifyAccess {
                                                               : null;
             assert refModule != lookupModule || refModule != prevLookupModule;
             if (isModuleAccessible(refc, lookupModule, prevLookupModule))
-                return true;
-
-            // not exported but allow access during VM initialization
-            // because java.base does not have its exports setup
-            if (!jdk.internal.misc.VM.isModuleSystemInited())
                 return true;
 
             // public class not accessible to lookupClass


### PR DESCRIPTION
A simple fix.   This is caused by a bug in `VerifyAccess::isClassAccessible` that checks if a class is exported from `java.base` before the exports are fully setup.    It should check if the module system is fully initialized before checking the module exports instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328261](https://bugs.openjdk.org/browse/JDK-8328261): public lookup fails with IllegalAccessException when used while module system is being initialized (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18356/head:pull/18356` \
`$ git checkout pull/18356`

Update a local copy of the PR: \
`$ git checkout pull/18356` \
`$ git pull https://git.openjdk.org/jdk.git pull/18356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18356`

View PR using the GUI difftool: \
`$ git pr show -t 18356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18356.diff">https://git.openjdk.org/jdk/pull/18356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18356#issuecomment-2004559115)