### PR TITLE
8329012: IGV: Update required JDK version in README.md

### DIFF
--- a/src/utils/IdealGraphVisualizer/README.md
+++ b/src/utils/IdealGraphVisualizer/README.md
@@ -8,7 +8,7 @@ tool itself is fairly general with only a few modules that contain C2 specific
 elements.
 
 The tool is built on top of the NetBeans Platform, and requires a JDK version
-between 11 and 17 (the JDKs supported by the current NetBeans Platform).
+between 17 and 21 (the JDKs supported by the current NetBeans Platform).
 
 # Building and Running
 


### PR DESCRIPTION
While building IGV, I found the jdk version described in the README.md is incorrect.

According to the pom.xml: https://github.com/openjdk/jdk/blob/master/src/utils/IdealGraphVisualizer/pom.xml#L82 
It should be updated to "between 17 and 21".

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329012](https://bugs.openjdk.org/browse/JDK-8329012): IGV: Update required JDK version in README.md (**Bug** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18481/head:pull/18481` \
`$ git checkout pull/18481`

Update a local copy of the PR: \
`$ git checkout pull/18481` \
`$ git pull https://git.openjdk.org/jdk.git pull/18481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18481`

View PR using the GUI difftool: \
`$ git pr show -t 18481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18481.diff">https://git.openjdk.org/jdk/pull/18481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18481#issuecomment-2019289986)