### PR TITLE
8329131: Fold libjli_static back into libjli on AIX

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -126,7 +126,11 @@ SetupJdkLibrary = $(NamedParamsMacroTemplate)
 define SetupJdkLibraryBody
   ifeq ($$($1_OUTPUT_DIR), )
     ifneq ($$(MODULE), )
-      $1_OUTPUT_DIR := $$(call FindLibDirForModule, $$(MODULE))
+      ifeq ($$($1_TYPE), STATIC_LIBRARY)
+        $1_OUTPUT_DIR := $$(SUPPORT_OUTPUTDIR)/native/$$(MODULE)
+      else
+        $1_OUTPUT_DIR := $$(call FindLibDirForModule, $$(MODULE))
+      endif
     else
       $$(error Must specify OUTPUT_DIR in a MODULE free context)
     endif

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -73,8 +73,6 @@ include native/Paths.gmk
 #       used both for C and C++.
 #   LIBS_<toolchain>_<OS> the libraries to link to for the specified target
 #       OS and toolchain, used both for C and C++.
-#   ARFLAGS the archiver flags to be used on unix platforms
-#   LIBFLAGS the flags for the lib tool used on windows
 #   OBJECT_DIR the directory where we store the object files
 #   OUTPUT_DIR the directory where the resulting binary is put
 #   SYMBOLS_DIR the directory where the debug symbols are put, defaults to OUTPUT_DIR

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -151,9 +151,7 @@ define SetupBuildLauncherBody
       LDFLAGS_macosx := $$(call SET_EXECUTABLE_ORIGIN,/../lib) \
           -L$(call FindLibDirForModule, java.base), \
       LDFLAGS_aix := -L$(SUPPORT_OUTPUTDIR)/native/java.base, \
-      JDK_LIBS_linux := -ljli, \
-      JDK_LIBS_macosx := -ljli, \
-      JDK_LIBS_aix := -ljli_static, \
+      JDK_LIBS_unix := -ljli, \
       JDK_LIBS_windows := \
           $(SUPPORT_OUTPUTDIR)/native/java.base/libjava/java.lib \
           $$($1_WINDOWS_JLI_LIB), \
@@ -177,7 +175,7 @@ define SetupBuildLauncherBody
   $$(BUILD_LAUNCHER_$1): $$(BUILD_PLIST_$1)
 
   ifeq ($(call isTargetOs, aix), true)
-    $$(BUILD_LAUNCHER_$1): $(call FindStaticLib, java.base, jli_static)
+    $$(BUILD_LAUNCHER_$1): $(call FindStaticLib, java.base, jli)
   endif
 
   ifeq ($(call isTargetOs, windows), true)

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -78,7 +78,7 @@ define CreateStaticLibrary
     endif
   endif
 
-  $1_VARDEPS := $$($1_AR) $$(ARFLAGS) $$($1_ARFLAGS) $$($1_LIBS) \
+  $1_VARDEPS := $$($1_AR) $$(ARFLAGS) $$($1_LIBS) \
       $$($1_EXTRA_LIBS)
   ifeq ($$($1_ENABLE_PARTIAL_LINKING), true)
     $1_VARDEPS += $$($1_LD) $$($1_SYSROOT_LDFLAGS)
@@ -116,7 +116,7 @@ define CreateStaticLibrary
         endif
 	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
 	  $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
-	    $$($1_AR) $$(ARFLAGS) $$($1_ARFLAGS) -r -cs $$($1_TARGET) \
+	    $$($1_AR) $$(ARFLAGS) -r -cs $$($1_TARGET) \
 	        $$($1_AR_OBJ_ARG) $$($1_RES))
         ifeq ($(STATIC_BUILD), true)
 	  $(RM) $$(@D)/$$(basename $$(@F)).symbols; \

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -38,7 +38,7 @@ endef
 
 ################################################################################
 define CreateStaticLibraryMicrosoft
-  $1_VARDEPS := $$($1_LIB) $$(LIBFLAGS) $$($1_LIBFLAGS) $$($1_LIBS) \
+  $1_VARDEPS := $$($1_LIB) $$(LIBFLAGS) $$($1_LIBS) \
       $$($1_EXTRA_LIBS)
   $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
       $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).vardeps)
@@ -50,7 +50,7 @@ define CreateStaticLibraryMicrosoft
 	$$(call LogInfo, Building static library $$($1_BASENAME))
 	$$(call MakeDir, $$($1_OUTPUT_DIR) $$($1_SYMBOLS_DIR))
 	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
-	    $$($1_LIB) -nologo $$(LIBFLAGS) $$($1_LIBFLAGS) -out:$$($1_TARGET) \
+	    $$($1_LIB) -nologo $$(LIBFLAGS) -out:$$($1_TARGET) \
 	        $$($1_LD_OBJ_ARG) $$($1_RES))
 endef
 

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -163,8 +163,14 @@ ifneq ($(USE_EXTERNAL_LIBZ), true)
       $(subst .c,$(OBJ_SUFFIX),$(LIBJLI_EXTRA_FILE_LIST))
 endif
 
+ifeq ($(call isTargetOs, aix), true)
+  # AIX requires a static libjli because the compiler doesn't support '-rpath'
+  BUILD_LIBJLI_TYPE := STATIC_LIBRARY
+endif
+
 $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     NAME := jli, \
