### PR TITLE
8329354: java/text/Format/MessageFormat/CompactSubFormats.java fails

### DIFF
--- a/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
+++ b/test/jdk/java/text/Format/MessageFormat/CompactSubFormats.java
@@ -64,7 +64,8 @@ public class CompactSubFormats {
     public void recognizedCompactStylesTest() {
         // An exception won't be thrown since 'compact_regular' will be interpreted as a
         // subformatPattern.
-        assertEquals(new DecimalFormat("compact_regular"),
+        DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.US);
+        assertEquals(new DecimalFormat("compact_regular", symbols),
                 new MessageFormat("{0,number,compact_regular}", Locale.US).getFormatsByArgumentIndex()[0]);
     }
 


### PR DESCRIPTION
Hi all,

java/text/Format/MessageFormat/CompactSubFormats.java fails in our testing machines.
I'm not an expert in this area and just guess it can be fixed like this.
Please review it.

Thanks.
Best regards,
Jie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329354](https://bugs.openjdk.org/browse/JDK-8329354): java/text/Format/MessageFormat/CompactSubFormats.java fails (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18557/head:pull/18557` \
`$ git checkout pull/18557`

Update a local copy of the PR: \
`$ git checkout pull/18557` \
`$ git pull https://git.openjdk.org/jdk.git pull/18557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18557`

View PR using the GUI difftool: \
`$ git pr show -t 18557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18557.diff">https://git.openjdk.org/jdk/pull/18557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18557#issuecomment-2027884544)