### PR TITLE
8329580: Parallel: Remove VerifyObjectStartArray

### DIFF
--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -377,24 +377,6 @@ void PSOldGen::verify() {
   object_space()->verify();
 }
 
-class VerifyObjectStartArrayClosure : public ObjectClosure {
-  ObjectStartArray* _start_array;
-
-public:
-  VerifyObjectStartArrayClosure(ObjectStartArray* start_array) :
-    _start_array(start_array) { }
-
-  virtual void do_object(oop obj) {
-    HeapWord* test_addr = cast_from_oop<HeapWord*>(obj) + 1;
-    guarantee(_start_array->object_start(test_addr) == cast_from_oop<HeapWord*>(obj), "ObjectStartArray cannot find start of object");
-  }
-};
-
-void PSOldGen::verify_object_start_array() {
-  VerifyObjectStartArrayClosure check(&_start_array);
-  object_iterate(&check);
-}
-
 #ifndef PRODUCT
 void PSOldGen::record_spaces_top() {
   assert(ZapUnusedHeapArea, "Not mangling unused space");

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -149,7 +149,6 @@ class PSOldGen : public CHeapObj<mtGC> {
   virtual void print_on(outputStream* st) const;
 
   void verify();
-  void verify_object_start_array();
 
   // Performance Counter support
   void update_counters();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -913,12 +913,6 @@ void PSParallelCompact::pre_compact()
     Universe::verify("Before GC");
   }
 
-  // Verify object start arrays
-  if (VerifyObjectStartArray &&
-      VerifyBeforeGC) {
-    heap->old_gen()->verify_object_start_array();
-  }
-
   DEBUG_ONLY(mark_bitmap()->verify_clear();)
   DEBUG_ONLY(summary_data().verify_clear();)
 
@@ -1532,12 +1526,6 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
 
   if (VerifyAfterGC && heap->total_collections() >= VerifyGCStartAt) {
     Universe::verify("After GC");
-  }
-
-  // Re-verify object start arrays
-  if (VerifyObjectStartArray &&
-      VerifyAfterGC) {
-    old_gen->verify_object_start_array();
   }
 
   if (ZapUnusedHeapArea) {

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -419,12 +419,6 @@ bool PSScavenge::invoke_no_policy() {
     // Let the size policy know we're starting
     size_policy->minor_collection_begin();
 
-    // Verify the object start arrays.
-    if (VerifyObjectStartArray &&
-        VerifyBeforeGC) {
-      old_gen->verify_object_start_array();
-    }
-
     // Verify no unmarked old->young roots
     if (VerifyRememberedSets) {
       heap->card_table()->verify_all_young_refs_imprecise();
@@ -633,12 +627,6 @@ bool PSScavenge::invoke_no_policy() {
 #if COMPILER2_OR_JVMCI
     DerivedPointerTable::update_pointers();
 #endif
-
-    // Re-verify object start arrays
-    if (VerifyObjectStartArray &&
-        VerifyAfterGC) {
-      old_gen->verify_object_start_array();
-    }
 
     if (VerifyRememberedSets) {
       heap->card_table()->verify_all_young_refs_imprecise();

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -507,9 +507,6 @@
   product(bool, VerifyRememberedSets, false, DIAGNOSTIC,                    \
           "Verify GC remembered sets")                                      \
                                                                             \
-  product(bool, VerifyObjectStartArray, true, DIAGNOSTIC,                   \
-          "Verify GC object start array if verify before/after")            \
-                                                                            \
   product(bool, DisableExplicitGC, false,                                   \
           "Ignore calls to System.gc()")                                    \
                                                                             \

--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -36,7 +36,7 @@ package gc.g1;
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
  *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
- *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
+ *   -XX:+VerifyRememberedSets
  *   -XX:+G1VerifyBitmaps
  *   gc.g1.TestVerificationInConcurrentCycle
  */
@@ -55,7 +55,7 @@ package gc.g1;
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
  *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
- *   -XX:+VerifyRememberedSets -XX:+VerifyObjectStartArray
+ *   -XX:+VerifyRememberedSets
  *   gc.g1.TestVerificationInConcurrentCycle
  */
 


### PR DESCRIPTION
Simple removing a jvm verification flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329580](https://bugs.openjdk.org/browse/JDK-8329580): Parallel: Remove VerifyObjectStartArray (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18596/head:pull/18596` \
`$ git checkout pull/18596`

Update a local copy of the PR: \
`$ git checkout pull/18596` \
`$ git pull https://git.openjdk.org/jdk.git pull/18596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18596`

View PR using the GUI difftool: \
`$ git pr show -t 18596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18596.diff">https://git.openjdk.org/jdk/pull/18596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18596#issuecomment-2034009377)