### PR TITLE
8329651: TestLibGraal.java crashes with assert(_stack_base != nullptr)

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -491,9 +491,11 @@ void Thread::print_on_error(outputStream* st, char* buf, int buflen) const {
   if (os_thr != nullptr) {
     st->fill_to(67);
     if (os_thr->get_state() != ZOMBIE) {
+      // Use raw field members for stack base/size as this could be
+      // called before a thread has run enough to initialize them.
       st->print(" [id=%d, stack(" PTR_FORMAT "," PTR_FORMAT ") (" PROPERFMT ")]",
-                osthread()->thread_id(), p2i(stack_end()), p2i(stack_base()),
-                PROPERFMTARGS(stack_size()));
+                osthread()->thread_id(), p2i(_stack_base - _stack_size), p2i(_stack_base),
+                PROPERFMTARGS(_stack_size));
     } else {
       st->print(" terminated");
     }


### PR DESCRIPTION
The first thing a new thread does is record its stack size and base. But it is made visible to the rest of the system prior to that. So  we have a risk of trying to print information for a thread that may never have actually executed yet. `Thread::print_on_error` should access the `_stack_base` and `_stack_size` fields directly, not through the accessors with the assert.

Testing:
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329651](https://bugs.openjdk.org/browse/JDK-8329651): TestLibGraal.java crashes with assert(_stack_base != nullptr) (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18615/head:pull/18615` \
`$ git checkout pull/18615`

Update a local copy of the PR: \
`$ git checkout pull/18615` \
`$ git pull https://git.openjdk.org/jdk.git pull/18615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18615`

View PR using the GUI difftool: \
`$ git pr show -t 18615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18615.diff">https://git.openjdk.org/jdk/pull/18615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18615#issuecomment-2036460239)