### PR TITLE
JDK-8328709: AIX os::get_summary_cpu_info support Power 10

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -138,7 +138,7 @@ extern "C" int getargs(procsinfo*, int, char*, int);
 #define ERROR_MP_VMGETINFO_FAILED                    102
 #define ERROR_MP_VMGETINFO_CLAIMS_NO_SUPPORT_FOR_64K 103
 
-// excerpts from systemcfg.h that might be missing on older os levels
+// excerpts from sys/systemcfg.h that might be missing on older os levels
 #ifndef PV_7
   #define PV_7 0x200000          /* Power PC 7 */
 #endif
@@ -157,7 +157,12 @@ extern "C" int getargs(procsinfo*, int, char*, int);
 #ifndef PV_9_Compat
   #define PV_9_Compat  0x408000  /* Power PC 9 */
 #endif
-
+#ifndef PV_10
+  #define PV_10 0x500000          /* Power PC 10 */
+#endif
+#ifndef PV_10_Compat
+  #define PV_10_Compat  0x508000  /* Power PC 10 */
+#endif
 
 static address resolve_function_descriptor_to_code_pointer(address p);
 
@@ -1333,6 +1338,9 @@ void os::print_memory_info(outputStream* st) {
 void os::get_summary_cpu_info(char* buf, size_t buflen) {
   // read _system_configuration.version
   switch (_system_configuration.version) {
+  case PV_10:
+    strncpy(buf, "Power PC 10", buflen);
+    break;
   case PV_9:
     strncpy(buf, "Power PC 9", buflen);
     break;
@@ -1371,6 +1379,9 @@ void os::get_summary_cpu_info(char* buf, size_t buflen) {
     break;
   case PV_9_Compat:
     strncpy(buf, "PV_9_Compat", buflen);
+    break;
+  case PV_10_Compat:
+    strncpy(buf, "PV_10_Compat", buflen);
     break;
   default:
     strncpy(buf, "unknown", buflen);


### PR DESCRIPTION
AIX os::get_summary_cpu_info function still misses support for Power 10 processors, this should be changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328709](https://bugs.openjdk.org/browse/JDK-8328709): AIX os::get_summary_cpu_info  support Power 10 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18432/head:pull/18432` \
`$ git checkout pull/18432`

Update a local copy of the PR: \
`$ git checkout pull/18432` \
`$ git pull https://git.openjdk.org/jdk.git pull/18432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18432`

View PR using the GUI difftool: \
`$ git pr show -t 18432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18432.diff">https://git.openjdk.org/jdk/pull/18432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18432#issuecomment-2012579051)