### PR TITLE
8326568: jdk/test/com/sun/net/httpserver/bugs/B6431193.java should use try-with-resource and try-finally

### DIFF
--- a/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,52 +47,45 @@ public class B6431193 {
         i.close();
     }
 
-    /**
-     * @param args
-     */
-    public static void main(String[] args) {
+    public static void main(String[] args) throws IOException {
         class MyHandler implements HttpHandler {
             public void handle(HttpExchange t) throws IOException {
-                InputStream is = t.getRequestBody();
-                read(is);
-                // .. read the request body
+                try (InputStream is = t.getRequestBody();
+                     OutputStream os = t.getResponseBody()) {
+                    read(is);
+                    // .. read the request body
                     String response = "This is the response";
-                t.sendResponseHeaders(200, response.length());
-                OutputStream os = t.getResponseBody();
-                os.write(response.getBytes());
-                os.close();
-                error = Thread.currentThread().isDaemon();
+                    t.sendResponseHeaders(200, response.length());
+                    os.write(response.getBytes());
+                    os.close();
+                    error = Thread.currentThread().isDaemon();
+                }
             }
         }
 
-
-        HttpServer server;
+        InetAddress loopback = InetAddress.getLoopbackAddress();
+        HttpServer server = HttpServer.create(new InetSocketAddress(loopback, 0), 10);
         try {
-            InetAddress loopback = InetAddress.getLoopbackAddress();
-            server = HttpServer.create(new InetSocketAddress(loopback, 0), 10);
-
             server.createContext("/apps", new MyHandler());
             server.setExecutor(null);
             // creates a default executor
-                server.start();
+            server.start();
             int port = server.getAddress().getPort();
-            String s = "http://localhost:"+port+"/apps/foo";
             URL url = URIBuilder.newBuilder()
-                      .scheme("http")
-                      .loopback()
-                      .port(port)
-                      .path("/apps/foo")
-                      .toURL();
+                    .scheme("http")
+                    .loopback()
+                    .port(port)
+                    .path("/apps/foo")
+                    .toURL();
             InputStream is = url.openConnection(Proxy.NO_PROXY).getInputStream();
-            read (is);
-            server.stop(0);
+            read(is);
             if (error) {
-                throw new RuntimeException ("error in test");
+                throw new RuntimeException("error in test");
             }
-
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new AssertionError("Unexpected exception: " + e, e);
+        } finally {
+            server.stop(0);
         }
     }
 }


### PR DESCRIPTION
Currently this test occasionally doesn't cleanup between runs, sometimes not stopping the server or leaving Streams open

Changes:
- Use try-with-resources to ensure streams close.
- Use try-finally to make sure the server stops before the test exits.

I ran tiers 1-3 and ran this specific test on repeat and everything seems stable after the changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326568](https://bugs.openjdk.org/browse/JDK-8326568): jdk/test/com/sun/net/httpserver/bugs/B6431193.java should use try-with-resource and try-finally (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18514/head:pull/18514` \
`$ git checkout pull/18514`

Update a local copy of the PR: \
`$ git checkout pull/18514` \
`$ git pull https://git.openjdk.org/jdk.git pull/18514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18514`

View PR using the GUI difftool: \
`$ git pr show -t 18514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18514.diff">https://git.openjdk.org/jdk/pull/18514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18514#issuecomment-2023001580)