### PR TITLE
8328524: [x86] StringRepeat.java failure on linux-x86: Could not reserve enough space for 2097152KB object heap

### DIFF
--- a/test/jdk/java/lang/String/StringRepeat.java
+++ b/test/jdk/java/lang/String/StringRepeat.java
@@ -31,7 +31,7 @@
  * @test
  * @summary This exercises String#repeat patterns with 16 * 1024 * 1024 repeats.
  * @requires os.maxMemory >= 2G
- * @requires !(os.family == "windows" & sun.arch.data.model == "32")
+ * @requires vm.bits == "64"
  * @run main/othervm -Xmx2g StringRepeat 16777216
  */
 


### PR DESCRIPTION
…rve enough space for 2097152KB object heap

I would like to fix this as the two related issues mentioned in the JBS bug.
We see it currently in most GHA runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328524](https://bugs.openjdk.org/browse/JDK-8328524): [x86] StringRepeat.java failure on linux-x86: Could not reserve enough space for 2097152KB object heap (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18380/head:pull/18380` \
`$ git checkout pull/18380`

Update a local copy of the PR: \
`$ git checkout pull/18380` \
`$ git pull https://git.openjdk.org/jdk.git pull/18380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18380`

View PR using the GUI difftool: \
`$ git pr show -t 18380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18380.diff">https://git.openjdk.org/jdk/pull/18380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18380#issuecomment-2007431230)