### PR TITLE
8328673: Convert closed text/html/CSS manual applet test to main

### DIFF
--- a/test/jdk/javax/swing/text/html/CSS/bug4271058.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4271058.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4270889 4271058 4285098
  * @summary Tests that <table border>, <table align> and <td width> tags work
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4271058
 */

--- a/test/jdk/javax/swing/text/html/CSS/bug4271058.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4271058.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4270889 4271058 4285098
+ * @summary Tests that <table border>, <table align> and <td width> tags work
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4271058
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+
+public class bug4271058 {
+
+    private static String INSTRUCTIONS = """
+        What should be seen is three 2x2 tables.
+
+        The first table should have borders and lines distinguishing
+        table cells. If they are not shown, test fails (bug 4271058).
+
+        In the second table, the first (left) column should be about
+        four times as wide as the second (right) column.
+        If this is not so, test fails (bug 4270889).
+
+        The third table should be right aligned, i.e. its right edge
+        should be close to the right edge of the viewable area.
+        Otherwise test fails (bug 4285098).
+        """;
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("CSS tag Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(15)
+                .columns(30)
+                .testUI(bug4271058::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        String htmlText =
+            "<html><table border width=300 height=200>" +
+            "<tr><th>col A</th><th>col B</th></tr>" +
+            "<tr>" +
+            "<td>aaaaaa</td>" +
+            "<td>bbbbbbb</td>" +
+            "</tr></table>" +
+            "<table border width=300>" +
+            "<tr><th>A</th><th>B</th></tr>" +
+            "<tr>" +
+            "<td width=\"80%\">a</td>" +
+            "<td width=\"20%\">b</td>" +
+            "</tr></table>" +
+            "<table align=right border width=200>" +
+            "<tr><th>col A</th><th>col B</th></tr>" +
+            "<tr>" +
+            "<td>aaaaaa</td>" +
+            "<td>bbbbbbb</td>" +
+            "</tr></table></html>";
+
+        JEditorPane lbl = new JEditorPane("text/html", htmlText);
+        JFrame frame = new JFrame("bug4271058");
+        frame.add(lbl);
+        frame.pack();
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/text/html/CSS/bug4271058.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4271058.java
@@ -52,11 +52,12 @@ public class bug4271058 {
 
     public static void main(String[] args) throws Exception {
          PassFailJFrame.builder()
-                .title("CSS tag Instructions")
+                .title("CSS html tag verification Instructions")
                 .instructions(INSTRUCTIONS)
                 .rows(15)
                 .columns(30)
                 .testUI(bug4271058::createTestUI)
+                .screenCapture()
                 .build()
                 .awaitAndCheck();
     }

--- a/test/jdk/javax/swing/text/html/CSS/bug4286458.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4286458.java
@@ -54,15 +54,13 @@ public class bug4286458 {
     private static JFrame createTestUI() {
 
         String text =
-            "</html><body><table border=\"1\" cellpadding=\"-10\">" +
+            "<html><body><table border=\"1\" cellpadding=\"-10\">" +
             "<tr><td>This line should be clearly readable</td></tr>" +
             "</table></body></html>";
 
         JFrame f = new JFrame("bug4286458");
-        JEditorPane jep = new JEditorPane();
-        jep.setEditorKit(new HTMLEditorKit());
+        JEditorPane jep = new JEditorPane("text/html", text);
         jep.setEditable(false);
-        jep.setText(text);
 
         f.add(jep);
         f.pack();

--- a/test/jdk/javax/swing/text/html/CSS/bug4286458.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4286458.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4286458
  * @summary  Tests if cellpadding in tables is non-negative number
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual bug4286458
 */

--- a/test/jdk/javax/swing/text/html/CSS/bug4286458.java
+++ b/test/jdk/javax/swing/text/html/CSS/bug4286458.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4286458
+ * @summary  Tests if cellpadding in tables is non-negative number
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4286458
+*/
+
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.text.html.HTMLEditorKit;
+
+public class bug4286458 {
+
+    private static String INSTRUCTIONS = """
+        If you can clearly read the line of text in the appeared frame
+        press PASS. Otherwise test fails.""";
+
+    public static void main(String[] args) throws Exception {
+         PassFailJFrame.builder()
+                .title("CSS tag Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows(5)
+                .columns(30)
+                .testUI(bug4286458::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        String text =
+            "</html><body><table border=\"1\" cellpadding=\"-10\">" +
+            "<tr><td>This line should be clearly readable</td></tr>" +
+            "</table></body></html>";
+
+        JFrame f = new JFrame("bug4286458");
+        JEditorPane jep = new JEditorPane();
+        jep.setEditorKit(new HTMLEditorKit());
+        jep.setEditable(false);
+        jep.setText(text);
+
+        f.add(jep);
+        f.pack();
+        return f;
+    }
+}


### PR DESCRIPTION
Couple closed manual applet text/html/CSS tests are converted to main based and opensourced

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328673](https://bugs.openjdk.org/browse/JDK-8328673): Convert closed text/html/CSS manual applet test to main (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [8ff80bbb](https://git.openjdk.org/jdk/pull/18424/files/8ff80bbbc1199d2ad87df1d601417c20b425a02f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18424/head:pull/18424` \
`$ git checkout pull/18424`

Update a local copy of the PR: \
`$ git checkout pull/18424` \
`$ git pull https://git.openjdk.org/jdk.git pull/18424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18424`

View PR using the GUI difftool: \
`$ git pr show -t 18424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18424.diff">https://git.openjdk.org/jdk/pull/18424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18424#issuecomment-2011694480)