### PR TITLE
8329083: RISC-V: Update profiles supported on riscv

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -99,9 +99,9 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
   product(bool, UseRVA20U64, true, "Use RVA20U64 profile")                       \
-  product(bool, UseRVC, false, "Use RVC instructions")                           \
   product(bool, UseRVA22U64, false, EXPERIMENTAL, "Use RVA22U64 profile")        \
   product(bool, UseRVA23U64, false, EXPERIMENTAL, "Use RVA23U64 profile")        \
+  product(bool, UseRVC, false, "Use RVC instructions")                           \
   product(bool, UseRVV, false, "Use RVV instructions")                           \
   product(bool, UseZba, false, "Use Zba instructions")                           \
   product(bool, UseZbb, false, "Use Zbb instructions")                           \

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -101,6 +101,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseRVA20U64, true, "Use RVA20U64 profile")                       \
   product(bool, UseRVC, false, "Use RVC instructions")                           \
   product(bool, UseRVA22U64, false, EXPERIMENTAL, "Use RVA22U64 profile")        \
+  product(bool, UseRVA23U64, false, EXPERIMENTAL, "Use RVA23U64 profile")        \
   product(bool, UseRVV, false, "Use RVV instructions")                           \
   product(bool, UseZba, false, "Use Zba instructions")                           \
   product(bool, UseZbb, false, "Use Zbb instructions")                           \

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -45,6 +45,18 @@ VM_Version::RVFeatureValue* VM_Version::_feature_list[] = {
 RV_FEATURE_FLAGS(ADD_RV_FEATURE_IN_LIST)
   nullptr};
 
+void VM_Version::useRVA20U64Profile() {
+  RV_USE_RVA20U64;
+}
+
+void VM_Version::useRVA22U64Profile() {
+  RV_USE_RVA22U64;
+}
+
+void VM_Version::useRVA23U64Profile() {
+  RV_USE_RVA23U64;
+}
+
 void VM_Version::initialize() {
   _supports_atomic_getset4 = true;
   _supports_atomic_getadd4 = true;
@@ -61,44 +73,14 @@ void VM_Version::initialize() {
          (int)satp_mode.value()));
   }
 
-  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20-profiles
   if (UseRVA20U64) {
-    if (FLAG_IS_DEFAULT(UseRVC)) {
-      FLAG_SET_DEFAULT(UseRVC, true);
-    }
+    useRVA20U64Profile();
   }
