### PR TITLE
8321550: Update several runtime/cds tests to use vm flags or mark as flagless

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -50,9 +50,9 @@ public class TestCDSVMCrash {
         }
         // else this is the main test
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
-                                                                             "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
-                                                                             "-Xshare:on", TestCDSVMCrash.class.getName(),
-                                                                             "throwOOME");
+                                                                      "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
+                                                                      "-Xshare:on", TestCDSVMCrash.class.getName(),
+                                                                      "throwOOME");
         // executeAndLog should throw an exception in the VM crashed
         try {
             CDSTestUtils.executeAndLog(pb, "cds_vm_crash");

--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -49,7 +49,7 @@ public class TestCDSVMCrash {
             }
         }
         // else this is the main test
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
                                                                              "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
                                                                              "-Xshare:on", TestCDSVMCrash.class.getName(),
                                                                              "throwOOME");

--- a/test/hotspot/jtreg/runtime/cds/appcds/FillerObjectLoadTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/FillerObjectLoadTest.java
@@ -27,6 +27,7 @@
  * @summary VM crash caused by unloaded FillerObject_klass
  * @library /test/lib
  * @requires vm.cds
+ * @requires vm.flagless
  * @run driver FillerObjectLoadTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestDumpClassListSource.java
@@ -29,6 +29,7 @@
  * @bug 8279009 8275084
  * @requires vm.cds
  * @requires vm.cds.custom.loaders
+ * @requires vm.flagless
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @compile test-classes/Hello.java ClassSpecializerTestApp.java ClassListWithCustomClassNoSource.java
  * @run main/othervm TestDumpClassListSource

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
@@ -42,7 +42,7 @@ public class ResolvedReferencesNotNullTest {
         String appJar = TestCommon.getTestJar(SharedStringsUtils.TEST_JAR_NAME_FULL);
         String whiteboxParam = SharedStringsUtils.getWbParam();
 
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-cp",
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp",
                                                                              appJar,
                                                                              whiteboxParam,
                                                                              "-XX:+UnlockDiagnosticVMOptions",

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/ResolvedReferencesNotNullTest.java
@@ -43,13 +43,13 @@ public class ResolvedReferencesNotNullTest {
         String whiteboxParam = SharedStringsUtils.getWbParam();
 
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-cp",
-                                                                             appJar,
-                                                                             whiteboxParam,
-                                                                             "-XX:+UnlockDiagnosticVMOptions",
-                                                                             "-XX:+WhiteBoxAPI",
-                                                                             "ResolvedReferencesWb",
-                                                                             "false" // ResolvedReferencesTestApp is not archived
-                                                                             );
+                                                                      appJar,
+                                                                      whiteboxParam,
+                                                                      "-XX:+UnlockDiagnosticVMOptions",
+                                                                      "-XX:+WhiteBoxAPI",
+                                                                      "ResolvedReferencesWb",
+                                                                      "false" // ResolvedReferencesTestApp is not archived
+                                                                      );
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.shouldHaveExitValue(0);
 


### PR DESCRIPTION
Simple update to a few CDS tests:

- add `@requires vm.flagless` if the test is using `ProcessTools.createLimitedTestJavaProcessBuilder()`;
- some tests are using `ProcessTools.createLimitedTestJavaProcessBuilder()` by mistake; change it back to `ProcessTools.createTestJavaProcessBuilder()`.

Passed tiers 1 - 3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321550](https://bugs.openjdk.org/browse/JDK-8321550): Update several runtime/cds tests to use vm flags or mark as flagless (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - Committer)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18520/head:pull/18520` \
`$ git checkout pull/18520`

Update a local copy of the PR: \
`$ git checkout pull/18520` \
`$ git pull https://git.openjdk.org/jdk.git pull/18520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18520`

View PR using the GUI difftool: \
`$ git pr show -t 18520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18520.diff">https://git.openjdk.org/jdk/pull/18520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18520#issuecomment-2023368414)