### PR TITLE
8329174: update CodeBuffer layout in comment after constants section moved

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -66,17 +66,17 @@
 // The structure of the CodeBuffer while code is being accumulated:
 //
 //    _total_start ->    \
-//    _insts._start ->              +----------------+
+//    _consts._start ->             +----------------+
+//                                  |                |
+//                                  |   Constants    |
+//                                  |                |
+//    _insts._start ->              |----------------|
 //                                  |                |
 //                                  |     Code       |
 //                                  |                |
 //    _stubs._start ->              |----------------|
 //                                  |                |
 //                                  |    Stubs       | (also handlers for deopt/exception)
-//                                  |                |
-//    _consts._start ->             |----------------|
-//                                  |                |
-//                                  |   Constants    |
 //                                  |                |
 //                                  +----------------+
 //    + _total_size ->              |                |


### PR DESCRIPTION
Enhancement [JDK-6961697](https://bugs.openjdk.org/browse/JDK-6961697) moved nmethod constants section before instruction section, but the layout scheme in codeBuffer.cpp was not changed correspondingly. The mismatch between layout scheme in source code and actual layout is misleading, so we'd better fix it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329174](https://bugs.openjdk.org/browse/JDK-8329174): update CodeBuffer layout in comment after constants section moved (**Bug** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18529/head:pull/18529` \
`$ git checkout pull/18529`

Update a local copy of the PR: \
`$ git checkout pull/18529` \
`$ git pull https://git.openjdk.org/jdk.git pull/18529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18529`

View PR using the GUI difftool: \
`$ git pr show -t 18529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18529.diff">https://git.openjdk.org/jdk/pull/18529.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18529#issuecomment-2024307947)