### PR TITLE
8315767: InetAddress: constructing objects from BSD literal addresses

### DIFF
--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -297,7 +297,7 @@ class Inet4Address extends InetAddress {
      * {@code 255} for {@code "0255"}, {@linkplain Inet4Address#parseAddressStringPosix this}
      * method interprets the numbers based on their prefix (hexadecimal {@code "0x"},
      * octal {@code "0"}) and returns {@code 173} for {@code "0255"}.
-     * 
+     *
      * @param addressLiteral IPv4 address literal to parse
      * @param throwIAE whether to throw {@code IllegalArgumentException} if the
      *                 given {@code addressLiteral} string cannot be parsed as

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -101,7 +101,7 @@ import java.util.Objects;
  * <i>RFC&nbsp;6943: Issues in Identifier Comparison for Security
  * Purposes</i></a>.
  * <p> For methods that return a textual representation as output
- * value, the first form, i.e. a dotted-quad string, is used.
+ * value, the first form, i.e. a dotted-quad string in strict decimal notation, is used.
  *
  * <h3> The Scope of a Multicast Address </h3>
  *

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -252,7 +252,7 @@ class Inet4Address extends InetAddress {
      */
     public static Inet4Address ofPosixLiteral(String posixIPAddressLiteral) {
         Objects.requireNonNull(posixIPAddressLiteral);
-        return parseAddressStringPosix(posixIPAddressLiteral, true);
+        return parseAddressStringPosix(posixIPAddressLiteral);
     }
 
     /**
@@ -318,12 +318,12 @@ class Inet4Address extends InetAddress {
      * @throws IllegalArgumentException if the given {@code addressLiteral} string
      * cannot be parsed as an IPv4 address literal and {@code throwIAE} is {@code true}.
      */
-    static Inet4Address parseAddressStringPosix(String addressLiteral, boolean throwIAE) {
+    private static Inet4Address parseAddressStringPosix(String addressLiteral) {
         byte [] parsedBytes = IPAddressUtil.parseBsdLiteralV4(addressLiteral);
-        if (parsedBytes == null && throwIAE) {
+        if (parsedBytes == null) {
             throw IPAddressUtil.invalidIpAddressLiteral(addressLiteral);
         }
-        return (parsedBytes == null) ? null : new Inet4Address(null, parsedBytes);
+        return new Inet4Address(null, parsedBytes);
     }
 
     /**

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -242,7 +242,7 @@ class Inet4Address extends InetAddress {
      * {@link Inet4Address#ofLiteral Inet4Address.ofLiteral} will throw
      * {@code IllegalArgumentException}.
      *
-     * @param posixIPAddressLiteral the textual representation of an IPv4 address.
+     * @param posixIPAddressLiteral a textual representation of an IPv4 address.
      * @return an {@link Inet4Address} object with no hostname set, and constructed
      *         from the provided IPv4 address literal.
      * @throws IllegalArgumentException if the {@code posixIPAddressLiteral} cannot be

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -191,8 +191,8 @@ class Inet4Address extends InetAddress {
 
     /**
      * Creates an {@code Inet4Address} based on the provided {@linkplain
-     * Inet4Address##format textual representation} of an IPv4 address in
-     * POSIX {@code inet_addr} compatible form.
+     * Inet4Address##format-posix textual representation of an IPv4 address in
+     * POSIX {@code inet_addr} compatible form}.
      * <p> <a id="format-posix"></a> The method {@code ofPosixLiteral}
      * implements <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html">
      * POSIX {@code inet_addr}</a> compatible parsing algorithm, allowing

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -94,10 +94,10 @@ import java.util.Objects;
  * }
  *
  * <p> The above forms adhere "strict" decimal-only syntax.
- * Additionally, the following (loose) syntax is available with
- * {@link Inet4Address#ofPosixLiteral(String)} method that implements
+ * Additionally, the
+ * {@link Inet4Address#ofPosixLiteral(String)} method implements a
  * <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html">
- * POSIX {@code inet_addr}</a> compatible parsing algorithm, allowing
+ * POSIX {@code inet_addr}</a> compatible "loose" parsing algorithm, allowing
  * octal and hexadecimal address segments. Please refer to
  * <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1"> <i>RFC&nbsp;
  * 6943: Issues in Identifier Comparison for Security Purposes</i></a>.

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -94,34 +94,12 @@ import java.util.Objects;
  * }
  *
  * <p> The above forms adhere "strict" decimal-only syntax.
- * Additionally, the
- * {@link Inet4Address#ofPosixLiteral(String)} method implements a
- * <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html">
- * POSIX {@code inet_addr}</a> compatible "loose" parsing algorithm, allowing
- * octal and hexadecimal address segments. Please refer to
- * <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1"> <i>RFC&nbsp;
- * 6943: Issues in Identifier Comparison for Security Purposes</i></a>.
- * <p> <a id="format-posix"></a> The following (non-decimal) forms are
- * supported by {@link Inet4Address#ofPosixLiteral(String)} method:
- * {@snippet :
- *  // Dotted-quad 'x.x.x.x' form with four part address literal
- *  Inet4Address.ofPosixLiteral("0177.0000.0000.0001"); // ==> /127.0.0.1
- *  Inet4Address.ofPosixLiteral("0127.0.0.1"); // ==> /87.0.0.1
- *
- *  // Dotted-triple 'x.x.x' form with three part address literal,
- *  // the last part is placed in the rightmost two bytes
- *  // of the constructed address
- *  Inet4Address.ofPosixLiteral("0x7F.0.0x101"); // ==> /127.0.1.1
- *
- *  // Dotted-double 'x.x' form with two part address literal,
- *  // the last part is placed in the rightmost three bytes
- *  // of the constructed address
- *  Inet4Address.ofPosixLiteral("0177.0200401"); // ==> /127.1.1.1
- *
- *  // Dotless 'x' form with one value that is stored directly in
- *  // the constructed address bytes without any rearrangement
- *  Inet4Address.ofPosixLiteral("017700000001"); // ==> /127.0.0.1
- * }
+ * Additionally, the {@link Inet4Address#ofPosixLiteral(String)}
+ * method implements a POSIX {@code inet_addr} compatible "loose"
+ * parsing algorithm, allowing octal and hexadecimal address segments.
+ * Please refer to <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1">
+ * <i>RFC&nbsp;6943: Issues in Identifier Comparison for Security
+ * Purposes</i></a>.
  * <p> For methods that return a textual representation as output
  * value, the first form, i.e. a dotted-quad string, is used.
  *
@@ -214,9 +192,42 @@ class Inet4Address extends InetAddress {
     /**
      * Creates an {@code Inet4Address} based on the provided {@linkplain
      * Inet4Address##format textual representation} of an IPv4 address in
-     * {@linkplain Inet4Address##format-posix POSIX form.}
-     * <p> If the provided IPv4 address literal cannot represent a {@linkplain
-     * Inet4Address##format valid IPv4 address} an {@code IllegalArgumentException} is thrown.
+     * POSIX {@code inet_addr} compatible form.
+     * <p> <a id="format-posix"></a> The method {@code ofPosixLiteral}
+     * implements <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html">
+     * POSIX {@code inet_addr}</a> compatible parsing algorithm, allowing
+     * octal and hexadecimal address segments. {@code "0"} is the prefix
+     * for octal numbers, {@code "0x"} and {@code "0X"} are the prefixes
+     * for hexadecimal numbers. Non-zero address segments that start from
+     * non-zero digits are parsed as decimal numbers. The following
+     * (non-decimal) forms are supported by this method:
+     * {@snippet :
+     *  // Dotted-quad 'x.x.x.x' form with four part address literal
+     *  Inet4Address.ofPosixLiteral("0177.0.0.1"); // ==> /127.0.0.1
+     *  Inet4Address.ofPosixLiteral("0x7F.0.0.1"); // ==> /127.0.0.1
+     *
+     *  // Dotted-triple 'x.x.x' form with three part address literal,
+     *  // the last part is placed in the rightmost two bytes
+     *  // of the constructed address
+     *  Inet4Address.ofPosixLiteral("0177.0.0402"); // ==> /127.0.1.2
+     *  Inet4Address.ofPosixLiteral("0x7F.0.0x102"); // ==> /127.0.1.2
+     *
+     *  // Dotted-double 'x.x' form with two part address literal,
+     *  // the last part is placed in the rightmost three bytes
+     *  // of the constructed address
+     *  Inet4Address.ofPosixLiteral("0177.0201003"); // ==> /127.1.2.3
+     *  Inet4Address.ofPosixLiteral("0x7F.0x10203"); // ==> /127.1.2.3
+     *  Inet4Address.ofPosixLiteral("127.66051"); // ==> /127.1.2.3
+     *
+     *  // Dotless 'x' form with one value that is stored directly in
+     *  // the constructed address bytes without any rearrangement
+     *  Inet4Address.ofPosixLiteral("0100401404"); // ==> /1.2.3.4
+     *  Inet4Address.ofPosixLiteral("0x1020304"); // ==> /1.2.3.4
+     *  Inet4Address.ofPosixLiteral("16909060"); // ==> /1.2.3.4
+     * }
+     * <p> If the provided IPv4 address literal cannot represent a
+     * valid IPv4 address in {@linkplain Inet4Address##format-posix
+     * POSIX form} an {@code IllegalArgumentException} is thrown.
      * <p> This method doesn't block, i.e. no hostname lookup is performed.
      *
      * @apiNote

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -94,14 +94,14 @@ import java.util.Objects;
  * }
  *
  * <p> The above forms adhere "strict" decimal-only syntax.
- * The following (loose) syntax is optionally available with
+ * Additionally, the following (loose) syntax is available with
  * {@link Inet4Address#ofPosixLiteral(String)} method that implements
  * <a href="https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html">
  * POSIX {@code inet_addr}</a> compatible parsing algorithm, allowing
  * octal and hexadecimal address segments. Please refer to
  * <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1"> <i>RFC&nbsp;
- * 6943: Issues in Identifier Comparison for Security Purposes</i></a>
- * at the section 3.1.1. The following (non-decimal) forms are supported
+ * 6943: Issues in Identifier Comparison for Security Purposes</i></a>.
+ * <p> The following (non-decimal) forms are supported
  * in this mode:
  * {@snippet :
  *  // Dotted-quad 'x.x.x.x' form with four part address literal

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -101,8 +101,8 @@ import java.util.Objects;
  * octal and hexadecimal address segments. Please refer to
  * <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1"> <i>RFC&nbsp;
  * 6943: Issues in Identifier Comparison for Security Purposes</i></a>.
- * <p> The following (non-decimal) forms are supported
- * in this mode:
+ * <p> <a id="format-posix"></a> The following (non-decimal) forms are
+ * supported by {@link Inet4Address#ofPosixLiteral(String)} method:
  * {@snippet :
  *  // Dotted-quad 'x.x.x.x' form with four part address literal
  *  Inet4Address.ofPosixLiteral("0177.0000.0000.0001"); // ==> /127.0.0.1
@@ -213,23 +213,23 @@ class Inet4Address extends InetAddress {
 
     /**
      * Creates an {@code Inet4Address} based on the provided {@linkplain
-     * Inet4Address##format textual representation} of an IPv4 address in POSIX form.
-     * This form allows extended syntax, accepting hexadecimal and octal address
-     * segments as specified in {@code inet_addr} POSIX API (loose syntax). Please
-     * refer to <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1">
-     * <i>RFC&nbsp;6943: Issues in Identifier Comparison for Security Purposes</i></a>.
+     * Inet4Address##format textual representation} of an IPv4 address in
+     * {@linkplain Inet4Address##format-posix POSIX form.}
      * <p> If the provided IPv4 address literal cannot represent a {@linkplain
      * Inet4Address##format valid IPv4 address} an {@code IllegalArgumentException} is thrown.
      * <p> This method doesn't block, i.e. no hostname lookup is performed.
      *
      * @apiNote
      * This method produces different results compared to {@linkplain Inet4Address#ofLiteral}
-     * when {@code posixIPAddressLiteral} parameter contains octal address segments below
-     * {@code 0256} (decimal {@code 174}). Unlike {@linkplain Inet4Address#ofLiteral}
-     * that ignores leading zeros, parses all numbers as decimal and produces
-     * {@code 255} for {@code "0255"}, {@linkplain Inet4Address#ofPosixLiteral this}
-     * method interprets the numbers based on their prefix (hexadecimal {@code "0x"},
-     * octal {@code "0"}) and returns {@code 173} for {@code "0255"}.
+     * when {@code posixIPAddressLiteral} parameter contains address segments with
+     * leading zeroes. An address segment with a leading zero is always parsed as an octal
+     * number by this method, therefore {@code 0255} (octal) will be parsed as
+     * {@code 173} (decimal). On the other hand, {@link Inet4Address#ofLiteral
+     * Inet4Address.ofLiteral} ignores leading zeros, parses all numbers as decimal and produces
+     * {@code 255}. Where this method would parse {@code 0256.0256.0256.0256} (octal) and
+     * produce {@code 174.174.174.174} (decimal) in four dotted quad notation,
+     * {@link Inet4Address#ofLiteral Inet4Address.ofLiteral} will throw
+     * {@code IllegalArgumentException}.
      *
      * @param posixIPAddressLiteral the textual representation of an IPv4 address.
      * @return an {@link Inet4Address} object with no hostname set, and constructed
@@ -277,11 +277,8 @@ class Inet4Address extends InetAddress {
     }
 
     /**
-     * Parses the given string as an IPv4 address literal in POSIX form.
-     * This form allows extended syntax, accepting hexadecimal and octal address
-     * segments as specified in {@code inet_addr} POSIX API (loose syntax). Please
-     * refer to <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1">
-     * <i>RFC&nbsp;6943: Issues in Identifier Comparison for Security Purposes</i></a>.
+     * Parses the given string as an IPv4 address literal in
+     * {@linkplain Inet4Address##format-posix POSIX form.}
      *
      * <p> If the given {@code addressLiteral} string cannot be parsed as an IPv4 address literal
      * in POSIX form and {@code throwIAE} is {@code false}, {@code null} is returned.
@@ -291,12 +288,15 @@ class Inet4Address extends InetAddress {
      *
      * @apiNote
      * This method produces different results compared to {@linkplain Inet4Address#parseAddressString}
-     * when {@code addressLiteral} string contains octal address segments below
-     * {@code 0256} (decimal {@code 174}). Unlike {@linkplain Inet4Address#parseAddressString}
-     * that ignores leading zeros, parses all numbers as decimal and produces
-     * {@code 255} for {@code "0255"}, {@linkplain Inet4Address#parseAddressStringPosix this}
-     * method interprets the numbers based on their prefix (hexadecimal {@code "0x"},
-     * octal {@code "0"}) and returns {@code 173} for {@code "0255"}.
+     * when {@code addressLiteral} parameter contains address segments with leading
+     * zeroes. An address segment with a leading zero is always parsed as an octal
+     * number by this method, therefore {@code 0255} (octal) will be parsed as
+     * {@code 173} (decimal). On the other hand, {@link Inet4Address#parseAddressString}
+     * ignores leading zeros, parses all numbers as decimal and produces {@code 255}.
+     * Where this method would parse {@code 0256.0256.0256.0256} (octal) and produce
+     * {@code 174.174.174.174} (decimal) in four dotted quad notation, {@linkplain
+     * Inet4Address#parseAddressString} will either throw {@code IllegalArgumentException}
+     * or return {@code null}, depending on the value of {@code throwIAE}.
      *
      * @param addressLiteral IPv4 address literal to parse
      * @param throwIAE whether to throw {@code IllegalArgumentException} if the

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -70,9 +70,9 @@ import java.util.Objects;
  * <p> When only one part is given, the value is stored directly in
  * the network address without any byte rearrangement.
  *
- * <p> For example, the following (decimal) forms are supported by methods
+ * <p> For example, the following (decimal) forms are supported by the methods
  * {@link Inet4Address#ofLiteral(String)} and {@link InetAddress#getByName(String)}
- * capable of parsing textual representations of IPv4 addresses:
+ * which are capable of parsing textual representations of IPv4 addresses:
  * {@snippet :
  *  // Dotted-decimal 'd.d.d.d' form with four part address literal
  *  InetAddress.getByName("007.008.009.010"); // ==> /7.8.9.10
@@ -93,7 +93,7 @@ import java.util.Objects;
  *  Inet4Address.ofLiteral("02130706689"); // ==> /127.0.1.1
  * }
  *
- * <p> The above forms adhere "strict" decimal-only syntax.
+ * <p> The above forms adhere to "strict" decimal-only syntax.
  * Additionally, the {@link Inet4Address#ofPosixLiteral(String)}
  * method implements a POSIX {@code inet_addr} compatible "loose"
  * parsing algorithm, allowing octal and hexadecimal address segments.

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -70,9 +70,9 @@ import java.util.Objects;
  * <p> When only one part is given, the value is stored directly in
  * the network address without any byte rearrangement.
  *
- * <p> These forms support parts specified in decimal format only.
- * For example, the following forms are supported by methods capable
- * of parsing textual representations of IPv4 addresses:
+ * <p> For example, the following (decimal) forms are supported by methods
+ * {@link Inet4Address#ofLiteral(String)} and {@link InetAddress#getByName(String)}
+ * capable of parsing textual representations of IPv4 addresses:
  * {@snippet :
  *  // Dotted-decimal 'd.d.d.d' form with four part address literal
  *  InetAddress.getByName("007.008.009.010"); // ==> /7.8.9.10

--- a/src/java.base/share/classes/java/net/Inet4Address.java
+++ b/src/java.base/share/classes/java/net/Inet4Address.java
@@ -99,7 +99,8 @@ import java.util.Objects;
  * parsing algorithm, allowing octal and hexadecimal address segments.
  * Please refer to <a href="https://www.ietf.org/rfc/rfc6943.html#section-3.1.1">
  * <i>RFC&nbsp;6943: Issues in Identifier Comparison for Security
- * Purposes</i></a>.
+ * Purposes</i></a>. Aside from {@code Inet4Address.ofPosixLiteral(String)}, all methods only
+ * support strict decimal parsing.
  * <p> For methods that return a textual representation as output
  * value, the first form, i.e. a dotted-quad string in strict decimal notation, is used.
  *

--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -1722,6 +1722,7 @@ public sealed class InetAddress implements Serializable permits Inet4Address, In
      * @throws NullPointerException if the {@code ipAddressLiteral} is {@code null}.
      * @see Inet4Address#ofLiteral(String)
      * @see Inet6Address#ofLiteral(String)
+     * @see Inet4Address#ofPosixLiteral(String)
      * @since 22
      */
     public static InetAddress ofLiteral(String ipAddressLiteral) {

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -709,6 +709,10 @@ public class IPAddressUtil {
                 fieldValue = parseV4FieldBsd(radix, charBuffer, fieldNumber);
                 if (fieldValue >= 0) {
                     if (fieldValue < 256) {
+                        // Store the parsed field in the byte buffer.
+                        // If the field value is greater than 255, it can only be the last field.
+                        // If it is not the last one, parseV4FieldBsd enforces this limit
+                        // and returns TERMINAL_PARSE_ERROR.
                         res[fieldNumber] = (byte) fieldValue;
                     }
                     fieldNumber++;

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -727,7 +727,7 @@ public class IPAddressUtil {
         if (fieldValue < 0) {
             return null;
         }
-        // If the last fieldValue is greater than 255 (fieldNumer < 4),
+        // If the last fieldValue is greater than 255 (fieldNumber < 4),
         // it is written to the last (4 - (fieldNumber - 1)) octets
         // in the network order
         if (fieldNumber < 4) {

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -671,9 +671,9 @@ public class IPAddressUtil {
 
     /**
      * Parse String as IPv4 address literal by following
-     * BSD-style formatting rules.
+     * POSIX-style formatting rules.
      *
-     * @param input a String representing an IPv4 address in BSD format
+     * @param input a String representing an IPv4 address in POSIX format
      * @return a byte array representing the IPv4 numeric address
      * if input string is a parsable BSD style IPv4 address literal,
      * {@code null} otherwise.

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -682,6 +682,10 @@ public class IPAddressUtil {
 
         byte[] res = new byte[]{0,0,0,0};
 
+        int len = input.length();
+        if (len == 0) {
+            return null;
+        }
         char firstSymbol = input.charAt(0);
         // Check if first digit is not a decimal digit
         if (parseAsciiDigit(firstSymbol, DECIMAL) == -1) {
@@ -689,7 +693,7 @@ public class IPAddressUtil {
         }
 
         // Last character is dot OR is not a supported digit: [0-9,A-F,a-f]
-        char lastSymbol = input.charAt(input.length() - 1);
+        char lastSymbol = input.charAt(len - 1);
         if (lastSymbol == '.' || parseAsciiHexDigit(lastSymbol) == -1) {
             return null;
         }

--- a/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
+++ b/src/java.base/share/classes/sun/net/util/IPAddressUtil.java
@@ -675,7 +675,7 @@ public class IPAddressUtil {
      *
      * @param input a String representing an IPv4 address in POSIX format
      * @return a byte array representing the IPv4 numeric address
-     * if input string is a parsable BSD style IPv4 address literal,
+     * if input string is a parsable POSIX formatted IPv4 address literal,
      * {@code null} otherwise.
      */
     public static byte[] parseBsdLiteralV4(String input) {

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -331,6 +331,7 @@ public class OfLiteralTest {
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "127.08.9.1"),  // 8, 9 are invalid octals
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "127.8.09.1"),
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "048"),
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, ""),            // empty
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x1FFFFFFFF"), // 2^33 - 1 is too large
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100000000")  // 2^32 is too large
         );

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 8272215
+ * @bug 8272215 8315767
  * @summary Test for ofLiteral API in InetAddress classes
  * @run junit/othervm -Djdk.net.hosts.file=nonExistingHostsFile.txt
  *                     OfLiteralTest
@@ -67,11 +67,15 @@ public class OfLiteralTest {
         InetAddress ofLiteralResult = switch (inetAddressClass) {
             case INET_ADDRESS -> InetAddress.ofLiteral(addressLiteral);
             case INET4_ADDRESS -> Inet4Address.ofLiteral(addressLiteral);
+            case INET4_ADDRESS_POSIX -> Inet4Address.ofPosixLiteral(addressLiteral);
             case INET6_ADDRESS -> Inet6Address.ofLiteral(addressLiteral);
         };
-        InetAddress getByNameResult = InetAddress.getByName(addressLiteral);
         Assert.assertArrayEquals(expectedAddressBytes, ofLiteralResult.getAddress());
-        Assert.assertEquals(getByNameResult, ofLiteralResult);
+        // POSIX literals are not compatible with InetAddress.getByName()
+        if (inetAddressClass != InetAddressClass.INET4_ADDRESS_POSIX) {
+            InetAddress getByNameResult = InetAddress.getByName(addressLiteral);
+            Assert.assertEquals(getByNameResult, ofLiteralResult);
+        }
     }
 
     private static Stream<Arguments> validLiteralArguments() throws Exception {
@@ -100,6 +104,30 @@ public class OfLiteralTest {
         // ::FFFF:129.144.52.38 address bytes
         byte[] ipv6Ipv4MappedAddressExpBytes = new byte[]{
                 (byte) 129, (byte) 144, 52, 38};
+
+        // 87.0.0.1 address bytes
+        byte[] ipv4_87_0_0_1 = new byte[]{87, 0, 0, 1};
+
+        // 127.0.0.1 address bytes
+        byte[] ipv4_127_0_0_1 = new byte[]{127, 0, 0, 1};
+
+        // 17.99.141.27 address bytes
+        byte[] ipv4_17_99_141_27 = new byte[]{17, 99, (byte)141, 27};
+
+        // 127.8.0.1 address bytes
+        byte[] ipv4_127_8_0_1 = new byte[]{127, 8, 0, 1};
+
+        // 0.0.0.42 address bytes
+        byte[] ipv4_0_0_0_42 = new byte[]{0, 0, 0, 42};
+
+        // 0.0.0.34 address bytes
+        byte[] ipv4_0_0_0_34 = new byte[]{0, 0, 0, 34};
+
+        // 127.0.1.1 address bytes
+        byte[] ipv4_127_0_1_1 = new byte[]{127, 0, 1, 1};
+
+        // 127.1.1.1 address bytes
+        byte[] ipv4_127_1_1_1 = new byte[]{127, 1, 1, 1};
 
         Stream<Arguments> validLiterals = Stream.of(
                 // IPv6 address literals are parsable by Inet6Address.ofLiteral
@@ -170,7 +198,51 @@ public class OfLiteralTest {
                 //      with leading 0 that is discarded and address
                 //      parsed as decimal
                 Arguments.of(InetAddressClass.INET_ADDRESS,
-                        "03735928559", ipv4ExpBytes)
+                        "03735928559", ipv4ExpBytes),
+                //      form:'x.x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0127.0.0.1", ipv4_87_0_0_1),
+                //      form:'x.x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0177.0.0.1", ipv4_127_0_0_1),
+                //      form:'x.x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0s treated as octal segment prefixes
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0177.0000.0000.0001", ipv4_127_0_0_1),
+                //      form:'x.x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "127.010.0.1", ipv4_127_8_0_1),
+                //      form:'x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0x treated as hexadecimal segment prefixes
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0x7F.0.0x101", ipv4_127_0_1_1),
+                //      form:'x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0s treated as octal segment prefixes
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0177.0200401", ipv4_127_1_1_1),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "017700000001", ipv4_127_0_0_1),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "02130706433", ipv4_17_99_141_27),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      without leading 0 treated as decimal
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "2130706433", ipv4_127_0_0_1),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      without leading 0 treated as decimal
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "42", ipv4_0_0_0_42),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "042", ipv4_0_0_0_34)
         );
 
         // Generate addresses for loopback and wildcard address test cases
@@ -251,7 +323,16 @@ public class OfLiteralTest {
                 Arguments.of(InetAddressClass.INET_ADDRESS, "0x1.2.3.4"),
                 Arguments.of(InetAddressClass.INET4_ADDRESS, "1.2.0x3.4"),
                 Arguments.of(InetAddressClass.INET_ADDRESS, "0xFFFFFFFF"),
-                Arguments.of(InetAddressClass.INET4_ADDRESS, "0xFFFFFFFF")
+                Arguments.of(InetAddressClass.INET4_ADDRESS, "0xFFFFFFFF"),
+
+                // invalid IPv4 literals in POSIX/BSD form
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100.1.2.3"), // 0x100 is too large
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "1.2.3.0x100"),
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "127.08.9.1"),  // 8, 9 are invalid octals
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "127.8.09.1"),
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "048"),
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x1FFFFFFFF"), // 2^33 - 1 is too large
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100000000")  // 2^32 is too large
         );
         // Construct arguments for a test case with IPv6-scoped address with scope-id
         // specified as a string with non-existing network interface name
@@ -297,6 +378,7 @@ public class OfLiteralTest {
         return switch (inetAddressClass) {
             case INET_ADDRESS -> () -> InetAddress.ofLiteral(input);
             case INET4_ADDRESS -> () -> Inet4Address.ofLiteral(input);
+            case INET4_ADDRESS_POSIX -> () -> Inet4Address.ofPosixLiteral(input);
             case INET6_ADDRESS -> () -> Inet6Address.ofLiteral(input);
         };
     }
@@ -304,6 +386,7 @@ public class OfLiteralTest {
     enum InetAddressClass {
         INET_ADDRESS,
         INET4_ADDRESS,
+        INET4_ADDRESS_POSIX,
         INET6_ADDRESS
     }
 }

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 8272215 8315767
- * @summary Test for ofLiteral API in InetAddress classes
+ * @summary Test for ofLiteral, ofPosixLiteral APIs in InetAddress classes
  * @run junit/othervm -Djdk.net.hosts.file=nonExistingHostsFile.txt
  *                     OfLiteralTest
  * @run junit/othervm -Djdk.net.hosts.file=nonExistingHostsFile.txt

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -124,10 +124,10 @@ public class OfLiteralTest {
         byte[] ipv4_0_0_0_34 = new byte[]{0, 0, 0, 34};
 
         // 127.0.1.1 address bytes
-        byte[] ipv4_127_0_1_1 = new byte[]{127, 0, 1, 1};
+        byte[] ipv4_127_0_1_2 = new byte[]{127, 0, 1, 2};
 
         // 127.1.1.1 address bytes
-        byte[] ipv4_127_1_1_1 = new byte[]{127, 1, 1, 1};
+        byte[] ipv4_127_1_2_3 = new byte[]{127, 1, 2, 3};
 
         // 255.255.255.255 address bytes
         byte[] ipv4_255_255_255_255 = new byte[]{(byte)255, (byte)255, (byte)255, (byte)255};
@@ -223,13 +223,25 @@ public class OfLiteralTest {
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
                         "0377.0377.0377.0377", ipv4_255_255_255_255),
                 //      form:'x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0s treated as octal segment prefixes
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0177.0.0402", ipv4_127_0_1_2),
+                //      form:'x.x.x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0x treated as hexadecimal segment prefixes
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
-                        "0x7F.0.0x101", ipv4_127_0_1_1),
+                        "0x7F.0.0x102", ipv4_127_0_1_2),
                 //      form:'x.x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0s treated as octal segment prefixes
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
-                        "0177.0200401", ipv4_127_1_1_1),
+                        "0177.0201003", ipv4_127_1_2_3),
+                //      form:'x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0x treated as hexadecimal prefixes
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0x7F.0x10203", ipv4_127_1_2_3),
+                //      form:'x.x' method:InetAddress.ofPosixLiteral -
+                //      without prefixes treated as decimal
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "127.66051", ipv4_127_1_2_3),
                 //      form:'x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0 treated as octal segment prefix
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
@@ -245,6 +257,10 @@ public class OfLiteralTest {
                 //      form:'x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0x treated as hex prefix
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0x1020304", oneToFourAddressExpBytes),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0x treated as hex prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
                         "0xFFFFFFFF", ipv4_255_255_255_255),
                 //      form:'x' method:InetAddress.ofPosixLiteral -
                 //      without leading 0 treated as decimal
