### PR TITLE
8328383: Method is not used: com.sun.tools.javac.comp.Attr::thisSym

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -328,13 +328,6 @@ public class Attr extends JCTree.Visitor {
         return sym != null && sym.kind == TYP;
     }
 
-    /** The current `this' symbol.
-     *  @param env    The current environment.
-     */
-    Symbol thisSym(DiagnosticPosition pos, Env<AttrContext> env) {
-        return rs.resolveSelf(pos, env, env.enclClass.sym, names._this);
-    }
-
     /** Attribute a parsed identifier.
      * @param tree Parsed identifier name
      * @param topLevel The toplevel to use


### PR DESCRIPTION
Please review this simple fix that is just removing a method not used by any client. As indicated in the title the method belong to class `com.sun.tools.javac.comp.Attr`

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328383](https://bugs.openjdk.org/browse/JDK-8328383): Method is not used: com.sun.tools.javac.comp.Attr::thisSym (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18566/head:pull/18566` \
`$ git checkout pull/18566`

Update a local copy of the PR: \
`$ git checkout pull/18566` \
`$ git pull https://git.openjdk.org/jdk.git pull/18566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18566`

View PR using the GUI difftool: \
`$ git pr show -t 18566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18566.diff">https://git.openjdk.org/jdk/pull/18566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18566#issuecomment-2030315853)