### PR TITLE
8320718: C2: comparison folding disregards pinned stores

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestGCMStorePlacement.java
@@ -172,7 +172,6 @@ public class TestGCMStorePlacement {
 
     static void testOsrReducible4() {
         // Trigger OSR compilation.
-        // TODO: transform back into for loop
         int i = 0;
         while (i < 2049) {
             // On OSR entry, i == intCounter == 2048. This test checks that

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1534,6 +1534,11 @@ public class IRNode {
         trapNodes(UNSTABLE_IF_TRAP, "unstable_if");
     }
 
+    public static final String UNSTABLE_FUSED_IF_TRAP = PREFIX + "UNSTABLE_FUSED_IF_TRAP" + POSTFIX;
+    static {
+        trapNodes(UNSTABLE_FUSED_IF_TRAP, "unstable_fused_if");
+    }
+
     public static final String UNREACHED_TRAP = PREFIX + "UNREACHED_TRAP" + POSTFIX;
     static {
         trapNodes(UNREACHED_TRAP, "unreached");

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeChecksWithInterleavedStores.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeChecksWithInterleavedStores.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.rangechecks;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/**
+ * @test
+ * @bug 8320718
+ * @summary Test that range check-like pairs of checks are not folded into
+ *          single checks in the presence of interleaved stores. Doing so would
+ *          risk illegally hoisting the stores above their corresponding checks.
+ * @library /test/lib /
+ * @run driver compiler.rangechecks.TestExplicitRangeChecksIR
+ */
+
+public class TestRangeChecksWithInterleavedStores {
+
+    static int sum = 0;
+    static boolean alwaysFalse = false;
+
+    public static void main(String[] args) {
+        TestFramework testFramework = new TestFramework();
+        testFramework.addScenarios(new Scenario(1),
+                                   new Scenario(2, "-XX:+StressGCM"));
+        testFramework.start();
+    }
+
+    @Test
+    @IR(counts = {IRNode.UNSTABLE_IF_TRAP, "2"})
+    @IR(failOn = IRNode.UNSTABLE_FUSED_IF_TRAP)
+    static boolean testTwoChecksWithPinnedStore(int i) {
+        if (i < 0) {
+            return false;
+        }
+        // This store is pinned to the above if-check. If the above if-check was
+        // fused with the one below, the store would be free to be scheduled on
+        // method entry, incrementing 'sum' even if i < 0.
+        sum++;
+        if (i >= 10) {
+            return false;
+        }
+        return true;
+    }
+
+    @Run(test = {"testTwoChecksWithPinnedStore"}, mode = RunMode.STANDALONE)
+    public void runTestTwoChecksWithPinnedStore(RunInfo info) {
+        sum = 0;
+        for (int i = 0; i < 10_000; ++i) {
+            testTwoChecksWithPinnedStore(5);
+        }
+        TestFramework.assertCompiledByC2(info.getTest());
+        Asserts.assertEQ(10_000, sum);
+        sum = 0;
+        testTwoChecksWithPinnedStore(-1);
+        TestFramework.assertDeoptimizedByC2(info.getTest());
+        Asserts.assertEQ(0, sum);
+    }
+
+    @Test
+    @IR(counts = {IRNode.UNSTABLE_IF_TRAP, "3"})
+    @IR(failOn = IRNode.UNSTABLE_FUSED_IF_TRAP)
+    static boolean testThreeChecksWithPinnedStore(int i) {
+        if (i < 0) {
+            return false;
+        }
+        // This store is pinned to the above if-check. If the above if-check was
+        // fused with the one below (i >= 10), the store would be free to be
+        // scheduled on method entry, incrementing 'sum' even if i < 0.
+        sum++;
+        if (alwaysFalse) {
+            return false;
+        }
+        if (i >= 10) {
+            return false;
+        }
+        return true;
+    }
+
+    @Run(test = {"testThreeChecksWithPinnedStore"}, mode = RunMode.STANDALONE)
+    public void runTestThreeChecksWithPinnedStore(RunInfo info) {
+        sum = 0;
+        for (int i = 0; i < 10_000; ++i) {
+            testThreeChecksWithPinnedStore(5);
+        }
+        TestFramework.assertCompiledByC2(info.getTest());
+        Asserts.assertEQ(10_000, sum);
+        sum = 0;
+        testThreeChecksWithPinnedStore(-1);
+        TestFramework.assertDeoptimizedByC2(info.getTest());
+        Asserts.assertEQ(0, sum);
+    }
+}

--- a/test/hotspot/jtreg/compiler/rangechecks/TestRangeChecksWithInterleavedStores.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestRangeChecksWithInterleavedStores.java
@@ -33,7 +33,7 @@ import compiler.lib.ir_framework.*;
  *          single checks in the presence of interleaved stores. Doing so would
  *          risk illegally hoisting the stores above their corresponding checks.
  * @library /test/lib /
- * @run driver compiler.rangechecks.TestExplicitRangeChecksIR
+ * @run driver compiler.rangechecks.TestRangeChecksWithInterleavedStores
  */
 
 public class TestRangeChecksWithInterleavedStores {


### PR DESCRIPTION
C2 [tries to fold](https://github.com/openjdk/jdk/blob/8fc9097b3720314ef7efaf1f3ac31898c8d6ca19/src/hotspot/share/opto/ifnode.cpp#L1326-L1369) pairs of range check-like comparisons into single unsigned comparisons. In [the case](https://github.com/openjdk/jdk/blob/8fc9097b3720314ef7efaf1f3ac31898c8d6ca19/src/hotspot/share/opto/ifnode.cpp#L1356-L1365) where there is a third, unrelated comparison in between the two folding candidates, this optimization does not take into account whether there is any node (e.g. a store) pinned to the successful projection of the dominating candidate. This results in C2 folding the comparisons, and the pinned nodes being allowed to be hoisted above the original comparisons, which can lead to miscompilations. See further details in the [JBS issue description](https://bugs.openjdk.org/browse/JDK-8320718).

This changeset ensures that two comparisons are not folded when there are nodes pinned to the successful projection of the dominating comparison, regardless of whether the two comparisons are [consecutive](https://github.com/openjdk/jdk/blob/8fc9097b3720314ef7efaf1f3ac31898c8d6ca19/src/hotspot/share/opto/ifnode.cpp#L1331-L1347) or [separated](https://github.com/openjdk/jdk/blob/8fc9097b3720314ef7efaf1f3ac31898c8d6ca19/src/hotspot/share/opto/ifnode.cpp#L1348-L1366) by a third, unrelated test.

The changeset adds negative IR tests checking that comparisons are not folded in the scenario described above, and that, consequently, stores are not hoisted above the comparisons. It also includes the simplified reproducer contributed by @TobiHartmann and a variant of it that reproduces the issue using the default GCM heuristics.

#### Testing

- tier1-5, stress test, fuzzing (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode).
- Tested that, with the changeset, the original JavaFuzzer-generated test does not fail on 1000 `StressGCM` runs (the failure frequency without the changeset is higher than 50%).
- Tested manually that the changeset does not affect the optimizations applied to the `compiler/rangechecks/TestExplicitRangeChecks.java` tests ([this starter RFE](https://bugs.openjdk.org/browse/JDK-8329101) proposes automating this task by adding IR checks to the tests).
- Tested that the changeset does not introduce performance regressions on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320718](https://bugs.openjdk.org/browse/JDK-8320718): C2: comparison folding disregards pinned stores (**Bug** - P3)


### Contributors
 * Tobias Hartmann `<thartmann@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18506/head:pull/18506` \
`$ git checkout pull/18506`

Update a local copy of the PR: \
`$ git checkout pull/18506` \
`$ git pull https://git.openjdk.org/jdk.git pull/18506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18506`

View PR using the GUI difftool: \
`$ git pr show -t 18506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18506.diff">https://git.openjdk.org/jdk/pull/18506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18506#issuecomment-2022382431)