### PR TITLE
8329595: spurious  variable "might not have been initialized" on static final field

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -2195,15 +2195,7 @@ public class Flow {
 
         @Override
         protected void markDead() {
-            if (!isConstructor) {
-                inits.inclRange(returnadr, nextadr);
-            } else {
-                for (int address = returnadr; address < nextadr; address++) {
-                    if (!(isFinalUninitializedStaticField(vardecls[address].sym))) {
-                        inits.incl(address);
-                    }
-                }
-            }
+            inits.inclRange(returnadr, nextadr);
             uninits.inclRange(returnadr, nextadr);
         }
 
@@ -2223,10 +2215,6 @@ public class Flow {
             return sym.owner.kind == TYP &&
                    ((sym.flags() & (FINAL | HASINIT | PARAMETER)) == FINAL &&
                    classDef.sym.isEnclosedBy((ClassSymbol)sym.owner));
-        }
-
-        boolean isFinalUninitializedStaticField(VarSymbol sym) {
-            return isFinalUninitializedField(sym) && sym.isStatic();
         }
 
         /** Initialize new trackable variable by setting its address field
@@ -2447,7 +2435,7 @@ public class Flow {
                         clearPendingExits(false);
                     });
 
-                    // verify all static final fields got initailized
+                    // verify all static final fields got initialized
                     for (int i = firstadr; i < nextadr; i++) {
                         JCVariableDecl vardecl = vardecls[i];
                         VarSymbol var = vardecl.sym;

--- a/test/langtools/tools/javac/DefiniteAssignment/StaticFinalNestedClass.java
+++ b/test/langtools/tools/javac/DefiniteAssignment/StaticFinalNestedClass.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8329595
+ * @summary Verify spurious "might not have been initialized" error on static final field
+ * @run main StaticFinalNestedClass
+ */
+public class StaticFinalNestedClass {
+    public class Inner {                    // note this inner class is NOT static
+        public static final String NAME;
+        static {
+            try {
+                NAME = "bob";
+            } catch (Exception e) {
+                throw new Error(e);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        new StaticFinalNestedClass().new Inner();
+    }
+}


### PR DESCRIPTION
This bug causes the compiler to generate a bogus error `variable NAME might not have been initialized` for the following program:
```java
public class StaticFinalNestedClass {
    public class Inner {
        public static final String NAME;
        static {
            try {
                NAME = "bob";
            } catch (Exception e) {
                throw new Error(e);
            }
        }
    }
}
```
An interesting fact is that if you make the class `Inner` a `static` inner class, then the bug disappears. The oddness of that fact is indicative of the oddness of the underlying problem, some of which I probably contributed to and which I'll try to summarize...

First some background. The various flow analyzers are written to recurse through the entire AST including nested classes in one go. So for example if there is an inner class, the analysis of the outer class is paused while the inner class is analyzed, and then the former state is restored and the outer class analysis proceeds. This causes a bit of chaos in situations where the analyzer needs to "jump around" for whatever reason. For example, when `super()` is encountered while analyzing a constructor, we need to analyze any field initializers because that's when they execute.

As a result, there are several cases where the same code gets visited more than once, which is not harmful but is obviously inefficient. But it also leads to this bug.

So what is the actual bug? The bug is that (one of the times) the inner class static initializer was being checked for uninitialized variables was when the outer class constructor was being analyzed, and that analysis recursed into the inner class. Because the outer class constructor was being analyzed, and no other method had been entered yet, the `isConstructor` flag was still set to `true`, so the code that marks all fields as initialized when an exception is thrown from a constructor or static initializer (because the instance or class is unusable so don't bother complaining about uninitialized fields) was only marking the instance fields.

In commit 12e983a72e72 I did some refactoring to create a method `forEachInitializer()` for analyzing initializers, but the existing behavior of recursing into nested classes was preserved in order to not break things. With this commit, in order to impose some order, `forEachInitializer()` is being changed to not recurse into nested classes. Instead, the various bits of code that use `forEachInitializer()` and also need to recurse into nested classes now do that explicitly themselves (and the rest do not, eliminating some redundancy). This change also makes it easier to fix the actual bug - the bug fix is to simply remove a workaround for the previous redundant recursion. I've broken the changes into two corresponding commits for clarity.

There was also a separate bug in `forEachInitializer()`. It takes a boolean `isStatic` parameter (for whether you want to visit instance initializers or static initializers). The bug is that it would only recurse into nested classes with the same staticness as `isStatic`. That's explains the odd observation about the static-ness of class `Inner` in the given test case. Of course, now that `forEachInitializer()` no longer recurses into nested classes that problem goes away as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329595](https://bugs.openjdk.org/browse/JDK-8329595): spurious  variable "might not have been initialized" on static final field (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18610/head:pull/18610` \
`$ git checkout pull/18610`

Update a local copy of the PR: \
`$ git checkout pull/18610` \
`$ git pull https://git.openjdk.org/jdk.git pull/18610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18610`

View PR using the GUI difftool: \
`$ git pr show -t 18610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18610.diff">https://git.openjdk.org/jdk/pull/18610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18610#issuecomment-2036011917)