### PR TITLE
8329358: Generational ZGC: Remove the unused method ZPointer::set_remset_bits

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.hpp
+++ b/src/hotspot/share/gc/z/zAddress.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,6 @@ public:
   static zaddress uncolor(zpointer ptr);
   static zaddress uncolor_store_good(zpointer ptr);
   static zaddress_unsafe uncolor_unsafe(zpointer ptr);
-  static zpointer set_remset_bits(zpointer ptr);
 
   static bool is_load_bad(zpointer ptr);
   static bool is_load_good(zpointer ptr);

--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -452,13 +452,6 @@ inline zaddress_unsafe ZPointer::uncolor_unsafe(zpointer ptr) {
   assert(ZPointer::is_store_bad(ptr), "Unexpected ptr");
   const uintptr_t raw_addr = untype(ptr);
   return to_zaddress_unsafe(raw_addr >> ZPointer::load_shift_lookup(raw_addr));
-}
-
-inline zpointer ZPointer::set_remset_bits(zpointer ptr) {
-  uintptr_t raw_addr = untype(ptr);
-  assert(raw_addr != 0, "raw nulls should have been purged in promotion to old gen");
-  raw_addr |= ZPointerRemembered0 | ZPointerRemembered1;
-  return to_zpointer(raw_addr);
 }
 
 inline bool ZPointer::is_load_bad(zpointer ptr) {


### PR DESCRIPTION
Hi all,

This patch removes the unused method `ZPointer::set_remset_bits`. It seems that we don't need to set two remembered bits at the same time.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329358](https://bugs.openjdk.org/browse/JDK-8329358): Generational ZGC: Remove the unused method ZPointer::set_remset_bits (**Enhancement** - P5)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18559/head:pull/18559` \
`$ git checkout pull/18559`

Update a local copy of the PR: \
`$ git checkout pull/18559` \
`$ git pull https://git.openjdk.org/jdk.git pull/18559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18559`

View PR using the GUI difftool: \
`$ git pr show -t 18559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18559.diff">https://git.openjdk.org/jdk/pull/18559.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18559#issuecomment-2028094973)