### PR TITLE
8329099: Undocumented exception thrown by Instruction factory methods accepting Opcode

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
@@ -54,6 +54,8 @@ public sealed interface ArrayLoadInstruction extends Instruction
      *
      * @param op the opcode for the specific type of array load instruction,
      *           which must be of kind {@link Opcode.Kind#ARRAY_LOAD}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#ARRAY_LOAD}.
      */
     static ArrayLoadInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.ARRAY_LOAD);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
@@ -54,6 +54,8 @@ public sealed interface ArrayStoreInstruction extends Instruction
      *
      * @param op the opcode for the specific type of array store instruction,
      *           which must be of kind {@link Opcode.Kind#ARRAY_STORE}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#ARRAY_STORE}.
      */
     static ArrayStoreInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.ARRAY_STORE);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
@@ -56,6 +56,8 @@ public sealed interface BranchInstruction extends Instruction
      * @param op the opcode for the specific type of branch instruction,
      *           which must be of kind {@link Opcode.Kind#BRANCH}
      * @param target the target of the branch
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#BRANCH}.
      */
     static BranchInstruction of(Opcode op, Label target) {
         Util.checkKind(op, Opcode.Kind.BRANCH);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
@@ -131,6 +131,8 @@ public sealed interface ConstantInstruction extends Instruction {
      *
      * @param op the opcode for the specific type of intrinsic constant instruction,
      *           which must be of kind {@link Opcode.Kind#CONSTANT}
+     * @throws IllegalArgumentException if the opcode does not represent a constant
+     *                                  with implicit value
      */
     static IntrinsicConstantInstruction ofIntrinsic(Opcode op) {
         Util.checkKind(op, Opcode.Kind.CONSTANT);
@@ -145,6 +147,8 @@ public sealed interface ConstantInstruction extends Instruction {
      * @param op the opcode for the specific type of intrinsic constant instruction,
      *           which must be of kind {@link Opcode.Kind#CONSTANT}
      * @param value the constant value
+     * @throws IllegalArgumentException if the opcode is not {@link Opcode#BIPUSH}
+     *                                  or {@link Opcode#SIPUSH}
      */
     static ArgumentConstantInstruction ofArgument(Opcode op, int value) {
         Util.checkKind(op, Opcode.Kind.CONSTANT);
@@ -159,6 +163,8 @@ public sealed interface ConstantInstruction extends Instruction {
      * @param op the opcode for the specific type of load constant instruction,
      *           which must be of kind {@link Opcode.Kind#CONSTANT}
      * @param constant the constant value
+     * @throws IllegalArgumentException if the opcode is not {@link Opcode#LDC},
+     *                                  {@link Opcode#LDC_W}, or {@link Opcode#LDC2_W}
      */
     static LoadConstantInstruction ofLoad(Opcode op, LoadableConstantEntry constant) {
         Util.checkKind(op, Opcode.Kind.CONSTANT);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
@@ -70,6 +70,8 @@ public sealed interface ConvertInstruction extends Instruction
      *
      * @param op the opcode for the specific type of conversion instruction,
      *           which must be of kind {@link Opcode.Kind#CONVERT}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#CONVERT}.
      */
     static ConvertInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.CONVERT);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
@@ -68,6 +68,8 @@ public sealed interface DiscontinuedInstruction extends Instruction {
          * @param op the opcode for the specific type of JSR instruction,
          *           which must be of kind {@link Opcode.Kind#DISCONTINUED_JSR}
          * @param target target label of the subroutine
+         * @throws IllegalArgumentException if the opcode kind is not
+         *         {@link Opcode.Kind#DISCONTINUED_JSR}.
          */
         static JsrInstruction of(Opcode op, Label target) {
             Util.checkKind(op, Opcode.Kind.DISCONTINUED_JSR);
@@ -109,6 +111,8 @@ public sealed interface DiscontinuedInstruction extends Instruction {
          * @param op the opcode for the specific type of RET instruction,
          *           which must be of kind {@link Opcode.Kind#DISCONTINUED_RET}
          * @param slot the local variable slot to load return address from
+         * @throws IllegalArgumentException if the opcode kind is not
+         *         {@link Opcode.Kind#DISCONTINUED_RET}.
          */
         static RetInstruction of(Opcode op, int slot) {
             Util.checkKind(op, Opcode.Kind.DISCONTINUED_RET);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
@@ -89,6 +89,8 @@ public sealed interface FieldInstruction extends Instruction
      * @param op the opcode for the specific type of field access instruction,
      *           which must be of kind {@link Opcode.Kind#FIELD_ACCESS}
      * @param field a constant pool entry describing the field
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#FIELD_ACCESS}.
      */
     static FieldInstruction of(Opcode op, FieldRefEntry field) {
         Util.checkKind(op, Opcode.Kind.FIELD_ACCESS);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
@@ -104,6 +104,8 @@ public sealed interface InvokeInstruction extends Instruction
      * @param op the opcode for the specific type of invocation instruction,
      *           which must be of kind {@link Opcode.Kind#INVOKE}
      * @param method a constant pool entry describing the method
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#INVOKE}.
      */
     static InvokeInstruction of(Opcode op, MemberRefEntry method) {
         Util.checkKind(op, Opcode.Kind.INVOKE);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
@@ -73,6 +73,8 @@ public sealed interface LoadInstruction extends Instruction
      * @param op the opcode for the specific type of load instruction,
      *           which must be of kind {@link Opcode.Kind#LOAD}
      * @param slot the local variable slot to load from
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#LOAD}.
      */
     static LoadInstruction of(Opcode op, int slot) {
         Util.checkKind(op, Opcode.Kind.LOAD);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
@@ -48,6 +48,8 @@ public sealed interface MonitorInstruction extends Instruction
      *
      * @param op the opcode for the specific type of monitor instruction,
      *           which must be of kind {@link Opcode.Kind#MONITOR}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#MONITOR}.
      */
     static MonitorInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.MONITOR);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
@@ -28,7 +28,6 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.TypeKind;
-import static java.util.Objects.requireNonNull;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.javac.PreviewFeature;
 
@@ -56,7 +55,8 @@ public sealed interface NewPrimitiveArrayInstruction extends Instruction
      *                                  primitive array component type
      */
     static NewPrimitiveArrayInstruction of(TypeKind typeKind) {
-        if (requireNonNull(typeKind).newarraycode() < 0) {
+        // Implicit null-check:
+        if (typeKind.newarraycode() < 0) {
             throw new IllegalArgumentException("Illegal component type: " + typeKind.typeName());
         }
         return new AbstractInstruction.UnboundNewPrimitiveArrayInstruction(typeKind);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
@@ -28,6 +28,7 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.TypeKind;
+import static java.util.Objects.requireNonNull;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.javac.PreviewFeature;
 
@@ -51,8 +52,13 @@ public sealed interface NewPrimitiveArrayInstruction extends Instruction
      * {@return a new primitive array instruction}
      *
      * @param typeKind the component type of the array
+     * @throws IllegalArgumentException when the {@code typeKind} is not a legal
+     *                                  primitive array component type
      */
     static NewPrimitiveArrayInstruction of(TypeKind typeKind) {
+        if (requireNonNull(typeKind).newarraycode() < 0) {
+            throw new IllegalArgumentException("Illegal component type: " + typeKind.typeName());
+        }
         return new AbstractInstruction.UnboundNewPrimitiveArrayInstruction(typeKind);
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
@@ -54,6 +54,8 @@ public sealed interface OperatorInstruction extends Instruction
      *
      * @param op the opcode for the specific type of array load instruction,
      *           which must be of kind {@link Opcode.Kind#OPERATOR}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#OPERATOR}.
      */
     static OperatorInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.OPERATOR);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
@@ -65,6 +65,8 @@ public sealed interface ReturnInstruction extends Instruction
      *
      * @param op the opcode for the specific type of return instruction,
      *           which must be of kind {@link Opcode.Kind#RETURN}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#RETURN}.
      */
     static ReturnInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.RETURN);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
@@ -49,6 +49,8 @@ public sealed interface StackInstruction extends Instruction
      *
      * @param op the opcode for the specific type of stack instruction,
      *           which must be of kind {@link Opcode.Kind#STACK}
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#STACK}.
      */
     static StackInstruction of(Opcode op) {
         Util.checkKind(op, Opcode.Kind.STACK);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
@@ -72,6 +72,8 @@ public sealed interface StoreInstruction extends Instruction
      * @param op the opcode for the specific type of store instruction,
      *           which must be of kind {@link Opcode.Kind#STORE}
      * @param slot the local variable slot to store to
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#STORE}.
      */
     static StoreInstruction of(Opcode op, int slot) {
         Util.checkKind(op, Opcode.Kind.STORE);

--- a/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
@@ -59,6 +59,8 @@ public sealed interface TypeCheckInstruction extends Instruction
      * @param op the opcode for the specific type of type check instruction,
      *           which must be of kind {@link Opcode.Kind#TYPE_CHECK}
      * @param type the type against which to check or cast
+     * @throws IllegalArgumentException if the opcode kind is not
+     *         {@link Opcode.Kind#TYPE_CHECK}.
      */
     static TypeCheckInstruction of(Opcode op, ClassEntry type) {
         Util.checkKind(op, Opcode.Kind.TYPE_CHECK);

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -232,6 +232,12 @@
  * the convenience method {@code CodeBuilder.invokeInstruction}, which in turn behaves
  * as if it calls method {@code CodeBuilder.with}. This composing of method calls on the
  * builder enables the composing of transforms (as described later).
+ * <p>
+ * Unless otherwise noted, passing a {@code null} argument to a constructor
+ * or method of any Class-File API class or interface will cause a {@link
+ * java.lang.NullPointerException NullPointerException} to be thrown. Additionally,
+ * invoking a method with an array or collection containing a {@code null} element
+ * will cause a {@code NullPointerException}, unless otherwise specified. </p>
  *
  * <h3>Symbolic information</h3>
  * To describe symbolic information for classes and types, the API uses the


### PR DESCRIPTION
`IllegalArgumentException` thrown by some static factory methods of the following `java.lang.classfile.instruction` interfaces are not documented:

- `ArrayLoadInstruction`
- `ArrayStoreInstruction`
- `BranchInstruction`
- `ConvertInstruction`
- `DiscontinuedInstruction`
- `FieldInstruction`
- `InvokeInstruction`
- `LoadInstruction`
- `MonitorInstruction`
- `NewPrimitiveArrayInstruction`
- `OperatorInstruction`
- `ReturnInstruction`
- `StackInstruction`
- `StoreInstruction`
- `TypeCheckInstruction`

`NewPrimitiveArrayInstruction::of` factory method also does not perform the check for invalid argument.

This patch adds all the missing `@throws` Javadoc tags and fixes `NewPrimitiveArrayInstruction::of` factory method to perform the argument check.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8329501](https://bugs.openjdk.org/browse/JDK-8329501) to be approved

### Issues
 * [JDK-8329099](https://bugs.openjdk.org/browse/JDK-8329099): Undocumented exception thrown by Instruction factory methods accepting Opcode (**Bug** - P4)
 * [JDK-8329501](https://bugs.openjdk.org/browse/JDK-8329501): Undocumented exception thrown by Instruction factory methods accepting Opcode (**CSR**)


### Reviewers
 * [Brian Goetz](https://openjdk.org/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18578/head:pull/18578` \
`$ git checkout pull/18578`

Update a local copy of the PR: \
`$ git checkout pull/18578` \
`$ git pull https://git.openjdk.org/jdk.git pull/18578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18578`

View PR using the GUI difftool: \
`$ git pr show -t 18578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18578.diff">https://git.openjdk.org/jdk/pull/18578.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18578#issuecomment-2031543176)