### PR TITLE
8328402: Implement pausing functionality for the PassFailJFrame

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -657,7 +657,7 @@ public final class PassFailJFrame {
                     + TimeUnit.MINUTES.toMillis(testTimeOut);
 
             label =  new JLabel("", JLabel.CENTER);
-            button = new JButton(TimeoutHandlerPanel.PAUSE_BUTTON_LABEL);
+            button = new JButton(PAUSE_BUTTON_LABEL);
 
             button.setFocusPainted(false);
             button.setFont(new Font(Font.DIALOG, Font.BOLD, 10));

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -644,8 +644,9 @@ public final class PassFailJFrame {
         private static final String PAUSED_LABEL_SUFFIX = " PAUSED";
         private static final String PAUSE_BUTTON_LABEL = "Pause Timer";
         private static final String RESUME_BUTTON_LABEL = "Resume Timer";
+
         private long endTime;
-        private long pauseTimeLeft = 0L;
+        private long pauseTimeLeft;
 
         private final Timer timer;
 
@@ -700,8 +701,8 @@ public final class PassFailJFrame {
                 label.setText(label.getText() + PAUSED_LABEL_SUFFIX);
                 button.setText(RESUME_BUTTON_LABEL);
             } else {
-                label.setText(label.getText().replace(PAUSED_LABEL_SUFFIX, ""));
                 endTime = System.currentTimeMillis() + pauseTimeLeft;
+                updateTime(pauseTimeLeft);
                 timer.start();
                 button.setText(PAUSE_BUTTON_LABEL);
             }


### PR DESCRIPTION
> we need to add next to Pass/Fail a "Pause Timer" button, that
(a) stops the count down
(b) changes the Pause Timer to "Resume Timer"
~~(c) disables Pass/Fail until the timer is resumed~~
the test will not have to pause or be aware - only the PassFailJFrame machinery.
~~So the tester can do anything they want except exit the test in the paused mode.~~

This PR implements everything except the (c).
I see nothing wrong with completing the test from the paused state, and it does not add an extra click.  


Example screenshots:

![image](https://github.com/openjdk/jdk/assets/77687766/65d34bf8-1e46-4e68-b39e-a77f257ec3c0)
![image](https://github.com/openjdk/jdk/assets/77687766/3a43e059-2d48-46f3-9d1b-c2ab84fcce37)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328402](https://bugs.openjdk.org/browse/JDK-8328402): Implement pausing functionality for the PassFailJFrame (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [10f4580e](https://git.openjdk.org/jdk/pull/18368/files/10f4580e57a18845661b16c0e830dbfb6f93b8fd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18368/head:pull/18368` \
`$ git checkout pull/18368`

Update a local copy of the PR: \
`$ git checkout pull/18368` \
`$ git pull https://git.openjdk.org/jdk.git pull/18368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18368`

View PR using the GUI difftool: \
`$ git pr show -t 18368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18368.diff">https://git.openjdk.org/jdk/pull/18368.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18368#issuecomment-2005558984)