### PR TITLE
8328602: Parallel: Incorrect assertion in fill_dense_prefix_end

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1109,7 +1109,7 @@ void PSParallelCompact::fill_dense_prefix_end(SpaceId id) {
   // Comparing two sizes to decide if filling is required:
   //
   // The size of the filler (min-obj-size) is 2 heap words with the default
-  // MinObjAlignment, since both markword and klass takes 1 heap word.
+  // MinObjAlignment, since both markword and klass take 1 heap word.
   //
   // The size of the gap (if any) right before dense-prefix-end is
   // MinObjAlignment.

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1106,16 +1106,28 @@ void PSParallelCompact::summarize_spaces_quick()
 }
 
 void PSParallelCompact::fill_dense_prefix_end(SpaceId id) {
-  // Since both markword and klass takes 1 heap word, the min-obj-size is 2
-  // heap words.
-  // If min-fill-size decreases to 1, this whole method becomes redundant.
-  assert(CollectedHeap::min_fill_size() == 2, "inv");
+  // Comparing two sizes to decide if filling is required:
+  //
+  // The size of the filler (min-obj-size) is 2 heap words with the default
+  // MinObjAlignment, since both markword and klass takes 1 heap word.
+  //
+  // The size of the gap (if any) right before dense-prefix-end is
+  // MinObjAlignment.
+  //
+  // Need to fill in the gap only if it's smaller than min-obj-size, and the
+  // filler obj will extend to next region.
+
+  // Note: If min-fill-size decreases to 1, this whole method becomes redundant.
+  assert(CollectedHeap::min_fill_size() >= 2, "inv");
 #ifndef _LP64
-  // In 32-bit system, min-obj-alignment is >= 8 bytes, so the gap (if any)
-  // right before denses-prefix must be greater than min-fill-size; nothing to
-  // do.
+  // In 32-bit system, each heap word is 4 bytes, so MinObjAlignment == 2.
+  // The gap is always equal to min-fill-size, so nothing to do.
   return;
 #endif
+  if (MinObjAlignment > 1) {
+    return;
+  }
+  assert(CollectedHeap::min_fill_size() == 2, "inv");
   HeapWord* const dense_prefix_end = dense_prefix(id);
   RegionData* const region_after_dense_prefix = _summary_data.addr_to_region_ptr(dense_prefix_end);
   idx_t const dense_prefix_bit = _mark_bitmap.addr_to_bit(dense_prefix_end);


### PR DESCRIPTION
Relax too-strong assertion about min-filler-size to account for large obj-alignment.

Test: with explicit large obj-alignment

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328602](https://bugs.openjdk.org/browse/JDK-8328602): Parallel: Incorrect assertion in fill_dense_prefix_end (**Bug** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer) ⚠️ Review applies to [db2dc865](https://git.openjdk.org/jdk/pull/18396/files/db2dc86575ef2d743c30d1035a2171c1558174e6)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18396/head:pull/18396` \
`$ git checkout pull/18396`

Update a local copy of the PR: \
`$ git checkout pull/18396` \
`$ git pull https://git.openjdk.org/jdk.git pull/18396/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18396`

View PR using the GUI difftool: \
`$ git pr show -t 18396`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18396.diff">https://git.openjdk.org/jdk/pull/18396.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18396#issuecomment-2009334109)