### PR TITLE
8329178: Clean up jdk.accessibility native compilation

### DIFF
--- a/make/modules/jdk.accessibility/Launcher.gmk
+++ b/make/modules/jdk.accessibility/Launcher.gmk
@@ -26,29 +26,21 @@
 include LauncherCommon.gmk
 
 ifeq ($(call isTargetOs, windows), true)
-
   ACCESSIBILITY_SRCDIR := $(TOPDIR)/src/jdk.accessibility/windows/native
-  TOOLS_CFLAGS := $(addprefix -I, \
-      $(ACCESSIBILITY_SRCDIR)/include/bridge \
-      $(ACCESSIBILITY_SRCDIR)/common \
-      $(ACCESSIBILITY_SRCDIR)/toolscommon)
 
   ##############################################################################
-  # jabswitch
+  # Build jabswitch
+  ##############################################################################
 
   $(eval $(call SetupJdkExecutable, BUILD_JABSWITCH, \
       NAME := jabswitch, \
-      SRC := $(ACCESSIBILITY_SRCDIR)/jabswitch, \
-      INCLUDE_FILES := jabswitch.cpp, \
-      CFLAGS_FILTER_OUT := -Zc:wchar_t-, \
       CXXFLAGS_FILTER_OUT := -Zc:wchar_t-, \
-      CFLAGS := -Zc:wchar_t -analyze- -Od -Gd -D_WINDOWS -D_UNICODE \
-          -DUNICODE -RTC1 -EHsc, \
       CXXFLAGS := -Zc:wchar_t -analyze- -Od -Gd -D_WINDOWS -D_UNICODE \
           -DUNICODE -RTC1 -EHsc, \
       DISABLED_WARNINGS_microsoft_jabswitch.cpp := 4267 4996, \
-      LIBS := advapi32.lib version.lib user32.lib, \
-      VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
+      LIBS_windows := advapi32.lib user32.lib version.lib, \
+      VERSIONINFO_RESOURCE := \
+          $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
       MANIFEST := $(ACCESSIBILITY_SRCDIR)/jabswitch/jabswitch.manifest, \
       MANIFEST_VERSION := $(VERSION_NUMBER_FOUR_POSITIONS), \
   ))
@@ -56,47 +48,54 @@ ifeq ($(call isTargetOs, windows), true)
   TARGETS += $(BUILD_JABSWITCH)
 
   ##############################################################################
-  # jaccessinspector
-
-  define SetupInspector
+  # Setup rules to create 32/64 bit version of jaccessinspector
+  #
   # Parameter 1 File name suffix
   # Parameter 2 ACCESSBRIDGE_ARCH_ -D suffix
-
+  ##############################################################################
+  define SetupInspector
     $$(eval $$(call SetupJdkExecutable, BUILD_JACCESSINSPECTOR$1, \
       NAME := jaccessinspector$1, \
-      SRC := $(ACCESSIBILITY_SRCDIR)/jaccessinspector $(ACCESSIBILITY_SRCDIR)/common \
-          $(ACCESSIBILITY_SRCDIR)/toolscommon $(ACCESSIBILITY_SRCDIR)/bridge, \
-      CFLAGS := $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      CXXFLAGS := $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      LDFLAGS := -stack:655360, \
-      LIBS := advapi32.lib user32.lib, \
-      VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/jaccessinspector/jaccessinspectorWindow.rc, \
+      SRC := jaccessinspector, \
+      EXTRA_SRC := \
+          bridge \
+          common \
+          toolscommon, \
+      EXTRA_HEADER_DIRS := include/bridge, \
+      CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      LDFLAGS_windows := -stack:655360, \
+      LIBS_windows := advapi32.lib user32.lib, \
+      VERSIONINFO_RESOURCE := \
+          $(ACCESSIBILITY_SRCDIR)/jaccessinspector/jaccessinspectorWindow.rc, \
     ))
 
     TARGETS += $$(BUILD_JACCESSINSPECTOR$1)
-
   endef
 
   ##############################################################################
