### PR TITLE
8327493: Update minimum Xcode version in docs

### DIFF
--- a/doc/building.html
+++ b/doc/building.html
@@ -613,7 +613,7 @@ be accepted by <code>configure</code>.</p>
 <p>To use clang instead of gcc on Linux, use
 <code>--with-toolchain-type=clang</code>.</p>
 <h3 id="apple-xcode">Apple Xcode</h3>
-<p>The oldest supported version of Xcode is 8.</p>
+<p>The oldest supported version of Xcode is 13.0.</p>
 <p>You will need the Xcode command line developer tools to be able to
 build the JDK. (Actually, <em>only</em> the command line tools are
 needed, not the IDE.) The simplest way to install these is to run:</p>

--- a/doc/building.md
+++ b/doc/building.md
@@ -420,7 +420,7 @@ To use clang instead of gcc on Linux, use `--with-toolchain-type=clang`.
 
 ### Apple Xcode
 
-The oldest supported version of Xcode is 8.
+The oldest supported version of Xcode is 13.0.
 
 You will need the Xcode command line developer tools to be able to build the
 JDK. (Actually, *only* the command line tools are needed, not the IDE.) The


### PR DESCRIPTION
The file building.{md,html} indicates the required minimum version of Xcode to use. When the required minimum version of Clang was updated to 13 ([JDK-8325878](https://bugs.openjdk.org/browse/JDK-8325878)), the minimum Xcode version was not updated. It should now be Xcode 13.0, rather than 8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327493](https://bugs.openjdk.org/browse/JDK-8327493): Update minimum Xcode version in docs (**Enhancement** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18483/head:pull/18483` \
`$ git checkout pull/18483`

Update a local copy of the PR: \
`$ git checkout pull/18483` \
`$ git pull https://git.openjdk.org/jdk.git pull/18483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18483`

View PR using the GUI difftool: \
`$ git pr show -t 18483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18483.diff">https://git.openjdk.org/jdk/pull/18483.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18483#issuecomment-2019918292)