### PR TITLE
8328318: Wrong description in X509Extension.getExtensionValue method javadoc

### DIFF
--- a/src/java.base/share/classes/java/security/cert/X509Extension.java
+++ b/src/java.base/share/classes/java/security/cert/X509Extension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/cert/X509Extension.java
+++ b/src/java.base/share/classes/java/security/cert/X509Extension.java
@@ -161,6 +161,8 @@ public interface X509Extension {
      * <th scope="col">Extension Name</th></tr>
      * </thead>
      * <tbody style="text-align:left">
+     * <tr><th scope="row">1.3.6.1.5.5.7.1.1</th>
+     * <td>AuthorityInformationAccess</td></tr>
      * <tr><th scope="row">2.5.29.14</th>
      * <td>SubjectKeyIdentifier</td></tr>
      * <tr><th scope="row">2.5.29.15</th>

--- a/src/java.base/share/classes/java/security/cert/X509Extension.java
+++ b/src/java.base/share/classes/java/security/cert/X509Extension.java
@@ -165,8 +165,6 @@ public interface X509Extension {
      * <td>SubjectKeyIdentifier</td></tr>
      * <tr><th scope="row">2.5.29.15</th>
      * <td>KeyUsage</td></tr>
-     * <tr><th scope="row">2.5.29.16</th>
-     * <td>PrivateKeyUsage</td></tr>
      * <tr><th scope="row">2.5.29.17</th>
      * <td>SubjectAlternativeName</td></tr>
      * <tr><th scope="row">2.5.29.18</th>
@@ -175,12 +173,18 @@ public interface X509Extension {
      * <td>BasicConstraints</td></tr>
      * <tr><th scope="row">2.5.29.30</th>
      * <td>NameConstraints</td></tr>
+     * <tr><th scope="row">2.5.29.31</th>
+     * <td>CRLDistributionPoints</td></tr>
+     * <tr><th scope="row">2.5.29.32</th>
+     * <td>CertificatePolicies</td></tr>
      * <tr><th scope="row">2.5.29.33</th>
      * <td>PolicyMappings</td></tr>
      * <tr><th scope="row">2.5.29.35</th>
      * <td>AuthorityKeyIdentifier</td></tr>
      * <tr><th scope="row">2.5.29.36</th>
      * <td>PolicyConstraints</td></tr>
+     * <tr><th scope="row">2.5.29.37</th>
+     * <td>ExtendedKeyUsage</td></tr>
      * </tbody>
      * </table>
      *


### PR DESCRIPTION
Removed `PrivateKeyUsagePeriod` from method javadoc and added several commonly used extensions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328318](https://bugs.openjdk.org/browse/JDK-8328318): Wrong description in X509Extension.getExtensionValue method javadoc (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**) ⚠️ Review applies to [272d1663](https://git.openjdk.org/jdk/pull/18565/files/272d1663bbd77a5771ce94426ab393e118ac4578)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18565/head:pull/18565` \
`$ git checkout pull/18565`

Update a local copy of the PR: \
`$ git checkout pull/18565` \
`$ git pull https://git.openjdk.org/jdk.git pull/18565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18565`

View PR using the GUI difftool: \
`$ git pr show -t 18565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18565.diff">https://git.openjdk.org/jdk/pull/18565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18565#issuecomment-2030273356)