-  # jaccesswalker
-
-  define SetupWalker
+  # Setup rules to create 32/64 bit version of jaccesswalker
   # Parameter 1 File name suffix
   # Parameter 2 ACCESSBRIDGE_ARCH_ -D suffix
-
+  ##############################################################################
+  define SetupWalker
     $$(eval $$(call SetupJdkExecutable, BUILD_JACCESSWALKER$1, \
       NAME := jaccesswalker$1, \
-      SRC := $(ACCESSIBILITY_SRCDIR)/jaccesswalker $(ACCESSIBILITY_SRCDIR)/common \
-          $(ACCESSIBILITY_SRCDIR)/toolscommon $(ACCESSIBILITY_SRCDIR)/bridge, \
-      CFLAGS := $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      CXXFLAGS := $(TOOLS_CFLAGS) -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      LDFLAGS := -stack:655360, \
-      LIBS := advapi32.lib comctl32.lib gdi32.lib user32.lib, \
-      VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/jaccesswalker/jaccesswalkerWindow.rc, \
+      SRC := jaccesswalker, \
+      EXTRA_SRC := \
+          bridge \
+          common \
+          toolscommon, \
+      EXTRA_HEADER_DIRS := include/bridge, \
+      CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+      LDFLAGS_windows := -stack:655360, \
+      LIBS_windows := advapi32.lib comctl32.lib gdi32.lib user32.lib, \
+      VERSIONINFO_RESOURCE := \
+          $(ACCESSIBILITY_SRCDIR)/jaccesswalker/jaccesswalkerWindow.rc, \
    ))
 
     TARGETS += $$(BUILD_JACCESSWALKER$1)
-
   endef
 
   ifeq ($(call isTargetCpuBits, 32), true)
@@ -108,7 +107,4 @@ ifeq ($(call isTargetOs, windows), true)
     $(eval $(call SetupInspector,,64))
     $(eval $(call SetupWalker,,64))
   endif
-
 endif
-
-################################################################################

--- a/make/modules/jdk.accessibility/Launcher.gmk
+++ b/make/modules/jdk.accessibility/Launcher.gmk
@@ -55,19 +55,19 @@ ifeq ($(call isTargetOs, windows), true)
   ##############################################################################
   define SetupInspector
     $$(eval $$(call SetupJdkExecutable, BUILD_JACCESSINSPECTOR$1, \
-      NAME := jaccessinspector$1, \
-      SRC := jaccessinspector, \
-      EXTRA_SRC := \
-          bridge \
-          common \
-          toolscommon, \
-      EXTRA_HEADER_DIRS := include/bridge, \
-      CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      LDFLAGS_windows := -stack:655360, \
-      LIBS_windows := advapi32.lib user32.lib, \
-      VERSIONINFO_RESOURCE := \
-          $(ACCESSIBILITY_SRCDIR)/jaccessinspector/jaccessinspectorWindow.rc, \
+        NAME := jaccessinspector$1, \
+        SRC := jaccessinspector, \
+        EXTRA_SRC := \
+            bridge \
+            common \
+            toolscommon, \
+        EXTRA_HEADER_DIRS := include/bridge, \
+        CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+        CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+        LDFLAGS_windows := -stack:655360, \
+        LIBS_windows := advapi32.lib user32.lib, \
+        VERSIONINFO_RESOURCE := \
+            $(ACCESSIBILITY_SRCDIR)/jaccessinspector/jaccessinspectorWindow.rc, \
     ))
 
     TARGETS += $$(BUILD_JACCESSINSPECTOR$1)
