### PR TITLE
8293345: SunPKCS11 provider checks on PKCS11 Mechanism are problematic

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,6 +120,9 @@ final class Config {
 
     // whether to print debug info during startup
     private boolean showInfo = false;
+
+    // whether to disable legacy mechanisms
+    private boolean disableLegacy = true;
 
     // template manager, initialized from parsed attributes
     private TemplateManager templateManager;
@@ -249,6 +252,10 @@ final class Config {
 
     boolean getShowInfo() {
         return (SunPKCS11.debug != null) || showInfo;
+    }
+
+    boolean getDisableLegacy() {
+        return disableLegacy;
     }
 
     TemplateManager getTemplateManager() {
@@ -453,6 +460,8 @@ final class Config {
                 destroyTokenAfterLogout = parseBooleanEntry(st.sval);
             case "showInfo"->
                 showInfo = parseBooleanEntry(st.sval);
+            case "disableLegacy"->
+                disableLegacy = parseBooleanEntry(st.sval);
             case "keyStoreCompatibilityMode"->
                 keyStoreCompatibilityMode = parseBooleanEntry(st.sval);
             case "explicitCancel"->

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -121,8 +121,8 @@ final class Config {
     // whether to print debug info during startup
     private boolean showInfo = false;
 
-    // whether to disable legacy mechanisms
-    private boolean disableLegacy = true;
+    // whether to allow legacy mechanisms
+    private boolean allowLegacy = false;
 
     // template manager, initialized from parsed attributes
     private TemplateManager templateManager;
@@ -254,8 +254,8 @@ final class Config {
         return (SunPKCS11.debug != null) || showInfo;
     }
 
-    boolean getDisableLegacy() {
-        return disableLegacy;
+    boolean getAllowLegacy() {
+        return allowLegacy;
     }
 
     TemplateManager getTemplateManager() {
@@ -460,8 +460,8 @@ final class Config {
                 destroyTokenAfterLogout = parseBooleanEntry(st.sval);
             case "showInfo"->
                 showInfo = parseBooleanEntry(st.sval);
-            case "disableLegacy"->
-                disableLegacy = parseBooleanEntry(st.sval);
+            case "allowLegacy"->
+                allowLegacy = parseBooleanEntry(st.sval);
             case "keyStoreCompatibilityMode"->
                 keyStoreCompatibilityMode = parseBooleanEntry(st.sval);
             case "explicitCancel"->

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1222,25 +1222,6 @@ public final class SunPKCS11 extends AuthProvider {
         }
     }
 
-    private static boolean isLegacy(CK_MECHANISM_INFO mechInfo)
-            throws PKCS11Exception {
-        // assume full support if no mech info available
-        // For vendor-specific mechanisms, often no mech info is provided
-        boolean partialSupport = false;
-
-        if (mechInfo != null) {
-            if ((mechInfo.flags & CKF_DECRYPT) != 0) {
-                // non-legacy cipher mechs should support encryption
-                partialSupport |= ((mechInfo.flags & CKF_ENCRYPT) == 0);
-            }
-            if ((mechInfo.flags & CKF_VERIFY) != 0) {
-                // non-legacy signature mechs should support signing
-                partialSupport |= ((mechInfo.flags & CKF_SIGN) == 0);
-            }
-        }
-        return partialSupport;
-    }
-
     // test if a token is present and initialize this provider for it if so.
     // does nothing if no token is found
     // called from constructor and by poller
@@ -1309,12 +1290,6 @@ public final class SunPKCS11 extends AuthProvider {
                 }
                 continue;
             }
-            if (isLegacy(mechInfo)) {
-                if (showInfo) {
-                    System.out.println("DISABLED due to legacy");
-                }
-                continue;
-            }
 
             if (brokenMechanisms.contains(longMech)) {
                 if (showInfo) {
@@ -1336,6 +1311,7 @@ public final class SunPKCS11 extends AuthProvider {
             if (ds == null) {
                 continue;
             }
+            boolean disableLegacy = config.getDisableLegacy();
             descLoop:
             for (Descriptor d : ds) {
                 Integer oldMech = supportedAlgs.get(d);
@@ -1349,6 +1325,21 @@ public final class SunPKCS11 extends AuthProvider {
                                     requiredMech & 0xFFFFFFFFL) == null) {
                                 continue descLoop;
                             }
+                        }
+                    }
+
+                    // assume full support if no mech info available
+                    if (disableLegacy && mechInfo != null) {
+                        if ((d.type == CIP &&
+                                (mechInfo.flags & CKF_ENCRYPT) == 0) ||
+                                (d.type == SIG &&
+                                (mechInfo.flags & CKF_SIGN) == 0)) {
+                            if (showInfo) {
+                                System.out.println("DISABLED " +  d.type +
+                                        " " + d.algorithm +
+                                        " due to partial support");
+                            }
+                            continue;
                         }
                     }
                     supportedAlgs.put(d, integerMech);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -1311,7 +1311,7 @@ public final class SunPKCS11 extends AuthProvider {
             if (ds == null) {
                 continue;
             }
-            boolean disableLegacy = config.getDisableLegacy();
+            boolean allowLegacy = config.getAllowLegacy();
             descLoop:
             for (Descriptor d : ds) {
                 Integer oldMech = supportedAlgs.get(d);
@@ -1329,7 +1329,7 @@ public final class SunPKCS11 extends AuthProvider {
                     }
 
                     // assume full support if no mech info available
-                    if (disableLegacy && mechInfo != null) {
+                    if (!allowLegacy && mechInfo != null) {
                         if ((d.type == CIP &&
                                 (mechInfo.flags & CKF_ENCRYPT) == 0) ||
                                 (d.type == SIG &&


### PR DESCRIPTION
Existing legacy mechanism check disables mechanism(s) when the support is partial, e.g. supports decryption but not encryption, or supports verification but not signing. Some mechanisms can be used for both encryption/decryption and sign/verify such as RSA related ones. If the particular mechanism supports sign/verify/decryption but not encryption, it'd be disabled as a result. Fine tune the legacy mechanism check with the service type, i.e. supports encryption for Cipher,  sign for Signature, so the mechanism is disabled based on the service type.
For completeness sake, I also added a PKCS11 provider configuration option to control this.  If not set, SunPKCS11 provider will disable legacy mechanisms by default.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8329300](https://bugs.openjdk.org/browse/JDK-8329300) to be approved

### Issues
 * [JDK-8293345](https://bugs.openjdk.org/browse/JDK-8293345): SunPKCS11 provider checks on PKCS11 Mechanism are problematic (**Enhancement** - P3)
 * [JDK-8329300](https://bugs.openjdk.org/browse/JDK-8329300): SunPKCS11 provider checks on PKCS11 Mechanism are problematic (**CSR**)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18387/head:pull/18387` \
`$ git checkout pull/18387`

Update a local copy of the PR: \
`$ git checkout pull/18387` \
`$ git pull https://git.openjdk.org/jdk.git pull/18387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18387`

View PR using the GUI difftool: \
`$ git pr show -t 18387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18387.diff">https://git.openjdk.org/jdk/pull/18387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18387#issuecomment-2008586764)