### PR TITLE
8329545: [s390x] Fix garbage value being passed in Argument Register

### DIFF
--- a/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
+++ b/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
@@ -166,7 +166,7 @@ static void move_stack(MacroAssembler* masm, Register tmp_reg, int in_stk_bias, 
     case StorageType::INTEGER:
       switch (from_reg.stack_size()) {
         case 8: __ mem2reg_opt(as_Register(to_reg), from_addr, true);break;
-        case 4: __ mem2reg_opt(as_Register(to_reg), from_addr, false);break;
+        case 4: __ mem2reg_signed_opt(as_Register(to_reg), from_addr);break;
         default: ShouldNotReachHere();
       }
       break;

--- a/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
+++ b/src/hotspot/cpu/s390/foreignGlobals_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Fix sign extension on 4 byte load from argument stack slot to GPR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329545](https://bugs.openjdk.org/browse/JDK-8329545): [s390x] Fix garbage value being passed in Argument Register (**Bug** - P2)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18601/head:pull/18601` \
`$ git checkout pull/18601`

Update a local copy of the PR: \
`$ git checkout pull/18601` \
`$ git pull https://git.openjdk.org/jdk.git pull/18601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18601`

View PR using the GUI difftool: \
`$ git pr show -t 18601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18601.diff">https://git.openjdk.org/jdk/pull/18601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18601#issuecomment-2034359986)