@@ -254,6 +270,14 @@ public class OfLiteralTest {
                 //      without leading 0 treated as decimal
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
                         "42", ipv4_0_0_0_42),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0100401404", oneToFourAddressExpBytes),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      without prefixes treated as decimal
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "16909060", oneToFourAddressExpBytes),
                 //      form:'x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0 treated as octal segment prefix
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -123,10 +123,10 @@ public class OfLiteralTest {
         // 0.0.0.34 address bytes
         byte[] ipv4_0_0_0_34 = new byte[]{0, 0, 0, 34};
 
-        // 127.0.1.1 address bytes
+        // 127.0.1.2 address bytes
         byte[] ipv4_127_0_1_2 = new byte[]{127, 0, 1, 2};
 
-        // 127.1.1.1 address bytes
+        // 127.1.2.3 address bytes
         byte[] ipv4_127_1_2_3 = new byte[]{127, 1, 2, 3};
 
         // 255.255.255.255 address bytes

--- a/test/jdk/java/net/InetAddress/OfLiteralTest.java
+++ b/test/jdk/java/net/InetAddress/OfLiteralTest.java
@@ -129,6 +129,9 @@ public class OfLiteralTest {
         // 127.1.1.1 address bytes
         byte[] ipv4_127_1_1_1 = new byte[]{127, 1, 1, 1};
 
+        // 255.255.255.255 address bytes
+        byte[] ipv4_255_255_255_255 = new byte[]{(byte)255, (byte)255, (byte)255, (byte)255};
+
         Stream<Arguments> validLiterals = Stream.of(
                 // IPv6 address literals are parsable by Inet6Address.ofLiteral
                 // and InetAddress.ofLiteral methods
@@ -215,6 +218,10 @@ public class OfLiteralTest {
                 //      with leading 0 treated as octal segment prefix
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
                         "127.010.0.1", ipv4_127_8_0_1),
+                //      form:'x.x.x.x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0377.0377.0377.0377", ipv4_255_255_255_255),
                 //      form:'x.x.x' method:InetAddress.ofPosixLiteral -
                 //      with leading 0x treated as hexadecimal segment prefixes
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
@@ -231,6 +238,14 @@ public class OfLiteralTest {
                 //      with leading 0 treated as octal segment prefix
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
                         "02130706433", ipv4_17_99_141_27),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0 treated as octal segment prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "037777777777", ipv4_255_255_255_255),
+                //      form:'x' method:InetAddress.ofPosixLiteral -
+                //      with leading 0x treated as hex prefix
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
+                        "0xFFFFFFFF", ipv4_255_255_255_255),
                 //      form:'x' method:InetAddress.ofPosixLiteral -
                 //      without leading 0 treated as decimal
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX,
@@ -333,7 +348,8 @@ public class OfLiteralTest {
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "048"),
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, ""),            // empty
                 Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x1FFFFFFFF"), // 2^33 - 1 is too large
