### PR TITLE
8326962: C2 SuperWord: cache VPointer

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -531,13 +531,13 @@ void SuperWord::find_adjacent_refs() {
       set_align_to_ref(align_to_mem_ref);
     }
 
-    const VPointer& align_to_ref_p = get_pointer(mem_ref);
+    const VPointer& align_to_ref_p = vpointer(mem_ref);
     // Set alignment relative to "align_to_ref" for all related memory operations.
     for (int i = memops.size() - 1; i >= 0; i--) {
       MemNode* s = memops.at(i)->as_Mem();
       if (isomorphic(s, mem_ref) &&
            (!_do_vector_loop || same_origin_idx(s, mem_ref))) {
-        const VPointer& p2 = get_pointer(s);
+        const VPointer& p2 = vpointer(s);
         if (p2.comparable(align_to_ref_p)) {
           int align = memory_alignment(s, iv_adjustment);
           set_alignment(s, align);
@@ -593,11 +593,11 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
   // Count number of comparable memory ops
   for (uint i = 0; i < memops.size(); i++) {
     MemNode* s1 = memops.at(i)->as_Mem();
-    const VPointer& p1 = get_pointer(s1);
+    const VPointer& p1 = vpointer(s1);
     for (uint j = i+1; j < memops.size(); j++) {
       MemNode* s2 = memops.at(j)->as_Mem();
       if (isomorphic(s1, s2)) {
-        const VPointer& p2 = get_pointer(s2);
+        const VPointer& p2 = vpointer(s2);
         if (p1.comparable(p2)) {
           (*cmp_ct.adr_at(i))++;
           (*cmp_ct.adr_at(j))++;
@@ -618,7 +618,7 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
     if (s->is_Store()) {
       int vw = vector_width_in_bytes(s);
       assert(vw > 1, "sanity");
-      const VPointer& p = get_pointer(s);
+      const VPointer& p = vpointer(s);
       if ( cmp_ct.at(j) >  max_ct ||
           (cmp_ct.at(j) == max_ct &&
             ( vw >  max_vw ||
@@ -641,7 +641,7 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
       if (s->is_Load()) {
         int vw = vector_width_in_bytes(s);
         assert(vw > 1, "sanity");
-        const VPointer& p = get_pointer(s);
+        const VPointer& p = vpointer(s);
         if ( cmp_ct.at(j) >  max_ct ||
             (cmp_ct.at(j) == max_ct &&
               ( vw >  max_vw ||
@@ -714,7 +714,7 @@ int SuperWord::get_vw_bytes_special(MemNode* s) {
 //---------------------------get_iv_adjustment---------------------------
 // Calculate loop's iv adjustment for this memory ops.
 int SuperWord::get_iv_adjustment(MemNode* mem_ref) {
-  const VPointer& align_to_ref_p = get_pointer(mem_ref);
+  const VPointer& align_to_ref_p = vpointer(mem_ref);
   int offset = align_to_ref_p.offset_in_bytes();
   int scale  = align_to_ref_p.scale_in_bytes();
   int elt_size = align_to_ref_p.memory_size();
@@ -875,8 +875,8 @@ bool SuperWord::are_adjacent_refs(Node* s1, Node* s2) const {
 
   // Adjacent memory references must have the same base, be comparable
   // and have the correct distance between them.
-  const VPointer& p1 = get_pointer(s1->as_Mem());
-  const VPointer& p2 = get_pointer(s2->as_Mem());
+  const VPointer& p1 = vpointer(s1->as_Mem());
+  const VPointer& p2 = vpointer(s2->as_Mem());
   if (p1.base() != p2.base() || !p1.comparable(p2)) return false;
   int diff = p2.offset_in_bytes() - p1.offset_in_bytes();
   return diff == data_size(s1);
@@ -1637,7 +1637,7 @@ const AlignmentSolution* SuperWord::pack_alignment_solution(const Node_List* pac
   assert(pack != nullptr && (pack->at(0)->is_Load() || pack->at(0)->is_Store()), "only load/store packs");
 
   const MemNode* mem_ref = pack->at(0)->as_Mem();
-  const VPointer& mem_ref_p = get_pointer(mem_ref);
+  const VPointer& mem_ref_p = vpointer(mem_ref);
   const CountedLoopEndNode* pre_end = _vloop.pre_loop_end();
   assert(pre_end->stride_is_con(), "pre loop stride is constant");
 
@@ -3310,7 +3310,7 @@ int SuperWord::memory_alignment(MemNode* s, int iv_adjust) {
     tty->print("SuperWord::memory_alignment within a vector memory reference for %d:  ", s->_idx); s->dump();
   }
 #endif
-  const VPointer& p = get_pointer(s);
+  const VPointer& p = vpointer(s);
   if (!p.valid()) {
     NOT_PRODUCT(if(is_trace_superword_alignment()) tty->print_cr("SuperWord::memory_alignment: VPointer p invalid, return bottom_align");)
     return bottom_align;
@@ -3413,7 +3413,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   Node* orig_limit = pre_opaq->original_loop_limit();
   assert(orig_limit != nullptr && igvn().type(orig_limit) != Type::TOP, "");
 
-  const VPointer& align_to_ref_p = get_pointer(align_to_ref);
+  const VPointer& align_to_ref_p = vpointer(align_to_ref);
   assert(align_to_ref_p.valid(), "sanity");
 
   // For the main-loop, we want the address of align_to_ref to be memory aligned

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -531,13 +531,13 @@ void SuperWord::find_adjacent_refs() {
       set_align_to_ref(align_to_mem_ref);
     }
 
-    VPointer align_to_ref_p(mem_ref, _vloop);
+    const VPointer& align_to_ref_p = get_pointer(mem_ref);
     // Set alignment relative to "align_to_ref" for all related memory operations.
     for (int i = memops.size() - 1; i >= 0; i--) {
       MemNode* s = memops.at(i)->as_Mem();
       if (isomorphic(s, mem_ref) &&
            (!_do_vector_loop || same_origin_idx(s, mem_ref))) {
-        VPointer p2(s, _vloop);
+        const VPointer& p2 = get_pointer(s);
         if (p2.comparable(align_to_ref_p)) {
           int align = memory_alignment(s, iv_adjustment);
           set_alignment(s, align);
@@ -593,11 +593,11 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
   // Count number of comparable memory ops
   for (uint i = 0; i < memops.size(); i++) {
     MemNode* s1 = memops.at(i)->as_Mem();
-    VPointer p1(s1, _vloop);
+    const VPointer& p1 = get_pointer(s1);
     for (uint j = i+1; j < memops.size(); j++) {
       MemNode* s2 = memops.at(j)->as_Mem();
       if (isomorphic(s1, s2)) {
-        VPointer p2(s2, _vloop);
+        const VPointer& p2 = get_pointer(s2);
         if (p1.comparable(p2)) {
           (*cmp_ct.adr_at(i))++;
           (*cmp_ct.adr_at(j))++;
@@ -618,7 +618,7 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
     if (s->is_Store()) {
       int vw = vector_width_in_bytes(s);
       assert(vw > 1, "sanity");
-      VPointer p(s, _vloop);
+      const VPointer& p = get_pointer(s);
       if ( cmp_ct.at(j) >  max_ct ||
           (cmp_ct.at(j) == max_ct &&
             ( vw >  max_vw ||
@@ -641,7 +641,7 @@ MemNode* SuperWord::find_align_to_ref(Node_List &memops, int &idx) {
       if (s->is_Load()) {
         int vw = vector_width_in_bytes(s);
         assert(vw > 1, "sanity");
-        VPointer p(s, _vloop);
+        const VPointer& p = get_pointer(s);
         if ( cmp_ct.at(j) >  max_ct ||
             (cmp_ct.at(j) == max_ct &&
               ( vw >  max_vw ||
@@ -714,7 +714,7 @@ int SuperWord::get_vw_bytes_special(MemNode* s) {
 //---------------------------get_iv_adjustment---------------------------
 // Calculate loop's iv adjustment for this memory ops.
 int SuperWord::get_iv_adjustment(MemNode* mem_ref) {
-  VPointer align_to_ref_p(mem_ref, _vloop);
+  const VPointer& align_to_ref_p = get_pointer(mem_ref);
   int offset = align_to_ref_p.offset_in_bytes();
   int scale  = align_to_ref_p.scale_in_bytes();
   int elt_size = align_to_ref_p.memory_size();
@@ -875,8 +875,8 @@ bool SuperWord::are_adjacent_refs(Node* s1, Node* s2) const {
 
   // Adjacent memory references must have the same base, be comparable
   // and have the correct distance between them.
-  VPointer p1(s1->as_Mem(), _vloop);
-  VPointer p2(s2->as_Mem(), _vloop);
+  const VPointer& p1 = get_pointer(s1->as_Mem());
+  const VPointer& p2 = get_pointer(s2->as_Mem());
   if (p1.base() != p2.base() || !p1.comparable(p2)) return false;
   int diff = p2.offset_in_bytes() - p1.offset_in_bytes();
   return diff == data_size(s1);
@@ -1637,7 +1637,7 @@ const AlignmentSolution* SuperWord::pack_alignment_solution(const Node_List* pac
   assert(pack != nullptr && (pack->at(0)->is_Load() || pack->at(0)->is_Store()), "only load/store packs");
 
   const MemNode* mem_ref = pack->at(0)->as_Mem();
-  VPointer mem_ref_p(mem_ref, _vloop);
+  const VPointer& mem_ref_p = get_pointer(mem_ref);
   const CountedLoopEndNode* pre_end = _vloop.pre_loop_end();
   assert(pre_end->stride_is_con(), "pre loop stride is constant");
 
@@ -3310,7 +3310,7 @@ int SuperWord::memory_alignment(MemNode* s, int iv_adjust) {
     tty->print("SuperWord::memory_alignment within a vector memory reference for %d:  ", s->_idx); s->dump();
   }
 #endif
-  VPointer p(s, _vloop);
+  const VPointer& p = get_pointer(s);
   if (!p.valid()) {
     NOT_PRODUCT(if(is_trace_superword_alignment()) tty->print_cr("SuperWord::memory_alignment: VPointer p invalid, return bottom_align");)
     return bottom_align;
@@ -3413,7 +3413,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   Node* orig_limit = pre_opaq->original_loop_limit();
   assert(orig_limit != nullptr && igvn().type(orig_limit) != Type::TOP, "");
 
-  VPointer align_to_ref_p(align_to_ref, _vloop);
+  const VPointer& align_to_ref_p = get_pointer(align_to_ref);
   assert(align_to_ref_p.valid(), "sanity");
 
   // For the main-loop, we want the address of align_to_ref to be memory aligned

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -495,9 +495,9 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.dependency_graph().mutually_independent(nodes);
   }
 
-  // VLoopDependencyGraph Accessors
-  const VPointer& get_pointer(const MemNode* mem) const {
-    return _vloop_analyzer.pointers().get(mem);
+  // VLoopVPointer Accessors
+  const VPointer& vpointer(const MemNode* mem) const {
+    return _vloop_analyzer.vpointers().vpointer(mem);
   }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -495,6 +495,11 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.dependency_graph().mutually_independent(nodes);
   }
 
+  // VLoopDependencyGraph Accessors
+  const VPointer& get_pointer(const MemNode* mem) const {
+    return _vloop_analyzer.pointers().get(mem);
+  }
+
 #ifndef PRODUCT
   // TraceAutoVectorization and TraceSuperWord
   bool is_trace_superword_alignment() const {

--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -425,7 +425,7 @@ class SuperWord : public ResourceObj {
   // Decide if loop can eventually be vectorized, and what unrolling factor is required.
   static void unrolling_analysis(const VLoop &vloop, int &local_loop_unroll_factor);
 
-  // VLoop Accessors
+  // VLoop accessors
   PhaseIdealLoop* phase()     const { return _vloop.phase(); }
   PhaseIterGVN& igvn()        const { return _vloop.phase()->igvn(); }
   IdealLoopTree* lpt()        const { return _vloop.lpt(); }
@@ -434,7 +434,7 @@ class SuperWord : public ResourceObj {
   int iv_stride()             const { return cl()->stride_con(); }
   bool in_bb(const Node* n)   const { return _vloop.in_bb(n); }
 
-  // VLoopReductions Accessors
+  // VLoopReductions accessors
   bool is_marked_reduction(const Node* n) const {
     return _vloop_analyzer.reductions().is_marked_reduction(n);
   }
@@ -443,12 +443,12 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.reductions().is_marked_reduction_pair(n1, n2);
   }
 
-  // VLoopMemorySlices Accessors
+  // VLoopMemorySlices accessors
   bool same_memory_slice(MemNode* n1, MemNode* n2) const {
     return _vloop_analyzer.memory_slices().same_memory_slice(n1, n2);
   }
 
-  // VLoopBody Accessors
+  // VLoopBody accessors
   const GrowableArray<Node*>& body() const {
     return _vloop_analyzer.body().body();
   }
@@ -457,7 +457,7 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.body().bb_idx(n);
   }
 
-  // VLoopTypes Accessors
+  // VLoopTypes accessors
   const Type* velt_type(Node* n) const {
     return _vloop_analyzer.types().velt_type(n);
   }
@@ -482,7 +482,7 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.types().vector_width_in_bytes(n);
   }
 
-  // VLoopDependencyGraph Accessors
+  // VLoopDependencyGraph accessors
   const VLoopDependencyGraph& dependency_graph() const {
     return _vloop_analyzer.dependency_graph();
   }
@@ -495,7 +495,7 @@ class SuperWord : public ResourceObj {
     return _vloop_analyzer.dependency_graph().mutually_independent(nodes);
   }
 
-  // VLoopVPointer Accessors
+  // VLoopVPointer accessors
   const VPointer& vpointer(const MemNode* mem) const {
     return _vloop_analyzer.vpointers().vpointer(mem);
   }

--- a/src/hotspot/share/opto/traceAutoVectorizationTag.hpp
+++ b/src/hotspot/share/opto/traceAutoVectorizationTag.hpp
@@ -29,12 +29,13 @@
 #include "utilities/stringUtils.hpp"
 
 #define COMPILER_TRACE_AUTO_VECTORIZATION_TAG(flags) \
-  flags(POINTER_ANALYSIS,     "Trace VPointer") \
+  flags(POINTER_ANALYSIS,     "Trace VPointer (verbose)") \
   flags(PRECONDITIONS,        "Trace VLoop::check_preconditions") \
   flags(LOOP_ANALYZER,        "Trace VLoopAnalyzer::setup_submodules") \
   flags(MEMORY_SLICES,        "Trace VLoopMemorySlices") \
   flags(BODY,                 "Trace VLoopBody") \
   flags(TYPES,                "Trace VLoopTypes") \
+  flags(POINTERS,             "Trace VLoopPointers") \
   flags(DEPENDENCY_GRAPH,     "Trace VLoopDependencyGraph") \
   flags(SW_ALIGNMENT,         "Trace SuperWord alignment analysis") \
   flags(SW_ADJACENT_MEMOPS,   "Trace SuperWord::find_adjacent_refs") \

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -183,13 +183,13 @@ VStatus VLoopAnalyzer::setup_submodules_helper() {
 
 void VLoopVPointers::compute_and_cache() {
   // Count
-  int number_of_vpointers = 0;
+  _vpointers_length = 0;
   _body.for_each_mem([&] (const MemNode* mem, int bb_idx) {
-    number_of_vpointers++;
+    _vpointers_length++;
   });
 
   // Allocate
-  uint bytes = number_of_vpointers * sizeof(VPointer);
+  uint bytes = _vpointers_length * sizeof(VPointer);
   _vpointers = (VPointer*)_arena->Amalloc(bytes);
 
   // Compute and Cache
@@ -208,7 +208,7 @@ const VPointer& VLoopVPointers::vpointer(const MemNode* mem) const {
   assert(mem != nullptr && _vloop.in_bb(mem), "only mem in loop");
   int bb_idx = _body.bb_idx(mem);
   int pointers_idx = _bb_idx_to_vpointer.at(bb_idx);
-  assert(pointers_idx >= 0, "mem node must have a cached pointer");
+  assert(0 <= pointers_idx && pointers_idx < _vpointers_length, "valid range");
   return _vpointers[pointers_idx];
 }
 

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -216,14 +216,11 @@ const VPointer& VLoopVPointers::vpointer(const MemNode* mem) const {
 void VLoopVPointers::print() const {
   tty->print_cr("\nVLoopVPointers::print:");
 
-  for (int i = 0; i < _body.body().length(); i++) {
-    MemNode* mem = _body.body().at(i)->isa_Mem();
-    if (mem != nullptr && _vloop.in_bb(mem)) {
-      const VPointer& p = vpointer(mem);
-      tty->print("  ");
-      p.print();
-    }
-  }
+  _body.for_each_mem([&] (const MemNode* mem, int bb_idx) {
+    const VPointer& p = vpointer(mem);
+    tty->print("  ");
+    p.print();
+  });
 }
 #endif
 

--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -257,7 +257,7 @@ void VLoopDependencyGraph::construct() {
       MemNode* n1 = slice_nodes.at(j);
       memory_pred_edges.clear();
 
-      VPointer p1(n1, _vloop);
+      const VPointer& p1 = _pointers.get(n1);
       // For all memory nodes before it, check if we need to add a memory edge.
       for (int k = slice_nodes.length() - 1; k > j; k--) {
         MemNode* n2 = slice_nodes.at(k);
@@ -265,7 +265,7 @@ void VLoopDependencyGraph::construct() {
         // Ignore Load-Load dependencies:
         if (n1->is_Load() && n2->is_Load()) { continue; }
 
-        VPointer p2(n2, _vloop);
+        const VPointer& p2 = _pointers.get(n2);
         if (!VPointer::not_equal(p1.cmp(p2))) {
           // Possibly overlapping memory
           memory_pred_edges.append(_body.bb_idx(n2));

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -362,6 +362,16 @@ public:
     return _body_idx.at(n->_idx);
   }
 
+  template<typename Callback>
+  void for_each_mem(Callback callback) const {
+    for (int i = 0; i < _body.length(); i++) {
+      MemNode* mem = _body.at(i)->isa_Mem();
+      if (mem != nullptr && _vloop.in_bb(mem)) {
+        callback(mem, i);
+      }
+    }
+  }
+
 private:
   void set_bb_idx(Node* n, int i) {
     _body_idx.at_put_grow(n->_idx, i);

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -471,6 +471,7 @@ private:
 
   // Array of cached pointers
   VPointer* _vpointers;
+  int _vpointers_length;
 
   // Map bb_idx -> index in _vpointers. -1 if not mapped.
   GrowableArray<int> _bb_idx_to_vpointer;

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -490,9 +490,14 @@ public:
                         -1) {}
   NONCOPYABLE(VLoopVPointers);
 
-  void compute_and_cache();
+  void compute_vpointers();
   const VPointer& vpointer(const MemNode* mem) const;
   NOT_PRODUCT( void print() const; )
+
+private:
+  void count_vpointers();
+  void allocate_vpointers_array();
+  void compute_and_cache_vpointers();
 };
 
 // Submodule of VLoopAnalyzer.

--- a/src/hotspot/share/opto/vectorization.hpp
+++ b/src/hotspot/share/opto/vectorization.hpp
@@ -156,7 +156,7 @@ public:
     return _vtrace.is_trace(TraceAutoVectorizationTag::DEPENDENCY_GRAPH);
   }
 
-  bool is_trace_pointers() const {
+  bool is_trace_vpointers() const {
     return _vtrace.is_trace(TraceAutoVectorizationTag::POINTERS);
   }
 
@@ -453,34 +453,34 @@ private:
 
 // Submodule of VLoopAnalyzer.
 // We compute and cache the VPointer for every load and store.
-class VLoopPointers : public StackObj {
+class VLoopVPointers : public StackObj {
 private:
   Arena*                   _arena;
   const VLoop&             _vloop;
   const VLoopBody&         _body;
 
   // Array of cached pointers
-  VPointer* _pointers;
+  VPointer* _vpointers;
 
-  // Map bb_idx -> index in _pointers. -1 if not mapped.
-  GrowableArray<int> _bb_idx_to_pointer;
+  // Map bb_idx -> index in _vpointers. -1 if not mapped.
+  GrowableArray<int> _bb_idx_to_vpointer;
 
 public:
-  VLoopPointers(Arena* arena,
-                const VLoop& vloop,
-                const VLoopBody& body) :
+  VLoopVPointers(Arena* arena,
+                 const VLoop& vloop,
+                 const VLoopBody& body) :
     _arena(arena),
     _vloop(vloop),
     _body(body),
-    _pointers(nullptr),
-    _bb_idx_to_pointer(arena,
-                       vloop.estimated_body_length(),
-                       vloop.estimated_body_length(),
-                       -1) {}
-  NONCOPYABLE(VLoopPointers);
+    _vpointers(nullptr),
+    _bb_idx_to_vpointer(arena,
+                        vloop.estimated_body_length(),
+                        vloop.estimated_body_length(),
+                        -1) {}
+  NONCOPYABLE(VLoopVPointers);
 
   void compute_and_cache();
-  const VPointer& get(const MemNode* mem) const;
+  const VPointer& vpointer(const MemNode* mem) const;
   NOT_PRODUCT( void print() const; )
 };
 
@@ -500,7 +500,7 @@ private:
   const VLoop&             _vloop;
   const VLoopBody&         _body;
   const VLoopMemorySlices& _memory_slices;
-  const VLoopPointers&     _pointers;
+  const VLoopVPointers&    _vpointers;
 
   // bb_idx -> DependenceNode*
   GrowableArray<DependencyNode*> _dependency_nodes;
@@ -513,12 +513,12 @@ public:
                        const VLoop& vloop,
                        const VLoopBody& body,
                        const VLoopMemorySlices& memory_slices,
-                       const VLoopPointers& pointers) :
+                       const VLoopVPointers& pointers) :
     _arena(arena),
     _vloop(vloop),
     _body(body),
     _memory_slices(memory_slices),
-    _pointers(pointers),
+    _vpointers(pointers),
     _dependency_nodes(arena,
                       vloop.estimated_body_length(),
                       vloop.estimated_body_length(),
@@ -612,7 +612,7 @@ private:
   VLoopMemorySlices    _memory_slices;
   VLoopBody            _body;
   VLoopTypes           _types;
-  VLoopPointers        _pointers;
+  VLoopVPointers       _vpointers;
   VLoopDependencyGraph _dependency_graph;
 
 public:
@@ -624,8 +624,8 @@ public:
     _memory_slices   (&_arena, vloop),
     _body            (&_arena, vloop, vshared),
     _types           (&_arena, vloop, _body),
-    _pointers        (&_arena, vloop, _body),
-    _dependency_graph(&_arena, vloop, _body, _memory_slices, _pointers)
+    _vpointers       (&_arena, vloop, _body),
+    _dependency_graph(&_arena, vloop, _body, _memory_slices, _vpointers)
   {
     _success = setup_submodules();
   }
@@ -639,7 +639,7 @@ public:
   const VLoopMemorySlices& memory_slices()       const { return _memory_slices; }
   const VLoopBody& body()                        const { return _body; }
   const VLoopTypes& types()                      const { return _types; }
-  const VLoopPointers& pointers()                const { return _pointers; }
+  const VLoopVPointers& vpointers()              const { return _vpointers; }
   const VLoopDependencyGraph& dependency_graph() const { return _dependency_graph; }
 
 private:


### PR DESCRIPTION
This is a subtask of [JDK-8315361](https://bugs.openjdk.org/browse/JDK-8315361).

Parsing `VPointer` currently happens all over SuperWord. And often in quadratic loops, where we compare all-with-all loads/stores.

I propose to cache the `VPointer`s, then we can do a constant-time cache lookup rather than parsing the pointer subgraph every time.

There are now only a few cases where we cannot use the cached `VPointer`:
- `SuperWord::unrolling_analysis`: we have no `VLoopAnalyzer`, and so no submodules like `VLoopPointers`. We don't need to cache, since we only iterate over the loop body once, and create only a single `VPointer` per memop.
- `SuperWord::output`: when we have a `Load`, and try to bypass `StoreVector` nodes. The `StoreVector` nodes are new, and so we have no cached `VPointer` for them. This could be fixed somehow, but I don't want to deal with it now. I intend to refactor `SuperWord::output` soon, and can look into options at that point (either I bypass before we insert the vector nodes, or I remember what scalar memop the vector was created from, and then get the cached pointer this way).

This changeset is also a preparation step for [JDK-8325155](https://bugs.openjdk.org/browse/JDK-8325155). I will have a list of pointers, and sort them such that creating adjacent refs is much more efficient.

**Benchmarking SuperWord Compile Time**

I use the same benchmark from https://github.com/openjdk/jdk/pull/18532.

On master:
```
    C2 Compile Time:       56.816 s
         IdealLoop:            56.604 s
           AutoVectorize:      56.192 s
```

With this patch:
```
    C2 Compile Time:       49.719 s
         IdealLoop:            49.509 s
           AutoVectorize:      49.106 s
```

This saves us about `7 sec`, which is significant. I will have to see what it effect it has once we also apply https://github.com/openjdk/jdk/pull/18532, but I think the combined effect will be very significant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326962](https://bugs.openjdk.org/browse/JDK-8326962): C2 SuperWord: cache VPointer (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18577/head:pull/18577` \
`$ git checkout pull/18577`

Update a local copy of the PR: \
`$ git checkout pull/18577` \
`$ git pull https://git.openjdk.org/jdk.git pull/18577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18577`

View PR using the GUI difftool: \
`$ git pr show -t 18577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18577.diff">https://git.openjdk.org/jdk/pull/18577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18577#issuecomment-2032002927)