### PR TITLE
JDK-8327169: serviceability/dcmd/vm/SystemMapTest.java and SystemDumpMapTest.java may fail after JDK-8326586

### DIFF
--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -142,8 +142,8 @@ public:
     for(uintx i = _last; i < _count; i++) {
       if (range_intersects(from, to, _ranges[i].from, _ranges[i].to)) {
         bm.set_flag(_flags[i]);
-        _last = i;
       } else if (to <= _ranges[i].from) {
+        _last = i;
         break;
       }
     }

--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -89,8 +89,11 @@ class CachedNMTInformation : public VirtualMemoryWalker {
   Range* _ranges;
   MEMFLAGS* _flags;
   size_t _count, _capacity;
+  mutable size_t _last;
+
 public:
-  CachedNMTInformation() : _ranges(nullptr), _flags(nullptr), _count(0), _capacity(0) {}
+  CachedNMTInformation() : _ranges(nullptr), _flags(nullptr),
+                           _count(0), _capacity(0), _last(0) {}
 
   ~CachedNMTInformation() {
     ALLOW_C_FUNCTION(free, ::free(_ranges);)
@@ -131,17 +134,16 @@ public:
     // We optimize for sequential lookups. Since this class is used when a list
     // of OS mappings is scanned (VirtualQuery, /proc/pid/maps), and these lists
     // are usually sorted in order of addresses, ascending.
-    static uintx last = 0;
-    if (to <= _ranges[last].from) {
+    if (to <= _ranges[_last].from) {
       // the range is to the right of the given section, we need to re-start the search
-      last = 0;
+      _last = 0;
     }
     MemFlagBitmap bm;
-    for(uintx i = last; i < _count; i++) {
+    for(uintx i = _last; i < _count; i++) {
       if (range_intersects(from, to, _ranges[i].from, _ranges[i].to)) {
         bm.set_flag(_flags[i]);
+        _last = i;
       } else if (to <= _ranges[i].from) {
-        last = i;
         break;
       }
     }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8326586 improved speed of System.map by exploiting the fact that VMA addresses are usually ordered ascending when read from /proc/pid/maps, and keeping track of the index of the last matching NMT region. That was a dramatic speed increase.

However, there is an embarrassing error. The index was kept inside a function-local static variable. But it depends on the number of NMT regions, and after calling System.map once at point-in-time A, it is equal to (number of NMT regions that were alive at A). If we call System.map again, at point-in-time B, and in the meantime mappings were released and we have fewer NMT regions, the stored index refers to an invalid position (larger than NMT region array count).

This messes up the next System.map printing. It can also theoretically cause a crash, since we dereference that out-of-bounds index, but I was not able to reproduce (the referenced array is usually over-allocated). Since we use the wrong - too high - index, we never enter the printing loop inside `CachedNMTInformation::lookup`, so we never print NMT regions. This makes the tests fail.

Tests: I was able to intermittendly reproduce the error without the patch by running a JVM and simulating NMT region cleanup between two calls to System.map. With this patch, the error is gone.

--

The obvious solution is to not use function-scope statics, but to store the last used index in a member inside CachedNMTInformation, and thus give it the same lifetime as that cache.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327169](https://bugs.openjdk.org/browse/JDK-8327169): serviceability/dcmd/vm/SystemMapTest.java and SystemDumpMapTest.java may fail after JDK-8326586 (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18392/head:pull/18392` \
`$ git checkout pull/18392`

Update a local copy of the PR: \
`$ git checkout pull/18392` \
`$ git pull https://git.openjdk.org/jdk.git pull/18392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18392`

View PR using the GUI difftool: \
`$ git pr show -t 18392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18392.diff">https://git.openjdk.org/jdk/pull/18392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18392#issuecomment-2009111143)