### PR TITLE
JDK-8329074: AIX build fails after JDK-8328824

### DIFF
--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -198,7 +198,7 @@ ifeq ($(call isTargetOs, aix), true)
       EXTRA_FILES := $(LIBJLI_EXTRA_FILES), \
       OPTIMIZATION := HIGH, \
       CFLAGS := $(STATIC_LIBRARY_FLAGS) $(CFLAGS_JDKLIB) $(LIBJLI_CFLAGS) \
-          $(LIBZ_CFLAGS) (addprefix -I, $(LIBJLI_SRC_DIRS)), \
+          $(LIBZ_CFLAGS) $(addprefix -I, $(LIBJLI_SRC_DIRS)), \
       DISABLED_WARNINGS_clang_aix := format-nonliteral \
           deprecated-non-prototype, \
       ARFLAGS := $(ARFLAGS), \


### PR DESCRIPTION
After [JDK-8328824](https://bugs.openjdk.org/browse/JDK-8328824), we run in the AIX build into this failure :

/opt/freeware/bin/bash: -c: line 1: syntax error near unexpected token `('
gmake[3]: *** [lib/CoreLibraries.gmk:194: /openjdk/nb/aix_ppc64/jdk-dev-opt/support/native/java.base/libjli_static/args.o] Error 2
gmake[3]: *** Waiting for unfinished jobs....

Looks like an addprefix usage is wrong, a '$' is missing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329074](https://bugs.openjdk.org/browse/JDK-8329074): AIX build fails after JDK-8328824 (**Bug** - P2)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Goetz Lindenmaier](https://openjdk.org/census#goetz) (@GoeLin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18484/head:pull/18484` \
`$ git checkout pull/18484`

Update a local copy of the PR: \
`$ git checkout pull/18484` \
`$ git pull https://git.openjdk.org/jdk.git pull/18484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18484`

View PR using the GUI difftool: \
`$ git pr show -t 18484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18484.diff">https://git.openjdk.org/jdk/pull/18484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18484#issuecomment-2019922124)