### PR TITLE
8329432: PopFrame and ForceEarlyReturn functions should use JvmtiHandshake

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -1748,6 +1748,7 @@ JvmtiEnv::PopFrame(jthread thread) {
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
   jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  Handle thread_handle(current_thread, thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
     return err;
@@ -1774,11 +1775,7 @@ JvmtiEnv::PopFrame(jthread thread) {
 
   MutexLocker mu(JvmtiThreadState_lock);
   UpdateForPopTopFrameClosure op(state);
-  if (self) {
-    op.doit(java_thread, self);
-  } else {
-    Handshake::execute(&op, java_thread);
-  }
+  JvmtiHandshake::execute(&op, &tlh, java_thread, thread_handle);
   return op.result();
 } /* end PopFrame */
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2194,7 +2194,7 @@ JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
 }
 
 void
-SetForceEarlyReturn::doit(Thread *target, bool self) {
+SetForceEarlyReturn::doit(Thread *target) {
   JavaThread* java_thread = JavaThread::cast(target);
   Thread* current_thread = Thread::current();
   HandleMark   hm(current_thread);
@@ -2329,7 +2329,7 @@ JvmtiModuleClosure::get_all_modules(JvmtiEnv* env, jint* module_count_ptr, jobje
 }
 
 void
-UpdateForPopTopFrameClosure::doit(Thread *target, bool self) {
+UpdateForPopTopFrameClosure::doit(Thread *target) {
   Thread* current_thread  = Thread::current();
   HandleMark hm(current_thread);
   JavaThread* java_thread = JavaThread::cast(target);

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -456,16 +456,6 @@ class JvmtiEnvIterator : public StackObj {
   JvmtiEnv* next(JvmtiEnvBase* env) { return env->next_environment(); }
 };
 
-class JvmtiHandshakeClosure : public HandshakeClosure {
- protected:
-  jvmtiError _result;
- public:
-  JvmtiHandshakeClosure(const char* name)
-    : HandshakeClosure(name),
-      _result(JVMTI_ERROR_THREAD_NOT_ALIVE) {}
-  jvmtiError result() { return _result; }
-};
-
 // Used in combination with the JvmtiHandshake class.
 // It is intended to support both platform and virtual threads.
 class JvmtiUnitedHandshakeClosure : public HandshakeClosure {
@@ -499,36 +489,44 @@ class JvmtiHandshake : public Handshake {
   static void execute(JvmtiUnitedHandshakeClosure* hs_cl, jthread target);
 };
 
-class SetForceEarlyReturn : public JvmtiHandshakeClosure {
+class SetForceEarlyReturn : public JvmtiUnitedHandshakeClosure {
 private:
   JvmtiThreadState* _state;
   jvalue _value;
   TosState _tos;
 public:
   SetForceEarlyReturn(JvmtiThreadState* state, jvalue value, TosState tos)
-    : JvmtiHandshakeClosure("SetForceEarlyReturn"),
+    : JvmtiUnitedHandshakeClosure("SetForceEarlyReturn"),
      _state(state),
      _value(value),
      _tos(tos) {}
-  void do_thread(Thread *target) {
-    doit(target, false /* self */);
-  }
   void doit(Thread *target, bool self);
+  void do_thread(Thread *target) {
+    doit(target, _self);
+  }
+  void do_vthread(Handle target_h) {
+    assert(_target_jt != nullptr, "sanity check");
+    doit(_target_jt, _self); // mounted virtual thread
+  }
 };
 
 // HandshakeClosure to update for pop top frame.
-class UpdateForPopTopFrameClosure : public JvmtiHandshakeClosure {
+class UpdateForPopTopFrameClosure : public JvmtiUnitedHandshakeClosure {
 private:
   JvmtiThreadState* _state;
 
 public:
   UpdateForPopTopFrameClosure(JvmtiThreadState* state)
-    : JvmtiHandshakeClosure("UpdateForPopTopFrame"),
+    : JvmtiUnitedHandshakeClosure("UpdateForPopTopFrame"),
      _state(state) {}
-  void do_thread(Thread *target) {
-    doit(target, false /* self */);
-  }
   void doit(Thread *target, bool self);
+  void do_thread(Thread *target) {
+    doit(target, _self);
+  }
+  void do_vthread(Handle target_h) {
+    assert(_target_jt != nullptr, "sanity check");
+    doit(_target_jt, _self); // mounted virtual thread
+  }
 };
 
 // HandshakeClosure to set frame pop.

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -500,13 +500,14 @@ public:
      _state(state),
      _value(value),
      _tos(tos) {}
-  void doit(Thread *target, bool self);
+  void doit(Thread *target);
   void do_thread(Thread *target) {
-    doit(target, _self);
+    doit(target);
   }
   void do_vthread(Handle target_h) {
     assert(_target_jt != nullptr, "sanity check");
-    doit(_target_jt, _self); // mounted virtual thread
+    assert(_target_jt->vthread() == target_h(), "sanity check");
+    doit(_target_jt); // mounted virtual thread
   }
 };
 
@@ -519,13 +520,14 @@ public:
   UpdateForPopTopFrameClosure(JvmtiThreadState* state)
     : JvmtiUnitedHandshakeClosure("UpdateForPopTopFrame"),
      _state(state) {}
-  void doit(Thread *target, bool self);
+  void doit(Thread *target);
   void do_thread(Thread *target) {
-    doit(target, _self);
+    doit(target);
   }
   void do_vthread(Handle target_h) {
     assert(_target_jt != nullptr, "sanity check");
-    doit(_target_jt, _self); // mounted virtual thread
+    assert(_target_jt->vthread() == target_h(), "sanity check");
+    doit(_target_jt); // mounted virtual thread
   }
 };
 


### PR DESCRIPTION
The internal JVM TI `JvmtiHandshake` and `JvmtiUnitedHandshakeClosure` classes were introduced in the JDK 22 to unify/simplify the JVM TI functions supporting implementation of the virtual threads. This enhancement is to refactor JVM TI functions `PopFrame` and `ForceEarlyReturn` on the base of `JvmtiHandshake` and `JvmtiUnitedHandshakeClosure` classes.

Testing:

    Ran mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329432](https://bugs.openjdk.org/browse/JDK-8329432): PopFrame and ForceEarlyReturn functions should use JvmtiHandshake (**Enhancement** - P4)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [9ca1ea20](https://git.openjdk.org/jdk/pull/18570/files/9ca1ea20dac40c6d45eafeb757f77dad1672da57)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18570/head:pull/18570` \
`$ git checkout pull/18570`

Update a local copy of the PR: \
`$ git checkout pull/18570` \
`$ git pull https://git.openjdk.org/jdk.git pull/18570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18570`

View PR using the GUI difftool: \
`$ git pr show -t 18570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18570.diff">https://git.openjdk.org/jdk/pull/18570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18570#issuecomment-2030848907)