### PR TITLE
8326627: Document Double/Float.valueOf(String) behavior for numeric strings with non-ASCII digits

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -815,10 +815,6 @@ public final class Double extends Number
      * Finally, after rounding a {@code Double} object representing
      * this {@code double} value is returned.
      *
-     * <p> To interpret localized string representations of a
-     * floating-point value, use subclasses of {@link
-     * java.text.NumberFormat}.
-     *
      * <p>Note that trailing format specifiers, specifiers that
      * determine the type of a floating-point literal
      * ({@code 1.0f} is a {@code float} value;
@@ -888,6 +884,16 @@ public final class Double extends Number
      *      // Perform suitable alternative action
      *  }
      * }
+     *
+     * @apiNote To interpret localized string representations of a
+     * floating-point value, or string representations that have
+     * non-ASCII digits, use {@link java.text.NumberFormat}. For
+     * example,
+     * {@snippet lang="java" :
+     *     NumberFormat.getInstance(l).parse(s).doubleValue();
+     * }
+     * where {@code l} is the desired locale, or
+     * {@link java.util.Locale#ROOT} if locale insensitive.
      *
      * @param      s   the string to be parsed.
      * @return     a {@code Double} object holding the value

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -489,10 +489,6 @@ public final class Float extends Number
      * Finally, after rounding a {@code Float} object representing
      * this {@code float} value is returned.
      *
-     * <p>To interpret localized string representations of a
-     * floating-point value, use subclasses of {@link
-     * java.text.NumberFormat}.
-     *
      * <p>Note that trailing format specifiers, specifiers that
      * determine the type of a floating-point literal
      * ({@code 1.0f} is a {@code float} value;
@@ -515,6 +511,16 @@ public final class Float extends Number
      * a {@code NumberFormatException} be thrown, the documentation
      * for {@link Double#valueOf Double.valueOf} lists a regular
      * expression which can be used to screen the input.
+     *
+     * @apiNote To interpret localized string representations of a
+     * floating-point value, or string representations that have
+     * non-ASCII digits, use {@link java.text.NumberFormat}. For
+     * example,
+     * {@snippet lang="java" :
+     *     NumberFormat.getInstance(l).parse(s).floatValue();
+     * }
+     * where {@code l} is the desired locale, or
+     * {@link java.util.Locale#ROOT} if locale insensitive.
      *
      * @param   s   the string to be parsed.
      * @return  a {@code Float} object holding the value

--- a/test/jdk/java/lang/Double/ParseDouble.java
+++ b/test/jdk/java/lang/Double/ParseDouble.java
@@ -193,6 +193,7 @@ public class ParseDouble {
         "\u0661e\u0661", // 1e1 in Arabic-Indic digits
         "\u06F1e\u06F1", // 1e1 in Extended Arabic-Indic digits
         "\u0967e\u0967", // 1e1 in Devanagari digits
+        "\uD835\uDFD9e\uD835\uDFD9", // 1e1 in Mathematical Alphanumeric Symbols
 
         // JCK test lex03592m3
         ".",

--- a/test/jdk/java/lang/Float/ParseFloat.java
+++ b/test/jdk/java/lang/Float/ParseFloat.java
@@ -201,7 +201,8 @@ public class ParseFloat {
         // Non-ASCII digits are not recognized
         "\u0661e\u0661", // 1e1 in Arabic-Indic digits
         "\u06F1e\u06F1", // 1e1 in Extended Arabic-Indic digits
-        "\u0967e\u0967" // 1e1 in Devanagari digits
+        "\u0967e\u0967", // 1e1 in Devanagari digits
+        "\uD835\uDFD9e\uD835\uDFD9" // 1e1 in Mathematical Alphanumeric Symbols
     };
 
     static String goodStrings[] = {


### PR DESCRIPTION
Clarifying the behavior for non-ASCII digits in Double/Float.valueOf(String) method descriptions. A draft CSR has also been created.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8329214](https://bugs.openjdk.org/browse/JDK-8329214) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8326627](https://bugs.openjdk.org/browse/JDK-8326627): Document Double/Float.valueOf(String) behavior for numeric strings with non-ASCII digits (**Bug** - P4)
 * [JDK-8329214](https://bugs.openjdk.org/browse/JDK-8329214): Document Double/Float.valueOf(String) behavior for numeric strings with non-ASCII digits (**CSR**)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18526/head:pull/18526` \
`$ git checkout pull/18526`

Update a local copy of the PR: \
`$ git checkout pull/18526` \
`$ git pull https://git.openjdk.org/jdk.git pull/18526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18526`

View PR using the GUI difftool: \
`$ git pr show -t 18526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18526.diff">https://git.openjdk.org/jdk/pull/18526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18526#issuecomment-2023904844)