### PR TITLE
8329102: Clean up jdk.jpackage native compilation

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -291,6 +291,10 @@ define SetupJdkExecutableBody
       -I$(TOPDIR)/src/java.base/windows/native/common \
       $$($1_EXTRA_RCFLAGS)
 
+  ifneq ($$($1_HEADERS_FROM_SRC), false)
+    $1_SRC_HEADER_FLAGS := $$(addprefix -I, $$(wildcard $$($1_SRC)))
+  endif
+
   $1_JDK_LIBS += $$($1_JDK_LIBS_$$(OPENJDK_TARGET_OS))
   $1_JDK_LIBS += $$($1_JDK_LIBS_$$(OPENJDK_TARGET_OS_TYPE))
   # Prepend JDK libs before external libs

--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -26,169 +26,156 @@
 include LibCommon.gmk
 include LauncherCommon.gmk
 
+JPACKAGE_OUTPUT_DIR := \
+    $(JDK_OUTPUTDIR)/modules/$(MODULE)/jdk/jpackage/internal/resources
+
+JPACKAGE_CFLAGS_windows := -DUNICODE -D_UNICODE
+JPACKAGE_CXXFLAGS_windows := -EHsc $(JPACKAGE_CFLAGS_windows)
+
+################################################################################
+## Build jpackageapplauncher
 ################################################################################
 
-
 ifeq ($(call isTargetOs, linux), true)
-  JPACKAGE_APPLAUNCHER_SRC := \
-      $(call FindSrcDirsForComponent, jdk.jpackage, applauncher)
-  JPACKAGE_APPLAUNCHER_LINK_TYPE := C
-  JPACKAGE_APPLAUNCHER_INCLUDE_FILES := %.c
+  JPACKAGEAPPLAUNCHER_LINK_TYPE := C
+  JPACKAGEAPPLAUNCHER_INCLUDE_FILES := %.c
 else
-  JPACKAGE_APPLAUNCHER_SRC := \
-      $(call FindSrcDirsForComponent, jdk.jpackage, applauncher) \
-      $(call FindSrcDirsForComponent, jdk.jpackage, common)
-  JPACKAGE_APPLAUNCHER_LINK_TYPE := C++
+  JPACKAGEAPPLAUNCHER_LINK_TYPE := C++
 endif
 
-JPACKAGE_OUTPUT_DIR := $(JDK_OUTPUTDIR)/modules/$(MODULE)/jdk/jpackage/internal/resources
-JPACKAGE_CXXFLAGS_windows := -EHsc -DUNICODE -D_UNICODE
-JPACKAGE_CFLAGS_windows := -DUNICODE -D_UNICODE
-JPACKAGE_APPLAUNCHER_INCLUDES := $(addprefix -I, $(JPACKAGE_APPLAUNCHER_SRC))
-
 # Output app launcher executable in resources dir, and symbols in the object dir
-$(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHEREXE, \
+$(eval $(call SetupJdkExecutable, BUILD_JPACKAGEAPPLAUNCHER, \
     NAME := jpackageapplauncher, \
-    LINK_TYPE := $(JPACKAGE_APPLAUNCHER_LINK_TYPE), \
+    LINK_TYPE := $(JPACKAGEAPPLAUNCHER_LINK_TYPE), \
     OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
     SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/jpackageapplauncher, \
-    SRC := $(JPACKAGE_APPLAUNCHER_SRC), \
-    INCLUDE_FILES := $(JPACKAGE_APPLAUNCHER_INCLUDE_FILES), \
+    SRC := applauncher, \
+    EXTRA_SRC := common, \
+    INCLUDE_FILES := $(JPACKAGEAPPLAUNCHER_INCLUDE_FILES), \
     OPTIMIZATION := LOW, \
     DISABLED_WARNINGS_clang_LinuxPackage.c := format-nonliteral, \
     DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
     CFLAGS_FILTER_OUT := -MD, \
     CXXFLAGS_FILTER_OUT := -MD, \
-    CXXFLAGS := $(JPACKAGE_APPLAUNCHER_INCLUDES), \
-    CFLAGS := $(JPACKAGE_APPLAUNCHER_INCLUDES), \
     CFLAGS_macosx := -Wno-format-nonliteral, \
-    CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
     CFLAGS_windows := -MT $(JPACKAGE_CFLAGS_windows), \
+    CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
     LD_SET_ORIGIN := false, \
-    LIBS_macosx := -framework Cocoa  -rpath @executable_path/../Frameworks/ -rpath @executable_path/../PlugIns/, \
-    LIBS_windows := user32.lib ole32.lib msi.lib shlwapi.lib \
-        Shell32.lib, \
-    LIBS_linux := -ldl, \
+    LDFLAGS_macosx := -rpath @executable_path/../Frameworks/ \
+        -rpath @executable_path/../PlugIns/, \
+    LIBS_macosx := -framework Cocoa, \
+    LIBS_windows := msi.lib ole32.lib shell32.lib shlwapi.lib user32.lib, \
+    LIBS_linux := $(LIBDL), \
     MANIFEST := $(JAVA_MANIFEST), \
     MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS) \
 ))
 
