### PR TITLE
8328862: Remove unused GrowableArrayFilterIterator

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,7 +102,6 @@ public:
 };
 
 template <typename E> class GrowableArrayIterator;
-template <typename E, typename UnaryPredicate> class GrowableArrayFilterIterator;
 
 // Extends GrowableArrayBase with a typed data array.
 //
@@ -841,7 +840,6 @@ public:
 template <typename E>
 class GrowableArrayIterator : public StackObj {
   friend class GrowableArrayView<E>;
-  template <typename F, typename UnaryPredicate> friend class GrowableArrayFilterIterator;
 
  private:
   const GrowableArrayView<E>* _array; // GrowableArray we iterate over
@@ -863,56 +861,6 @@ class GrowableArrayIterator : public StackObj {
   }
 
   bool operator!=(const GrowableArrayIterator<E>& rhs)  {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position != rhs._position;
-  }
-};
-
-// Custom STL-style iterator to iterate over elements of a GrowableArray that satisfy a given predicate
-template <typename E, class UnaryPredicate>
-class GrowableArrayFilterIterator : public StackObj {
-  friend class GrowableArrayView<E>;
-
- private:
-  const GrowableArrayView<E>* _array; // GrowableArray we iterate over
-  int _position;                      // Current position in the GrowableArray
-  UnaryPredicate _predicate;          // Unary predicate the elements of the GrowableArray should satisfy
-
- public:
-  GrowableArrayFilterIterator(const GrowableArrayIterator<E>& begin, UnaryPredicate filter_predicate) :
-      _array(begin._array), _position(begin._position), _predicate(filter_predicate) {
-    // Advance to first element satisfying the predicate
-    while(_position != _array->length() && !_predicate(_array->at(_position))) {
-      ++_position;
-    }
-  }
-
-  GrowableArrayFilterIterator<E, UnaryPredicate>& operator++() {
-    do {
-      // Advance to next element satisfying the predicate
-      ++_position;
-    } while(_position != _array->length() && !_predicate(_array->at(_position)));
-    return *this;
-  }
-
-  E operator*() { return _array->at(_position); }
-
-  bool operator==(const GrowableArrayIterator<E>& rhs)  {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position == rhs._position;
-  }
-
-  bool operator!=(const GrowableArrayIterator<E>& rhs)  {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position != rhs._position;
-  }
-
-  bool operator==(const GrowableArrayFilterIterator<E, UnaryPredicate>& rhs)  {
-    assert(_array == rhs._array, "iterator belongs to different array");
-    return _position == rhs._position;
-  }
-
-  bool operator!=(const GrowableArrayFilterIterator<E, UnaryPredicate>& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position != rhs._position;
   }


### PR DESCRIPTION
Please review this trivial removal of the unused GrowableArrayFilterIterator
class template.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328862](https://bugs.openjdk.org/browse/JDK-8328862): Remove unused GrowableArrayFilterIterator (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18466/head:pull/18466` \
`$ git checkout pull/18466`

Update a local copy of the PR: \
`$ git checkout pull/18466` \
`$ git pull https://git.openjdk.org/jdk.git pull/18466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18466`

View PR using the GUI difftool: \
`$ git pr show -t 18466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18466.diff">https://git.openjdk.org/jdk/pull/18466.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18466#issuecomment-2017012101)