### PR TITLE
JDK-8327875: ChoiceFormat should advise throwing UnsupportedOperationException for unused methods

### DIFF
--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -220,8 +220,7 @@ import java.util.Objects;
  * incorrect patterns.
  * <p>This class inherits instance methods from {@code NumberFormat} it does
  * not utilize; a subclass could override and throw {@code
- * UnsupportedOperationException} for such methods to better enforce the
- * {@code NumberFormat} contract.
+ * UnsupportedOperationException} for such methods.
  * @implNote Given an incorrect pattern, this implementation may either
  * throw an exception or succeed and discard the incorrect portion. A {@code
  * NumberFormatException} is thrown if a {@code limit} can not be

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -134,20 +134,6 @@ import java.util.Objects;
  * Use two single quotes in a row to produce a literal single quote. For example,
  * {@code new ChoiceFormat("1# ''one'' ").format(1)} returns {@code " 'one' "}.
  *
- * @apiNote A subclass could perform more consistent pattern validation by
- * throwing an {@code IllegalArgumentException} for all incorrect cases.
- * <p>This class inherits instance methods from {@code NumberFormat} it does
- * not utilize; a subclass could override and throw {@code
- * UnsupportedOperationException} for such methods to better enforce the
- * {@code NumberFormat} contract.
- * @implNote Given an incorrect pattern, this implementation may either
- * throw an exception or succeed and discard the incorrect portion. A {@code
- * NumberFormatException} is thrown if a {@code limit} can not be
- * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
- * if a {@code SubPattern} is missing, or the intervals are not ascending.
- * Discarding the incorrect portion may result in a ChoiceFormat with
- * empty {@code limits} and {@code formats}.
- *
  * <h2>Usage Information</h2>
  *
  * <p>
@@ -227,6 +213,22 @@ import java.util.Objects;
  * It is recommended to create separate format instances for each thread.
  * If multiple threads access a format concurrently, it must be synchronized
  * externally.
+ *
+ * @apiNote A subclass could perform more consistent pattern validation by
+ * throwing an {@code IllegalArgumentException} for all incorrect cases.
+ * See the {@code Implementation Note} for this implementation's behavior regarding
+ * incorrect patterns.
+ * <p>This class inherits instance methods from {@code NumberFormat} it does
+ * not utilize; a subclass could override and throw {@code
+ * UnsupportedOperationException} for such methods to better enforce the
+ * {@code NumberFormat} contract.
+ * @implNote Given an incorrect pattern, this implementation may either
+ * throw an exception or succeed and discard the incorrect portion. A {@code
+ * NumberFormatException} is thrown if a {@code limit} can not be
+ * parsed as a numeric value and an {@code IllegalArgumentException} is thrown
+ * if a {@code SubPattern} is missing, or the intervals are not ascending.
+ * Discarding the incorrect portion may result in a ChoiceFormat with
+ * empty {@code limits} and {@code formats}.
  *
  *
  * @see          DecimalFormat

--- a/src/java.base/share/classes/java/text/ChoiceFormat.java
+++ b/src/java.base/share/classes/java/text/ChoiceFormat.java
@@ -136,6 +136,10 @@ import java.util.Objects;
  *
  * @apiNote A subclass could perform more consistent pattern validation by
  * throwing an {@code IllegalArgumentException} for all incorrect cases.
+ * <p>This class inherits instance methods from {@code NumberFormat} it does
+ * not utilize; a subclass could override and throw {@code
+ * UnsupportedOperationException} for such methods to better enforce the
+ * {@code NumberFormat} contract.
  * @implNote Given an incorrect pattern, this implementation may either
  * throw an exception or succeed and discard the incorrect portion. A {@code
  * NumberFormatException} is thrown if a {@code limit} can not be


### PR DESCRIPTION
Please review this PR which advises ChoiceFormat subclasses throw `UnsupportedOperationException` for unused inherited methods.

The CSR covers the proposed wording, and the reasons as to why this is a specification and not an implementation update. In addition, the `api/implNote` tags have been moved to the bottom of the class description, as they are no longer only relevant to the pattern section, (where they were previously located).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8328992](https://bugs.openjdk.org/browse/JDK-8328992) to be approved

### Issues
 * [JDK-8327875](https://bugs.openjdk.org/browse/JDK-8327875): ChoiceFormat should advise throwing UnsupportedOperationException for unused methods (**Enhancement** - P5)
 * [JDK-8328992](https://bugs.openjdk.org/browse/JDK-8328992): ChoiceFormat should advise throwing UnsupportedOperationException for unused methods (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18499/head:pull/18499` \
`$ git checkout pull/18499`

Update a local copy of the PR: \
`$ git checkout pull/18499` \
`$ git pull https://git.openjdk.org/jdk.git pull/18499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18499`

View PR using the GUI difftool: \
`$ git pr show -t 18499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18499.diff">https://git.openjdk.org/jdk/pull/18499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18499#issuecomment-2021457200)