### PR TITLE
8326521: JFR: CompilerPhase event test fails on windows 32 bit

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerPhase.java
@@ -42,6 +42,7 @@ import jdk.test.whitebox.WhiteBox;
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:-NeverActAsServerClassMachine
  *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *     -XX:CompileOnly=jdk.jfr.event.compiler.TestCompilerPhase::dummyMethod
  *     -XX:+SegmentedCodeCache -Xbootclasspath/a:.


### PR DESCRIPTION
This test failure is a problem for the Adoptium CI. The reason that this test fails on 32 bit Windows is that Hotspot only uses the C1 compiler in this configuration by design. If the system is Windows and not 64 bit, [NeverActAsServerClassMachine](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compilerDefinitions.cpp#L569) will be set. This results in setting the compilation mode to be [quick_only](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compilerDefinitions.cpp#L191), which results in [constraining to C1 compilation](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compilerDefinitions.inline.hpp#L53).

The CompilerPhase JFR events are only emitted from C2 code in hotspot. So although the test succeeds in compiling the method it intends to (with C1), it isn't able to generate the JFR events it expects, and so fails.
```
----------System.out:(4/182)----------
CompileCommand: compileonly jdk/jfr/event/compiler/TestCompilerPhase.dummyMethod bool compileonly = true
1 compiler directives added
WB error: invalid compilation level 4
----------System.err:(16/1050)----------
java.lang.RuntimeException: No events: expected false, was true
at jdk.test.lib.Asserts.fail(Asserts.java:594)
at jdk.test.lib.Asserts.assertFalse(Asserts.java:461)
at jdk.test.lib.jfr.Events.hasEvents(Events.java:161)
at jdk.jfr.event.compiler.TestCompilerPhase.main(TestCompilerPhase.java:76)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:840)

JavaTest Message: Test threw exception: java.lang.RuntimeException: No events: expected false, was true
JavaTest Message: shutting down test

STATUS:Failed.`main' threw exception: java.lang.RuntimeException: No events: expected false, was true
```
This PR prevents `NeverActAsServerClassMachine` from being set during the test, so that it isn't restricted to C1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326521](https://bugs.openjdk.org/browse/JDK-8326521): JFR: CompilerPhase event test fails on windows 32 bit (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18379/head:pull/18379` \
`$ git checkout pull/18379`

Update a local copy of the PR: \
`$ git checkout pull/18379` \
`$ git pull https://git.openjdk.org/jdk.git pull/18379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18379`

View PR using the GUI difftool: \
`$ git pr show -t 18379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18379.diff">https://git.openjdk.org/jdk/pull/18379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18379#issuecomment-2007307832)