-  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22-profiles
   if (UseRVA22U64) {
-    if (FLAG_IS_DEFAULT(UseRVC)) {
-      FLAG_SET_DEFAULT(UseRVC, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZba)) {
-      FLAG_SET_DEFAULT(UseZba, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZbb)) {
-      FLAG_SET_DEFAULT(UseZbb, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZbs)) {
-      FLAG_SET_DEFAULT(UseZbs, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZfh)) {
-      FLAG_SET_DEFAULT(UseZfh, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZic64b)) {
-      FLAG_SET_DEFAULT(UseZic64b, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZicbom)) {
-      FLAG_SET_DEFAULT(UseZicbom, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZicbop)) {
-      FLAG_SET_DEFAULT(UseZicbop, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZicboz)) {
-      FLAG_SET_DEFAULT(UseZicboz, true);
-    }
-    if (FLAG_IS_DEFAULT(UseZihintpause)) {
-      FLAG_SET_DEFAULT(UseZihintpause, true);
-    }
+    useRVA22U64Profile();
+  }
+  if (UseRVA23U64) {
+    useRVA23U64Profile();
   }
 
   // Enable vendor specific features

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -170,6 +170,56 @@ class VM_Version : public Abstract_VM_Version {
   RV_FEATURE_FLAGS(DECLARE_RV_FEATURE)
   #undef DECLARE_RV_FEATURE
 
+  // enable extensions based on profile, current supported profiles:
+  //  RVA20U64
+  //  RVA22U64
+  //  RVA23U64
+  #define RV_ENABLE_EXTENSION(UseExtension)     \
+    if (FLAG_IS_DEFAULT(UseExtension)) {        \
+      FLAG_SET_DEFAULT(UseExtension, true);     \
+    }                                           \
+
+  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva20-profiles
+  #define RV_USE_RVA20U64                            \
+    RV_ENABLE_EXTENSION(UseRVC)                      \
+
+  static void useRVA20U64Profile();
+
+  // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22-profiles
+  #define RV_USE_RVA22U64                            \
+    RV_ENABLE_EXTENSION(UseRVC)                      \
+    RV_ENABLE_EXTENSION(UseRVV)                      \
+    RV_ENABLE_EXTENSION(UseZba)                      \
+    RV_ENABLE_EXTENSION(UseZbb)                      \
+    RV_ENABLE_EXTENSION(UseZbs)                      \
+    RV_ENABLE_EXTENSION(UseZfh)                      \
+    RV_ENABLE_EXTENSION(UseZic64b)                   \
+    RV_ENABLE_EXTENSION(UseZicbom)                   \
+    RV_ENABLE_EXTENSION(UseZicbop)                   \
+    RV_ENABLE_EXTENSION(UseZicboz)                   \
+    RV_ENABLE_EXTENSION(UseZihintpause)              \
+
+  static void useRVA22U64Profile();
+
+  // https://github.com/riscv/riscv-profiles/blob/main/rva23-profile.adoc#rva23u64-profile
+  #define RV_USE_RVA23U64                           \
+    RV_ENABLE_EXTENSION(UseRVC)                     \
+    RV_ENABLE_EXTENSION(UseRVV)                     \
+    RV_ENABLE_EXTENSION(UseZacas)                   \
+    RV_ENABLE_EXTENSION(UseZba)                     \
+    RV_ENABLE_EXTENSION(UseZbb)                     \
+    RV_ENABLE_EXTENSION(UseZbs)                     \
+    RV_ENABLE_EXTENSION(UseZfh)                     \
+    RV_ENABLE_EXTENSION(UseZcb)                     \
+    RV_ENABLE_EXTENSION(UseZic64b)                  \
+    RV_ENABLE_EXTENSION(UseZicbom)                  \
+    RV_ENABLE_EXTENSION(UseZicbop)                  \
+    RV_ENABLE_EXTENSION(UseZicboz)                  \
+    RV_ENABLE_EXTENSION(UseZihintpause)             \
+    RV_ENABLE_EXTENSION(UseZvfh)                    \
+
+  static void useRVA23U64Profile();
+
   // VM modes (satp.mode) privileged ISA 1.10
   enum VM_MODE : int {
     VM_NOTSET = -1,

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -174,6 +174,7 @@ class VM_Version : public Abstract_VM_Version {
   //  RVA20U64
   //  RVA22U64
   //  RVA23U64
+  // NOTE: we only enable the mandatory extensions, not optional extension.
   #define RV_ENABLE_EXTENSION(UseExtension)     \
     if (FLAG_IS_DEFAULT(UseExtension)) {        \
       FLAG_SET_DEFAULT(UseExtension, true);     \
@@ -188,11 +189,9 @@ class VM_Version : public Abstract_VM_Version {
   // https://github.com/riscv/riscv-profiles/blob/main/profiles.adoc#rva22-profiles
   #define RV_USE_RVA22U64                            \
     RV_ENABLE_EXTENSION(UseRVC)                      \
-    RV_ENABLE_EXTENSION(UseRVV)                      \
     RV_ENABLE_EXTENSION(UseZba)                      \
     RV_ENABLE_EXTENSION(UseZbb)                      \
     RV_ENABLE_EXTENSION(UseZbs)                      \
-    RV_ENABLE_EXTENSION(UseZfh)                      \
     RV_ENABLE_EXTENSION(UseZic64b)                   \
     RV_ENABLE_EXTENSION(UseZicbom)                   \
     RV_ENABLE_EXTENSION(UseZicbop)                   \
@@ -205,18 +204,15 @@ class VM_Version : public Abstract_VM_Version {
   #define RV_USE_RVA23U64                           \
     RV_ENABLE_EXTENSION(UseRVC)                     \
     RV_ENABLE_EXTENSION(UseRVV)                     \
-    RV_ENABLE_EXTENSION(UseZacas)                   \
     RV_ENABLE_EXTENSION(UseZba)                     \
     RV_ENABLE_EXTENSION(UseZbb)                     \
     RV_ENABLE_EXTENSION(UseZbs)                     \
-    RV_ENABLE_EXTENSION(UseZfh)                     \
     RV_ENABLE_EXTENSION(UseZcb)                     \
     RV_ENABLE_EXTENSION(UseZic64b)                  \
     RV_ENABLE_EXTENSION(UseZicbom)                  \
     RV_ENABLE_EXTENSION(UseZicbop)                  \
     RV_ENABLE_EXTENSION(UseZicboz)                  \
     RV_ENABLE_EXTENSION(UseZihintpause)             \
-    RV_ENABLE_EXTENSION(UseZvfh)                    \
 
   static void useRVA23U64Profile();
 


### PR DESCRIPTION
Hi,
Can you help to review this patch to update vm flags related to riscv profile?
Thanks

Currently there are vm options like -XX:+UseRVA20U64 and -XX:+UseRVA22U64 on riscv to indicate the supported riscv extension via profiles.
These profiles should be updated to reflect the full supported extensions and new profile like UseRVA23U64 should be added too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329083](https://bugs.openjdk.org/browse/JDK-8329083): RISC-V: Update profiles supported on riscv (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18599/head:pull/18599` \
`$ git checkout pull/18599`

Update a local copy of the PR: \
`$ git checkout pull/18599` \
`$ git pull https://git.openjdk.org/jdk.git pull/18599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18599`

View PR using the GUI difftool: \
`$ git pr show -t 18599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18599.diff">https://git.openjdk.org/jdk/pull/18599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18599#issuecomment-2034193165)