### PR TITLE
8323682: C2: guard check is not generated in Arrays.copyOfRange intrinsic when allocation is eliminated by EA

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4318,20 +4318,23 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
       klass_node = _gvn.transform(cast);
     }
 
-    // Bail out if either start or end is negative.
+    // Bail out if start is negative.
     generate_negative_guard(start, bailout, &start);
-    generate_negative_guard(end,   bailout, &end);
 
     Node* length = end;
     if (_gvn.type(start) != TypeInt::ZERO) {
       length = _gvn.transform(new SubINode(end, start));
     }
 
-    // Bail out if length is negative.
+    // Bail out if length is negative (i.e., if start > end).
     // Without this the new_array would throw
     // NegativeArraySizeException but IllegalArgumentException is what
     // should be thrown
     generate_negative_guard(length, bailout, &length);
+
+    // Bail out if start is larger than the original length
+    Node* orig_tail = _gvn.transform(new SubINode(orig_length, start));
+    generate_negative_guard(orig_tail, bailout, &orig_tail);
 
     if (bailout->req() > 1) {
       PreserveJVMState pjvms(this);
@@ -4342,8 +4345,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
 
     if (!stopped()) {
       // How many elements will we copy from the original?
-      // The answer is MinI(orig_length - start, length).
-      Node* orig_tail = _gvn.transform(new SubINode(orig_length, start));
+      // The answer is MinI(orig_tail, length).
       Node* moved = generate_min_max(vmIntrinsics::_min, orig_tail, length);
 
       // Generate a direct call to the right arraycopy function(s).
@@ -4391,7 +4393,7 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
       if (!stopped()) {
         newcopy = new_array(klass_node, length, 0);  // no arguments to push
 
-        ArrayCopyNode* ac = ArrayCopyNode::make(this, true, original, start, newcopy, intcon(0), moved, true, false,
+        ArrayCopyNode* ac = ArrayCopyNode::make(this, true, original, start, newcopy, intcon(0), moved, true, true,
                                                 load_object_klass(original), klass_node);
         if (!is_copyOfRange) {
           ac->set_copyof(validated);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -4318,8 +4318,9 @@ bool LibraryCallKit::inline_array_copyOf(bool is_copyOfRange) {
       klass_node = _gvn.transform(cast);
     }
 
-    // Bail out if start is negative.
+    // Bail out if either start or end is negative.
     generate_negative_guard(start, bailout, &start);
+    generate_negative_guard(end,   bailout, &end);
 
     Node* length = end;
     if (_gvn.type(start) != TypeInt::ZERO) {

--- a/src/hotspot/share/opto/macroArrayCopy.cpp
+++ b/src/hotspot/share/opto/macroArrayCopy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1266,7 +1266,7 @@ void PhaseMacroExpand::expand_arraycopy_node(ArrayCopyNode *ac) {
     generate_arraycopy(ac, alloc, &ctrl, merge_mem, &io,
                        adr_type, T_OBJECT,
                        src, src_offset, dest, dest_offset, length,
-                       true, !ac->is_copyofrange());
+                       true, ac->has_negative_length_guard());
 
     return;
   }

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8323682
+ * @summary Test that the appropriate guards are generated for the copyOfRange
+ *          intrinsic, even if the result of the array copy are not used.
+ *
+ * @run main/othervm -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestArrayCopyOfRangeGuards::test
+ *                   -Xbatch
+ *                   compiler.arraycopy.TestArrayCopyOfRangeGuards
+ */
+
+package compiler.arraycopy;
+
+import java.util.Arrays;
+
+public class TestArrayCopyOfRangeGuards {
+    static int counter = 0;
+
+    public static void main(String[] args) {
+        Object[] array = new Object[10];
+        for (int i = 0; i < 50_000; i++) {
+            test(array);
+        }
+        if (counter != 50_000) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+
+    static void test(Object[] array) {
+        try {
+            Arrays.copyOfRange(array, 15, 20, Object[].class);
+        } catch (ArrayIndexOutOfBoundsException e) {
+            // Expected
+            counter++;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestArrayCopyOfRangeGuards.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8323682
  * @summary Test that the appropriate guards are generated for the copyOfRange
- *          intrinsic, even if the result of the array copy are not used.
+ *          intrinsic, even if the result of the array copy is not used.
  *
  * @run main/othervm -XX:-TieredCompilation
  *                   -XX:CompileCommand=compileonly,compiler.arraycopy.TestArrayCopyOfRangeGuards::test


### PR DESCRIPTION
### Issue Summary

The library intrinsic `_copyOfRange` does not add a guard for start indices that are larger than the length of the source arrays. Macro expansion of `ArrayCopy` nodes later adds such a guard, but in certain situations escape analysis may result in removing the `ArrayCopy` node before it is expanded. The result is incorrect behavior of the compiled program (as the missing guard may have relevant side effects, such as throwing an exception).

### Changeset

- Add the missing guard (start index <= source array length).
- Add a regression test.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/8437807452)
- tier1 to tier5 on windows-x64, linux-x64, linux-aarch64, macosx-x64, and macosx-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323682](https://bugs.openjdk.org/browse/JDK-8323682): C2: guard check is not generated in Arrays.copyOfRange intrinsic when allocation is eliminated by EA (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [47cfe37d](https://git.openjdk.org/jdk/pull/18472/files/47cfe37d5e246d0284e24137c96f3661eb4200e8)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18472/head:pull/18472` \
`$ git checkout pull/18472`

Update a local copy of the PR: \
`$ git checkout pull/18472` \
`$ git pull https://git.openjdk.org/jdk.git pull/18472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18472`

View PR using the GUI difftool: \
`$ git pr show -t 18472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18472.diff">https://git.openjdk.org/jdk/pull/18472.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18472#issuecomment-2018019489)