### PR TITLE
8329204: Diagnostic command for zeroing unused parts of the heap

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3077,3 +3077,20 @@ void G1CollectedHeap::finish_codecache_marking_cycle() {
   CodeCache::on_gc_marking_cycle_finish();
   CodeCache::arm_all_nmethods();
 }
+
+class G1ZeroUnusedClosure: public HeapRegionClosure {
+  size_t _used;
+public:
+  G1ZeroUnusedClosure() : _used(0) {}
+  bool do_heap_region(HeapRegion* r) {
+    _used += r->zero_unused();
+    return false;
+  }
+  size_t result() { return _used; }
+};
+
+size_t G1CollectedHeap::zero_unused() {
+  G1ZeroUnusedClosure blk;
+  heap_region_iterate(&blk);
+  return blk.result();
+}

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -932,6 +932,8 @@ public:
 
   void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap) override;
 
+  size_t zero_unused() override;
+
   static void start_codecache_marking_cycle_if_inactive(bool concurrent_mark_start);
   static void finish_codecache_marking_cycle();
 

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -706,6 +706,10 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
+size_t HeapRegion::zero_unused() {
+  return SpaceMangler::zero_unused(MemRegion(top(), end()));
+}
+
 void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
   _bot_part.update_for_block(start, end);
 }

--- a/src/hotspot/share/gc/g1/g1HeapRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.hpp
@@ -160,6 +160,8 @@ public:
   // dead.
   void fill_range_with_dead_objects(HeapWord* start, HeapWord* end);
 
+  size_t zero_unused();
+
   // All allocations are done without updating the BOT. The BOT
   // needs to be kept in sync for old generation regions and
   // this is done by explicit updates when crossing thresholds.

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -142,6 +142,14 @@ size_t MutableNUMASpace::free_in_words() const {
   return s;
 }
 
