### PR TITLE
8328501: Incorrect `@since` tags for java security interfaces

### DIFF
--- a/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPrivateKey.java
@@ -70,7 +70,6 @@ public interface DSAPrivateKey extends DSAKey, java.security.PrivateKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default DSAParams getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAPublicKey.java
@@ -70,7 +70,6 @@ public interface DSAPublicKey extends DSAKey, java.security.PublicKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default DSAParams getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPrivateKey.java
@@ -65,7 +65,6 @@ public interface ECPrivateKey extends PrivateKey, ECKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default ECParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/ECPublicKey.java
@@ -67,7 +67,6 @@ public interface ECPublicKey extends PublicKey, ECKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default ECParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPrivateKey.java
@@ -61,7 +61,6 @@ public interface EdECPrivateKey extends EdECKey, PrivateKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default NamedParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/EdECPublicKey.java
@@ -56,7 +56,6 @@ public interface EdECPublicKey extends EdECKey, PublicKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default NamedParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -68,6 +68,7 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
+     * @since 22
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -68,7 +68,6 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 11
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPrivateKey.java
@@ -68,7 +68,7 @@ public interface RSAPrivateKey extends java.security.PrivateKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
+     * @since 11
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -65,7 +65,6 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 11
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -65,7 +65,7 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
+     * @since 11
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/RSAPublicKey.java
@@ -65,6 +65,7 @@ public interface RSAPublicKey extends java.security.PublicKey, RSAKey
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
+     * @since 22
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPrivateKey.java
@@ -62,7 +62,6 @@ public interface XECPrivateKey extends XECKey, PrivateKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
+++ b/src/java.base/share/classes/java/security/interfaces/XECPublicKey.java
@@ -60,7 +60,6 @@ public interface XECPublicKey extends XECKey, PublicKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default AlgorithmParameterSpec getParams() {

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPrivateKey.java
@@ -65,7 +65,6 @@ public interface DHPrivateKey extends DHKey, java.security.PrivateKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default DHParameterSpec getParams() {

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
+++ b/src/java.base/share/classes/javax/crypto/interfaces/DHPublicKey.java
@@ -65,7 +65,6 @@ public interface DHPublicKey extends DHKey, java.security.PublicKey {
      * The default implementation returns {@code null}.
      *
      * @return {@inheritDoc java.security.AsymmetricKey}
-     * @since 22
      */
     @Override
     default DHParameterSpec getParams() {


### PR DESCRIPTION
For context, I am writing tests to check for accurate use of `@since` tags in documentation comments in source code.
We're following these rules for now:

### Rule 1: Introduction of New Elements

- If an element is new in JDK N, with no equivalent in JDK N-1, it must include `@since N`.
  - Exception: Member elements (fields, methods, nested classes) may omit `@since` if their version matches the value specified for the enclosing class or interface.

### Rule 2: Existing Elements in Subsequent JDK Versions

- If an element exists in JDK N, with an equivalent in JDK N-1, it should not include `@since N`.

### Rule 3: Handling Missing `@since` Tags in methods if there is no `@since`

- When inspecting methods, prioritize the `@since` annotation of the supertype's overridden method.
- If unavailable or if the enclosing class's `@since` is newer, use the enclosing element's `@since`.

  I.e. if A extends B, and we add a method to B in JDK N, and add an override of the method to A in JDK M (M > N), we will use N as the effective `@since` for the method.

The override of `getParams` in these interfaces was done in in JDK 22 and an `@since 22` was, but this method has been inherited to these interfaces for a long time.

As pointed out by my mentor Jan, 

```
import javax.crypto.interfaces.DHPublicKey;

public class DhkeyTest {

    public static void main(DHPublicKey key) {
        System.err.println(key.getParams());
    }
    
}
```

this compiles using JDK 8 without any compile-time errors. The @ since tag shouldn't be here


- the same goes for these other interfaces 

java.security.interfaces.DSAPublicKey
java.security.interfaces.XECPublicKey
java.security.interfaces.DSAPrivateKey
java.security.interfaces.ECPrivateKey
java.security.interfaces.XECPrivateKey
java.security.interfaces.EdECPrivateKey
java.security.interfaces.ECPublicKey
java.security.interfaces.EdECPublicKey
javax.crypto.interfaces.DHPrivateKey
javax.crypto.interfaces.DHPublicKey
java.security.interfaces.RSAPublicKey
java.security.interfaces.RSAPrivateKey

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328501](https://bugs.openjdk.org/browse/JDK-8328501): Incorrect `@<!---->since` tags for java security interfaces (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**) ⚠️ Review applies to [b04a75e5](https://git.openjdk.org/jdk/pull/18373/files/b04a75e55a207f1cbee7efffe3073960bbccf68a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18373/head:pull/18373` \
`$ git checkout pull/18373`

Update a local copy of the PR: \
`$ git checkout pull/18373` \
`$ git pull https://git.openjdk.org/jdk.git pull/18373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18373`

View PR using the GUI difftool: \
`$ git pr show -t 18373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18373.diff">https://git.openjdk.org/jdk/pull/18373.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18373#issuecomment-2006921012)