### PR TITLE
8319678: Several tests from corelibs areas ignore VM flags

### DIFF
--- a/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
+++ b/test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,15 +23,13 @@
 
 import java.util.stream.Stream;
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Arguments;
-
 import static java.lang.System.err;
 import static java.lang.System.out;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /*
  * @test
@@ -85,7 +83,7 @@ class UncaughtExceptionsTest {
     @MethodSource("testCases")
     void test(String className, int exitValue, String stdOutMatch, String stdErrMatch) throws Throwable {
         String cmd = "UncaughtExitSimulator$" + className;
-        ProcessBuilder processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(cmd);
+        ProcessBuilder processBuilder = ProcessTools.createTestJavaProcessBuilder(cmd);
         OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(processBuilder);
         outputAnalyzer.shouldHaveExitValue(exitValue);
         outputAnalyzer.stderrShouldMatch(stdErrMatch);

--- a/test/jdk/java/lang/annotation/LoaderLeakTest.java
+++ b/test/jdk/java/lang/annotation/LoaderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class LoaderLeakTest {
     }
 
     private void runJavaProcessExpectSuccessExitCode(String ... command) throws Throwable {
-        var processBuilder = ProcessTools.createLimitedTestJavaProcessBuilder(command)
+        var processBuilder = ProcessTools.createTestJavaProcessBuilder(command)
                                                       .directory(Paths.get(Utils.TEST_CLASSES).toFile());
         ProcessTools.executeCommand(processBuilder).shouldHaveExitValue(0);
     }

--- a/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
@@ -277,10 +277,7 @@ public class Main {
                         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(clientProcessStr);
                         OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
                         System.out.println(outputAnalyzer.getOutput());
-                        int exitValue = outputAnalyzer.getExitValue();
-                        if(0 != exitValue) {
-                            die("Error: error happened in client process, exitValue = " + exitValue);
-                        }
+                        outputAnalyzer.shouldHaveExitValue(0);
                     } catch (IOException ex) {
                         die("Error: Unable start client process, ex=" + ex.getMessage());
                     } catch (Exception ex) {

--- a/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
+++ b/test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,13 @@
  * @test
  * @summary The RMI benchmark test. This java class is used to run the test
  *          under JTREG.
- * @library ../../../../testlibrary ../../
+ * @library ../../../../testlibrary ../../ /test/lib
  * @modules java.desktop
  *          java.rmi/sun.rmi.registry
  *          java.rmi/sun.rmi.server
  *          java.rmi/sun.rmi.transport
  *          java.rmi/sun.rmi.transport.tcp
- * @build TestLibrary bench.BenchInfo bench.HtmlReporter bench.Util
+ * @build TestLibrary bench.BenchInfo bench.HtmlReporter bench.Util jdk.test.lib.process.ProcessTools
  * bench.Benchmark bench.Reporter bench.XmlReporter bench.ConfigFormatException
  * bench.Harness bench.TextReporter bench.rmi.BenchServer
  * bench.rmi.DoubleArrayCalls bench.rmi.LongCalls bench.rmi.ShortCalls
@@ -51,19 +51,12 @@
 
 package bench.rmi;
 
-import bench.ConfigFormatException;
-import bench.Harness;
-import bench.HtmlReporter;
-import bench.Reporter;
-import bench.TextReporter;
-import bench.XmlReporter;
-import static bench.rmi.Main.OutputFormat.*;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.rmi.AlreadyBoundException;
@@ -76,6 +69,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
 import java.util.TimerTask;
+
+import bench.ConfigFormatException;
+import bench.Harness;
+import bench.HtmlReporter;
+import bench.Reporter;
+import bench.TextReporter;
+import bench.XmlReporter;
+import static bench.rmi.Main.OutputFormat.HTML;
+import static bench.rmi.Main.OutputFormat.TEXT;
+import static bench.rmi.Main.OutputFormat.XML;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * RMI/Serialization benchmark tests.
@@ -234,13 +239,6 @@ public class Main {
                     //Setup for client mode, server will fork client process
                     //after its initiation.
                     List<String> clientProcessStr = new ArrayList<>();
-                    clientProcessStr.add(System.getProperty("test.jdk") +
-                            File.separator + "bin" + File.separator + "java");
-                    String classpath = System.getProperty("java.class.path");
-                    if (classpath != null) {
-                        clientProcessStr.add("-cp");
-                        clientProcessStr.add(classpath);
-                    }
                     clientProcessStr.add("-Djava.security.policy=" + TEST_SRC_PATH + "policy.all");
                     clientProcessStr.add("-Djava.security.manager=allow");
                     clientProcessStr.add("-Dtest.src=" + TEST_SRC_PATH);
@@ -276,20 +274,16 @@ public class Main {
                     }
 
                     try {
-                        Process client = new ProcessBuilder(clientProcessStr).
-                                inheritIO().start();
-                        try {
-                            client.waitFor();
-                            int exitValue = client.exitValue();
-                            if (0 != exitValue) {
-                                die("Error: error happened in client process, exitValue = " + exitValue);
-                            }
-                        } finally {
-                            client.destroyForcibly();
+                        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(clientProcessStr);
+                        OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
+                        System.out.println(outputAnalyzer.getOutput());
+                        int exitValue = outputAnalyzer.getExitValue();
+                        if(0 != exitValue) {
+                            die("Error: error happened in client process, exitValue = " + exitValue);
                         }
                     } catch (IOException ex) {
                         die("Error: Unable start client process, ex=" + ex.getMessage());
-                    } catch (InterruptedException ex) {
+                    } catch (Exception ex) {
                         die("Error: Error happening to client process, ex=" + ex.getMessage());
                     }
                     break;

--- a/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
+++ b/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 import tests.Helper;
 import tests.JImageGenerator;
 
@@ -32,12 +34,12 @@ import tests.JImageGenerator;
  * @summary Tests whether a custom Hijrah configuration properties file works correctly
  * @bug 8187987
  * @requires (vm.compMode != "Xcomp" & os.maxMemory >= 2g)
- * @library /tools/lib
+ * @library /tools/lib /test/lib
  * @enablePreview
  * @modules java.base/jdk.internal.jimage
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
- * @build HijrahConfigCheck tests.*
+ * @build HijrahConfigCheck tests.* jdk.test.lib.compiler.CompilerUtils jdk.test.lib.process.ProcessTools
  * @run main/othervm -Xmx1g HijrahConfigTest
  */
 public class HijrahConfigTest {
@@ -66,13 +68,7 @@ public class HijrahConfigTest {
 
         // Run tests
         Path launcher = outputPath.resolve("bin").resolve("java");
-        ProcessBuilder builder = new ProcessBuilder(
-                launcher.toAbsolutePath().toString(), "-ea", "-esa", "HijrahConfigCheck");
-        Process p = builder.inheritIO().start();
-        p.waitFor();
-        int exitValue = p.exitValue();
-        if (exitValue != 0) {
-            throw new RuntimeException("HijrahConfigTest failed. Exit value: " + exitValue);
-        }
+        OutputAnalyzer analyzer =  ProcessTools.executeCommand(launcher.toAbsolutePath().toString(),"-ea", "-esa", "HijrahConfigCheck");
+        analyzer.shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
+++ b/test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
@@ -68,7 +68,7 @@ public class HijrahConfigTest {
 
         // Run tests
         Path launcher = outputPath.resolve("bin").resolve("java");
-        OutputAnalyzer analyzer =  ProcessTools.executeCommand(launcher.toAbsolutePath().toString(),"-ea", "-esa", "HijrahConfigCheck");
+        OutputAnalyzer analyzer =  ProcessTools.executeCommand(launcher.toAbsolutePath().toString(), "-ea", "-esa", "HijrahConfigCheck");
         analyzer.shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/javax/naming/spi/providers/InitialContextTest.java
+++ b/test/jdk/javax/naming/spi/providers/InitialContextTest.java
@@ -62,7 +62,7 @@ import jdk.test.lib.process.ProcessTools;
  *          executing scenarios.
  * @library /test/lib
  * @build jdk.test.lib.process.ProcessTools
- * @run main/othervm InitialContextTest
+ * @run main InitialContextTest
  */
 public class InitialContextTest {
 
@@ -264,11 +264,9 @@ public class InitialContextTest {
         String [] commands = {jar, "cf", jarName.toString(),"-C", jarRoot.toString(), "."};
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(commands);
-            if(outputAnalyzer.getExitValue() != 0) {
-                throw new RuntimeException(outputAnalyzer.getOutput());
-            }
+            outputAnalyzer.shouldHaveExitValue(0);
         } catch (Exception ex) {
-            throw new RuntimeException(ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 
@@ -282,11 +280,9 @@ public class InitialContextTest {
                 .collect(Collectors.toList()));
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(commands.toArray(new String[commands.size()]));
-            if(outputAnalyzer.getExitValue() != 0) {
-                throw new RuntimeException(outputAnalyzer.getOutput());
-            }
+            outputAnalyzer.shouldHaveExitValue(0);
         } catch (Exception ex) {
-            throw new RuntimeException(ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 
@@ -302,7 +298,7 @@ public class InitialContextTest {
         String cp = classpath.stream()
                 .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));
-        System.setProperty("test.noclasspath", "true");
+//        System.setProperty("test.noclasspath", "true");
         commands.add("-cp");
         commands.add(cp);
         commands.add(classname);
@@ -312,7 +308,7 @@ public class InitialContextTest {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
             return new Result(outputAnalyzer.getExitValue(), outputAnalyzer.getOutput());
         } catch (Exception ex) {
-            throw new RuntimeException(ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 

--- a/test/jdk/javax/naming/spi/providers/InitialContextTest.java
+++ b/test/jdk/javax/naming/spi/providers/InitialContextTest.java
@@ -298,7 +298,6 @@ public class InitialContextTest {
         String cp = classpath.stream()
                 .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));
-//        System.setProperty("test.noclasspath", "true");
         commands.add("-cp");
         commands.add(cp);
         commands.add(classname);

--- a/test/jdk/javax/naming/spi/providers/InitialContextTest.java
+++ b/test/jdk/javax/naming/spi/providers/InitialContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,23 +21,38 @@
  * questions.
  */
 
-import javax.naming.Context;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.SequenceInputStream;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.lang.String.format;
+import javax.naming.Context;
+
 import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
@@ -45,6 +60,9 @@ import static java.util.Collections.singletonMap;
  * @summary Examines different ways JNDI providers can hook up themselves and
  *          become available. Each case mimics the most straightforward way of
  *          executing scenarios.
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools
+ * @run main/othervm InitialContextTest
  */
 public class InitialContextTest {
 
@@ -243,9 +261,15 @@ public class InitialContextTest {
 
     private static void jar(Path jarName, Path jarRoot) {
         String jar = getJDKTool("jar");
-        ProcessBuilder p = new ProcessBuilder(jar, "cf", jarName.toString(),
-                "-C", jarRoot.toString(), ".");
-        quickFail(run(p));
+        String [] commands = {jar, "cf", jarName.toString(),"-C", jarRoot.toString(), "."};
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(commands);
+            if(outputAnalyzer.getExitValue() != 0) {
+                throw new RuntimeException(outputAnalyzer.getOutput());
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex.getMessage());
+        }
     }
 
     private static void javac(Path compilationOutput, Path... sourceFiles) {
@@ -256,22 +280,20 @@ public class InitialContextTest {
         commands.addAll(paths.stream()
                 .map(Path::toString)
                 .collect(Collectors.toList()));
-        quickFail(run(new ProcessBuilder(commands)));
-    }
-
-    private static void quickFail(Result r) {
-        if (r.exitValue != 0)
-            throw new RuntimeException(r.output);
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeCommand(commands.toArray(new String[commands.size()]));
+            if(outputAnalyzer.getExitValue() != 0) {
+                throw new RuntimeException(outputAnalyzer.getOutput());
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex.getMessage());
+        }
     }
 
     private static Result java(Map<String, String> properties,
                                Collection<Path> classpath,
                                String classname) {
-
-        String java = getJDKTool("java");
-
         List<String> commands = new ArrayList<>();
-        commands.add(java);
         commands.addAll(properties.entrySet()
                 .stream()
                 .map(e -> "-D" + e.getKey() + "=" + e.getValue())
@@ -280,38 +302,18 @@ public class InitialContextTest {
         String cp = classpath.stream()
                 .map(Path::toString)
                 .collect(Collectors.joining(File.pathSeparator));
+        System.setProperty("test.noclasspath", "true");
         commands.add("-cp");
         commands.add(cp);
         commands.add(classname);
-
-        return run(new ProcessBuilder(commands));
-    }
-
-    private static Result run(ProcessBuilder b) {
-        Process p = null;
-        try {
-            p = b.start();
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    format("Couldn't start process '%s'", b.command()), e);
-        }
-
-        String output;
-        try {
-            output = toString(p.getInputStream(), p.getErrorStream());
-        } catch (IOException e) {
-            throw new RuntimeException(
-                    format("Couldn't read process output '%s'", b.command()), e);
-        }
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(commands);
 
         try {
-            p.waitFor();
-        } catch (InterruptedException e) {
-            throw new RuntimeException(
-                    format("Process hasn't finished '%s'", b.command()), e);
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
+            return new Result(outputAnalyzer.getExitValue(), outputAnalyzer.getOutput());
+        } catch (Exception ex) {
+            throw new RuntimeException(ex.getMessage());
         }
-
-        return new Result(p.exitValue(), output);
     }
 
     private static String getJDKTool(String name) {

--- a/test/jdk/sun/misc/EscapePath.java
+++ b/test/jdk/sun/misc/EscapePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,19 @@
 /* @test
  * @bug 4359123
  * @summary  Test loading of classes with # in the path
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools
+ * @run main/othervm EscapePath
  */
-import java.io.*;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 public class EscapePath {
 
@@ -75,14 +86,22 @@ public class EscapePath {
         fos.close();
     }
 
-    private static void invokeJava() throws Exception {
-        String command = System.getProperty("java.home") +
-                         File.separator + "bin" + File.separator +
-                         "java -classpath " + "a#b/ Hello";
-        Process p = Runtime.getRuntime().exec(command);
-        p.waitFor();
-        int result = p.exitValue();
-        if (result != 0)
-            throw new RuntimeException("Path encoding failure.");
+    private static void invokeJava() {
+        List<String> commands = new ArrayList<>();
+
+        System.setProperty("test.noclasspath", "true");
+        commands.add("-classpath");
+        commands.add("a#b");
+        commands.add("Hello");
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(commands);
+
+        try {
+            OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
+            if(outputAnalyzer.getExitValue() != 0) {
+                throw new RuntimeException("Path encoding failure.");
+            }
+        } catch (Exception ex) {
+            throw new RuntimeException(ex.getMessage());
+        }
     }
 }

--- a/test/jdk/sun/misc/EscapePath.java
+++ b/test/jdk/sun/misc/EscapePath.java
@@ -27,7 +27,7 @@
  * @summary  Test loading of classes with # in the path
  * @library /test/lib
  * @build jdk.test.lib.process.ProcessTools
- * @run main/othervm EscapePath
+ * @run main EscapePath
  */
 
 import java.io.File;
@@ -89,7 +89,6 @@ public class EscapePath {
     private static void invokeJava() {
         List<String> commands = new ArrayList<>();
 
-        System.setProperty("test.noclasspath", "true");
         commands.add("-classpath");
         commands.add("a#b");
         commands.add("Hello");
@@ -97,11 +96,9 @@ public class EscapePath {
 
         try {
             OutputAnalyzer outputAnalyzer = ProcessTools.executeProcess(pb);
-            if(outputAnalyzer.getExitValue() != 0) {
-                throw new RuntimeException("Path encoding failure.");
-            }
+            outputAnalyzer.shouldHaveExitValue(0);
         } catch (Exception ex) {
-            throw new RuntimeException(ex.getMessage());
+            throw new RuntimeException(ex);
         }
     }
 }


### PR DESCRIPTION
Updated following tests to use ProcessTools methods:
 test/jdk/java/lang/Thread/UncaughtExceptionsTest.java
 test/jdk/java/lang/annotation/LoaderLeakTest.java
 test/jdk/java/rmi/reliability/benchmark/bench/rmi/Main.java
 test/jdk/java/time/nontestng/java/time/chrono/HijrahConfigTest.java
 test/jdk/javax/naming/spi/providers/InitialContextTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8319678](https://bugs.openjdk.org/browse/JDK-8319678): Several tests from corelibs areas ignore VM flags (**Sub-task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [04a35331](https://git.openjdk.org/jdk/pull/18602/files/04a35331765781d57fda5e547e569b33d0c1c406)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18602/head:pull/18602` \
`$ git checkout pull/18602`

Update a local copy of the PR: \
`$ git checkout pull/18602` \
`$ git pull https://git.openjdk.org/jdk.git pull/18602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18602`

View PR using the GUI difftool: \
`$ git pr show -t 18602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18602.diff">https://git.openjdk.org/jdk/pull/18602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18602#issuecomment-2034375506)