### PR TITLE
8328556: Do not extract large CKO_SECRET_KEY keys from the NSS Software Token

### DIFF
--- a/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
+++ b/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ *
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import javax.crypto.*;
+import java.security.Key;
+import java.security.KeyPairGenerator;
+import java.security.Provider;
+
+/*
+ * @test
+ * @bug 8328556
+ * @library /test/lib ..
+ * @run main/othervm/timeout=30 -DCUSTOM_P11_CONFIG_NAME=p11-nss-sensitive.txt TestLargeSecretKeys
+ */
+
+public final class TestLargeSecretKeys extends PKCS11Test {
+
+    public void main(Provider p) throws Exception {
+        Key k = generateLargeSecretKey(p);
+        Mac m = Mac.getInstance("HmacSHA512", p);
+        m.init(k);
+        m.doFinal(new byte[10]);
+        // Before the fix for 8328556, the next call would require to re-build
+        // the key in the NSS Software Token by means of a call to
+        // C_UnwrapKey because the key's CKA_SENSITIVE attribute is CK_TRUE.
+        // Thid call would fail with a CKR_TEMPLATE_INCONSISTENT error due to
+        // secret key length checks in NSS: length of 384 bytes is greater
+        // than 256 (defined as MAX_KEY_LEN in pkcs11i.h). With 8328556, the
+        // key was never extracted after its first use so re-building for the
+        // second use is not necessary.
+        m.init(k);
+        m.doFinal(new byte[10]);
+    }
+
+    private static Key generateLargeSecretKey(Provider p) throws Exception {
+        KeyPairGenerator kpg1 = KeyPairGenerator.getInstance("DH", p);
+        KeyPairGenerator kpg2 = KeyPairGenerator.getInstance("DH", p);
+        kpg1.initialize(3072);
+        kpg2.initialize(3072);
+        Key privK = kpg1.generateKeyPair().getPrivate();
+        Key pubK = kpg2.generateKeyPair().getPublic();
+        KeyAgreement ka = KeyAgreement.getInstance("DH", p);
+        ka.init(privK);
+        ka.doPhase(pubK, true);
+        return ka.generateSecret("TlsPremasterSecret");
+    }
+
+    public static void main(String[] args) throws Exception {
+        main(new TestLargeSecretKeys());
+    }
+}

--- a/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
+++ b/test/jdk/sun/security/pkcs11/Mac/TestLargeSecretKeys.java
@@ -44,7 +44,7 @@ public final class TestLargeSecretKeys extends PKCS11Test {
         // Before the fix for 8328556, the next call would require to re-build
         // the key in the NSS Software Token by means of a call to
         // C_UnwrapKey because the key's CKA_SENSITIVE attribute is CK_TRUE.
-        // Thid call would fail with a CKR_TEMPLATE_INCONSISTENT error due to
+        // This call would fail with a CKR_TEMPLATE_INCONSISTENT error due to
         // secret key length checks in NSS: length of 384 bytes is greater
         // than 256 (defined as MAX_KEY_LEN in pkcs11i.h). With 8328556, the
         // key was never extracted after its first use so re-building for the


### PR DESCRIPTION
Hi,

I'd like to propose a fix for "8328556: Do not extract large CKO_SECRET_KEY keys from the NSS Software Token". See more details in the JBS ticket [1].

No regressions observed in jdk/sun/security/pkcs11.

Thanks,
Martin.-

--
[1] - https://bugs.openjdk.org/browse/JDK-8328556

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328556](https://bugs.openjdk.org/browse/JDK-8328556): Do not extract large CKO_SECRET_KEY keys from the NSS Software Token (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18389/head:pull/18389` \
`$ git checkout pull/18389`

Update a local copy of the PR: \
`$ git checkout pull/18389` \
`$ git pull https://git.openjdk.org/jdk.git pull/18389/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18389`

View PR using the GUI difftool: \
`$ git pr show -t 18389`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18389.diff">https://git.openjdk.org/jdk/pull/18389.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18389#issuecomment-2008618929)