### PR TITLE
8328612: AdaptiveSizePolicySpaceOverheadTester::is_exceeded() print max_eden_size twice

### DIFF
--- a/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/shared/adaptiveSizePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -338,12 +338,11 @@ class AdaptiveSizePolicySpaceOverheadTester: public GCOverheadTester {
     log_trace(gc, ergo)(
           "AdaptiveSizePolicySpaceOverheadTester::is_exceeded:"
           " promo_limit: " SIZE_FORMAT
-          " max_eden_size: " SIZE_FORMAT
           " total_free_limit: " SIZE_FORMAT
           " max_old_gen_size: " SIZE_FORMAT
           " max_eden_size: " SIZE_FORMAT
           " mem_free_limit: " SIZE_FORMAT,
-          promo_limit, _max_eden_size, total_free_limit,
+          promo_limit, total_free_limit,
           _max_old_gen_size, _max_eden_size,
           (size_t)mem_free_limit);
 


### PR DESCRIPTION
A trivial cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328612](https://bugs.openjdk.org/browse/JDK-8328612): AdaptiveSizePolicySpaceOverheadTester::is_exceeded() print max_eden_size twice (**Bug** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18453/head:pull/18453` \
`$ git checkout pull/18453`

Update a local copy of the PR: \
`$ git checkout pull/18453` \
`$ git pull https://git.openjdk.org/jdk.git pull/18453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18453`

View PR using the GUI difftool: \
`$ git pr show -t 18453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18453.diff">https://git.openjdk.org/jdk/pull/18453.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18453#issuecomment-2015104553)