### PR TITLE
8325883: Move Monitor Deflation reporting out of safepoint cleanup

### DIFF
--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 #include "classfile/javaClasses.hpp"
 #include "classfile/vmClasses.hpp"
 #include "classfile/vmSymbols.hpp"
+#include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/universe.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
@@ -95,5 +97,12 @@ void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAP
     }
 
     (void)ObjectSynchronizer::deflate_idle_monitors();
+
+    if (log_is_enabled(Debug, monitorinflation)) {
+      // The VMThread calls do_final_audit_and_print_stats() which calls
+      // audit_and_print_stats() at the Info level at VM exit time.
+      LogStreamHandle(Debug, monitorinflation) ls;
+      ObjectSynchronizer::audit_and_print_stats(&ls, false /* on_exit */);
+    }
   }
 }

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -588,12 +588,6 @@ void SafepointSynchronize::do_cleanup_tasks() {
     // Serial cleanup using VMThread.
     cleanup.work(0);
   }
-
-  if (log_is_enabled(Debug, monitorinflation)) {
-    // The VMThread calls do_final_audit_and_print_stats() which calls
-    // audit_and_print_stats() at the Info level at VM exit time.
-    ObjectSynchronizer::audit_and_print_stats(false /* on_exit */);
-  }
 }
 
 // Methods for determining if a JavaThread is safepoint safe.

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1950,38 +1950,20 @@ void ObjectSynchronizer::do_final_audit_and_print_stats() {
   log_info(monitorinflation)("Starting the final audit.");
 
   if (log_is_enabled(Info, monitorinflation)) {
-    // The other audit_and_print_stats() call is done at the Debug
-    // level at a safepoint in SafepointSynchronize::do_cleanup_tasks.
-    audit_and_print_stats(true /* on_exit */);
+    LogStreamHandle(Info, monitorinflation) ls;
+    audit_and_print_stats(&ls, true /* on_exit */);
   }
 }
 
-// This function can be called at a safepoint or it can be called when
-// we are trying to exit the VM. When we are trying to exit the VM, the
-// list walker functions can run in parallel with the other list
-// operations so spin-locking is used for safety.
+// This function can be called by the monitor deflation thread or it can be called when
+// we are trying to exit the VM. The list walker functions can run in parallel with
+// the other list operations so spin-locking is (order access next are?) used for safety.
+// I don't see spin locking?
 //
 // Calls to this function can be added in various places as a debugging
-// aid; pass 'true' for the 'on_exit' parameter to have in-use monitor
-// details logged at the Info level and 'false' for the 'on_exit'
-// parameter to have in-use monitor details logged at the Trace level.
+// aid.
 //
-void ObjectSynchronizer::audit_and_print_stats(bool on_exit) {
-  assert(on_exit || SafepointSynchronize::is_at_safepoint(), "invariant");
-
-  LogStreamHandle(Debug, monitorinflation) lsh_debug;
-  LogStreamHandle(Info, monitorinflation) lsh_info;
-  LogStreamHandle(Trace, monitorinflation) lsh_trace;
-  LogStream* ls = nullptr;
-  if (log_is_enabled(Trace, monitorinflation)) {
-    ls = &lsh_trace;
-  } else if (log_is_enabled(Debug, monitorinflation)) {
-    ls = &lsh_debug;
-  } else if (log_is_enabled(Info, monitorinflation)) {
-    ls = &lsh_info;
-  }
-  assert(ls != nullptr, "sanity check");
-
+void ObjectSynchronizer::audit_and_print_stats(outputStream* ls, bool on_exit) {
   int error_cnt = 0;
 
   ls->print_cr("Checking in_use_list:");
@@ -1993,12 +1975,14 @@ void ObjectSynchronizer::audit_and_print_stats(bool on_exit) {
     log_error(monitorinflation)("found in_use_list errors: error_cnt=%d", error_cnt);
   }
 
-  if ((on_exit && log_is_enabled(Info, monitorinflation)) ||
-      (!on_exit && log_is_enabled(Trace, monitorinflation))) {
-    // When exiting this log output is at the Info level. When called
-    // at a safepoint, this log output is at the Trace level since
-    // there can be a lot of it.
-    log_in_use_monitor_details(ls, !on_exit /* log_all */);
+  // When exiting, only log the interesting entries at the Info level.
+  // When called at intervals by the MonitorDeflationThread, log output at the Trace level since
+  // there can be a lot of it.
+  if (!on_exit && log_is_enabled(Trace, monitorinflation)) {
+    LogStreamHandle(Trace, monitorinflation) ls_tr;
+    log_in_use_monitor_details(&ls_tr, true /* log_all */);
+  } else if (on_exit) {
+    log_in_use_monitor_details(ls, false /* log_all */);
   }
 
   ls->flush();

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1955,7 +1955,7 @@ void ObjectSynchronizer::do_final_audit_and_print_stats() {
   }
 }
 
-// This function can be called by the monitor deflation thread or it can be called when
+// This function can be called by the MonitorDeflationThread or it can be called when
 // we are trying to exit the VM. The list walker functions can run in parallel with
 // the other list operations.
 // Calls to this function can be added in various places as a debugging
@@ -1974,8 +1974,8 @@ void ObjectSynchronizer::audit_and_print_stats(outputStream* ls, bool on_exit) {
   }
 
   // When exiting, only log the interesting entries at the Info level.
-  // When called at intervals by the MonitorDeflationThread, log output at the Trace level since
-  // there can be a lot of it.
+  // When called at intervals by the MonitorDeflationThread, log output
+  // at the Trace level since there can be a lot of it.
   if (!on_exit && log_is_enabled(Trace, monitorinflation)) {
     LogStreamHandle(Trace, monitorinflation) ls_tr;
     log_in_use_monitor_details(&ls_tr, true /* log_all */);

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1957,9 +1957,7 @@ void ObjectSynchronizer::do_final_audit_and_print_stats() {
 
 // This function can be called by the monitor deflation thread or it can be called when
 // we are trying to exit the VM. The list walker functions can run in parallel with
-// the other list operations so spin-locking is (order access next are?) used for safety.
-// I don't see spin locking?
-//
+// the other list operations.
 // Calls to this function can be added in various places as a debugging
 // aid.
 //

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -185,7 +185,7 @@ public:
   static jlong time_since_last_async_deflation_ms();
 
   // debugging
-  static void audit_and_print_stats(bool on_exit);
+  static void audit_and_print_stats(outputStream* out, bool on_exit);
   static void chk_in_use_list(outputStream* out, int* error_cnt_p);
   static void chk_in_use_entry(ObjectMonitor* n, outputStream* out,
                                int* error_cnt_p);


### PR DESCRIPTION
Moved monitor logging out of the safepoint cleanup code to intervals in the MonitorDeflationThread, and made logging come out at the specified level (Info, Debug or Trace).

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325883](https://bugs.openjdk.org/browse/JDK-8325883): Move Monitor Deflation reporting out of safepoint cleanup (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [0e3919da](https://git.openjdk.org/jdk/pull/18528/files/0e3919da209e4977f2e1c94b4e7230115f50323b)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18528/head:pull/18528` \
`$ git checkout pull/18528`

Update a local copy of the PR: \
`$ git checkout pull/18528` \
`$ git pull https://git.openjdk.org/jdk.git pull/18528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18528`

View PR using the GUI difftool: \
`$ git pr show -t 18528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18528.diff">https://git.openjdk.org/jdk/pull/18528.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18528#issuecomment-2024159845)