### PR TITLE
8317720: RISC-V: Implement Adler32 intrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1419,6 +1419,10 @@ enum VectorMask {
   INSN(vredmaxu_vs,   0b1010111, 0b010, 0b000110);
   INSN(vredmax_vs,    0b1010111, 0b010, 0b000111);
 
+  // Vector Widening Integer Reduction Instructions
+  INSN(vwredsum_vs,    0b1010111, 0b000, 0b110001);
+  INSN(vwredsumu_vs,   0b1010111, 0b000, 0b110000);
+
   // Vector Floating-Point Compare Instructions
   INSN(vmfle_vv, 0b1010111, 0b001, 0b011001);
   INSN(vmflt_vv, 0b1010111, 0b001, 0b011011);
@@ -1456,6 +1460,10 @@ enum VectorMask {
   INSN(vmulhu_vv,  0b1010111, 0b010, 0b100100);
   INSN(vmulh_vv,   0b1010111, 0b010, 0b100111);
   INSN(vmul_vv,    0b1010111, 0b010, 0b100101);
+
+  // Vector Widening Integer Multiply Instructions
+  INSN(vwmul_vv,    0b1010111, 0b010, 0b111011);
+  INSN(vwmulu_vv,   0b1010111, 0b010, 0b111000);
 
   // Vector Integer Min/Max Instructions
   INSN(vmax_vv,  0b1010111, 0b000, 0b000111);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5047,31 +5047,38 @@ class StubGenerator: public StubCodeGenerator {
 
     __ andi(temp, data, right_8_bits);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 8);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 16);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 24);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 32);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 40);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
+
     __ srli(temp, data, 48);
     __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
     __ add(acc1, acc1, temp);
     __ add(acc2, acc2, acc1);
+
     __ srli(temp, data, 56);
     __ add(acc1, acc1, temp);
     __ add(acc2, acc2, acc1);
@@ -5138,7 +5145,7 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ bgeu(len, temp0, L_nmax);
     __ beqz(len, L_combine);
 
-    __ bind(L_simple_by1_loop);
+  __ bind(L_simple_by1_loop);
     __ lbu(temp0, Address(buff, 0));
     __ addi(buff, buff, 1);
     __ add(s1, s1, temp0);
@@ -5154,19 +5161,19 @@ const static uint64_t right_8_bits = right_n_bits(8);
 
     __ j(L_combine);
 
-    __ bind(L_nmax);
+  __ bind(L_nmax);
     __ sub(len, len, nmax);
     __ sub(count, nmax, 16);
     __ bltz(len, L_by16);
 
-    __ bind(L_nmax_loop_entry);
+  __ bind(L_nmax_loop_entry);
     const Register buf_end = c_rarg6;
     // buf_end will be used as endpoint for loop below
     __ add(buf_end, buff, count); // buf_end will be used as endpoint for loop below
     __ andi(count, count, 16-1); // count = (count % 16)
     __ sub(count, count, 16); // count after all iterations
 
-    __ bind(L_nmax_loop);
+  __ bind(L_nmax_loop);
 
     __ ld(temp0, Address(buff, 0));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
@@ -5186,11 +5193,11 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ sub(count, nmax, 16);
     __ bgez(len, L_nmax_loop_entry);
 
-    __ bind(L_by16);
+  __ bind(L_by16);
     __ add(len, len, count);
     __ bltz(len, L_by1);
 
-    __ bind(L_by16_loop);
+  __ bind(L_by16_loop);
 
     __ ld(temp0, Address(buff, 0));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
@@ -5200,11 +5207,11 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ sub(len, len, 16);
     __ bgez(len, L_by16_loop);
 
-    __ bind(L_by1);
+  __ bind(L_by1);
     __ add(len, len, 15);
     __ bltz(len, L_do_mod);
 
-    __ bind(L_by1_loop);
+  __ bind(L_by1_loop);
     __ lbu(temp0, Address(buff, 0));
     __ addi(buff, buff, 1);
     __ add(s1, temp0, s1);
@@ -5212,7 +5219,7 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ sub(len, len, 1);
     __ bgez(len, L_by1_loop);
 
-    __ bind(L_do_mod);
+  __ bind(L_do_mod);
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);
 
@@ -5221,7 +5228,7 @@ const static uint64_t right_8_bits = right_n_bits(8);
 
     // Combine lower bits and higher bits
     // adler = s1 | (s2 << 16)
-    __ bind(L_combine);
+  __ bind(L_combine);
     __ slli(s2, s2, 16);
     __ orr(s1, s1, s2);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5043,7 +5043,6 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void generate_updateBytesAdler32_accum(const Register acc1, const Register acc2, const Register data, const Register temp) {
-    assert_different_registers(data, temp, acc1, acc2);
 
     __ andi(temp, data, right_8_bits);
     __ add(acc1, acc1, temp);
@@ -5177,7 +5176,7 @@ const static uint64_t right_8_bits = right_n_bits(8);
 
     __ ld(temp0, Address(buff, 0));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
-    __ ld(temp1, Address(buff, sizeof(jlong)));
+    __ ld(temp0, Address(buff, sizeof(jlong)));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
 
     __ addi(buff, buff, 16);
@@ -5201,9 +5200,10 @@ const static uint64_t right_8_bits = right_n_bits(8);
 
     __ ld(temp0, Address(buff, 0));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
-    __ ld(temp1, Address(buff, sizeof(jlong)));
+    __ ld(temp0, Address(buff, sizeof(jlong)));
     generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
 
+    __ addi(buff, buff, 16);
     __ sub(len, len, 16);
     __ bgez(len, L_by16_loop);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5119,6 +5119,7 @@ const static uint64_t right_8_bits = right_n_bits(8);
     Register temp1 = c_rarg5;
     Register temp2 = t2;
     Register temp3 = x28; // t3
+    Register buf_end = c_rarg6;
 
     // Max number of bytes we can process before having to take the mod
     // 0x15B0 is 5552 in decimal, the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
@@ -5166,7 +5167,6 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ bltz(len, L_by16);
 
   __ bind(L_nmax_loop_entry);
-    const Register buf_end = c_rarg6;
     // buf_end will be used as endpoint for loop below
     __ add(buf_end, buff, count); // buf_end will be used as endpoint for loop below
     __ andi(count, count, 16-1); // count = (count % 16)

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5042,72 +5042,38 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-  void generate_updateBytesAdler32_accum(const Register buff, const Register acc1, const Register acc2,
-    const Register temp0, const Register temp1, const Register temp2) {
-    __ ld(temp0, Address(buff, 0));
-    __ ld(temp1, Address(buff, sizeof(jlong)));
-    __ addi(buff, buff, 16);
+  void generate_updateBytesAdler32_accum(const Register acc1, const Register acc2, const Register data, const Register temp) {
+    assert_different_registers(data, temp, acc1, acc2);
 
-    __ andi(temp2, temp0, right_8_bits);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 8);
-    __ andi(temp2, temp2, right_8_bits);
+    __ andi(temp, data, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 8);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 16);
-    __ andi(temp2, temp2, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 16);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 24);
-    __ andi(temp2, temp2, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 24);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 32);
-    __ andi(temp2, temp2, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 32);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 40);
-    __ andi(temp2, temp2, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 40);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp0, 48);
-    __ andi(temp2, temp2, right_8_bits);
+    __ add(acc1, acc1, temp);
+    __ srli(temp, data, 48);
+    __ andi(temp, temp, right_8_bits);
     __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
+    __ add(acc1, acc1, temp);
     __ add(acc2, acc2, acc1);
