### PR TITLE
8329559: Test javax/swing/JFrame/bug4419914.java failed because The End and Start buttons are not placed correctly and Tab focus does not move as expected

### DIFF
--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -65,11 +65,12 @@ public class bug4419914 {
         frame.setFocusCycleRoot(true);
         frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
         frame.setLocale(Locale.ENGLISH);
-
         frame.enableInputMethods(false);
-        frame.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
-        frame.setLocale(Locale.ENGLISH);
-        frame.setLayout(new BorderLayout());
+
+        frame.getContentPane().setComponentOrientation(
+                               ComponentOrientation.RIGHT_TO_LEFT);
+        frame.getContentPane().setLocale(Locale.ENGLISH);
+        frame.getContentPane().setLayout(new BorderLayout());
         frame.add(new JButton("SOUTH"), BorderLayout.SOUTH);
         frame.add(new JButton("CENTER"), BorderLayout.CENTER);
         frame.add(new JButton("END"), BorderLayout.LINE_END);

--- a/test/jdk/javax/swing/JFrame/bug4419914.java
+++ b/test/jdk/javax/swing/JFrame/bug4419914.java
@@ -53,8 +53,8 @@ public class bug4419914 {
         PassFailJFrame.builder()
                 .title("Tab movement Instructions")
                 .instructions(INSTRUCTIONS)
-                .rows(12)
-                .columns(42)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(48)
                 .testUI(bug4419914::createTestUI)
                 .build()
                 .awaitAndCheck();


### PR DESCRIPTION
Test issue shows the End and Start buttons are not placed as per instructions due to ComponentOrientation RTL was not honoured, as with `getContentPane()` being removed from `add` call of JFrame, it was also additionally removed from other JFrame calls which resulted in the RTL not being propagated to its child. Fix is to add `getContentPane()` to the non-add methods of JFrame as was done in the applet version of the test..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329559](https://bugs.openjdk.org/browse/JDK-8329559): Test javax/swing/JFrame/bug4419914.java failed because The End and Start buttons are not placed correctly and Tab focus does not move as expected (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18612/head:pull/18612` \
`$ git checkout pull/18612`

Update a local copy of the PR: \
`$ git checkout pull/18612` \
`$ git pull https://git.openjdk.org/jdk.git pull/18612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18612`

View PR using the GUI difftool: \
`$ git pr show -t 18612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18612.diff">https://git.openjdk.org/jdk/pull/18612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18612#issuecomment-2036234175)