@@ -80,19 +80,19 @@ ifeq ($(call isTargetOs, windows), true)
   ##############################################################################
   define SetupWalker
     $$(eval $$(call SetupJdkExecutable, BUILD_JACCESSWALKER$1, \
-      NAME := jaccesswalker$1, \
-      SRC := jaccesswalker, \
-      EXTRA_SRC := \
-          bridge \
-          common \
-          toolscommon, \
-      EXTRA_HEADER_DIRS := include/bridge, \
-      CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
-      LDFLAGS_windows := -stack:655360, \
-      LIBS_windows := advapi32.lib comctl32.lib gdi32.lib user32.lib, \
-      VERSIONINFO_RESOURCE := \
-          $(ACCESSIBILITY_SRCDIR)/jaccesswalker/jaccesswalkerWindow.rc, \
+        NAME := jaccesswalker$1, \
+        SRC := jaccesswalker, \
+        EXTRA_SRC := \
+            bridge \
+            common \
+            toolscommon, \
+        EXTRA_HEADER_DIRS := include/bridge, \
+        CFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+        CXXFLAGS := -DACCESSBRIDGE_ARCH_$2 -EHsc, \
+        LDFLAGS_windows := -stack:655360, \
+        LIBS_windows := advapi32.lib comctl32.lib gdi32.lib user32.lib, \
+        VERSIONINFO_RESOURCE := \
+            $(ACCESSIBILITY_SRCDIR)/jaccesswalker/jaccesswalkerWindow.rc, \
    ))
 
     TARGETS += $$(BUILD_JACCESSWALKER$1)

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -28,77 +28,83 @@ include LibCommon.gmk
 ################################################################################
 
 ifeq ($(call isTargetOs, windows), true)
-
   ACCESSIBILITY_SRCDIR := $(TOPDIR)/src/jdk.accessibility/windows/native
 
+  ##############################################################################
+  # Setup rules to create 32/64 bit version of javaaccessbridge
+  #
+  # Parameter 1 Suffix
+  # Parameter 2 ACCESSBRIDGE_ARCH_ suffix
+  ##############################################################################
   define SetupJavaDLL
