### PR TITLE
8328647: TestGarbageCollectorMXBean.java fails with C1-only and -Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/x/TestGarbageCollectorMXBean.java
@@ -28,6 +28,7 @@ package gc.x;
  * @requires vm.gc.ZSinglegen
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.x.TestGarbageCollectorMXBean 256 512
  * @run main/othervm -XX:+UseZGC -XX:-ZGenerational -Xms512M -Xmx512M -Xlog:gc gc.x.TestGarbageCollectorMXBean 512 512
  */

--- a/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
+++ b/test/hotspot/jtreg/gc/z/TestGarbageCollectorMXBean.java
@@ -28,6 +28,7 @@ package gc.z;
  * @requires vm.gc.ZGenerational
  * @summary Test ZGC garbage collector MXBean
  * @modules java.management
+ * @requires vm.compMode != "Xcomp"
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms256M -Xmx512M -Xlog:gc gc.z.TestGarbageCollectorMXBean 256 512
  * @run main/othervm -XX:+UseZGC -XX:+ZGenerational -Xms512M -Xmx512M -Xlog:gc gc.z.TestGarbageCollectorMXBean 512 512
  */


### PR DESCRIPTION
Trivial patch to turn off this test when running with -Xcomp. The test doesn't expect to see GCCauses related to the code cache, so stop running with flags puts pressure on the code cache.