### PR TITLE
8329493: Parallel: Remove unused ParallelArguments::heap_max_size_bytes

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -133,10 +133,6 @@ size_t ParallelArguments::heap_reserved_size_bytes() {
   return MaxHeapSize;
 }
 
-size_t ParallelArguments::heap_max_size_bytes() {
-  return MaxHeapSize;
-}
-
 CollectedHeap* ParallelArguments::create_heap() {
   return new ParallelScavengeHeap();
 }

--- a/src/hotspot/share/gc/parallel/parallelArguments.hpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.hpp
@@ -43,7 +43,6 @@ private:
 
 public:
   static size_t heap_reserved_size_bytes();
-  static size_t heap_max_size_bytes();
 };
 
 #endif // SHARE_GC_PARALLEL_PARALLELARGUMENTS_HPP


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329493](https://bugs.openjdk.org/browse/JDK-8329493): Parallel: Remove unused ParallelArguments::heap_max_size_bytes (**Enhancement** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18575/head:pull/18575` \
`$ git checkout pull/18575`

Update a local copy of the PR: \
`$ git checkout pull/18575` \
`$ git pull https://git.openjdk.org/jdk.git pull/18575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18575`

View PR using the GUI difftool: \
`$ git pr show -t 18575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18575.diff">https://git.openjdk.org/jdk/pull/18575.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18575#issuecomment-2031412147)