### PR TITLE
8309751: Duplicate constant pool entries added during default method processing

### DIFF
--- a/src/hotspot/share/classfile/bytecodeAssembler.cpp
+++ b/src/hotspot/share/classfile/bytecodeAssembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,15 +33,48 @@
 #include "utilities/bytes.hpp"
 #include "utilities/checkedCast.hpp"
 
+void BytecodeConstantPool::init() {
+  for (int i = 1; i < _orig->length(); i++) {
+    bool new_entry = false;
+    BytecodeCPEntry entry;
+    switch(_orig->tag_at(i).value()) {
+    case JVM_CONSTANT_Class:
+    case JVM_CONSTANT_UnresolvedClass:
+      entry = BytecodeCPEntry::klass(_orig->klass_slot_at(i).name_index());
+      break;
+    case JVM_CONSTANT_Utf8:
+      entry = BytecodeCPEntry::utf8(_orig->symbol_at(i));
+      break;
+    case JVM_CONSTANT_NameAndType:
+      entry = BytecodeCPEntry::name_and_type(_orig->name_ref_index_at(i), _orig->signature_ref_index_at(i));
+      break;
+    case JVM_CONSTANT_Methodref:
+      entry = BytecodeCPEntry::methodref(_orig->uncached_klass_ref_index_at(i), _orig->uncached_name_and_type_ref_index_at(i));
+      break;
+    case JVM_CONSTANT_String:
+      entry = BytecodeCPEntry::string(_orig->unresolved_string_at(i));
+      break;
+    }
+    if (entry._tag != BytecodeCPEntry::tag::ERROR_TAG) {
+      bool created = false;
+      u2* probe =_indices.put_if_absent(entry, i, &created);
+      if (created) {
+        _orig_cp_added += 1;
+        _entries.append(entry);
+      }
+    }
+  }
+}
+
 u2 BytecodeConstantPool::find_or_add(BytecodeCPEntry const& bcpe, TRAPS) {
 
   // Check for overflow
-  int new_size = _orig->length() + _entries.length();
+  int new_size = _orig->length() + _entries.length() - _orig_cp_added;
   if (new_size > USHRT_MAX) {
     THROW_MSG_0(vmSymbols::java_lang_InternalError(), "default methods constant pool overflowed");
   }
 
-  u2 index = checked_cast<u2>(_entries.length());
+  u2 index = checked_cast<u2>(new_size);
   bool created = false;
   u2* probe = _indices.put_if_absent(bcpe, index, &created);
   if (created) {
@@ -49,7 +82,7 @@ u2 BytecodeConstantPool::find_or_add(BytecodeCPEntry const& bcpe, TRAPS) {
   } else {
     index = *probe;
   }
-  return checked_cast<u2>(index + _orig->length());
+  return index;
 }
 
 ConstantPool* BytecodeConstantPool::create_constant_pool(TRAPS) const {
@@ -57,7 +90,7 @@ ConstantPool* BytecodeConstantPool::create_constant_pool(TRAPS) const {
     return _orig;
   }
 
-  int new_size = _orig->length() + _entries.length();
+  int new_size = _orig->length() + _entries.length() - _orig_cp_added;
   ConstantPool* cp = ConstantPool::allocate(
       _orig->pool_holder()->class_loader_data(),
       new_size, CHECK_NULL);
@@ -69,9 +102,10 @@ ConstantPool* BytecodeConstantPool::create_constant_pool(TRAPS) const {
   // Preserve dynamic constant information from the original pool
   cp->copy_fields(_orig);
 
-  for (int i = 0; i < _entries.length(); ++i) {
+  for (int i = _orig_cp_added; i < _entries.length(); ++i) {
     BytecodeCPEntry entry = _entries.at(i);
-    int idx = i + _orig->length();
+    u2* value = _indices.get(entry);
+    int idx = *value;
     switch (entry._tag) {
       case BytecodeCPEntry::UTF8:
         entry._u.utf8->increment_refcount();
@@ -83,7 +117,7 @@ ConstantPool* BytecodeConstantPool::create_constant_pool(TRAPS) const {
         break;
       case BytecodeCPEntry::STRING:
         cp->unresolved_string_at_put(
-            idx, cp->symbol_at(entry._u.string));
+            idx, entry._u.utf8);
         break;
       case BytecodeCPEntry::NAME_AND_TYPE:
         cp->name_and_type_at_put(idx,

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -939,9 +939,10 @@ static void create_defaults_and_exceptions(GrowableArray<EmptyVtableSlot*>* slot
 
   GrowableArray<Method*> overpasses;
   GrowableArray<Method*> defaults;
-  BytecodeConstantPool bpool(klass->constants());
 
   BytecodeBuffer* buffer = nullptr; // Lazily create a reusable buffer
+  BytecodeConstantPool* bpool = nullptr;
+
   for (int i = 0; i < slots->length(); ++i) {
     EmptyVtableSlot* slot = slots->at(i);
 
@@ -974,11 +975,15 @@ static void create_defaults_and_exceptions(GrowableArray<EmptyVtableSlot*>* slot
         } else {
           buffer->clear();
         }
-        int max_stack = BytecodeAssembler::assemble_method_error(&bpool, buffer,
+        // Lazily allocate bytecode constant pool also.
+        if (bpool == nullptr) {
+          bpool = new BytecodeConstantPool(klass->constants());
+        }
+        int max_stack = BytecodeAssembler::assemble_method_error(bpool, buffer,
            method->get_exception_name(), method->get_exception_message(), CHECK);
         AccessFlags flags = accessFlags_from(
           JVM_ACC_PUBLIC | JVM_ACC_SYNTHETIC | JVM_ACC_BRIDGE);
-        Method* m = new_method(&bpool, buffer, slot->name(), slot->signature(),
+        Method* m = new_method(bpool, buffer, slot->name(), slot->signature(),
           flags, max_stack, slot->size_of_parameters(),
           ConstMethod::OVERPASS, CHECK);
         // We push to the methods list:
@@ -995,7 +1000,7 @@ static void create_defaults_and_exceptions(GrowableArray<EmptyVtableSlot*>* slot
   log_debug(defaultmethods)("Created %d default  methods", defaults.length());
 
   if (overpasses.length() > 0) {
-    switchover_constant_pool(&bpool, klass, &overpasses, CHECK);
+    switchover_constant_pool(bpool, klass, &overpasses, CHECK);
     merge_in_new_methods(klass, &overpasses, CHECK);
   }
   if (defaults.length() > 0) {


### PR DESCRIPTION
This uses Ashutosh's patch to avoid adding duplicate constant pool entries during default method processing, with one change to make it conditional if not needed. I tested this locally and started writing a test, but writing a test is more difficult because duplicate constant pool entries don't actually violate the spec.

Tested with tier1-4 and ran some startup performance benchmarks on the patch.