### PR TITLE
8328633: s390x: Improve vectorization of Match.sqrt() on floats

### DIFF
--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -7292,7 +7292,7 @@ instruct negD_reg(regD dst, regD src, flagsReg cr) %{
 
 // Sqrt float precision
 instruct sqrtF_reg(regF dst, regF src) %{
-  match(Set dst (ConvD2F (SqrtD (ConvF2D src))));
+  match(Set dst (SqrtF src));
   // CC remains unchanged.
   ins_cost(ALU_REG_COST);
   size(4);
@@ -7315,7 +7315,7 @@ instruct sqrtD_reg(regD dst, regD src) %{
 %}
 
 instruct sqrtF_mem(regF dst, memoryRX src) %{
-  match(Set dst (ConvD2F (SqrtD (ConvF2D src))));
+  match(Set dst (SqrtF src));
   // CC remains unchanged.
   ins_cost(ALU_MEMORY_COST);
   size(6);


### PR DESCRIPTION
[JDK-8190800](https://bugs.openjdk.org/browse/JDK-8190800) added `VSqrtF` and `SqrtF` nodes to support the vectorization of Match.sqrt() on floats. For s390x port, however, the scalar version of `sqrtF` still uses the old match rule that converts Float to Double first. It can be simplified to just use `SqrtF`.

The old match rule also affects the vectorization of Math.sqrt() on float.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328633](https://bugs.openjdk.org/browse/JDK-8328633): s390x: Improve vectorization of Match.sqrt() on floats (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18406/head:pull/18406` \
`$ git checkout pull/18406`

Update a local copy of the PR: \
`$ git checkout pull/18406` \
`$ git pull https://git.openjdk.org/jdk.git pull/18406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18406`

View PR using the GUI difftool: \
`$ git pr show -t 18406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18406.diff">https://git.openjdk.org/jdk/pull/18406.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18406#issuecomment-2010219447)