### PR TITLE
8328679: Improve comment for UNSAFE_ENTRY_SCOPED in unsafe.cpp

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -76,25 +76,26 @@
 #define UNSAFE_LEAF(result_type, header) \
   JVM_LEAF(static result_type, header)
 
-// Note that scoped accesses (cf. scopedMemoryAccess.cpp) can install
-// an async handshake on the entry to an Unsafe method. When that happens,
-// it is expected that we are not allowed to touch the underlying memory
-// that might have gotten unmapped. Therefore, we check at the entry
-// to unsafe functions, if we have such async exception conditions,
-// and return immediately if that is the case.
+// All memory access methods (e.g. getInt, copyMemory) must use this macro.
+// We call these methods "scoped" methods, as access to these methods is
+// typically governed by a "scope" (a MemorySessionImpl object), and no
+// access is allowed when the scope is no longer alive.
 //
-// We can't have safepoints in this code.
-// It would be problematic if an async exception handshake were installed later on
-// during another safepoint in the function, but before the memory access happens,
-// as the memory will be freed after the handshake is installed. We must notice
-// the installed handshake and return early before doing the memory access to prevent
-// accesses to freed memory.
+// Closing a scope object (cf. scopedMemoryAccess.cpp) can install
+// an async handshake on the entry to scoped method. When that happens,
+// scoped methods are not allowed to touch the underlying memory (as that
+// memory might have been released). Therefore, when entering a scoped method
+// we check if an async exception has been installed, and return immediately
+// if that is the case.
 //
-// Note also that we MUST do a scoped memory access in the VM (or Java) thread
-// state. Since we rely on a handshake to check for threads that are accessing
-// scoped memory, and we need the handshaking thread to wait until we get to a
-// safepoint, in order to make sure we are not in the middle of accessing memory
-// that is about to be freed. (i.e. there can be no UNSAFE_LEAF_SCOPED)
+// We can't have safepoints in the middle of a scoped method.
+// If an async exception handshake were installed in such a safepoint,
+// memory access might still occur before the handshake is honored by
+// the accessing thread.
+//
+// Corollary: as threads in native state are considered to be at a safepoint,
+// scoped methods must NOT be executed while in the native thread state.
+// Because of this, there can be no UNSAFE_LEAF_SCOPED.
 #define UNSAFE_ENTRY_SCOPED(result_type, header) \
   JVM_ENTRY(static result_type, header) \
   if (thread->has_async_exception_condition()) {return (result_type)0;}

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -82,7 +82,7 @@
 // access is allowed when the scope is no longer alive.
 //
 // Closing a scope object (cf. scopedMemoryAccess.cpp) can install
-// an async handshake on the entry to scoped method. When that happens,
+// an async exception during a safepoint. When that happens,
 // scoped methods are not allowed to touch the underlying memory (as that
 // memory might have been released). Therefore, when entering a scoped method
 // we check if an async exception has been installed, and return immediately

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -88,7 +88,7 @@
 // we check if an async exception has been installed, and return immediately
 // if that is the case.
 //
-// We can't have safepoints in the middle of a scoped method.
+// As a rule, we disallow safepoints in the middle of a scoped method.
 // If an async exception handshake were installed in such a safepoint,
 // memory access might still occur before the handshake is honored by
 // the accessing thread.


### PR DESCRIPTION
This small PR is an attempt at improving the comment in the UNSAFE_ENTRY_SCOPED macro.
I found that the comment contained some duplicated claims, did not properly introduced the concepts it referred to, and some of its claims were not explained in full.

As this is a delicate part of how FFM ensures the "no use after free" guarantee, I think it would be a good idea for this comment to better reflect what the expectations are.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328679](https://bugs.openjdk.org/browse/JDK-8328679): Improve comment for UNSAFE_ENTRY_SCOPED in unsafe.cpp (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18429/head:pull/18429` \
`$ git checkout pull/18429`

Update a local copy of the PR: \
`$ git checkout pull/18429` \
`$ git pull https://git.openjdk.org/jdk.git pull/18429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18429`

View PR using the GUI difftool: \
`$ git pr show -t 18429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18429.diff">https://git.openjdk.org/jdk/pull/18429.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18429#issuecomment-2011964216)