### PR TITLE
8329355: Test compiler/c2/irTests/TestIfMinMax.java fails on RISC-V

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
@@ -32,6 +32,7 @@ import jdk.test.lib.Utils;
  * @test
  * @bug 8324655
  * @summary Test that if expressions are properly folded into min/max nodes
+ * @requires os.arch != "riscv64"
  * @library /test/lib /
  * @run main compiler.c2.irTests.TestIfMinMax
  */


### PR DESCRIPTION
Please review this small change fixing an IR matching failure on linux-riscv platform.

JDK-8324655 tries to identify min/max patterns in CMoves and transform them into Min and Max nodes.
But architectures like RISC-V doesn't have support of conditional moves at the ISA level for now.
So we set ConditionalMoveLimit parameter to 0 for this platform and conditionals moves are emulated
with normal compare and branch instructions instead [1]. This is why the IR matching test added by
JDK-8324655 fails on this platform. A simple way to fix this would be skip this test for this case.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/riscv.ad#L9775

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329355](https://bugs.openjdk.org/browse/JDK-8329355): Test compiler/c2/irTests/TestIfMinMax.java fails on RISC-V (**Bug** - P4)


### Reviewers
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Author)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18558/head:pull/18558` \
`$ git checkout pull/18558`

Update a local copy of the PR: \
`$ git checkout pull/18558` \
`$ git pull https://git.openjdk.org/jdk.git pull/18558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18558`

View PR using the GUI difftool: \
`$ git pr show -t 18558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18558.diff">https://git.openjdk.org/jdk/pull/18558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18558#issuecomment-2027980079)