### PR TITLE
8329109: Threads::print_on() tries to print CPU time for terminated GC threads

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1336,10 +1336,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   }
 
   PrintOnClosure cl(st);
-  cl.do_thread(VMThread::vm_thread());
-  Universe::heap()->gc_threads_do(&cl);
-  cl.do_thread(WatcherThread::watcher_thread());
-  cl.do_thread(AsyncLogWriter::instance());
+  non_java_threads_do(&cl);
 
   st->flush();
 }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1280,52 +1280,15 @@ JavaThread* Threads::owning_thread_from_monitor(ThreadsList* t_list, ObjectMonit
 class PrintOnClosure : public ThreadClosure {
 private:
   outputStream* _st;
-  bool _print_stacks;
-  bool _internal_format;
-#if INCLUDE_SERVICES
-  ConcurrentLocksDump* _concurrent_locks;
-#endif // INCLUDE_SERVICES
-  bool _print_extended_info;
 
 public:
-  PrintOnClosure(outputStream* st, bool print_stacks,
-                 bool internal_format,
-                 bool print_extended_info) :
-    _st(st),
-    _print_stacks(print_stacks),
-    _internal_format(internal_format),
-#if INCLUDE_SERVICES
-    _concurrent_locks(nullptr),
-#endif // INCLUDE_SERVICES
-    _print_extended_info(print_extended_info) {}
-
-#if INCLUDE_SERVICES
-  void set_concurrent_locks(ConcurrentLocksDump* cl) { _concurrent_locks = cl; }
-#endif // INCLUDE_SERVICES
+  PrintOnClosure(outputStream* st) :
+      _st(st) {}
 
   virtual void do_thread(Thread* thread) {
     if (thread != nullptr) {
-      if (thread->is_Java_thread()) {
-        JavaThread* p = JavaThread::cast(thread);
-        ResourceMark rm;
-        p->print_on(_st, _print_extended_info);
-        if (_print_stacks) {
-          if (_internal_format) {
-            p->trace_stack();
-          } else {
-            p->print_stack_on(_st);
-          }
-        }
-        _st->cr();
-#if INCLUDE_SERVICES
-        if (_concurrent_locks != nullptr) {
-          _concurrent_locks->print_locks_on(p, _st);
-        }
-#endif // INCLUDE_SERVICES
-      } else {
-        thread->print_on(_st);
-        _st->cr();
-      }
+      thread->print_on(_st);
+      _st->cr();
     }
   }
 };
@@ -1343,13 +1306,10 @@ void Threads::print_on(outputStream* st, bool print_stacks,
                VM_Version::vm_info_string());
   st->cr();
 
-  PrintOnClosure cl(st, print_stacks, internal_format, print_extended_info);
-
-  #if INCLUDE_SERVICES
+#if INCLUDE_SERVICES
   // Dump concurrent locks
   ConcurrentLocksDump concurrent_locks;
   if (print_concurrent_locks) {
-    cl.set_concurrent_locks(&concurrent_locks);
     concurrent_locks.dump_at_safepoint();
   }
 #endif // INCLUDE_SERVICES
@@ -1357,18 +1317,29 @@ void Threads::print_on(outputStream* st, bool print_stacks,
   ThreadsSMRSupport::print_info_on(st);
   st->cr();
 
-  if (SafepointSynchronize::is_at_safepoint()) {
-    // Threads::threads_do() is synchronized with thread termination
-    Threads::threads_do(&cl);
-  } else {
-    ALL_JAVA_THREADS(p) {
-      cl.do_thread(p);
+  ALL_JAVA_THREADS(p) {
+    ResourceMark rm;
+    p->print_on(st, print_extended_info);
+    if (print_stacks) {
+      if (internal_format) {
+        p->trace_stack();
+      } else {
+        p->print_stack_on(st);
+      }
     }
-    cl.do_thread(VMThread::vm_thread());
-    Universe::heap()->gc_threads_do(&cl);
-    cl.do_thread(WatcherThread::watcher_thread());
-    cl.do_thread(AsyncLogWriter::instance());
+    st->cr();
+#if INCLUDE_SERVICES
+    if (print_concurrent_locks) {
+      concurrent_locks.print_locks_on(p, st);
+    }
+#endif // INCLUDE_SERVICES
   }
+
+  PrintOnClosure cl(st);
+  cl.do_thread(VMThread::vm_thread());
+  Universe::heap()->gc_threads_do(&cl);
+  cl.do_thread(WatcherThread::watcher_thread());
+  cl.do_thread(AsyncLogWriter::instance());
 
   st->flush();
 }


### PR DESCRIPTION
*EDIT 2024-04-02:* Use `Threads::non_java_threads_do(ThreadClosure* tc)` to print non-java threads (commit b2dabc95d760496d4896b30ef1a44cc5c250189d). It uses thread list iterators that synchronize with thread creation and termination. If a non-java thread is about to terminate, it waits for in progress iterations (see [NonJavaThread::remove_from_the_list](https://github.com/openjdk/jdk/blob/47f33a59eaaffc74881fcc9e29d13ff9b2538c2a/src/hotspot/share/runtime/nonJavaThread.cpp#L97-L102)).

Testing:

The output of a minimal example with G1 is almost identical (attached below). The order of non-java threads can differ.

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. JCK, SPECjvm2008, SPECjbb2015, Renaissance Suite, and SAP specific tests.
Testing was done with fastdebug builds on the main platforms and also on Linux/PPC64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329109](https://bugs.openjdk.org/browse/JDK-8329109): Threads::print_on() tries to print CPU time for terminated GC threads (**Bug** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18518/head:pull/18518` \
`$ git checkout pull/18518`

Update a local copy of the PR: \
`$ git checkout pull/18518` \
`$ git pull https://git.openjdk.org/jdk.git pull/18518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18518`

View PR using the GUI difftool: \
`$ git pr show -t 18518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18518.diff">https://git.openjdk.org/jdk/pull/18518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18518#issuecomment-2024590236)