### PR TITLE
8326734: text-decoration applied to <span> lost when mixed with <u> or <s>

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -850,10 +850,8 @@ public class CSS implements Serializable {
             return null;
         }
         String newValue = underline && strikeThrough
-                               ? "underline,line-through"
-                               : underline
-                                         ? "underline"
-                                         : "line-through";
+                          ? "underline,line-through"
+                          : (underline ? "underline" : "line-through");
         return new StringValue().parseCssValue(newValue);
     }
 

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -843,6 +843,20 @@ public class CSS implements Serializable {
         return r != null ? r : conv.parseCssValue(key.getDefaultValue());
     }
 
+    static Object mergeTextDecoration(String value) {
+        boolean underline = value.contains("underline");
+        boolean strikeThrough = value.contains("line-through");
+        if (!underline && !strikeThrough) {
+            return null;
+        }
+        String newValue = underline && strikeThrough
+                               ? "underline,line-through"
+                               : underline
+                                         ? "underline"
+                                         : "line-through";
+        return new StringValue().parseCssValue(newValue);
+    }
+
     /**
      * Maps from a StyleConstants to a CSS Attribute.
      */

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -3453,31 +3453,24 @@ public class HTMLDocument extends DefaultStyledDocument {
                     attr.removeAttribute(IMPLIED);
                 }
 
-                Object textDecoration0 = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
-                Object textDecoration1 = charAttr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+                Object newDecoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+                Object currentDecoration = charAttr.getAttribute(CSS.Attribute.TEXT_DECORATION);
 
                 charAttr.addAttribute(t, attr.copyAttributes());
                 if (styleAttributes != null) {
                     charAttr.addAttributes(styleAttributes);
                 }
-                if (textDecoration1 == null) {
-                    // No 'text-decoration' on the stack
-                    // No fix-up necessary
-                } else if (textDecoration0 == null) {
-                    // No 'text-decoration' in the incoming styles
-                    // No fix-up necessary
-                } else {
-                    if ("none".equals(textDecoration0.toString())) {
-                        // Nothing to do
-                    } else {
-                        StyleSheet sheet = getStyleSheet();
-                        sheet.addCSSAttribute(charAttr, CSS.Attribute.TEXT_DECORATION,
-                                              CSS.mergeTextDecoration(textDecoration1 + ","
-                                                                      + textDecoration0)
-                                                 .toString());
-                    }
-                }
 
