### PR TITLE
8328630: Add logging when needed symbols in dll are missing.

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -711,9 +711,11 @@ void* os::get_default_process_handle() {
 }
 
 void* os::dll_lookup(void* handle, const char* name) {
+  ::dlerror(); // Clear any previous error
   void* ret = ::dlsym(handle, name);
   if (ret == nullptr) {
     const char* tmp = ::dlerror();
+    // It is possible that we found a NULL symbol, hence no error.
     if (tmp != nullptr) {
       log_debug(os)("Symbol %s not found in dll: %s", name, tmp);
     }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -711,10 +711,12 @@ void* os::get_default_process_handle() {
 }
 
 void* os::dll_lookup(void* handle, const char* name) {
-  void* ret = dlsym(handle, name);
+  void* ret = ::dlsym(handle, name);
   if (ret == nullptr) {
-    const char* tmp = dlerror();
-    log_debug(os)("Symbol %s not found in dll: %s", name, tmp);
+    const char* tmp = ::dlerror();
+    if (tmp != nullptr) {
+      log_debug(os)("Symbol %s not found in dll: %s", name, tmp);
+    }
   }
   return ret;
 }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -712,7 +712,7 @@ void* os::get_default_process_handle() {
 
 void* os::dll_lookup(void* handle, const char* name) {
   void* ret = dlsym(handle, name);
-  if (ret == NULL) {
+  if (ret == nullptr) {
     const char* tmp = dlerror();
     log_debug(os)("Symbol %s not found in dll: %s", name, tmp);
   }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -711,7 +711,12 @@ void* os::get_default_process_handle() {
 }
 
 void* os::dll_lookup(void* handle, const char* name) {
-  return dlsym(handle, name);
+  void* ret = dlsym(handle, name);
+  if (ret == NULL) {
+    const char* tmp = dlerror();
+    log_debug(os)("Symbol %s not found in dll: %s", name, tmp);
+  }
+  return ret;
 }
 
 void os::dll_unload(void *lib) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1280,7 +1280,7 @@ void  os::dll_unload(void *lib) {
 }
 
 void* os::dll_lookup(void *lib, const char *name) {
-  GetLastError(); // Clear old pending errors
+  ::GetLastError(); // Clear old pending errors
   void* ret = ::GetProcAddress((HMODULE)lib, name);
   if (ret == nullptr) {
     char buf[512];

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1279,8 +1279,33 @@ void  os::dll_unload(void *lib) {
   }
 }
 
+static size_t format_message_fixup(char* buf, size_t end) {
+  if (end > 3) {
+    if (buf[end - 1] == '\n') end--;
+    if (buf[end - 1] == '\r') end--;
+    if (buf[end - 1] == '.')  end--;
+    buf[end] = '\0';
+  }
+  return end;
+}
+
 void* os::dll_lookup(void *lib, const char *name) {
-  return (void*)::GetProcAddress((HMODULE)lib, name);
+  void* ret = ::GetProcAddress((HMODULE)lib, name);
+  DWORD errval;
+  if ((errval = GetLastError()) != 0) {
+    char buf[512];
+    size_t n = (size_t)FormatMessage(
+                                     FORMAT_MESSAGE_FROM_SYSTEM|FORMAT_MESSAGE_IGNORE_INSERTS,
+                                     nullptr,
+                                     errval,
+                                     0,
+                                     buf,
+                                     (DWORD)sizeof(buf),
+                                     nullptr);
+    format_message_fixup(buf, n);
+    log_debug(os)("Symbol %s not found in dll: %s", name, buf);
+  }
+  return ret;
 }
 
 // Directory routines copied from src/win32/native/java/io/dirent_md.c
@@ -2165,14 +2190,7 @@ size_t os::lasterror(char* buf, size_t len) {
                                      buf,
                                      (DWORD)len,
                                      nullptr);
-    if (n > 3) {
-      // Drop final '.', CR, LF
-      if (buf[n - 1] == '\n') n--;
-      if (buf[n - 1] == '\r') n--;
-      if (buf[n - 1] == '.') n--;
-      buf[n] = '\0';
-    }
-    return n;
+    return format_message_fixup(buf, n);
   }
 
   if (errno != 0) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1280,7 +1280,7 @@ void  os::dll_unload(void *lib) {
 }
 
 void* os::dll_lookup(void *lib, const char *name) {
-  ::GetLastError(); // Clear old pending errors
+  ::SetLastError(0); // Clear old pending errors
   void* ret = ::GetProcAddress((HMODULE)lib, name);
   if (ret == nullptr) {
     char buf[512];


### PR DESCRIPTION
Hi, please consider this additional logging.

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328630](https://bugs.openjdk.org/browse/JDK-8328630): Add logging when needed symbols in dll are missing. (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18404/head:pull/18404` \
`$ git checkout pull/18404`

Update a local copy of the PR: \
`$ git checkout pull/18404` \
`$ git pull https://git.openjdk.org/jdk.git pull/18404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18404`

View PR using the GUI difftool: \
`$ git pr show -t 18404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18404.diff">https://git.openjdk.org/jdk/pull/18404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18404#issuecomment-2010110236)