### PR TITLE
8328758: GetCurrentContendedMonitor function should use JvmtiHandshake

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2498,6 +2498,16 @@ GetCurrentContendedMonitorClosure::do_thread(Thread *target) {
 }
 
 void
+GetCurrentContendedMonitorClosure::do_vthread(Handle target_h) {
+  if (_target_jt == nullptr) {
+    _result = JVMTI_ERROR_NONE; // target virtual thread is unmounted
+    return;
+  }
+  // mounted virtual thread case
+  do_thread(_target_jt);
+}
+
+void
 GetStackTraceClosure::do_thread(Thread *target) {
   Thread* current = Thread::current();
   ResourceMark rm(current);

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -593,21 +593,22 @@ public:
 };
 
 // HandshakeClosure to get current contended monitor. It is used for both platform and virtual threads.
-class GetCurrentContendedMonitorClosure : public JvmtiHandshakeClosure {
+class GetCurrentContendedMonitorClosure : public JvmtiUnitedHandshakeClosure {
 private:
-  JavaThread *_calling_thread;
   JvmtiEnv *_env;
+  JavaThread *_calling_thread;
   jobject *_owned_monitor_ptr;
-  bool _is_virtual;
 
 public:
-  GetCurrentContendedMonitorClosure(JavaThread* calling_thread, JvmtiEnv *env, jobject *mon_ptr, bool is_virtual)
-    : JvmtiHandshakeClosure("GetCurrentContendedMonitor"),
-      _calling_thread(calling_thread),
+  GetCurrentContendedMonitorClosure(JvmtiEnv *env,
+                                    JavaThread* calling_thread,
+                                    jobject *owned_monitor_ptr)
+    : JvmtiUnitedHandshakeClosure("GetCurrentContendedMonitor"),
       _env(env),
-      _owned_monitor_ptr(mon_ptr),
-      _is_virtual(is_virtual) {}
+      _calling_thread(calling_thread),
+      _owned_monitor_ptr(owned_monitor_ptr) {}
   void do_thread(Thread *target);
+  void do_vthread(Handle target_h);
 };
 
 // HandshakeClosure to get stack trace.


### PR DESCRIPTION
The internal JVM TI `JvmtiHandshake` and `JvmtiUnitedHandshakeClosure` classes were introduced in the JDK 22 to unify/simplify the JVM TI functions supporting implementation of the virtual threads. This enhancement is to refactor JVM TI `GetCurrentContendedMonitor` function on the base of `JvmtiHandshake` and `JvmtiUnitedHandshakeClosure` classes.

Testing:
 - Ran mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328758](https://bugs.openjdk.org/browse/JDK-8328758): GetCurrentContendedMonitor function should use JvmtiHandshake (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18444/head:pull/18444` \
`$ git checkout pull/18444`

Update a local copy of the PR: \
`$ git checkout pull/18444` \
`$ git pull https://git.openjdk.org/jdk.git pull/18444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18444`

View PR using the GUI difftool: \
`$ git pr show -t 18444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18444.diff">https://git.openjdk.org/jdk/pull/18444.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18444#issuecomment-2014225250)