### PR TITLE
8328573: Add ASSERT macro and not use 'CardTable::card_shift_in_words' in 'G1BlockOffsetTable::check_index'

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -49,9 +49,9 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
 
 #ifdef ASSERT
 void G1BlockOffsetTable::check_index(size_t index, const char* msg) const {
-  assert((index) < (_reserved.word_size() >> CardTable::card_shift_in_words()),
+  assert((index) < (_reserved.byte_size() >> CardTable::card_shift()),
          "%s - index: " SIZE_FORMAT ", _vs.committed_size: " SIZE_FORMAT,
-         msg, (index), (_reserved.word_size() >> CardTable::card_shift_in_words()));
+         msg, (index), (_reserved.byte_size() >> CardTable::card_shift()));
   assert(G1CollectedHeap::heap()->is_in(address_for_index_raw(index)),
          "Index " SIZE_FORMAT " corresponding to " PTR_FORMAT
          " (%u) is not in committed area.",

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -72,7 +72,9 @@ private:
 
   inline void set_offset_array(size_t left, size_t right, u_char offset);
 
+#ifdef ASSERT
   void check_index(size_t index, const char* msg) const NOT_DEBUG_RETURN;
+#endif // ASSERT
 
 public:
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -61,7 +61,9 @@ inline HeapWord* G1BlockOffsetTablePart::block_start_reaching_into_card(const vo
 }
 
 u_char G1BlockOffsetTable::offset_array(size_t index) const {
+#ifdef ASSERT
   check_index(index, "index out of range");
+#endif // ASSERT
   return Atomic::load(&_offset_array[index]);
 }
 
@@ -70,12 +72,16 @@ void G1BlockOffsetTable::set_offset_array_raw(size_t index, u_char offset) {
 }
 
 void G1BlockOffsetTable::set_offset_array(size_t index, u_char offset) {
+#ifdef ASSERT
   check_index(index, "index out of range");
+#endif // ASSERT
   set_offset_array_raw(index, offset);
 }
 
 void G1BlockOffsetTable::set_offset_array(size_t index, HeapWord* high, HeapWord* low) {
+#ifdef ASSERT
   check_index(index, "index out of range");
+#endif // ASSERT
   assert(high >= low, "addresses out of order");
   size_t offset = pointer_delta(high, low);
   check_offset(offset, "offset too large");
@@ -83,7 +89,9 @@ void G1BlockOffsetTable::set_offset_array(size_t index, HeapWord* high, HeapWord
 }
 
 void G1BlockOffsetTable::set_offset_array(size_t left, size_t right, u_char offset) {
+#ifdef ASSERT
   check_index(right, "right index out of range");
+#endif // ASSERT
   assert(left <= right, "indexes out of order");
   size_t num_cards = right - left + 1;
   memset_with_concurrent_readers
@@ -102,12 +110,16 @@ inline size_t G1BlockOffsetTable::index_for(const void* p) const {
          "p (" PTR_FORMAT ") not in reserved [" PTR_FORMAT ", " PTR_FORMAT ")",
          p2i(p), p2i(_reserved.start()), p2i(_reserved.end()));
   size_t result = index_for_raw(p);
+#ifdef ASSERT
   check_index(result, "bad index from address");
+#endif // ASSERT
   return result;
 }
 
 inline HeapWord* G1BlockOffsetTable::address_for_index(size_t index) const {
+#ifdef ASSERT
   check_index(index, "index out of range");
+#endif // ASSERT
   HeapWord* result = address_for_index_raw(index);
   assert(result >= _reserved.start() && result < _reserved.end(),
          "bad address from index result " PTR_FORMAT


### PR DESCRIPTION
Hi all,

This patch adds the ASSERT macro to the declaration and usages of the method `G1BlockOffsetTable::check_index`. And the `CardTable::card_shift_in_words` is changed to `CardTable::card_shift` in order to prepare [JDK-8328508](https://bugs.openjdk.org/browse/JDK-8328508).

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328573](https://bugs.openjdk.org/browse/JDK-8328573): Add ASSERT macro and not use 'CardTable::card_shift_in_words' in 'G1BlockOffsetTable::check_index' (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18391/head:pull/18391` \
`$ git checkout pull/18391`

Update a local copy of the PR: \
`$ git checkout pull/18391` \
`$ git pull https://git.openjdk.org/jdk.git pull/18391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18391`

View PR using the GUI difftool: \
`$ git pr show -t 18391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18391.diff">https://git.openjdk.org/jdk/pull/18391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18391#issuecomment-2008933602)