### PR TITLE
JDK-8329557: Fix statement around MathContext.DECIMAL128 rounding

### DIFF
--- a/src/java.base/share/classes/java/math/MathContext.java
+++ b/src/java.base/share/classes/java/math/MathContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,8 @@ public final class MathContext implements Serializable {
      * A {@code MathContext} object with a precision setting
      * matching the precision of the IEEE 754-2019 decimal32 format, 7 digits, and a
      * rounding mode of {@link RoundingMode#HALF_EVEN HALF_EVEN}.
-     * Note the exponent range of decimal32 is <em>not</em> used for
-     * rounding.
+     * Note the exponent range of decimal32 (min exponent of -95, max
+     * exponent of 96) is <em>not</em> used for rounding.
      */
     public static final MathContext DECIMAL32 =
         new MathContext(7, RoundingMode.HALF_EVEN);
@@ -92,8 +92,8 @@ public final class MathContext implements Serializable {
      * A {@code MathContext} object with a precision setting
      * matching the precision of the IEEE 754-2019 decimal64 format, 16 digits, and a
      * rounding mode of {@link RoundingMode#HALF_EVEN HALF_EVEN}.
-     * Note the exponent range of decimal64 is <em>not</em> used for
-     * rounding.
+     * Note the exponent range of decimal64 (min exponent of -383, max
+     * exponent of 384) is <em>not</em> used for rounding.
      */
     public static final MathContext DECIMAL64 =
         new MathContext(16, RoundingMode.HALF_EVEN);
@@ -102,8 +102,8 @@ public final class MathContext implements Serializable {
      * A {@code MathContext} object with a precision setting
      * matching the precision of the IEEE 754-2019 decimal128 format, 34 digits, and a
      * rounding mode of {@link RoundingMode#HALF_EVEN HALF_EVEN}.
-     * Note the exponent range of decimal64 is <em>not</em> used for
-     * rounding.
+     * Note the exponent range of decimal128 (min exponent of -6143,
+     * max exponent of 6144) is <em>not</em> used for rounding.
      */
     public static final MathContext DECIMAL128 =
         new MathContext(34, RoundingMode.HALF_EVEN);


### PR DESCRIPTION
Happened to notice a semantic typo in the description of MathContext.DECIMAL128, use of "decimal64" where "decimal128" was intended, and added some additional information to make the related descriptions more informative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329557](https://bugs.openjdk.org/browse/JDK-8329557): Fix statement around MathContext.DECIMAL128 rounding (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18587/head:pull/18587` \
`$ git checkout pull/18587`

Update a local copy of the PR: \
`$ git checkout pull/18587` \
`$ git pull https://git.openjdk.org/jdk.git pull/18587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18587`

View PR using the GUI difftool: \
`$ git pr show -t 18587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18587.diff">https://git.openjdk.org/jdk/pull/18587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18587#issuecomment-2033292252)