### PR TITLE
8329254: optimize integral reverse operations on x86 GFNI target.

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -2951,6 +2951,8 @@ uint64_t VM_Version::CpuidInfo::feature_flags() const {
       if (sef_cpuid7_ecx1_eax.bits.avx_ifma != 0)
         result |= CPU_AVX_IFMA;
     }
+    if (sef_cpuid7_ecx.bits.gfni != 0)
+        result |= CPU_GFNI;
     if (sef_cpuid7_ebx.bits.avx512f != 0 &&
         xem_xcr0_eax.bits.opmask != 0 &&
         xem_xcr0_eax.bits.zmm512 != 0 &&
@@ -2976,8 +2978,6 @@ uint64_t VM_Version::CpuidInfo::feature_flags() const {
         result |= CPU_AVX512_VPCLMULQDQ;
       if (sef_cpuid7_ecx.bits.vaes != 0)
         result |= CPU_AVX512_VAES;
-      if (sef_cpuid7_ecx.bits.gfni != 0)
-        result |= CPU_GFNI;
       if (sef_cpuid7_ecx.bits.avx512_vnni != 0)
         result |= CPU_AVX512_VNNI;
       if (sef_cpuid7_ecx.bits.avx512_bitalg != 0)

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -5662,7 +5662,7 @@ instruct bytes_reversebit_int(rRegI dst, rRegI src, rRegI rtmp, rFlagsReg cr) %{
   ins_pipe( ialu_reg );
 %}
 
-instruct bytes_reversebit_int_gfni(rRegI dst, rRegI src, regF xtmp1, regF xtmp2, rRegL rtmp, rFlagsReg cr) %{
+instruct bytes_reversebit_int_gfni(rRegI dst, rRegI src, vlRegF xtmp1, vlRegF xtmp2, rRegL rtmp, rFlagsReg cr) %{
   predicate(VM_Version::supports_gfni());
   match(Set dst (ReverseI src));
   effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP rtmp, KILL cr);
@@ -5684,7 +5684,7 @@ instruct bytes_reversebit_long(rRegL dst, rRegL src, rRegL rtmp1, rRegL rtmp2, r
   ins_pipe( ialu_reg );
 %}
 
-instruct bytes_reversebit_long_gfni(rRegL dst, rRegL src, regD xtmp1, regD xtmp2, rRegL rtmp, rFlagsReg cr) %{
+instruct bytes_reversebit_long_gfni(rRegL dst, rRegL src, vlRegD xtmp1, vlRegD xtmp2, rRegL rtmp, rFlagsReg cr) %{
   predicate(VM_Version::supports_gfni());
   match(Set dst (ReverseL src));
   effect(TEMP dst, TEMP xtmp1, TEMP xtmp2, TEMP rtmp, KILL cr);


### PR DESCRIPTION
- Efficient GFNI based instruction sequence to compute integral reverse operation was added along with JEP-426 (VectorAPI 4th Incubation). https://bugs.openjdk.org/browse/JDK-8284960

- However, the CPUID based feature detection for GFNI was incorrectly performed under AVX512 check, fixing it shows roughly 2X performance improvement for Integer/Long.reverse APIs on E-core targets (MTL+).

```
BaseLine:
Benchmark              (size)  Mode  Cnt  Score   Error  Units
Integers.reverse          500  avgt    2  0.120          us/op
Longs.reverse             500  avgt    2  0.221          us/op

Withopt:
Benchmark              (size)  Mode  Cnt  Score   Error  Units
Integers.reverse          500  avgt    2  0.050          us/op
Longs.reverse             500  avgt    2  0.086          us/op
```

Kindly review.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329254](https://bugs.openjdk.org/browse/JDK-8329254): optimize integral reverse operations on x86 GFNI target. (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18530/head:pull/18530` \
`$ git checkout pull/18530`

Update a local copy of the PR: \
`$ git checkout pull/18530` \
`$ git pull https://git.openjdk.org/jdk.git pull/18530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18530`

View PR using the GUI difftool: \
`$ git pr show -t 18530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18530.diff">https://git.openjdk.org/jdk/pull/18530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18530#issuecomment-2024988264)