### PR TITLE
8329655: Cleanup KlassObj and klassOop names after the PermGen removal

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1199,7 +1199,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   ldrw(scan_temp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klassoop.
+  // %%% Could store the aligned, prescaled offset in the klass.
   // lea(scan_temp, Address(recv_klass, scan_temp, times_vte_scale, vtable_base));
   lea(scan_temp, Address(recv_klass, scan_temp, Address::lsl(3)));
   add(scan_temp, scan_temp, vtable_base);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1199,7 +1199,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   ldrw(scan_temp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klass.
+  // Could store the aligned, prescaled offset in the klass.
   // lea(scan_temp, Address(recv_klass, scan_temp, times_vte_scale, vtable_base));
   lea(scan_temp, Address(recv_klass, scan_temp, Address::lsl(3)));
   add(scan_temp, scan_temp, vtable_base);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1879,7 +1879,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
   int log_vte_size= exact_log2(vtableEntry::size_in_bytes());
 
   lwz(scan_temp, in_bytes(Klass::vtable_length_offset()), recv_klass);
-  // %%% We should store the aligned, prescaled offset in the klassoop.
+  // %%% We should store the aligned, prescaled offset in the klass.
   // Then the next several instructions would fold away.
 
   sldi(scan_temp, scan_temp, log_vte_size);
@@ -2010,7 +2010,7 @@ void MacroAssembler::check_klass_subtype_fast_path(Register sub_klass,
     // super_check_offset is register.
     assert_different_registers(sub_klass, super_klass, cached_super, super_check_offset.as_register());
   }
-  // The loaded value is the offset from KlassOopDesc.
+  // The loaded value is the offset from Klass.
 
   ld(cached_super, super_check_offset, sub_klass);
   cmpd(CCR0, cached_super, super_klass);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1879,7 +1879,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
   int log_vte_size= exact_log2(vtableEntry::size_in_bytes());
 
   lwz(scan_temp, in_bytes(Klass::vtable_length_offset()), recv_klass);
-  // %%% We should store the aligned, prescaled offset in the klass.
+  // We should store the aligned, prescaled offset in the klass.
   // Then the next several instructions would fold away.
 
   sldi(scan_temp, scan_temp, log_vte_size);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2502,7 +2502,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   lwu(scan_tmp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klass.
+  // Could store the aligned, prescaled offset in the klass.
   shadd(scan_tmp, scan_tmp, recv_klass, scan_tmp, 3);
   add(scan_tmp, scan_tmp, vtable_base);
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2502,7 +2502,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   lwu(scan_tmp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klassoop.
+  // %%% Could store the aligned, prescaled offset in the klass.
   shadd(scan_tmp, scan_tmp, recv_klass, scan_tmp, 3);
   add(scan_tmp, scan_tmp, vtable_base);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4339,7 +4339,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   movl(scan_temp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klass.
+  // Could store the aligned, prescaled offset in the klass.
   lea(scan_temp, Address(recv_klass, scan_temp, times_vte_scale, vtable_base));
 
   if (return_method) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4339,7 +4339,7 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
 
   movl(scan_temp, Address(recv_klass, Klass::vtable_length_offset()));
 
-  // %%% Could store the aligned, prescaled offset in the klassoop.
+  // %%% Could store the aligned, prescaled offset in the klass.
   lea(scan_temp, Address(recv_klass, scan_temp, times_vte_scale, vtable_base));
 
   if (return_method) {

--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1323,9 +1323,9 @@ void LIRGenerator::do_getModifiers(Intrinsic* x) {
   // from the primitive class itself. See spec for Class.getModifiers that provides
   // the typed array klasses with similar modifiers as their component types.
 
-  Klass* univ_klass_obj = Universe::byteArrayKlassObj();
-  assert(univ_klass_obj->modifier_flags() == (JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC), "Sanity");
-  LIR_Opr prim_klass = LIR_OprFact::metadataConst(univ_klass_obj);
+  Klass* univ_klass = Universe::byteArrayKlass();
+  assert(univ_klass->modifier_flags() == (JVM_ACC_ABSTRACT | JVM_ACC_FINAL | JVM_ACC_PUBLIC), "Sanity");
+  LIR_Opr prim_klass = LIR_OprFact::metadataConst(univ_klass);
 
   LIR_Opr recv_klass = new_register(T_METADATA);
   __ move(new LIR_Address(receiver.result(), java_lang_Class::klass_offset(), T_ADDRESS), recv_klass, info);

--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -41,7 +41,6 @@
 #include "runtime/java.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "utilities/bitMap.inline.hpp"
-
 #if INCLUDE_G1GC
 #include "gc/g1/g1CollectedHeap.hpp"
 #include "gc/g1/g1HeapRegion.hpp"
@@ -188,7 +187,7 @@ void ArchiveHeapWriter::ensure_buffer_space(size_t min_bytes) {
 }
 
 void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShared>* roots) {
-  Klass* k = Universe::objectArrayKlassObj(); // already relocated to point to archived klass
+  Klass* k = Universe::objectArrayKlass(); // already relocated to point to archived klass
   int length = roots->length();
   _heap_roots_word_size = objArrayOopDesc::object_size(length);
   size_t byte_size = _heap_roots_word_size * HeapWordSize;
@@ -315,7 +314,7 @@ int ArchiveHeapWriter::filler_array_length(size_t fill_bytes) {
 
 HeapWord* ArchiveHeapWriter::init_filler_array_at_buffer_top(int array_length, size_t fill_bytes) {
   assert(UseCompressedClassPointers, "Archived heap only supported for compressed klasses");
-  Klass* oak = Universe::objectArrayKlassObj(); // already relocated to point to archived klass
+  Klass* oak = Universe::objectArrayKlass(); // already relocated to point to archived klass
   HeapWord* mem = offset_to_buffered_address<HeapWord*>(_buffer_used);
   memset(mem, 0, fill_bytes);
   oopDesc::set_mark(mem, markWord::prototype());
@@ -594,7 +593,7 @@ void ArchiveHeapWriter::relocate_embedded_oops(GrowableArrayCHeap<oop, mtClassSh
   // Relocate HeapShared::roots(), which is created in copy_roots_to_buffer() and
   // doesn't have a corresponding src_obj, so we can't use EmbeddedOopRelocator on it.
   oop requested_roots = requested_obj_from_buffer_offset(_heap_roots_offset);
-  update_header_for_requested_obj(requested_roots, nullptr, Universe::objectArrayKlassObj());
+  update_header_for_requested_obj(requested_roots, nullptr, Universe::objectArrayKlass());
   int length = roots != nullptr ? roots->length() : 0;
   for (int i = 0; i < length; i++) {
     if (UseCompressedOops) {

--- a/src/hotspot/share/cds/dynamicArchive.cpp
+++ b/src/hotspot/share/cds/dynamicArchive.cpp
@@ -180,7 +180,7 @@ public:
   void iterate_primitive_array_klasses(MetaspaceClosure* it) {
     for (int i = T_BOOLEAN; i <= T_LONG; i++) {
       assert(is_java_primitive((BasicType)i), "sanity");
-      Klass* k = Universe::typeArrayKlassObj((BasicType)i);  // this give you "[I", etc
+      Klass* k = Universe::typeArrayKlass((BasicType)i);  // this give you "[I", etc
       assert(MetaspaceShared::is_shared_static((void*)k),
         "one-dimensional primitive array should be in static archive");
       ArrayKlass* ak = ArrayKlass::cast(k);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -691,7 +691,7 @@ void KlassSubGraphInfo::add_subgraph_object_klass(Klass* orig_k) {
             "must be boot class");
       check_allowed_klass(InstanceKlass::cast(ObjArrayKlass::cast(orig_k)->bottom_klass()));
     }
-    if (buffered_k == Universe::objectArrayKlassObj()) {
+    if (buffered_k == Universe::objectArrayKlass()) {
       // Initialized early during Universe::genesis. No need to be added
       // to the list.
       return;

--- a/src/hotspot/share/ci/ciObjectFactory.cpp
+++ b/src/hotspot/share/ci/ciObjectFactory.cpp
@@ -180,14 +180,14 @@ void ciObjectFactory::init_shared_objects() {
   init_ident_of(ciEnv::_unloaded_ciobjarrayklass);
   assert(ciEnv::_unloaded_ciobjarrayklass->is_obj_array_klass(), "just checking");
 
-  get_metadata(Universe::boolArrayKlassObj());
-  get_metadata(Universe::charArrayKlassObj());
-  get_metadata(Universe::floatArrayKlassObj());
-  get_metadata(Universe::doubleArrayKlassObj());
-  get_metadata(Universe::byteArrayKlassObj());
-  get_metadata(Universe::shortArrayKlassObj());
-  get_metadata(Universe::intArrayKlassObj());
-  get_metadata(Universe::longArrayKlassObj());
+  get_metadata(Universe::boolArrayKlass());
+  get_metadata(Universe::charArrayKlass());
+  get_metadata(Universe::floatArrayKlass());
+  get_metadata(Universe::doubleArrayKlass());
+  get_metadata(Universe::byteArrayKlass());
+  get_metadata(Universe::shortArrayKlass());
+  get_metadata(Universe::intArrayKlass());
+  get_metadata(Universe::longArrayKlass());
 
   assert(_non_perm_count == 0, "no shared non-perm objects");
 

--- a/src/hotspot/share/ci/ciTypeArrayKlass.cpp
+++ b/src/hotspot/share/ci/ciTypeArrayKlass.cpp
@@ -44,7 +44,7 @@ ciTypeArrayKlass::ciTypeArrayKlass(Klass* k) : ciArrayKlass(k) {
 //
 // Implementation of make.
 ciTypeArrayKlass* ciTypeArrayKlass::make_impl(BasicType t) {
-  Klass* k = Universe::typeArrayKlassObj(t);
+  Klass* k = Universe::typeArrayKlass(t);
   return CURRENT_ENV->get_type_array_klass(k);
 }
 

--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1259,7 +1259,7 @@ oop java_lang_Class::create_basic_type_mirror(const char* basic_type_name, Basic
   // introducing a new VM klass (see comment in ClassFileParser)
   oop java_class = InstanceMirrorKlass::cast(vmClasses::Class_klass())->allocate_instance(nullptr, CHECK_NULL);
   if (type != T_VOID) {
-    Klass* aklass = Universe::typeArrayKlassObj(type);
+    Klass* aklass = Universe::typeArrayKlass(type);
     assert(aklass != nullptr, "correct bootstrap");
     release_set_array_klass(java_class, aklass);
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -367,7 +367,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
       k = k->array_klass(ndims, CHECK_NULL);
     }
   } else {
-    k = Universe::typeArrayKlassObj(t);
+    k = Universe::typeArrayKlass(t);
     k = TypeArrayKlass::cast(k)->array_klass(ndims, CHECK_NULL);
   }
   return k;
@@ -782,7 +782,7 @@ Klass* SystemDictionary::find_instance_or_array_klass(Thread* current,
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
     if (t != T_OBJECT) {
-      k = Universe::typeArrayKlassObj(t);
+      k = Universe::typeArrayKlass(t);
     } else {
       k = SystemDictionary::find_instance_klass(current, ss.as_symbol(), class_loader, protection_domain);
     }
@@ -1727,7 +1727,7 @@ Klass* SystemDictionary::find_constrained_instance_or_array_klass(
     int ndims = ss.skip_array_prefix();  // skip all '['s
     BasicType t = ss.type();
     if (t != T_OBJECT) {
-      klass = Universe::typeArrayKlassObj(t);
+      klass = Universe::typeArrayKlass(t);
     } else {
       MutexLocker mu(current, SystemDictionary_lock);
       klass = LoaderConstraintTable::find_constrained_klass(ss.as_symbol(), class_loader_data(class_loader));

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -249,7 +249,7 @@ inline bool G1CollectedHeap::requires_barriers(stackChunkOop obj) const {
 
 inline bool G1CollectedHeap::is_obj_filler(const oop obj) {
   Klass* k = obj->klass_raw();
-  return k == Universe::fillerArrayKlassObj() || k == vmClasses::FillerObject_klass();
+  return k == Universe::fillerArrayKlass() || k == vmClasses::FillerObject_klass();
 }
 
 inline bool G1CollectedHeap::is_obj_dead(const oop obj, const HeapRegion* hr) const {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1427,7 +1427,7 @@ bool PSParallelCompact::invoke_no_policy(bool maximum_heap_compaction) {
     DerivedPointerTable::set_active(false);
 #endif
 
-    // adjust_roots() updates Universe::_intArrayKlassObj which is
+    // adjust_roots() updates Universe::_intArrayKlass which is
     // needed by the compaction for filling holes in the dense prefix.
     adjust_roots();
 

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -462,7 +462,7 @@ CollectedHeap::fill_with_array(HeapWord* start, size_t words, bool zap)
   const size_t len = payload_size * HeapWordSize / sizeof(jint);
   assert((int)len >= 0, "size too large " SIZE_FORMAT " becomes %d", words, (int)len);
 
-  ObjArrayAllocator allocator(Universe::fillerArrayKlassObj(), words, (int)len, /* do_zero */ false);
+  ObjArrayAllocator allocator(Universe::fillerArrayKlass(), words, (int)len, /* do_zero */ false);
   allocator.initialize(start);
   if (CDSConfig::is_dumping_heap()) {
     // This array is written into the CDS archive. Make sure it

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -1607,10 +1607,10 @@ run:
           ARRAY_INTRO(-3);
           int item = STACK_INT(-1);
           // if it is a T_BOOLEAN array, mask the stored value to 0/1
-          if (arrObj->klass() == Universe::boolArrayKlassObj()) {
+          if (arrObj->klass() == Universe::boolArrayKlass()) {
             item &= 1;
           } else {
-            assert(arrObj->klass() == Universe::byteArrayKlassObj(),
+            assert(arrObj->klass() == Universe::byteArrayKlass(),
                    "should be byte array otherwise");
           }
           ((typeArrayOop)arrObj)->byte_at_put(index, item);

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -450,9 +450,9 @@ static void write_primitive(JfrCheckpointWriter* writer, KlassPtr type_array_kla
   assert(writer != nullptr, "invariant");
   assert(_artifacts != nullptr, "invariant");
   writer->write(primitive_id(type_array_klass));
-  writer->write(cld_id(get_cld(Universe::boolArrayKlassObj()), false));
+  writer->write(cld_id(get_cld(Universe::boolArrayKlass()), false));
   writer->write(mark_symbol(primitive_symbol(type_array_klass), false));
-  writer->write(package_id(Universe::boolArrayKlassObj(), false));
+  writer->write(package_id(Universe::boolArrayKlass(), false));
   writer->write(get_primitive_flags());
   writer->write<bool>(false);
 }
@@ -468,14 +468,14 @@ static bool is_initial_typeset_for_chunk() {
 // It will use a reserved constant.
 static void do_primitives() {
   assert(is_initial_typeset_for_chunk(), "invariant");
-  write_primitive(_writer, Universe::boolArrayKlassObj());
-  write_primitive(_writer, Universe::byteArrayKlassObj());
-  write_primitive(_writer, Universe::charArrayKlassObj());
-  write_primitive(_writer, Universe::shortArrayKlassObj());
-  write_primitive(_writer, Universe::intArrayKlassObj());
-  write_primitive(_writer, Universe::longArrayKlassObj());
-  write_primitive(_writer, Universe::floatArrayKlassObj());
-  write_primitive(_writer, Universe::doubleArrayKlassObj());
+  write_primitive(_writer, Universe::boolArrayKlass());
+  write_primitive(_writer, Universe::byteArrayKlass());
+  write_primitive(_writer, Universe::charArrayKlass());
+  write_primitive(_writer, Universe::shortArrayKlass());
+  write_primitive(_writer, Universe::intArrayKlass());
+  write_primitive(_writer, Universe::longArrayKlass());
+  write_primitive(_writer, Universe::floatArrayKlass());
+  write_primitive(_writer, Universe::doubleArrayKlass());
   write_primitive(_writer, nullptr); // void.class
 }
 

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -485,8 +485,8 @@ ScopeValue* CodeInstaller::get_scope_value(HotSpotCompiledCodeStream* stream, u1
 void CodeInstaller::record_object_value(ObjectValue* sv, HotSpotCompiledCodeStream* stream, JVMCI_TRAPS) {
   oop javaMirror = JNIHandles::resolve(sv->klass()->as_ConstantOopWriteValue()->value());
   Klass* klass = java_lang_Class::as_Klass(javaMirror);
-  bool isLongArray = klass == Universe::longArrayKlassObj();
-  bool isByteArray = klass == Universe::byteArrayKlassObj();
+  bool isLongArray = klass == Universe::longArrayKlass();
+  bool isByteArray = klass == Universe::byteArrayKlass();
 
   u2 length = stream->read_u2("values:length");
   for (jint i = 0; i < length; i++) {

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -636,7 +636,7 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, ARGU
           resolved_klass = resolved_klass->array_klass(ndim, CHECK_NULL);
         }
       } else {
-        resolved_klass = TypeArrayKlass::cast(Universe::typeArrayKlassObj(ss.type()))->array_klass(ndim, CHECK_NULL);
+        resolved_klass = TypeArrayKlass::cast(Universe::typeArrayKlass(ss.type()))->array_klass(ndim, CHECK_NULL);
       }
     } else {
       resolved_klass = SystemDictionary::find_instance_klass(THREAD, class_name,
@@ -656,7 +656,7 @@ C2V_VMENTRY_NULL(jobject, getArrayType, (JNIEnv* env, jobject, jchar type_char, 
     if (type == T_VOID) {
       return nullptr;
     }
-    array_klass = Universe::typeArrayKlassObj(type);
+    array_klass = Universe::typeArrayKlass(type);
     if (array_klass == nullptr) {
       JVMCI_THROW_MSG_NULL(InternalError, err_msg("No array klass for primitive type %s", type2name(type)));
     }

--- a/src/hotspot/share/jvmci/jvmciEnv.cpp
+++ b/src/hotspot/share/jvmci/jvmciEnv.cpp
@@ -1430,7 +1430,7 @@ JVMCIPrimitiveArray JVMCIEnv::new_byteArray(int length, JVMCI_TRAPS) {
 JVMCIObjectArray JVMCIEnv::new_byte_array_array(int length, JVMCI_TRAPS) {
   JavaThread* THREAD = JavaThread::current(); // For exception macros.
   if (is_hotspot()) {
-    Klass* byteArrayArrayKlass = TypeArrayKlass::cast(Universe::byteArrayKlassObj  ())->array_klass(CHECK_(JVMCIObject()));
+    Klass* byteArrayArrayKlass = TypeArrayKlass::cast(Universe::byteArrayKlass())->array_klass(CHECK_(JVMCIObject()));
     objArrayOop result = ObjArrayKlass::cast(byteArrayArrayKlass) ->allocate(length, CHECK_(JVMCIObject()));
     return wrap(result);
   } else {

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -196,7 +196,7 @@ KlassInfoTable::~KlassInfoTable() {
 }
 
 uint KlassInfoTable::hash(const Klass* p) {
-  return (uint)(((uintptr_t)p - (uintptr_t)_ref) >> 2);
+  return (uint)(((uintptr_t)p - _ref) >> 2);
 }
 
 KlassInfoEntry* KlassInfoTable::lookup(Klass* k) {

--- a/src/hotspot/share/memory/heapInspection.cpp
+++ b/src/hotspot/share/memory/heapInspection.cpp
@@ -83,14 +83,14 @@ const char* KlassInfoEntry::name() const {
   if (_klass->name() != nullptr) {
     name = _klass->external_name();
   } else {
-    if (_klass == Universe::boolArrayKlassObj())         name = "<boolArrayKlass>";         else
-    if (_klass == Universe::charArrayKlassObj())         name = "<charArrayKlass>";         else
-    if (_klass == Universe::floatArrayKlassObj())        name = "<floatArrayKlass>";        else
-    if (_klass == Universe::doubleArrayKlassObj())       name = "<doubleArrayKlass>";       else
-    if (_klass == Universe::byteArrayKlassObj())         name = "<byteArrayKlass>";         else
-    if (_klass == Universe::shortArrayKlassObj())        name = "<shortArrayKlass>";        else
-    if (_klass == Universe::intArrayKlassObj())          name = "<intArrayKlass>";          else
-    if (_klass == Universe::longArrayKlassObj())         name = "<longArrayKlass>";         else
+    if (_klass == Universe::boolArrayKlass())         name = "<boolArrayKlass>";         else
+    if (_klass == Universe::charArrayKlass())         name = "<charArrayKlass>";         else
+    if (_klass == Universe::floatArrayKlass())        name = "<floatArrayKlass>";        else
+    if (_klass == Universe::doubleArrayKlass())       name = "<doubleArrayKlass>";       else
+    if (_klass == Universe::byteArrayKlass())         name = "<byteArrayKlass>";         else
+    if (_klass == Universe::shortArrayKlass())        name = "<shortArrayKlass>";        else
+    if (_klass == Universe::intArrayKlass())          name = "<intArrayKlass>";          else
+    if (_klass == Universe::longArrayKlass())         name = "<longArrayKlass>";         else
       name = "<no name>";
   }
   return name;
@@ -170,7 +170,7 @@ public:
 
 KlassInfoTable::KlassInfoTable(bool add_all_classes) {
   _size_of_instances_in_words = 0;
-  _ref = (HeapWord*) Universe::boolArrayKlassObj();
+  _ref = (uintptr_t) Universe::boolArrayKlass();
   _buckets =
     (KlassInfoBucket*)  AllocateHeap(sizeof(KlassInfoBucket) * _num_buckets,
        mtInternal, CURRENT_PC, AllocFailStrategy::RETURN_NULL);

--- a/src/hotspot/share/memory/heapInspection.hpp
+++ b/src/hotspot/share/memory/heapInspection.hpp
@@ -108,9 +108,8 @@ class KlassInfoTable: public StackObj {
   size_t _size_of_instances_in_words;
 
   // An aligned reference address (typically the least
-  // address in the perm gen) used for hashing klass
-  // objects.
-  HeapWord* _ref;
+  // address in the metaspace) used for hashing klasses.
+  uintptr_t _ref;
 
   KlassInfoBucket* _buckets;
   uint hash(const Klass* p);

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -41,41 +41,41 @@
 #include "utilities/utf8.hpp"
 
 typeArrayOop oopFactory::new_boolArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::boolArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::boolArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_charArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::charArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::charArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_floatArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::floatArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::floatArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_doubleArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::doubleArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::doubleArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_byteArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::byteArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::byteArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_shortArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::shortArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::shortArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_intArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::intArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::intArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_longArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::longArrayKlassObj())->allocate(length, THREAD);
+  return TypeArrayKlass::cast(Universe::longArrayKlass())->allocate(length, THREAD);
 }
 
 // create java.lang.Object[]
 objArrayOop oopFactory::new_objectArray(int length, TRAPS)  {
-  assert(Universe::objectArrayKlassObj() != nullptr, "Too early?");
-  return ObjArrayKlass::cast(Universe::objectArrayKlassObj())->allocate(length, THREAD);
+  assert(Universe::objectArrayKlass() != nullptr, "Too early?");
+  return ObjArrayKlass::cast(Universe::objectArrayKlass())->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_charArray(const char* utf8_str, TRAPS) {
@@ -88,9 +88,9 @@ typeArrayOop oopFactory::new_charArray(const char* utf8_str, TRAPS) {
 }
 
 typeArrayOop oopFactory::new_typeArray(BasicType type, int length, TRAPS) {
-  Klass* type_asKlassOop = Universe::typeArrayKlassObj(type);
-  TypeArrayKlass* type_asArrayKlass = TypeArrayKlass::cast(type_asKlassOop);
-  typeArrayOop result = type_asArrayKlass->allocate(length, THREAD);
+  Klass* klass = Universe::typeArrayKlass(type);
+  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
+  typeArrayOop result = typeArrayKlass->allocate(length, THREAD);
   return result;
 }
 
@@ -100,16 +100,16 @@ typeArrayOop oopFactory::new_typeArray(BasicType type, int length, TRAPS) {
 // this.  They cast Symbol* into this type.
 typeArrayOop oopFactory::new_symbolArray(int length, TRAPS) {
   BasicType type = LP64_ONLY(T_LONG) NOT_LP64(T_INT);
-  Klass* type_asKlassOop = Universe::typeArrayKlassObj(type);
-  TypeArrayKlass* type_asArrayKlass = TypeArrayKlass::cast(type_asKlassOop);
-  typeArrayOop result = type_asArrayKlass->allocate(length, THREAD);
+  Klass* klass = Universe::typeArrayKlass(type);
+  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
+  typeArrayOop result = typeArrayKlass->allocate(length, THREAD);
   return result;
 }
 
 typeArrayOop oopFactory::new_typeArray_nozero(BasicType type, int length, TRAPS) {
-  Klass* type_asKlassOop = Universe::typeArrayKlassObj(type);
-  TypeArrayKlass* type_asArrayKlass = TypeArrayKlass::cast(type_asKlassOop);
-  typeArrayOop result = type_asArrayKlass->allocate_common(length, false, THREAD);
+  Klass* klass = Universe::typeArrayKlass(type);
+  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
+  typeArrayOop result = typeArrayKlass->allocate_common(length, false, THREAD);
   return result;
 }
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -111,9 +111,9 @@ static LatestMethodCache _throw_no_such_method_error_cache; // Unsafe.throwNoSuc
 static LatestMethodCache _do_stack_walk_cache;              // AbstractStackWalker.doStackWalk()
 
 // Known objects
-Klass* Universe::_typeArrayKlassObjs[T_LONG+1]        = { nullptr /*, nullptr...*/ };
-Klass* Universe::_objectArrayKlassObj                 = nullptr;
-Klass* Universe::_fillerArrayKlassObj                 = nullptr;
+Klass* Universe::_typeArrayKlasses[T_LONG+1]        = { nullptr /*, nullptr...*/ };
+Klass* Universe::_objectArrayKlass                  = nullptr;
+Klass* Universe::_fillerArrayKlass                  = nullptr;
 OopHandle Universe::_basic_type_mirrors[T_VOID+1];
 #if INCLUDE_CDS_JAVA_HEAP
 int Universe::_archived_basic_type_mirror_indices[T_VOID+1];
@@ -265,21 +265,21 @@ oop Universe::java_mirror(BasicType t) {
 
 void Universe::basic_type_classes_do(KlassClosure *closure) {
   for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
-    closure->do_klass(_typeArrayKlassObjs[i]);
+    closure->do_klass(_typeArrayKlasses[i]);
   }
   // We don't do the following because it will confuse JVMTI.
-  // _fillerArrayKlassObj is used only by GC, which doesn't need to see
+  // _fillerArrayKlass is used only by GC, which doesn't need to see
   // this klass from basic_type_classes_do().
   //
-  // closure->do_klass(_fillerArrayKlassObj);
+  // closure->do_klass(_fillerArrayKlass);
 }
 
 void Universe::metaspace_pointers_do(MetaspaceClosure* it) {
-  it->push(&_fillerArrayKlassObj);
+  it->push(&_fillerArrayKlass);
   for (int i = 0; i < T_LONG+1; i++) {
-    it->push(&_typeArrayKlassObjs[i]);
+    it->push(&_typeArrayKlasses[i]);
   }
-  it->push(&_objectArrayKlassObj);
+  it->push(&_objectArrayKlass);
 
   it->push(&_the_empty_int_array);
   it->push(&_the_empty_short_array);
@@ -334,12 +334,12 @@ void Universe::serialize(SerializeClosure* f) {
   _virtual_machine_error.serialize(f);
 #endif
 
-  f->do_ptr(&_fillerArrayKlassObj);
+  f->do_ptr(&_fillerArrayKlass);
   for (int i = 0; i < T_LONG+1; i++) {
-    f->do_ptr(&_typeArrayKlassObjs[i]);
+    f->do_ptr(&_typeArrayKlasses[i]);
   }
 
-  f->do_ptr(&_objectArrayKlassObj);
+  f->do_ptr(&_objectArrayKlass);
   f->do_ptr(&_the_array_interfaces_array);
   f->do_ptr(&_the_empty_int_array);
   f->do_ptr(&_the_empty_short_array);
@@ -396,9 +396,9 @@ void Universe::genesis(TRAPS) {
       // Initialization of the fillerArrayKlass must come before regular
       // int-TypeArrayKlass so that the int-Array mirror points to the
       // int-TypeArrayKlass.
-      _fillerArrayKlassObj = TypeArrayKlass::create_klass(T_INT, "[Ljdk/internal/vm/FillerElement;", CHECK);
+      _fillerArrayKlass = TypeArrayKlass::create_klass(T_INT, "[Ljdk/internal/vm/FillerElement;", CHECK);
       for (int i = T_BOOLEAN; i < T_LONG+1; i++) {
-        _typeArrayKlassObjs[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
+        _typeArrayKlasses[i] = TypeArrayKlass::create_klass((BasicType)i, CHECK);
       }
 
       ClassLoaderData* null_cld = ClassLoaderData::the_null_class_loader_data();
@@ -437,18 +437,18 @@ void Universe::genesis(TRAPS) {
       _the_array_interfaces_array->at_put(1, vmClasses::Serializable_klass());
     }
 
-    initialize_basic_type_klass(_fillerArrayKlassObj, CHECK);
+    initialize_basic_type_klass(_fillerArrayKlass, CHECK);
 
-    initialize_basic_type_klass(boolArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(charArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(floatArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(doubleArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(byteArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(shortArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(intArrayKlassObj(), CHECK);
-    initialize_basic_type_klass(longArrayKlassObj(), CHECK);
+    initialize_basic_type_klass(boolArrayKlass(), CHECK);
+    initialize_basic_type_klass(charArrayKlass(), CHECK);
+    initialize_basic_type_klass(floatArrayKlass(), CHECK);
+    initialize_basic_type_klass(doubleArrayKlass(), CHECK);
+    initialize_basic_type_klass(byteArrayKlass(), CHECK);
+    initialize_basic_type_klass(shortArrayKlass(), CHECK);
+    initialize_basic_type_klass(intArrayKlass(), CHECK);
+    initialize_basic_type_klass(longArrayKlass(), CHECK);
 
-    assert(_fillerArrayKlassObj != intArrayKlassObj(),
+    assert(_fillerArrayKlass != intArrayKlass(),
            "Internal filler array klass should be different to int array Klass");
   } // end of core bootstrapping
 
@@ -472,7 +472,7 @@ void Universe::genesis(TRAPS) {
   // ordinary object arrays, _objectArrayKlass will be loaded when
   // SystemDictionary::initialize(CHECK); is run. See the extra check
   // for Object_klass_loaded in objArrayKlassKlass::allocate_objArray_klass_impl.
-  _objectArrayKlassObj = InstanceKlass::
+  _objectArrayKlass = InstanceKlass::
     cast(vmClasses::Object_klass())->array_klass(1, CHECK);
   // OLD
   // Add the class to the class hierarchy manually to make sure that
@@ -480,7 +480,7 @@ void Universe::genesis(TRAPS) {
   // ---
   // New
   // Have already been initialized.
-  _objectArrayKlassObj->append_to_sibling_list();
+  _objectArrayKlass->append_to_sibling_list();
 
   #ifdef ASSERT
   if (FullGCALot) {

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -65,11 +65,11 @@ class Universe: AllStatic {
 
  private:
   // Known classes in the VM
-  static Klass* _typeArrayKlassObjs[T_LONG+1];
-  static Klass* _objectArrayKlassObj;
+  static Klass* _typeArrayKlasses[T_LONG+1];
+  static Klass* _objectArrayKlass;
   // Special int-Array that represents filler objects that are used by GC to overwrite
   // dead objects. References to them are generally an error.
-  static Klass* _fillerArrayKlassObj;
+  static Klass* _fillerArrayKlass;
 
   // Known objects in the VM
   static OopHandle    _main_thread_group;             // Reference to the main thread group object
@@ -174,24 +174,24 @@ class Universe: AllStatic {
   static void set_verify_data(uintptr_t mask, uintptr_t bits) PRODUCT_RETURN;
 
   // Known classes in the VM
-  static Klass* boolArrayKlassObj()                 { return typeArrayKlassObj(T_BOOLEAN); }
-  static Klass* byteArrayKlassObj()                 { return typeArrayKlassObj(T_BYTE); }
-  static Klass* charArrayKlassObj()                 { return typeArrayKlassObj(T_CHAR); }
-  static Klass* intArrayKlassObj()                  { return typeArrayKlassObj(T_INT); }
-  static Klass* shortArrayKlassObj()                { return typeArrayKlassObj(T_SHORT); }
-  static Klass* longArrayKlassObj()                 { return typeArrayKlassObj(T_LONG); }
-  static Klass* floatArrayKlassObj()                { return typeArrayKlassObj(T_FLOAT); }
-  static Klass* doubleArrayKlassObj()               { return typeArrayKlassObj(T_DOUBLE); }
+  static Klass* boolArrayKlass()                 { return typeArrayKlass(T_BOOLEAN); }
+  static Klass* byteArrayKlass()                 { return typeArrayKlass(T_BYTE); }
+  static Klass* charArrayKlass()                 { return typeArrayKlass(T_CHAR); }
+  static Klass* intArrayKlass()                  { return typeArrayKlass(T_INT); }
+  static Klass* shortArrayKlass()                { return typeArrayKlass(T_SHORT); }
+  static Klass* longArrayKlass()                 { return typeArrayKlass(T_LONG); }
+  static Klass* floatArrayKlass()                { return typeArrayKlass(T_FLOAT); }
+  static Klass* doubleArrayKlass()               { return typeArrayKlass(T_DOUBLE); }
 
-  static Klass* objectArrayKlassObj()               { return _objectArrayKlassObj; }
+  static Klass* objectArrayKlass()               { return _objectArrayKlass; }
 
-  static Klass* fillerArrayKlassObj()               { return _fillerArrayKlassObj; }
+  static Klass* fillerArrayKlass()               { return _fillerArrayKlass; }
 
-  static Klass* typeArrayKlassObj(BasicType t) {
+  static Klass* typeArrayKlass(BasicType t) {
     assert((uint)t >= T_BOOLEAN, "range check for type: %s", type2name(t));
     assert((uint)t < T_LONG+1,   "range check for type: %s", type2name(t));
-    assert(_typeArrayKlassObjs[t] != nullptr, "domain check");
-    return _typeArrayKlassObjs[t];
+    assert(_typeArrayKlasses[t] != nullptr, "domain check");
+    return _typeArrayKlasses[t];
   }
 
   // Known objects in the VM

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1052,7 +1052,7 @@ JVM_ENTRY(jint, MHN_getNamedCon(JNIEnv *env, jobject igcls, jint which, jobjectA
     assert(which >= 0 && which < con_value_count, "");
     int con = con_values[which];
     objArrayHandle box(THREAD, (objArrayOop) JNIHandles::resolve(box_jh));
-    if (box.not_null() && box->klass() == Universe::objectArrayKlassObj() && box->length() > 0) {
+    if (box.not_null() && box->klass() == Universe::objectArrayKlass() && box->length() > 0) {
       const char* str = &con_names[0];
       for (int i = 0; i < which; i++)
         str += strlen(str) + 1;   // skip name and null
@@ -1255,7 +1255,7 @@ JVM_ENTRY(void, MHN_copyOutBootstrapArguments(JNIEnv* env, jobject igcls,
   InstanceKlass* caller = InstanceKlass::cast(caller_k);
   typeArrayOop index_info_oop = (typeArrayOop) JNIHandles::resolve(index_info_jh);
   if (index_info_oop == nullptr ||
-      index_info_oop->klass() != Universe::intArrayKlassObj() ||
+      index_info_oop->klass() != Universe::intArrayKlass() ||
       typeArrayOop(index_info_oop)->length() < 2) {
       THROW_MSG(vmSymbols::java_lang_InternalError(), "bad index info (0)");
   }

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -138,7 +138,7 @@ Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* f
   int elem_size = type2aelembytes(elem_bt);
 
   // On-heap vector values are represented as primitive arrays.
-  TypeArrayKlass* tak = TypeArrayKlass::cast(Universe::typeArrayKlassObj(elem_bt));
+  TypeArrayKlass* tak = TypeArrayKlass::cast(Universe::typeArrayKlass(elem_bt));
 
   typeArrayOop arr = tak->allocate(num_elem, CHECK_NH); // safepoint
 

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -328,7 +328,7 @@ static Klass* basic_type_mirror_to_arrayklass(oop basic_type_mirror, TRAPS) {
     THROW_0(vmSymbols::java_lang_IllegalArgumentException());
   }
   else {
-    return Universe::typeArrayKlassObj(type);
+    return Universe::typeArrayKlass(type);
   }
 }
 

--- a/test/hotspot/gtest/oops/test_typeArrayOop.cpp
+++ b/test/hotspot/gtest/oops/test_typeArrayOop.cpp
@@ -36,7 +36,7 @@ TEST_VM(typeArrayOopDesc, bool_at_put) {
   char* addr = align_up(mem, 16);
 
   typeArrayOop o = (typeArrayOop) cast_to_oop(addr);
-  o->set_klass(Universe::boolArrayKlassObj());
+  o->set_klass(Universe::boolArrayKlass());
   o->set_length(10);
 
 


### PR DESCRIPTION
We have a few places that uses the terms `KlassObj` and `klassOop` when referring to Klasses. This is old code from before the PermGen removal, when Klasses also were Java objects.

These names tripped me up when I was reading the heap heapInspection.cpp and first though we were mixing the klass *mirror* objects and klass pointers in the hash code calculation:
```
   // An aligned reference address (typically the least
   // address in the perm gen) used for hashing klass
   // objects.
   HeapWord* _ref;
...
_ref = (HeapWord*) Universe::boolArrayKlassObj();
...
uint KlassInfoTable::hash(const Klass* p) {
  return (uint)(((uintptr_t)p - (uintptr_t)_ref) >> 2);
}
```

I propose that we rename these functions (and stop casting the Klass* to a (HeapWord*)).

Tested with serviceability/dcmd/gc/ClassHistogramTest.java but will run this through our lower tiers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329655](https://bugs.openjdk.org/browse/JDK-8329655): Cleanup KlassObj and klassOop names after the PermGen removal (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18618/head:pull/18618` \
`$ git checkout pull/18618`

Update a local copy of the PR: \
`$ git checkout pull/18618` \
`$ git pull https://git.openjdk.org/jdk.git pull/18618/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18618`

View PR using the GUI difftool: \
`$ git pr show -t 18618`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18618.diff">https://git.openjdk.org/jdk/pull/18618.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18618#issuecomment-2036719414)