### PR TITLE
8329637: Apparent typo in java.security file property jdk.tls.keyLimits

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -892,7 +892,7 @@ jdk.tls.legacyAlgorithms=NULL, anon, RC4, DES, 3DES_EDE_CBC
 #   KeyLimits:
 #       " KeyLimit { , KeyLimit } "
 #
-#   WeakKeyLimit:
+#   KeyLimit:
 #       AlgorithmName Action Length
 #
 #   AlgorithmName:


### PR DESCRIPTION
Fix a minor typo in the `java.security` file that got missed during the original TLSv1.3 work.

No test needed, comments only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8329642](https://bugs.openjdk.org/browse/JDK-8329642) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8329637](https://bugs.openjdk.org/browse/JDK-8329637): Apparent typo in java.security file property jdk.tls.keyLimits (**Bug** - P4)
 * [JDK-8329642](https://bugs.openjdk.org/browse/JDK-8329642): Apparent typo in java.security file property jdk.tls.keyLimits (**CSR**)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18613/head:pull/18613` \
`$ git checkout pull/18613`

Update a local copy of the PR: \
`$ git checkout pull/18613` \
`$ git pull https://git.openjdk.org/jdk.git pull/18613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18613`

View PR using the GUI difftool: \
`$ git pr show -t 18613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18613.diff">https://git.openjdk.org/jdk/pull/18613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18613#issuecomment-2037818974)