### PR TITLE
8247449: Revisit the argument processing logic for MetaspaceShared::disable_optimized_module_handling()

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -235,18 +235,17 @@ void CDSConfig::init_shared_archive_paths() {
   }
 }
 
-void CDSConfig::check_system_property(const char* key, const char* value) {
+void CDSConfig::check_internal_module_property(const char* key, const char* value) {
   if (Arguments::is_internal_module_property(key)) {
     stop_using_optimized_module_handling();
     log_info(cds)("optimized module handling: disabled due to incompatible property: %s=%s", key, value);
   }
-  if (strcmp(key, "jdk.module.showModuleResolution") == 0 ||
-      strcmp(key, "jdk.module.validation") == 0 ||
-      strcmp(key, "java.system.class.loader") == 0) {
-    stop_dumping_full_module_graph();
-    stop_using_full_module_graph();
-    log_info(cds)("full module graph: disabled due to incompatible property: %s=%s", key, value);
-  }
+}
+
+void CDSConfig::handle_incompatible_property(const char* prop) {
+  stop_dumping_full_module_graph();
+  stop_using_full_module_graph();
+  log_info(cds)("full module graph: disabled due to incompatible property: %s", prop);
 }
 
 static const char* unsupported_properties[] = {

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -249,8 +249,8 @@ void CDSConfig::check_incompatible_property(const char* key, const char* value) 
     "jdk.module.validation"
   };
 
-  for (uint i = 0; i < ARRAY_SIZE(incompatible_properties); i++) {
-    if (strcmp(key, incompatible_properties[i]) == 0) {
+  for (const char* property : incompatible_properties) {
+    if (strcmp(key, property) == 0) {
       stop_dumping_full_module_graph();
       stop_using_full_module_graph();
       log_info(cds)("full module graph: disabled due to incompatible property: %s=%s", key, value);

--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -242,10 +242,22 @@ void CDSConfig::check_internal_module_property(const char* key, const char* valu
   }
 }
 
-void CDSConfig::handle_incompatible_property(const char* prop) {
-  stop_dumping_full_module_graph();
-  stop_using_full_module_graph();
-  log_info(cds)("full module graph: disabled due to incompatible property: %s", prop);
+void CDSConfig::check_incompatible_property(const char* key, const char* value) {
+  static const char* incompatible_properties[] = {
+    "java.system.class.loader",
+    "jdk.module.showModuleResolution",
+    "jdk.module.validation"
+  };
+
+  for (uint i = 0; i < ARRAY_SIZE(incompatible_properties); i++) {
+    if (strcmp(key, incompatible_properties[i]) == 0) {
+      stop_dumping_full_module_graph();
+      stop_using_full_module_graph();
+      log_info(cds)("full module graph: disabled due to incompatible property: %s=%s", key, value);
+      break;
+    }
+  }
+
 }
 
 static const char* unsupported_properties[] = {

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -58,7 +58,8 @@ public:
 
   // Initialization and command-line checking
   static void initialize() NOT_CDS_RETURN;
-  static void check_system_property(const char* key, const char* value) NOT_CDS_RETURN;
+  static void check_internal_module_property(const char* key, const char* value) NOT_CDS_RETURN;
+  static void handle_incompatible_property(const char* prop) NOT_CDS_RETURN;
   static void check_unsupported_dumping_properties() NOT_CDS_RETURN;
   static bool check_vm_args_consistency(bool patch_mod_javabase,  bool mode_flag_cmd_line) NOT_CDS_RETURN_(true);
 

--- a/src/hotspot/share/cds/cdsConfig.hpp
+++ b/src/hotspot/share/cds/cdsConfig.hpp
@@ -59,7 +59,7 @@ public:
   // Initialization and command-line checking
   static void initialize() NOT_CDS_RETURN;
   static void check_internal_module_property(const char* key, const char* value) NOT_CDS_RETURN;
-  static void handle_incompatible_property(const char* prop) NOT_CDS_RETURN;
+  static void check_incompatible_property(const char* key, const char* value) NOT_CDS_RETURN;
   static void check_unsupported_dumping_properties() NOT_CDS_RETURN;
   static bool check_vm_args_consistency(bool patch_mod_javabase,  bool mode_flag_cmd_line) NOT_CDS_RETURN_(true);
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1257,6 +1257,10 @@ bool Arguments::add_property(const char* prop, PropertyWriteable writeable, Prop
     value = &prop[key_len + 1];
   }
 
+  if (internal == ExternalProperty) {
+    CDSConfig::check_incompatible_property(key, value);
+  }
+
   if (strcmp(key, "java.compiler") == 0) {
     // we no longer support java.compiler system property, log a warning and let it get
     // passed to Java, like any other system property
@@ -2491,11 +2495,6 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
       if (is_internal_module_property(option->optionString + 2)) {
         needs_module_property_warning = true;
         continue;
-      }
-      if (match_option(option, "-Djava.system.class.loader=", &value) ||
-          match_option(option, "-Djdk.module.showModuleResolution", &value) ||
-          match_option(option, "-Djdk.module.validation", &value)) {
-        CDSConfig::handle_incompatible_property((const char*)option->optionString + 2);
       }
       if (!add_property(tail)) {
         return JNI_ENOMEM;


### PR DESCRIPTION
The changes include:

- refactor` CDSConfig::check_system_property()` into `CDSConfig:check_internal_module_property()` and `CDSConfig::check_incompatible_property()`;
- `CDSConfig:check_internal_module_property()` will be called from `Arguments::create_module_property()` and `Arguments::create_numbered_module_property()`;
- `CDSConfig::check_incompatible_property()` will be called from `Arguments::add_property()` only for `ExternalProperty`.

Passed tiers 1 - 3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247449](https://bugs.openjdk.org/browse/JDK-8247449): Revisit the argument processing logic for MetaspaceShared::disable_optimized_module_handling() (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) ⚠️ Review applies to [7a59275f](https://git.openjdk.org/jdk/pull/18495/files/7a59275f922eab168aa036099d9c5d0159c750ca)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer) ⚠️ Review applies to [7a59275f](https://git.openjdk.org/jdk/pull/18495/files/7a59275f922eab168aa036099d9c5d0159c750ca)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18495/head:pull/18495` \
`$ git checkout pull/18495`

Update a local copy of the PR: \
`$ git checkout pull/18495` \
`$ git pull https://git.openjdk.org/jdk.git pull/18495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18495`

View PR using the GUI difftool: \
`$ git pr show -t 18495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18495.diff">https://git.openjdk.org/jdk/pull/18495.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18495#issuecomment-2021256514)