+size_t MutableNUMASpace::zero_unused() {
+  size_t res = 0;
+  for (int i = 0; i < lgrp_spaces()->length(); i++) {
+    res += lgrp_spaces()->at(i)->space()->zero_unused();
+  }
+  return res;
+}
+
 int MutableNUMASpace::lgrp_space_index(int lgrp_id) const {
   return lgrp_spaces()->find_if([&](LGRPSpace* space) {
     return space->lgrp_id() == checked_cast<uint>(lgrp_id);

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -184,7 +184,7 @@ public:
   virtual size_t used_in_words() const;
   virtual size_t free_in_words() const;
 
-  size_t zero_unused() override;
+  virtual size_t zero_unused();
 
   virtual size_t tlab_capacity(Thread* thr) const;
   virtual size_t tlab_used(Thread* thr) const;

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -184,6 +184,8 @@ public:
   virtual size_t used_in_words() const;
   virtual size_t free_in_words() const;
 
+  size_t zero_unused() override;
+
   virtual size_t tlab_capacity(Thread* thr) const;
   virtual size_t tlab_used(Thread* thr) const;
   virtual size_t unsafe_max_tlab_alloc(Thread* thr) const;

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -184,6 +184,10 @@ void MutableSpace::set_top_for_allocations() {
 }
 #endif
 
+size_t MutableSpace::zero_unused() {
+  return mangler()->zero_unused();
+}
+
 HeapWord* MutableSpace::cas_allocate(size_t size) {
   do {
     // Read top before end, else the range check may pass when it shouldn't.

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -119,6 +119,8 @@ class MutableSpace: public CHeapObj<mtGC> {
 
   virtual void ensure_parsability() { }
 
+  virtual size_t zero_unused();
+
   virtual void mangle_region(MemRegion mr) PRODUCT_RETURN;
 
   // Boolean queries.

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -858,6 +858,14 @@ void ParallelScavengeHeap::gen_mangle_unused_area() {
 }
 #endif
 
+size_t ParallelScavengeHeap::zero_unused() {
+  size_t res = young_gen()->eden_space()->zero_unused();
+  res += young_gen()->to_space()->zero_unused();
+  res += young_gen()->from_space()->zero_unused();
+  res += old_gen()->object_space()->zero_unused();
+  return res;
+}
+
 void ParallelScavengeHeap::register_nmethod(nmethod* nm) {
   ScavengableNMethods::register_nmethod(nm);
 }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.hpp
@@ -254,6 +254,8 @@ class ParallelScavengeHeap : public CollectedHeap {
   // Mangle the unused parts of all spaces in the heap
   void gen_mangle_unused_area() PRODUCT_RETURN;
 
+  size_t zero_unused() override;
+
   GCMemoryManager* old_gc_manager() const { return _old_manager; }
   GCMemoryManager* young_gc_manager() const { return _young_manager; }
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -1009,6 +1009,13 @@ void DefNewGeneration::record_spaces_top() {
   from()->set_top_for_allocations();
 }
 
+size_t DefNewGeneration::zero_unused() {
+  size_t res = eden()->zero_unused();
+  res += to()->zero_unused();
+  res += from()->zero_unused();
+  return res;
+}
+
 void DefNewGeneration::update_counters() {
   if (UsePerfData) {
     _eden_counters->update_all();

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -236,6 +236,8 @@ class DefNewGeneration: public Generation {
   // Save the tops for eden, from, and to
   void record_spaces_top();
 
+  virtual size_t zero_unused();
+
   // Accessing marks
   void save_marks();
 

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -163,6 +163,8 @@ class Generation: public CHeapObj<mtGC> {
   // still unsuccessful, return "null".
   virtual HeapWord* expand_and_allocate(size_t word_size, bool is_tlab) = 0;
 
+  virtual size_t zero_unused() = 0;
+
   // Printing
   virtual const char* name() const = 0;
   virtual const char* short_name() const = 0;

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -1049,3 +1049,21 @@ void SerialHeap::record_gen_tops_before_GC() {
   }
 }
 #endif  // not PRODUCT
+
+class GenGCZeroUnusedClosure: public SerialHeap::GenClosure {
+  size_t res;
+ public:
+   GenGCZeroUnusedClosure() : res(0) {}
+  void do_generation(Generation* gen) {
+    res += gen->zero_unused();
+  }
+  size_t getResult() {
+    return res;
+  }
+};
+size_t SerialHeap::zero_unused() {
+  GenGCZeroUnusedClosure blk;
+  blk.do_generation(_young_gen);
+  blk.do_generation(_old_gen);
+  return blk.getResult();
+}

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -324,6 +324,8 @@ private:
   // Save the tops of the spaces in all generations
   void record_gen_tops_before_GC() PRODUCT_RETURN;
 
+  virtual size_t zero_unused() override;
+
   // Return true if we need to perform full collection.
   bool should_do_full_collection(size_t size, bool full,
                                  bool is_tlab, GenerationType max_gen) const;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -512,6 +512,10 @@ void TenuredGeneration::record_spaces_top() {
   _the_space->set_top_for_allocations();
 }
 
+size_t TenuredGeneration::zero_unused() {
+  return _the_space->zero_unused();
+}
+
 void TenuredGeneration::verify() {
   _the_space->verify();
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -160,6 +160,8 @@ public:
 
   void record_spaces_top();
 
+  virtual size_t zero_unused();
+
   // Statistics
 
   void update_gc_stats(Generation* current_generation, bool full);

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -308,6 +308,11 @@ protected:
   }
 
   virtual void fill_with_dummy_object(HeapWord* start, HeapWord* end, bool zap);
+
+  virtual size_t zero_unused() {
+    return size_t(-1);
+  }
+
   static constexpr size_t min_dummy_object_size() {
     return oopDesc::header_size();
   }

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -107,6 +107,10 @@ void ContiguousSpace::print_on(outputStream* st) const {
                p2i(bottom()), p2i(top()), p2i(end()));
 }
 
+size_t ContiguousSpace::zero_unused() {
+  return mangler()->zero_unused();
+}
+
 void ContiguousSpace::verify() const {
   HeapWord* p = bottom();
   HeapWord* t = top();

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -166,6 +166,7 @@ public:
 
   // Used to save the space's current top for later use during mangling.
   void set_top_for_allocations() PRODUCT_RETURN;
+  size_t zero_unused();
 
   // For detecting GC bugs.  Should only be called at GC boundaries, since
   // some unused space may be used as scratch space during GC's.

--- a/src/hotspot/share/gc/shared/spaceDecorator.cpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.cpp
@@ -137,3 +137,9 @@ void  SpaceMangler::check_mangled_unused_area_complete() {
 }
 #undef DEBUG_MANGLING
 #endif // not PRODUCT
+
+size_t SpaceMangler::zero_unused() {
+  size_t len = pointer_delta(end(), top(), 1);
+  Copy::zero_to_bytes(top(), len);
+  return len;
+}

--- a/src/hotspot/share/gc/shared/spaceDecorator.cpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.cpp
@@ -143,3 +143,9 @@ size_t SpaceMangler::zero_unused() {
   Copy::zero_to_bytes(top(), len);
   return len;
 }
+
+size_t SpaceMangler::zero_unused(MemRegion mr) {
+  size_t len = mr.byte_size();
+  Copy::zero_to_bytes(mr.start(), len);
+  return len;
+}

--- a/src/hotspot/share/gc/shared/spaceDecorator.hpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.hpp
@@ -106,6 +106,7 @@ class SpaceMangler: public CHeapObj<mtGC> {
   void mangle_unused_area();
   // Mangle all the unused region [top, end)
   void mangle_unused_area_complete();
+  size_t zero_unused();
   // Do some sparse checking on the area that should have been mangled.
   void check_mangled_unused_area(HeapWord* limit) PRODUCT_RETURN;
   // Do a complete check of the area that should be mangled.

--- a/src/hotspot/share/gc/shared/spaceDecorator.hpp
+++ b/src/hotspot/share/gc/shared/spaceDecorator.hpp
@@ -107,6 +107,7 @@ class SpaceMangler: public CHeapObj<mtGC> {
   // Mangle all the unused region [top, end)
   void mangle_unused_area_complete();
   size_t zero_unused();
+  static size_t zero_unused(MemRegion mr);
   // Do some sparse checking on the area that should have been mangled.
   void check_mangled_unused_area(HeapWord* limit) PRODUCT_RETURN;
   // Do a complete check of the area that should be mangled.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1170,6 +1170,22 @@ void ShenandoahHeap::trash_humongous_region_at(ShenandoahHeapRegion* start) {
   }
 }
 
+class ShenandoahZeroUnusedClosure: public ShenandoahHeapRegionClosure {
+  size_t _used;
+public:
+  ShenandoahZeroUnusedClosure() : _used(0) {}
+  void heap_region_do(ShenandoahHeapRegion* r) {
+    _used += r->zero_unused();
+  }
+  size_t result() { return _used; }
+};
+
+size_t ShenandoahHeap::zero_unused() {
+  ShenandoahZeroUnusedClosure blk;
+  heap_region_iterate(&blk);
+  return blk.result();
+}
+
 class ShenandoahCheckCleanGCLABClosure : public ThreadClosure {
 public:
   ShenandoahCheckCleanGCLABClosure() {}

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -673,6 +673,8 @@ public:
 
   void trash_humongous_region_at(ShenandoahHeapRegion *r);
 
+  size_t zero_unused() override;
+
 private:
   void trash_cset_regions();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -668,3 +668,11 @@ void ShenandoahHeapRegion::record_unpin() {
 size_t ShenandoahHeapRegion::pin_count() const {
   return Atomic::load(&_critical_pins);
 }
+
+size_t ShenandoahHeapRegion::zero_unused() {
+  if (is_committed()) {
+    return SpaceMangler::zero_unused(MemRegion(top(), end()));
+  } else {
+    return 0;
+  }
+}

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.hpp
@@ -387,6 +387,8 @@ public:
   inline void set_update_watermark(HeapWord* w);
   inline void set_update_watermark_at_safepoint(HeapWord* w);
 
+  size_t zero_unused();
+
 private:
   void do_commit();
   void do_uncommit();

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -110,6 +110,7 @@
   template(PrintCompileQueue)                     \
   template(PrintClassHierarchy)                   \
   template(PrintClasses)                          \
+  template(ZeroUnusedMemory)                      \
   template(ICBufferFull)                          \
   template(PrintMetadata)                         \
   template(GTestExecuteAtSafepoint)               \

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1281,7 +1281,7 @@ void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
 
 #endif // LINUX
 
-class VM_ZeroUnusedMemory : public VM_Operation {
+class VM_ZeroUnusedMemory : public VM_GC_Sync_Operation {
 private:
   outputStream* _out;
 public:

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -148,6 +148,7 @@ void DCmd::register_dcmds(){
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CompilerDirectivesRemoveDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CompilerDirectivesClearDCmd>(full_export, true, false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CompilationMemoryStatisticDCmd>(full_export, true, false));
+  DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<ZeroUnusedMemoryDCmd>(full_export, true, false));
 
   // Enhanced JMX Agent Support
   // These commands won't be exported via the DiagnosticCommandMBean until an
@@ -1279,3 +1280,13 @@ void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
 }
 
 #endif // LINUX
+
+void ZeroUnusedMemoryDCmd::execute(DCmdSource source, TRAPS) {
+  Universe::heap()->collect(GCCause::_dcmd_gc_run);
+  size_t res = Universe::heap()->zero_unused();
+  if (res == size_t(-1)) {
+    output()->print_cr("Zeroing unused memory not supported by %s", Universe::heap()->name());
+  } else {
+    output()->print_cr("Successfully zeroed " SIZE_FORMAT " bytes of unused heap", res);
+  }
+}

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -1069,7 +1069,7 @@ public:
     JavaPermission p = { "java.lang.management.ManagementPermission", "control", nullptr };
     return p;
   }
-  virtual void execute(DCmdSource source, TRAPS);
+  void execute(DCmdSource source, TRAPS) override;
 };
 
 #endif // SHARE_SERVICES_DIAGNOSTICCOMMAND_HPP

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -1053,4 +1053,23 @@ public:
 
 #endif // LINUX
 
+class ZeroUnusedMemoryDCmd : public DCmd {
+public:
+  ZeroUnusedMemoryDCmd(outputStream* output, bool heap) : DCmd(output, heap) {}
+  static const char* name() {
+    return "System.zero_unused_memory";
+  }
+  static const char* description() {
+    return "Call System.gc() and zero unused memory.";
+  }
+  static const char* impact() {
+    return "Medium: depends on the size of the unallocated part of the committed heap";
+  }
+  static const JavaPermission permission() {
+    JavaPermission p = { "java.lang.management.ManagementPermission", "control", nullptr };
+    return p;
+  }
+  virtual void execute(DCmdSource source, TRAPS);
+};
+
 #endif // SHARE_SERVICES_DIAGNOSTICCOMMAND_HPP


### PR DESCRIPTION
Diagnostic command for zeroing unused parts of the heap

I propose to add a new diagnostic command `System.zero_unused_memory` which zeros out all unused parts of the heap. The name of the command is intentionally GC/heap agnostic because in the future it might be extended to also zero unused parts of the Metaspace and/or CodeCache.

Currently `System.zero_unused_memory` triggers a full GC and afterwards zeros unused parts of the heap. Zeroing can help snapshotting technologies like [CRIU][1] or [Firecracker][2] to shrink the snapshot size of VMs/containers with running JVM processes because pages which only contain zero bytes can be easily removed from the image by making the image *sparse* (e.g. with [`fallocate -p`][3]).

Notice that uncommitting unused heap parts in the JVM doesn't help in the context of virtualization (e.g. KVM/Firecracker) because from the host perspective they are still dirty and can't be easily removed from the snapshot image because they usually contain some non-zero data. More details can be found in my FOSDEM talk ["Zeroing and the semantic gap between host and guest"][4].

Furthermore, removing pages which only contain zero bytes (i.e. "empty pages") from a snapshot image not only decreases the image size but also speeds up the restore process because empty pages don't have to be read from the image file but will be populated by the kernel zero page first until they are used for the first time. This also decreases the initial memory footprint of a restored process. 

An additional argument for memory zeroing is security. By zeroing unused heap parts, we can make sure that secrets contained in unreferenced Java objects are deleted. Something that's currently impossibly to achieve from Java because even if a Java program zeroes out arrays with sensitive data after usage, it can never guarantee that the corresponding object hasn't already been moved by the GC and an old, unreferenced copy of that data still exists somewhere in the heap.

A prototype implementation for this proposal for Serial, Parallel, G1 and Shenandoah GC is available in the linked pull request.

[1]: https://criu.org
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/snapshot-support.md
[3]: https://man7.org/linux/man-pages/man1/fallocate.1.html
[4]: https://fosdem.org/2024/schedule/event/fosdem-2024-3454-zeroing-and-the-semantic-gap-between-host-and-guest/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329204](https://bugs.openjdk.org/browse/JDK-8329204): Diagnostic command for zeroing unused parts of the heap (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18521/head:pull/18521` \
`$ git checkout pull/18521`

Update a local copy of the PR: \
`$ git checkout pull/18521` \
`$ git pull https://git.openjdk.org/jdk.git pull/18521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18521`

View PR using the GUI difftool: \
`$ git pr show -t 18521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18521.diff">https://git.openjdk.org/jdk/pull/18521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18521#issuecomment-2023380497)