### PR TITLE
8328627: JShell documentation should be clearer about "remote runtime system"

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -218,20 +218,19 @@ where possible options include:\n\
 \    -q                    Quiet feedback.  Same as: --feedback concise\n\
 \    -s                    Really quiet feedback.  Same as: --feedback silent\n\
 \    -v                    Verbose feedback.  Same as: --feedback verbose\n\
-\    -J<flag>              Pass <flag> directly to the runtime system.\n\
-\                            Use one -J for each runtime flag or flag argument\n\
-\                            Note: this will pass the flag to the main JShell\n\
-\                            runtime system, which is typically distinct from\n\
-\                            the runtime system that runs the JShell code snippets.\n\
-\                            To affect the runtime system running the JShell code\n\
-\                            snippets, use -R<flag>. Alternativelly, run the\n\
-\                            code snippets in the same runtime system as JShell\n\
-\                            using: --execution local\n\
-\    -R<flag>              Pass <flag> to the remote runtime system.\n\
-\                            This remote system is by default used to run JShell\n\
-\                            code snippets.\n\
-\                            Use one -R for each remote flag or flag argument\n\
-\    -C<flag>              Pass <flag> to the compiler.\n\
+\    -J<flag>              passes <flag> to the runtime system, but has no effect\n\
+\                            on the execution of code snippets. To specify options\n\
+\                            that affect the execution of code snippets, use\n\
+\                            -R<flag>. Alternatively, use -J<flag> with\n\
+\                            --execution local.\n\
+\    -R<flag>              passes <flag> to the runtime system only when code\n\
+\                            snippets are executed. For example, -R-Dfoo=bar\n\
+\                            means that execution of the snippet\n\
+\                            System.getProperty("foo") will return "bar".\n\
+\    -C<flag>              passes <flag> to the Java compiler inside JShell.\n\
+\                            For example, -C-Xlint enables all the recommended\n\
+\                            lint warnings, and -C--release=<N> has the effect\n\
+\                            of passing `--release=N`.\n\
 \                            Use one -C for each compiler flag or flag argument\n\
 \    --version             Print version information and exit\n\
 \    --show-version        Print version information and continue\n\

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -220,7 +220,16 @@ where possible options include:\n\
 \    -v                    Verbose feedback.  Same as: --feedback verbose\n\
 \    -J<flag>              Pass <flag> directly to the runtime system.\n\
 \                            Use one -J for each runtime flag or flag argument\n\
+\                            Note: this will pass the flag to the main JShell\n\
+\                            runtime system, which is typically distinct from\n\
+\                            the runtime system that runs the JShell code snippets.\n\
+\                            To affect the runtime system running the JShell code\n\
+\                            snippets, use -R<flag>. Alternativelly, run the\n\
+\                            code snippets in the same runtime system as JShell\n\
+\                            using: --execution local\n\
 \    -R<flag>              Pass <flag> to the remote runtime system.\n\
+\                            This remote system is by default used to run JShell\n\
+\                            code snippets.\n\
 \                            Use one -R for each remote flag or flag argument\n\
 \    -C<flag>              Pass <flag> to the compiler.\n\
 \                            Use one -C for each compiler flag or flag argument\n\

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/resources/l10n.properties
@@ -219,7 +219,7 @@ where possible options include:\n\
 \    -s                    Really quiet feedback.  Same as: --feedback silent\n\
 \    -v                    Verbose feedback.  Same as: --feedback verbose\n\
 \    -J<flag>              passes <flag> to the runtime system, but has no effect\n\
-\                            on the execution of code snippets. To specify options\n\
+\                            on the execution of code snippets. To specify flags\n\
 \                            that affect the execution of code snippets, use\n\
 \                            -R<flag>. Alternatively, use -J<flag> with\n\
 \                            --execution local.\n\
@@ -229,8 +229,8 @@ where possible options include:\n\
 \                            System.getProperty("foo") will return "bar".\n\
 \    -C<flag>              passes <flag> to the Java compiler inside JShell.\n\
 \                            For example, -C-Xlint enables all the recommended\n\
-\                            lint warnings, and -C--release=<N> has the effect\n\
-\                            of passing `--release=N`.\n\
+\                            lint warnings, and -C--release=<N> compiles for\n\
+\                            Java SE N, as if --release N was specified.\n\
 \                            Use one -C for each compiler flag or flag argument\n\
 \    --version             Print version information and exit\n\
 \    --show-version        Print version information and continue\n\

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -122,9 +122,10 @@ module.
 Specifies the root modules to resolve in addition to the initial module.
 .TP
 \f[V]-C\f[R]\f[I]flag\f[R]
-Provides a flag to pass to the compiler.
-To pass more than one flag, provide an instance of this option for each
-flag or flag argument needed.
+passes \f[I]flag\f[R] to the Java compiler inside JShell.
+For example, \f[V]-C-Xlint\f[R] enables all the recommended lint
+warnings, and \f[V]-C--release=N\f[R] has the effect of passing
+\f[V]--release=N\f[R].
 .TP
 \f[V]--class-path\f[R] \f[I]path\f[R]
 Specifies the directories and archives that are searched to locate class
