### PR TITLE
8328779: ZGC: XMark::follow_object does not need to invoke ContinuationGCSupport::relativize_stack_chunk

### DIFF
--- a/src/hotspot/share/gc/x/xMark.cpp
+++ b/src/hotspot/share/gc/x/xMark.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,15 +287,10 @@ void XMark::follow_array_object(objArrayOop obj, bool finalizable) {
 }
 
 void XMark::follow_object(oop obj, bool finalizable) {
-  if (ContinuationGCSupport::relativize_stack_chunk(obj)) {
-    // Loom doesn't support mixing of finalizable marking and strong marking of
-    // stack chunks. See: RelativizeDerivedOopClosure.
+  if (obj->is_stackChunk()) {
     XMarkBarrierOopClosure<false /* finalizable */> cl;
     obj->oop_iterate(&cl);
-    return;
-  }
-
-  if (finalizable) {
+  } else if (finalizable) {
     XMarkBarrierOopClosure<true /* finalizable */> cl;
     obj->oop_iterate(&cl);
   } else {


### PR DESCRIPTION
Hi all, 

`XMark::follow_object` unnecessarily invokes `ContinuationGCSupport::relativize_stack_chunk`. This patch changes it to `oopDesc::is_stackChunk` instead, just like `ZMark::follow_object`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328779](https://bugs.openjdk.org/browse/JDK-8328779): ZGC: XMark::follow_object does not need to invoke ContinuationGCSupport::relativize_stack_chunk (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18452/head:pull/18452` \
`$ git checkout pull/18452`

Update a local copy of the PR: \
`$ git checkout pull/18452` \
`$ git pull https://git.openjdk.org/jdk.git pull/18452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18452`

View PR using the GUI difftool: \
`$ git pr show -t 18452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18452.diff">https://git.openjdk.org/jdk/pull/18452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18452#issuecomment-2015094528)