### PR TITLE
8327505: Test com/sun/jmx/remote/NotificationMarshalVersions/TestSerializationMismatch.java fails

### DIFF
--- a/test/jdk/com/sun/jmx/remote/NotificationMarshalVersions/Client/Client.java
+++ b/test/jdk/com/sun/jmx/remote/NotificationMarshalVersions/Client/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 public class Client {
+
+    public static final int COUNTER_TIMEOUT_SECONDS = 60;
+
     public static void run(String url) throws Exception {
         final int notifEmittedCnt = 10;
         final CountDownLatch counter = new CountDownLatch(notifEmittedCnt);
@@ -84,8 +87,8 @@ public class Client {
         System.out.println();
         try {
             System.out.println("waiting for " + notifEmittedCnt + " notifications to arrive");
-            if (!counter.await(30, TimeUnit.SECONDS)) {
-                throw new InterruptedException();
+            if (!counter.await(COUNTER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                throw new Error("Client: Counter await expired");
             }
             if (duplNotification.get()) {
                 System.out.println("ERROR: received duplicated notifications");
@@ -94,7 +97,7 @@ public class Client {
             System.out.println("\nshutting down client");
         } catch (InterruptedException e) {
             System.out.println("ERROR: notification processing thread interrupted");
-            throw new Error("notification thread interrupted unexpectedly");
+            throw new Error("notification thread interrupted unexpectedly", e);
         }
     }
 }


### PR DESCRIPTION
Client.java has a fixed 30-second timeout on the CountDownLatch to wait for 10 notifications.

If it fails, you can't tell if CountDownLatch.await threw, or returned false and the app threw InterruptedException, due to the way Client.java handles these.

Seems most likely the 30 second wait expired, as we are dealing with -Xcomp failures in a debug build.  Passing runs can take a few seconds, but can be 25 seconds.

Increasing the timeout and tidying up the handling so we can see the specific reason in future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327505](https://bugs.openjdk.org/browse/JDK-8327505): Test com/sun/jmx/remote/NotificationMarshalVersions/TestSerializationMismatch.java fails (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18381/head:pull/18381` \
`$ git checkout pull/18381`

Update a local copy of the PR: \
`$ git checkout pull/18381` \
`$ git pull https://git.openjdk.org/jdk.git pull/18381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18381`

View PR using the GUI difftool: \
`$ git pr show -t 18381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18381.diff">https://git.openjdk.org/jdk/pull/18381.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18381#issuecomment-2007805543)