-    __ srli(temp2, temp0, 56);
-    __ add(acc1, acc1, temp2);
-    __ add(acc2, acc2, acc1);
-
-    __ andi(temp2, temp1, right_8_bits);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 8);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 16);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 24);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 32);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 40);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ srli(temp2, temp1, 48);
-    __ andi(temp2, temp2, right_8_bits);
-    __ add(acc2, acc2, acc1);
-    __ add(acc1, acc1, temp2);
-    __ add(acc2, acc2, acc1);
-    __ srli(temp2, temp1, 56);
-    __ add(acc1, acc1, temp2);
+    __ srli(temp, data, 56);
+    __ add(acc1, acc1, temp);
     __ add(acc2, acc2, acc1);
   }
 
@@ -5201,7 +5167,13 @@ const static uint64_t right_8_bits = right_n_bits(8);
     __ sub(count, count, 16); // count after all iterations
 
     __ bind(L_nmax_loop);
-    generate_updateBytesAdler32_accum(buff, s1, s2, temp0, temp1, temp2);
+
+    __ ld(temp0, Address(buff, 0));
+    generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
+    __ ld(temp1, Address(buff, sizeof(jlong)));
+    generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
+
+    __ addi(buff, buff, 16);
     __ ble(buff, buf_end, L_nmax_loop);
 
     // s1 = s1 % BASE
@@ -5220,7 +5192,10 @@ const static uint64_t right_8_bits = right_n_bits(8);
 
     __ bind(L_by16_loop);
 
-    generate_updateBytesAdler32_accum(buff, s1, s2, temp0, temp1, temp2);
+    __ ld(temp0, Address(buff, 0));
+    generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
+    __ ld(temp1, Address(buff, sizeof(jlong)));
+    generate_updateBytesAdler32_accum(s1, s2, temp0, temp1);
 
     __ sub(len, len, 16);
     __ bgez(len, L_by16_loop);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5169,8 +5169,6 @@ const static uint64_t right_8_bits = right_n_bits(8);
   __ bind(L_nmax_loop_entry);
     // buf_end will be used as endpoint for loop below
     __ add(buf_end, buff, count); // buf_end will be used as endpoint for loop below
-    __ andi(count, count, 16-1); // count = (count % 16)
-    __ sub(count, count, 16); // count after all iterations
 
   __ bind(L_nmax_loop);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5116,7 +5116,7 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vbytes = v1;
     VectorRegister vtable = v3;
     VectorRegister vtemp1 = v4;
