### PR TITLE
8326960: GHA: RISC-V sysroot cannot be debootstrapped due to ongoing Debian t64 transition

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -61,27 +61,32 @@ jobs:
             debian-arch: arm64
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
+            tolerate-sysroot-errors: false
           - target-cpu: arm
             gnu-arch: arm
             debian-arch: armhf
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
+            tolerate-sysroot-errors: false
             gnu-abi: eabihf
           - target-cpu: s390x
             gnu-arch: s390x
             debian-arch: s390x
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
+            tolerate-sysroot-errors: false
           - target-cpu: ppc64le
             gnu-arch: powerpc64le
             debian-arch: ppc64el
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: bullseye
+            tolerate-sysroot-errors: false
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
             debian-repository: https://httpredir.debian.org/debian/
             debian-version: sid
+            tolerate-sysroot-errors: true
 
     steps:
       - name: 'Checkout the JDK source'
@@ -130,6 +135,7 @@ jobs:
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Create sysroot'
+        id: create-sysroot
         run: >
           sudo debootstrap
           --arch=${{ matrix.debian-arch }}
@@ -140,6 +146,7 @@ jobs:
           ${{ matrix.debian-version }}
           sysroot
           ${{ matrix.debian-repository }}
+        continue-on-error: ${{ matrix.tolerate-sysroot-errors }}
         if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Prepare sysroot'
@@ -151,7 +158,12 @@ jobs:
           rm -rf sysroot/usr/{sbin,bin,share}
           rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
           rm -rf sysroot/usr/libexec/gcc
-        if: steps.get-cached-sysroot.outputs.cache-hit != 'true'
+        if: steps.create-sysroot.outcome == 'success' && steps.get-cached-sysroot.outputs.cache-hit != 'true'
+
+      - name: 'Remove broken sysroot'
+        run: |
+          sudo rm -rf sysroot/
+        if: steps.create-sysroot.outcome != 'success' && steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Configure'
         run: >
@@ -173,6 +185,7 @@ jobs:
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
+        if: steps.create-sysroot.outcome == 'success'
 
       - name: 'Build'
         id: build
@@ -180,3 +193,4 @@ jobs:
         with:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
+        if: steps.create-sysroot.outcome == 'success'


### PR DESCRIPTION
Debian "unstable" is currently undergoing t64 (hello, Y2038) transition, which breaks "sid" repo that we use for debootstrapping RISC-V very often. This is seen across multiple repositories, and requires everyone to look through GHA failures all the time. This PR tries to fix this: if debootstrap for "sid" repos fails, the build for that arch would not continue. IMO, it is a better compromise for current situation. We will flip back to expecting the debootstrap to complete well after either t64 transition finishes, or we switch to more stable Debian repo once it graduates.

Additional testing:
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326960](https://bugs.openjdk.org/browse/JDK-8326960): GHA: RISC-V sysroot cannot be debootstrapped due to ongoing Debian t64 transition (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18435/head:pull/18435` \
`$ git checkout pull/18435`

Update a local copy of the PR: \
`$ git checkout pull/18435` \
`$ git pull https://git.openjdk.org/jdk.git pull/18435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18435`

View PR using the GUI difftool: \
`$ git pr show -t 18435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18435.diff">https://git.openjdk.org/jdk/pull/18435.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18435#issuecomment-2012994522)