### PR TITLE
8329661: Refactor ScavengableNMethods::verify_unlisted_nmethods

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -854,9 +854,6 @@ bool SerialHeap::is_in(const void* p) const {
   return _young_gen->is_in(p) || _old_gen->is_in(p);
 }
 
-#ifdef ASSERT
-#endif
-
 void SerialHeap::object_iterate(ObjectClosure* cl) {
   _young_gen->object_iterate(cl);
   _old_gen->object_iterate(cl);

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -178,10 +178,6 @@ public:
 
   bool requires_barriers(stackChunkOop obj) const override;
 
-#ifdef ASSERT
-  bool is_in_partial_collection(const void* p);
-#endif
-
   // Optimized nmethod scanning support routines
   void register_nmethod(nmethod* nm) override;
   void unregister_nmethod(nmethod* nm) override;

--- a/src/hotspot/share/gc/shared/scavengableNMethods.cpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.cpp
@@ -157,7 +157,7 @@ void ScavengableNMethods::nmethods_do_and_prune(CodeBlobToOopClosure* cl) {
   }
 
   // Check for stray marks.
-  debug_only(verify_unlisted_nmethods());
+  debug_only(verify_nmethods());
 }
 
 void ScavengableNMethods::prune_nmethods_not_into_young() {
@@ -188,7 +188,7 @@ void ScavengableNMethods::prune_unlinked_nmethods() {
   }
 
   // Check for stray marks.
-  debug_only(verify_unlisted_nmethods());
+  debug_only(verify_nmethods());
 }
 
 // Walk the list of methods which might contain oops to the java heap.
@@ -228,7 +228,7 @@ void ScavengableNMethods::mark_on_list_nmethods() {
 }
 
 // Make sure that the effects of mark_on_list_nmethods is gone.
-void ScavengableNMethods::verify_unlisted_nmethods() {
+void ScavengableNMethods::verify_nmethods() {
   NMethodIterator iter(NMethodIterator::all_blobs);
   while(iter.next()) {
     nmethod* nm = iter.method();

--- a/src/hotspot/share/gc/shared/scavengableNMethods.cpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.cpp
@@ -157,7 +157,7 @@ void ScavengableNMethods::nmethods_do_and_prune(CodeBlobToOopClosure* cl) {
   }
 
   // Check for stray marks.
-  debug_only(verify_unlisted_nmethods(nullptr));
+  debug_only(verify_unlisted_nmethods());
 }
 
 void ScavengableNMethods::prune_nmethods_not_into_young() {
@@ -188,25 +188,13 @@ void ScavengableNMethods::prune_unlinked_nmethods() {
   }
 
   // Check for stray marks.
-  debug_only(verify_unlisted_nmethods(nullptr));
+  debug_only(verify_unlisted_nmethods());
 }
 
 // Walk the list of methods which might contain oops to the java heap.
 void ScavengableNMethods::nmethods_do(CodeBlobToOopClosure* cl) {
   nmethods_do_and_prune(cl);
 }
-
-#ifndef PRODUCT
-void ScavengableNMethods::asserted_non_scavengable_nmethods_do(CodeBlobClosure* cl) {
-  // While we are here, verify the integrity of the list.
-  mark_on_list_nmethods();
-  for (nmethod* cur = _head; cur != nullptr; cur = gc_data(cur).next()) {
-    assert(gc_data(cur).on_list(), "else shouldn't be on this list");
-    gc_data(cur).clear_marked();
-  }
-  verify_unlisted_nmethods(cl);
-}
-#endif // PRODUCT
 
 void ScavengableNMethods::unlist_nmethod(nmethod* nm, nmethod* prev) {
   assert_locked_or_safepoint(CodeCache_lock);
@@ -239,9 +227,8 @@ void ScavengableNMethods::mark_on_list_nmethods() {
   }
 }
 
-// If the closure is given, run it on the unlisted nmethods.
-// Also make sure that the effects of mark_on_list_nmethods is gone.
-void ScavengableNMethods::verify_unlisted_nmethods(CodeBlobClosure* cl) {
+// Make sure that the effects of mark_on_list_nmethods is gone.
+void ScavengableNMethods::verify_unlisted_nmethods() {
   NMethodIterator iter(NMethodIterator::all_blobs);
   while(iter.next()) {
     nmethod* nm = iter.method();
@@ -249,10 +236,6 @@ void ScavengableNMethods::verify_unlisted_nmethods(CodeBlobClosure* cl) {
     // Can not verify already unlinked nmethods as they are partially invalid already.
     if (!nm->is_unlinked()) {
       verify_nmethod(nm);
-    }
-
-    if (cl != nullptr && !gc_data(nm).on_list()) {
-      cl->do_code_blob(nm);
     }
   }
 }

--- a/src/hotspot/share/gc/shared/scavengableNMethods.hpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.hpp
@@ -55,8 +55,6 @@ public:
   // Remove nmethods that no longer have scavengable oops.
   static void nmethods_do(CodeBlobToOopClosure* cl);
 
-  static void asserted_non_scavengable_nmethods_do(CodeBlobClosure* cl) PRODUCT_RETURN;
-
 private:
   static void nmethods_do_and_prune(CodeBlobToOopClosure* cl);
   static void unlist_nmethod(nmethod* nm, nmethod* prev);
@@ -64,7 +62,7 @@ private:
   static bool has_scavengable_oops(nmethod* nm);
 
   static void mark_on_list_nmethods() PRODUCT_RETURN;
-  static void verify_unlisted_nmethods(CodeBlobClosure* cl) PRODUCT_RETURN;
+  static void verify_unlisted_nmethods() PRODUCT_RETURN;
 };
 
 #endif // SHARE_GC_SHARED_SCAVENGABLENMETHODS_HPP

--- a/src/hotspot/share/gc/shared/scavengableNMethods.hpp
+++ b/src/hotspot/share/gc/shared/scavengableNMethods.hpp
@@ -62,7 +62,7 @@ private:
   static bool has_scavengable_oops(nmethod* nm);
 
   static void mark_on_list_nmethods() PRODUCT_RETURN;
-  static void verify_unlisted_nmethods() PRODUCT_RETURN;
+  static void verify_nmethods() PRODUCT_RETURN;
 };
 
 #endif // SHARE_GC_SHARED_SCAVENGABLENMETHODS_HPP


### PR DESCRIPTION
Simple removing redundant verification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329661](https://bugs.openjdk.org/browse/JDK-8329661): Refactor ScavengableNMethods::verify_unlisted_nmethods (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18621/head:pull/18621` \
`$ git checkout pull/18621`

Update a local copy of the PR: \
`$ git checkout pull/18621` \
`$ git pull https://git.openjdk.org/jdk.git pull/18621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18621`

View PR using the GUI difftool: \
`$ git pr show -t 18621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18621.diff">https://git.openjdk.org/jdk/pull/18621.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18621#issuecomment-2036921852)