### PR TITLE
8321428: Depreciate java.beans.beancontext.* 

### DIFF
--- a/src/java.desktop/share/classes/java/beans/Beans.java
+++ b/src/java.desktop/share/classes/java/beans/Beans.java
@@ -103,7 +103,8 @@ public class Beans {
      * @throws IOException if an I/O error occurs.
      * @since 1.2
      */
-    @SuppressWarnings("deprecation")
+    @Deprecated(since = "23", forRemoval = true)
+    @SuppressWarnings({"deprecation", "removal"})
     public static Object instantiate(ClassLoader cls, String beanName,
                                      BeanContext beanContext)
             throws IOException, ClassNotFoundException {
@@ -352,7 +353,8 @@ public class Beans {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
+    @Deprecated(since = "23", forRemoval = true)
+    @SuppressWarnings({ "unchecked", "removal" })
     private static void unsafeBeanContextAdd(BeanContext beanContext, Object res) {
         beanContext.add(res);
     }

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContext.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContext.java
@@ -53,7 +53,8 @@ import java.util.Locale;
  * @see java.util.Collection
  */
 
-@SuppressWarnings("rawtypes")
+@Deprecated(forRemoval=true, since="23")
+@SuppressWarnings({"rawtypes", "removal"})
 public interface BeanContext extends BeanContextChild, Collection, DesignMode, Visibility {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChild.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChild.java
@@ -65,6 +65,8 @@ import java.beans.beancontext.BeanContext;
  * @see java.beans.VetoableChangeListener
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextChild {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildComponentProxy.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildComponentProxy.java
@@ -41,6 +41,8 @@ import java.awt.Component;
  * @see java.beans.beancontext.BeanContextSupport
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextChildComponentProxy {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextChildSupport.java
@@ -54,6 +54,8 @@ import java.io.Serializable;
  * @see java.beans.beancontext.BeanContextChild
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class BeanContextChildSupport implements BeanContextChild, BeanContextServicesListener, Serializable {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextContainerProxy.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextContainerProxy.java
@@ -40,6 +40,8 @@ import java.awt.Container;
  * @see java.beans.beancontext.BeanContextSupport
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextContainerProxy {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextEvent.java
@@ -46,6 +46,8 @@ import java.util.EventObject;
  * @see         java.beans.beancontext.BeanContext
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public abstract class BeanContextEvent extends EventObject {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipEvent.java
@@ -50,6 +50,9 @@ import java.util.Iterator;
  * @see         java.beans.beancontext.BeanContextEvent
  * @see         java.beans.beancontext.BeanContextMembershipListener
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class BeanContextMembershipEvent extends BeanContextEvent {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipListener.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextMembershipListener.java
@@ -40,6 +40,8 @@ import java.util.EventListener;
  * @see         java.beans.beancontext.BeanContext
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextMembershipListener extends EventListener {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextProxy.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextProxy.java
@@ -72,6 +72,8 @@ package java.beans.beancontext;
  * @see java.beans.beancontext.BeanContextChildSupport
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextProxy {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceAvailableEvent.java
@@ -35,6 +35,8 @@ import java.util.Iterator;
  * </p>
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class BeanContextServiceAvailableEvent extends BeanContextEvent {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceProvider.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceProvider.java
@@ -49,6 +49,8 @@ import java.util.Iterator;
  * </p>
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextServiceProvider {
 
    /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceProviderBeanInfo.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceProviderBeanInfo.java
@@ -35,6 +35,8 @@ import java.beans.BeanInfo;
  * services.
  */
 
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextServiceProviderBeanInfo extends BeanInfo {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedEvent.java
@@ -34,6 +34,9 @@ import java.io.Serial;
  * identify the service being revoked.
  * </p>
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class BeanContextServiceRevokedEvent extends BeanContextEvent {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedListener.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServiceRevokedListener.java
@@ -34,6 +34,9 @@ import java.util.EventListener;
  * interested in processing a {@code BeanContextServiceRevokedEvent}
  * implements this interface.
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextServiceRevokedListener extends EventListener {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServices.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServices.java
@@ -42,6 +42,9 @@ import java.beans.beancontext.BeanContextServicesListener;
  * to expose generic "services" to the BeanContextChild objects within.
  * </p>
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextServices extends BeanContext, BeanContextServicesListener {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesListener.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesListener.java
@@ -35,6 +35,9 @@ import java.beans.beancontext.BeanContextServiceRevokedListener;
  * A class that is interested in processing a
  * {@code BeanContextServiceAvailableEvent} implements this interface.
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public interface BeanContextServicesListener extends BeanContextServiceRevokedListener {
 
     /**

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextServicesSupport.java
@@ -54,6 +54,9 @@ import java.util.TooManyListenersException;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class      BeanContextServicesSupport extends BeanContextSupport
        implements BeanContextServices {
 

--- a/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/BeanContextSupport.java
@@ -59,6 +59,9 @@ import java.util.Map;
  * @author Laurence P. G. Cable
  * @since 1.2
  */
+
+@SuppressWarnings("removal")
+@Deprecated(forRemoval=true, since="23")
 public class      BeanContextSupport extends BeanContextChildSupport
        implements BeanContext,
                   Serializable,

--- a/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
+++ b/src/java.desktop/share/classes/java/beans/beancontext/package-info.java
@@ -33,4 +33,5 @@
  *
  * @since 1.2
  */
+
 package java.beans.beancontext;


### PR DESCRIPTION
[https://bugs.openjdk.org/browse/JDK-8321428](url)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8320930](https://bugs.openjdk.org/browse/JDK-8320930) to be approved

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8321428](https://bugs.openjdk.org/browse/JDK-8321428)

### Issues
 * [JDK-8321428](https://bugs.openjdk.org/browse/JDK-8321428): Deprecate for removal the package java.beans.beancontext (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.
 * [JDK-8320930](https://bugs.openjdk.org/browse/JDK-8320930): Deprecate for removal the package java.beans.beancontext (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18413/head:pull/18413` \
`$ git checkout pull/18413`

Update a local copy of the PR: \
`$ git checkout pull/18413` \
`$ git pull https://git.openjdk.org/jdk.git pull/18413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18413`

View PR using the GUI difftool: \
`$ git pr show -t 18413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18413.diff">https://git.openjdk.org/jdk/pull/18413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18413#issuecomment-2015889258)