### PR TITLE
8329103: assert(!thread->in_asgct()) failed during multi-mode profiling

### DIFF
--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -657,15 +657,17 @@ protected:
 class ThreadInAsgct {
  private:
   Thread* _thread;
+  bool _saved_in_asgct;
  public:
   ThreadInAsgct(Thread* thread) : _thread(thread) {
     assert(thread != nullptr, "invariant");
-    assert(!thread->in_asgct(), "invariant");
+    // AsyncGetCallTrace is reentrant - save the previous state.
+    _saved_in_asgct = thread->in_asgct();
     thread->set_in_asgct(true);
   }
   ~ThreadInAsgct() {
     assert(_thread->in_asgct(), "invariant");
-    _thread->set_in_asgct(false);
+    _thread->set_in_asgct(_saved_in_asgct);
   }
 };
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -661,7 +661,7 @@ class ThreadInAsgct {
  public:
   ThreadInAsgct(Thread* thread) : _thread(thread) {
     assert(thread != nullptr, "invariant");
-    // AsyncGetCallTrace is reentrant - save the previous state.
+    // Allow AsyncGetCallTrace to be reentrant - save the previous state.
     _saved_in_asgct = thread->in_asgct();
     thread->set_in_asgct(true);
   }


### PR DESCRIPTION
This fix makes `AsyncGetCallTrace` reentrant and async-signal-safe.
Reentrancy is required in the cases when two or more profiling engines are running at the same time, e.g., when CPU and Wall clock profilers work together and therefore one profiler may interrupt another in the middle of getting a stack trace.

Tested with async-profiler:
```
java -agentpath:/path/to/libasyncProfiler.so=start,event=cpu,interval=1ms,wall=1ms,file=profile.jfr
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329103](https://bugs.openjdk.org/browse/JDK-8329103): assert(!thread-&gt;in_asgct()) failed during multi-mode profiling (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18504/head:pull/18504` \
`$ git checkout pull/18504`

Update a local copy of the PR: \
`$ git checkout pull/18504` \
`$ git pull https://git.openjdk.org/jdk.git pull/18504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18504`

View PR using the GUI difftool: \
`$ git pr show -t 18504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18504.diff">https://git.openjdk.org/jdk/pull/18504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18504#issuecomment-2021740856)