### PR TITLE
JDK-8329564: [JVMCI] TranslatedException::debugPrintStackTrace does not work in the libjvmci compiler.

### DIFF
--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -764,7 +764,7 @@ class SerializeClosure;
   template(decodeAndThrowThrowable_name,               "decodeAndThrowThrowable")                                 \
   template(encodeAnnotations_name,                     "encodeAnnotations")                                       \
   template(encodeAnnotations_signature,                "([BLjava/lang/Class;Ljdk/internal/reflect/ConstantPool;Z[Ljava/lang/Class;)[B")\
-  template(decodeAndThrowThrowable_signature,          "(IJZ)V")                                                  \
+  template(decodeAndThrowThrowable_signature,          "(IJZZ)V")                                                  \
   template(classRedefinedCount_name,                   "classRedefinedCount")                                     \
   template(classLoader_name,                           "classLoader")                                             \
   template(componentType_name,                         "componentType")                                           \

--- a/src/hotspot/share/classfile/vmSymbols.hpp
+++ b/src/hotspot/share/classfile/vmSymbols.hpp
@@ -764,7 +764,7 @@ class SerializeClosure;
   template(decodeAndThrowThrowable_name,               "decodeAndThrowThrowable")                                 \
   template(encodeAnnotations_name,                     "encodeAnnotations")                                       \
   template(encodeAnnotations_signature,                "([BLjava/lang/Class;Ljdk/internal/reflect/ConstantPool;Z[Ljava/lang/Class;)[B")\
-  template(decodeAndThrowThrowable_signature,          "(IJZZ)V")                                                  \
+  template(decodeAndThrowThrowable_signature,          "(IJZZ)V")                                                 \
   template(classRedefinedCount_name,                   "classRedefinedCount")                                     \
   template(classLoader_name,                           "classLoader")                                             \
   template(componentType_name,                         "componentType")                                           \

