### PR TITLE
8328366: Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -1140,12 +1140,7 @@ public class ForkJoinPool extends AbstractExecutorService {
             boolean isCommon = (pool.workerNamePrefix == null);
             @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
-            if (sm == null) {
-                if (isCommon)
-                    return new ForkJoinWorkerThread.InnocuousForkJoinWorkerThread(pool);
-                else
-                    return new ForkJoinWorkerThread(null, pool, true, false);
-            } else if (isCommon)
+            if (sm != null && isCommon)
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);

--- a/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
+++ b/test/jdk/java/util/concurrent/tck/ForkJoinPool9Test.java
@@ -79,6 +79,9 @@ public class ForkJoinPool9Test extends JSR166TestCase {
             assertSame(ForkJoinPool.commonPool(), ForkJoinTask.getPool());
             Thread currentThread = Thread.currentThread();
 
+            ClassLoader preexistingContextClassLoader =
+                    currentThread.getContextClassLoader();
+
             Stream.of(systemClassLoader, null).forEach(cl -> {
                 if (randomBoolean())
                     // should always be permitted, without effect
@@ -95,6 +98,11 @@ public class ForkJoinPool9Test extends JSR166TestCase {
                     () -> System.getProperty("foo"),
                     () -> currentThread.setContextClassLoader(
                         classLoaderDistinctFromSystemClassLoader));
+            else {
+                currentThread.setContextClassLoader(classLoaderDistinctFromSystemClassLoader);
+                assertSame(currentThread.getContextClassLoader(), classLoaderDistinctFromSystemClassLoader);
+                currentThread.setContextClassLoader(preexistingContextClassLoader);
+            }
             // TODO ?
 //          if (haveSecurityManager
 //              && Thread.currentThread().getClass().getSimpleName()


### PR DESCRIPTION
This is a draft PR with a potential solution to 8328366 without regressing 8327501.

@DougLea To avoid regressions in the future, where would regression tests for this ideally be located?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328366](https://bugs.openjdk.org/browse/JDK-8328366): Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 (**Bug** - P3)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18374/head:pull/18374` \
`$ git checkout pull/18374`

Update a local copy of the PR: \
`$ git checkout pull/18374` \
`$ git pull https://git.openjdk.org/jdk.git pull/18374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18374`

View PR using the GUI difftool: \
`$ git pr show -t 18374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18374.diff">https://git.openjdk.org/jdk/pull/18374.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18374#issuecomment-2010000727)