### PR TITLE
Fix Runtime Exception when ZipFileSystem not initialized 

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystemProvider.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystemProvider.java
@@ -152,8 +152,9 @@ public class ZipFileSystemProvider extends FileSystemProvider {
             } catch (IOException x) {
                 // ignore the ioe from toRealPath(), return FSNFE
             }
-            if (zipfs == null)
-                throw new FileSystemNotFoundException();
+            if (zipfs == null) {
+                return newFileSystem(uri, Map.of());
+            }
             return zipfs;
         }
     }


### PR DESCRIPTION
*Background*

When it's to build a File or a Path which point to a file within an archive (jar, zip), the system would result in Runtime Error.

```
Paths.get("jar:file:/........path_to_the_file"); //this would throw FileSystemNotFoundException
```

Instead of thrown a RuntimeExpcetion, can we create it on the fly instead ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18423/head:pull/18423` \
`$ git checkout pull/18423`

Update a local copy of the PR: \
`$ git checkout pull/18423` \
`$ git pull https://git.openjdk.org/jdk.git pull/18423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18423`

View PR using the GUI difftool: \
`$ git pr show -t 18423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18423.diff">https://git.openjdk.org/jdk/pull/18423.diff</a>

</details>
