### PR TITLE
8328858: More runtime/stack tests fail intermittently on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/stack/Stack003.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack003.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 100 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is twice that depth just measured).
+ *     of invocations (which is 200 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes all HS versions (2.0, 1.3, 1.4) on all
@@ -67,7 +67,7 @@ public class Stack003 {
         System.out.println("Max. depth: " + depth);
         for (int i = 0; i < ITERATIONS; i++) {
             try {
-                recurse(2 * depth);
+                recurse(200 * depth);
                 System.out.println("?");
             } catch (StackOverflowError | OutOfMemoryError err) {
                 // OK.

--- a/test/hotspot/jtreg/runtime/stack/Stack004.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack004.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 100 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is twice that depth just measured).
+ *     of invocations (which is 200 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes all HS versions (2.0, 1.3, 1.4) on all
@@ -68,7 +68,7 @@ public class Stack004 {
         System.out.println("Max. depth: " + depth);
         for (int i = 0; i < 100; i++) {
             try {
-                recurse(2 * depth);
+                recurse(200 * depth);
                 System.out.println("?");
             } catch (StackOverflowError | OutOfMemoryError err) {
                 // OK.

--- a/test/hotspot/jtreg/runtime/stack/Stack005.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack005.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 100 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is twice that depth just measured).
+ *     of invocations (which is 200 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes all HS versions (2.0, 1.3, 1.4) on all
@@ -64,7 +64,7 @@ public class Stack005 {
         System.out.println("Max. depth: " + depth);
         for (int i = 0; i < 100; i++) {
             try {
-                test.recurse(2 * depth);
+                test.recurse(200 * depth);
                 System.out.println("?");
             } catch (StackOverflowError | OutOfMemoryError err) {
                 // OK.

--- a/test/hotspot/jtreg/runtime/stack/Stack006.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack006.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 100 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is twice that depth just measured).
+ *     of invocations (which is 200 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes all HS versions (2.0, 1.3, 1.4) on all
@@ -64,7 +64,7 @@ public class Stack006 implements Stack006i {
         System.out.println("Max. depth: " + depth);
         for (int i = 0; i < 100; i++) {
             try {
-                test.recurse(2 * depth);
+                test.recurse(200 * depth);
                 System.out.println("?");
             } catch (StackOverflowError | OutOfMemoryError err) {
                 // OK.

--- a/test/hotspot/jtreg/runtime/stack/Stack007.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack007.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 10000 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is 10 times that depth just measured).
+ *     of invocations (which is 100 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes HS versions 1.3 and 1.4 on Win32, Solaris,
@@ -66,7 +66,7 @@ public class Stack007 implements Stack007i {
         System.out.println("Max. depth: " + depth);
         for (int i = 0; i < ITERATIONS; i++) {
             try {
-                test.recurse(10 * depth);
+                test.recurse(100 * depth);
                 System.out.println("?");
             } catch (StackOverflowError | OutOfMemoryError err) {
                 // OK.

--- a/test/hotspot/jtreg/runtime/stack/Stack008.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack008.java
@@ -36,7 +36,7 @@
  *     before 1st StackOverflowError, and then tries to reproduce
  *     such StackOverflowError 100 times -- each time by trying to
  *     invoke the same recursive method for the given fixed depth
- *     of invocations (which is twice that depth just measured).
+ *     of invocations (which is 200 times that depth just measured).
  *     The test is deemed passed, if VM have not crashed.
  * COMMENTS
  *     This test crashes all HS versions (2.0, 1.3, 1.4) on Solaris,
@@ -78,7 +78,7 @@ public class Stack008 {
         //
         for (int i = 0; i < 100; i++) {
             try {
-                invokeRecurse(2 * depth);
+                invokeRecurse(200 * depth);
 //              System.out.println("?");
             } catch (Throwable exception) {
                 Throwable target = getTargetException(exception);

--- a/test/hotspot/jtreg/runtime/stack/Stack009.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack009.java
@@ -35,7 +35,7 @@
  *     StackOverflowError, and then tries to make an invocation
  *     for the fixed invocations depth from within the "catch"
  *     block just caught the 1st stack overflow. The depth of new
- *     invocations is 10 times that depth seen at the 1st stack
+ *     invocations is 100 times that depth seen at the 1st stack
  *     overflow; so that another stack overflow occurs.
  *     The test is deemed passed, if VM have not crashed, and
  *     if there is no exception thrown other than due to stack
@@ -60,7 +60,7 @@ public class Stack009 {
                 System.out.println("Max. depth: " + depth);
 
                 try {
-                    recurse(10 * depth);
+                    recurse(100 * depth);
                     System.out.println("?");
                 } catch (StackOverflowError | OutOfMemoryError error2) {
                     // ignore

--- a/test/hotspot/jtreg/runtime/stack/Stack010.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack010.java
@@ -36,7 +36,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.

--- a/test/hotspot/jtreg/runtime/stack/Stack013.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack013.java
@@ -36,7 +36,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -76,7 +76,7 @@ public class Stack013 extends Stack013i {
         Stack013i threads[] = new Stack013i[THREADS];
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Stack013();
-            threads[i].depthToTry = 10 * maxDepth;
+            threads[i].depthToTry = 100 * maxDepth;
             threads[i].cycles = CYCLES;
             threads[i].start();
         }

--- a/test/hotspot/jtreg/runtime/stack/Stack014.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack014.java
@@ -39,7 +39,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -79,7 +79,7 @@ public class Stack014 extends Stack014i {
         Stack014i threads[] = new Stack014i[THREADS];
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Stack014();
-            threads[i].depthToTry = 10 * maxDepth;
+            threads[i].depthToTry = 100 * maxDepth;
             threads[i].cycles = CYCLES;
             threads[i].start();
         }

--- a/test/hotspot/jtreg/runtime/stack/Stack015.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack015.java
@@ -37,7 +37,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     in 10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before.
+ *     of invocations which is 100 times that depth measured before.
  *     The test is deemed passed, if VM have not crashed, and
  *     if exception other than due to stack overflow was not
  *     thrown.
@@ -55,7 +55,7 @@ public class Stack015 extends Stack015i {
     final static int THREADS = 10;
     final static int CYCLES = 10;
     final static int STEP = 10;
-    final static int RESERVE = 10;
+    final static int RESERVE = 100;
 
     public static void main(String[] args) {
         //

--- a/test/hotspot/jtreg/runtime/stack/Stack016.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack016.java
@@ -36,7 +36,7 @@
  *     stack overflow, and then tries to provoke similar stack overflows
  *     in 10 times in each of 10 threads. Each provocation consists of
  *     invoking that recursive method for the given fixed depth
- *     of invocations which is 10 times that depth measured before,
+ *     of invocations which is 100 times that depth measured before,
  *     and then trying to invoke that recursive method once again
  *     from within the catch clause just caught StackOverflowError.
  *     The test is deemed passed, if VM have not crashed, and
@@ -58,7 +58,7 @@ public class Stack016 extends Thread {
     private final static int THREADS = 10;
     private final static int CYCLES = 10;
     private final static int STEP = 10;
-    private final static int RESERVE = 10;
+    private final static int RESERVE = 100;
     private final static int PROBES = STEP * RESERVE;
 
     public static void main(String[] args) {


### PR DESCRIPTION
While [JDK-8328312](https://bugs.openjdk.org/browse/JDK-8328312) fixed libgraal failures on `runtime/stack/Stack011.java` and `runtime/stack/Stack012.java`, other `runtime/stack/Stack0*` tests still fail:
```
java.lang.Exception: TEST_RFE: no stack overflow thrown, need to try deeper recursion?
        at Stack013i.run(Stack013.java:127)
        at Stack013.run(Stack013.java:53)
java.lang.RuntimeException: Exception in the thread Thread[#22,Thread-2,5,]
        at Stack013.main(Stack013.java:98)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.lang.Exception: TEST_RFE: no stack overflow thrown, need to try deeper recursion?
        at Stack013i.run(Stack013.java:127)
        at Stack013.run(Stack013.java:53)
```

This PR mitigates such failures by bumping `depthToTry` by at least an order of magnitude.

The right long term fix for these tests is probably [JDK-8328859](https://bugs.openjdk.org/browse/JDK-8328859).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328858](https://bugs.openjdk.org/browse/JDK-8328858): More runtime/stack tests fail intermittently on libgraal (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18465/head:pull/18465` \
`$ git checkout pull/18465`

Update a local copy of the PR: \
`$ git checkout pull/18465` \
`$ git pull https://git.openjdk.org/jdk.git pull/18465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18465`

View PR using the GUI difftool: \
`$ git pr show -t 18465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18465.diff">https://git.openjdk.org/jdk/pull/18465.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18465#issuecomment-2016771045)