+    TYPE := $(BUILD_LIBJLI_TYPE), \
     EXCLUDE_FILES := $(LIBJLI_EXCLUDE_FILES), \
     EXTRA_FILES := $(LIBJLI_EXTRA_FILES), \
     OPTIMIZATION := HIGH, \
@@ -173,7 +179,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     DISABLED_WARNINGS_clang := format-nonliteral deprecated-non-prototype, \
     LIBS_unix := $(LIBZ_LIBS), \
     LIBS_linux := $(LIBDL) -lpthread, \
-    LIBS_aix := $(LIBDL),\
     LIBS_macosx := \
         -framework ApplicationServices \
         -framework Cocoa \
@@ -183,26 +188,3 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
 ))
 
 TARGETS += $(BUILD_LIBJLI)
-
-LIBJLI_SRC_DIRS := $(call FindSrcDirsForComponent, java.base, libjli)
-
-ifeq ($(call isTargetOs, aix), true)
-  # AIX also requires a static libjli because the compiler doesn't support
-  # '-rpath'
-  $(eval $(call SetupNativeCompilation, BUILD_LIBJLI_STATIC, \
-      NAME := jli_static, \
-      TYPE := STATIC_LIBRARY, \
-      OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE), \
-      SRC := $(LIBJLI_SRC_DIRS), \
-      EXCLUDE_FILES := $(LIBJLI_EXCLUDE_FILES), \
-      EXTRA_FILES := $(LIBJLI_EXTRA_FILES), \
-      OPTIMIZATION := HIGH, \
-      CFLAGS := $(STATIC_LIBRARY_FLAGS) $(CFLAGS_JDKLIB) $(LIBJLI_CFLAGS) \
-          $(LIBZ_CFLAGS) $(addprefix -I, $(LIBJLI_SRC_DIRS)), \
-      DISABLED_WARNINGS_clang_aix := format-nonliteral \
-          deprecated-non-prototype, \
-      ARFLAGS := $(ARFLAGS), \
-      OBJECT_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjli_static))
-
-  TARGETS += $(BUILD_LIBJLI_STATIC)
-endif

--- a/make/modules/java.instrument/Lib.gmk
+++ b/make/modules/java.instrument/Lib.gmk
@@ -41,9 +41,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBINSTRUMENT, \
     LDFLAGS_macosx := -L$(call FindLibDirForModule, java.base), \
     LDFLAGS_aix := -L$(SUPPORT_OUTPUTDIR)/native/java.base, \
     JDK_LIBS := $(JDKLIB_LIBS), \
-    JDK_LIBS_linux := -ljli, \
-    JDK_LIBS_macosx := -ljli, \
-    JDK_LIBS_aix := -ljli_static, \
+    JDK_LIBS_unix := -ljli, \
     JDK_LIBS_windows := $(WIN_JAVA_LIB) \
         $(SUPPORT_OUTPUTDIR)/native/java.base/libjli/jli.lib jvm.lib, \
     LIBS_unix := $(LIBZ_LIBS), \
@@ -57,7 +55,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBINSTRUMENT, \
 ))
 
 ifeq ($(call isTargetOs, aix), true)
-  $(BUILD_LIBINSTRUMENT): $(call FindStaticLib, java.base, jli_static)
+  $(BUILD_LIBINSTRUMENT): $(call FindStaticLib, java.base, jli)
 else
   $(BUILD_LIBINSTRUMENT): $(call FindLib, java.base, jli)
 endif

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -94,6 +94,9 @@ else
     BUILD_JDK_JTREG_EXECUTABLES_LIBS_exelauncher := -ldl
   endif
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest := -ljli
+  ifeq ($(call isTargetOs, aix), true)
+    BUILD_JDK_JTREG_EXECUTABLES_LDFLAGS_exeJliLaunchTest := -L$(SUPPORT_OUTPUTDIR)/native/java.base
+  endif
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeCallerAccessTest := -ljvm
   BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeNullCallerTest := $(LIBCXX) -ljvm
 endif


### PR DESCRIPTION
On AIX, we need a static libjli, since the linker cannot find other libraries (like libjvm.so and libjava.so) using a relative path, as on other platforms.

However, for reasons unclear, we still build a dynamic libjli.so on AIX, even though this is never used. Instead, we also build a static libjli_static.a library (which is then forced to have a different name as to not collide with the dynamic library).

This should be fixed. We should build exactly one libjli on all platforms, be it static or dynamic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8329131](https://bugs.openjdk.org/browse/JDK-8329131): Fold libjli_static back into libjli on AIX (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) ⚠️ Review applies to [c6f396d1](https://git.openjdk.org/jdk/pull/18497/files/c6f396d1bfe12b675ac1fd89bd734ef02cd17ab2)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18497/head:pull/18497` \
`$ git checkout pull/18497`

Update a local copy of the PR: \
`$ git checkout pull/18497` \
`$ git pull https://git.openjdk.org/jdk.git pull/18497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18497`

View PR using the GUI difftool: \
`$ git pr show -t 18497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18497.diff">https://git.openjdk.org/jdk/pull/18497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18497#issuecomment-2021323526)