-JPACKAGE_TARGETS += $(BUILD_JPACKAGE_APPLAUNCHEREXE)
-
-
-################################################################################
+TARGETS += $(BUILD_JPACKAGEAPPLAUNCHER)
 
 ifeq ($(call isTargetOs, linux), true)
+  ##############################################################################
+  ## Build libjpackageapplauncheraux
+  ##############################################################################
 
-  JPACKAGE_LIBAPPLAUNCHER_SRC := \
-      $(call FindSrcDirsForComponent, jdk.jpackage, applauncher) \
-      $(call FindSrcDirsForComponent, jdk.jpackage, libapplauncher) \
-      $(call FindSrcDirsForComponent, jdk.jpackage, common)
-
-  JPACKAGE_LIBAPPLAUNCHER_INCLUDES := $(addprefix -I, $(JPACKAGE_LIBAPPLAUNCHER_SRC))
-
-  $(eval $(call SetupJdkLibrary, BUILD_JPACKAGE_LIBAPPLAUNCHER, \
+  $(eval $(call SetupJdkLibrary, BUILD_LIBJPACKAGEAPPLAUNCHERAUX, \
       NAME := jpackageapplauncheraux, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
-      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncheraux, \
-      SRC := $(JPACKAGE_LIBAPPLAUNCHER_SRC), \
+      SYMBOLS_DIR := \
+          $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncheraux, \
+      SRC := libapplauncher, \
+      EXTRA_SRC := \
+          applauncher \
+          common, \
       EXCLUDE_FILES := LinuxLauncher.c LinuxPackage.c, \
       LINK_TYPE := C++, \
       OPTIMIZATION := LOW, \
       DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_tstrings.cpp := format-nonliteral, \
-      CXXFLAGS := $(JPACKAGE_LIBAPPLAUNCHER_INCLUDES), \
-      CFLAGS := $(JPACKAGE_LIBAPPLAUNCHER_INCLUDES), \
       LD_SET_ORIGIN := false, \
-      LIBS := -ldl, \
+      LIBS_linux := $(LIBDL), \
   ))
 
-  JPACKAGE_TARGETS += $(BUILD_JPACKAGE_LIBAPPLAUNCHER)
-
+  TARGETS += $(BUILD_LIBJPACKAGEAPPLAUNCHERAUX)
 endif
 
-
-################################################################################
-
 ifeq ($(call isTargetOs, windows), true)
+  ##############################################################################
+  ## Build libjpackage
+  ##############################################################################
 
-  $(eval $(call SetupJdkLibrary, BUILD_LIB_JPACKAGE, \
+  $(eval $(call SetupJdkLibrary, BUILD_LIBJPACKAGE, \
       NAME := jpackage, \
       OPTIMIZATION := LOW, \
-      EXTRA_SRC := jdk.jpackage:common, \
+      EXTRA_SRC := common, \
       CXXFLAGS_windows := $(JPACKAGE_CXXFLAGS_windows), \
       LDFLAGS := $(LDFLAGS_CXX_JDK), \
-      LIBS := advapi32.lib ole32.lib msi.lib user32.lib \
-          shlwapi.lib Shell32.lib, \
+      LIBS_windows := advapi32.lib msi.lib ole32.lib shell32.lib shlwapi.lib \
+          user32.lib, \
   ))
 
-  JPACKAGE_TARGETS += $(BUILD_LIB_JPACKAGE)
+  TARGETS += $(BUILD_LIBJPACKAGE)
 
-  JPACKAGE_WIXHELPER_SRC := \
-      $(call FindSrcDirsForComponent, jdk.jpackage, libwixhelper) \
-      $(call FindSrcDirsForComponent, jdk.jpackage, common)
+  ##############################################################################
+  ## Build libwixhelper
+  ##############################################################################
 
   # Build Wix custom action helper
   # Output library in resources dir, and symbols in the object dir
-  $(eval $(call SetupJdkLibrary, BUILD_LIB_WIXHELPER, \
+  $(eval $(call SetupJdkLibrary, BUILD_LIBWIXHELPER, \
       NAME := wixhelper, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libwixhelper, \
       OPTIMIZATION := LOW, \
-      SRC := $(JPACKAGE_WIXHELPER_SRC), \
+      EXTRA_SRC := common, \
       CXXFLAGS_FILTER_OUT := -MD, \
-      CXXFLAGS := $(addprefix -I, $(JPACKAGE_WIXHELPER_SRC)), \
       CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
       LDFLAGS := $(LDFLAGS_CXX_JDK), \
-      LIBS := ole32.lib msi.lib User32.lib shlwapi.lib \
-          Shell32.lib, \
+      LIBS_windows := msi.lib ole32.lib shell32.lib shlwapi.lib user32.lib, \
   ))
 
-  JPACKAGE_TARGETS += $(BUILD_LIB_WIXHELPER)
+  TARGETS += $(BUILD_LIBWIXHELPER)
 
-  JPACKAGE_MSIWRAPPER_SRC := \
-      $(call FindSrcDirsForComponent, jdk.jpackage, msiwrapper) \
-      $(call FindSrcDirsForComponent, jdk.jpackage, common)
+  ##############################################################################
+  ## Build msiwrapper
+  ##############################################################################
 
   # Build exe installer wrapper for msi installer
-  $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_MSIWRAPPER, \
+  $(eval $(call SetupJdkExecutable, BUILD_MSIWRAPPER, \
       NAME := msiwrapper, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/msiwrapper, \
-      SRC := $(JPACKAGE_MSIWRAPPER_SRC), \
+      EXTRA_SRC := common, \
       CXXFLAGS_FILTER_OUT := -MD, \
-      CXXFLAGS := $(addprefix -I, $(JPACKAGE_MSIWRAPPER_SRC)), \
       CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
-      LIBS := ole32.lib msi.lib user32.lib shlwapi.lib Shell32.lib, \
+      LIBS_windows := msi.lib ole32.lib shell32.lib shlwapi.lib user32.lib, \
   ))
 
-  JPACKAGE_TARGETS += $(BUILD_JPACKAGE_MSIWRAPPER)
+  TARGETS += $(BUILD_MSIWRAPPER)
+
+  ##############################################################################
+  ## Build jpackageapplauncherw
+  ##############################################################################
 
   # Build non-console version of launcher
-  $(eval $(call SetupJdkExecutable, BUILD_JPACKAGE_APPLAUNCHERWEXE, \
+  $(eval $(call SetupJdkExecutable, BUILD_JPACKAGEAPPLAUNCHERW, \
       NAME := jpackageapplauncherw, \
-      LINK_TYPE := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LINK_TYPE), \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
-      SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/jpackageapplauncherw, \
-      SRC := $(BUILD_JPACKAGE_APPLAUNCHEREXE_SRC), \
-      OPTIMIZATION := $(BUILD_JPACKAGE_APPLAUNCHEREXE_OPTIMIZATION), \
-      CXXFLAGS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_CXXFLAGS), \
-      CXXFLAGS_windows := $(BUILD_JPACKAGE_APPLAUNCHEREXE_CXXFLAGS_windows) -DJP_LAUNCHERW, \
-      CFLAGS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_CFLAGS), \
-      CFLAGS_windows := $(BUILD_JPACKAGE_APPLAUNCHEREXE_CFLAGS_windows) -DJP_LAUNCHERW, \
-      LD_SET_ORIGIN := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LD_SET_ORIGIN), \
-      LDFLAGS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LDFLAGS), \
-      LIBS := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LIBS), \
-      LIBS_windows := $(BUILD_JPACKAGE_APPLAUNCHEREXE_LIBS_windows), \
+      SYMBOLS_DIR := \
+          $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/jpackageapplauncherw, \
+      SRC := applauncher, \
+      EXTRA_SRC := common, \
+      OPTIMIZATION := LOW, \
+      CFLAGS_FILTER_OUT := -MD, \
+      CXXFLAGS_FILTER_OUT := -MD, \
+      CFLAGS := -DJP_LAUNCHERW, \
+      CXXFLAGS := -DJP_LAUNCHERW, \
+      CFLAGS_windows := -MT $(JPACKAGE_CFLAGS_windows), \
+      CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
+      LD_SET_ORIGIN := false, \
+      LIBS_windows := msi.lib ole32.lib shell32.lib shlwapi.lib user32.lib, \
       MANIFEST := $(JAVA_MANIFEST), \
       MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS) \
   ))
 
-  JPACKAGE_TARGETS += $(BUILD_JPACKAGE_APPLAUNCHERWEXE)
-
+  TARGETS += $(BUILD_JPACKAGEAPPLAUNCHERW)
 endif
-
-
-TARGETS += $(JPACKAGE_TARGETS)
-
-$(JPACKAGE_TARGETS): $(call FindLib, java.base, java)


### PR DESCRIPTION
This is a follow-up on JDK-8328680, making the same kind of cleanup to jdk.jpackage. The code here needed more work than for the other modules, so I wanted have it in a separate PR to get a more thorough review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329102](https://bugs.openjdk.org/browse/JDK-8329102): Clean up jdk.jpackage native compilation (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18491/head:pull/18491` \
`$ git checkout pull/18491`

Update a local copy of the PR: \
`$ git checkout pull/18491` \
`$ git pull https://git.openjdk.org/jdk.git pull/18491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18491`

View PR using the GUI difftool: \
`$ git pr show -t 18491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18491.diff">https://git.openjdk.org/jdk/pull/18491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18491#issuecomment-2021170303)