### PR TITLE
8324781: runtime/Thread/TestAlwaysPreTouchStacks.java failed with Expected a higher ratio between stack committed and reserved

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -43,6 +43,9 @@ class os::Linux {
   static const char *_libc_version;
   static const char *_libpthread_version;
 
+  static long _release_major;
+  static long _release_minor;
+
   static bool _supports_fast_thread_cpu_time;
 
   static GrowableArray<int>* _cpu_to_node;
@@ -52,6 +55,7 @@ class os::Linux {
 
  protected:
 
+  static bool _is_uek_release;
   static julong _physical_memory;
   static pthread_t _main_thread;
 
@@ -66,6 +70,7 @@ class os::Linux {
   static int commit_memory_impl(char* addr, size_t bytes,
                                 size_t alignment_hint, bool exec);
 
+  static void version_init();
   static void set_libc_version(const char *s)       { _libc_version = s; }
   static void set_libpthread_version(const char *s) { _libpthread_version = s; }
 
@@ -93,7 +98,10 @@ class os::Linux {
     bool     has_steal_ticks;
   };
 
-  static void kernel_version(long* major, long* minor);
+  static void kernel_version(long* major, long* minor) {
+    *major = _release_major;
+    *minor = _release_minor;
+  }
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.
   static bool get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu);

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -112,7 +112,6 @@ runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
 runtime/os/TestTransparentHugePageUsage.java 8324776 linux-all
-runtime/Thread/TestAlwaysPreTouchStacks.java 8324781 linux-all
 
 applications/jcstress/accessAtomic.java 8325984 generic-all
 applications/jcstress/acqrel.java 8325984 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -86,7 +86,6 @@ gc/epsilon/TestMemoryMXBeans.java 8206434 generic-all
 gc/g1/humongousObjects/objectGraphTest/TestObjectGraphAfterGC.java 8156755 generic-all
 gc/g1/logging/TestG1LoggingFailure.java 8169634 generic-all
 gc/g1/humongousObjects/TestHeapCounters.java 8178918 generic-all
-gc/parallel/TestAlwaysPreTouchBehavior.java 8325218 linux-all
 gc/TestAllocHumongousFragment.java#adaptive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all


### PR DESCRIPTION
The testcase failed on Oracle CI since JDK-8315923. The root cause is that Oracle CI runs Linux-5.4.17-UEK where the value of MADV_POPULATE_WRITE (23) is used as MADV_DONTEXEC which is not supported by upstream. This PR solves the testcase failure by checking the support of (MADV_POPULATE_WRITE_value + 1) for UEK releases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8324781](https://bugs.openjdk.org/browse/JDK-8324781): runtime/Thread/TestAlwaysPreTouchStacks.java failed with Expected a higher ratio between stack committed and reserved (**Bug** - P2)
 * [JDK-8325218](https://bugs.openjdk.org/browse/JDK-8325218): gc/parallel/TestAlwaysPreTouchBehavior.java fails (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18417/head:pull/18417` \
`$ git checkout pull/18417`

Update a local copy of the PR: \
`$ git checkout pull/18417` \
`$ git pull https://git.openjdk.org/jdk.git pull/18417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18417`

View PR using the GUI difftool: \
`$ git pr show -t 18417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18417.diff">https://git.openjdk.org/jdk/pull/18417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18417#issuecomment-2011099143)