### PR TITLE
8328507: Move StackWatermark code from safepoint cleanup

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -350,11 +350,6 @@ protected:
     return 0;
   }
 
-  // If a GC uses a stack watermark barrier, the stack processing is lazy, concurrent,
-  // incremental and cooperative. In order for that to work well, mechanisms that stop
-  // another thread might want to ensure its roots are in a sane state.
-  virtual bool uses_stack_watermark_barrier() const { return false; }
-
   // Perform a collection of the heap; intended for use in implementing
   // "System.gc".  This probably implies as full a collection as the
   // "CollectedHeap" supports.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -87,6 +87,7 @@
 #include "runtime/java.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/safepointMechanism.hpp"
+#include "runtime/stackWatermarkSet.hpp"
 #include "runtime/vmThread.hpp"
 #include "utilities/events.hpp"
 #include "utilities/powerOfTwo.hpp"
@@ -2302,6 +2303,7 @@ bool ShenandoahHeap::uncommit_bitmap_slice(ShenandoahHeapRegion *r) {
 }
 
 void ShenandoahHeap::safepoint_synchronize_begin() {
+  StackWatermarkSet::safepoint_synchronize_begin();
   SuspendibleThreadSet::synchronize();
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2013, 2021, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -538,11 +538,6 @@ public:
 
   void sync_pinned_region_status();
   void assert_pinned_region_status() NOT_DEBUG_RETURN;
-
-// ---------- Concurrent Stack Processing support
-//
-public:
-  bool uses_stack_watermark_barrier() const override { return true; }
 
 // ---------- Allocation support
 //

--- a/src/hotspot/share/gc/x/xCollectedHeap.cpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@
 #include "memory/universe.hpp"
 #include "oops/stackChunkOop.hpp"
 #include "runtime/continuationJavaClasses.hpp"
+#include "runtime/stackWatermarkSet.hpp"
 #include "utilities/align.hpp"
 
 XCollectedHeap* XCollectedHeap::heap() {
@@ -215,10 +216,6 @@ size_t XCollectedHeap::unsafe_max_tlab_alloc(Thread* ignored) const {
   return _heap.unsafe_max_tlab_alloc();
 }
 
-bool XCollectedHeap::uses_stack_watermark_barrier() const {
-  return true;
-}
-
 MemoryUsage XCollectedHeap::memory_usage() {
   return _heap.serviceability_memory_pool()->get_memory_usage();
 }
@@ -277,6 +274,7 @@ VirtualSpaceSummary XCollectedHeap::create_heap_space_summary() {
 }
 
 void XCollectedHeap::safepoint_synchronize_begin() {
+  StackWatermarkSet::safepoint_synchronize_begin();
   SuspendibleThreadSet::synchronize();
 }
 

--- a/src/hotspot/share/gc/x/xCollectedHeap.hpp
+++ b/src/hotspot/share/gc/x/xCollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,8 +86,6 @@ public:
   size_t tlab_used(Thread* thr) const override;
   size_t max_tlab_size() const override;
   size_t unsafe_max_tlab_alloc(Thread* thr) const override;
-
-  bool uses_stack_watermark_barrier() const override;
 
   MemoryUsage memory_usage() override;
   GrowableArray<GCMemoryManager*> memory_managers() override;

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,7 @@
 #include "oops/stackChunkOop.hpp"
 #include "runtime/continuationJavaClasses.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/stackWatermarkSet.hpp"
 #include "services/memoryUsage.hpp"
 #include "utilities/align.hpp"
 
@@ -240,10 +241,6 @@ size_t ZCollectedHeap::unsafe_max_tlab_alloc(Thread* ignored) const {
   return _heap.unsafe_max_tlab_alloc();
 }
 
-bool ZCollectedHeap::uses_stack_watermark_barrier() const {
-  return true;
-}
-
 MemoryUsage ZCollectedHeap::memory_usage() {
   const size_t initial_size = ZHeap::heap()->initial_capacity();
   const size_t committed    = ZHeap::heap()->capacity();
@@ -338,6 +335,7 @@ bool ZCollectedHeap::contains_null(const oop* p) const {
 }
 
 void ZCollectedHeap::safepoint_synchronize_begin() {
+  StackWatermarkSet::safepoint_synchronize_begin();
   ZGeneration::young()->synchronize_relocation();
   ZGeneration::old()->synchronize_relocation();
   SuspendibleThreadSet::synchronize();

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,6 @@ public:
   size_t tlab_used(Thread* thr) const override;
   size_t max_tlab_size() const override;
   size_t unsafe_max_tlab_alloc(Thread* thr) const override;
-
-  bool uses_stack_watermark_barrier() const override;
 
   MemoryUsage memory_usage() override;
   GrowableArray<GCMemoryManager*> memory_managers() override;

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -70,7 +70,6 @@ class SafepointSynchronize : AllStatic {
 
   // The enums are listed in the order of the tasks when done serially.
   enum SafepointCleanupTasks {
-    SAFEPOINT_CLEANUP_LAZY_ROOT_PROCESSING,
     SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP,
     // Leave this one last.
     SAFEPOINT_CLEANUP_NUM_TASKS

--- a/src/hotspot/share/runtime/stackWatermarkSet.cpp
+++ b/src/hotspot/share/runtime/stackWatermarkSet.cpp
@@ -121,7 +121,6 @@ void StackWatermarkSet::on_safepoint(JavaThread* jt) {
 
 void StackWatermarkSet::start_processing(JavaThread* jt, StackWatermarkKind kind) {
   verify_processing_context();
-  assert(!jt->is_terminated(), "Poll after termination is a bug");
   StackWatermark* watermark = get(jt, kind);
   if (watermark != nullptr) {
     watermark->start_processing();

--- a/src/hotspot/share/runtime/stackWatermarkSet.cpp
+++ b/src/hotspot/share/runtime/stackWatermarkSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,9 @@
 #include "runtime/safepointMechanism.inline.hpp"
 #include "runtime/stackWatermark.inline.hpp"
 #include "runtime/stackWatermarkSet.inline.hpp"
+#include "runtime/threadSMR.hpp"
+#include "runtime/vmOperation.hpp"
+#include "runtime/vmThread.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/preserveException.hpp"
@@ -156,5 +159,15 @@ uintptr_t StackWatermarkSet::lowest_watermark(JavaThread* jt) {
     return 0;
   } else {
     return watermark;
+  }
+}
+
+void StackWatermarkSet::safepoint_synchronize_begin() {
+  if (VMThread::vm_operation()->skip_thread_oop_barriers()) {
+    return;
+  }
+
+  for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thread = jtiwh.next(); ) {
+    StackWatermarkSet::start_processing(thread, StackWatermarkKind::gc);
   }
 }

--- a/src/hotspot/share/runtime/stackWatermarkSet.hpp
+++ b/src/hotspot/share/runtime/stackWatermarkSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,6 +88,10 @@ public:
   // The lowest watermark among the watermarks in the set (the first encountered
   // watermark in the set as you unwind frames)
   static uintptr_t lowest_watermark(JavaThread* jt);
+
+  // We are synchronizing a safepoint, so we might want to ensure processing has at least
+  // started, as safepoint operations sometimes assume that is the case
+  static void safepoint_synchronize_begin();
 };
 
 #endif // SHARE_RUNTIME_STACKWATERMARKSET_HPP


### PR DESCRIPTION
There is some stack watermark code in safepoint cleanup that flushes out concurrent stack processing, as a defensive measure to guard safepoint operations that assume the stacks have been fixed up. However, we wish to get rid of safepoint cleanup so this operation should move out from the safepoint. This proposal moves it into CollectedHeap::safepoint_synchronize_begin instead which runs before we start shutting down Java threads. This moves the code into more obvious GC places and reduces time spent inside of non-GC safepoints.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328507](https://bugs.openjdk.org/browse/JDK-8328507): Move StackWatermark code from safepoint cleanup (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) ⚠️ Review applies to [f18381c8](https://git.openjdk.org/jdk/pull/18378/files/f18381c8117ba100e72d02e5911a47c884aab5e3)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18378/head:pull/18378` \
`$ git checkout pull/18378`

Update a local copy of the PR: \
`$ git checkout pull/18378` \
`$ git pull https://git.openjdk.org/jdk.git pull/18378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18378`

View PR using the GUI difftool: \
`$ git pr show -t 18378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18378.diff">https://git.openjdk.org/jdk/pull/18378.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18378#issuecomment-2007219374)