### PR TITLE
JDK-8329118: Run MessageFormat additional subformat pattern tests under en_US locale

### DIFF
--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -26,7 +26,7 @@
  * @bug 8318761 8329118
  * @summary Test MessageFormatPattern ability to recognize and produce
  *          appropriate FormatType and FormatStyle for CompactNumberFormat.
- * @run junit/othervm -Duser.language=en -Duser.country=US CompactSubFormats
+ * @run junit CompactSubFormats
  */
 
 import java.text.CompactNumberFormat;
@@ -40,9 +40,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-// This tests expects an en_US locale, as this locale provides distinct instances
-// for different styles.
 public class CompactSubFormats {
+
+    // This test expects an en_US locale, as this locale provides distinct instances
+    // for different styles.
+    private static final Locale loc = Locale.of("en", "US");
 
     // Ensure the built-in FormatType and FormatStyles for cnFmt are as expected
     @Test
@@ -50,9 +52,9 @@ public class CompactSubFormats {
         var mFmt = new MessageFormat(
                 "{0,number,compact_short}{1,number,compact_long}");
         var compactShort = NumberFormat.getCompactNumberInstance(
-                mFmt.getLocale(), NumberFormat.Style.SHORT);
+                loc, NumberFormat.Style.SHORT);
         var compactLong = NumberFormat.getCompactNumberInstance(
-                mFmt.getLocale(), NumberFormat.Style.LONG);
+                loc, NumberFormat.Style.LONG);
         assertEquals(mFmt.getFormatsByArgumentIndex()[0], compactShort);
         assertEquals(mFmt.getFormatsByArgumentIndex()[1], compactLong);
     }
@@ -73,9 +75,9 @@ public class CompactSubFormats {
     public void toPatternTest() {
         var mFmt = new MessageFormat("{0}{1}");
         mFmt.setFormatByArgumentIndex(0, NumberFormat.getCompactNumberInstance(
-                mFmt.getLocale(), NumberFormat.Style.SHORT));
+                loc, NumberFormat.Style.SHORT));
         mFmt.setFormatByArgumentIndex(1, NumberFormat.getCompactNumberInstance(
-                mFmt.getLocale(), NumberFormat.Style.LONG));
+                loc, NumberFormat.Style.LONG));
         assertEquals("{0,number,compact_short}{1,number,compact_long}", mFmt.toPattern());
     }
 

--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -50,11 +50,11 @@ public class CompactSubFormats {
     @Test
     public void applyPatternTest() {
         var mFmt = new MessageFormat(
-                "{0,number,compact_short}{1,number,compact_long}");
+                "{0,number,compact_short}{1,number,compact_long}", loc);
         var compactShort = NumberFormat.getCompactNumberInstance(
-                loc, NumberFormat.Style.SHORT);
+                mFmt.getLocale(), NumberFormat.Style.SHORT);
         var compactLong = NumberFormat.getCompactNumberInstance(
-                loc, NumberFormat.Style.LONG);
+                mFmt.getLocale(), NumberFormat.Style.LONG);
         assertEquals(mFmt.getFormatsByArgumentIndex()[0], compactShort);
         assertEquals(mFmt.getFormatsByArgumentIndex()[1], compactLong);
     }
