### PR TITLE
8329261: G1: interpreter post-barrier x86 code asserts index size of wrong buffer

### DIFF
--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -269,8 +269,6 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
                                                   Register thread,
                                                   Register tmp,
                                                   Register tmp2) {
-  // Generated code assumes that buffer index is pointer sized.
-  STATIC_ASSERT(in_bytes(SATBMarkQueue::byte_width_of_index()) == sizeof(intptr_t));
 #ifdef _LP64
   assert(thread == r15_thread, "must be");
 #endif // _LP64
@@ -320,6 +318,9 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
   // dirty card and log.
 
   __ movb(Address(card_addr, 0), G1CardTable::dirty_card_val());
+
+  // Generated code assumes that buffer index is pointer sized.
+  STATIC_ASSERT(in_bytes(G1DirtyCardQueue::byte_width_of_index()) == sizeof(intptr_t));
 
   __ movptr(tmp2, queue_index);
   __ testptr(tmp2, tmp2);

--- a/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/g1/g1BarrierSetAssembler_x86.cpp
@@ -319,7 +319,7 @@ void G1BarrierSetAssembler::g1_write_barrier_post(MacroAssembler* masm,
 
   __ movb(Address(card_addr, 0), G1CardTable::dirty_card_val());
 
-  // Generated code assumes that buffer index is pointer sized.
+  // The code below assumes that buffer index is pointer sized.
   STATIC_ASSERT(in_bytes(G1DirtyCardQueue::byte_width_of_index()) == sizeof(intptr_t));
 
   __ movptr(tmp2, queue_index);


### PR DESCRIPTION
This changeset updates an assert in G1's interpreter x86 post-barrier logic so that it refers to the right queue (`G1DirtyCardQueue` rather than pre-barrier's `SATBMarkQueue`) and moves the assert closer to the logic that exploits it.

Thanks to Kim Barrett for reporting the issue and suggesting the fix.

**Testing**: built on windows-x64, linux-x64, and macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329261](https://bugs.openjdk.org/browse/JDK-8329261): G1: interpreter post-barrier x86 code asserts index size of wrong buffer (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18616/head:pull/18616` \
`$ git checkout pull/18616`

Update a local copy of the PR: \
`$ git checkout pull/18616` \
`$ git pull https://git.openjdk.org/jdk.git pull/18616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18616`

View PR using the GUI difftool: \
`$ git pr show -t 18616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18616.diff">https://git.openjdk.org/jdk/pull/18616.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18616#issuecomment-2036585076)