### PR TITLE
8329641: RISC-V: Enable some tests related to SHA-2 instrinsic

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -153,6 +153,7 @@ class VM_Version : public Abstract_VM_Version {
   decl(ext_Zihintpause , "Zihintpause" , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZihintpause)) \
   decl(ext_Zacas       , "Zacas"       , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZacas))       \
   decl(ext_Zvfh        , "Zvfh"        , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZvfh))        \
+  decl(ext_Zvkn        , "Zvkn"        , RV_NO_FLAG_BIT, true , UPDATE_DEFAULT(UseZvkn))        \
   decl(mvendorid       , "VendorId"    , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)              \
   decl(marchid         , "ArchId"      , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)              \
   decl(mimpid          , "ImpId"       , RV_NO_FLAG_BIT, false, NO_UPDATE_DEFAULT)              \

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -79,7 +79,7 @@ public class IntrinsicPredicates {
 
     public static final BooleanSupplier SHA256_INSTRUCTION_AVAILABLE
             = new OrPredicate(new CPUSpecificPredicate("aarch64.*", new String[] { "sha256"       }, null),
-              new OrPredicate(new CPUSpecificPredicate("riscv64.*", new String[] { "sha256"       }, null),
+              new OrPredicate(new CPUSpecificPredicate("riscv64.*", new String[] { "zvkn"         }, null),
               new OrPredicate(new CPUSpecificPredicate("s390.*",    new String[] { "sha256"       }, null),
               new OrPredicate(new CPUSpecificPredicate("ppc64.*",   new String[] { "sha"          }, null),
               new OrPredicate(new CPUSpecificPredicate("ppc64le.*", new String[] { "sha"          }, null),
@@ -92,7 +92,7 @@ public class IntrinsicPredicates {
 
     public static final BooleanSupplier SHA512_INSTRUCTION_AVAILABLE
             = new OrPredicate(new CPUSpecificPredicate("aarch64.*", new String[] { "sha512"       }, null),
-              new OrPredicate(new CPUSpecificPredicate("riscv64.*", new String[] { "sha512"       }, null),
+              new OrPredicate(new CPUSpecificPredicate("riscv64.*", new String[] { "zvkn"         }, null),
               new OrPredicate(new CPUSpecificPredicate("s390.*",    new String[] { "sha512"       }, null),
               new OrPredicate(new CPUSpecificPredicate("ppc64.*",   new String[] { "sha"          }, null),
               new OrPredicate(new CPUSpecificPredicate("ppc64le.*", new String[] { "sha"          }, null),


### PR DESCRIPTION
Hi, I witnessed that some SHA-2 tests are skipped on RISC-V. The supportedCPUFeatures in IntrinsicPredicates.java is not correct for RISC-V, because it should depend on Zvkn extension instead of sha256/sha512.  I tested this with QEMU system running linux-6.8 kernel. I used NR_riscv_hwprobe syscall to detect if the system supports the Zvkn extension. Because support for Zvkn extension is not fully tested on real hardwares, the code for detecting and enabling Zvkn extension is not included in this PR.

The code for detecting Zvkn extension
``` diff
diff --git a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
index df4a2e347cc..ef99acbf7c5 100644
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -178,6 +178,13 @@ void RiscvHwprobe::add_features_from_query_result() {
   if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZFH)) {
     VM_Version::ext_Zfh.enable_feature();
   }
+  if (is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNED)
+      && is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKNHB)
+      && is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKB)
+      && is_set(RISCV_HWPROBE_KEY_IMA_EXT_0, RISCV_HWPROBE_EXT_ZVKT)) {
+    VM_Version::ext_Zvkn.enable_feature();
+  }
   if (is_valid(RISCV_HWPROBE_KEY_CPUPERF_0)) {
     VM_Version::unaligned_access.enable_feature(
        query[RISCV_HWPROBE_KEY_CPUPERF_0].value & RISCV_HWPROBE_MISALIGNED_MASK);
```

This IntrinsicPredicates.java CPU matching change should only affect test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnSupportedCPU. java, test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnSupportedCPU.java test case. Before this patch they are skipped, after this patch they can be selected and pass normally.

We can test test/lib-test/jdk/test/whitebox/CPUInfoTest.java to see the actual CPU Features. 
```
----------configuration:(0/0)----------
----------System.out:(4/178)----------
WB.getCPUFeatures(): "rv64 i m a f d c v zba zbb zbs zvkn"
CPUInfo.getAdditionalCPUInfo(): ""
CPUInfo.getFeatures(): [rv64, i, m, a, f, d, c, v, zba, zbb, zbs, zvkn]
TEST PASSED
----------System.err:(2/88)----------
```

### Testing
- [x] Run tier1-3, hotspot:tier4 tests on SOPHON SG2042 (release)
- [ ] Run tier1-3 tests on ubuntu24(kernel version 6.8 and use qemu-system to boot ubuntu) (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329641](https://bugs.openjdk.org/browse/JDK-8329641): RISC-V: Enable some tests related to SHA-2 instrinsic (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18611/head:pull/18611` \
`$ git checkout pull/18611`

Update a local copy of the PR: \
`$ git checkout pull/18611` \
`$ git pull https://git.openjdk.org/jdk.git pull/18611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18611`

View PR using the GUI difftool: \
`$ git pr show -t 18611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18611.diff">https://git.openjdk.org/jdk/pull/18611.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18611#issuecomment-2036432272)