-                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100000000")  // 2^32 is too large
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "0x100000000"), // 2^32 is too large
+                Arguments.of(InetAddressClass.INET4_ADDRESS_POSIX, "040000000000")
         );
         // Construct arguments for a test case with IPv6-scoped address with scope-id
         // specified as a string with non-existing network interface name


### PR DESCRIPTION
There are two distinct approaches to parsing IPv4 literal addresses. One is the Java baseline "strict" syntax (all-decimal d.d.d.d form family), another one is the "loose" syntax of RFC 6943 section 3.1.1 [1] (POSIX `inet_addr` allowing octal and hexadecimal forms [2]). The goal of this PR is to provide interface to construct InetAddress objects from literal addresses in POSIX form, to applications that need to mimic the behavior of `inet_addr` used by standard network utilities such as netcat/curl/wget and the majority of web browsers. At present time, there's no way to construct `InetAddress` object from such literal addresses because the existing APIs such as `InetAddress.getByName()`, `InetAddress#ofLiteral()` and `Inet4Address#ofLiteral()` will consume an address and successfully parse it as decimal, regardless of the octal prefix. Hence, the resulting object will point to a different IP address.

Historically `InetAddress.getByName()/.getAllByName()` were the only way to convert a literal address into an InetAddress object. `getAllByName()` API relies on POSIX `getaddrinfo` / `inet_addr` which parses IP address segments with `strtoul` (accepts octal and hexadecimal bases).

