### PR TITLE
JDK-8328786: [AIX] move some important warnings/errors from trcVerbose to UL

### DIFF
--- a/src/hotspot/os/aix/libperfstat_aix.cpp
+++ b/src/hotspot/os/aix/libperfstat_aix.cpp
@@ -26,6 +26,7 @@
 
 #include "libperfstat_aix.hpp"
 #include "misc_aix.hpp"
+#include "logging/log.hpp"
 #include "runtime/os.hpp"
 
 #include <dlfcn.h>
@@ -76,7 +77,7 @@ bool libperfstat::init() {
   char ebuf[512];
   g_libhandle = os::dll_load(libperfstat, ebuf, sizeof(ebuf));
   if (!g_libhandle) {
-    trcVerbose("Cannot load %s (error: %s)", libperfstat, ebuf);
+    log_warning(os)("Cannot load %s (error: %s)", libperfstat, ebuf);
     return false;
   }
 
@@ -213,7 +214,7 @@ bool libperfstat::get_cpuinfo(cpuinfo_t* pci) {
 
   if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(PERFSTAT_CPU_TOTAL_T_LATEST), 1)) {
     if (-1 == libperfstat::perfstat_cpu_total(nullptr, &psct, sizeof(perfstat_cpu_total_t_71), 1)) {
-      trcVerbose("perfstat_cpu_total() failed (errno=%d)", errno);
+      log_warning(os)("perfstat_cpu_total() failed (errno=%d)", errno);
       return false;
     }
   }
@@ -248,7 +249,7 @@ bool libperfstat::get_partitioninfo(partitioninfo_t* ppi) {
   if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(PERFSTAT_PARTITON_TOTAL_T_LATEST), 1)) {
     if (-1 == libperfstat::perfstat_partition_total(nullptr, &pspt, sizeof(perfstat_partition_total_t_71), 1)) {
       ame_details = false;
-      trcVerbose("perfstat_partition_total() failed (errno=%d)", errno);
+      log_warning(os)("perfstat_partition_total() failed (errno=%d)", errno);
       return false;
     }
   }
@@ -314,7 +315,7 @@ bool libperfstat::get_wparinfo(wparinfo_t* pwi) {
   memset (&pswt, '\0', sizeof(pswt));
 
   if (-1 == libperfstat::perfstat_wpar_total(nullptr, &pswt, sizeof(PERFSTAT_WPAR_TOTAL_T_LATEST), 1)) {
-    trcVerbose("perfstat_wpar_total() failed (errno=%d)", errno);
+    log_warning(os)("perfstat_wpar_total() failed (errno=%d)", errno);
     return false;
   }
 

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -35,6 +35,7 @@
 #include "loadlib_aix.hpp"
 #include "misc_aix.hpp"
 #include "porting_aix.hpp"
+#include "logging/log.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/ostream.hpp"
 
@@ -194,7 +195,7 @@ static bool reload_table() {
       if (errno == ENOMEM) {
         buflen *= 2;
       } else {
-        trcVerbose("loadquery failed (%d)", errno);
+        log_warning(os)("loadquery failed (%d)", errno);
         goto cleanup;
       }
     } else {
@@ -211,7 +212,7 @@ static bool reload_table() {
 
     loaded_module_t* lm = (loaded_module_t*) ::malloc(sizeof(loaded_module_t));
     if (!lm) {
-      trcVerbose("OOM.");
+      log_warning(os)("OOM.");
       goto cleanup;
     }
 
@@ -224,7 +225,7 @@ static bool reload_table() {
 
     lm->path = g_stringlist.add(ldi->ldinfo_filename);
     if (!lm->path) {
-      trcVerbose("OOM.");
+      log_warning(os)("OOM.");
       free(lm);
       goto cleanup;
     }
@@ -246,7 +247,7 @@ static bool reload_table() {
     if (*p_mbr_name) {
       lm->member = g_stringlist.add(p_mbr_name);
       if (!lm->member) {
-        trcVerbose("OOM.");
+        log_warning(os)("OOM.");
         free(lm);
         goto cleanup;
       }

--- a/src/hotspot/os/aix/loadlib_aix.cpp
+++ b/src/hotspot/os/aix/loadlib_aix.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2019 SAP SE. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * Copyright (c) 2022, IBM Corp.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
trcVerbose is a macro that can be used in the AIX OpenJDK codebase.
It boils down to `if (Verbose) { <print message> } ;`
However this means that it can only be used in non product JVM because Verbose is a develop flag.
So more important warning/error/info messages should better be moved e.g. to UL so that they are usable in product JVMs too,

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328786](https://bugs.openjdk.org/browse/JDK-8328786): [AIX] move some important warnings/errors from trcVerbose to UL (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18517/head:pull/18517` \
`$ git checkout pull/18517`

Update a local copy of the PR: \
`$ git checkout pull/18517` \
`$ git pull https://git.openjdk.org/jdk.git pull/18517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18517`

View PR using the GUI difftool: \
`$ git pr show -t 18517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18517.diff">https://git.openjdk.org/jdk/pull/18517.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18517#issuecomment-2023096683)