### PR TITLE
8328865: [c2] No need to convert "(x+1)+y" into "(x+y)+1" when y is a CallNode

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -180,13 +180,17 @@ Node *AddNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     if (t12->singleton() && t12 != Type::TOP && (add1 != add1->in(1)) &&
         !(add1->in(1)->is_Phi() && (add1->in(1)->as_Phi()->is_tripcount(T_INT) || add1->in(1)->as_Phi()->is_tripcount(T_LONG)))) {
       assert(add1->in(1) != this, "dead loop in AddNode::Ideal");
-      add2 = add1->clone();
-      add2->set_req(2, in(2));
-      add2 = phase->transform(add2);
-      set_req_X(1, add2, phase);
-      set_req_X(2, a12, phase);
-      progress = this;
-      add2 = a12;
+      if (add2->Opcode() == Op_Proj && add2->in(0)->is_CallJava()) {
+        // Do nothing when y is a CallJavaNode.
+      } else {
+        add2 = add1->clone();
+        add2->set_req(2, in(2));
+        add2 = phase->transform(add2);
+        set_req_X(1, add2, phase);
+        set_req_X(2, a12, phase);
+        progress = this;
+        add2 = a12;
+      }
     }
   }
 

--- a/test/micro/org/openjdk/bench/vm/compiler/CallNode.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/CallNode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+
+public class CallNode {
+  private long val = 10;
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public long callNotInlined(long arg1, long arg2) {
+    return arg1 + arg2;
+  }
+
+  @Benchmark
+  public long test() {
+     long ret = 0;
+     for (int i = 0; i< 20000; i++) {
+       long tmp = val + 3;
+       ret = callNotInlined(1, 2);
+       ret += tmp;
+     }
+     return ret;
+  }
+
+}


### PR DESCRIPTION
This patch prohibits the conversion from  "(x+1)+y" into "(x+y)+1" when y is a CallNode to reduce unnecessary spillcode and ADDNode.

Testing: tier1-3 in x86_64 and LoongArch64

JMH in x86_64:
<pre>
before:
Benchmark           Mode  Cnt      Score   Error  Units
CallNode.test      thrpt    2  26397.733          ops/s

after:
Benchmark           Mode  Cnt      Score   Error  Units
CallNode.test      thrpt    2  27839.337          ops/s
</pre>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328865](https://bugs.openjdk.org/browse/JDK-8328865): [c2] No need to convert "(x+1)+y" into "(x+y)+1" when y is a CallNode (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18482/head:pull/18482` \
`$ git checkout pull/18482`

Update a local copy of the PR: \
`$ git checkout pull/18482` \
`$ git pull https://git.openjdk.org/jdk.git pull/18482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18482`

View PR using the GUI difftool: \
`$ git pr show -t 18482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18482.diff">https://git.openjdk.org/jdk/pull/18482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18482#issuecomment-2019550714)