@@ -187,16 +188,12 @@ Prints a summary of nonstandard options and exits the tool.
 Nonstandard options are subject to change without notice.
 .TP
 \f[V]-J\f[R]\f[I]flag\f[R]
-Provides a flag to pass to the runtime system.
-To pass more than one flag, provide an instance of this option for each
-flag or flag argument needed.
-\f[I]Note:\f[R] this will pass the flag to the main JShell runtime
-system, which is typically distinct from the runtime system that runs
-the JShell code snippets.
-To affect the runtime system running the JShell code snippets, use
-\f[V]-R*flag*\f[R].
-Alternativelly, run the code snippets in the same runtime system as
-JShell using \f[V]--execution local\f[R].
+passes \f[I]flag\f[R] to the runtime system, but has no effect on the
+execution of code snippets.
+To specify options that affect the execution of code snippets, use
+\f[V]-R\f[R]\f[I]flag\f[R].
+Alternatively, use \f[V]-J\f[R]\f[I]flag\f[R] with
+\f[V]--execution local\f[R].
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]
 Specifies where to find application modules.
@@ -215,10 +212,11 @@ Sets the feedback mode to \f[V]concise\f[R], which is the same as
 entering \f[V]--feedback concise\f[R].
 .TP
 \f[V]-R\f[R]\f[I]flag\f[R]
-Provides a flag to pass to the remote runtime system.
-This remote system is by default used to run JShell code snippets.
-To pass more than one flag, provide an instance of this option for each
-flag or flag argument to pass.
+passes \f[I]flag\f[R] to the runtime system only when code snippets are
+executed.
+For example, \f[V]-R-Dfoo=bar\f[R] means that execution of the snippet
+\f[V]System.getProperty(\[dq]foo\[dq])\f[R] will return
+\f[V]\[dq]bar\[dq]\f[R].
 .TP
 \f[V]-s\f[R]
 Sets the feedback mode to \f[V]silent\f[R], which is the same as

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -190,6 +190,13 @@ Nonstandard options are subject to change without notice.
 Provides a flag to pass to the runtime system.
 To pass more than one flag, provide an instance of this option for each
 flag or flag argument needed.
+\f[I]Note:\f[R] this will pass the flag to the main JShell runtime
+system, which is typically distinct from the runtime system that runs
+the JShell code snippets.
+To affect the runtime system running the JShell code snippets, use
+\f[V]-R*flag*\f[R].
+Alternativelly, run the code snippets in the same runtime system as
+JShell using \f[V]--execution local\f[R].
 .TP
 \f[V]--module-path\f[R] \f[I]modulepath\f[R]
 Specifies where to find application modules.
@@ -209,6 +216,7 @@ entering \f[V]--feedback concise\f[R].
 .TP
 \f[V]-R\f[R]\f[I]flag\f[R]
 Provides a flag to pass to the remote runtime system.
+This remote system is by default used to run JShell code snippets.
 To pass more than one flag, provide an instance of this option for each
 flag or flag argument to pass.
 .TP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -124,8 +124,8 @@ Specifies the root modules to resolve in addition to the initial module.
 \f[V]-C\f[R]\f[I]flag\f[R]
 passes \f[I]flag\f[R] to the Java compiler inside JShell.
 For example, \f[V]-C-Xlint\f[R] enables all the recommended lint
-warnings, and \f[V]-C--release=N\f[R] has the effect of passing
-\f[V]--release=N\f[R].
+warnings, and \f[V]-C--release=<N>\f[R] compiles for Java SE N, as if
+--release N was specified.
 .TP
 \f[V]--class-path\f[R] \f[I]path\f[R]
 Specifies the directories and archives that are searched to locate class
@@ -190,7 +190,7 @@ Nonstandard options are subject to change without notice.
 \f[V]-J\f[R]\f[I]flag\f[R]
 passes \f[I]flag\f[R] to the runtime system, but has no effect on the
 execution of code snippets.
-To specify options that affect the execution of code snippets, use
+To specify flags that affect the execution of code snippets, use
 \f[V]-R\f[R]\f[I]flag\f[R].
 Alternatively, use \f[V]-J\f[R]\f[I]flag\f[R] with
 \f[V]--execution local\f[R].


### PR DESCRIPTION
This change attempts to more clearly explain the difference between `-J` and `-R` for JShell.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328627](https://bugs.openjdk.org/browse/JDK-8328627): JShell documentation should be clearer about "remote runtime system" (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Contributors
 * Alex Buckley `<abuckley@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18450/head:pull/18450` \
`$ git checkout pull/18450`

Update a local copy of the PR: \
`$ git checkout pull/18450` \
`$ git pull https://git.openjdk.org/jdk.git pull/18450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18450`

View PR using the GUI difftool: \
`$ git pr show -t 18450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18450.diff">https://git.openjdk.org/jdk/pull/18450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18450#issuecomment-2014875789)