### PR TITLE
8328697: SubMenuShowTest and SwallowKeyEvents tests stabilization

### DIFF
--- a/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java
+++ b/test/jdk/java/awt/KeyboardFocusmanager/TypeAhead/SubMenuShowTest/SubMenuShowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,8 @@ public class SubMenuShowTest {
     }
 
     public static void doTest() {
+        robot.waitForIdle();
+        robot.delay(1000);
         boolean isMacOSX = Platform.isOSX();
         if (isMacOSX) {
             robot.keyPress(KeyEvent.VK_CONTROL);

--- a/test/jdk/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
+++ b/test/jdk/java/awt/event/KeyEvent/SwallowKeyEvents/SwallowKeyEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,6 +83,8 @@ public class SwallowKeyEvents {
         });
 
         test();
+        r.waitForIdle();
+        r.delay(500);
 
         System.out.println("key_pressed count: " + keyPressedCount);
 


### PR DESCRIPTION
Two tests may fail intermittently on Wayland, the standard `waitForIdle` and `delay` fixes the issue.

Manual and CI testing looks good.