### PR TITLE
8326438: C2: assert(ld->in(1)->Opcode() == Op_LoadN) failed: Assumption invalid: input to DecodeN is not LoadN

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1563,7 +1563,10 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
     // Improve graph before escape analysis and boxing elimination.
     record_for_igvn(ld);
     if (ld->is_DecodeN()) {
-      // Also record the actual load (LoadN) in case ld is DecodeN
+      // Also record the actual load (LoadN) in case ld is DecodeN. In some
+      // rare corner cases, ld->in(1) can be something other than LoadN (e.g.,
+      // a Phi). Recording such cases is still perfectly sound, but may be
+      // unnecessary and result in some minor IGVN overhead.
       record_for_igvn(ld->in(1));
     }
   }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1564,7 +1564,6 @@ Node* GraphKit::make_load(Node* ctl, Node* adr, const Type* t, BasicType bt,
     record_for_igvn(ld);
     if (ld->is_DecodeN()) {
       // Also record the actual load (LoadN) in case ld is DecodeN
-      assert(ld->in(1)->Opcode() == Op_LoadN, "Assumption invalid: input to DecodeN is not LoadN");
       record_for_igvn(ld->in(1));
     }
   }


### PR DESCRIPTION
### Issue Summary
The [`assert`](https://github.com/openjdk/jdk/blob/6f2676dc5f09d350c359f906b07f6f6d0d17f030/src/hotspot/share/opto/graphKit.cpp#L1567) added in [JDK-8310524](https://bugs.openjdk.org/browse/JDK-8310524) is too strong and may sometimes not hold due to the [GVN transformation in `LoadNode::make`](https://github.com/openjdk/jdk/blob/8cb9b479c529c058aee50f83920db650b0c18045/src/hotspot/share/opto/memnode.cpp#L973).

### Changeset
Remove the `assert`.

### Testing
N/A

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326438](https://bugs.openjdk.org/browse/JDK-8326438): C2: assert(ld-&gt;in(1)-&gt;Opcode() == Op_LoadN) failed: Assumption invalid: input to DecodeN is not LoadN (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [c74178e7](https://git.openjdk.org/jdk/pull/18434/files/c74178e7d192b257b78d84ffc97fb6f3de381eab)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18434/head:pull/18434` \
`$ git checkout pull/18434`

Update a local copy of the PR: \
`$ git checkout pull/18434` \
`$ git pull https://git.openjdk.org/jdk.git pull/18434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18434`

View PR using the GUI difftool: \
`$ git pr show -t 18434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18434.diff">https://git.openjdk.org/jdk/pull/18434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18434#issuecomment-2012679396)