### PR TITLE
8328312: runtime/stack/Stack0*.java fails intermittently on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/stack/Stack011.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack011.java
@@ -36,7 +36,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -75,7 +75,7 @@ public class Stack011 extends Thread {
         Stack011 threads[] = new Stack011[THREADS];
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Stack011();
-            threads[i].depthToTry = 10 * maxDepth;
+            threads[i].depthToTry = 100 * maxDepth;
             threads[i].start();
         }
         for (int i = 0; i < threads.length; i++) {

--- a/test/hotspot/jtreg/runtime/stack/Stack012.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack012.java
@@ -36,7 +36,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -77,7 +77,7 @@ public class Stack012 extends Thread {
         Stack012 threads[] = new Stack012[THREADS];
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Stack012();
-            threads[i].depthToTry = 10 * maxDepth;
+            threads[i].depthToTry = 100 * maxDepth;
             threads[i].start();
         }
         for (int i = 0; i < threads.length; i++) {


### PR DESCRIPTION
The `runtime/stack/Stack011.java` and `runtime/stack/Stack012.java` tests intermittently fail on libgraal:
```
java.lang.Exception: TEST_RFE: no stack overflow thrown, need to try deeper recursion?
        at Stack012.run(Stack012.java:110)
java.lang.RuntimeException: Exception in the thread Thread[#22,Thread-2,5,]
        at Stack012.main(Stack012.java:98)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.Exception: TEST_RFE: no stack overflow thrown, need to try deeper recursion?
        at Stack012.run(Stack012.java:110)
```

Increasing the recursion as suggested in the error message above resolves the failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328312](https://bugs.openjdk.org/browse/JDK-8328312): runtime/stack/Stack0*.java fails intermittently on libgraal (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18441/head:pull/18441` \
`$ git checkout pull/18441`

Update a local copy of the PR: \
`$ git checkout pull/18441` \
`$ git pull https://git.openjdk.org/jdk.git pull/18441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18441`

View PR using the GUI difftool: \
`$ git pr show -t 18441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18441.diff">https://git.openjdk.org/jdk/pull/18441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18441#issuecomment-2013962814)