### PR TITLE
8323552: AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -681,10 +681,6 @@ public abstract sealed class AbstractMemorySegmentImpl
         long dstBytes = dstToOffset - dstFromOffset;
         srcImpl.checkAccess(srcFromOffset, srcBytes, true);
         dstImpl.checkAccess(dstFromOffset, dstBytes, true);
-        if (dstImpl == srcImpl) {
-            srcImpl.checkValidState();
-            return -1;
-        }
 
         long bytes = Math.min(srcBytes, dstBytes);
         long i = 0;

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8323552
  * @run testng TestMismatch
  */
 
@@ -44,14 +45,14 @@ import static org.testng.Assert.assertThrows;
 
 public class TestMismatch {
 
-    // stores a increasing sequence of values into the memory of the given segment
+    // stores an increasing sequence of values into the memory of the given segment
     static MemorySegment initializeSegment(MemorySegment segment) {
         for (int i = 0 ; i < segment.byteSize() ; i++) {
             segment.set(ValueLayout.JAVA_BYTE, i, (byte)i);
         }
         return segment;
     }
-
+/*
     @Test(dataProvider = "slices", expectedExceptions = IndexOutOfBoundsException.class)
     public void testNegativeSrcFromOffset(MemorySegment s1, MemorySegment s2) {
         MemorySegment.mismatch(s1, -1, 0, s2, 0, 0);
@@ -276,6 +277,32 @@ public class TestMismatch {
                 }
             }
         }
+    }*/
+
+    @Test
+    public void testSameSegment() {
+        var segment = MemorySegment.ofArray(new byte[]{
+                1,2,3,4,  1,2,3,4,  1,4});
+
+        long match = MemorySegment.mismatch(
+                segment, 0L, 4L,
+                segment, 4L, 8L);
+        assertEquals(match, -1);
+
+        long noMatch = MemorySegment.mismatch(
+                segment, 0L, 4L,
+                segment, 1L, 5L);
+        assertEquals(noMatch, 0);
+
+        long noMatchEnd = MemorySegment.mismatch(
+                segment, 0L, 2L,
+                segment, 8L, 10L);
+        assertEquals(noMatchEnd, 1);
+
+        long same = MemorySegment.mismatch(
+                segment, 0L, 8L,
+                segment, 0L, 8L);
+        assertEquals(same, -1);
     }
 
     enum SegmentKind {

--- a/test/jdk/java/foreign/TestMismatch.java
+++ b/test/jdk/java/foreign/TestMismatch.java
@@ -52,7 +52,7 @@ public class TestMismatch {
         }
         return segment;
     }
-/*
+
     @Test(dataProvider = "slices", expectedExceptions = IndexOutOfBoundsException.class)
     public void testNegativeSrcFromOffset(MemorySegment s1, MemorySegment s2) {
         MemorySegment.mismatch(s1, -1, 0, s2, 0, 0);
@@ -277,7 +277,7 @@ public class TestMismatch {
                 }
             }
         }
-    }*/
+    }
 
     @Test
     public void testSameSegment() {


### PR DESCRIPTION
This PR proposes to remove an old optimization check that was incorrect making `AbstractMemorySegmentImpl::mismatch` always return `-1` if the source and destination segment are the same (disregarding offsets).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323552](https://bugs.openjdk.org/browse/JDK-8323552): AbstractMemorySegmentImpl#mismatch returns -1 when comparing distinct areas of the same instance of MemorySegment (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18426/head:pull/18426` \
`$ git checkout pull/18426`

Update a local copy of the PR: \
`$ git checkout pull/18426` \
`$ git pull https://git.openjdk.org/jdk.git pull/18426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18426`

View PR using the GUI difftool: \
`$ git pr show -t 18426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18426.diff">https://git.openjdk.org/jdk/pull/18426.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18426#issuecomment-2011734798)