The fallback to `getaddrinfo` is undesirable as it may end up with network queries (blocking mode), if `inet_addr` rejects the input literal address. The Java standard explicitly says that
```
"If a literal IP address is supplied, only the validity of the address format is checked."
```
@AlekseiEfimov contributed JDK-8272215 [3] that adds new factory methods `.ofLiteral()` to `InetAddress` classes. Although the new API is not affected by the `getaddrinfo` fallback issue, it is not sufficient for an application that needs to interoperate with external tooling that follows POSIX standard. In the current state, `InetAddress#ofLiteral()` and `Inet4Address#ofLiteral()` will consume the input literal address and (regardless of the octal prefix) parse it as decimal numbers. Hence, it's not possible to reliably construct an `InetAddress` object from a literal address in POSIX form that would point to the desired host.

It is proposed to extend the factory methods with `Inet4Address#ofPosixLiteral()` that allows parsing literal IP(v4) addresses in "loose" syntax, compatible with `inet_addr` POSIX api. The implementation is based on `.isBsdParsableV4()` method added along with JDK-8277608 [4]. The changes in the original algorithm are as follows:

- `IPAddressUtil#parseBsdLiteralV4()` method is extracted from `.isBsdParsableV4()`
- an additional check is added, whether an input string is empty
- `null` is returned whenever the original algorithm fails
- a condition was added to the parser loop, that stores the IPv4 address segment value when it fits in 1 byte (0 <= x < 256)
- an additional check was added to verify that the last field value is non-negative
- when the last field value is multi-byte (the number of fields is less than 4), it is written to the last (4-(fieldNumber-1)) octets

