### PR TITLE
8329096: G1: Change the type of G1BlockOffsetTable::_offset_base to uint8_t*

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -49,8 +49,8 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
 
 #ifdef ASSERT
 void G1BlockOffsetTable::check_address(uint8_t* addr, const char* msg) const {
-  uint8_t* start_addr = const_cast<uint8_t *>(_offset_base + (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
-  uint8_t* end_addr = const_cast<uint8_t *>(_offset_base + (uintptr_t(_reserved.end()) >> CardTable::card_shift()));
+  uint8_t* start_addr = const_cast<uint8_t*>(_offset_base + (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
+  uint8_t* end_addr = const_cast<uint8_t*>(_offset_base + (uintptr_t(_reserved.end()) >> CardTable::card_shift()));
   assert(addr >= start_addr && addr <= end_addr,
          "%s - offset address: " PTR_FORMAT ", start address: " PTR_FORMAT ", end address: " PTR_FORMAT,
          msg, (p2i(addr)), (p2i(start_addr)), (p2i(end_addr)));
@@ -108,7 +108,7 @@ void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(uint8_t* start
   assert(_bot->offset_array(start_card-1) < CardTable::card_size_in_words(),
          "Offset card has an unexpected value");
   uint8_t* start_card_for_region = start_card;
-  uint8_t offset = max_jubyte;
+  uint8_t offset = UINT8_MAX;
   for (uint i = 0; i < BOTConstants::N_powers; i++) {
     // -1 so that the card with the actual offset is counted.  Another -1
     // so that the reach ends in this region and not at the start

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -40,7 +40,7 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
 
   MemRegion bot_reserved = storage->reserved();
 
-  _offset_base = ((u_char*)bot_reserved.start() - (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
+  _offset_base = ((uint8_t*)bot_reserved.start() - (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
 
   log_trace(gc, bot)("G1BlockOffsetTable::G1BlockOffsetTable: ");
   log_trace(gc, bot)("    rs.base(): " PTR_FORMAT "  rs.size(): " SIZE_FORMAT "  rs end(): " PTR_FORMAT,
@@ -48,9 +48,9 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
 }
 
 #ifdef ASSERT
-void G1BlockOffsetTable::check_address(u_char* addr, const char* msg) const {
-  u_char* start_addr = const_cast<u_char *>(_offset_base + (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
-  u_char* end_addr = const_cast<u_char *>(_offset_base + (uintptr_t(_reserved.end()) >> CardTable::card_shift()));
+void G1BlockOffsetTable::check_address(uint8_t* addr, const char* msg) const {
+  uint8_t* start_addr = const_cast<uint8_t *>(_offset_base + (uintptr_t(_reserved.start()) >> CardTable::card_shift()));
+  uint8_t* end_addr = const_cast<uint8_t *>(_offset_base + (uintptr_t(_reserved.end()) >> CardTable::card_shift()));
   assert(addr >= start_addr && addr <= end_addr,
          "%s - offset address: " PTR_FORMAT ", start address: " PTR_FORMAT ", end address: " PTR_FORMAT,
          msg, (p2i(addr)), (p2i(start_addr)), (p2i(end_addr)));
@@ -102,18 +102,18 @@ G1BlockOffsetTablePart::G1BlockOffsetTablePart(G1BlockOffsetTable* array, HeapRe
 //      Move back N (e.g., 8) entries and repeat with the
 //        value of the new entry
 //
-void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(u_char* start_card, u_char* end_card) {
+void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(uint8_t* start_card, uint8_t* end_card) {
   assert(start_card <= end_card, "precondition");
   assert(start_card > _bot->entry_for_addr(_hr->bottom()), "Cannot be first card");
   assert(_bot->offset_array(start_card-1) < CardTable::card_size_in_words(),
          "Offset card has an unexpected value");
-  u_char* start_card_for_region = start_card;
-  u_char offset = max_jubyte;
+  uint8_t* start_card_for_region = start_card;
+  uint8_t offset = max_jubyte;
   for (uint i = 0; i < BOTConstants::N_powers; i++) {
     // -1 so that the card with the actual offset is counted.  Another -1
     // so that the reach ends in this region and not at the start
     // of the next.
-    u_char* reach = start_card - 1 + (BOTConstants::power_to_cards_back(i+1) - 1);
+    uint8_t* reach = start_card - 1 + (BOTConstants::power_to_cards_back(i+1) - 1);
     offset = CardTable::card_size_in_words() + i;
     if (reach >= end_card) {
       _bot->set_offset_array(start_card_for_region, end_card, offset);
@@ -131,13 +131,13 @@ void G1BlockOffsetTablePart::set_remainder_to_point_to_start_incl(u_char* start_
 // The card-interval [start_card, end_card] is a closed interval; this
 // is an expensive check -- use with care and only under protection of
 // suitable flag.
-void G1BlockOffsetTablePart::check_all_cards(u_char* start_card, u_char* end_card) const {
+void G1BlockOffsetTablePart::check_all_cards(uint8_t* start_card, uint8_t* end_card) const {
   if (end_card < start_card) {
     return;
   }
   guarantee(_bot->offset_array(start_card) == CardTable::card_size_in_words(), "Wrong value in second card");
-  for (u_char* c = start_card + 1; c <= end_card; c++ /* yeah! */) {
-    u_char entry = _bot->offset_array(c);
+  for (uint8_t* c = start_card + 1; c <= end_card; c++ /* yeah! */) {
+    uint8_t entry = _bot->offset_array(c);
     if ((unsigned)(c - start_card) > BOTConstants::power_to_cards_back(1)) {
       guarantee(entry > CardTable::card_size_in_words(),
                 "Should be in logarithmic region - "
@@ -147,7 +147,7 @@ void G1BlockOffsetTablePart::check_all_cards(u_char* start_card, u_char* end_car
                 (uint)entry, (uint)_bot->offset_array(c), CardTable::card_size_in_words());
     }
     size_t backskip = BOTConstants::entry_to_cards_back(entry);
-    u_char* landing_card = c - backskip;
+    uint8_t* landing_card = c - backskip;
     guarantee(landing_card >= (start_card - 1), "Inv");
     if (landing_card >= start_card) {
       guarantee(_bot->offset_array(landing_card) <= entry,
@@ -179,7 +179,7 @@ void G1BlockOffsetTablePart::check_all_cards(u_char* start_card, u_char* end_car
 void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
                                                    HeapWord* blk_end) {
   HeapWord* const cur_card_boundary = align_up_by_card_size(blk_start);
-  u_char* const offset_card =  _bot->entry_for_addr(cur_card_boundary);
+  uint8_t* const offset_card =  _bot->entry_for_addr(cur_card_boundary);
 
   assert(blk_start != nullptr && blk_end > blk_start,
          "phantom block");
@@ -200,7 +200,7 @@ void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
   // We need to now mark the subsequent cards that this block spans.
 
   // Index of card on which the block ends.
-  u_char* end_card = _bot->entry_for_addr(blk_end - 1);
+  uint8_t* end_card = _bot->entry_for_addr(blk_end - 1);
 
   // Are there more cards left to be updated?
   if (offset_card + 1 <= end_card) {
@@ -215,7 +215,7 @@ void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
 
   // The offset can be 0 if the block starts on a boundary.  That
   // is checked by an assertion above.
-  u_char* previous_card = _bot->entry_for_addr(blk_start);
+  uint8_t* previous_card = _bot->entry_for_addr(blk_start);
   HeapWord* boundary = _bot->addr_for_entry(previous_card);
   assert((_bot->offset_array(offset_card) == 0 && blk_start == boundary) ||
          (_bot->offset_array(offset_card) > 0 && _bot->offset_array(offset_card) < CardTable::card_size_in_words()),
@@ -225,10 +225,10 @@ void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
          "boundary: " PTR_FORMAT,
          (uint)_bot->offset_array(offset_card),
          p2i(blk_start), p2i(boundary));
-  for (u_char* j = offset_card + 1; j <= end_card; j++) {
+  for (uint8_t* j = offset_card + 1; j <= end_card; j++) {
     assert(_bot->offset_array(j) > 0 &&
            _bot->offset_array(j) <=
-             (u_char) (CardTable::card_size_in_words() + BOTConstants::N_powers - 1),
+             (uint8_t) (CardTable::card_size_in_words() + BOTConstants::N_powers - 1),
            "offset array should have been set - "
            "%u not > 0 OR %u not <= %u",
            (uint) _bot->offset_array(j),
@@ -240,11 +240,11 @@ void G1BlockOffsetTablePart::update_for_block_work(HeapWord* blk_start,
 
 void G1BlockOffsetTablePart::verify() const {
   assert(_hr->bottom() < _hr->top(), "Only non-empty regions should be verified.");
-  u_char* start_card = _bot->entry_for_addr(_hr->bottom());
-  u_char* end_card = _bot->entry_for_addr(_hr->top() - 1);
+  uint8_t* start_card = _bot->entry_for_addr(_hr->bottom());
+  uint8_t* end_card = _bot->entry_for_addr(_hr->top() - 1);
 
-  for (u_char* current_card = start_card; current_card < end_card; current_card++) {
-    u_char entry = _bot->offset_array(current_card);
+  for (uint8_t* current_card = start_card; current_card < end_card; current_card++) {
+    uint8_t entry = _bot->offset_array(current_card);
     if (entry < CardTable::card_size_in_words()) {
       // The entry should point to an object before the current card. Verify that
       // it is possible to walk from that object in to the current card by just
@@ -281,12 +281,12 @@ void G1BlockOffsetTablePart::verify() const {
 
 #ifndef PRODUCT
 void G1BlockOffsetTablePart::print_on(outputStream* out) {
-  u_char* from_card = _bot->entry_for_addr(_hr->bottom());
-  u_char* to_card = _bot->entry_for_addr(_hr->end());
+  uint8_t* from_card = _bot->entry_for_addr(_hr->bottom());
+  uint8_t* to_card = _bot->entry_for_addr(_hr->end());
   out->print_cr(">> BOT for area [" PTR_FORMAT "," PTR_FORMAT ") "
                 "cards [" SIZE_FORMAT "," SIZE_FORMAT ")",
                 p2i(_hr->bottom()), p2i(_hr->end()), p2i(from_card), p2i(to_card));
-  for (u_char* i = from_card; i < to_card; ++i) {
+  for (uint8_t* i = from_card; i < to_card; ++i) {
     out->print_cr("  entry " SIZE_FORMAT_W(8) " | " PTR_FORMAT " : %3u",
                   p2i(i), p2i(_bot->addr_for_entry(i)),
                   (uint) _bot->offset_array(i));

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -52,7 +52,7 @@ private:
   MemRegion _reserved;
 
   // Biased array-start of BOT array for fast BOT entry translation
-  volatile u_char* _offset_base;
+  volatile uint8_t* _offset_base;
 
   void check_offset(size_t offset, const char* msg) const {
     assert(offset < CardTable::card_size_in_words(),
@@ -62,16 +62,16 @@ private:
 
   // Bounds checking accessors:
   // For performance these have to devolve to array accesses in product builds.
-  inline u_char offset_array(u_char* addr) const;
+  inline uint8_t offset_array(uint8_t* addr) const;
 
-  inline void set_offset_array_raw(u_char* addr, u_char offset);
-  inline void set_offset_array(u_char* addr, u_char offset);
+  inline void set_offset_array_raw(uint8_t* addr, uint8_t offset);
+  inline void set_offset_array(uint8_t* addr, uint8_t offset);
 
-  inline void set_offset_array(u_char* addr, HeapWord* high, HeapWord* low);
+  inline void set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low);
 
-  inline void set_offset_array(u_char* left, u_char* right, u_char offset);
+  inline void set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset);
 
-  void check_address(u_char* addr, const char* msg) const NOT_DEBUG_RETURN;
+  void check_address(uint8_t* addr, const char* msg) const NOT_DEBUG_RETURN;
 
 public:
 
@@ -92,10 +92,10 @@ public:
   G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* storage);
 
   // Mapping from address to object start array entry
-  u_char* entry_for_addr(const void* const p) const;
+  uint8_t* entry_for_addr(const void* const p) const;
 
   // Mapping from object start array entry to address of first word
-  HeapWord* addr_for_entry(const u_char* const p) const;
+  HeapWord* addr_for_entry(const uint8_t* const p) const;
 };
 
 class G1BlockOffsetTablePart {
@@ -110,12 +110,12 @@ private:
 
   // Sets the entries corresponding to the cards starting at "start" and ending
   // at "end" to point back to the card before "start"; [start, end]
-  void set_remainder_to_point_to_start_incl(u_char* start, u_char* end);
+  void set_remainder_to_point_to_start_incl(uint8_t* start, uint8_t* end);
 
   // Update BOT entries corresponding to the mem range [blk_start, blk_end).
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
-  void check_all_cards(u_char* left_card, u_char* right_card) const NOT_DEBUG_RETURN;
+  void check_all_cards(uint8_t* left_card, uint8_t* right_card) const NOT_DEBUG_RETURN;
 
   static HeapWord* align_up_by_card_size(HeapWord* const addr) {
     return align_up(addr, CardTable::card_size());

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -90,7 +90,7 @@ void G1BlockOffsetTable::set_offset_array(uint8_t* left, uint8_t* right, uint8_t
 inline uint8_t* G1BlockOffsetTable::entry_for_addr(const void* const p) const {
   assert(_reserved.contains(p),
          "out of bounds access to block offset table");
-  uint8_t* result = const_cast<uint8_t *>(&_offset_base[uintptr_t(p) >> CardTable::card_shift()]);
+  uint8_t* result = const_cast<uint8_t*>(&_offset_base[uintptr_t(p) >> CardTable::card_shift()]);
   return result;
 }
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -38,14 +38,14 @@ inline HeapWord* G1BlockOffsetTablePart::block_start_reaching_into_card(const vo
 #ifdef ASSERT
   if (!_hr->is_continues_humongous()) {
     // For non-ContinuesHumongous regions, the first obj always starts from bottom.
-    u_char offset = _bot->offset_array(_bot->entry_for_addr(_hr->bottom()));
+    uint8_t offset = _bot->offset_array(_bot->entry_for_addr(_hr->bottom()));
     assert(offset == 0, "Found offset %u instead of 0 for region %u %s",
            offset, _hr->hrm_index(), _hr->get_short_type_str());
   }
 #endif
 
-  u_char* entry = _bot->entry_for_addr(addr);
-  u_char offset = _bot->offset_array(entry);
+  uint8_t* entry = _bot->entry_for_addr(addr);
+  uint8_t offset = _bot->offset_array(entry);
   while (offset >= CardTable::card_size_in_words()) {
     // The excess of the offset from N_words indicates a power of Base
     // to go back by.
@@ -58,45 +58,44 @@ inline HeapWord* G1BlockOffsetTablePart::block_start_reaching_into_card(const vo
   return q - offset;
 }
 
-u_char G1BlockOffsetTable::offset_array(u_char* addr) const {
+uint8_t G1BlockOffsetTable::offset_array(uint8_t* addr) const {
   check_address(addr, "Block offset table address out of range");
   return Atomic::load(addr);
 }
 
-void G1BlockOffsetTable::set_offset_array_raw(u_char* addr, u_char offset) {
+void G1BlockOffsetTable::set_offset_array_raw(uint8_t* addr, uint8_t offset) {
   Atomic::store(addr, offset);
 }
 
-void G1BlockOffsetTable::set_offset_array(u_char* addr, u_char offset) {
+void G1BlockOffsetTable::set_offset_array(uint8_t* addr, uint8_t offset) {
   check_address(addr, "Block offset table address out of range");
   set_offset_array_raw(addr, offset);
 }
 
-void G1BlockOffsetTable::set_offset_array(u_char* addr, HeapWord* high, HeapWord* low) {
+void G1BlockOffsetTable::set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low) {
   check_address(addr, "Block offset table address out of range");
   assert(high >= low, "addresses out of order");
   size_t offset = pointer_delta(high, low);
   check_offset(offset, "offset too large");
-  set_offset_array(addr, (u_char)offset);
+  set_offset_array(addr, (uint8_t)offset);
 }
 
-void G1BlockOffsetTable::set_offset_array(u_char* left, u_char* right, u_char offset) {
+void G1BlockOffsetTable::set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset) {
   check_address(right, "Right block offset table address out of range");
   assert(left <= right, "indexes out of order");
   size_t num_cards = right - left + 1;
-  memset_with_concurrent_readers
-    (const_cast<u_char*> (left), offset, num_cards);
+  memset_with_concurrent_readers(left, offset, num_cards);
 }
 
-inline u_char* G1BlockOffsetTable::entry_for_addr(const void* const p) const {
+inline uint8_t* G1BlockOffsetTable::entry_for_addr(const void* const p) const {
   assert(_reserved.contains(p),
          "out of bounds access to block offset table");
-  u_char* result = const_cast<u_char *>(&_offset_base[uintptr_t(p) >> CardTable::card_shift()]);
+  uint8_t* result = const_cast<uint8_t *>(&_offset_base[uintptr_t(p) >> CardTable::card_shift()]);
   return result;
 }
 
-inline HeapWord* G1BlockOffsetTable::addr_for_entry(const u_char* const p) const {
-  size_t delta = pointer_delta(p, _offset_base, sizeof(u_char));
+inline HeapWord* G1BlockOffsetTable::addr_for_entry(const uint8_t* const p) const {
+  size_t delta = pointer_delta(p, _offset_base, sizeof(uint8_t));
   HeapWord* result = (HeapWord*) (delta << CardTable::card_shift());
   assert(_reserved.contains(result),
          "out of bounds accessor from block offset table");


### PR DESCRIPTION
Hi all,

This patch changes the type of `G1BlockOffsetTable::_offset_base` to `uint8_t*`, just like `SerialBlockOffsetSharedArray::_offset_base` and `ObjectStartArray::_offset_base`. The tests `make test-tier1_gc` passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329096](https://bugs.openjdk.org/browse/JDK-8329096): G1: Change the type of G1BlockOffsetTable::_offset_base to uint8_t* (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [ccae364a](https://git.openjdk.org/jdk/pull/18502/files/ccae364aebef7144486dc9eec4990cbb8798c205)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [ccae364a](https://git.openjdk.org/jdk/pull/18502/files/ccae364aebef7144486dc9eec4990cbb8798c205)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18502/head:pull/18502` \
`$ git checkout pull/18502`

Update a local copy of the PR: \
`$ git checkout pull/18502` \
`$ git pull https://git.openjdk.org/jdk.git pull/18502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18502`

View PR using the GUI difftool: \
`$ git pr show -t 18502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18502.diff">https://git.openjdk.org/jdk/pull/18502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18502#issuecomment-2021566265)