### PR TITLE
8329546: Assume sized integral types are available

### DIFF
--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,11 @@
 // declarations and a few frequently used utility functions.
 
 #include <ctype.h>
+#include <inttypes.h>
 #include <string.h>
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <wchar.h>
@@ -49,7 +51,6 @@
 #include <errno.h>
 
 #if defined(LINUX) || defined(_ALLBSD_SOURCE)
-#include <inttypes.h>
 #include <signal.h>
 #ifndef __OpenBSD__
 #include <ucontext.h>
@@ -78,28 +79,6 @@
 #else
   #define NULL_WORD  NULL
 #endif
-
-#if !defined(LINUX) && !defined(_ALLBSD_SOURCE)
-// Compiler-specific primitive types
-typedef unsigned short     uint16_t;
-#ifndef _UINT32_T
-#define _UINT32_T
-typedef unsigned int       uint32_t;
-#endif // _UINT32_T
-
-#if !defined(_SYS_INT_TYPES_H)
-#ifndef _UINT64_T
-#define _UINT64_T
-typedef unsigned long long uint64_t;
-#endif // _UINT64_T
-// %%%% how to access definition of intptr_t portably in 5.5 onward?
-typedef int                     intptr_t;
-typedef unsigned int            uintptr_t;
-// If this gets an error, figure out a symbol XXX that implies the
-// prior definition of intptr_t, and add "&& !defined(XXX)" above.
-#endif // _SYS_INT_TYPES_H
-
-#endif // !LINUX && !_ALLBSD_SOURCE
 
 // checking for nanness
 #if defined(__APPLE__)


### PR DESCRIPTION
Please review this change that cleans up the inclusion of <stdint.h> and
<inttypes.h> when using gcc/clang as the compiler.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329546](https://bugs.openjdk.org/browse/JDK-8329546): Assume sized integral types are available (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18586/head:pull/18586` \
`$ git checkout pull/18586`

Update a local copy of the PR: \
`$ git checkout pull/18586` \
`$ git pull https://git.openjdk.org/jdk.git pull/18586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18586`

View PR using the GUI difftool: \
`$ git pr show -t 18586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18586.diff">https://git.openjdk.org/jdk/pull/18586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18586#issuecomment-2033015381)