### PR TITLE
8329488: Move OopStorage code from safepoint cleanup and remove safepoint cleanup code

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ public:
   // Returns true if there may be more work to do, false if nothing to do.
   bool delete_empty_blocks();
 
-  // Called by safepoint cleanup to notify the service thread (via
+  // Called by a periodic task to notify the service thread (via
   // Service_lock) that there may be some OopStorage objects with pending
   // cleanups to process.
   static void trigger_cleanup_if_needed();
@@ -209,6 +209,10 @@ public:
   // recognition of new requests.  Returns true if there was a pending
   // request.
   static bool has_cleanup_work_and_reset();
+
+  // Called by the service thread to initialize the perioidic task triggering
+  // occasional cleanups for the service thread to process.
+  static void initialize_periodic_cleanup_task();
 
   // Debugging and logging support.
   const char* name() const;

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -30,7 +30,6 @@
 #include "compiler/compilationPolicy.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/gcLocker.hpp"
-#include "gc/shared/oopStorage.hpp"
 #include "gc/shared/strongRootsScope.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shared/workerUtils.hpp"
@@ -539,12 +538,6 @@ public:
   }
 
   void work(uint worker_id) {
-    if (_subtasks.try_claim_task(SafepointSynchronize::SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP)) {
-      // Don't bother reporting event or time for this very short operation.
-      // To have any utility we'd also want to report whether needed.
-      OopStorage::trigger_cleanup_if_needed();
-    }
-
     _subtasks.all_tasks_claimed();
   }
 };

--- a/src/hotspot/share/runtime/safepoint.hpp
+++ b/src/hotspot/share/runtime/safepoint.hpp
@@ -70,7 +70,6 @@ class SafepointSynchronize : AllStatic {
 
   // The enums are listed in the order of the tasks when done serially.
   enum SafepointCleanupTasks {
-    SAFEPOINT_CLEANUP_REQUEST_OOPSTORAGE_CLEANUP,
     // Leave this one last.
     SAFEPOINT_CLEANUP_NUM_TASKS
   };

--- a/src/hotspot/share/runtime/serviceThread.cpp
+++ b/src/hotspot/share/runtime/serviceThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,10 @@ static void cleanup_oopstorages() {
 }
 
 void ServiceThread::service_thread_entry(JavaThread* jt, TRAPS) {
+  // Tell oop storage that we are ready to receive cleanup requests from
+  // now on, occasionally.
+  OopStorage::initialize_periodic_cleanup_task();
+
   while (true) {
     bool sensors_changed = false;
     bool has_jvmti_events = false;


### PR DESCRIPTION
Safepoint cleanup currently has one single job left: triggering some cleanup in the service thread for OopStorage. This trigger should move out of safepoint cleanup, so we can delete it. This patch proposes to use a periodic task instead to trigger cleanups.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329488](https://bugs.openjdk.org/browse/JDK-8329488): Move OopStorage code from safepoint cleanup and remove safepoint cleanup code (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18576/head:pull/18576` \
`$ git checkout pull/18576`

Update a local copy of the PR: \
`$ git checkout pull/18576` \
`$ git pull https://git.openjdk.org/jdk.git pull/18576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18576`

View PR using the GUI difftool: \
`$ git pr show -t 18576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18576.diff">https://git.openjdk.org/jdk/pull/18576.diff</a>

</details>