--- a/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
+++ b/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
@@ -122,26 +122,26 @@ final class TranslatedException extends Exception {
      * Prints a stack trace for {@code throwable} if the system property
      * {@code "jdk.internal.vm.TranslatedException.debug"} is true.
      */
-    private static void debugPrintStackTrace(Throwable throwable) {
-        if (Boolean.getBoolean("jdk.internal.vm.TranslatedException.debug")) {
+    private static void debugPrintStackTrace(Throwable throwable, boolean debug) {
+        if (debug) {
             System.err.print("DEBUG: ");
             throwable.printStackTrace();
         }
     }
 
-    private static Throwable initCause(Throwable throwable, Throwable cause) {
+    private static Throwable initCause(Throwable throwable, Throwable cause, boolean debug) {
         if (cause != null) {
             try {
                 throwable.initCause(cause);
             } catch (IllegalStateException e) {
                 // Cause could not be set or overwritten.
-                debugPrintStackTrace(e);
+                debugPrintStackTrace(e, debug);
             }
         }
         return throwable;
     }
 
-    private static Throwable create(String className, String message, Throwable cause) {
+    private static Throwable create(String className, String message, Throwable cause, boolean debug) {
         // Try create with reflection first.
         try {
             Class<?> cls = Class.forName(className);
@@ -157,13 +157,13 @@ final class TranslatedException extends Exception {
             }
             if (message == null) {
                 Constructor<?> cons = cls.getConstructor();
-                return initCause((Throwable) cons.newInstance(), cause);
+                return initCause((Throwable) cons.newInstance(), cause, debug);
             }
             Constructor<?> cons = cls.getDeclaredConstructor(String.class);
-            return initCause((Throwable) cons.newInstance(message), cause);
+            return initCause((Throwable) cons.newInstance(message), cause, debug);
         } catch (Throwable translationFailure) {
-            debugPrintStackTrace(translationFailure);
-            return initCause(new TranslatedException(message, className), cause);
+            debugPrintStackTrace(translationFailure, debug);
+            return initCause(new TranslatedException(message, className), cause, debug);
         }
     }
 
@@ -253,7 +253,7 @@ final class TranslatedException extends Exception {
      * @param encodedThrowable an encoded exception in the format specified by
      *            {@link #encodeThrowable}
      */
-    static Throwable decodeThrowable(byte[] encodedThrowable) {
+    static Throwable decodeThrowable(byte[] encodedThrowable, boolean debug) {
         ByteArrayInputStream bais = new ByteArrayInputStream(encodedThrowable);
         try (DataInputStream dis = new DataInputStream(new GZIPInputStream(bais))) {
             Throwable cause = null;
@@ -262,7 +262,7 @@ final class TranslatedException extends Exception {
             while (dis.available() != 0) {
                 String exceptionClassName = dis.readUTF();
                 String exceptionMessage = emptyAsNull(dis.readUTF());
-                throwable = create(exceptionClassName, exceptionMessage, cause);
+                throwable = create(exceptionClassName, exceptionMessage, cause, debug);
                 int stackTraceDepth = dis.readInt();
                 StackTraceElement[] stackTrace = new StackTraceElement[stackTraceDepth + myStack.length];
                 int stackTraceIndex = 0;
@@ -310,7 +310,7 @@ final class TranslatedException extends Exception {
             }
             return throwable;
         } catch (Throwable translationFailure) {
-            debugPrintStackTrace(translationFailure);
+            debugPrintStackTrace(translationFailure, debug);
             return new TranslatedException("Error decoding exception: " + encodedThrowable,
                                            translationFailure.getClass().getName());
         }

--- a/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
+++ b/src/java.base/share/classes/jdk/internal/vm/VMSupport.java
@@ -125,8 +125,9 @@ public class VMSupport {
      *            </pre>
      * @param buffer encoded info about the exception to throw (depends on {@code format})
      * @param inJVMHeap [@code true} if executing in the JVM heap, {@code false} otherwise
+     * @param debug specifies whether debug stack traces should be enabled in case of translation failure
      */
-    public static void decodeAndThrowThrowable(int format, long buffer, boolean inJVMHeap) throws Throwable {
+    public static void decodeAndThrowThrowable(int format, long buffer, boolean inJVMHeap, boolean debug) throws Throwable {
         if (format != 0) {
             String context = String.format("while encoding an exception to translate it %s the JVM heap",
                     inJVMHeap ? "to" : "from");
@@ -142,7 +143,7 @@ public class VMSupport {
             }
             throw new InternalError("unexpected problem occurred " + context);
         }
-        throw TranslatedException.decodeThrowable(bufferToBytes(buffer));
+        throw TranslatedException.decodeThrowable(bufferToBytes(buffer), debug);
     }
 
     private static byte[] bufferToBytes(long buffer) {

--- a/test/jdk/jdk/internal/vm/TestTranslatedException.java
+++ b/test/jdk/jdk/internal/vm/TestTranslatedException.java
@@ -60,7 +60,7 @@ public class TestTranslatedException {
         encodeDecode(throwable);
 
         try {
-            VMSupport.decodeAndThrowThrowable(0, 0L, true);
+            VMSupport.decodeAndThrowThrowable(0, 0L, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (NullPointerException decoded) {
             // Expected
@@ -69,7 +69,7 @@ public class TestTranslatedException {
         }
 
         try {
-            VMSupport.decodeAndThrowThrowable(1, 0L, true);
+            VMSupport.decodeAndThrowThrowable(1, 0L, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (InternalError decoded) {
             if (!decoded.getMessage().startsWith("native buffer could not be allocated")) {
@@ -80,7 +80,7 @@ public class TestTranslatedException {
         }
 
         try {
-            VMSupport.decodeAndThrowThrowable(2, 0L, true);
+            VMSupport.decodeAndThrowThrowable(2, 0L, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (OutOfMemoryError decoded) {
             // Expected
@@ -89,7 +89,7 @@ public class TestTranslatedException {
         }
 
         try {
-            VMSupport.decodeAndThrowThrowable(3, 0L, true);
+            VMSupport.decodeAndThrowThrowable(3, 0L, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (InternalError decoded) {
             // Expected
@@ -98,7 +98,7 @@ public class TestTranslatedException {
         }
 
         try {
-            VMSupport.decodeAndThrowThrowable(4, 0L, true);
+            VMSupport.decodeAndThrowThrowable(4, 0L, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (InternalError decoded) {
             // Expected
@@ -112,7 +112,7 @@ public class TestTranslatedException {
         try {
             unsafe.putInt(buffer, problem.length);
             unsafe.copyMemory(problem, Unsafe.ARRAY_BYTE_BASE_OFFSET, null, buffer + 4, problem.length);
-            VMSupport.decodeAndThrowThrowable(3, buffer, true);
+            VMSupport.decodeAndThrowThrowable(3, buffer, true, false);
             throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
         } catch (InternalError decoded) {
             String msg = decoded.getMessage();
@@ -139,7 +139,7 @@ public class TestTranslatedException {
                     bufferSize = -res;
                 } else {
                     try {
-                        VMSupport.decodeAndThrowThrowable(format, buffer, true);
+                        VMSupport.decodeAndThrowThrowable(format, buffer, true, false);
                         throw new AssertionError("expected decodeAndThrowThrowable to throw an exception");
                     } catch (Throwable decoded) {
                         assertThrowableEquals(throwable, decoded);


### PR DESCRIPTION
Problem:
The debugging stack traces in `jdk.internal.vm.TranslatedException` do not work in libjvmci because they are enabled via the `jdk.internal.vm.TranslatedException.debug` system property. However, HotSpot system properties are not accessible via `System.getProperty()` in libjvmci.

Fix:
The value of `jdk.internal.vm.TranslatedException.debug` is passed from the VM via a boolean flag to `VMSupport::decodeAndThrowThrowable()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329564](https://bugs.openjdk.org/browse/JDK-8329564): [JVMCI] TranslatedException::debugPrintStackTrace does not work in the libjvmci compiler. (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18591/head:pull/18591` \
`$ git checkout pull/18591`

Update a local copy of the PR: \
`$ git checkout pull/18591` \
`$ git pull https://git.openjdk.org/jdk.git pull/18591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18591`

View PR using the GUI difftool: \
`$ git pr show -t 18591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18591.diff">https://git.openjdk.org/jdk/pull/18591.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18591#issuecomment-2033717607)