-    # Parameter 1 Suffix
-    # Parameter 2 ACCESSBRIDGE_ARCH_ suffix
-
-    $(call SetupJdkLibrary, BUILD_JAVAACCESSBRIDGE$1, \
+    $(call SetupJdkLibrary, BUILD_LIBJAVAACCESSBRIDGE$1, \
         NAME := javaaccessbridge$1, \
         SRC := libjavaaccessbridge, \
         EXTRA_SRC := common, \
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft := 4311 4302 4312, \
-        CFLAGS_FILTER_OUT := -MD, \
         CXXFLAGS_FILTER_OUT := -MD, \
-        CFLAGS := -MT -DACCESSBRIDGE_ARCH_$2, \
         CXXFLAGS := -MT -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge \
             java.desktop:include, \
-        LIBS := kernel32.lib user32.lib gdi32.lib \
-            winspool.lib comdlg32.lib advapi32.lib shell32.lib \
-            $(SUPPORT_OUTPUTDIR)/native/java.desktop/libjawt/jawt.lib \
-            ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib, \
-        VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
+        JDK_LIBS_windows := $(SUPPORT_OUTPUTDIR)/native/java.desktop/libjawt/jawt.lib, \
+        LIBS_windows := advapi32.lib comdlg32.lib gdi32.lib kernel32.lib \
+            odbc32.lib odbccp32.lib ole32.lib oleaut32.lib shell32.lib \
+            user32.lib uuid.lib winspool.lib, \
+        VERSIONINFO_RESOURCE := \
+            $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
     )
 
-    $$(BUILD_JAVAACCESSBRIDGE$1): $(call FindStaticLib, java.desktop, jawt, /libjawt)
+    $$(BUILD_LIBJAVAACCESSBRIDGE$1): $(call FindStaticLib, java.desktop, jawt, /libjawt)
 
-    TARGETS += $$(BUILD_JAVAACCESSBRIDGE$1)
+    TARGETS += $$(BUILD_LIBJAVAACCESSBRIDGE$1)
   endef
 
+  ##############################################################################
+  # Setup rules to create 32/64 bit version of windowsaccessbridge
+  #
+  # Parameter 1 Suffix
+  # Parameter 2 ACCESSBRIDGE_ARCH_ suffix
+  ##############################################################################
   define SetupWinDLL
-    # Parameter 1 Suffix
-    # Parameter 2 ACCESSBRIDGE_ARCH_ suffix
-    $(call SetupJdkLibrary, BUILD_WINDOWSACCESSBRIDGE$1, \
+    $(call SetupJdkLibrary, BUILD_LIBWINDOWSACCESSBRIDGE$1, \
         NAME := windowsaccessbridge$1, \
         SRC := libwindowsaccessbridge, \
         EXTRA_SRC := common, \
         OPTIMIZATION := LOW, \
         DISABLED_WARNINGS_microsoft_WinAccessBridge.cpp := 4302 4311, \
-        CFLAGS := -DACCESSBRIDGE_ARCH_$2, \
         CXXFLAGS := -DACCESSBRIDGE_ARCH_$2, \
         EXTRA_HEADER_DIRS := \
             include/bridge, \
         LDFLAGS := \
             -def:$(ACCESSIBILITY_SRCDIR)/libwindowsaccessbridge/WinAccessBridge.DEF, \
-        LIBS := kernel32.lib user32.lib gdi32.lib \
-            winspool.lib comdlg32.lib advapi32.lib shell32.lib \
-            ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib, \
-        VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
+        LIBS_windows := advapi32.lib comdlg32.lib gdi32.lib kernel32.lib \
+            odbc32.lib odbccp32.lib ole32.lib oleaut32.lib shell32.lib \
+            user32.lib uuid.lib winspool.lib, \
+        VERSIONINFO_RESOURCE := \
+            $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
     )
 
-    TARGETS += $$(BUILD_WINDOWSACCESSBRIDGE$1)
-
-  endef
-
-  define SetupAccessBridgeSysInfo
-
-    $(call SetupJdkLibrary, BUILD_ACCESSBRIDGESYSINFO, \
-        NAME := jabsysinfo, \
-        OPTIMIZATION := LOW, \
-        VERSIONINFO_RESOURCE := $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
-    )
-
-    TARGETS += $$(BUILD_ACCESSBRIDGESYSINFO)
-
+    TARGETS += $$(BUILD_LIBWINDOWSACCESSBRIDGE$1)
   endef
 
   ifeq ($(call isTargetCpuBits, 32), true)
-    $(eval $(call SetupAccessBridgeSysInfo))
+    ############################################################################
+    # Build libjabsysinfo
+    ############################################################################
+
+    $(eval $(call SetupJdkLibrary, BUILD_LIBJABSYSINFO, \
+        NAME := jabsysinfo, \
+        OPTIMIZATION := LOW, \
+        VERSIONINFO_RESOURCE := \
+            $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
+    )
+
+    TARGETS += $(BUILD_LIBJABSYSINFO)
+  endif
+
+  ifeq ($(call isTargetCpuBits, 32), true)
     $(eval $(call SetupJavaDLL,-32,32))
     $(eval $(call SetupJavaDLL,,LEGACY))
     $(eval $(call SetupWinDLL,-32,32))
@@ -107,7 +113,4 @@ ifeq ($(call isTargetOs, windows), true)
     $(eval $(call SetupJavaDLL,,64))
     $(eval $(call SetupWinDLL,-64,64))
   endif
-
 endif
-
-################################################################################


### PR DESCRIPTION
This is a follow-up on JDK-8328680, making the same kind of cleanup to jdk.accessibility. The code here needed more work than for the other modules, so I wanted have it in a separate PR to get a more thorough review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329178](https://bugs.openjdk.org/browse/JDK-8329178): Clean up jdk.accessibility native compilation (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18510/head:pull/18510` \
`$ git checkout pull/18510`

Update a local copy of the PR: \
`$ git checkout pull/18510` \
`$ git pull https://git.openjdk.org/jdk.git pull/18510/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18510`

View PR using the GUI difftool: \
`$ git pr show -t 18510`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18510.diff">https://git.openjdk.org/jdk/pull/18510.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18510#issuecomment-2022757923)