### PR TITLE
8328619: sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java failed with BindException: Address already in use

### DIFF
--- a/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,8 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Change file permission for out-of-the-box management an do test used by
- * PasswordFilePermissionTest and SSLConfigFilePermissionTest tests
+ * Change file permission for out-of-the-box management, and test.
+ * Used by PasswordFilePermissionTest and SSLConfigFilePermissionTest tests.
  *
  * @author Taras Ledkov
  */
@@ -141,12 +141,13 @@ public abstract class AbstractFilePermissionTest {
         Files.setPosixFilePermissions(file2PermissionTest, perms_0700);
 
         if (doTest() != 0) {
+            System.out.println("FAILURE");
             ++failures;
         }
     }
 
     /**
-     * Test 1 - SSL config file is secure - VM should start
+     * Test 2 - SSL config file is NOT secure - VM should not start
      */
     private void test2() throws Exception {
         final Set<PosixFilePermission> perms = Files.getPosixFilePermissions(file2PermissionTest);
@@ -155,6 +156,7 @@ public abstract class AbstractFilePermissionTest {
         Files.setPosixFilePermissions(file2PermissionTest, perms);
 
         if (doTest() == 0) {
+            System.out.println("FAILURE");
             ++failures;
         }
     }
@@ -172,7 +174,6 @@ public abstract class AbstractFilePermissionTest {
             command.add(TEST_CLASSES);
             command.add(className);
 
-
             ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(command);
 
             System.out.println("test cmdline: " + Arrays.toString(processBuilder.command().toArray()).replace(",", ""));
@@ -181,13 +182,15 @@ public abstract class AbstractFilePermissionTest {
             System.out.println("test output:");
             System.out.println(output.getOutput());
 
-            if ((output.getExitValue() == 0)  ||
-                !output.getOutput().contains("Exception thrown by the agent : " +
-                        "java.rmi.server.ExportException: Port already in use")) {
-                return output.getExitValue();
+            if (output.getOutput().contains("Exception thrown by the agent: java.rmi.server.ExportException: Port already in use")) {
+                if (i < MAX_GET_FREE_PORT_TRIES - 1) {
+                    System.out.println("Retrying...");
+                    continue;
+                }
             }
+            // Fail on too many port failures, and all other startup failures.
+            return output.getExitValue();
         }
-
         return -1;
     }
 

--- a/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/AbstractFilePermissionTest.java
@@ -140,8 +140,9 @@ public abstract class AbstractFilePermissionTest {
         perms_0700.add(PosixFilePermission.OWNER_EXECUTE);
         Files.setPosixFilePermissions(file2PermissionTest, perms_0700);
 
-        if (doTest() != 0) {
-            System.out.println("FAILURE");
+        int e = doTest();
+        if (e != 0) {
+            System.out.println("FAILURE: expected exit code 0, got: " + e);
             ++failures;
         }
     }
@@ -155,8 +156,9 @@ public abstract class AbstractFilePermissionTest {
         perms.add(PosixFilePermission.OTHERS_EXECUTE);
         Files.setPosixFilePermissions(file2PermissionTest, perms);
 
-        if (doTest() == 0) {
-            System.out.println("FAILURE");
+        int e = doTest();
+        if (e == 0) {
+            System.out.println("FAILURE: expected exit code non-zero, got: " + e);
             ++failures;
         }
     }


### PR DESCRIPTION
Test uses  jdk.test.lib.Utils.getFreePort() when launching a new Java command.
Looks like it already recognises "java.rmi.server.ExportException: Port already in use: " and retries, but there is a long-standing typo in the check.

e.g. 

test output:
Error: Exception thrown by the agent: java.rmi.server.ExportException: Port already in use: 37049; nested exception is: 
	java.net.BindException: Address already in use
	
Test checks for:
        !output.getOutput().contains("Exception thrown by the agent : java.rmi.server.ExportException: Port already in use")
		
Oops, we have an extra space in there.  A day-one typo from JDK-7195249.

While here, try to clarify the while loop which recognises this port failure.  Also add something to clarify which test(s) failed, and correct a comment in test2 of AbstractFilePermissionTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328619](https://bugs.openjdk.org/browse/JDK-8328619): sun/management/jmxremote/bootstrap/SSLConfigFilePermissionTest.java failed with BindException: Address already in use (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18470/head:pull/18470` \
`$ git checkout pull/18470`

Update a local copy of the PR: \
`$ git checkout pull/18470` \
`$ git pull https://git.openjdk.org/jdk.git pull/18470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18470`

View PR using the GUI difftool: \
`$ git pr show -t 18470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18470.diff">https://git.openjdk.org/jdk/pull/18470.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18470#issuecomment-2018083795)