### PR TITLE
8328948: GHA: Restoring sysroot from cache skips the build after JDK-8326960

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -177,7 +177,7 @@ jobs:
           echo "Dumping config.log:" &&
           cat config.log &&
           exit 1)
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'
 
       - name: 'Build'
         id: build
@@ -185,4 +185,4 @@ jobs:
         with:
           make-target: 'hotspot ${{ inputs.make-arguments }}'
           platform: linux-${{ matrix.target-cpu }}
-        if: steps.create-sysroot.outcome == 'success'
+        if: steps.create-sysroot.outcome == 'success' || steps.get-cached-sysroot.outputs.cache-hit == 'true'


### PR DESCRIPTION
When doing [JDK-8326960](https://bugs.openjdk.org/browse/JDK-8326960), I missed the case when sysroot would be restored from the cache. This would skip the configure and build steps, because it would only consult the status for create-sysroot job. This is only a problem when PR gets tested the _second_ time, the first time we would always create a sysroot. I only noticed this after merging the master into existing PRs.

This is a regression that might hide build issues on platforms, and so it should be fixed ASAP.

Additional testing:
 - [x] GHA first run: cross-compiled builds run
 - [x] GHA second run: cross-compiled builds run

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328948](https://bugs.openjdk.org/browse/JDK-8328948): GHA: Restoring sysroot from cache skips the build after JDK-8326960 (**Bug** - P2)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18475/head:pull/18475` \
`$ git checkout pull/18475`

Update a local copy of the PR: \
`$ git checkout pull/18475` \
`$ git pull https://git.openjdk.org/jdk.git pull/18475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18475`

View PR using the GUI difftool: \
`$ git pr show -t 18475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18475.diff">https://git.openjdk.org/jdk/pull/18475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18475#issuecomment-2018411045)