### PR TITLE
8325371: Missing ClassFile.Option in package summary

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -180,7 +180,7 @@ public sealed interface ClassFile
 
     /**
      * Option describing whether to filter unresolved labels.
-     * Default is {@code FAIL_ON_DEAD_LABELS} to throw IllegalStateException
+     * Default is {@code FAIL_ON_DEAD_LABELS} to throw IllegalArgumentException
      * when any {@link ExceptionCatch}, {@link LocalVariableInfo},
      * {@link LocalVariableTypeInfo}, or {@link CharacterRangeInfo}
      * reference to unresolved {@link Label} during bytecode serialization.

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -174,20 +174,26 @@
  * for some statically enumerated options, as well as factories for more complex options,
  * including:
  * <ul>
- *   <li>{@link java.lang.classfile.ClassFile.StackMapsOption}
- * -- generate stackmaps (default is {@code STACK_MAPS_WHEN_REQUIRED})</li>
+ *   <li>{@link java.lang.classfile.ClassFile.AttributeMapperOption#of(java.util.function.Function)}
+ * -- specify format of custom attributes</li>
+ *   <li>{@link java.lang.classfile.ClassFile.AttributesProcessingOption}
+ * -- unrecognized or problematic original attributes (default is {@code PASS_ALL_ATTRIBUTES})</li>
+ *   <li>{@link java.lang.classfile.ClassFile.ClassHierarchyResolverOption#of(java.lang.classfile.ClassHierarchyResolver)}
+ * -- specify a custom class hierarchy resolver used by stack map generation</li>
+ *   <li>{@link java.lang.classfile.ClassFile.ConstantPoolSharingOption}}
+ * -- share constant pool when transforming (default is {@code SHARED_POOL})</li>
+ *   <li>{@link java.lang.classfile.ClassFile.DeadCodeOption}}
+ * -- patch out unreachable code (default is {@code PATCH_DEAD_CODE})</li>
+ *   <li>{@link java.lang.classfile.ClassFile.DeadLabelsOption}}
+ * -- filter unresolved labels (default is {@code FAIL_ON_DEAD_LABELS})</li>
  *   <li>{@link java.lang.classfile.ClassFile.DebugElementsOption}
  * -- processing of debug information, such as local variable metadata (default is {@code PASS_DEBUG}) </li>
  *   <li>{@link java.lang.classfile.ClassFile.LineNumbersOption}
  * -- processing of line numbers (default is {@code PASS_LINE_NUMBERS}) </li>
- *   <li>{@link java.lang.classfile.ClassFile.AttributesProcessingOption}
- * -- unrecognized or problematic original attributes (default is {@code PASS_ALL_ATTRIBUTES})</li>
- *   <li>{@link java.lang.classfile.ClassFile.ConstantPoolSharingOption}}
- * -- share constant pool when transforming (default is {@code SHARED_POOL})</li>
- *   <li>{@link java.lang.classfile.ClassFile.ClassHierarchyResolverOption#of(java.lang.classfile.ClassHierarchyResolver)}
- * -- specify a custom class hierarchy resolver used by stack map generation</li>
- *   <li>{@link java.lang.classfile.ClassFile.AttributeMapperOption#of(java.util.function.Function)}
- * -- specify format of custom attributes</li>
+ *   <li>{@link java.lang.classfile.ClassFile.ShortJumpsOption}
+ * -- automatically rewrite short jumps to long when necessary (default is {@code FIX_SHORT_JUMPS})</li>
+ *   <li>{@link java.lang.classfile.ClassFile.StackMapsOption}
+ * -- generate stackmaps (default is {@code STACK_MAPS_WHEN_REQUIRED})</li>
  * </ul>
  * <p>
  * Most options allow you to request that certain parts of the classfile be


### PR DESCRIPTION
Some of the Class-File API options were not mentioned in the package summary and one exception mentioned `ClassFile.DeadLabelsOption` javadoc was wrong.
This patch fixes the javadoc.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325371](https://bugs.openjdk.org/browse/JDK-8325371): Missing ClassFile.Option in package summary (**Bug** - P4)


### Reviewers
 * [Brian Goetz](https://openjdk.org/census#briangoetz) (@briangoetz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18594/head:pull/18594` \
`$ git checkout pull/18594`

Update a local copy of the PR: \
`$ git checkout pull/18594` \
`$ git pull https://git.openjdk.org/jdk.git pull/18594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18594`

View PR using the GUI difftool: \
`$ git pr show -t 18594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18594.diff">https://git.openjdk.org/jdk/pull/18594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18594#issuecomment-2033957843)