### PR TITLE
8328273: sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java failed with java.rmi.server.ExportException: Port already in use

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DefaultAgentFilterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,7 +171,7 @@ public class DefaultAgentFilterTest {
                     AtomicBoolean error = new AtomicBoolean(false);
                     AtomicBoolean bindError = new AtomicBoolean(false);
                     // The predicate below tries to recognise failures.  On a port clash, it sees e.g.
-                    // Error: Exception thrown by the agent : java.rmi.server.ExportException: Port already in use: 46481; nested exception is:
+                    // Error: Exception thrown by the agent: java.rmi.server.ExportException: Port already in use: 46481; nested exception is:
                     // ...and will never see "main enter" from TestApp.
                     p = ProcessTools.startProcess(
                             TEST_APP_NAME + "{" + name + "}",

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ public class RmiRegistrySslTest {
             System.out.println("test output:");
             System.out.println(output.getOutput());
 
-            if (!output.getOutput().contains("Exception thrown by the agent : " +
+            if (!output.getOutput().contains("Exception thrown by the agent: " +
                     "java.rmi.server.ExportException: Port already in use")) {
                 return output.getExitValue();
             }


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the test failure reported in https://bugs.openjdk.org/browse/JDK-8328273?

As noted in that issue, the `sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java` intermittently fails with a port already in use error. The test attempts to find a free port and then uses it during the test. The interesting part is that the test already has a loop of 10 attempts to retry the test if the port wasn't actually free. So for the test to fail, it would then mean that each of the 10 attempts of using a free port failed (which should be extremely rare and should almost never happen). 

I didn't have an answer for that until today and had it on my TODO to look further. Credit goes to Kevin @kevinjwalls for identifying the issue - turns out this is the exact same issue that Kevin fixed in https://github.com/openjdk/jdk/pull/18470 for a different test. After noticing that fix, I spotted the same typo in the exception message check in this test. That explains why it wasn't retrying at most 10 times. The test was thus immediately failing on first attempt whenever the chosen free port was in use.

I have run this test with a test repeat of 50 with this change and the test now passes always. Without this change and a test repeat of 50, the test failed 2 times. I've additionally searched for any other similar typos in other tests and haven't found any (I searched for the string "Exception thrown by the agent :").

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328273](https://bugs.openjdk.org/browse/JDK-8328273): sun/management/jmxremote/bootstrap/RmiRegistrySslTest.java failed with java.rmi.server.ExportException: Port already in use (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18561/head:pull/18561` \
`$ git checkout pull/18561`

Update a local copy of the PR: \
`$ git checkout pull/18561` \
`$ git pull https://git.openjdk.org/jdk.git pull/18561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18561`

View PR using the GUI difftool: \
`$ git pr show -t 18561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18561.diff">https://git.openjdk.org/jdk/pull/18561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18561#issuecomment-2029033361)