The new method hasn't been added to InetAddress superclass because the change is only related to IPv4 addressing. This reduces the chance that client code will call the wrong factory method.

`test/jdk/java/net/InetAddress/OfLiteralTest.java` was updated to include `.ofPosixLiteral()` tests

Javadocs in `Inet4Address` were updated accordingly

The new method can be used as follows
```java
import java.net.InetAddress;
import java.net.Inet4Address;

public class Test {
    public static void main(String[] args) throws Throwable {
        if (args.length < 1) {
            System.err.println("USAGE: java Test <host>");
            return;
        }
        InetAddress ia = Inet4Address.ofPosixLiteral(args[0]);
        System.out.println(ia.toString());
    }
}
```
The output would be
```shell
$ ./build/images/jdk/bin/java Test 2130706433
/127.0.0.1
$ ./build/images/jdk/bin/java Test 02130706433
/17.99.141.27
$ ./build/images/jdk/bin/java Test 2130706438
/127.0.0.6
$ ./build/images/jdk/bin/java Test 02130706438
Exception in thread "main" java.lang.IllegalArgumentException: Invalid IP address literal: 02130706438
        at java.base/sun.net.util.IPAddressUtil.invalidIpAddressLiteral(IPAddressUtil.java:169)
        at java.base/java.net.Inet4Address.parseAddressStringPosix(Inet4Address.java:302)
        at java.base/java.net.Inet4Address.ofPosixLiteral(Inet4Address.java:239)
        at Test.main(Test.java:10)
```

