### PR TITLE
8328986: Deprecate UseRTM* flags for removal

### DIFF
--- a/src/hotspot/cpu/x86/globals_x86.hpp
+++ b/src/hotspot/cpu/x86/globals_x86.hpp
@@ -154,16 +154,18 @@ define_pd_global(intx, InitArrayShortSize, 8*BytesPerLong);
                                                                             \
   /* Use Restricted Transactional Memory for lock eliding */                \
   product(bool, UseRTMLocking, false,                                       \
-          "Enable RTM lock eliding for inflated locks in compiled code")    \
+          "(Deprecated) Enable RTM lock eliding for inflated locks "        \
+          "in compiled code")                                               \
                                                                             \
   product(bool, UseRTMForStackLocks, false, EXPERIMENTAL,                   \
           "Enable RTM lock eliding for stack locks in compiled code")       \
                                                                             \
   product(bool, UseRTMDeopt, false,                                         \
-          "Perform deopt and recompilation based on RTM abort ratio")       \
+          "(Deprecated) Perform deopt and recompilation based on "          \
+          "RTM abort ratio")                                                \
                                                                             \
   product(int, RTMRetryCount, 5,                                            \
-          "Number of RTM retries on lock abort or busy")                    \
+          "(Deprecated) Number of RTM retries on lock abort or busy")       \
           range(0, max_jint)                                                \
                                                                             \
   product(int, RTMSpinLoopCount, 100, EXPERIMENTAL,                         \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -503,19 +503,8 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RegisterFinalizersAtInit",     JDK_Version::jdk(22), JDK_Version::jdk(23), JDK_Version::jdk(24) },
 #if defined(X86)
   { "UseRTMLocking",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "UseRTMForStackLocks",          JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseRTMDeopt",                  JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "RTMRetryCount",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMSpinLoopCount",             JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMAbortThreshold",            JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMLockingThreshold",          JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMAbortRatio",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMTotalCountIncrRate",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "RTMLockingCalculationDelay",   JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "UseRTMXendForLockBusy",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-#ifdef COMPILER2
-  { "PrintPreciseRTMLockingStatistics", JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-#endif
 #endif // X86
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -513,7 +513,10 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RTMTotalCountIncrRate",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "RTMLockingCalculationDelay",   JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseRTMXendForLockBusy",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+#ifdef COMPILER2
+  { "PrintPreciseRTMLockingStatistics", JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #endif
+#endif // X86
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -501,7 +501,19 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RegisterFinalizersAtInit",     JDK_Version::jdk(22), JDK_Version::jdk(23), JDK_Version::jdk(24) },
-
+#if defined(X86)
+  { "UseRTMLocking",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "UseRTMForStackLocks",          JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "UseRTMDeopt",                  JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMRetryCount",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMSpinLoopCount",             JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMAbortThreshold",            JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMLockingThreshold",          JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMAbortRatio",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMTotalCountIncrRate",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "RTMLockingCalculationDelay",   JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "UseRTMXendForLockBusy",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+#endif
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
 

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -3783,6 +3783,48 @@ handler.
 This option is disabled by default.
 Options related to RTM are available only on x86 CPUs that support
 Transactional Synchronization Extensions (TSX).
+.RS
+.PP
+RTM is part of Intel\[aq]s TSX, which is an x86 instruction set
+extension and facilitates the creation of multithreaded applications.
+RTM introduces the new instructions \f[V]XBEGIN\f[R], \f[V]XABORT\f[R],
+\f[V]XEND\f[R], and \f[V]XTEST\f[R].
+The \f[V]XBEGIN\f[R] and \f[V]XEND\f[R] instructions enclose a set of
+instructions to run as a transaction.
+If no conflict is found when running the transaction, then the memory
+and register modifications are committed together at the \f[V]XEND\f[R]
+instruction.
+The \f[V]XABORT\f[R] instruction can be used to explicitly abort a
+transaction and the \f[V]XTEST\f[R] instruction checks if a set of
+instructions is being run in a transaction.
+.PP
+A lock on a transaction is inflated when another thread tries to access
+the same transaction, thereby blocking the thread that didn\[aq]t
+originally request access to the transaction.
+RTM requires that a fallback set of operations be specified in case a
+transaction aborts or fails.
+An RTM lock is a lock that has been delegated to the TSX\[aq]s system.
+.PP
+RTM improves performance for highly contended locks with low conflict in
+a critical region (which is code that must not be accessed by more than
+one thread concurrently).
+RTM also improves the performance of coarse-grain locking, which
+typically doesn\[aq]t perform well in multithreaded applications.
+(Coarse-grain locking is the strategy of holding locks for long periods
+to minimize the overhead of taking and releasing locks, while
+fine-grained locking is the strategy of trying to achieve maximum
+parallelism by locking only when necessary and unlocking as soon as
+possible.)
+Also, for lightly contended locks that are used by different threads,
+RTM can reduce false cache line sharing, also known as cache line
+ping-pong.
+This occurs when multiple threads from different processors are
+accessing different resources, but the resources share the same cache
+line.
+As a result, the processors repeatedly invalidate the cache lines of
+other processors, which forces them to read from main memory instead of
+their cache.
+.RE
 .SH OBSOLETE JAVA OPTIONS
 .PP
 These \f[V]java\f[R] options are still accepted but ignored, and a

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -2477,24 +2477,6 @@ This option has a limit of 2 GB; otherwise, an error is generated.
 The maximum code cache size shouldn\[aq]t be less than the initial code
 cache size; see the option \f[V]-XX:InitialCodeCacheSize\f[R].
 .TP
-\f[V]-XX:RTMAbortRatio=\f[R]\f[I]abort_ratio\f[R]
-Specifies the RTM abort ratio is specified as a percentage (%) of all
-executed RTM transactions.
-If a number of aborted transactions becomes greater than this ratio,
-then the compiled code is deoptimized.
-This ratio is used when the \f[V]-XX:+UseRTMDeopt\f[R] option is
-enabled.
-The default value of this option is 50.
-This means that the compiled code is deoptimized if 50% of all
-transactions are aborted.
-.TP
-\f[V]-XX:RTMRetryCount=\f[R]\f[I]number_of_retries\f[R]
-Specifies the number of times that the RTM locking code is retried, when
-it is aborted or busy, before falling back to the normal locking
-mechanism.
-The default value for this option is 5.
-The \f[V]-XX:UseRTMLocking\f[R] option must be enabled.
-.TP
 \f[V]-XX:+SegmentedCodeCache\f[R]
 Enables segmentation of the code cache, without which the code cache
 consists of one large segment.
@@ -2727,65 +2709,6 @@ FMA intrinsics are generated for the
 \f[I]b\f[R]\f[V],\f[R] \f[I]c\f[R]\f[V])\f[R] methods that calculate the
 value of \f[V](\f[R] \f[I]a\f[R] \f[V]*\f[R] \f[I]b\f[R] \f[V]+\f[R]
 \f[I]c\f[R] \f[V])\f[R] expressions.
-.TP
-\f[V]-XX:+UseRTMDeopt\f[R]
-Autotunes RTM locking depending on the abort ratio.
-This ratio is specified by the \f[V]-XX:RTMAbortRatio\f[R] option.
-If the number of aborted transactions exceeds the abort ratio, then the
-method containing the lock is deoptimized and recompiled with all locks
-as normal locks.
-This option is disabled by default.
-The \f[V]-XX:+UseRTMLocking\f[R] option must be enabled.
-.TP
-\f[V]-XX:+UseRTMLocking\f[R]
-Generates Restricted Transactional Memory (RTM) locking code for all
-inflated locks, with the normal locking mechanism as the fallback
-handler.
-This option is disabled by default.
-Options related to RTM are available only on x86 CPUs that support
-Transactional Synchronization Extensions (TSX).
-.RS
-.PP
-RTM is part of Intel\[aq]s TSX, which is an x86 instruction set
-extension and facilitates the creation of multithreaded applications.
-RTM introduces the new instructions \f[V]XBEGIN\f[R], \f[V]XABORT\f[R],
-\f[V]XEND\f[R], and \f[V]XTEST\f[R].
-The \f[V]XBEGIN\f[R] and \f[V]XEND\f[R] instructions enclose a set of
-instructions to run as a transaction.
-If no conflict is found when running the transaction, then the memory
-and register modifications are committed together at the \f[V]XEND\f[R]
-instruction.
-The \f[V]XABORT\f[R] instruction can be used to explicitly abort a
-transaction and the \f[V]XTEST\f[R] instruction checks if a set of
-instructions is being run in a transaction.
-.PP
-A lock on a transaction is inflated when another thread tries to access
-the same transaction, thereby blocking the thread that didn\[aq]t
-originally request access to the transaction.
-RTM requires that a fallback set of operations be specified in case a
-transaction aborts or fails.
-An RTM lock is a lock that has been delegated to the TSX\[aq]s system.
-.PP
-RTM improves performance for highly contended locks with low conflict in
-a critical region (which is code that must not be accessed by more than
-one thread concurrently).
-RTM also improves the performance of coarse-grain locking, which
-typically doesn\[aq]t perform well in multithreaded applications.
-(Coarse-grain locking is the strategy of holding locks for long periods
-to minimize the overhead of taking and releasing locks, while
-fine-grained locking is the strategy of trying to achieve maximum
-parallelism by locking only when necessary and unlocking as soon as
-possible.)
-Also, for lightly contended locks that are used by different threads,
-RTM can reduce false cache line sharing, also known as cache line
-ping-pong.
-This occurs when multiple threads from different processors are
-accessing different resources, but the resources share the same cache
-line.
-As a result, the processors repeatedly invalidate the cache lines of
-other processors, which forces them to read from main memory instead of
-their cache.
-.RE
 .TP
 \f[V]-XX:+UseSuperWord\f[R]
 Enables the transformation of scalar operations into superword
@@ -3825,6 +3748,41 @@ The default value is 2.
 .PP
 Use the option \f[V]-XX:MinRAMPercentage\f[R] instead.
 .RE
+.TP
+\f[V]-XX:RTMAbortRatio=\f[R]\f[I]abort_ratio\f[R]
+Specifies the RTM abort ratio is specified as a percentage (%) of all
+executed RTM transactions.
+If a number of aborted transactions becomes greater than this ratio,
+then the compiled code is deoptimized.
+This ratio is used when the \f[V]-XX:+UseRTMDeopt\f[R] option is
+enabled.
+The default value of this option is 50.
+This means that the compiled code is deoptimized if 50% of all
+transactions are aborted.
+.TP
+\f[V]-XX:RTMRetryCount=\f[R]\f[I]number_of_retries\f[R]
+Specifies the number of times that the RTM locking code is retried, when
+it is aborted or busy, before falling back to the normal locking
+mechanism.
+The default value for this option is 5.
+The \f[V]-XX:UseRTMLocking\f[R] option must be enabled.
+.TP
+\f[V]-XX:+UseRTMDeopt\f[R]
+Autotunes RTM locking depending on the abort ratio.
+This ratio is specified by the \f[V]-XX:RTMAbortRatio\f[R] option.
+If the number of aborted transactions exceeds the abort ratio, then the
+method containing the lock is deoptimized and recompiled with all locks
+as normal locks.
+This option is disabled by default.
+The \f[V]-XX:+UseRTMLocking\f[R] option must be enabled.
+.TP
+\f[V]-XX:+UseRTMLocking\f[R]
+Generates Restricted Transactional Memory (RTM) locking code for all
+inflated locks, with the normal locking mechanism as the fallback
+handler.
+This option is disabled by default.
+Options related to RTM are available only on x86 CPUs that support
+Transactional Synchronization Extensions (TSX).
 .SH OBSOLETE JAVA OPTIONS
 .PP
 These \f[V]java\f[R] options are still accepted but ignored, and a

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -62,6 +62,14 @@ public class VMDeprecatedOptions {
             {"CreateMinidumpOnCrash", "false"}
           }
         ));
+        if (Platform.isX86() || Platform.isX64()) {
+          deprecated.addAll(
+            Arrays.asList(new String[][] {
+              {"UseRTMLocking",         "false"},
+              {"UseRTMDeopt",           "false"},
+            })
+          );
+        }
         if (wb.isJFRIncluded()) {
             deprecated.add(new String[] {"FlightRecorder", "false"});
         }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -67,6 +67,7 @@ public class VMDeprecatedOptions {
             Arrays.asList(new String[][] {
               {"UseRTMLocking",         "false"},
               {"UseRTMDeopt",           "false"},
+              {"RTMRetryCount",         "5"}
             })
           );
         }


### PR DESCRIPTION
HotSpot supports RTM (restricted transactional memory) for locking since JDK 8 on Intel's processors ([JDK-8031320](https://bugs.openjdk.org/browse/JDK-8031320)). It was added to other platforms but has since been disabled and removed on all but Intel's processors. There was attempt to deprecate it ([JDK-8292082](https://bugs.openjdk.org/browse/JDK-8292082)) during JDK 20 development but at that time it was decided to keep it. Recently we discussed this with Intel and they agreed with RTM deprecation and removal from HotSpot.

RTM adds complexity and maintenance burden to HotSpot locking code. It was never enabled by default because it only helped in some cases of heavy lock contention. We are not testing RTM feature since JDK 14 when we problem-list related tests: [JDK-8226899](https://bugs.openjdk.org/browse/JDK-8226899). 

New LIGHTWEIGHT locking implementation will not support RTM locking: [JDK-8320321](https://bugs.openjdk.org/browse/JDK-8320321).

I propose to deprecate the related flags and remove the flags and all related code in a later release.

Changes are based on @rkennke changes for JDK 20 [#9810](https://github.com/openjdk/jdk/pull/9810)

Testing: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8328991](https://bugs.openjdk.org/browse/JDK-8328991) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8328986](https://bugs.openjdk.org/browse/JDK-8328986): Deprecate UseRTM* flags for removal (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).
 * [JDK-8328991](https://bugs.openjdk.org/browse/JDK-8328991): Deprecate UseRTM* flags for removal (**CSR**)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) ⚠️ Review applies to [923ee7ca](https://git.openjdk.org/jdk/pull/18478/files/923ee7ca0b1848cc6376dcbd302744d798e3d5be)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Contributors
 * Roman Kennke `<rkennke@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18478/head:pull/18478` \
`$ git checkout pull/18478`

Update a local copy of the PR: \
`$ git checkout pull/18478` \
`$ git pull https://git.openjdk.org/jdk.git pull/18478/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18478`

View PR using the GUI difftool: \
`$ git pr show -t 18478`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18478.diff">https://git.openjdk.org/jdk/pull/18478.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18478#issuecomment-2018886418)