### PR TITLE
8329115: Crash involving return from inner switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -2473,6 +2473,9 @@ public class Attr extends JCTree.Visitor {
             log.error(tree.pos(), Errors.RetOutsideMeth);
         } else if (env.info.yieldResult != null) {
             log.error(tree.pos(), Errors.ReturnOutsideSwitchExpression);
+            if (tree.expr != null) {
+                attribExpr(tree.expr, env, env.info.yieldResult.pt);
+            }
         } else if (!env.info.isLambda &&
                 !env.info.isNewClass &&
                 env.enclMethod != null &&

--- a/test/langtools/tools/javac/patterns/T8329115.java
+++ b/test/langtools/tools/javac/patterns/T8329115.java
@@ -1,0 +1,20 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8329115
+ * @summary Crash involving return from inner switch
+ * @compile/fail/ref=T8329115.out -XDrawDiagnostics -XDdev T8329115.java
+ */
+public class T8329115 {
+    record R1() {}
+    record R2() {}
+
+    int test() {
+        return switch (new R1()) {
+            case R1() -> {
+                return switch (new R2()) { // crashes, instead it should just be the error: attempt to return out of a switch expression
+                    case R2() -> 1;
+                };
+            }
+        };
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8329115.out
+++ b/test/langtools/tools/javac/patterns/T8329115.out
@@ -1,0 +1,3 @@
+T8329115.java:14:17: compiler.err.return.outside.switch.expression
+T8329115.java:12:16: compiler.err.switch.expression.no.result.expressions
+2 errors


### PR DESCRIPTION
When a `return` is used erroneously in a `switch`, attribution should continue for the `tree.expr` of a return node if exists.

```java
int test() {
      return switch (new R1()) {
          case R1() -> {
              return switch (new R2()) { // crashes, instead it should just be the error: attempt to return out of a switch expression
                  case R2() -> 1;
              };
          }
      };
  }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329115](https://bugs.openjdk.org/browse/JDK-8329115): Crash involving return from inner switch (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18494/head:pull/18494` \
`$ git checkout pull/18494`

Update a local copy of the PR: \
`$ git checkout pull/18494` \
`$ git pull https://git.openjdk.org/jdk.git pull/18494/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18494`

View PR using the GUI difftool: \
`$ git pr show -t 18494`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18494.diff">https://git.openjdk.org/jdk/pull/18494.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18494#issuecomment-2021153532)