-    VectorRegister vtemp2 = v5;
+    VectorRegister vtemp2 = vtemp1->successor();
     VectorRegister vtemp3 = v30;
     VectorRegister vzero = v12;
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5175,8 +5175,6 @@ class StubGenerator: public StubCodeGenerator {
     // vtable now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
 
     __ vmv_v_i(vzero, 0);
-    __ vmv_v_i(vtemp1, 0);
-    __ vmv_v_i(vtemp2, 0);
 
     __ mv(base, BASE);
     __ mv(nmax, NMAX);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5168,7 +5168,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Generating accumulation coefficients for further calculations
     __ vid_v(vtemp1);
-    __ li(temp0, 16);
+    __ mv(temp0, 16);
     __ vmv_v_x(vtable, temp0);
     __ vsub_vv(vtable, vtable, vtemp1);
     // vtable now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5083,7 +5083,7 @@ class StubGenerator: public StubCodeGenerator {
     assert(unroll_factor <= 8, "Not enough vector registers in unroll_regs");
     // Below is partial loop unrolling for updateBytesAdler32:
     // First, the unroll*16 bytes are processed, the results are in
-    // unroll_regs[i], unroll_regs[i + 8] and unroll_regs[i + 8]->successor()
+    // v4, v5, v6, ..., v25, v26, v27
     // Second, the final summation for unrolled part of the loop should be performed
 
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
@@ -5148,11 +5148,6 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vbytes = v1;
     VectorRegister vtable = v2;
     VectorRegister vzero = v3;
-    VectorRegister work_regs[] = {
-      v4, v5, v6, v7, v8, v9, v10, v11,
-      v12, v13, v14, v15, v16, v17, v18, v19,
-      v20, v21, v22, v23, v24, v25, v26, v27
-    };
     VectorRegister unroll_regs[] = {
       v4, v5, v6, v7, v8, v9, v10, v11,
       v12, v14, v16, v18, v20, v22, v24, v26
@@ -5185,11 +5180,6 @@ class StubGenerator: public StubCodeGenerator {
 
     __ mv(base, BASE);
     __ mv(nmax, NMAX);
-
-    // Zeroing all work registers
-    for (int i = 0; i < 24; i++) {
-      __ vmv_v_i(work_regs[i], 0);
-    }
 
     __ srli(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
     // s1 is initialized to the lower 16 bits of adler

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5076,7 +5076,7 @@ class StubGenerator: public StubCodeGenerator {
     // vs2acc = (b1 * 16) + (b2 * 15) + (b3 * 14) + ... + (b16 * 1)
     __ vwmulu_vv(vtemp1, vtable, vbytes); // vtemp2 now contains the second part of multiplication
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
-    __ vadd_vv(vtemp3, vtemp1, vtemp2); // 0x14 * 0xFF * 2 = 0x27D8 -- max value per element,
+    __ vadd_vv(vtemp3, vtemp1, vtemp2); // 0x10 * 0xFF * 2 = 0x1FE0 -- max value per element,
                                         // so no need to do vector-widening operation
     __ vwredsumu_vs(vs2acc, vtemp3, vzero);
   }

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5076,7 +5076,7 @@ class StubGenerator: public StubCodeGenerator {
     // vs2acc = (b1 * 16) + (b2 * 15) + (b3 * 14) + ... + (b16 * 1)
     __ vwmulu_vv(vtemp1, vtable, vbytes); // vtemp2 now contains the second part of multiplication
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
-    __ vadd_vv(vtemp3, vtemp1, vtemp2); // 0x14 * 0xFF * 2 = 0x27D8 -- max value per element, 
+    __ vadd_vv(vtemp3, vtemp1, vtemp2); // 0x14 * 0xFF * 2 = 0x27D8 -- max value per element,
                                         // so no need to do vector-widening operation
     __ vwredsumu_vs(vs2acc, vtemp3, vzero);
   }

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5076,8 +5076,8 @@ class StubGenerator: public StubCodeGenerator {
     // vs2acc = (b1 * 16) + (b2 * 15) + (b3 * 14) + ... + (b16 * 1)
     __ vwmulu_vv(vtemp1, vtable, vbytes); // vtemp2 now contains the second part of multiplication
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
-    __ vadd_vv(vtemp3, vtemp1, vtemp2);   // 0x14 * 0xFF * 2 = 0x27D8 -- max value per element, 
-                                          // so no need to do vector-widening operation
+    __ vadd_vv(vtemp3, vtemp1, vtemp2); // 0x14 * 0xFF * 2 = 0x27D8 -- max value per element, 
+                                        // so no need to do vector-widening operation
     __ vwredsumu_vs(vs2acc, vtemp3, vzero);
   }
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5243,7 +5243,6 @@ class StubGenerator: public StubCodeGenerator {
     __ blt(buff, buf_end, L_nmax_loop);
 
     const int remainder = ((NMAX / 16) % unroll);
-    assert(remainder < 8, "There are not enough vector registers in unroll_regs");
     // Do the calculations for remaining 16*remainder bytes
     generate_updateBytesAdler32_unroll(buff, s1, s2, remainder, vtable, vbytes,
       vzero, unroll_regs, temp0, temp1, temp2, vtemp1, vtemp2);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5043,7 +5043,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void generate_updateBytesAdler32_accum(Register buff, VectorRegister vzero, VectorRegister vbytes,
-                                         VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
+    VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
     // Below is a vectorized implementation of updating s1 and s2 for 16 bytes.
     // We use b1, b2, ..., b16 to denote the 16 bytes loaded in each iteration.
     // In non-vectorized code, we update s1 and s2 as:
@@ -5070,8 +5070,8 @@ class StubGenerator: public StubCodeGenerator {
     // vs1acc = b1 + b2 + b3 + ... + b16
     __ vwredsumu_vs(vs1acc, vbytes, vzero);
 
-    // vs2acc = { (b1 * 16) + (b2 * 15) + (b3 * 14) + ... + (b8 * 9) }
-    // vs2acc->successor() = { (b9 * 8) + (b10 * 7) + (b11 * 6) + ... + (b16 * 1) }
+    // vs2acc = { (b1 * 16), (b2 * 15), (b3 * 14), ..., (b8 * 9) }
+    // vs2acc->successor() = { (b9 * 8), (b10 * 7), (b11 * 6), ..., (b16 * 1) }
     __ vwmulu_vv(vs2acc, vtable, vbytes); // vs2acc->successor() now contains the second part of multiplication
     // The only thing that remains is to sum up the remembered result
   }
@@ -5154,7 +5154,6 @@ class StubGenerator: public StubCodeGenerator {
     };
     VectorRegister vtemp1 = v28;
     VectorRegister vtemp2 = v29;
-    VectorRegister vtemp3 = v30;
 
     // Max number of bytes we can process before having to take the mod
     // 0x15B0 is 5552 in decimal, the largest n such that 255n(n+1)/2 + (n+1)(BASE-1) <= 2^32-1
@@ -5208,7 +5207,6 @@ class StubGenerator: public StubCodeGenerator {
 
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);
-
     // s2 = s2 % BASE
     __ remuw(s2, s2, base);
 
@@ -5237,7 +5235,6 @@ class StubGenerator: public StubCodeGenerator {
 
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);
-
     // s2 = s2 % BASE
     __ remuw(s2, s2, base);
 
@@ -5271,7 +5268,6 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_do_mod);
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);
-
     // s2 = s2 % BASE
     __ remuw(s2, s2, base);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5042,9 +5042,8 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-  void generate_updateBytesAdler32_accum(Register buff, Register temp0,
-          VectorRegister vtemp1, VectorRegister vtemp2, VectorRegister vtemp3, VectorRegister vzero,
-          VectorRegister vbytes, VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
+  void generate_updateBytesAdler32_accum(Register buff, VectorRegister vzero,
+    VectorRegister vbytes, VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
     // Below is a vectorized implementation of updating s1 and s2 for 16 bytes.
     // We use b1, b2, ..., b16 to denote the 16 bytes loaded in each iteration.
     // In non-vectorized code, we update s1 and s2 as:
@@ -5205,7 +5204,7 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_nmax_loop);
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
     for (int i = 0; i < unroll; i++)
-      generate_updateBytesAdler32_accum(buff, temp0, vtemp1, vtemp2, vtemp3, vzero, vbytes, unroll_regs[i], unroll_regs[i + 8], vtable);
+      generate_updateBytesAdler32_accum(buff, vzero, vbytes, unroll_regs[i], unroll_regs[i + 8], vtable);
     // Summing up
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
     for (int i = 0; i < unroll; i++) {
@@ -5233,7 +5232,7 @@ class StubGenerator: public StubCodeGenerator {
     // Do the calculations for remaining 16*remainder bytes
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
     for (int i = 0; i < remainder; i++)
-      generate_updateBytesAdler32_accum(buff, temp0, vtemp1, vtemp2, vtemp3, vzero, vbytes, unroll_regs[i], unroll_regs[i + 8], vtable);
+      generate_updateBytesAdler32_accum(buff, vzero, vbytes, unroll_regs[i], unroll_regs[i + 8], vtable);
     // Summing up
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
     for (int i = 0; i < remainder; i++) {
@@ -5271,7 +5270,7 @@ class StubGenerator: public StubCodeGenerator {
 
   __ bind(L_by16_loop);
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
-    generate_updateBytesAdler32_accum(buff, temp0, vtemp1, vtemp2, vtemp3, vzero, vbytes, unroll_regs[0], unroll_regs[8], vtable);
+    generate_updateBytesAdler32_accum(buff, vzero, vbytes, unroll_regs[0], unroll_regs[8], vtable);
     // s1 = s1 + unroll_regs[0], s2 = s2 + unroll_regs[8]
     __ vsetivli(temp0, 8, Assembler::e16, Assembler::m1);
     // s2 = s2 + s1 * 16

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5042,8 +5042,8 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-  void generate_updateBytesAdler32_accum(Register buff, VectorRegister vzero,
-    VectorRegister vbytes, VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
+  void generate_updateBytesAdler32_accum(Register buff, VectorRegister vzero, VectorRegister vbytes,
+                                         VectorRegister vs1acc, VectorRegister vs2acc, VectorRegister vtable) {
     // Below is a vectorized implementation of updating s1 and s2 for 16 bytes.
     // We use b1, b2, ..., b16 to denote the 16 bytes loaded in each iteration.
     // In non-vectorized code, we update s1 and s2 as:
@@ -5071,8 +5071,8 @@ class StubGenerator: public StubCodeGenerator {
     __ vwredsumu_vs(vs1acc, vbytes, vzero);
 
     // vs2acc = { (b1 * 16) + (b2 * 15) + (b3 * 14) + ... + (b8 * 9) }
-    // vs2acc + 1 register = { (b9 * 8) + (b10 * 7) + (b11 * 6) + ... + (b16 * 1) }
-    __ vwmulu_vv(vs2acc, vtable, vbytes); // vs2acc + 1 register now contains the second part of multiplication
+    // vs2acc->successor() = { (b9 * 8) + (b10 * 7) + (b11 * 6) + ... + (b16 * 1) }
+    __ vwmulu_vv(vs2acc, vtable, vbytes); // vs2acc->successor() now contains the second part of multiplication
   }
 
   /***

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5265,6 +5265,8 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(len, len, nmax);
     __ sub(count, nmax, 16);
     __ bltz(len, L_by16);
+
+  __ bind(L_nmax_loop_entry);
     __ sub(count, count, 32);
 
   __ bind(L_nmax_loop);
@@ -5286,7 +5288,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ sub(len, len, nmax);
     __ sub(count, nmax, 16);
-    __ bgez(len, L_nmax_loop);
+    __ bgez(len, L_nmax_loop_entry);
 
   __ bind(L_by16);
     __ add(len, len, count);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5043,7 +5043,7 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void adler32_process_bytes(Register buff, Register s1, Register s2, VectorRegister vtable,
-    VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister *vs2acc,
+    VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister vs2acc,
     Register temp0, Register temp1, Register temp2,  Register temp3,
     VectorRegister vtemp1, VectorRegister vtemp2, int step, Assembler::LMUL LMUL) {
 
@@ -5080,7 +5080,7 @@ class StubGenerator: public StubCodeGenerator {
     // 2. It is safe to perform sign-extension during vmv.x.s with 16-bits elements
     __ vwredsumu_vs(vs1acc, vbytes, vzero);
     // Multiplication for s2_new
-    __ vwmulu_vv(vs2acc[0], vtable, vbytes);
+    __ vwmulu_vv(vs2acc, vtable, vbytes);
 
     // s2 = s2 + s1 * log2(step)
     __ slli(temp1, s1, exact_log2(step));
@@ -5090,7 +5090,7 @@ class StubGenerator: public StubCodeGenerator {
     if (MaxVectorSize > 16) {
       __ vsetvli(temp0, temp3, Assembler::e16, LMUL);
     } else {
-      // Half of vector-widening multiplication result is in successor of vs2acc[0]
+      // Half of vector-widening multiplication result is in successor of vs2acc
       // group for vlen == 16, in which case we need to double vector register
       // group width in order to reduction sum all of them
       Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
@@ -5101,7 +5101,7 @@ class StubGenerator: public StubCodeGenerator {
     // 0xFF * (64 + 63 + ... + 2 + 1) = 0x817E0 max for whole register group, so:
     // 1. Need to do vector-widening reduction sum
     // 2. It is safe to perform sign-extension during vmv.x.s with 32-bits elements
-    __ vwredsumu_vs(vtemp1, vs2acc[0], vzero);
+    __ vwredsumu_vs(vtemp1, vs2acc, vzero);
 
     // Extracting results for:
     // s1_new
@@ -5151,9 +5151,7 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vzero = v31;
     VectorRegister vbytes = v8; // group: v8, v9, v10, v11
     VectorRegister vs1acc = v12; // group: v12, v13, v14, v15
-    VectorRegister vs2acc[] = {
-      v16, v18, v20, v22
-    };
+    VectorRegister vs2acc = v16; // group: v16, v17, v18, v19, v20, v21, v22, v23
     VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
     VectorRegister vtable_32 = v4; // group: v4, v5
     VectorRegister vtable_16 = v30;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5080,9 +5080,8 @@ static const uint64_t right_16_bits = right_n_bits(16);
 
     // Summing up calculated results for s2_new
     __ vsetvli(temp0, count, Assembler::e16, Assembler::m4);
-    // 0xFF   * 0x10 = 0xFF0   max per single vector element,
-    // 0xFF0  * 0x10 = 0xFF00  max per vector,
-    // 0xFF00 * 0x4  = 0x3FC00 max for the whole group, so:
+    // Upper bound for reduction sum:
+    // 0xFF * (64 + 63 + ... + 2 + 1) = 0x817E0 max for whole register group, so:
     // 1. Need to do vector-widening reduction sum
     // 2. It is safe to perform sign-extension during vmv.x.s with 32-bits elements
     __ vwredsumu_vs(vtemp1, vs2acc[0], vzero);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5072,7 +5072,7 @@ static const uint64_t right_16_bits = right_n_bits(16);
     __ addi(buff, buff, 64);
 
     // Reduction sum for s1_new
-    // 0xFF * 64 = 0xFF0, so:
+    // 0xFF * 64 = 0x3FC0, so:
     // 1. Need to do vector-widening reduction sum
     // 2. It is safe to perform sign-extension during vmv.x.s with 16-bits elements
     __ vwredsumu_vs(vs1acc[0], vbytes[0], vzero);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5214,7 +5214,7 @@ static const uint64_t right_16_bits = right_n_bits(16);
     VectorRegister vs2acc[] = {
       v16, v18, v20, v22
     };
-    VectorRegister vtable_64 = v24; // group: v25, v26, v27
+    VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
     VectorRegister vtable_16 = (MaxVectorSize == 16) ? v27 : v30;
     VectorRegister vtemp1 = v28; // group: v29, v30, v31
     VectorRegister vtemp2 = v29;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5070,8 +5070,12 @@ static const uint64_t right_16_bits = right_n_bits(16);
     __ vle8_v(vbytes[0], buff);
     __ add(buff, buff, temp0);
 
-    // Reduction sum for s1_new, multiplication for s2_new
+    // Reduction sum for s1_new
+    // 0xFF * 64 = 0xFF0, so:
+    // 1. Need to do vector-widening reduction sum
+    // 2. It is safe to perform sign-extension during vmv.x.s with 16-bits elements
     __ vwredsumu_vs(vs1acc[0], vbytes[0], vzero);
+    // Multiplication for s2_new
     __ vwmulu_vv(vs2acc[0], vtable, vbytes[0]);
 
     // s2 = s2 + s1 * 64

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5291,12 +5291,13 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_by16);
     __ add(len, len, count);
     __ bltz(len, L_by1);
+    __ mv(count, 16);
 
   __ bind(L_by16_loop);
-    generate_updateBytesAdler32_unroll_by16(buff, s1, s2, len, vtable_16, vzero,
+    generate_updateBytesAdler32_unroll_by16(buff, s1, s2, count, vtable_16, vzero,
       vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2, 1);
     __ sub(len, len, 16);
-    __ bgtz(len, L_by16_loop);
+    __ bgez(len, L_by16_loop);
 
   __ bind(L_by1);
     __ add(len, len, 15);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5065,10 +5065,11 @@ static const uint64_t right_16_bits = right_n_bits(16);
     //          = s2 + s1 * 64 + (b1 * 64 + b2 * 63 + ... + b64 * 1) =
     //          = s2 + s1 * 64 + (b1, b2, ... b64) dot (64, 63, ... 1)
 
+    __ mv(count, 64);
     // Load data
     __ vsetvli(temp0, count, Assembler::e8, Assembler::m4);
     __ vle8_v(vbytes[0], buff);
-    __ add(buff, buff, temp0);
+    __ addi(buff, buff, 64);
 
     // Reduction sum for s1_new
     // 0xFF * 64 = 0xFF0, so:
@@ -5283,7 +5284,6 @@ static const uint64_t right_16_bits = right_n_bits(16);
     __ sub(len, len, nmax);
     __ sub(count, nmax, 16);
     __ bltz(len, L_by16);
-    __ mv(step, 64);
 
   // Align L_nmax loop by 64
   __ bind(L_nmax_loop_entry);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5204,7 +5204,7 @@ static const uint64_t right_16_bits = right_n_bits(16);
     Register right_16_bits = c_rarg7;
     Register step = x28; // t3
 
-    VectorRegister vzero = v4; // group: v5, v6, v7
+    VectorRegister vzero = v31;
     VectorRegister vbytes[] = {
       v8, v9, v10, v11
     };
@@ -5233,17 +5233,14 @@ static const uint64_t right_16_bits = right_n_bits(16);
     __ vmv_v_x(vtable_64, temp1);
     __ vsub_vv(vtable_64, vtable_64, vtemp1);
     // vtable_64 group now contains { 0x40, 0x3f, 0x3e, ..., 0x3, 0x2, 0x1 }
-    __ vmv_v_i(vzero, 0);
+    __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
     if (MaxVectorSize > 16) {
       // Need to generate vtable_16 explicitly
-      __ mv(temp1, 16);
-      __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m1);
-
-      // Generating accumulation coefficients for further calculations
       __ vid_v(vtemp1);
-      __ vmv_v_x(vtable_16, temp1);
+      __ vmv_v_i(vtable_16, 16);
       __ vsub_vv(vtable_16, vtable_16, vtemp1);
     }
+    __ vmv_v_i(vzero, 0);
 
     __ mv(base, BASE);
     __ mv(nmax, NMAX);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5042,10 +5042,10 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-  void adler32_process_bytes(Register buff, Register s1, Register s2, Register temp3,
-    VectorRegister vtable, VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister *vs2acc,
-    Register temp0, Register temp1, Register temp2, VectorRegister vtemp1, VectorRegister vtemp2,
-    int step, Assembler::LMUL LMUL) {
+  void adler32_process_bytes(Register buff, Register s1, Register s2, VectorRegister vtable,
+    VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister *vs2acc,
+    Register temp0, Register temp1, Register temp2,  Register temp3,
+    VectorRegister vtemp1, VectorRegister vtemp2, int step, Assembler::LMUL LMUL) {
 
     assert((LMUL == Assembler::m4 && step == 64) ||
            (LMUL == Assembler::m2 && step == 32) ||
@@ -5249,19 +5249,19 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(count, count, 32);
 
   __ bind(L_nmax_loop);
-    adler32_process_bytes(buff, s1, s2, temp3, vtable_64, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2,
-      step_64, Assembler::m4);
+    adler32_process_bytes(buff, s1, s2, vtable_64, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
+      vtemp1, vtemp2, step_64, Assembler::m4);
     __ sub(count, count, step_64);
     __ bgtz(count, L_nmax_loop);
 
     // There are three iterations left to do
-    adler32_process_bytes(buff, s1, s2, temp3, vtable_32, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2,
-      step_32, Assembler::m2);
-    adler32_process_bytes(buff, s1, s2, temp3, vtable_16, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2,
-      step_16, Assembler::m1);
+    adler32_process_bytes(buff, s1, s2, vtable_32, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
+      vtemp1, vtemp2, step_32, Assembler::m2);
+    adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3, 
+      vtemp1, vtemp2, step_16, Assembler::m1);
 
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);
@@ -5280,9 +5280,9 @@ class StubGenerator: public StubCodeGenerator {
     __ blt(len, count, L_by16_loop);
 
   __ bind(L_by16_loop_unroll);
-    adler32_process_bytes(buff, s1, s2, count, vtable_64, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2,
-      step_64, Assembler::m4);
+    adler32_process_bytes(buff, s1, s2, vtable_64, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
+      vtemp1, vtemp2, step_64, Assembler::m4);
     __ sub(len, len, step_64);
     // By now the count should still be 64
     __ bge(len, count, L_by16_loop_unroll);
@@ -5290,9 +5290,9 @@ class StubGenerator: public StubCodeGenerator {
     __ blt(len, count, L_by1);
 
   __ bind(L_by16_loop);
-    adler32_process_bytes(buff, s1, s2, count, vtable_16, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2,
-      step_16, Assembler::m1);
+    adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
+      vtemp1, vtemp2, step_16, Assembler::m1);
     __ sub(len, len, step_16);
     __ bgez(len, L_by16_loop);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5047,8 +5047,10 @@ class StubGenerator: public StubCodeGenerator {
     Register temp0, Register temp1, Register temp2, VectorRegister vtemp1, VectorRegister vtemp2,
     int step, Assembler::LMUL LMUL) {
 
-    assert((LMUL == Assembler::m4 && step == 64) || (LMUL == Assembler::m2 && step == 32) ||
-      (LMUL == Assembler::m1 && step == 16), "LMUL should be aligned with step: m4 and 64, m2 and 32 or m1 and 16");
+    assert((LMUL == Assembler::m4 && step == 64) ||
+           (LMUL == Assembler::m2 && step == 32) ||
+           (LMUL == Assembler::m1 && step == 16),
+           "LMUL should be aligned with step: m4 and 64, m2 and 32 or m1 and 16");
     // Below is function for calculating Adler32 checksum with 64-, 32- or 16-byte step. LMUL=m4, m2 or m1 is used.
     // The results are in v12, v13, ..., v22, v23. Example below is for 64-byte step case.
     // We use b1, b2, ..., b64 to denote the 64 bytes loaded in each iteration.

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5042,8 +5042,6 @@ class StubGenerator: public StubCodeGenerator {
     return (address) start;
   }
 
-static const uint64_t right_16_bits = right_n_bits(16);
-
   void adler32_process_bytes(Register buff, Register s1, Register s2, Register count,
     VectorRegister vtable, VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister *vs2acc,
     Register temp0, Register temp1, Register temp2, VectorRegister vtemp1, VectorRegister vtemp2,
@@ -5152,7 +5150,6 @@ static const uint64_t right_16_bits = right_n_bits(16);
     Register temp0 = c_rarg4;
     Register temp1 = c_rarg5;
     Register temp2 = c_rarg6;
-    Register right_16_bits = c_rarg7;
     Register step = x28; // t3
 
     VectorRegister vzero = v31;
@@ -5206,14 +5203,14 @@ static const uint64_t right_16_bits = right_n_bits(16);
 
     __ mv(base, BASE);
     __ mv(nmax, NMAX);
-    __ mv(right_16_bits, right_n_bits(16));
 
     __ srli(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
     // s1 is initialized to the lower 16 bits of adler
     // s2 is initialized to the upper 16 bits of adler
     if (!UseZbb) {
-      __ andr(s2, s2, right_16_bits);
-      __ andr(s1, adler, right_16_bits); // s1 = (adler & 0xffff)
+      __ mv(temp0, right_n_bits(16));
+      __ andr(s2, s2, temp0);
+      __ andr(s1, adler, temp0); // s1 = (adler & 0xffff)
     } else {
       __ zext_h(s2, s2);
       __ zext_h(s1, adler);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5230,15 +5230,13 @@ static const uint64_t right_16_bits = right_n_bits(16);
 
     // Generating accumulation coefficients for further calculations
     __ vid_v(vtemp1);
-    __ vmv_v_x(vtable_64, temp1);
-    __ vsub_vv(vtable_64, vtable_64, vtemp1);
+    __ vrsub_vx(vtable_64, vtemp1, temp1);
     // vtable_64 group now contains { 0x40, 0x3f, 0x3e, ..., 0x3, 0x2, 0x1 }
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
     if (MaxVectorSize > 16) {
       // Need to generate vtable_16 explicitly
       __ vid_v(vtemp1);
-      __ vmv_v_i(vtable_16, 16);
-      __ vsub_vv(vtable_16, vtable_16, vtemp1);
+      __ vrsub_vi(vtable_16, vtemp1, 16);
     }
     __ vmv_v_i(vzero, 0);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5155,8 +5155,8 @@ class StubGenerator: public StubCodeGenerator {
       v16, v18, v20, v22
     };
     VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
-    VectorRegister vtable_32 = (MaxVectorSize == 16) ? v26 : v4;
-    VectorRegister vtable_16 = (MaxVectorSize == 16) ? v27 : v30;
+    VectorRegister vtable_32 = v4; // group: v4, v5
+    VectorRegister vtable_16 = v30;
     VectorRegister vtemp1 = v28;
     VectorRegister vtemp2 = v29;
 
@@ -5176,25 +5176,25 @@ class StubGenerator: public StubCodeGenerator {
     __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m4);
 
     // Generating accumulation coefficients for further calculations
+    // vtable_64:
     __ vid_v(vtemp1);
     __ vrsub_vx(vtable_64, vtemp1, temp1);
     // vtable_64 group now contains { 0x40, 0x3f, 0x3e, ..., 0x3, 0x2, 0x1 }
-    if (MaxVectorSize > 16) {
-      // Need to generate vtable_32 explicitly
-      __ mv(temp1, 32);
-      __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
-      __ vid_v(vtemp1);
-      __ vrsub_vx(vtable_32, vtemp1, temp1);
-      // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
-    }
+
+    // vtable_32:
+    __ mv(temp1, 32);
+    __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
+    __ vid_v(vtemp1);
+    __ vrsub_vx(vtable_32, vtemp1, temp1);
+    // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
+
+    // vtable_16:
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
-    if (MaxVectorSize > 16) {
-      // Need to generate vtable_16 explicitly
-      __ mv(temp1, 16);
-      __ vid_v(vtemp1);
-      __ vrsub_vx(vtable_16, vtemp1, temp1);
-      // vtable_32 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
-    }
+    __ mv(temp1, 16);
+    __ vid_v(vtemp1);
+    __ vrsub_vx(vtable_16, vtemp1, temp1);
+    // vtable_16 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
+
     __ vmv_v_i(vzero, 0);
 
     __ mv(base, BASE);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5216,7 +5216,7 @@ static const uint64_t right_16_bits = right_n_bits(16);
     };
     VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
     VectorRegister vtable_16 = (MaxVectorSize == 16) ? v27 : v30;
-    VectorRegister vtemp1 = v28; // group: v29, v30, v31
+    VectorRegister vtemp1 = v28;
     VectorRegister vtemp2 = v29;
 
     // Max number of bytes we can process before having to take the mod

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5206,17 +5206,10 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(base, BASE);
     __ mv(nmax, NMAX);
 
-    __ srli(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
     // s1 is initialized to the lower 16 bits of adler
     // s2 is initialized to the upper 16 bits of adler
-    if (!UseZbb) {
-      __ mv(temp0, right_n_bits(16));
-      __ andr(s2, s2, temp0);
-      __ andr(s1, adler, temp0); // s1 = (adler & 0xffff)
-    } else {
-      __ zext_h(s2, s2);
-      __ zext_h(s1, adler);
-    }
+    __ zero_extend(s1, s1, 16); // s1 = (adler & 0xffff)
+    __ srliw(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
 
     // The pipelined loop needs at least 16 elements for 1 iteration
     // It does check this, but it is more effective to skip to the cleanup loop

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5302,8 +5302,9 @@ static const uint64_t right_16_bits = right_n_bits(16);
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
     if (MaxVectorSize > 16) {
       // Need to generate vtable_16 explicitly
+      __ mv(temp1, 16);
       __ vid_v(vtemp1);
-      __ vrsub_vi(vtable_16, vtemp1, 16);
+      __ vrsub_vx(vtable_16, vtemp1, temp1);
       // vtable_32 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
     }
     __ vmv_v_i(vzero, 0);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5087,16 +5087,13 @@ class StubGenerator: public StubCodeGenerator {
     __ add(s2, s2, temp1);
 
     // Summing up calculated results for s2_new
-    if (MaxVectorSize > 16) {
-      __ vsetvli(temp0, temp3, Assembler::e16, LMUL);
-    } else {
-      // Half of vector-widening multiplication result is in successor of vs2acc
-      // group for vlen == 16, in which case we need to double vector register
-      // group width in order to reduction sum all of them
-      Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
-                               (LMUL == Assembler::m2) ? Assembler::m4 : Assembler::m8;
-      __ vsetvli(temp0, temp3, Assembler::e16, LMULx2);
-    }
+    //
+    // Half of vector-widening multiplication result is in successor of vs2acc
+    // group for vlen == 16, in which case we need to double vector register
+    // group width in order to reduction sum all of them
+    Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
+                             (LMUL == Assembler::m2) ? Assembler::m4 : Assembler::m8;
+    __ vsetvli(temp0, temp3, Assembler::e16, LMULx2);
     // Upper bound for reduction sum:
     // 0xFF * (64 + 63 + ... + 2 + 1) = 0x817E0 max for whole register group, so:
     // 1. Need to do vector-widening reduction sum

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5204,9 +5204,6 @@ class StubGenerator: public StubCodeGenerator {
     const uint64_t BASE = 0xfff1;
     const uint64_t NMAX = 0x15B0;
 
-    // LMUL factor for L_nmax loop
-    const int LMUL = 4;
-
     __ enter(); // required for proper stackwalking of RuntimeStub frame
     __ mv(temp1, 64);
     __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m4);
@@ -5268,14 +5265,14 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_nmax_loop);
     adler32_process_bytes_by64(buff, s1, s2, count, vtable_64, vzero,
       vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2);
-    __ sub(count, count, 16*LMUL);
+    __ sub(count, count, 64);
     __ bgtz(count, L_nmax_loop);
 
     // There are three iterations left to do
     const int remainder = 3;
     __ mv(count, 16*remainder);
-    adler32_process_bytes_by16(buff, s1, s2, count, vtable_16,
-      vzero, vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2, remainder);
+    adler32_process_bytes_by16(buff, s1, s2, count, vtable_16, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, vtemp1, vtemp2, remainder);
 
     // s1 = s1 % BASE
     __ remuw(s1, s1, base);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5266,6 +5266,7 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(count, nmax, 16);
     __ bltz(len, L_by16);
 
+  // Align L_nmax loop by 64
   __ bind(L_nmax_loop_entry);
     __ sub(count, count, 32);
 
@@ -5275,7 +5276,7 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(count, count, 16*LMUL);
     __ bgtz(count, L_nmax_loop);
 
-    // There are three iterations left to do in this loop
+    // There are three iterations left to do
     const int remainder = 3;
     __ mv(count, 16*remainder);
     generate_updateBytesAdler32_unroll_by16(buff, s1, s2, count, vtable_16,

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5234,7 +5234,7 @@ class StubGenerator: public StubCodeGenerator {
       vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
       vtemp1, vtemp2, step_32, Assembler::m2);
     adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3, 
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
       vtemp1, vtemp2, step_16, Assembler::m1);
 
     // s1 = s1 % BASE

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5153,8 +5153,8 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vs1acc = v12; // group: v12, v13, v14, v15
     VectorRegister vs2acc = v16; // group: v16, v17, v18, v19, v20, v21, v22, v23
     VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
-    VectorRegister vtable_32 = (MaxVectorSize == 16) ? v26 : v4; // group: v4, v5
-    VectorRegister vtable_16 = (MaxVectorSize == 16) ? v27 : v30;
+    VectorRegister vtable_32 = v4; // group: v4, v5
+    VectorRegister vtable_16 = v30;
     VectorRegister vtemp1 = v28;
     VectorRegister vtemp2 = v29;
 
@@ -5179,23 +5179,19 @@ class StubGenerator: public StubCodeGenerator {
     __ vrsub_vx(vtable_64, vtemp1, temp1);
     // vtable_64 group now contains { 0x40, 0x3f, 0x3e, ..., 0x3, 0x2, 0x1 }
 
-    if (MaxVectorSize > 16) {
-      // Need to generate vtable_32 explicitly
-      __ mv(temp1, 32);
-      __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
-      __ vid_v(vtemp1);
-      __ vrsub_vx(vtable_32, vtemp1, temp1);
-      // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
-    }
+    // vtable_32:
+    __ mv(temp1, 32);
+    __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
+    __ vid_v(vtemp1);
+    __ vrsub_vx(vtable_32, vtemp1, temp1);
+    // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
 
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
-    if (MaxVectorSize > 16) {
-      // Need to generate vtable_16 explicitly
-      __ mv(temp1, 16);
-      __ vid_v(vtemp1);
-      __ vrsub_vx(vtable_16, vtemp1, temp1);
-      // vtable_16 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
-    }
+    // vtable_16:
+    __ mv(temp1, 16);
+    __ vid_v(vtemp1);
+    __ vrsub_vx(vtable_16, vtemp1, temp1);
+    // vtable_16 now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
 
     __ vmv_v_i(vzero, 0);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5045,11 +5045,11 @@ class StubGenerator: public StubCodeGenerator {
   void adler32_process_bytes(Register buff, Register s1, Register s2, VectorRegister vtable,
     VectorRegister vzero, VectorRegister vbytes, VectorRegister vs1acc, VectorRegister vs2acc,
     Register temp0, Register temp1, Register temp2,  Register temp3,
-    VectorRegister vtemp1, VectorRegister vtemp2, int step, Assembler::LMUL LMUL) {
+    VectorRegister vtemp1, VectorRegister vtemp2, int step, Assembler::LMUL lmul) {
 
-    assert((LMUL == Assembler::m4 && step == 64) ||
-           (LMUL == Assembler::m2 && step == 32) ||
-           (LMUL == Assembler::m1 && step == 16),
+    assert((lmul == Assembler::m4 && step == 64) ||
+           (lmul == Assembler::m2 && step == 32) ||
+           (lmul == Assembler::m1 && step == 16),
            "LMUL should be aligned with step: m4 and 64, m2 and 32 or m1 and 16");
     // Below is function for calculating Adler32 checksum with 64-, 32- or 16-byte step. LMUL=m4, m2 or m1 is used.
     // The results are in v12, v13, ..., v22, v23. Example below is for 64-byte step case.
@@ -5070,7 +5070,7 @@ class StubGenerator: public StubCodeGenerator {
 
     __ mv(temp3, step);
     // Load data
-    __ vsetvli(temp0, temp3, Assembler::e8, LMUL);
+    __ vsetvli(temp0, temp3, Assembler::e8, lmul);
     __ vle8_v(vbytes, buff);
     __ addi(buff, buff, step);
 
@@ -5088,14 +5088,14 @@ class StubGenerator: public StubCodeGenerator {
 
     // Summing up calculated results for s2_new
     if (MaxVectorSize > 16) {
-      __ vsetvli(temp0, temp3, Assembler::e16, LMUL);
+      __ vsetvli(temp0, temp3, Assembler::e16, lmul);
     } else {
       // Half of vector-widening multiplication result is in successor of vs2acc
       // group for vlen == 16, in which case we need to double vector register
       // group width in order to reduction sum all of them
-      Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
-                               (LMUL == Assembler::m2) ? Assembler::m4 : Assembler::m8;
-      __ vsetvli(temp0, temp3, Assembler::e16, LMULx2);
+      Assembler::LMUL lmulx2 = (lmul == Assembler::m1) ? Assembler::m2 :
+                               (lmul == Assembler::m2) ? Assembler::m4 : Assembler::m8;
+      __ vsetvli(temp0, temp3, Assembler::e16, lmulx2);
     }
     // Upper bound for reduction sum:
     // 0xFF * (64 + 63 + ... + 2 + 1) = 0x817E0 max for whole register group, so:

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5204,8 +5204,8 @@ class StubGenerator: public StubCodeGenerator {
 
     // s1 is initialized to the lower 16 bits of adler
     // s2 is initialized to the upper 16 bits of adler
-    __ zero_extend(s1, s1, 16); // s1 = (adler & 0xffff)
     __ srliw(s2, adler, 16); // s2 = ((adler >> 16) & 0xffff)
+    __ zero_extend(s1, adler, 16); // s1 = (adler & 0xffff)
 
     // The pipelined loop needs at least 16 elements for 1 iteration
     // It does check this, but it is more effective to skip to the cleanup loop

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5265,8 +5265,8 @@ class StubGenerator: public StubCodeGenerator {
     __ add(len, len, count);
     __ bltz(len, L_by1);
     // Trying to unroll
-    __ mv(count, step_64);
-    __ blt(len, count, L_by16_loop);
+    __ mv(t2, step_64);
+    __ blt(len, t2, L_by16_loop);
 
   __ bind(L_by16_loop_unroll);
     adler32_process_bytes(buff, s1, s2, vtable_64, vzero,
@@ -5275,7 +5275,6 @@ class StubGenerator: public StubCodeGenerator {
     __ sub(len, len, step_64);
     // By now the count should still be 64
     __ bge(len, count, L_by16_loop_unroll);
-    __ mv(count, step_16);
 
   __ bind(L_by16_loop);
     adler32_process_bytes(buff, s1, s2, vtable_16, vzero,

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5153,8 +5153,8 @@ class StubGenerator: public StubCodeGenerator {
     VectorRegister vs1acc = v12; // group: v12, v13, v14, v15
     VectorRegister vs2acc = v16; // group: v16, v17, v18, v19, v20, v21, v22, v23
     VectorRegister vtable_64 = v24; // group: v24, v25, v26, v27
-    VectorRegister vtable_32 = v4; // group: v4, v5
-    VectorRegister vtable_16 = v30;
+    VectorRegister vtable_32 = (MaxVectorSize == 16) ? v26 : v4; // group: v4, v5
+    VectorRegister vtable_16 = (MaxVectorSize == 16) ? v27 : v30;
     VectorRegister vtemp1 = v28;
     VectorRegister vtemp2 = v29;
 
@@ -5179,19 +5179,23 @@ class StubGenerator: public StubCodeGenerator {
     __ vrsub_vx(vtable_64, vtemp1, temp1);
     // vtable_64 group now contains { 0x40, 0x3f, 0x3e, ..., 0x3, 0x2, 0x1 }
 
-    // vtable_32:
-    __ mv(temp1, 32);
-    __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
-    __ vid_v(vtemp1);
-    __ vrsub_vx(vtable_32, vtemp1, temp1);
-    // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
+    if (MaxVectorSize > 16) {
+      // Need to generate vtable_32 explicitly
+      __ mv(temp1, 32);
+      __ vsetvli(temp0, temp1, Assembler::e8, Assembler::m2);
+      __ vid_v(vtemp1);
+      __ vrsub_vx(vtable_32, vtemp1, temp1);
+      // vtable_32 group now contains { 0x20, 0x1f, 0x1e, ..., 0x3, 0x2, 0x1 }
+    }
 
-    // vtable_16:
     __ vsetivli(temp0, 16, Assembler::e8, Assembler::m1);
-    __ mv(temp1, 16);
-    __ vid_v(vtemp1);
-    __ vrsub_vx(vtable_16, vtemp1, temp1);
-    // vtable_16 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
+    if (MaxVectorSize > 16) {
+      // Need to generate vtable_16 explicitly
+      __ mv(temp1, 16);
+      __ vid_v(vtemp1);
+      __ vrsub_vx(vtable_16, vtemp1, temp1);
+      // vtable_16 group now contains { 0x10, 0xf, 0xe, ..., 0x3, 0x2, 0x1 }
+    }
 
     __ vmv_v_i(vzero, 0);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5087,13 +5087,16 @@ class StubGenerator: public StubCodeGenerator {
     __ add(s2, s2, temp1);
 
     // Summing up calculated results for s2_new
-    //
-    // Half of vector-widening multiplication result is in successor of vs2acc
-    // group for vlen == 16, in which case we need to double vector register
-    // group width in order to reduction sum all of them
-    Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
-                             (LMUL == Assembler::m2) ? Assembler::m4 : Assembler::m8;
-    __ vsetvli(temp0, temp3, Assembler::e16, LMULx2);
+    if (MaxVectorSize > 16) {
+      __ vsetvli(temp0, temp3, Assembler::e16, LMUL);
+    } else {
+      // Half of vector-widening multiplication result is in successor of vs2acc
+      // group for vlen == 16, in which case we need to double vector register
+      // group width in order to reduction sum all of them
+      Assembler::LMUL LMULx2 = (LMUL == Assembler::m1) ? Assembler::m2 :
+                               (LMUL == Assembler::m2) ? Assembler::m4 : Assembler::m8;
+      __ vsetvli(temp0, temp3, Assembler::e16, LMULx2);
+    }
     // Upper bound for reduction sum:
     // 0xFF * (64 + 63 + ... + 2 + 1) = 0x817E0 max for whole register group, so:
     // 1. Need to do vector-widening reduction sum

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5140,13 +5140,13 @@ class StubGenerator: public StubCodeGenerator {
     Register s2     = c_rarg3;
     Register buff   = c_rarg1;
     Register len    = c_rarg2;
-    Register nmax  = x29; // t4
-    Register base  = x30; // t5
-    Register count = x31; // t6
-    Register temp0 = c_rarg4;
-    Register temp1 = c_rarg5;
-    Register temp2 = c_rarg6;
-    Register temp3 = x28; // t3
+    Register nmax  = c_rarg4;
+    Register base  = c_rarg5;
+    Register count = c_rarg6;
+    Register temp0 = x28; // t3
+    Register temp1 = x29; // t4
+    Register temp2 = x30; // t5
+    Register temp3 = x31; // t6
 
     VectorRegister vzero = v31;
     VectorRegister vbytes = v8; // group: v8, v9, v10, v11

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5131,8 +5131,8 @@ class StubGenerator: public StubCodeGenerator {
     StubCodeMark mark(this, "StubRoutines", "updateBytesAdler32");
     address start = __ pc();
 
-    Label L_simple_by1_loop, L_nmax, L_nmax_loop, L_nmax_loop_entry,
-      L_by16, L_by16_loop, L_by16_loop_unroll, L_by1_loop, L_do_mod, L_combine, L_by1;
+    Label L_nmax, L_nmax_loop, L_nmax_loop_entry, L_by16, L_by16_loop,
+      L_by16_loop_unroll, L_by1_loop, L_do_mod, L_combine, L_by1;
 
     // Aliases
     Register adler  = c_rarg0;
@@ -5213,20 +5213,9 @@ class StubGenerator: public StubCodeGenerator {
     __ bgeu(len, temp0, L_nmax);
     __ beqz(len, L_combine);
 
-  __ bind(L_simple_by1_loop);
-    __ lbu(temp0, Address(buff, 0));
-    __ addi(buff, buff, step_1);
-    __ add(s1, s1, temp0);
-    __ add(s2, s2, s1);
+    // Jumping to L_by1_loop
     __ sub(len, len, step_1);
-    __ bgtz(len, L_simple_by1_loop);
-
-    // s1 = s1 % BASE
-    __ remuw(s1, s1, base);
-    // s2 = s2 % BASE
-    __ remuw(s2, s2, base);
-
-    __ j(L_combine);
+    __ j(L_by1_loop);
 
   __ bind(L_nmax);
     __ sub(len, len, nmax);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5288,6 +5288,12 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_by1);
     __ add(len, len, 15);
     __ bltz(len, L_do_mod);
+    __ mv(count, step_16);
+    __ blt(len, count, L_by1_loop);
+    adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
+      vtemp1, vtemp2, step_16, Assembler::m1);
+    __ sub(len, len, step_16);
 
   __ bind(L_by1_loop);
     __ lbu(temp0, Address(buff, 0));

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5265,20 +5265,20 @@ class StubGenerator: public StubCodeGenerator {
     __ add(len, len, count);
     __ bltz(len, L_by1);
     // Trying to unroll
-    __ mv(t2, step_64);
-    __ blt(len, t2, L_by16_loop);
+    __ mv(temp3, step_64);
+    __ blt(len, temp3, L_by16_loop);
 
   __ bind(L_by16_loop_unroll);
     adler32_process_bytes(buff, s1, s2, vtable_64, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
       vtemp1, vtemp2, step_64, Assembler::m4);
     __ sub(len, len, step_64);
-    // By now the count should still be 64
-    __ bge(len, count, L_by16_loop_unroll);
+    // By now the temp3 should still be 64
+    __ bge(len, temp3, L_by16_loop_unroll);
 
   __ bind(L_by16_loop);
     adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
+      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, temp3,
       vtemp1, vtemp2, step_16, Assembler::m1);
     __ sub(len, len, step_16);
     __ bgez(len, L_by16_loop);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5276,7 +5276,6 @@ class StubGenerator: public StubCodeGenerator {
     // By now the count should still be 64
     __ bge(len, count, L_by16_loop_unroll);
     __ mv(count, step_16);
-    __ blt(len, count, L_by1);
 
   __ bind(L_by16_loop);
     adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
@@ -5288,12 +5287,6 @@ class StubGenerator: public StubCodeGenerator {
   __ bind(L_by1);
     __ add(len, len, 15);
     __ bltz(len, L_do_mod);
-    __ mv(count, step_16);
-    __ blt(len, count, L_by1_loop);
-    adler32_process_bytes(buff, s1, s2, vtable_16, vzero,
-      vbytes, vs1acc, vs2acc, temp0, temp1, temp2, count,
-      vtemp1, vtemp2, step_16, Assembler::m1);
-    __ sub(len, len, step_16);
 
   __ bind(L_by1_loop);
     __ lbu(temp0, Address(buff, 0));

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -141,10 +141,6 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32CIntrinsics, false);
   }
 
-  if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
-    FLAG_SET_DEFAULT(UseAdler32Intrinsics, true);
-  }
-
   if (UseVectorizedMismatchIntrinsic) {
     warning("VectorizedMismatch intrinsic is not available on this CPU.");
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
@@ -236,6 +232,18 @@ void VM_Version::initialize() {
   // NOTE: Make sure codes dependent on UseRVV are put after c2_initialize(),
   //       as there are extra checks inside it which could disable UseRVV
   //       in some situations.
+
+  // Adler32
+  if (UseRVV) {
+    if (FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
+      FLAG_SET_DEFAULT(UseAdler32Intrinsics, true);
+    }
+  } else if (UseAdler32Intrinsics) {
+    if (!FLAG_IS_DEFAULT(UseAdler32Intrinsics)) {
+      warning("Adler32 intrinsic requires RVV instructions (not available on this CPU).");
+    }
+    FLAG_SET_DEFAULT(UseAdler32Intrinsics, false);
+  }
 
   // ChaCha20
   if (UseRVV) {


### PR DESCRIPTION
Hello everyone! Please review this ~non-vectorized~ implementation of `_updateBytesAdler32` intrinsic. Reference implementation for AArch64 can be found [here](https://github.com/openjdk/jdk9/blob/master/hotspot/src/cpu/aarch64/vm/stubGenerator_aarch64.cpp#L3281).

### Correctness checks

Test `test/hotspot/jtreg/compiler/intrinsics/zip/TestAdler32.java` is ok. All tier1 also passed.

### Performance results on T-Head board

Enabled intrinsic:

| Benchmark                          |    (count) |  Mode |  Cnt  |   Score  |  Error |  Units |
| ------------------------------------- | ----------- | ------ | --------- | ------ | --------- | ---------- |
| Adler32.TestAdler32.testAdler32Update |      64 | thrpt  | 25 | 5522.693 | 23.387 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |     128 | thrpt |  25 | 3430.761 |  9.210 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |     256 | thrpt |  25 | 1962.888 |  5.323 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |     512 | thrpt  | 25 | 1050.938 |  0.144 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |    1024 | thrpt  | 25 |  549.227 |  0.375 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |    2048 | thrpt  | 25 |  280.829 |  0.170 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |    5012 | thrpt  | 25 |  116.333 |  0.057 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |    8192 | thrpt  | 25  |  71.392 |  0.060 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |   16384 | thrpt |  25  |  35.784 |  0.019 | ops/ms |
| Adler32.TestAdler32.testAdler32Update |   32768 | thrpt |  25  |  17.924 |  0.010 | ops/ms |
| Adler32.TestAdler32.testAdler32Update  |  65536 | thrpt |  25  |   8.940 |  0.003 | ops/ms |

Disabled intrinsic:

| Benchmark                          |    (count) |  Mode |  Cnt  |   Score  |  Error |  Units |
| ------------------------------------- | ----------- | ------ | --------- | ------ | --------- | ---------- |
|Adler32.TestAdler32.testAdler32Update|64|thrpt|25|655.633|5.845|ops/ms|
|Adler32.TestAdler32.testAdler32Update|128|thrpt|25|587.418|10.062|ops/ms|
|Adler32.TestAdler32.testAdler32Update|256|thrpt|25|546.675|11.598|ops/ms|
|Adler32.TestAdler32.testAdler32Update|512|thrpt|25|432.328|11.517|ops/ms|
|Adler32.TestAdler32.testAdler32Update|1024|thrpt|25|311.771|4.238|ops/ms|
|Adler32.TestAdler32.testAdler32Update|2048|thrpt|25|202.648|2.486|ops/ms|
|Adler32.TestAdler32.testAdler32Update|5012|thrpt|25|100.246|1.119|ops/ms|
|Adler32.TestAdler32.testAdler32Update|8192|thrpt|25|65.931|0.546|ops/ms|
|Adler32.TestAdler32.testAdler32Update|16384|thrpt|25|34.570|0.353|ops/ms|
|Adler32.TestAdler32.testAdler32Update|32768|thrpt|25|17.622|0.190|ops/ms|
|Adler32.TestAdler32.testAdler32Update|65536|thrpt|25|8.895|0.087|ops/ms|

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317720](https://bugs.openjdk.org/browse/JDK-8317720): RISC-V: Implement Adler32 intrinsic (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18382/head:pull/18382` \
`$ git checkout pull/18382`

Update a local copy of the PR: \
`$ git checkout pull/18382` \
`$ git pull https://git.openjdk.org/jdk.git pull/18382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18382`

View PR using the GUI difftool: \
`$ git pr show -t 18382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18382.diff">https://git.openjdk.org/jdk/pull/18382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18382#issuecomment-2007708003)