### PR TITLE
8328997: Remove unnecessary template parameter lists in GrowableArray

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -117,13 +117,13 @@ class GrowableArrayView : public GrowableArrayBase {
 protected:
   E* _data; // data array
 
-  GrowableArrayView<E>(E* data, int capacity, int initial_len) :
+  GrowableArrayView(E* data, int capacity, int initial_len) :
       GrowableArrayBase(capacity, initial_len), _data(data) {}
 
   ~GrowableArrayView() {}
 
 public:
-  bool operator==(const GrowableArrayView<E>& rhs) const {
+  bool operator==(const GrowableArrayView& rhs) const {
     if (_len != rhs._len)
       return false;
     for (int i = 0; i < _len; i++) {
@@ -134,7 +134,7 @@ public:
     return true;
   }
 
-  bool operator!=(const GrowableArrayView<E>& rhs) const {
+  bool operator!=(const GrowableArrayView& rhs) const {
     return !(*this == rhs);
   }
 
@@ -351,7 +351,7 @@ template <typename E>
 class GrowableArrayFromArray : public GrowableArrayView<E> {
 public:
 
-  GrowableArrayFromArray<E>(E* data, int len) :
+  GrowableArrayFromArray(E* data, int len) :
     GrowableArrayView<E>(data, len, len) {}
 };
 
@@ -486,7 +486,7 @@ public:
     return this->at(location);
   }
 
-  void swap(GrowableArrayWithAllocator<E, Derived>* other) {
+  void swap(GrowableArrayWithAllocator* other) {
     ::swap(this->_data, other->_data);
     ::swap(this->_len, other->_len);
     ::swap(this->_capacity, other->_capacity);
@@ -688,8 +688,8 @@ public:
 //  See: init_checks.
 
 template <typename E>
-class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E> > {
-  friend class GrowableArrayWithAllocator<E, GrowableArray<E> >;
+class GrowableArray : public GrowableArrayWithAllocator<E, GrowableArray<E>> {
+  friend class GrowableArrayWithAllocator<E, GrowableArray>;
   friend class GrowableArrayTest;
 
   static E* allocate(int max) {
@@ -737,7 +737,7 @@ public:
   GrowableArray() : GrowableArray(2 /* initial_capacity */) {}
 
   explicit GrowableArray(int initial_capacity) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity),
           initial_capacity),
       _metadata() {
@@ -745,7 +745,7 @@ public:
   }
 
   GrowableArray(int initial_capacity, MEMFLAGS memflags) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity, memflags),
           initial_capacity),
       _metadata(memflags) {
@@ -753,7 +753,7 @@ public:
   }
 
   GrowableArray(int initial_capacity, int initial_len, const E& filler) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity),
           initial_capacity, initial_len, filler),
       _metadata() {
@@ -761,7 +761,7 @@ public:
   }
 
   GrowableArray(int initial_capacity, int initial_len, const E& filler, MEMFLAGS memflags) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity, memflags),
           initial_capacity, initial_len, filler),
       _metadata(memflags) {
@@ -769,7 +769,7 @@ public:
   }
 
   GrowableArray(Arena* arena, int initial_capacity, int initial_len, const E& filler) :
-      GrowableArrayWithAllocator<E, GrowableArray<E> >(
+      GrowableArrayWithAllocator<E, GrowableArray>(
           allocate(initial_capacity, arena),
           initial_capacity, initial_len, filler),
       _metadata(arena) {
@@ -852,15 +852,15 @@ class GrowableArrayIterator : public StackObj {
 
  public:
   GrowableArrayIterator() : _array(nullptr), _position(0) { }
-  GrowableArrayIterator<E>& operator++() { ++_position; return *this; }
-  E operator*()                          { return _array->at(_position); }
+  GrowableArrayIterator& operator++() { ++_position; return *this; }
+  E operator*()                       { return _array->at(_position); }
 
-  bool operator==(const GrowableArrayIterator<E>& rhs)  {
+  bool operator==(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position == rhs._position;
   }
 
-  bool operator!=(const GrowableArrayIterator<E>& rhs)  {
+  bool operator!=(const GrowableArrayIterator& rhs)  {
     assert(_array == rhs._array, "iterator belongs to different array");
     return _position != rhs._position;
   }


### PR DESCRIPTION
Please review this change to the GrowableArray code to remove unnecessary
template parameter lists.  They aren't needed, and some may become
syntactically invalid in the future.

Testing: mach5 tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328997](https://bugs.openjdk.org/browse/JDK-8328997): Remove unnecessary template parameter lists in GrowableArray (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18480/head:pull/18480` \
`$ git checkout pull/18480`

Update a local copy of the PR: \
`$ git checkout pull/18480` \
`$ git pull https://git.openjdk.org/jdk.git pull/18480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18480`

View PR using the GUI difftool: \
`$ git pr show -t 18480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18480.diff">https://git.openjdk.org/jdk/pull/18480.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18480#issuecomment-2019129023)