### PR TITLE
8329292: Fix missing cleanups in java.management and jdk.management

### DIFF
--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -26,6 +26,8 @@
 include LibCommon.gmk
 
 ################################################################################
+## Build libmanagement
+################################################################################
 
 LIBMANAGEMENT_OPTIMIZATION := HIGH
 ifeq ($(call isTargetOs, linux)+$(COMPILE_WITH_DEBUG_SYMBOLS), true+true)

--- a/make/modules/jdk.management/Lib.gmk
+++ b/make/modules/jdk.management/Lib.gmk
@@ -26,6 +26,8 @@
 include LibCommon.gmk
 
 ################################################################################
+## Build libmanagement_ext
+################################################################################
 
 ifeq ($(call isTargetOs, windows), true)
   # In (at least) VS2013 and later, -DPSAPI_VERSION=1 is needed to generate
@@ -43,7 +45,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT_EXT, \
     NAME := management_ext, \
     OPTIMIZATION := $(LIBMANAGEMENT_EXT_OPTIMIZATION), \
     DISABLED_WARNINGS_clang_UnixOperatingSystem.c := format-nonliteral, \
-    CFLAGS := $(CFLAGS_JDKLIB) $(LIBMANAGEMENT_EXT_CFLAGS), \
+    CFLAGS := $(LIBMANAGEMENT_EXT_CFLAGS), \
     JDK_LIBS := $(JDKLIB_LIBS), \
     JDK_LIBS_windows := $(WIN_JAVA_LIB) jvm.lib, \
     LIBS_aix := -lperfstat,\


### PR DESCRIPTION
For some reason, I missed adding the new standard header for SetupJdkLibrary in java.management and jdk.management. I also missed to remove a now superfluous CFLAGS_JDKLIB in libmanagement_ext. 