@@ -67,24 +67,24 @@ public class CompactSubFormats {
         // An exception won't be thrown since 'compact_regular' will be interpreted as a
         // subformatPattern.
         assertEquals(new DecimalFormat("compact_regular"),
-                new MessageFormat("{0,number,compact_regular}").getFormatsByArgumentIndex()[0]);
+                new MessageFormat("{0,number,compact_regular}", loc).getFormatsByArgumentIndex()[0]);
     }
 
     // SHORT and LONG CompactNumberFormats should produce correct patterns
     @Test
     public void toPatternTest() {
-        var mFmt = new MessageFormat("{0}{1}");
+        var mFmt = new MessageFormat("{0}{1}", loc);
         mFmt.setFormatByArgumentIndex(0, NumberFormat.getCompactNumberInstance(
-                loc, NumberFormat.Style.SHORT));
+                mFmt.getLocale(), NumberFormat.Style.SHORT));
         mFmt.setFormatByArgumentIndex(1, NumberFormat.getCompactNumberInstance(
-                loc, NumberFormat.Style.LONG));
+                mFmt.getLocale(), NumberFormat.Style.LONG));
         assertEquals("{0,number,compact_short}{1,number,compact_long}", mFmt.toPattern());
     }
 
     // A custom cnFmt cannot be recognized, thus does not produce any built-in pattern
     @Test
     public void badToPatternTest() {
-        var mFmt = new MessageFormat("{0}");
+        var mFmt = new MessageFormat("{0}", loc);
         // Non-recognizable compactNumberFormat
         mFmt.setFormatByArgumentIndex(0, new CompactNumberFormat("",
                         DecimalFormatSymbols.getInstance(Locale.US), new String[]{""}));

--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -26,7 +26,7 @@
  * @bug 8318761 8329118
  * @summary Test MessageFormatPattern ability to recognize and produce
  *          appropriate FormatType and FormatStyle for CompactNumberFormat.
- * @run junit -Duser.language=en -Duser.country=US CompactSubFormats
+ * @run junit/othervm -Duser.language=en -Duser.country=US CompactSubFormats
  */
 
 import java.text.CompactNumberFormat;

--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @bug 8318761
+ * @bug 8318761 8329118
  * @summary Test MessageFormatPattern ability to recognize and produce
  *          appropriate FormatType and FormatStyle for CompactNumberFormat.
- * @run junit CompactSubFormats
+ * @run junit -Duser.language=en -Duser.country=US CompactSubFormats
  */
 
 import java.text.CompactNumberFormat;
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// This tests expects an en_US locale, as this locale provides distinct instances
+// for different styles.
 public class CompactSubFormats {
 
     // Ensure the built-in FormatType and FormatStyles for cnFmt are as expected

--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -40,17 +40,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+// This test expects an US locale, as this locale provides distinct instances
+// for different styles.
 public class CompactSubFormats {
-
-    // This test expects an en_US locale, as this locale provides distinct instances
-    // for different styles.
-    private static final Locale loc = Locale.of("en", "US");
 
     // Ensure the built-in FormatType and FormatStyles for cnFmt are as expected
     @Test
     public void applyPatternTest() {
         var mFmt = new MessageFormat(
-                "{0,number,compact_short}{1,number,compact_long}", loc);
+                "{0,number,compact_short}{1,number,compact_long}", Locale.US);
         var compactShort = NumberFormat.getCompactNumberInstance(
                 mFmt.getLocale(), NumberFormat.Style.SHORT);
         var compactLong = NumberFormat.getCompactNumberInstance(
@@ -67,13 +65,13 @@ public class CompactSubFormats {
         // An exception won't be thrown since 'compact_regular' will be interpreted as a
         // subformatPattern.
         assertEquals(new DecimalFormat("compact_regular"),
-                new MessageFormat("{0,number,compact_regular}", loc).getFormatsByArgumentIndex()[0]);
+                new MessageFormat("{0,number,compact_regular}", Locale.US).getFormatsByArgumentIndex()[0]);
     }
 
     // SHORT and LONG CompactNumberFormats should produce correct patterns
     @Test
     public void toPatternTest() {
-        var mFmt = new MessageFormat("{0}{1}", loc);
+        var mFmt = new MessageFormat("{0}{1}", Locale.US);
         mFmt.setFormatByArgumentIndex(0, NumberFormat.getCompactNumberInstance(
                 mFmt.getLocale(), NumberFormat.Style.SHORT));
         mFmt.setFormatByArgumentIndex(1, NumberFormat.getCompactNumberInstance(
@@ -84,7 +82,7 @@ public class CompactSubFormats {
     // A custom cnFmt cannot be recognized, thus does not produce any built-in pattern
     @Test
     public void badToPatternTest() {
-        var mFmt = new MessageFormat("{0}", loc);
+        var mFmt = new MessageFormat("{0}", Locale.US);
         // Non-recognizable compactNumberFormat
         mFmt.setFormatByArgumentIndex(0, new CompactNumberFormat("",
                         DecimalFormatSymbols.getInstance(Locale.US), new String[]{""}));

--- a/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
@@ -50,12 +50,12 @@ public class ListSubFormats {
     // 'unit' associated FormatStyles
     @Test
     public void applyPatternTest() {
-        var mFmt = new MessageFormat("{0,list}{1,list,or}{2,list,unit}");
-        var listStandard = ListFormat.getInstance(loc,
+        var mFmt = new MessageFormat("{0,list}{1,list,or}{2,list,unit}", loc);
+        var listStandard = ListFormat.getInstance(mFmt.getLocale(),
                 ListFormat.Type.STANDARD, ListFormat.Style.FULL);
-        var listOr = ListFormat.getInstance(loc,
+        var listOr = ListFormat.getInstance(mFmt.getLocale(),
                 ListFormat.Type.OR, ListFormat.Style.FULL);
-        var listUnit = ListFormat.getInstance(loc,
+        var listUnit = ListFormat.getInstance(mFmt.getLocale(),
                 ListFormat.Type.UNIT, ListFormat.Style.FULL);
         assertEquals(mFmt.getFormatsByArgumentIndex()[0], listStandard);
         assertEquals(mFmt.getFormatsByArgumentIndex()[1], listOr);
@@ -68,12 +68,12 @@ public class ListSubFormats {
     public void badApplyPatternTest() {
         // Wrong FormatStyle
         IllegalArgumentException exc = assertThrows(IllegalArgumentException.class, () ->
-                new MessageFormat("{0,list,standard}"));
+                new MessageFormat("{0,list,standard}", loc));
         assertEquals("Unexpected modifier for List: standard", exc.getMessage());
 
         // Wrong FormatType
         exc = assertThrows(IllegalArgumentException.class, () ->
-                new MessageFormat("{0,listt,or}"));
+                new MessageFormat("{0,listt,or}", loc));
         assertEquals("unknown format type: listt", exc.getMessage());
 
     }
@@ -82,22 +82,23 @@ public class ListSubFormats {
     // produce correct patterns.
     @Test
     public void toPatternTest() {
-        var mFmt = new MessageFormat("{0}{1}{2}");
+        var mFmt = new MessageFormat("{0}{1}{2}", loc);
         mFmt.setFormatByArgumentIndex(0,
-                ListFormat.getInstance(loc, ListFormat.Type.STANDARD, ListFormat.Style.FULL));
+                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.STANDARD, ListFormat.Style.FULL));
         mFmt.setFormatByArgumentIndex(1,
-                ListFormat.getInstance(loc, ListFormat.Type.OR, ListFormat.Style.FULL));
+                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.OR, ListFormat.Style.FULL));
         mFmt.setFormatByArgumentIndex(2,
-                ListFormat.getInstance(loc, ListFormat.Type.UNIT, ListFormat.Style.FULL));
+                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.UNIT, ListFormat.Style.FULL));
         assertEquals("{0,list}{1,list,or}{2,list,unit}", mFmt.toPattern());
     }
 
     // A custom ListFormat cannot be recognized, thus does not produce any built-in pattern
     @Test
     public void badToPatternTest() {
-        var mFmt = new MessageFormat("{0}");
+        var mFmt = new MessageFormat("{0}", loc);
         mFmt.setFormatByArgumentIndex(0,
-                ListFormat.getInstance(loc, ListFormat.Type.UNIT, ListFormat.Style.NARROW));
+                ListFormat.getInstance(mFmt.getLocale(),
+                        ListFormat.Type.UNIT, ListFormat.Style.NARROW));
         assertEquals("{0}", mFmt.toPattern());
     }
 }

--- a/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
@@ -23,12 +23,12 @@
 
 /*
  * @test
- * @bug 8318761
+ * @bug 8318761 8329118
  * @summary Test MessageFormatPattern ability to recognize and produce the
  *          appropriate FormatType and FormatStyle for ListFormat. ListFormat's
  *          STANDARD, OR, and UNIT types are supported as built-in patterns for
  *          MessageFormat. All types use the FULL style.
- * @run junit ListSubFormats
+ * @run junit -Duser.language=en -Duser.country=US ListSubFormats
  */
 
 import java.text.ListFormat;
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+// This tests expects an en_US locale, as this locale provides distinct instances
+// for different styles.
 public class ListSubFormats {
 
     // Recognize the 'list' FormatType as well as '', 'or', and

--- a/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
@@ -28,31 +28,34 @@
  *          appropriate FormatType and FormatStyle for ListFormat. ListFormat's
  *          STANDARD, OR, and UNIT types are supported as built-in patterns for
  *          MessageFormat. All types use the FULL style.
- * @run junit/othervm -Duser.language=en -Duser.country=US ListSubFormats
+ * @run junit ListSubFormats
  */
 
 import java.text.ListFormat;
 import java.text.MessageFormat;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-// This tests expects an en_US locale, as this locale provides distinct instances
-// for different styles.
 public class ListSubFormats {
+
+    // This test expects an en_US locale, as this locale provides distinct instances
+    // for different styles.
+    private static final Locale loc = Locale.of("en", "US");
 
     // Recognize the 'list' FormatType as well as '', 'or', and
     // 'unit' associated FormatStyles
     @Test
     public void applyPatternTest() {
         var mFmt = new MessageFormat("{0,list}{1,list,or}{2,list,unit}");
-        var listStandard = ListFormat.getInstance(mFmt.getLocale(),
+        var listStandard = ListFormat.getInstance(loc,
                 ListFormat.Type.STANDARD, ListFormat.Style.FULL);
-        var listOr = ListFormat.getInstance(mFmt.getLocale(),
+        var listOr = ListFormat.getInstance(loc,
                 ListFormat.Type.OR, ListFormat.Style.FULL);
-        var listUnit = ListFormat.getInstance(mFmt.getLocale(),
+        var listUnit = ListFormat.getInstance(loc,
                 ListFormat.Type.UNIT, ListFormat.Style.FULL);
         assertEquals(mFmt.getFormatsByArgumentIndex()[0], listStandard);
         assertEquals(mFmt.getFormatsByArgumentIndex()[1], listOr);
@@ -81,11 +84,11 @@ public class ListSubFormats {
     public void toPatternTest() {
         var mFmt = new MessageFormat("{0}{1}{2}");
         mFmt.setFormatByArgumentIndex(0,
-                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.STANDARD, ListFormat.Style.FULL));
+                ListFormat.getInstance(loc, ListFormat.Type.STANDARD, ListFormat.Style.FULL));
         mFmt.setFormatByArgumentIndex(1,
-                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.OR, ListFormat.Style.FULL));
+                ListFormat.getInstance(loc, ListFormat.Type.OR, ListFormat.Style.FULL));
         mFmt.setFormatByArgumentIndex(2,
-                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.UNIT, ListFormat.Style.FULL));
+                ListFormat.getInstance(loc, ListFormat.Type.UNIT, ListFormat.Style.FULL));
         assertEquals("{0,list}{1,list,or}{2,list,unit}", mFmt.toPattern());
     }
 
@@ -94,7 +97,7 @@ public class ListSubFormats {
     public void badToPatternTest() {
         var mFmt = new MessageFormat("{0}");
         mFmt.setFormatByArgumentIndex(0,
-                ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.UNIT, ListFormat.Style.NARROW));
+                ListFormat.getInstance(loc, ListFormat.Type.UNIT, ListFormat.Style.NARROW));
         assertEquals("{0}", mFmt.toPattern());
     }
 }

--- a/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
@@ -28,7 +28,7 @@
  *          appropriate FormatType and FormatStyle for ListFormat. ListFormat's
  *          STANDARD, OR, and UNIT types are supported as built-in patterns for
  *          MessageFormat. All types use the FULL style.
- * @run junit -Duser.language=en -Duser.country=US ListSubFormats
+ * @run junit/othervm -Duser.language=en -Duser.country=US ListSubFormats
  */
 
 import java.text.ListFormat;

--- a/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/ListSubFormats.java
@@ -40,17 +40,15 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+// This test expects an US locale, as this locale provides distinct instances
+// for different styles.
 public class ListSubFormats {
-
-    // This test expects an en_US locale, as this locale provides distinct instances
-    // for different styles.
-    private static final Locale loc = Locale.of("en", "US");
 
     // Recognize the 'list' FormatType as well as '', 'or', and
     // 'unit' associated FormatStyles
     @Test
     public void applyPatternTest() {
-        var mFmt = new MessageFormat("{0,list}{1,list,or}{2,list,unit}", loc);
+        var mFmt = new MessageFormat("{0,list}{1,list,or}{2,list,unit}", Locale.US);
         var listStandard = ListFormat.getInstance(mFmt.getLocale(),
                 ListFormat.Type.STANDARD, ListFormat.Style.FULL);
         var listOr = ListFormat.getInstance(mFmt.getLocale(),
@@ -68,12 +66,12 @@ public class ListSubFormats {
     public void badApplyPatternTest() {
         // Wrong FormatStyle
         IllegalArgumentException exc = assertThrows(IllegalArgumentException.class, () ->
-                new MessageFormat("{0,list,standard}", loc));
+                new MessageFormat("{0,list,standard}", Locale.US));
         assertEquals("Unexpected modifier for List: standard", exc.getMessage());
 
         // Wrong FormatType
         exc = assertThrows(IllegalArgumentException.class, () ->
-                new MessageFormat("{0,listt,or}", loc));
+                new MessageFormat("{0,listt,or}", Locale.US));
         assertEquals("unknown format type: listt", exc.getMessage());
 
     }
@@ -82,7 +80,7 @@ public class ListSubFormats {
     // produce correct patterns.
     @Test
     public void toPatternTest() {
-        var mFmt = new MessageFormat("{0}{1}{2}", loc);
+        var mFmt = new MessageFormat("{0}{1}{2}", Locale.US);
         mFmt.setFormatByArgumentIndex(0,
                 ListFormat.getInstance(mFmt.getLocale(), ListFormat.Type.STANDARD, ListFormat.Style.FULL));
         mFmt.setFormatByArgumentIndex(1,
@@ -95,7 +93,7 @@ public class ListSubFormats {
     // A custom ListFormat cannot be recognized, thus does not produce any built-in pattern
     @Test
     public void badToPatternTest() {
-        var mFmt = new MessageFormat("{0}", loc);
+        var mFmt = new MessageFormat("{0}", Locale.US);
         mFmt.setFormatByArgumentIndex(0,
                 ListFormat.getInstance(mFmt.getLocale(),
                         ListFormat.Type.UNIT, ListFormat.Style.NARROW));


### PR DESCRIPTION
Please review this PR which updates two MessageFormat sub format related tests to be guaranteed to run under the `en_US` locale.

There exists locale that do not provide distinct instances for separate styles. For example, the `en_IN` locale provides the same LONG and SHORT compact number instances. The test data is built to test sub formats under the assumption that different styles do provide distinct instances.

As this is the case, these tests should be ran under a locale that does provide distinct instances for separate styles.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329118](https://bugs.openjdk.org/browse/JDK-8329118): Run MessageFormat additional subformat pattern tests under en_US locale (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18498/head:pull/18498` \
`$ git checkout pull/18498`

Update a local copy of the PR: \
`$ git checkout pull/18498` \
`$ git pull https://git.openjdk.org/jdk.git pull/18498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18498`

View PR using the GUI difftool: \
`$ git pr show -t 18498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18498.diff">https://git.openjdk.org/jdk/pull/18498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18498#issuecomment-2021453887)