### PR TITLE
8329421: Native methods can not be selectively printed

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -2787,7 +2787,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
           }
         }
 
-        DirectiveSet* directive = DirectivesStack::getDefaultDirective(CompileBroker::compiler(CompLevel_simple));
+        DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, CompileBroker::compiler(CompLevel_simple));
         if (directive->PrintAssemblyOption) {
           nm->print_code();
         }

--- a/test/hotspot/jtreg/compiler/calls/NativeCalls.java
+++ b/test/hotspot/jtreg/compiler/calls/NativeCalls.java
@@ -22,44 +22,37 @@
  */
 
 /* @test
- * @bug 8329126
- * @summary check that native methods get compiled
+ * @bug 8329126 8329421
+ * @summary check that native methods get compiled and printed
  *
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  *
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:+TieredCompilation compiler.calls.NativeCalls
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:-TieredCompilation compiler.calls.NativeCalls
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:+TieredCompilation -XX:TieredStopAtLevel=1 compiler.calls.NativeCalls
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:+TieredCompilation -XX:TieredStopAtLevel=2 compiler.calls.NativeCalls
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:+TieredCompilation -XX:TieredStopAtLevel=3 compiler.calls.NativeCalls
- * @run main/othervm/native -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:.
- *    -Xbatch -XX:-UseOnStackReplacement -XX:+TieredCompilation -XX:TieredStopAtLevel=4 compiler.calls.NativeCalls
+ * @run main/othervm/native compiler.calls.NativeCalls
  */
 
 package compiler.calls;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.regex.Pattern;
 
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 import jdk.test.whitebox.WhiteBox;
 
 public class NativeCalls {
     static Method emptyStaticNativeMethod;
     static Method callNativeMethod;
-    static WhiteBox wb;
     static {
         init();
     }
     static void init() {
         System.loadLibrary("NativeCalls");
-        wb = WhiteBox.getWhiteBox();
         try {
             emptyStaticNativeMethod = NativeCalls.class.getDeclaredMethod("emptyStaticNative");
             callNativeMethod = NativeCalls.class.getDeclaredMethod("callNative");
@@ -74,13 +67,85 @@ public class NativeCalls {
         emptyStaticNative();
     }
 
-    static public void main(String[] args) {
-        for (int i = 0; i < 20_000; i++) {
-            callNative();
+    static public void main(String[] args) throws Exception {
+
+        ArrayList<String> baseOptions = new ArrayList<String>();
+        baseOptions.add("-XX:+UnlockDiagnosticVMOptions");
+        baseOptions.add("-XX:+WhiteBoxAPI");
+        baseOptions.add("-Xbootclasspath/a:.");
+        baseOptions.add("-Xbatch");
+        baseOptions.add("-XX:-UseOnStackReplacement");
+        baseOptions.add("-XX:+PrintCompilation");
+        baseOptions.add(Executor.class.getName());
+        String nativeMethodName = NativeCalls.class.getName() + "::" + emptyStaticNativeMethod.getName();
+        List<Variant> variants = List.of(new Variant(List.of("-XX:+TieredCompilation"), "true", "false"),
+                                         new Variant(List.of("-XX:-TieredCompilation"), "true", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation",
+                                                             "-XX:+PreferInterpreterNativeStubs"), "false", "false"),
+                                         new Variant(List.of("-XX:-TieredCompilation",
+                                                             "-XX:+PreferInterpreterNativeStubs"), "false", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"), "true", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=2"), "true", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=3"), "true", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation", "-XX:TieredStopAtLevel=4"), "true", "false"),
+                                         new Variant(List.of("-XX:+TieredCompilation",
+                                                             "-XX:CompileCommand=print," + nativeMethodName), "true", "true"),
+                                         new Variant(List.of("-XX:-TieredCompilation",
+                                                             "-XX:CompileCommand=print," + nativeMethodName), "true", "true"),
+                                         new Variant(List.of("-XX:-TieredCompilation",
+                                                             "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintAssembly"), "true", "true"),
+                                         new Variant(List.of("-XX:+TieredCompilation",
+                                                             "-XX:CompileCommand=exclude," + nativeMethodName), "false", "false"),
+                                         new Variant(List.of("-XX:-TieredCompilation",
+                                                             "-XX:CompileCommand=exclude," + nativeMethodName), "false", "false"));
+        for (Variant v : variants) {
+            ArrayList<String> command = new ArrayList<String>(v.options);
+            command.addAll(baseOptions);
+            command.add(v.compile);
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(command);
+            OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+            analyzer.shouldHaveExitValue(0);
+            System.out.println(analyzer.getOutput());
+            if (Boolean.valueOf(v.print).booleanValue() &&
+                analyzer.asLines().stream().
+                filter(Pattern.compile("Compiled method.+" + nativeMethodName + ".*").asPredicate()).
+                findAny().isEmpty()) {
+                throw new Error(nativeMethodName + " not printed");
+            }
         }
-        if (wb.getMethodCompilationLevel(callNativeMethod) > 0) {
-            if (!wb.isMethodCompiled(emptyStaticNativeMethod)) {
-                throw new Error("TEST BUG: '" + emptyStaticNativeMethod + "' should be compiled");
+    }
+
+    public static class Variant {
+        Collection<String> options;
+        String compile;
+        String print;
+        public Variant(Collection<String> options, String compile, String print) {
+            this.options = options;
+            this. compile = compile;
+            this. print = print;
+        }
+    }
+
+    public static class Executor {
+
+        static WhiteBox wb = WhiteBox.getWhiteBox();
+
+        static public void main(String[] args) {
+
+            if (args.length != 1) {
+                throw new Error("Expected two arguments");
+            }
+            boolean compile = Boolean.valueOf(args[0]);
+            for (int i = 0; i < 20_000; i++) {
+                callNative();
+            }
+            if (wb.getMethodCompilationLevel(callNativeMethod) > 0) {
+                if (compile && !wb.isMethodCompiled(emptyStaticNativeMethod)) {
+                    throw new Error("TEST BUG: '" + emptyStaticNativeMethod + "' should be compiled");
+                }
+                if (!compile && wb.isMethodCompiled(emptyStaticNativeMethod)) {
+                    throw new Error("TEST BUG: '" + emptyStaticNativeMethod + "' should not be compiled");
+                }
             }
         }
     }


### PR DESCRIPTION
Native methods (i.e. "native wrappers") can not be selectively printed with `-XX:CompileCommand=print,class::method`. Currently the only way to print native methods is to use the global `-XX:+PrintAssembly` option. But this prints *all* compiled methods which can be too much if we're just interested in a specific native wrapper. There's no reason to not apply `-XX:CompileCommand` options correctly to native methods as well. 