### PR TITLE
8328702: C2: Crash during parsing because sub type check is not folded

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -6458,14 +6458,19 @@ template <class T1, class T2> bool TypePtr::maybe_java_subtype_of_helper_for_arr
   if (other->klass() == ciEnv::current()->Object_klass() && other->_interfaces->empty() && other_exact) {
     return true;
   }
-  int dummy;
-  bool this_top_or_bottom = (this_one->base_element_type(dummy) == Type::TOP || this_one->base_element_type(dummy) == Type::BOTTOM);
-  if (!this_one->is_loaded() || !other->is_loaded() || this_top_or_bottom) {
+  if (!this_one->is_loaded() || !other->is_loaded()) {
     return true;
   }
   if (this_one->is_instance_type(other)) {
     return other->klass()->equals(ciEnv::current()->Object_klass()) && other->_interfaces->intersection_with(this_one->_interfaces)->eq(other->_interfaces);
   }
+
+  int dummy;
+  bool this_top_or_bottom = (this_one->base_element_type(dummy) == Type::TOP || this_one->base_element_type(dummy) == Type::BOTTOM);
+  if (this_top_or_bottom) {
+    return true;
+  }
+
   assert(this_one->is_array_type(other), "");
 
   const T1* other_ary = this_one->is_array_type(other);

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=Xcomp
+ * @bug 8328702
+ * @summary Check that SubTypeCheckNode is properly folded when having an array with bottom type elements checked
+ *          against an interface.
+ *
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
+ *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
+ *                   compiler.types.TestSubTypeCheckWithBottomArray
+ */
+
+/*
+ * @test id=Xbatch
+ * @bug 8328702
+ * @summary Check that SubTypeCheckNode is properly folded when having an array with bottom type elements checked
+ *          against an interface.
+ *
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
+ *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
+ *                   compiler.types.TestSubTypeCheckWithBottomArray
+ */
+
+/*
+ * @test id=stress
+ * @bug 8328702
+ * @summary Check that PartialSubtypeCheckNode is properly folded when having an array with bottom type elements checked
+ *          either against an interface or an unrelated non-sub-class.
+ *
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
+ *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
+ *                   compiler.types.TestSubTypeCheckWithBottomArray
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
+ *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
+ *                   compiler.types.TestSubTypeCheckWithBottomArray
+ */
+
+package compiler.types;
+
+public class TestSubTypeCheckWithBottomArray {
+    static byte[] bArr = new byte[10];
+    static Object[] oArr = new Object[10];
+    static boolean flag;
+
+    public static void main(String[] args) {
+        A a = new A();
+        B b = new B();
+        Y y = new Y();
+        Z z = new Z();
+        for (int i = 0; i < 10000; i++) {
+            // With -Xcomp: Immediatly crashes because of no profiling -> don't know anything.
+            checkInterface(a); // Make sure that checkInterface() sometimes passes instanceof.
+            checkInterface(b); // Use two sub classes such that checkcast is required.
+            testInterface();
+
+            checkClass(y); // Make sure that checkClass() sometimes passes instanceof.
+            checkClass(z); // Use two sub classes such that checkcast is required.
+            testClass();
+            flag = !flag;
+        }
+    }
+
+    static void testInterface() {
+        checkInterface(flag ? bArr : oArr); // Inlined, never passes instanceof
+    }
+
+    static void checkInterface(Object o) {
+        if (o instanceof I i) {
+            // Use of i: Needs CheckCastPP which is replaced by top because [bottom <: I cannot be true.
+            // But: SubTypeCheckNode is not folded away -> broken graph (data dies, control not)
+            i.getClass();
+        }
+    }
+
+    static void testClass() {
+        checkClass(flag ? bArr : oArr); // Inlined, never passes instanceof
+    }
+
+    static void checkClass(Object o) {
+        if (o instanceof X x) {
+            // Use of i: Needs CheckCastPP which is replaced by top because [bottom <: I cannot be true.
+            // But: SubTypeCheckNode is not folded away -> broken graph (data dies, control not)
+            x.getClass();
+        }
+    }
+
+}
+
+interface I {}
+class A implements I {}
+class B implements I {}
+
+class X {}
+class Y extends X {}
+class Z extends X {}


### PR DESCRIPTION
The test case shows a problem where data is folded during parsing while control is not. This leaves the graph in a broken state and we fail with an assertion.

We have the following (pseudo) code for some class `X`:
```
o = flag ? new Object[] : new byte[]; 
if (o instanceof X) {
   X x = (X)o; // checkcast
}
```
For the `checkcast`, C2 knows that the type of `o` is some kind of array, i.e. type `[bottom`. But this cannot be a sub type of `X`. Therefore, the `CheckCastPP` node created for the `checkcast` result is replaced by top by the type system. However, the `SubTypeCheckNode` for the `checkcast` is not folded and the graph is broken.

The problem of not folding the `SubTypeCheckNode` can be traced back to `SubTypeCheckNode::sub` calling `static_subtype_check()` when transforming the node after it's creation. `static_subtype_check()` should detect that the sub type check is always wrong here:
https://github.com/openjdk/jdk/blob/d0a265039a36292d87b249af0e8977982e5acc7b/src/hotspot/share/opto/compile.cpp#L4454-L4460

But it does not because these two checks return the following:
1. Check: is `o` a sub type of `X`? -> returns no, so far so good.
2. Check: _could_ `o` be a sub type of `X`? -> returns no which is wrong! `[bottom` is only a sub type of `Object` and can never be a subtype of `X`

In `maybe_java_subtype_of_helper_for_arr()`, we wrongly conclude that any array with a base element type `bottom` _could_ be a sub type of anything:
https://github.com/openjdk/jdk/blob/d0a265039a36292d87b249af0e8977982e5acc7b/src/hotspot/share/opto/type.cpp#L6462-L6465
But this is only true if the super class is also an array class - but not if `other` (super klass) is an instance klass as in this case.

The fix for this is to first check the immediately following check which handles the case of comparing an array klass to an instance klass: An array klass can only ever be a sub class of an instance klass if it's the `Object` class. But in our case, we have `X` and this would return false:

https://github.com/openjdk/jdk/blob/d0a265039a36292d87b249af0e8977982e5acc7b/src/hotspot/share/opto/type.cpp#L6466-L6468

The very same problem can also be triggered with `X` being an interface instead. There are tests for both these cases.

#### Additionally Required Fix
When running with `-XX:+ExpandSubTypeCheckAtParseTime`, we eagerly expand the sub type check during parsing and therefore do not emit a `SubTypeCheckNode`. When additionally running with `-XX:+StressReflectiveCode`, the static sub type performed in `static_subtype_check()` is skipped when emitting the expanded sub type check (`skip` is default-initialized with the flag value of `StressReflectiveCode`):
https://github.com/openjdk/jdk/blob/d0a265039a36292d87b249af0e8977982e5acc7b/src/hotspot/share/opto/compile.cpp#L4450-L4452

And again, the graph is left in a broken state because the sub type check cannot be folded.

I therefore propose to always perform the static sub type check when a sub type check is expanded during parsing (i.e.  if `ExpandSubTypeCheckAtParseTime` is set). I've added a run with these flags as well.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328702](https://bugs.openjdk.org/browse/JDK-8328702): C2: Crash during parsing because sub type check is not folded (**Bug** - P2)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18512/head:pull/18512` \
`$ git checkout pull/18512`

Update a local copy of the PR: \
`$ git checkout pull/18512` \
`$ git pull https://git.openjdk.org/jdk.git pull/18512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18512`

View PR using the GUI difftool: \
`$ git pr show -t 18512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18512.diff">https://git.openjdk.org/jdk/pull/18512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18512#issuecomment-2022836456)