### PR TITLE
JDK-8329089: Empty immutable list throws the wrong exception type for remove(first | last) operations

### DIFF
--- a/src/java.base/share/classes/java/util/ImmutableCollections.java
+++ b/src/java.base/share/classes/java/util/ImmutableCollections.java
@@ -258,6 +258,8 @@ class ImmutableCollections {
         @Override public void    add(int index, E element) { throw uoe(); }
         @Override public boolean addAll(int index, Collection<? extends E> c) { throw uoe(); }
         @Override public E       remove(int index) { throw uoe(); }
+        @Override public E       removeFirst() { throw uoe(); }
+        @Override public E       removeLast() { throw uoe(); }
         @Override public void    replaceAll(UnaryOperator<E> operator) { throw uoe(); }
         @Override public E       set(int index, E element) { throw uoe(); }
         @Override public void    sort(Comparator<? super E> c) { throw uoe(); }

--- a/test/jdk/java/util/Collection/MOAT.java
+++ b/test/jdk/java/util/Collection/MOAT.java
@@ -246,6 +246,7 @@ public class MOAT {
             testCollection(list);
             testImmutableList(list);
             testListMutatorsAlwaysThrow(list);
+            testImmutableListMutatorsAlwaysThrow(list);
             if (list.size() >= 1) {
                 // test subLists
                 List<Integer> headList = list.subList(0, list.size() - 1);
@@ -562,6 +563,12 @@ public class MOAT {
         testCollMutatorsAlwaysThrow(c);
         THROWS(UnsupportedOperationException.class,
                 () -> c.addAll(0, Collections.emptyList()));
+    }
+
+    private static void testImmutableListMutatorsAlwaysThrow(List<Integer> c) {
+        THROWS(UnsupportedOperationException.class,
+                c::removeFirst,
+                c::removeLast);
     }
 
     /**


### PR DESCRIPTION
This PR proposes to make empty immutable lists always throw UOE on `removeFirst` and `removeLast`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329089](https://bugs.openjdk.org/browse/JDK-8329089): Empty immutable list throws the wrong exception type for remove(first | last) operations (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18581/head:pull/18581` \
`$ git checkout pull/18581`

Update a local copy of the PR: \
`$ git checkout pull/18581` \
`$ git pull https://git.openjdk.org/jdk.git pull/18581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18581`

View PR using the GUI difftool: \
`$ git pr show -t 18581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18581.diff">https://git.openjdk.org/jdk/pull/18581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18581#issuecomment-2031665013)