[1] https://www.ietf.org/rfc/rfc6943.html#section-3.1.1
[2] https://pubs.opengroup.org/onlinepubs/9699919799/functions/inet_addr.html
[3] https://bugs.openjdk.org/browse/JDK-8272215
[4] https://github.com/openjdk/jdk/commit/cdc1582d1d7629c2077f6cd19786d23323111018

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8329876](https://bugs.openjdk.org/browse/JDK-8329876) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8315767](https://bugs.openjdk.org/browse/JDK-8315767): InetAddress: constructing objects from BSD literal addresses (**Enhancement** - P3)
 * [JDK-8329876](https://bugs.openjdk.org/browse/JDK-8329876): InetAddress: constructing objects from BSD literal addresses (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**) ⚠️ Review applies to [007807ac](https://git.openjdk.org/jdk/pull/18493/files/007807aceeaf5dea85395373587c541fdfd90746)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**) ⚠️ Review applies to [007807ac](https://git.openjdk.org/jdk/pull/18493/files/007807aceeaf5dea85395373587c541fdfd90746)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18493/head:pull/18493` \
`$ git checkout pull/18493`

Update a local copy of the PR: \
`$ git checkout pull/18493` \
`$ git pull https://git.openjdk.org/jdk.git pull/18493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18493`

View PR using the GUI difftool: \
`$ git pr show -t 18493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18493.diff">https://git.openjdk.org/jdk/pull/18493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18493#issuecomment-2043942722)