### PR TITLE
8329527: Opcode.IFNONNULL.primaryTypeKind() is not ReferenceType

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/Opcode.java
+++ b/src/java.base/share/classes/java/lang/classfile/Opcode.java
@@ -645,7 +645,7 @@ public enum Opcode {
     IFNULL(ClassFile.IFNULL, 3, Kind.BRANCH, TypeKind.ReferenceType),
 
     /** Branch if reference not null */
-    IFNONNULL(ClassFile.IFNONNULL, 3, Kind.BRANCH, TypeKind.IntType),
+    IFNONNULL(ClassFile.IFNONNULL, 3, Kind.BRANCH, TypeKind.ReferenceType),
 
     /** Branch always (wide index) */
     GOTO_W(ClassFile.GOTO_W, 5, Kind.BRANCH, TypeKind.VoidType),


### PR DESCRIPTION
`Opcode.IFNONNULL.primaryTypeKind()` wrongly returned `IntType` instead of the right `ReferenceType`.
Primary type kinds of `BRANCH` opcodes have yet no functional effect in the Class-File API.
This simple patch fixes the typo.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329527](https://bugs.openjdk.org/browse/JDK-8329527): Opcode.IFNONNULL.primaryTypeKind() is not ReferenceType (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18593/head:pull/18593` \
`$ git checkout pull/18593`

Update a local copy of the PR: \
`$ git checkout pull/18593` \
`$ git pull https://git.openjdk.org/jdk.git pull/18593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18593`

View PR using the GUI difftool: \
`$ git pr show -t 18593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18593.diff">https://git.openjdk.org/jdk/pull/18593.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18593#issuecomment-2033883665)