### PR TITLE
8329425: ProblemList containers/docker/TestJFREvents.java on linux-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -47,6 +47,6 @@ vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 83
 vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001/TestDescription.java 8043571 generic-all
 vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003/TestDescription.java 8043571 generic-all
 
-vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64
+vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64,windows-x64
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -49,4 +49,6 @@ vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003/TestDescription.ja
 
 vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 8299493 macosx-x64,windows-x64
 
+vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all
+
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -123,6 +123,7 @@ applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
+containers/docker/TestJFREvents.java 8327723 linux-x64
 
 #############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -640,6 +640,7 @@ javax/sound/sampled/Mixers/DisabledAssertionCrash.java 7067310 generic-all
 javax/sound/midi/Sequencer/Recording.java 8167580,8265485 linux-all,macosx-aarch64
 javax/sound/midi/Sequencer/Looping.java 8136897 generic-all
 javax/sound/sampled/Clip/ClipIsRunningAfterStop.java 8307574 linux-x64
+javax/sound/sampled/Clip/ClipFlushCrash.java 8308395 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
Trivial fixes to ProblemList noisy tests:

[JDK-8329425](https://bugs.openjdk.org/browse/JDK-8329425) ProblemList containers/docker/TestJFREvents.java on linux-x64
[JDK-8329426](https://bugs.openjdk.org/browse/JDK-8329426) ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java with Xcomp on windows-x64
[JDK-8329427](https://bugs.openjdk.org/browse/JDK-8329427) ProblemList javax/sound/sampled/Clip/ClipFlushCrash.java on linux-x64
[JDK-8329428](https://bugs.openjdk.org/browse/JDK-8329428) ProblemList vmTestbase/nsk/stress/thread/thread006.java on linux-all in Xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8329425](https://bugs.openjdk.org/browse/JDK-8329425): ProblemList containers/docker/TestJFREvents.java on linux-x64 (**Sub-task** - P4)
 * [JDK-8329426](https://bugs.openjdk.org/browse/JDK-8329426): ProblemList vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java with Xcomp on windows-x64 (**Sub-task** - P4)
 * [JDK-8329427](https://bugs.openjdk.org/browse/JDK-8329427): ProblemList javax/sound/sampled/Clip/ClipFlushCrash.java on linux-x64 (**Sub-task** - P4)
 * [JDK-8329428](https://bugs.openjdk.org/browse/JDK-8329428): ProblemList vmTestbase/nsk/stress/thread/thread006.java on linux-all in Xcomp (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18568/head:pull/18568` \
`$ git checkout pull/18568`

Update a local copy of the PR: \
`$ git checkout pull/18568` \
`$ git pull https://git.openjdk.org/jdk.git pull/18568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18568`

View PR using the GUI difftool: \
`$ git pr show -t 18568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18568.diff">https://git.openjdk.org/jdk/pull/18568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18568#issuecomment-2030671490)