### PR TITLE
8328555: hidpi problems for test java/awt/Dialog/DialogAnotherThread/JaWSTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -471,8 +471,9 @@ sun/java2d/DirectX/OnScreenRenderingResizeTest/OnScreenRenderingResizeTest.java 
 java/awt/Window/8159168/SetShapeTest.java 8274106 macosx-aarch64
 java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 macosx-aarch64
 
-# This test fails on macOS 14
+# These tests fail on macOS 14
 java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
+java/awt/Dialog/JaWSTest.java 8324782 macosx-all
 
 ############################################################################
 

--- a/test/jdk/java/awt/Dialog/JaWSTest.java
+++ b/test/jdk/java/awt/Dialog/JaWSTest.java
@@ -1,0 +1,139 @@
+/*
+  @test
+  @bug 4690465
+  @summary Tests that after dialog is hid on another EDT owning EDT gets notified.
+  @author dom@sparc.spb.su: area=awt.focus
+  @modules java.desktop/sun.awt
+  @key headful
+  @run applet JaWSTest.java
+*/
+
+/*
+  <applet code=JaWSTest.class width=10 height=10></applet>
+*/
+
+import java.awt.*;
+import java.awt.event.*;
+import sun.awt.SunToolkit;
+import sun.awt.AppContext;
+import java.applet.Applet;
+
+public class JaWSTest extends Applet implements ActionListener, Runnable {
+    static Frame frame;
+    static JaWSTest worker;
+    static Dialog dummyDialog;
+    static Object signalObject = new Object();
+    static AppContext appContextObject = null;
+    static Object exitLock = new Object();
+    Button button = null;
+    boolean dialogFinished = false;
+    public void init() {
+        worker = this;
+        frame = new Frame("Main User Frame");
+        button = new Button("Press To Save");
+        button.addActionListener(worker);
+        frame.add(button);
+        frame.pack();
+    }
+    public void start() {
+        frame.setVisible(true);
+        Robot robot = null;
+        try {
+            robot = new Robot();
+        } catch (Exception e) {
+            throw new RuntimeException("Can't create robot");
+        }
+        robot.delay(1000);
+        Point buttonLocation = button.getLocationOnScreen();
+        robot.mouseMove(buttonLocation.x, buttonLocation.y);
+        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.delay(10000);
+        if (!worker.dialogFinished) {
+            throw new RuntimeException("Dialog thread is blocked");
+        } else {
+            frame.dispose();
+        }
+//          synchronized(exitObject) {
+//              exitObject.wait();
+//          }
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        System.err.println("Action Performed");
+        synchronized (signalObject) {
+            ThreadGroup askUser = new ThreadGroup("askUser");
+            final Thread handler = new Thread(askUser, worker, "userDialog");
+
+            dummyDialog = new Dialog(frame, "Dummy Modal Dialog", true);
+            dummyDialog.setBounds(200, 200, 100, 100);
+            dummyDialog.addWindowListener(new WindowAdapter() {
+                    public void windowOpened(WindowEvent we) {
+                        System.err.println("handler is started");
+                        handler.start();
+                    }
+                    public void windowClosing(WindowEvent e) {
+                        dummyDialog.setVisible(false);
+                    }
+                });
+            dummyDialog.setResizable(false);
+            dummyDialog.toBack();
+            System.err.println("Before First Modal");
+            dummyDialog.setVisible(true);
+            System.err.println("After First Modal");
+            try {
+                signalObject.wait();
+            } catch (Exception e) {
+                e.printStackTrace();
+                dummyDialog.hide();
+            }
+            if (appContextObject != null) {
+                System.err.println("before");
+                appContextObject.dispose();
+                System.err.println("after");
+                appContextObject = null;
+            }
+            dummyDialog.dispose();
+        }
+        System.err.println("Show Something");
+        dialogFinished = true;
+//          synchronized(exitObject) {
+//              exitObject.notify();
+//          }
+    }
+
+    public void run() {
+        System.err.println("Running");
+        try {
+            appContextObject = SunToolkit.createNewAppContext();
+//              Frame localFrame = new Frame("Local Frame");
+//              final Dialog localDialog = new Dialog(localFrame, "Local Dialog", true);
+//              Button button = new Button("Press To Close");
+//              button.addActionListener(new ActionListener() {
+//                      public void actionPerformed(ActionEvent ae) {
+//                          System.err.println("Hiding");
+//                          localDialog.setVisible(false);
+//                      }
+//                  });
+//              localDialog.add(button);
+//              localDialog.pack();
+//              localDialog.setVisible(true);
+//              System.err.println("After Hiding");
+       } finally {
+           try {
+               Thread.sleep(1000);
+           } catch (InterruptedException ie) {
+               ie.printStackTrace();
+           }
+           System.err.println("Before Hiding 1");
+           dummyDialog.setVisible(false);
+           System.err.println("Before Synchronized");
+           synchronized (signalObject) {
+               System.err.println("In Synchronized");
+               signalObject.notify();
+               System.err.println("After Notify");
+           }
+        }
+        System.err.println("Stop Running");
+    }
+}


### PR DESCRIPTION
This previously closed test is cleaned up, opened and fixed to work on hidpi at fractional scales.
It has unrelated problems on macOS 14 and is problem listed there (as it was when it was a closed test).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328555](https://bugs.openjdk.org/browse/JDK-8328555): hidpi problems for test java/awt/Dialog/DialogAnotherThread/JaWSTest.java (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18438/head:pull/18438` \
`$ git checkout pull/18438`

Update a local copy of the PR: \
`$ git checkout pull/18438` \
`$ git pull https://git.openjdk.org/jdk.git pull/18438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18438`

View PR using the GUI difftool: \
`$ git pr show -t 18438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18438.diff">https://git.openjdk.org/jdk/pull/18438.diff</a>

</details>
