### PR TITLE
JDK-8328303: 3 JDI tests timed out with UT enabled

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
@@ -114,7 +114,7 @@ public class refType001 {
 
                     boolean isConnected = true;
                     boolean allEventsReceived = false;
-                    // handle events until debugee is disconnected
+                    // handle events until debuggee is disconnected
                     while (isConnected) {
                         EventSet eventSet = null;
                         try {
@@ -200,10 +200,12 @@ public class refType001 {
                                                    }
                                               }
 
-                                              // Check that all expected ClassPrepareEvent are received
+                                              // Check that all expected ClassPrepareEvent(s) are received.
                                               if (!allEventsReceived) {
                                                   allEventsReceived = true;
                                                   for (int i = 0; i < checkedTypes.length; i++) {
+                                                      // checkedTypes[i][2] is "0" initially,
+                                                      // "1" after corresponding ClassPrepareEvent is received.
                                                       if (checkedTypes[i][2] == "0") {
                                                           allEventsReceived = false;
                                                           break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
@@ -113,7 +113,7 @@ public class refType001 {
                 public void run() {
 
                     boolean isConnected = true;
-                    boolean eventsReceived = false;
+                    boolean allEventsReceived = false;
                     // handle events until debugee is disconnected
                     while (isConnected) {
                         EventSet eventSet = null;
@@ -201,14 +201,15 @@ public class refType001 {
                                               }
 
                                               // Check that all expected ClassPrepareEvent are received
-                                              if (!eventsReceived) {
-                                                  eventsReceived = true;
+                                              if (!allEventsReceived) {
+                                                  allEventsReceived = true;
                                                   for (int i = 0; i < checkedTypes.length; i++) {
                                                       if (checkedTypes[i][2] == "0") {
-                                                          eventsReceived = false;
+                                                          allEventsReceived = false;
+                                                          break;
                                                       }
                                                   }
-                                                  if (eventsReceived) {
+                                                  if (allEventsReceived) {
                                                       eventsReceivedLatch.countDown();
                                                   }
                                               }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/referenceType/refType001.java
@@ -273,7 +273,7 @@ public class refType001 {
             // wait for all expected events received or timeout exceeds
             try {
                 if (!eventsReceivedLatch.await(eventTimeout, TimeUnit.MILLISECONDS)) {
-                    log.complain("FAILURE 20: Timeout for waiting event was exceeded");
+                    log.complain("FAILURE 20: Timeout waiting for all events was exceeded");
                     testFailed = true;
                 }
             } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
@@ -297,7 +297,7 @@ public class thread001 {
             // wait for all expected events received or timeout exceeds
             try {
                 if (!eventsReceivedLatch.await(eventTimeout, TimeUnit.MILLISECONDS)) {
-                    log.complain("FAILURE 20: Timeout for waiting event was exceeded");
+                    log.complain("FAILURE 20: Timeout waiting for all events was exceeded");
                     testFailed = true;
                 }
             } catch (InterruptedException e) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
@@ -134,7 +134,7 @@ public class thread001 {
                 public void run() {
 
                     boolean isConnected = true;
-                    boolean eventsReceived = false;
+                    boolean allEventsReceived = false;
                     // handle events until debugee is disconnected
                     while (isConnected) {
                         EventSet eventSet = null;
@@ -231,15 +231,15 @@ public class thread001 {
                                           }
 
                                           // Check that all expected ClassPrepareEvent are received
-                                          if (!eventsReceived) {
-                                              eventsReceived = true;
+                                          if (!allEventsReceived) {
+                                              allEventsReceived = true;
                                               for (int i = 0; i < checkedThreads.length; i++) {
                                                   if (checkedThreads[i][2] == "0") {
-                                                      eventsReceived = false;
+                                                      allEventsReceived = false;
                                                       break;
                                                    }
                                               }
-                                              if (eventsReceived) {
+                                              if (allEventsReceived) {
                                                   eventsReceivedLatch.countDown();
                                               }
                                           }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 
 import java.io.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.Iterator;
 
 import nsk.share.*;
@@ -72,7 +74,8 @@ public class thread001 {
 
     static private int threadStatus;
 
-    static private volatile boolean testFailed, eventsReceived, threadsStarted;
+    static private volatile boolean testFailed;
+    static private CountDownLatch eventsReceivedLatch;
     static private int eventTimeout;
 
     public static void main (String args[]) {
@@ -83,8 +86,7 @@ public class thread001 {
         String command;
 
         testFailed = false;
-        eventsReceived = false;
-        threadsStarted = false;
+        eventsReceivedLatch = new CountDownLatch(1);
 
         argHandler = new ArgumentHandler(args);
         log = new Log(out, argHandler);
@@ -131,8 +133,10 @@ public class thread001 {
 
                 public void run() {
 
-                    // handle events until all threads started and all expected events received
-                    while (!(threadsStarted && eventsReceived)) {
+                    boolean isConnected = true;
+                    boolean eventsReceived = false;
+                    // handle events until debugee is disconnected
+                    while (isConnected) {
                         EventSet eventSet = null;
                         try {
                             eventSet = vm.eventQueue().remove(TIMEOUT_DELTA);
@@ -150,8 +154,10 @@ public class thread001 {
                             Event event = eventIterator.nextEvent();
 //                            log.display("\nEvent received:\n  " + event);
 
-                            // handle ClassPrepareEvent
-                            if (event instanceof ClassPrepareEvent) {
+                            if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+                                log.display("eventHandler got " + event);
+                                isConnected = false;
+                            } else  if (event instanceof ClassPrepareEvent) {
                                 ClassPrepareEvent castedEvent = (ClassPrepareEvent)event;
                                 log.display("\nClassPrepareEvent received:\n  " + event);
 
@@ -225,11 +231,17 @@ public class thread001 {
                                           }
 
                                           // Check that all expected ClassPrepareEvent are received
-                                          eventsReceived = true;
-                                          for (int i = 0; i < checkedThreads.length; i++) {
-                                               if (checkedThreads[i][2] == "0") {
-                                                    eventsReceived = false;
-                                               }
+                                          if (!eventsReceived) {
+                                              eventsReceived = true;
+                                              for (int i = 0; i < checkedThreads.length; i++) {
+                                                  if (checkedThreads[i][2] == "0") {
+                                                      eventsReceived = false;
+                                                      break;
+                                                   }
+                                              }
+                                              if (eventsReceived) {
+                                                  eventsReceivedLatch.countDown();
+                                              }
                                           }
                                      }
                                  }
@@ -240,7 +252,9 @@ public class thread001 {
                         } // event handled
 
 //                        log.display("Resuming event set");
-                        eventSet.resume();
+                        if (isConnected) {
+                            eventSet.resume();
+                        }
 
                     } // event set handled
 
@@ -280,17 +294,12 @@ public class thread001 {
                 testFailed = true;
             }
 
-            // notify EventHandler that all threads started
-            threadsStarted = true;
-
             // wait for all expected events received or timeout exceeds
             try {
-                  eventHandler.join(eventTimeout);
-                  if (eventHandler.isAlive()) {
-                      log.complain("FAILURE 20: Timeout for waiting event was exceeded");
-                      eventHandler.interrupt();
-                      testFailed = true;
-                  }
+                if (!eventsReceivedLatch.await(eventTimeout, TimeUnit.MILLISECONDS)) {
+                    log.complain("FAILURE 20: Timeout for waiting event was exceeded");
+                    testFailed = true;
+                }
             } catch (InterruptedException e) {
                   log.complain("TEST INCOMPLETE: InterruptedException caught while waiting for eventHandler's death");
                   testFailed = true;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ClassPrepareEvent/thread/thread001.java
@@ -135,7 +135,7 @@ public class thread001 {
 
                     boolean isConnected = true;
                     boolean allEventsReceived = false;
-                    // handle events until debugee is disconnected
+                    // handle events until debuggee is disconnected
                     while (isConnected) {
                         EventSet eventSet = null;
                         try {
@@ -230,10 +230,12 @@ public class thread001 {
                                                }
                                           }
 
-                                          // Check that all expected ClassPrepareEvent are received
+                                          // Check that all expected ClassPrepareEvent(s) are received.
                                           if (!allEventsReceived) {
                                               allEventsReceived = true;
                                               for (int i = 0; i < checkedThreads.length; i++) {
+                                                  // checkedTypes[i][2] is "0" initially,
+                                                  // "1" after corresponding ClassPrepareEvent is received.
                                                   if (checkedThreads[i][2] == "0") {
                                                       allEventsReceived = false;
                                                       break;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadDeathRequests/thrdeathreq001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadDeathRequests/thrdeathreq001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -168,8 +168,8 @@ public class thrdeathreq001 {
     }
 
     private int quitDebuggee() {
+        pipe.println(COMMAND_QUIT);
         if (elThread != null) {
-            elThread.isConnected = false;
             try {
                 if (elThread.isAlive())
                     elThread.join();
@@ -180,7 +180,6 @@ public class thrdeathreq001 {
             }
         }
 
-        pipe.println(COMMAND_QUIT);
         debuggee.waitFor();
         int debStat = debuggee.getStatus();
         if (debStat != (JCK_STATUS_BASE + PASSED)) {
@@ -195,30 +194,24 @@ public class thrdeathreq001 {
     }
 
     class EventListener extends Thread {
-        public volatile boolean isConnected = true;
 
         public void run() {
             try {
+                boolean isConnected = true;
                 do {
                     EventSet eventSet = vm.eventQueue().remove(1000);
                     if (eventSet != null) { // there is not a timeout
                         EventIterator it = eventSet.eventIterator();
                         while (it.hasNext()) {
                             Event event = it.nextEvent();
-                            if (event instanceof VMDeathEvent) {
-                                tot_res = FAILED;
+                            if (event instanceof VMDeathEvent || event instanceof VMDisconnectEvent) {
+                                log.display("EventListener: got " + event);
                                 isConnected = false;
-                                log.complain("TEST FAILED: unexpected VMDeathEvent");
-                            } else if (event instanceof VMDisconnectEvent) {
-                                tot_res = FAILED;
-                                isConnected = false;
-                                log.complain("TEST FAILED: unexpected VMDisconnectEvent");
-                            } else
+                            } else {
                                 log.display("EventListener: following JDI event occured: "
                                     + event.toString());
-                        }
-                        if (isConnected) {
-                            eventSet.resume();
+                                eventSet.resume();
+                            }
                         }
                     }
                 } while (isConnected);


### PR DESCRIPTION
The change fixes 3 nsk JDI tests.
Root cause in all 3 tests is the same - the tests requests JDI event with SUSPEND_ALL policy, but event handler thread stops handle incoming event and this causes debuggee to hang (suspended by JDI event).

All 3 tests are updated to exit event handler thread after getting VMDeathEvent or VMDisconnectEvent (and resume debuggee after any other events).
ClassPrepareEvent tests need to wait some time to allow handle all expected events before terminate the debuggee. The logic was implemented by using CountDownLatch.

All tests are passed with "--test-repeat 20"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328303](https://bugs.openjdk.org/browse/JDK-8328303): 3 JDI tests timed out with UT enabled (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [a30e3b70](https://git.openjdk.org/jdk/pull/18442/files/a30e3b70c98cabc3315fd6ee9c6ef9ea3fcc07fd)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [a30e3b70](https://git.openjdk.org/jdk/pull/18442/files/a30e3b70c98cabc3315fd6ee9c6ef9ea3fcc07fd)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [a30e3b70](https://git.openjdk.org/jdk/pull/18442/files/a30e3b70c98cabc3315fd6ee9c6ef9ea3fcc07fd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18442/head:pull/18442` \
`$ git checkout pull/18442`

Update a local copy of the PR: \
`$ git checkout pull/18442` \
`$ git pull https://git.openjdk.org/jdk.git pull/18442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18442`

View PR using the GUI difftool: \
`$ git pr show -t 18442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18442.diff">https://git.openjdk.org/jdk/pull/18442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18442#issuecomment-2013963820)