### PR TITLE
8325217: MethodSymbol.getModifiers() returns SEALED for restricted methods

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1994,7 +1994,8 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         @Override @DefinedBy(Api.LANGUAGE_MODEL)
         public Set<Modifier> getModifiers() {
-            long flags = flags();
+            // just in case the method is restricted but that is not a modifier
+            long flags = flags() & ~RESTRICTED;
             return Flags.asModifierSet((flags & DEFAULT) != 0 ? flags & ~ABSTRACT : flags);
         }
 

--- a/test/langtools/jdk/javadoc/doclet/testRestricted/TestRestricted.java
+++ b/test/langtools/jdk/javadoc/doclet/testRestricted/TestRestricted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8316972
+ * @bug 8316972 8325217
  * @summary Add javadoc support for restricted methods
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -107,9 +107,8 @@ public class TestRestricted extends JavadocTester {
                         """
                 <h3>restrictedMethod</h3>
                 <div class="horizontal-scroll">
-                <div class="member-signature"><span class="modifiers">sealed</span>&nbsp;<span clas\
-                s="return-type">void</span>&nbsp;<span class="element-name">restrictedMethod</span>\
-                ()</div>
+                <div class="member-signature"><span class="return-type">void</span>&nbsp;<span \
+                class="element-name">restrictedMethod</span>()</div>
                 <div class="restricted-block" id="restricted-restrictedMethod()"><span class="restr\
                 icted-label"><code>restrictedMethod</code> is a restricted method of the Java platf\
                 orm.</span>
@@ -121,9 +120,8 @@ public class TestRestricted extends JavadocTester {
                         """
                 <h3>restrictedPreviewMethod</h3>
                 <div class="horizontal-scroll">
-                <div class="member-signature"><span class="modifiers">sealed</span>&nbsp;<span clas\
-                s="return-type">int</span>&nbsp;<span class="element-name">restrictedPreviewMethod<\
-                /span>()</div>
+                <div class="member-signature"><span class="return-type">int</span>&nbsp;<span class=\
+                "element-name">restrictedPreviewMethod</span>()</div>
                 <div class="preview-block" id="preview-restrictedPreviewMethod()"><span class="prev\
                 iew-label"><code>restrictedPreviewMethod</code> is a preview API of the Java platfo\
                 rm.</span>


### PR DESCRIPTION
Please review this simple fix, basically javadoc is showing the `sealed` modifier for methods annotated with the `jdk.internal.javac.Restricted` annotation. This is because the `SEALED` and `RESTRICTED` flags share the same bit. The proposed solution is to drop the `RESTRICTED` flag at MethodSymbol::getModifiers before converting the flags to modifiers,

TIA,
Vicente

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325217](https://bugs.openjdk.org/browse/JDK-8325217): MethodSymbol.getModifiers() returns SEALED for restricted methods (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18543/head:pull/18543` \
`$ git checkout pull/18543`

Update a local copy of the PR: \
`$ git checkout pull/18543` \
`$ git pull https://git.openjdk.org/jdk.git pull/18543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18543`

View PR using the GUI difftool: \
`$ git pr show -t 18543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18543.diff">https://git.openjdk.org/jdk/pull/18543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18543#issuecomment-2026433648)