### PR TITLE
8329662: Add a test to verify the behaviour of the default HEAD() method on HttpRequest.Builder

### DIFF
--- a/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
+++ b/test/jdk/java/net/httpclient/HttpRequestBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,6 +259,16 @@ public class HttpRequestBuilderTest {
                 () -> HttpRequest.newBuilder(TEST_URI).HEAD(),
                 "HEAD");
 
+        // verify that the default HEAD() method implementation in HttpRequest.Builder
+        // interface works as expected
+        HttpRequest defaultHeadReq = new NotOverriddenHEADImpl().HEAD().uri(TEST_URI).build();
+        String actualMethod = defaultHeadReq.method();
+        if (!actualMethod.equals("HEAD")) {
+            throw new AssertionError("failed: expected HEAD method but got method: " + actualMethod);
+        }
+        if (defaultHeadReq.bodyPublisher().isEmpty()) {
+            throw new AssertionError("failed: missing bodyPublisher on HEAD request");
+        }
     }
 
     private static boolean shouldFail(Class<? extends Exception> ...exceptions) {
@@ -365,6 +375,81 @@ public class HttpRequestBuilderTest {
                         + arg2 + ") - Got expected exception: " + x);
                 return receiver;
             }
+        }
+    }
+
+    // doesn't override the default HEAD() method
+    private static final class NotOverriddenHEADImpl implements HttpRequest.Builder {
+        private final HttpRequest.Builder underlying = HttpRequest.newBuilder();
+
+        @Override
+        public HttpRequest.Builder uri(URI uri) {
+            return this.underlying.uri(uri);
+        }
+
+        @Override
+        public HttpRequest.Builder expectContinue(boolean enable) {
+            return this.underlying.expectContinue(enable);
+        }
+
+        @Override
+        public HttpRequest.Builder version(HttpClient.Version version) {
+            return this.underlying.version(version);
+        }
+
+        @Override
+        public HttpRequest.Builder header(String name, String value) {
+            return this.underlying.header(name, value);
+        }
+
+        @Override
+        public HttpRequest.Builder headers(String... headers) {
+            return this.underlying.headers(headers);
+        }
+
+        @Override
+        public HttpRequest.Builder timeout(Duration duration) {
+            return this.underlying.timeout(duration);
+        }
+
+        @Override
+        public HttpRequest.Builder setHeader(String name, String value) {
+            return this.underlying.setHeader(name, value);
+        }
+
+        @Override
+        public HttpRequest.Builder GET() {
+            return this.underlying.GET();
+        }
+
+        @Override
+        public HttpRequest.Builder POST(HttpRequest.BodyPublisher bodyPublisher) {
+            return this.underlying.POST(bodyPublisher);
+        }
+
+        @Override
+        public HttpRequest.Builder PUT(HttpRequest.BodyPublisher bodyPublisher) {
+            return this.underlying.PUT(bodyPublisher);
+        }
+
+        @Override
+        public HttpRequest.Builder DELETE() {
+            return this.underlying.DELETE();
+        }
+
+        @Override
+        public HttpRequest.Builder method(String method, HttpRequest.BodyPublisher bodyPublisher) {
+            return this.underlying.method(method, bodyPublisher);
+        }
+
+        @Override
+        public HttpRequest build() {
+            return this.underlying.build();
+        }
+
+        @Override
+        public HttpRequest.Builder copy() {
+            return this.underlying.copy();
         }
     }
 }


### PR DESCRIPTION
Can I please get a review of this test-only change which updates an existing test case to verify the behaviour of `HttpRequest.Builder.HEAD()` method?

As noted in https://bugs.openjdk.org/browse/JDK-8329662, this test now verifies the default implementation specified for `HttpRequest.Builder.HEAD()`. The existing tests were only verifing the behaviour of the `HEAD()` method implementation in the class of the instance returned from `HttpRequest.newBuilder()`. 

I have run this test in our CI with these changes and the test continues to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329662](https://bugs.openjdk.org/browse/JDK-8329662): Add a test to verify the behaviour of the default HEAD() method on HttpRequest.Builder (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18622/head:pull/18622` \
`$ git checkout pull/18622`

Update a local copy of the PR: \
`$ git checkout pull/18622` \
`$ git pull https://git.openjdk.org/jdk.git pull/18622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18622`

View PR using the GUI difftool: \
`$ git pr show -t 18622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18622.diff">https://git.openjdk.org/jdk/pull/18622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18622#issuecomment-2036964200)