### PR TITLE
WIP: Simplify DualPivotQuicksort intrinsics.

### DIFF
--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -347,7 +347,7 @@ class methodHandle;
                                                                                                                         \
   do_intrinsic(_arrayPartition,           java_util_DualPivotQuicksort, arrayPartition_name, arrayPartition_signature, F_S) \
    do_name(     arrayPartition_name,                             "partition")                                           \
-   do_signature(arrayPartition_signature, "(Ljava/lang/Class;Ljava/lang/Object;JIIIILjava/util/DualPivotQuicksort$PartitionOperation;)[I") \
+   do_signature(arrayPartition_signature, "(Ljava/lang/Class;Ljava/lang/Object;JIIII[ILjava/util/DualPivotQuicksort$PartitionOperation;)V") \
                                                                                                                         \
   do_intrinsic(_copyOfRange,              java_util_Arrays,       copyOfRange_name, copyOfRange_signature,       F_S)   \
    do_name(     copyOfRange_name,                                "copyOfRange")                                         \


### PR DESCRIPTION
This PR
1. makes DualPivotQuicksort.partition allocation free.
2. moves fallback implementations into intrinsic candidates instead of passing as argument. This avoids silent intrinsification when we extend it with new fallback implementation in the future.
3. cleans up arguments to the intrinsic candidates. Note that this removes `long offset`, which might be reserved for a future extension of off-heap case?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18399/head:pull/18399` \
`$ git checkout pull/18399`

Update a local copy of the PR: \
`$ git checkout pull/18399` \
`$ git pull https://git.openjdk.org/jdk.git pull/18399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18399`

View PR using the GUI difftool: \
`$ git pr show -t 18399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18399.diff">https://git.openjdk.org/jdk/pull/18399.diff</a>

</details>
