### PR TITLE
8329189: runtime/stack/Stack016.java fails on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/stack/Stack016.java
+++ b/test/hotspot/jtreg/runtime/stack/Stack016.java
@@ -58,7 +58,7 @@ public class Stack016 extends Thread {
     private final static int THREADS = 10;
     private final static int CYCLES = 10;
     private final static int STEP = 10;
-    private final static int RESERVE = 100;
+    private final static int RESERVE = 10;
     private final static int PROBES = STEP * RESERVE;
 
     public static void main(String[] args) {
@@ -88,7 +88,7 @@ public class Stack016 extends Thread {
         for (int i = 0; i < threads.length; i++) {
             threads[i] = new Stack016();
             threads[i].setName("Thread: " + (i + 1) + "/" + THREADS);
-            threads[i].depthToTry = RESERVE * maxDepth;
+            threads[i].depthToTry = RESERVE * maxDepth * 10;
             threads[i].start();
         }
         for (int i = 0; i < threads.length; i++) {


### PR DESCRIPTION
[JDK-8328858](https://bugs.openjdk.org/browse/JDK-8328858) adjusted  `depthToTry` in all `runtime/stack/Stack0*.java` tests but did so incorrectly for `Stack016.java`. The `RESERVE` value is used both to initialize `depthToTry` as well as controlling stack space to reserve for testing nested StackOverflowError handling.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329189](https://bugs.openjdk.org/browse/JDK-8329189): runtime/stack/Stack016.java fails on libgraal (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18511/head:pull/18511` \
`$ git checkout pull/18511`

Update a local copy of the PR: \
`$ git checkout pull/18511` \
`$ git pull https://git.openjdk.org/jdk.git pull/18511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18511`

View PR using the GUI difftool: \
`$ git pr show -t 18511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18511.diff">https://git.openjdk.org/jdk/pull/18511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18511#issuecomment-2022790673)