### PR TITLE
8328560: java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java imports Applet

### DIFF
--- a/test/jdk/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
+++ b/test/jdk/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,115 +22,100 @@
  */
 
 /*
-  @test 1.2 98/08/05
   @key headful
   @bug 4515763
   @summary Tests that clicking mouse and pressing keys generates correct amount of click-counts
-  @author andrei.dmitriev: area=awt.mouse
   @run main ClickDuringKeypress
 */
 
-/**
- * ClickDuringKeypress.java
- *
- * summary:
- */
+import java.awt.AWTException;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowEvent;
 
-import java.applet.Applet;
-import java.awt.*;
-import java.awt.event.*;
-
-public class ClickDuringKeypress implements MouseListener
- {
+public class ClickDuringKeypress implements MouseListener {
    //Declare things used in the test, like buttons and labels here
    final static int CLICKCOUNT = 10;
    final static int DOUBLE_CLICK_AUTO_DELAY = 10;
-   volatile int lastClickCount = 0;
-   volatile boolean clicked = false;
-   volatile boolean ready = false;
+   static volatile int lastClickCount = 0;
+   static volatile boolean clicked = false;
+   static volatile boolean ready = false;
 
-   Frame frame;
-   Robot robot;
+   static volatile Frame frame;
+   static volatile Robot robot;
+   static volatile ClickDuringKeypress clicker;
 
-   public void init()
-    {
-      //Create instructions for the user here, as well as set up
-      // the environment -- set the layout manager, add buttons,
-      // etc.
+   public static void main(String[] args) throws Exception {
+       clicker = new ClickDuringKeypress();
+       try {
+           EventQueue.invokeAndWait(ClickDuringKeypress::createUI);
+           robot = new Robot();
+           robot.mouseMove(200, 200);
+           EventQueue.invokeAndWait(frame::show);
+           doTest();
+       } finally {
+           if (frame != null) {
+               EventQueue.invokeAndWait(frame::dispose);
+           }
+       }
+   }
 
+   static void createUI() {
       frame = new Frame("ClickDuringKeypress");
-      frame.addMouseListener(this);
+      frame.addMouseListener(clicker);
       frame.addWindowListener(new WindowAdapter() {
           public void windowActivated(WindowEvent e) {
-              synchronized(ClickDuringKeypress.this) {
+              synchronized(clicker) {
                   ready = true;
-                  ClickDuringKeypress.this.notifyAll();
+                  ClickDuringKeypress.clicker.notifyAll();
               }
           }
       });
       frame.setBounds(0, 0, 400, 400);
+    }
 
-      start();
-
-    }//End  init()
-
-   public void start ()
-    {
-      try {
-        robot = new Robot();
-      } catch (AWTException e) {
-        System.out.println("Could not create Robot.");
-        throw new RuntimeException("Couldn't create Robot.  Test fails");
+    static void doTest() throws Exception {
+       synchronized(clicker) {
+           try {
+               if (!ready) {
+                   clicker.wait(5000);
+               }
+           } catch (InterruptedException ex) {
+           }
+           if (!ready) {
+               System.out.println("Not Activated. Test fails");
+               throw new RuntimeException("Not Activated. Test fails");
+           }
       }
-
-      robot.mouseMove(200, 200);
-      frame.show();
-
-      synchronized(this) {
-          try {
-              if (!ready) {
-                  wait(10000);
-              }
-          } catch (InterruptedException ex) {
-          }
-          if (!ready) {
-              System.out.println("Not Activated. Test fails");
-              throw new RuntimeException("Not Activated. Test fails");
-          }
-      }
-
-      doTest();
-
-      //What would normally go into main() will probably go here.
-      //Use System.out.println for diagnostic messages that you want
-      //to read after the test is done.
-      //Use Sysout.println for messages you want the tester to read.
-
-    }// start()
-
-    // Mouse should be over the Frame by this point
-    private void doTest() {
+      // Mouse should be over the Frame by this point
       robot.setAutoDelay(2000);
       robot.waitForIdle();
       robot.keyPress(KeyEvent.VK_B);
-      robot.mousePress(InputEvent.BUTTON1_MASK);
+      robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
       robot.delay(10);
-      robot.mouseRelease(InputEvent.BUTTON1_MASK);
+      robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
       // Should trigger mouseClicked
       robot.keyRelease(KeyEvent.VK_B);
       robot.delay(1000);
 
       robot.setAutoDelay(DOUBLE_CLICK_AUTO_DELAY);
       for (int i = 0; i < CLICKCOUNT / 2; i++) {
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(10);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.keyPress(KeyEvent.VK_B);
         robot.delay(10);
         robot.keyRelease(KeyEvent.VK_B);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(10);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
       }
       robot.waitForIdle();
       // check results
@@ -156,9 +141,4 @@ public class ClickDuringKeypress implements MouseListener
         clicked = true;
         lastClickCount = e.getClickCount();
     }
-
-     public static void main(String[] args) {
-         new ClickDuringKeypress().init();
-     }
-
- }// class ClickDuringKeypress
+}

--- a/test/jdk/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
+++ b/test/jdk/java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import java.awt.AWTException;
 import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Robot;
@@ -30,7 +29,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.awt.event.WindowEvent;
 
 /*
@@ -42,7 +40,7 @@ import java.awt.event.WindowEvent;
 */
 
 public class ClickDuringKeypress implements MouseListener {
-   //Declare things used in the test, like buttons and labels here
+
    final static int CLICKCOUNT = 10;
    final static int DOUBLE_CLICK_AUTO_DELAY = 20;
    static volatile int lastClickCount = 0;


### PR DESCRIPTION
This seems to have been some previous not very complete conversion of a test from applet to main.
It even still had Applet imported and miscellaneous comments. I've cleaned it up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328560](https://bugs.openjdk.org/browse/JDK-8328560): java/awt/event/MouseEvent/ClickDuringKeypress/ClickDuringKeypress.java imports Applet (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18386/head:pull/18386` \
`$ git checkout pull/18386`

Update a local copy of the PR: \
`$ git checkout pull/18386` \
`$ git pull https://git.openjdk.org/jdk.git pull/18386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18386`

View PR using the GUI difftool: \
`$ git pr show -t 18386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18386.diff">https://git.openjdk.org/jdk/pull/18386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18386#issuecomment-2008344475)