### PR TITLE
8329510: Update ProblemList for JFileChooser/8194044/FileSystemRootTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -663,7 +663,7 @@ javax/swing/JTree/DnD/LastNodeLowerHalfDrop.java 8159131 linux-all
 javax/swing/JTree/4633594/JTreeFocusTest.java 7105441 macosx-all
 javax/swing/AbstractButton/6711682/bug6711682.java 8060765 windows-all,macosx-all
 javax/swing/JFileChooser/6396844/TwentyThousandTest.java 8198003 generic-all
-javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8320944 windows-all
+javax/swing/JFileChooser/8194044/FileSystemRootTest.java 8327236 windows-all
 javax/swing/JPopupMenu/6800513/bug6800513.java 7184956 macosx-all
 javax/swing/JTabbedPane/8007563/Test8007563.java 8051591 generic-all
 javax/swing/JTabbedPane/4624207/bug4624207.java 8064922 macosx-all


### PR DESCRIPTION
Update the problem-list entry for ` javax/swing/JFileChooser/8194044/FileSystemRootTest.java` to refer to [JDK-8327236](https://bugs.openjdk.org/browse/JDK-8327236) under which the failure with `"root drive reported as false"` is tracked.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329510](https://bugs.openjdk.org/browse/JDK-8329510): Update ProblemList for JFileChooser/8194044/FileSystemRootTest.java (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18580/head:pull/18580` \
`$ git checkout pull/18580`

Update a local copy of the PR: \
`$ git checkout pull/18580` \
`$ git pull https://git.openjdk.org/jdk.git pull/18580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18580`

View PR using the GUI difftool: \
`$ git pr show -t 18580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18580.diff">https://git.openjdk.org/jdk/pull/18580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18580#issuecomment-2031657860)