### PR TITLE
8328628: JDK-8328157 incorrectly sets -MT on all compilers in jdk.jpackage

### DIFF
--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -59,11 +59,11 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHEREXE, \
     DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
     CFLAGS_FILTER_OUT := -MD, \
     CXXFLAGS_FILTER_OUT := -MD, \
-    CXXFLAGS := -MT $(JPACKAGE_APPLAUNCHER_INCLUDES), \
-    CFLAGS := -MT $(JPACKAGE_APPLAUNCHER_INCLUDES), \
+    CXXFLAGS := $(JPACKAGE_APPLAUNCHER_INCLUDES), \
+    CFLAGS := $(JPACKAGE_APPLAUNCHER_INCLUDES), \
     CFLAGS_macosx := -Wno-format-nonliteral, \
-    CXXFLAGS_windows := $(JPACKAGE_CXXFLAGS_windows), \
-    CFLAGS_windows := $(JPACKAGE_CFLAGS_windows), \
+    CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
+    CFLAGS_windows := -MT $(JPACKAGE_CFLAGS_windows), \
     LD_SET_ORIGIN := false, \
     LIBS_macosx := -framework Cocoa  -rpath @executable_path/../Frameworks/ -rpath @executable_path/../PlugIns/, \
     LIBS_windows := user32.lib ole32.lib msi.lib shlwapi.lib \
@@ -137,8 +137,8 @@ ifeq ($(call isTargetOs, windows), true)
       OPTIMIZATION := LOW, \
       SRC := $(JPACKAGE_WIXHELPER_SRC), \
       CXXFLAGS_FILTER_OUT := -MD, \
-      CXXFLAGS := -MT $(addprefix -I, $(JPACKAGE_WIXHELPER_SRC)), \
-      CXXFLAGS_windows := $(JPACKAGE_CXXFLAGS_windows), \
+      CXXFLAGS := $(addprefix -I, $(JPACKAGE_WIXHELPER_SRC)), \
+      CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
       LDFLAGS := $(LDFLAGS_CXX_JDK), \
       LIBS := ole32.lib msi.lib User32.lib shlwapi.lib \
           Shell32.lib, \
@@ -157,8 +157,8 @@ ifeq ($(call isTargetOs, windows), true)
       SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/msiwrapper, \
       SRC := $(JPACKAGE_MSIWRAPPER_SRC), \
       CXXFLAGS_FILTER_OUT := -MD, \
-      CXXFLAGS := -MT $(addprefix -I, $(JPACKAGE_MSIWRAPPER_SRC)), \
-      CXXFLAGS_windows := $(JPACKAGE_CXXFLAGS_windows), \
+      CXXFLAGS := $(addprefix -I, $(JPACKAGE_MSIWRAPPER_SRC)), \
+      CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
       LIBS := ole32.lib msi.lib user32.lib shlwapi.lib Shell32.lib, \
   ))
 


### PR DESCRIPTION
In [JDK-8328157](https://bugs.openjdk.org/browse/JDK-8328157), I rewrote the logic to replace -MD with -MT for compiling on Windows. Unfortunately, I mistakenly set -MT for all compilers, not just for visual studio.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328628](https://bugs.openjdk.org/browse/JDK-8328628): JDK-8328157 incorrectly sets -MT on all compilers in jdk.jpackage (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18401/head:pull/18401` \
`$ git checkout pull/18401`

Update a local copy of the PR: \
`$ git checkout pull/18401` \
`$ git pull https://git.openjdk.org/jdk.git pull/18401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18401`

View PR using the GUI difftool: \
`$ git pr show -t 18401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18401.diff">https://git.openjdk.org/jdk/pull/18401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18401#issuecomment-2009984795)