### PR TITLE
8328928: Serial: Use IsGCActiveMark instead of AutoModifyRestore in SerialHeap::do_collection

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -50,6 +50,7 @@
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/gcVMOperations.hpp"
 #include "gc/shared/genArguments.hpp"
+#include "gc/shared/isGCActiveMark.hpp"
 #include "gc/shared/locationPrinter.inline.hpp"
 #include "gc/shared/oopStorage.inline.hpp"
 #include "gc/shared/oopStorageParState.inline.hpp"
@@ -74,7 +75,6 @@
 #include "runtime/vmThread.hpp"
 #include "services/memoryManager.hpp"
 #include "services/memoryService.hpp"
-#include "utilities/autoRestore.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
@@ -497,7 +497,7 @@ void SerialHeap::do_collection(bool full,
 
   ClearedAllSoftRefs casr(do_clear_all_soft_refs, soft_ref_policy());
 
-  AutoModifyRestore<bool> temporarily(_is_gc_active, true);
+  IsGCActiveMark active_gc_mark;
 
   bool complete = full && (max_generation == OldGen);
   bool old_collects_young = complete && !ScavengeBeforeFullGC;


### PR DESCRIPTION
Hi all,

This patch uses `IsGCActiveMark` instead of `AutoModifyRestore` in `SerialHeap::do_collection` so that all the GCs use the `IsGCActiveMark` uniformly. The tests `make test-tier1_gc` passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328928](https://bugs.openjdk.org/browse/JDK-8328928): Serial: Use IsGCActiveMark instead of AutoModifyRestore in SerialHeap::do_collection (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18473/head:pull/18473` \
`$ git checkout pull/18473`

Update a local copy of the PR: \
`$ git checkout pull/18473` \
`$ git pull https://git.openjdk.org/jdk.git pull/18473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18473`

View PR using the GUI difftool: \
`$ git pr show -t 18473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18473.diff">https://git.openjdk.org/jdk/pull/18473.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18473#issuecomment-2018140186)