### PR TITLE
8329320: Simplify awt/print/PageFormat/NullPaper.java test

### DIFF
--- a/test/jdk/java/awt/print/PageFormat/NullPaper.java
+++ b/test/jdk/java/awt/print/PageFormat/NullPaper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,176 +21,28 @@
  * questions.
  */
 
+import java.awt.print.PageFormat;
+
 /*
-  @test
-  @bug 4199506
-  @summary  java.awt.print.PageFormat.setpaper(Paper paper)
-                 assertion test fails by not throwing
-                 NullPointerException when a null paper instance is
-                 passed as argument and this is specified in the doc.
-  @run main NullPaper
-*/
-
-
-//*** global search and replace NullPaper with name of the test ***
-
-/**
- * NullPaper.java
- *
- * summary: java.awt.print.PageFormat.setpaper(Paper paper)
-                 assertion test fails by not throwing
-                 NullPointerException when a null paper instance is
-                 passed as argument and this is specified in the doc.
-
+ * @test
+ * @bug 4199506
+ * @summary Verify PageFormat.setPaper(null) throws NullPointerException
+ *          as specified
+ * @run main NullPaper
  */
+public final class NullPaper {
+    public static void main(String[] args) {
+        try {
+            /* Setting the paper to null should throw an exception.
+             * The bug was the exception was not being thrown.
+             */
+            new PageFormat().setPaper(null);
 
-import java.awt.print.*;
-
-// This test is a "main" test as applets would need Runtime permission
-// "queuePrintJob".
-
-public class NullPaper {
-
-   private static void init()
-    {
-    boolean settingNullWorked = false;
-
-    try {
-        /* Setting the paper to null should throw an exception.
-         * The bug was the exception was not being thrown.
-         */
-        new PageFormat().setPaper(null);
-        settingNullWorked = true;
-
-    /* If the test succeeds we'll end up here, so write
-     * to standard out.
-     */
-    } catch (NullPointerException e) {
-        pass();
-
-    /* The test failed if we end up here because an exception
-     * other than the one we were expecting was thrown.
-     */
-    } catch (Exception e) {
-        fail("Instead of the expected NullPointerException, '" + e + "' was thrown.");
+            throw new RuntimeException("NullPointerException is expected "
+                                       + "but not thrown");
+        } catch (NullPointerException e) {
+            /* Expected */
+            System.out.println("NullPointerException caught - test passes");
+        }
     }
-
-    if (settingNullWorked) {
-        fail("The expected NullPointerException was not thrown");
-    }
-
-    }//End  init()
-
-
-   /*****************************************************
-     Standard Test Machinery Section
-      DO NOT modify anything in this section -- it's a
-      standard chunk of code which has all of the
-      synchronisation necessary for the test harness.
-      By keeping it the same in all tests, it is easier
-      to read and understand someone else's test, as
-      well as insuring that all tests behave correctly
-      with the test harness.
-     There is a section following this for test-defined
-      classes
-   ******************************************************/
-   private static boolean theTestPassed = false;
-   private static boolean testGeneratedInterrupt = false;
-   private static String failureMessage = "";
-
-   private static Thread mainThread = null;
-
-   private static int sleepTime = 300000;
-
-   public static void main( String args[] ) throws InterruptedException
-    {
-      mainThread = Thread.currentThread();
-      try
-       {
-         init();
-       }
-      catch( TestPassedException e )
-       {
-         //The test passed, so just return from main and harness will
-         // interepret this return as a pass
-         return;
-       }
-      //At this point, neither test passed nor test failed has been
-      // called -- either would have thrown an exception and ended the
-      // test, so we know we have multiple threads.
-
-      //Test involves other threads, so sleep and wait for them to
-      // called pass() or fail()
-      try
-       {
-         Thread.sleep( sleepTime );
-         //Timed out, so fail the test
-         throw new RuntimeException( "Timed out after " + sleepTime/1000 + " seconds" );
-       }
-      catch (InterruptedException e)
-       {
-         if( ! testGeneratedInterrupt ) throw e;
-
-         //reset flag in case hit this code more than once for some reason (just safety)
-         testGeneratedInterrupt = false;
-         if ( theTestPassed == false )
-          {
-            throw new RuntimeException( failureMessage );
-          }
-       }
-
-    }//main
-
-   public static synchronized void setTimeoutTo( int seconds )
-    {
-      sleepTime = seconds * 1000;
-    }
-
-   public static synchronized void pass()
-    {
-      System.out.println( "The test passed." );
-      //first check if this is executing in main thread
-      if ( mainThread == Thread.currentThread() )
-       {
-         //Still in the main thread, so set the flag just for kicks,
-         // and throw a test passed exception which will be caught
-         // and end the test.
-         theTestPassed = true;
-         throw new TestPassedException();
-       }
-      //pass was called from a different thread, so set the flag and interrupt
-      // the main thead.
-      theTestPassed = true;
-      testGeneratedInterrupt = true;
-      mainThread.interrupt();
-    }//pass()
-
-   public static synchronized void fail()
-    {
-      //test writer didn't specify why test failed, so give generic
-      fail( "it just plain failed! :-)" );
-    }
-
-   public static synchronized void fail( String whyFailed )
-    {
-      System.out.println( "The test failed: " + whyFailed );
-      //check if this called from main thread
-      if ( mainThread == Thread.currentThread() )
-       {
-         //If main thread, fail now 'cause not sleeping
-         throw new RuntimeException( whyFailed );
-       }
-      theTestPassed = false;
-      testGeneratedInterrupt = true;
-      failureMessage = whyFailed;
-      mainThread.interrupt();
-    }//fail()
-
- }// class NullPaper
-
-//This exception is used to exit from any level of call nesting
-// when it's determined that the test has passed, and immediately
-// end the test.
-class TestPassedException extends RuntimeException
- {
- }
+}

--- a/test/jdk/java/awt/print/PageFormat/NullPaper.java
+++ b/test/jdk/java/awt/print/PageFormat/NullPaper.java
@@ -41,7 +41,6 @@ public final class NullPaper {
             throw new RuntimeException("NullPointerException is expected "
                                        + "but not thrown");
         } catch (NullPointerException e) {
-            /* Expected */
             System.out.println("NullPointerException caught - test passes");
         }
     }


### PR DESCRIPTION
Remove all the leftovers of the _"standard instructions" machinery_ from the `NullPaper.java` test.

The test code consists of two lines now: concise and clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329320](https://bugs.openjdk.org/browse/JDK-8329320): Simplify awt/print/PageFormat/NullPaper.java test (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18547/head:pull/18547` \
`$ git checkout pull/18547`

Update a local copy of the PR: \
`$ git checkout pull/18547` \
`$ git pull https://git.openjdk.org/jdk.git pull/18547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18547`

View PR using the GUI difftool: \
`$ git pr show -t 18547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18547.diff">https://git.openjdk.org/jdk/pull/18547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18547#issuecomment-2027197312)