### PR TITLE
8329368: Generational ZGC: Remove the unnecessary friend classes in ZAllocator

### DIFF
--- a/src/hotspot/share/gc/z/zAllocator.hpp
+++ b/src/hotspot/share/gc/z/zAllocator.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,9 +34,6 @@ class ZAllocatorForRelocation;
 class ZPage;
 
 class ZAllocator {
-  friend class ZAllocatorEden;
-  friend class ZAllocatorSurvivor;
-  friend class ZAllocatorOld;
 
 public:
   static constexpr uint _relocation_allocators = static_cast<uint>(ZPageAge::old);

--- a/src/hotspot/share/gc/z/zAllocator.hpp
+++ b/src/hotspot/share/gc/z/zAllocator.hpp
@@ -34,7 +34,6 @@ class ZAllocatorForRelocation;
 class ZPage;
 
 class ZAllocator {
-
 public:
   static constexpr uint _relocation_allocators = static_cast<uint>(ZPageAge::old);
 


### PR DESCRIPTION
Hi all,

This trivial patch removes the unnecessary friend classes in `ZAllocator`. The tests `make test-tier1_gc` passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329368](https://bugs.openjdk.org/browse/JDK-8329368): Generational ZGC: Remove the unnecessary friend classes in ZAllocator (**Enhancement** - P5)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18560/head:pull/18560` \
`$ git checkout pull/18560`

Update a local copy of the PR: \
`$ git checkout pull/18560` \
`$ git pull https://git.openjdk.org/jdk.git pull/18560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18560`

View PR using the GUI difftool: \
`$ git pr show -t 18560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18560.diff">https://git.openjdk.org/jdk/pull/18560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18560#issuecomment-2028812322)