### PR TITLE
8328540: test javax/swing/JSplitPane/4885629/bug4885629.java fails on windows hidpi

### DIFF
--- a/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
+++ b/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
+++ b/test/jdk/javax/swing/JSplitPane/4885629/bug4885629.java
@@ -104,9 +104,9 @@ public class bug4885629 {
 
                     SwingUtilities.convertPointToScreen(p, sp);
 
-                    for (int i = 0; i < rect.width; i++) {
+                    for (int i = 1; i < rect.width - 1; i++) {
                         if (!BGCOLOR.equals(robot.getPixelColor(p.x + i, p.y + rect.height - 1))) {
-                            throw new Error("The divider's area has incorrect color.");
+                            throw new Error("The divider's area has incorrect color. i=" + i);
                         }
                     }
                 }


### PR DESCRIPTION
A simple fix to the test to skip sampling the leftmost and rightmost ends of the divider
to avoid possible issues at fractional scales.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328540](https://bugs.openjdk.org/browse/JDK-8328540): test javax/swing/JSplitPane/4885629/bug4885629.java fails on windows hidpi (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [9618fa4a](https://git.openjdk.org/jdk/pull/18384/files/9618fa4a8fa66fa34dbd00ccd7d9feee05cd5902)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18384/head:pull/18384` \
`$ git checkout pull/18384`

Update a local copy of the PR: \
`$ git checkout pull/18384` \
`$ git pull https://git.openjdk.org/jdk.git pull/18384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18384`

View PR using the GUI difftool: \
`$ git pr show -t 18384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18384.diff">https://git.openjdk.org/jdk/pull/18384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18384#issuecomment-2007857080)