### PR TITLE
8329570: G1: Excessive is_obj_dead_cond calls in verification

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -592,7 +592,6 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
   template <class T>
   void do_oop_work(T* p) {
     assert(_containing_obj != nullptr, "must be");
-    assert(!G1CollectedHeap::heap()->is_obj_dead_cond(_containing_obj, _vo), "Precondition");
 
     if (num_failures() >= G1MaxVerifyFailures) {
       return;
@@ -624,6 +623,7 @@ public:
     _num_failures(0) { }
 
   void set_containing_obj(oop const obj) {
+    assert(!G1CollectedHeap::heap()->is_obj_dead_cond(obj, _vo), "Precondition");
     _containing_obj = obj;
   }
 


### PR DESCRIPTION
While investigating [JDK-8329314](https://bugs.openjdk.org/browse/JDK-8329314) it was found that G1 was slower than Parallel when allocating objects because of the extra verification when running with fastdebug builds.

This tiny tests takes 30s with G1:
```
public class Test {
    static int n = 847734685;

    public static void main(String[] args) {
         String[] strs = new String[n + 1];
    }
}
```

A large portion of that time is spent inside this assert:
```
    assert(!G1CollectedHeap::heap()->is_obj_dead_cond(_containing_obj, _vo), "Precondition");
```
which is called for every single oop in the _containing_obj. If I move this assert to where _containing_obj is initialized, the test now completes in 4-5 seconds. I propose that we make this tiny change to improve the speed of the debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329570](https://bugs.openjdk.org/browse/JDK-8329570): G1: Excessive is_obj_dead_cond calls in verification (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18595/head:pull/18595` \
`$ git checkout pull/18595`

Update a local copy of the PR: \
`$ git checkout pull/18595` \
`$ git pull https://git.openjdk.org/jdk.git pull/18595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18595`

View PR using the GUI difftool: \
`$ git pr show -t 18595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18595.diff">https://git.openjdk.org/jdk/pull/18595.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18595#issuecomment-2033969992)