+                if (newDecoration != null
+                    && !"none".equals(newDecoration.toString())
+                    && currentDecoration != null) {
+                    StyleSheet sheet = getStyleSheet();
+                    sheet.addCSSAttribute(charAttr,
+                                          CSS.Attribute.TEXT_DECORATION,
+                                          CSS.mergeTextDecoration(newDecoration + ","
+                                                                  + currentDecoration)
+                                             .toString());
+                }
             }
 
             @Override

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -3450,7 +3450,8 @@ public class HTMLDocument extends DefaultStyledDocument {
 
                 if (newDecoration != null
                     && !"none".equals(newDecoration.toString())
-                    && previousDecoration != null) {
+                    && previousDecoration != null
+                    && !"none".equals(previousDecoration.toString())) {
                     StyleSheet sheet = getStyleSheet();
                     sheet.addCSSAttribute(charAttr,
                                           CSS.Attribute.TEXT_DECORATION,

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLDocument.java
@@ -2499,7 +2499,7 @@ public class HTMLDocument extends DefaultStyledDocument {
             tagMap.put(HTML.Tag.SCRIPT, ha);
             tagMap.put(HTML.Tag.SELECT, fa);
             tagMap.put(HTML.Tag.SMALL, ca);
-            tagMap.put(HTML.Tag.SPAN, new ConvertSpan());
+            tagMap.put(HTML.Tag.SPAN, new ConvertSpanAction());
             tagMap.put(HTML.Tag.STRIKE, conv);
             tagMap.put(HTML.Tag.S, conv);
             tagMap.put(HTML.Tag.STRONG, ca);
@@ -3440,7 +3440,7 @@ public class HTMLDocument extends DefaultStyledDocument {
             }
         }
 
-        final class ConvertSpan extends CharacterAction {
+        final class ConvertSpanAction extends CharacterAction {
             @Override
             void convertAttributes(HTML.Tag t, MutableAttributeSet attr) {
                 Object newDecoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);

--- a/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
@@ -24,9 +24,16 @@
  */
 package javax.swing.text.html;
 
-import javax.swing.text.*;
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import javax.swing.text.AttributeSet;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
 
 /**
  * An implementation of <code>AttributeSet</code> that can multiplex
@@ -196,15 +203,28 @@ class MuxingAttributeSet implements AttributeSet, Serializable {
      * @see AttributeSet#getAttribute
      */
     public Object getAttribute(Object key) {
-        AttributeSet[] as = getAttributes();
-        int n = as.length;
-        for (int i = 0; i < n; i++) {
-            Object o = as[i].getAttribute(key);
-            if (o != null) {
-                return o;
-            }
+        final AttributeSet[] as = getAttributes();
+        final int n = as.length;
+        if (key != CSS.Attribute.TEXT_DECORATION) {
+            return Arrays.stream(as)
+                         .map(a -> a.getAttribute(key))
+                         .filter(Objects::nonNull)
+                         .findFirst()
+                         .orElse(null);
+//            for (int i = 0; i < n; i++) {
+//                Object o = as[i].getAttribute(key);
+//                if (o != null) {
+//                    return o;
+//                }
+//            }
+        } else {
+            String values = Arrays.stream(as)
+                                  .map(a -> a.getAttribute(key))
+                                  .filter(Objects::nonNull)
+                                  .map(Object::toString)
+                                  .collect(Collectors.joining(","));
+            return CSS.mergeTextDecoration(values);
         }
-        return null;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/MuxingAttributeSet.java
@@ -206,25 +206,20 @@ class MuxingAttributeSet implements AttributeSet, Serializable {
         final AttributeSet[] as = getAttributes();
         final int n = as.length;
         if (key != CSS.Attribute.TEXT_DECORATION) {
-            return Arrays.stream(as)
-                         .map(a -> a.getAttribute(key))
-                         .filter(Objects::nonNull)
-                         .findFirst()
-                         .orElse(null);
-//            for (int i = 0; i < n; i++) {
-//                Object o = as[i].getAttribute(key);
-//                if (o != null) {
-//                    return o;
-//                }
-//            }
-        } else {
-            String values = Arrays.stream(as)
-                                  .map(a -> a.getAttribute(key))
-                                  .filter(Objects::nonNull)
-                                  .map(Object::toString)
-                                  .collect(Collectors.joining(","));
-            return CSS.mergeTextDecoration(values);
+            for (int i = 0; i < n; i++) {
+                Object o = as[i].getAttribute(key);
+                if (o != null) {
+                    return o;
+                }
+            }
         }
+
+        String values = Arrays.stream(as)
+                              .map(a -> a.getAttribute(key))
+                              .filter(Objects::nonNull)
+                              .map(Object::toString)
+                              .collect(Collectors.joining(","));
+        return CSS.mergeTextDecoration(values);
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -24,17 +24,53 @@
  */
 package javax.swing.text.html;
 
-import sun.swing.SwingUtilities2;
-import java.util.*;
-import java.awt.*;
-import java.io.*;
-import java.net.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.Serializable;
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.EmptyStackException;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.Vector;
+
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.UIManager;
-import javax.swing.border.*;
+import javax.swing.border.BevelBorder;
+import javax.swing.border.Border;
 import javax.swing.event.ChangeListener;
-import javax.swing.text.*;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.MutableAttributeSet;
+import javax.swing.text.SimpleAttributeSet;
+import javax.swing.text.Style;
+import javax.swing.text.StyleConstants;
+import javax.swing.text.StyleContext;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.View;
+
+import sun.swing.SwingUtilities2;
 
 /**
  * Support for defining the visual characteristics of

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -2820,7 +2820,21 @@ public class StyleSheet extends StyleContext {
         Object doGetAttribute(Object key) {
             Object retValue = super.getAttribute(key);
             if (retValue != null) {
-                return retValue;
+                if (key != CSS.Attribute.TEXT_DECORATION) {
+                    return retValue;
+                } else {
+                    AttributeSet parent = getResolveParent();
+                    if (parent != null) {
+                        Object parentValue = parent.getAttribute(key);
+                        if (parentValue != null) {
+                            return CSS.mergeTextDecoration(retValue + "," + parentValue);
+                        } else {
+                            return retValue;
+                        }
+                    } else {
+                        return retValue;
+                    }
+                }
             }
 
             if (key == CSS.Attribute.FONT_SIZE) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -2817,23 +2817,30 @@ public class StyleSheet extends StyleContext {
             return doGetAttribute(key);
         }
 
+        /**
+         * Merges the current value of the 'text-decoration' property
+         * with the value from parent.
+         */
+        private Object getTextDecoration(Object value) {
+            AttributeSet parent = getResolveParent();
+            if (parent == null) {
+                return value;
+            }
+
+            Object parentValue = parent.getAttribute(CSS.Attribute.TEXT_DECORATION);
+            return parentValue == null
+                   ? value
+                   : CSS.mergeTextDecoration(value + "," + parentValue);
+        }
+
         Object doGetAttribute(Object key) {
             Object retValue = super.getAttribute(key);
             if (retValue != null) {
                 if (key != CSS.Attribute.TEXT_DECORATION) {
                     return retValue;
                 } else {
-                    AttributeSet parent = getResolveParent();
-                    if (parent != null) {
-                        Object parentValue = parent.getAttribute(key);
-                        if (parentValue != null) {
-                            return CSS.mergeTextDecoration(retValue + "," + parentValue);
-                        } else {
-                            return retValue;
-                        }
-                    } else {
-                        return retValue;
-                    }
+                    // Merge current value with parent
+                    return getTextDecoration(retValue);
                 }
             }
 

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
@@ -1,5 +1,4 @@
 import java.awt.Dimension;
-import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -7,30 +6,15 @@ import java.io.IOException;
 
 import javax.imageio.ImageIO;
 import javax.swing.JEditorPane;
-import javax.swing.JFrame;
-import javax.swing.JScrollPane;
-import javax.swing.SwingUtilities;
-import javax.swing.text.AbstractDocument;
-import javax.swing.text.AttributeSet;
-import javax.swing.text.Document;
-import javax.swing.text.Element;
-import javax.swing.text.StyleContext;
-import javax.swing.text.StyledDocument;
 import javax.swing.text.View;
 import javax.swing.text.html.CSS;
-import javax.swing.text.html.HTMLDocument;
-import javax.swing.text.html.StyleSheet;
 
-/**
- * Test case for
- * <a href="https://bugs.openjdk.org/browse/JDK-8323801">JDK-8323801</a>:
- * {@code <s>} doesn't strikethrough the text.
- * <p>
- * If {@code <s>} is inside {@code <u>} or {@code <span>} with
- * {@code text-decoration: underline}, the text inside the {@code <s>} tag
- * is rendered without the strikethrough attribute.
- * Yet, if you replace {@code <s>} with {@code <strike>}, the text is rendered
- * with both underline and strikethrough attributes.
+/*
+ * @test
+ * @bug 8323801 8326734
+ * @summary Tests different combination of 'underline' and 'line-through';
+ *          the text should render with both 'underline' and 'line-through'.
+ * @run main HTMLTextDecoration
  */
 public final class HTMLTextDecoration {
     private static final String HTML = """
@@ -39,10 +23,9 @@ public final class HTMLTextDecoration {
             <head>
                 <meta charset="UTF-8">
                 <title>underline + line-through text</title>
-            <!--h1><code>text-decoration</code></h1-->
                 <style>
-                .underline   { text-decoration: underline }
-                .lineThrough { text-decoration: line-through }
+                    .underline   { text-decoration: underline }
+                    .lineThrough { text-decoration: line-through }
                 </style>
             </head>
             <body>
@@ -84,77 +67,64 @@ public final class HTMLTextDecoration {
             """;
 
     public static void main(String[] args) {
-        SwingUtilities.invokeLater(HTMLTextDecoration::createUI);
-    }
-
-    private static void createUI() {
-        JEditorPane html = new JEditorPane("text/html", HTML);
+        final JEditorPane html = new JEditorPane("text/html", HTML);
         html.setEditable(false);
 
-        Dimension size = html.getPreferredSize();
+        final Dimension size = html.getPreferredSize();
         html.setSize(size);
 
         BufferedImage image = new BufferedImage(size.width, size.height,
                                                 BufferedImage.TYPE_INT_RGB);
         Graphics g = image.createGraphics();
+        // Paint the editor pane to ensure all views are created
         html.paint(g);
         g.dispose();
 
-        try {
-            ImageIO.write(image, "png",
-                          new File("html.png"));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        int errorCount = 0;
+        String firstError = null;
 
-        System.out.println();
-        System.out.println("Result:");
-//        StyledDocument document = (StyledDocument) html.getDocument();
-//        StyleSheet styleSheet = ((HTMLDocument) document).getStyleSheet();
-//        Element root = document.getDefaultRootElement();
-//        Element body = root.getElement(1);
-//        for (int i = 0; i < body.getElementCount(); i++) {
-//            Element p = body.getElement(i);
-//            Element content = getContent(p);
-//            AttributeSet attr = content.getAttributes();
-//            Object decoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
-////            String strDecoration = decoration.toString();
-////            Font font = document.getFont(attr);
-//            System.out.println(i + ": " + decoration);
-//        }
-
-        System.out.println("\n\n------ Views ------");
-        View rootView = html.getUI().getRootView(html);
-        View bodyView = rootView.getView(1).getView(1);
+        System.out.println("----- Views -----");
+        final View bodyView = html.getUI()
+                                  .getRootView(html)
+                                  .getView(1)
+                                  .getView(1);
         for (int i = 0; i < bodyView.getViewCount(); i++) {
             View pView = bodyView.getView(i);
             View contentView = getContentView(pView);
-            AttributeSet attr = contentView.getAttributes();
-            Object decoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+
+            String decoration =
+                    contentView.getAttributes()
+                               .getAttribute(CSS.Attribute.TEXT_DECORATION)
+                               .toString();
+
             System.out.println(i + ": " + decoration);
+            if (!decoration.contains("underline")
+                || !decoration.contains("line-through")) {
+                errorCount++;
+                if (firstError == null) {
+                    firstError = "Line " + i + ": " + decoration;
+                }
+            }
         }
-        //((AbstractDocument) html.getDocument()).dump(System.out);
 
-        JFrame frame = new JFrame("underline + line-through text");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-
-        frame.add(new JScrollPane(html));
-
-        frame.pack();
-
-        frame.setLocationByPlatform(true);
-        frame.setVisible(true);
+        if (errorCount > 0) {
+            saveImage(image);
+            throw new RuntimeException(errorCount + " error(s) found, "
+                                       + "the first one: " + firstError);
+        }
     }
 
     private static View getContentView(View parent) {
         View view = parent.getView(0);
-        return view.getViewCount() > 0 ? getContentView(view) : view;
+        return view.getViewCount() > 0
+               ? getContentView(view)
+               : view;
     }
 
-    private static Element getContent(Element branch) {
-        Element element = branch.getElement(0);
-        return element.getElementCount() > 0
-               ? getContent(element)
-               : element;
+    private static void saveImage(BufferedImage image) {
+        try {
+            ImageIO.write(image, "png",
+                          new File("html.png"));
+        } catch (IOException ignored) { }
     }
 }

--- a/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
+++ b/test/jdk/javax/swing/text/html/HTMLDocument/HTMLTextDecoration.java
@@ -1,0 +1,160 @@
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+import javax.swing.JEditorPane;
+import javax.swing.JFrame;
+import javax.swing.JScrollPane;
+import javax.swing.SwingUtilities;
+import javax.swing.text.AbstractDocument;
+import javax.swing.text.AttributeSet;
+import javax.swing.text.Document;
+import javax.swing.text.Element;
+import javax.swing.text.StyleContext;
+import javax.swing.text.StyledDocument;
+import javax.swing.text.View;
+import javax.swing.text.html.CSS;
+import javax.swing.text.html.HTMLDocument;
+import javax.swing.text.html.StyleSheet;
+
+/**
+ * Test case for
+ * <a href="https://bugs.openjdk.org/browse/JDK-8323801">JDK-8323801</a>:
+ * {@code <s>} doesn't strikethrough the text.
+ * <p>
+ * If {@code <s>} is inside {@code <u>} or {@code <span>} with
+ * {@code text-decoration: underline}, the text inside the {@code <s>} tag
+ * is rendered without the strikethrough attribute.
+ * Yet, if you replace {@code <s>} with {@code <strike>}, the text is rendered
+ * with both underline and strikethrough attributes.
+ */
+public final class HTMLTextDecoration {
+    private static final String HTML = """
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="UTF-8">
+                <title>underline + line-through text</title>
+            <!--h1><code>text-decoration</code></h1-->
+                <style>
+                .underline   { text-decoration: underline }
+                .lineThrough { text-decoration: line-through }
+                </style>
+            </head>
+            <body>
+            <p><u><span style='text-decoration: line-through'>underline + line-through?</span></u></p>
+            <p><s><span style='text-decoration: underline'>underline + line-through?</span></s></p>
+            <p><strike><span style='text-decoration: underline'>underline + line-through?</span></strike></p>
+            
+            <p><span style='text-decoration: line-through'><span style='text-decoration: underline'>underline + line-through?</span></span></p>
+            <p><span style='text-decoration: underline'><span style='text-decoration: line-through'>underline + line-through?</span></span></p>
+            
+            <p style='text-decoration: line-through'><u>underline + line-through?</u></p>
+            <p style='text-decoration: underline'><s>underline + line-through?</s></p>
+            <p style='text-decoration: underline'><strike>underline + line-through?</strike></p>
+
+            <p style='text-decoration: line-through'><span style='text-decoration: underline'>underline + line-through?</span></p>
+            <p style='text-decoration: underline'><span style='text-decoration: line-through'>underline + line-through?</span></p>
+            
+            <p class="underline"><span class="lineThrough">underline + line-through?</span></p>
+            <p class="underline"><s>underline + line-through?</s></p>
+            <p class="underline"><strike>underline + line-through?</strike></p>
+
+            <p class="lineThrough"><span class="underline">underline + line-through?</span></p>
+            <p class="lineThrough"><u>underline + line-through?</u></p>
+
+            <div class="underline"><span class="lineThrough">underline + line-through?</span></div>
+            <div class="underline"><s>underline + line-through?</s></div>
+            <div class="underline"><strike>underline + line-through?</strike></div>
+
+            <div class="lineThrough"><span class="underline">underline + line-through?</span></div>
+            <div class="lineThrough"><u>underline + line-through?</u></div>
+
+            <div class="underline"><p class="lineThrough">underline + line-through?</p></div>
+            <div class="lineThrough"><p class="underline">underline + line-through?</p></div>
+
+            <div class="underline"><div class="lineThrough">underline + line-through?</div></div>
+            <div class="lineThrough"><div class="underline">underline + line-through?</div></div>
+            </body>
+            </html>
+            """;
+
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(HTMLTextDecoration::createUI);
+    }
+
+    private static void createUI() {
+        JEditorPane html = new JEditorPane("text/html", HTML);
+        html.setEditable(false);
+
+        Dimension size = html.getPreferredSize();
+        html.setSize(size);
+
+        BufferedImage image = new BufferedImage(size.width, size.height,
+                                                BufferedImage.TYPE_INT_RGB);
+        Graphics g = image.createGraphics();
+        html.paint(g);
+        g.dispose();
+
+        try {
+            ImageIO.write(image, "png",
+                          new File("html.png"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        System.out.println();
+        System.out.println("Result:");
+//        StyledDocument document = (StyledDocument) html.getDocument();
+//        StyleSheet styleSheet = ((HTMLDocument) document).getStyleSheet();
+//        Element root = document.getDefaultRootElement();
+//        Element body = root.getElement(1);
+//        for (int i = 0; i < body.getElementCount(); i++) {
+//            Element p = body.getElement(i);
+//            Element content = getContent(p);
+//            AttributeSet attr = content.getAttributes();
+//            Object decoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+////            String strDecoration = decoration.toString();
+////            Font font = document.getFont(attr);
+//            System.out.println(i + ": " + decoration);
+//        }
+
+        System.out.println("\n\n------ Views ------");
+        View rootView = html.getUI().getRootView(html);
+        View bodyView = rootView.getView(1).getView(1);
+        for (int i = 0; i < bodyView.getViewCount(); i++) {
+            View pView = bodyView.getView(i);
+            View contentView = getContentView(pView);
+            AttributeSet attr = contentView.getAttributes();
+            Object decoration = attr.getAttribute(CSS.Attribute.TEXT_DECORATION);
+            System.out.println(i + ": " + decoration);
+        }
+        //((AbstractDocument) html.getDocument()).dump(System.out);
+
+        JFrame frame = new JFrame("underline + line-through text");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        frame.add(new JScrollPane(html));
+
+        frame.pack();
+
+        frame.setLocationByPlatform(true);
+        frame.setVisible(true);
+    }
+
+    private static View getContentView(View parent) {
+        View view = parent.getView(0);
+        return view.getViewCount() > 0 ? getContentView(view) : view;
+    }
+
+    private static Element getContent(Element branch) {
+        Element element = branch.getElement(0);
+        return element.getElementCount() > 0
+               ? getContent(element)
+               : element;
+    }
+}


### PR DESCRIPTION
The value of the [`text-decoration`](https://www.w3.org/TR/REC-CSS1/#text-decoration) CSS property is not inherited correctly in Swing. If the `<span>` element is mixed with `<u>` or `<s>`, only the value from the `style` attribute of `<span>` is applied.

The fix to this issue is not as simple as that for the previous one in PR #17659, [JDK-8323801](https://bugs.openjdk.org/browse/JDK-8323801). Even in the seemingly simple case where `<u>` is followed by `<span style='text-decoration: line-through'>`, the situation is more complex because the styles are stored in `MuxingAttributeSet` in different elements of the array.

To resolve this problem, `CSS.Attribute.TEXT_DECORATION` is treated as a special case. Indeed, it is a special case: the values set to a single `text-decoration` property should be combined across the entire tree of nested HTML elements and their styles.

So, `MuxingAttributeSet` looks for `text-decoration` in the entire array and combines all the values.

The same way, `StyleSheet` also goes up the inheritance chain by combining the current value of `text-decoration` with that from `getResolveParent`.

The `ConvertSpanAction` combines the value of `text-decoration` of adjacent `<span>` elements.

Finally, `ConvertAction` and `CharacterAction` are refactored. The `ConvertAction` class duplicated the code from `CharacterAction`. Now `ConvertAction` extends `CharacterAction` and overrides a method to provide additional handling.

Thus, [JDK-8325620](https://bugs.openjdk.org/browse/JDK-8325620) is also resolved by this PR, the action used for `<b>`, `<i>`, `<u>` is `CharacterAction` as specified.