### PR TITLE
8329191: JVMCI compiler warning is truncated

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompiler.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompiler.cpp
@@ -229,9 +229,12 @@ void JVMCICompiler::on_upcall(const char* error, JVMCICompileState* compile_stat
     if (err > 10 && err * 10 > ok && !_disabled) {
       _disabled = true;
       int total = err + ok;
-      const char* disable_msg = err_msg("JVMCI compiler disabled "
-      "after %d of %d upcalls had errors (Last error: \"%s\"). "
-      "Use -Xlog:jit+compilation for more detail.", err, total, error);
+      // Using stringStream instead of err_msg to avoid truncation
+      stringStream st;
+      st.print("JVMCI compiler disabled "
+               "after %d of %d upcalls had errors (Last error: \"%s\"). "
+               "Use -Xlog:jit+compilation for more detail.", err, total, error);
+      const char* disable_msg = st.freeze();
       log_warning(jit,compilation)("%s", disable_msg);
       if (compile_state != nullptr) {
         const char* disable_error = os::strdup(disable_msg);

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -239,8 +239,10 @@ void JVMCIEnv::check_init(JVMCI_TRAPS) {
   if (_init_error == JNI_ENOMEM) {
     JVMCI_THROW_MSG(OutOfMemoryError, "JNI_ENOMEM creating or attaching to libjvmci");
   }
-  JVMCI_THROW_MSG(InternalError, err_msg("Error creating or attaching to libjvmci (err: %d, description: %s)",
-                  _init_error, _init_error_msg == nullptr ? "unknown" : _init_error_msg));
+  stringStream st;
+  st.print("Error creating or attaching to libjvmci (err: %d, description: %s)",
+           _init_error, _init_error_msg == nullptr ? "unknown" : _init_error_msg);
+  JVMCI_THROW_MSG(InternalError, st.freeze());
 }
 
 void JVMCIEnv::check_init(TRAPS) {
@@ -250,8 +252,10 @@ void JVMCIEnv::check_init(TRAPS) {
   if (_init_error == JNI_ENOMEM) {
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "JNI_ENOMEM creating or attaching to libjvmci");
   }
-  THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), err_msg("Error creating or attaching to libjvmci (err: %d, description: %s)",
-            _init_error, _init_error_msg == nullptr ? "unknown" : _init_error_msg));
+  stringStream st;
+  st.print("Error creating or attaching to libjvmci (err: %d, description: %s)",
+           _init_error, _init_error_msg == nullptr ? "unknown" : _init_error_msg);
+  THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), st.freeze());
 }
 
 // Prints a pending exception (if any) and its stack trace to st.

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1973,7 +1973,10 @@ static bool after_compiler_upcall(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
     const char* pending_stack_trace = nullptr;
     JVMCIENV->pending_exception_as_string(&pending_string, &pending_stack_trace);
     if (pending_string == nullptr) pending_string = "null";
-    const char* failure_reason = os::strdup(err_msg("uncaught exception in %s [%s]", function, pending_string), mtJVMCI);
+    // Using stringStream instead of err_msg to avoid truncation
+    stringStream st;
+    st.print("uncaught exception in %s [%s]", function, pending_string);
+    const char* failure_reason = os::strdup(st.freeze(), mtJVMCI);
     if (failure_reason == nullptr) {
       failure_reason = "uncaught exception";
       reason_on_C_heap = false;


### PR DESCRIPTION
```
$ java -Djdk.graal.CompilerConfiguration=XXcommunity HelloWorld
[0.035s][warning][jit,compilation] JVMCI compiler disabled after 11 of 11 upcalls had errors (Last error: "uncaught exception in call_HotSpotJVMCIRuntime_compileMethod [jdk.graal.compiler.debug.GraalError: Compiler configuration 'XXcommunity' not found. Available configurations are: enterp
```
The above message is truncated. It should be:
```
[0.032s][warning][jit,compilation] JVMCI compiler disabled after 11 of 11 upcalls had errors (Last error: "uncaught exception in call_HotSpotJVMCIRuntime_compileMethod [jdk.graal.compiler.debug.GraalError: Compiler configuration 'XXcommunity' not found. Available configurations are: enterprise, community, economy]"). Use -Xlog:jit+compilation for more detail.
```

This PR fixes this by using `stringStream` instead of `err_msg` when creating these messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329191](https://bugs.openjdk.org/browse/JDK-8329191): JVMCI compiler warning is truncated (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * @fniephaus (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18513/head:pull/18513` \
`$ git checkout pull/18513`

Update a local copy of the PR: \
`$ git checkout pull/18513` \
`$ git pull https://git.openjdk.org/jdk.git pull/18513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18513`

View PR using the GUI difftool: \
`$ git pr show -t 18513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18513.diff">https://git.openjdk.org/jdk/pull/18513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18513#issuecomment-2022857617)