### PR TITLE
8196106: Support nested infinite or recursive flat mapped streams

### DIFF
--- a/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,6 +432,21 @@ abstract class AbstractPipeline<E_IN, E_OUT, S extends BaseStream<E_OUT, S>>
          }
          return result;
      }
+
+    /**
+     * Returns whether any of the stages in the (entire) pipeline is short-circuiting
+     * or not.
+     * @return {@code true} if any stage in this pipeline is stateful,
+     *         {@code false} if not.
+     */
+    protected final boolean isShortCircuitingPipeline() {
+        var result = false;
+        for (var u = sourceStage.nextStage;
+             u != null && !(result = StreamOpFlag.SHORT_CIRCUIT.isKnown(u.combinedFlags));
+             u = u.nextStage) {
+        }
+        return result;
+    }
 
     /**
      * Get the source spliterator for this pipeline stage.  For a sequential or

--- a/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/AbstractPipeline.java
@@ -436,16 +436,15 @@ abstract class AbstractPipeline<E_IN, E_OUT, S extends BaseStream<E_OUT, S>>
     /**
      * Returns whether any of the stages in the (entire) pipeline is short-circuiting
      * or not.
-     * @return {@code true} if any stage in this pipeline is stateful,
+     * @return {@code true} if any stage in this pipeline is short-circuiting,
      *         {@code false} if not.
      */
     protected final boolean isShortCircuitingPipeline() {
-        var result = false;
-        for (var u = sourceStage.nextStage;
-             u != null && !(result = StreamOpFlag.SHORT_CIRCUIT.isKnown(u.combinedFlags));
-             u = u.nextStage) {
+        for (var u = sourceStage.nextStage; u != null; u = u.nextStage) {
+            if (StreamOpFlag.SHORT_CIRCUIT.isKnown(u.combinedFlags))
+                return true;
         }
-        return result;
+        return false;
     }
 
     /**

--- a/src/java.base/share/classes/java/util/stream/DoublePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/DoublePipeline.java
@@ -278,7 +278,7 @@ abstract class DoublePipeline<E_IN>
 
                     @Override
                     public void accept(double e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (DoubleStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);

--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -28,23 +28,15 @@ import jdk.internal.vm.annotation.ForceInline;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.Optional;
 import java.util.Spliterator;
 import java.util.concurrent.CountedCompleter;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
-import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.function.ToDoubleFunction;
-import java.util.function.ToIntFunction;
-import java.util.function.ToLongFunction;
 import java.util.stream.Gatherer.Integrator;
 
 /**

--- a/src/java.base/share/classes/java/util/stream/IntPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/IntPipeline.java
@@ -311,7 +311,7 @@ abstract class IntPipeline<E_IN>
 
                     @Override
                     public void accept(int e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (IntStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);

--- a/src/java.base/share/classes/java/util/stream/IntPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/IntPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 package java.util.stream;
 
+import jdk.internal.vm.annotation.Stable;
+
 import java.util.IntSummaryStatistics;
 import java.util.Objects;
 import java.util.OptionalDouble;
@@ -41,6 +43,7 @@ import java.util.function.IntToDoubleFunction;
 import java.util.function.IntToLongFunction;
 import java.util.function.IntUnaryOperator;
 import java.util.function.ObjIntConsumer;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 /**
@@ -297,43 +300,35 @@ abstract class IntPipeline<E_IN>
                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<Integer> opWrapSink(int flags, Sink<Integer> sink) {
-                return new Sink.ChainedInt<>(sink) {
-                    // true if cancellationRequested() has been called
-                    boolean cancellationRequestedCalled;
+                class FlatMap extends Sink.ChainedInt<Integer> implements IntPredicate {
+                    @Stable boolean cancel;
 
-                    // cache the consumer to avoid creation on every accepted element
-                    IntConsumer downstreamAsInt = downstream::accept;
+                    FlatMap() { super(sink); }
 
-                    @Override
-                    public void begin(long size) {
-                        downstream.begin(-1);
-                    }
+                    @Override public void begin(long size) { downstream.begin(-1); }
 
                     @Override
-                    public void accept(int t) {
-                        try (IntStream result = mapper.apply(t)) {
-                            if (result != null) {
-                                if (!cancellationRequestedCalled) {
-                                    result.sequential().forEach(downstreamAsInt);
-                                } else {
-                                    var s = result.sequential().spliterator();
-                                    do {
-                                    } while (!downstream.cancellationRequested() && s.tryAdvance(downstreamAsInt));
-                                }
-                            }
+                    public void accept(int input) {
+                        try (IntStream result = mapper.apply(input)) {
+                            if (result != null)
+                                result.sequential().allMatch(this);
                         }
                     }
 
                     @Override
                     public boolean cancellationRequested() {
-                        // If this method is called then an operation within the stream
-                        // pipeline is short-circuiting (see AbstractPipeline.copyInto).
-                        // Note that we cannot differentiate between an upstream or
-                        // downstream operation
-                        cancellationRequestedCalled = true;
-                        return downstream.cancellationRequested();
+                        return cancel || (cancel |= downstream.cancellationRequested());
                     }
-                };
+
+                    @Override
+                    public boolean test(int output) {
+                        if (cancel)
+                            return false;
+                        downstream.accept(output);
+                        return !cancellationRequested();
+                    }
+                }
+                return new FlatMap();
             }
         };
     }

--- a/src/java.base/share/classes/java/util/stream/LongPipeline.java
+++ b/src/java.base/share/classes/java/util/stream/LongPipeline.java
@@ -294,7 +294,7 @@ abstract class LongPipeline<E_IN>
 
                     @Override
                     public void accept(long e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (LongStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);

--- a/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
+++ b/src/java.base/share/classes/java/util/stream/ReferencePipeline.java
@@ -277,7 +277,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<R> sink) {
-                final boolean shorts = isShortCircuitingPipeline();
+                boolean shorts = isShortCircuitingPipeline();
                 final class FlatMap implements Sink<P_OUT>, Predicate<R> {
                     boolean cancel;
 
@@ -286,7 +286,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
 
                     @Override
                     public void accept(P_OUT e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (Stream<? extends R> result = mapper.apply(e)) {
                             if (result != null) {
                                 if (shorts)
                                     result.sequential().allMatch(this);
@@ -323,12 +323,12 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Integer> sink) {
-                final IntConsumer fastPath =
-                        isShortCircuitingPipeline()
-                                ? null
-                                : (sink instanceof IntConsumer ic)
-                                ? ic
-                                : sink::accept;
+                IntConsumer fastPath =
+                    isShortCircuitingPipeline()
+                        ? null
+                        : (sink instanceof IntConsumer ic)
+                            ? ic
+                            : sink::accept;
                 final class FlatMap implements Sink<P_OUT>, IntPredicate {
                     boolean cancel;
 
@@ -337,7 +337,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
 
                     @Override
                     public void accept(P_OUT e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (IntStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);
@@ -374,12 +374,12 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Double> sink) {
-                final DoubleConsumer fastPath =
-                        isShortCircuitingPipeline()
-                                ? null
-                                : (sink instanceof DoubleConsumer dc)
-                                ? dc
-                                : sink::accept;
+                DoubleConsumer fastPath =
+                    isShortCircuitingPipeline()
+                        ? null
+                        : (sink instanceof DoubleConsumer dc)
+                            ? dc
+                            : sink::accept;
                 final class FlatMap implements Sink<P_OUT>, DoublePredicate {
                     boolean cancel;
 
@@ -388,7 +388,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
 
                     @Override
                     public void accept(P_OUT e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (DoubleStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);
@@ -426,12 +426,12 @@ abstract class ReferencePipeline<P_IN, P_OUT>
                 StreamOpFlag.NOT_SORTED | StreamOpFlag.NOT_DISTINCT | StreamOpFlag.NOT_SIZED) {
             @Override
             Sink<P_OUT> opWrapSink(int flags, Sink<Long> sink) {
-                final LongConsumer fastPath =
-                        isShortCircuitingPipeline()
-                                ? null
-                                : (sink instanceof LongConsumer lc)
-                                ? lc
-                                : sink::accept;
+                LongConsumer fastPath =
+                    isShortCircuitingPipeline()
+                        ? null
+                        : (sink instanceof LongConsumer lc)
+                            ? lc
+                            : sink::accept;
                 final class FlatMap implements Sink<P_OUT>, LongPredicate {
                     boolean cancel;
 
@@ -440,7 +440,7 @@ abstract class ReferencePipeline<P_IN, P_OUT>
 
                     @Override
                     public void accept(P_OUT e) {
-                        try (final var result = mapper.apply(e)) {
+                        try (LongStream result = mapper.apply(e)) {
                             if (result != null) {
                                 if (fastPath == null)
                                     result.sequential().allMatch(this);

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/FlatMapOpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary flat-map operations
- * @bug 8044047 8076458 8075939
+ * @bug 8044047 8076458 8075939 8196106
  */
 
 package org.openjdk.tests.java.util.stream;
@@ -272,5 +272,32 @@ public class FlatMapOpTest extends OpTestCase {
                 peek(i -> count.incrementAndGet()).
                 limit(10).toArray();
         assertEquals(count.get(), 10);
+    }
+
+    @Test
+    public void testTerminationOfNestedInfiniteStreams() {
+        var refExpected = Stream.generate(() -> "").limit(5).toList();
+        var refResult = Stream.generate(() -> "")
+              .flatMap(c -> Stream.generate(() -> c).flatMap(x -> Stream.generate(() -> x)))
+              .limit(5).toList();
+        assertEquals(refResult, refExpected);
+
+        var intExpected = IntStream.generate(() -> 1).limit(5).sum();
+        var intResult = IntStream.generate(() -> 1)
+                .flatMap(c -> IntStream.generate(() -> c).flatMap(x -> IntStream.generate(() -> x)))
+                .limit(5).sum();
+        assertEquals(intResult, intExpected);
+
+        var longExpected = LongStream.generate(() -> 1L).limit(5).sum();
+        var longResult = LongStream.generate(() -> 1L)
+                .flatMap(c -> LongStream.generate(() -> c).flatMap(x -> LongStream.generate(() -> x)))
+                .limit(5).sum();
+        assertEquals(longResult, longExpected);
+
+        var doubleExpected = DoubleStream.generate(() -> 0d).limit(5).sum();
+        var doubleResult = DoubleStream.generate(() -> 0d)
+                .flatMap(c -> DoubleStream.generate(() -> c).flatMap(x -> DoubleStream.generate(() -> x)))
+                .limit(5).sum();
+        assertEquals(doubleResult, doubleExpected);
     }
 }

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/DoubleAccumulator.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/DoubleAccumulator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util.stream.ops;
+
+public class DoubleAccumulator {
+
+    double acc;
+
+    public DoubleAccumulator() {
+        acc = 0;
+    }
+
+    public void add(double v) {
+        acc += v;
+    }
+
+    public void merge(DoubleAccumulator other) {
+        acc += other.acc;
+    }
+
+    public double get() {
+        return acc;
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FlatMap.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FlatMap.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.util.stream.ops.ref;
+
+import org.openjdk.bench.java.util.stream.ops.LongAccumulator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.Arrays;
+
+/**
+ * Benchmark for flatMap() operation.
+ */
+@BenchmarkMode(Mode.Throughput)
+@Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@State(Scope.Thread)
+public class FlatMap {
+
+    /**
+     * Implementation notes:
+     *   - parallel version requires thread-safe sink, we use the same for sequential version for better comparison
+     *   - operations are explicit inner classes to untangle unwanted lambda effects
+     *   - the result of applying consecutive operations is the same, in order to have the same number of elements in sink
+     */
+
+    @Param({"10", "100", "1000"})
+    private int size;
+
+    private Function<Long, Stream<Long>> funArrayStream;
+    private Function<Long, Stream<Long>> funIterateStream;
+
+    private Long[] cachedInputArray;
+
+    @Setup
+    public void setup() {
+        final int cachedSize = size;
+        cachedInputArray = new Long[cachedSize];
+        for(int i = 0;i < cachedInputArray.length;++i)
+            cachedInputArray[i] = Long.valueOf(i);
+
+        funArrayStream = new Function<Long, Stream<Long>>() { @Override public Stream<Long> apply(Long l) {
+            return Arrays.stream(cachedInputArray);
+        } };
+        funIterateStream = new Function<Long, Stream<Long>>() { @Override public Stream<Long> apply(Long l) {
+            return Stream.iterate(0L, i -> i + 1).limit(cachedSize);
+        } };
+    }
+
+    @Benchmark
+    public long seq_array() {
+        return funArrayStream.apply(0L)
+                .flatMap(funArrayStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long par_array() {
+        return funArrayStream.apply(0L)
+                .parallel()
+                .flatMap(funArrayStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long seq_iterate() {
+        return funIterateStream.apply(0L)
+                .flatMap(funIterateStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long par_iterate() {
+        return funIterateStream.apply(0L)
+                .parallel()
+                .flatMap(funIterateStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FlatMap.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FlatMap.java
@@ -71,8 +71,11 @@ public class FlatMap {
     private Function<Long, Stream<Long>> funArrayStream;
     private Function<Long, Stream<Long>> funIterateStream;
     private LongFunction<LongStream> funLongStream;
+    private LongFunction<LongStream> funIterateLongStream;
     private IntFunction<IntStream> funIntStream;
+    private IntFunction<IntStream> funIterateIntStream;
     private DoubleFunction<DoubleStream> funDoubleStream;
+    private DoubleFunction<DoubleStream> funIterateDoubleStream;
 
     private Long[] cachedRefArray;
     private int[] cachedIntArray;
@@ -100,21 +103,27 @@ public class FlatMap {
             return Stream.iterate(0L, i -> i + 1).limit(cachedSize); } };
         funLongStream = new LongFunction<LongStream>() { @Override public LongStream apply(long l) {
             return Arrays.stream(cachedLongArray); } };
+        funIterateLongStream = new LongFunction<LongStream>() { @Override public LongStream apply(long l) {
+            return LongStream.iterate(0L, i -> i + 1).limit(cachedSize); } };
         funIntStream = new IntFunction<IntStream>() { @Override public IntStream apply(int i) {
             return Arrays.stream(cachedIntArray); } };
+        funIterateIntStream = new IntFunction<IntStream>() { @Override public IntStream apply(int i) {
+            return IntStream.iterate(0, ii -> ii + 1).limit(cachedSize); } };
         funDoubleStream = new DoubleFunction<DoubleStream>() { @Override public DoubleStream apply(double d) {
             return Arrays.stream(cachedDoubleArray); } };
+        funIterateDoubleStream = new DoubleFunction<DoubleStream>() { @Override public DoubleStream apply(double d) {
+            return DoubleStream.iterate(0d, i -> i + 1d).limit(cachedSize); } };
     }
 
     @Benchmark
-    public long seq_array() {
+    public long seq_array_ref() {
         return funArrayStream.apply(0L)
                 .flatMap(funArrayStream)
                 .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
     }
 
     @Benchmark
-    public long par_array() {
+    public long par_array_ref() {
         return funArrayStream.apply(0L)
                 .parallel()
                 .flatMap(funArrayStream)
@@ -122,14 +131,14 @@ public class FlatMap {
     }
 
     @Benchmark
-    public long seq_longstream() {
+    public long seq_array_long() {
         return funLongStream.apply(0L)
                 .flatMap(funLongStream)
                 .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
     }
 
     @Benchmark
-    public long par_longstream() {
+    public long par_array_long() {
         return funLongStream.apply(0L)
                 .parallel()
                 .flatMap(funLongStream)
@@ -137,14 +146,14 @@ public class FlatMap {
     }
 
     @Benchmark
-    public long seq_intstream() {
+    public long seq_array_int() {
         return funIntStream.apply(0)
                 .flatMap(funIntStream)
                 .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
     }
 
     @Benchmark
-    public long par_intstream() {
+    public long par_array_int() {
         return funIntStream.apply(0)
                 .parallel()
                 .flatMap(funIntStream)
@@ -152,14 +161,14 @@ public class FlatMap {
     }
 
     @Benchmark
-    public double seq_doublestream() {
+    public double seq_array_double() {
         return funDoubleStream.apply(0d)
                 .flatMap(funDoubleStream)
                 .collect(DoubleAccumulator::new, DoubleAccumulator::add, DoubleAccumulator::merge).get();
     }
 
     @Benchmark
-    public double par_doublestream() {
+    public double par_array_double() {
         return funDoubleStream.apply(0d)
                 .parallel()
                 .flatMap(funDoubleStream)
@@ -167,18 +176,64 @@ public class FlatMap {
     }
 
     @Benchmark
-    public long seq_iterate() {
+    public long seq_iterate_ref() {
         return funIterateStream.apply(0L)
                 .flatMap(funIterateStream)
                 .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
     }
 
     @Benchmark
-    public long par_iterate() {
+    public long par_iterate_ref() {
         return funIterateStream.apply(0L)
                 .parallel()
                 .flatMap(funIterateStream)
                 .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+
+    @Benchmark
+    public long seq_iterate_long() {
+        return funIterateLongStream.apply(0L)
+                .flatMap(funIterateLongStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long par_iterate_long() {
+        return funIterateLongStream.apply(0L)
+                .parallel()
+                .flatMap(funIterateLongStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long seq_iterate_int() {
+        return funIterateIntStream.apply(0)
+                .flatMap(funIterateIntStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public long par_iterate_int() {
+        return funIterateIntStream.apply(0)
+                .parallel()
+                .flatMap(funIterateIntStream)
+                .collect(LongAccumulator::new, LongAccumulator::add, LongAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public double seq_iterate_double() {
+        return funIterateDoubleStream.apply(0d)
+                .flatMap(funIterateDoubleStream)
+                .collect(DoubleAccumulator::new, DoubleAccumulator::add, DoubleAccumulator::merge).get();
+    }
+
+    @Benchmark
+    public double par_iterate_double() {
+        return funIterateDoubleStream.apply(0d)
+                .parallel()
+                .flatMap(funIterateDoubleStream)
+                .collect(DoubleAccumulator::new, DoubleAccumulator::add, DoubleAccumulator::merge).get();
     }
 
 }


### PR DESCRIPTION
This PR implements Gatherer-inspired encoding of `flatMap` that shows that it is both competitive performance-wise as well as improve correctness.

Below is the performance of `Stream::flatMap` (for reference types):

Before this PR (on my MacBook, aarch64):
```
Non-short-circuiting:

Benchmark                 (size)   Mode  Cnt        Score       Error  Units
FlatMap.par_array             10  thrpt   12   257582,480 ? 31360,242  ops/s
FlatMap.par_array            100  thrpt   12    55202,015 ? 14011,668  ops/s
FlatMap.par_array           1000  thrpt   12     6546,252 ?  3675,764  ops/s
FlatMap.par_doublestream      10  thrpt   12   267423,410 ? 37338,089  ops/s
FlatMap.par_doublestream     100  thrpt   12    27140,703 ?  4979,878  ops/s
FlatMap.par_doublestream    1000  thrpt   12     2978,178 ?  1890,250  ops/s
FlatMap.par_intstream         10  thrpt   12   268194,530 ? 37295,092  ops/s
FlatMap.par_intstream        100  thrpt   12    30897,034 ?  5388,245  ops/s
FlatMap.par_intstream       1000  thrpt   12     3969,043 ?  2494,641  ops/s
FlatMap.par_longstream        10  thrpt   12   279756,861 ? 19519,497  ops/s
FlatMap.par_longstream       100  thrpt   12    45733,955 ? 18385,144  ops/s
FlatMap.par_longstream      1000  thrpt   12     5115,615 ?  4147,237  ops/s
FlatMap.seq_array             10  thrpt   12  2937192,934 ? 58605,583  ops/s
FlatMap.seq_array            100  thrpt   12    41859,462 ?   139,021  ops/s
FlatMap.seq_array           1000  thrpt   12      442,677 ?     1,041  ops/s
FlatMap.seq_doublestream      10  thrpt   12  4972651,093 ? 35997,267  ops/s
FlatMap.seq_doublestream     100  thrpt   12    99265,005 ?   193,497  ops/s
FlatMap.seq_doublestream    1000  thrpt   12     1037,030 ?     3,254  ops/s
FlatMap.seq_intstream         10  thrpt   12  5133751,888 ? 23516,294  ops/s
FlatMap.seq_intstream        100  thrpt   12   145166,206 ?   399,263  ops/s
FlatMap.seq_intstream       1000  thrpt   12     1565,004 ?     3,207  ops/s
FlatMap.seq_longstream        10  thrpt   12  5047029,363 ? 24742,300  ops/s
FlatMap.seq_longstream       100  thrpt   12   233225,307 ?  7162,604  ops/s
FlatMap.seq_longstream      1000  thrpt   12     2999,926 ?     9,945  ops/s

// Short-circuiting:

Benchmark                   (size)   Mode  Cnt       Score       Error  Units
FlatMap.par_iterate_double      10  thrpt   12   46336,834 ?  6803,751  ops/s
FlatMap.par_iterate_double     100  thrpt   12   15365,884 ?  2750,656  ops/s
FlatMap.par_iterate_double    1000  thrpt   12    1677,618 ?   174,397  ops/s
FlatMap.par_iterate_int         10  thrpt   12   50275,901 ?  4321,430  ops/s
FlatMap.par_iterate_int        100  thrpt   12   16688,084 ?  2977,145  ops/s
FlatMap.par_iterate_int       1000  thrpt   12    1963,556 ?   384,075  ops/s
FlatMap.par_iterate_long        10  thrpt   12   50923,900 ?  3732,781  ops/s
FlatMap.par_iterate_long       100  thrpt   12   16660,676 ?  2086,627  ops/s
FlatMap.par_iterate_long      1000  thrpt   12    1949,490 ?   414,274  ops/s
FlatMap.par_iterate_ref         10  thrpt   12   26493,083 ?  5345,774  ops/s
FlatMap.par_iterate_ref        100  thrpt   12   10526,834 ?   165,435  ops/s
FlatMap.par_iterate_ref       1000  thrpt   12     923,592 ?     6,473  ops/s
FlatMap.seq_iterate_double      10  thrpt   12  457939,954 ? 21836,434  ops/s
FlatMap.seq_iterate_double     100  thrpt   12   10362,293 ?    79,699  ops/s
FlatMap.seq_iterate_double    1000  thrpt   12     101,664 ?     0,869  ops/s
FlatMap.seq_iterate_int         10  thrpt   12  438688,302 ?  8519,874  ops/s
FlatMap.seq_iterate_int        100  thrpt   12   10280,163 ?    94,136  ops/s
FlatMap.seq_iterate_int       1000  thrpt   12     100,687 ?     1,199  ops/s
FlatMap.seq_iterate_long        10  thrpt   12  437124,344 ? 39209,828  ops/s
FlatMap.seq_iterate_long       100  thrpt   12   10218,305 ?    80,571  ops/s
FlatMap.seq_iterate_long      1000  thrpt   12     100,560 ?     1,228  ops/s
FlatMap.seq_iterate_ref         10  thrpt   12  338190,816 ?  7213,549  ops/s
FlatMap.seq_iterate_ref        100  thrpt   12    8453,383 ?    44,707  ops/s
FlatMap.seq_iterate_ref       1000  thrpt   12      77,174 ?     0,701  ops/s
```

After this PR (on my MacBook, aarch64):

```
Non-short-circuiting:

Benchmark                 (size)   Mode  Cnt        Score       Error  Units
FlatMap.par_array             10  thrpt   12   309043,346 ? 22267,788  ops/s
FlatMap.par_array            100  thrpt   12    63773,183 ? 18772,809  ops/s
FlatMap.par_array           1000  thrpt   12     8454,577 ?   223,855  ops/s
FlatMap.par_doublestream      10  thrpt   12   287825,910 ? 40801,718  ops/s
FlatMap.par_doublestream     100  thrpt   12    29102,473 ?  4706,576  ops/s
FlatMap.par_doublestream    1000  thrpt   12     3966,528 ?  1915,358  ops/s
FlatMap.par_intstream         10  thrpt   12   291119,116 ? 32542,028  ops/s
FlatMap.par_intstream        100  thrpt   12    37945,217 ?  6986,065  ops/s
FlatMap.par_intstream       1000  thrpt   12     5004,935 ?  2325,120  ops/s
FlatMap.par_longstream        10  thrpt   12   306691,186 ? 30836,677  ops/s
FlatMap.par_longstream       100  thrpt   12    39204,098 ?  6159,602  ops/s
FlatMap.par_longstream      1000  thrpt   12     5197,154 ?  4293,582  ops/s
FlatMap.seq_array             10  thrpt   12  2852595,288 ? 19117,935  ops/s
FlatMap.seq_array            100  thrpt   12    41792,834 ?   125,631  ops/s
FlatMap.seq_array           1000  thrpt   12     1085,509 ?  1226,692  ops/s
FlatMap.seq_doublestream      10  thrpt   12  5405153,919 ? 25352,824  ops/s
FlatMap.seq_doublestream     100  thrpt   12    99297,136 ?   170,830  ops/s
FlatMap.seq_doublestream    1000  thrpt   12     1038,508 ?     1,066  ops/s
FlatMap.seq_intstream         10  thrpt   12  5558941,679 ? 25526,270  ops/s
FlatMap.seq_intstream        100  thrpt   12   145225,641 ?   334,990  ops/s
FlatMap.seq_intstream       1000  thrpt   12     1567,861 ?     2,790  ops/s
FlatMap.seq_longstream        10  thrpt   12  5592000,353 ? 20322,575  ops/s
FlatMap.seq_longstream       100  thrpt   12   241101,180 ?  9170,915  ops/s
FlatMap.seq_longstream      1000  thrpt   12     2132,999 ?  1589,173  ops/s

// Short-circuiting:

Benchmark                   (size)   Mode  Cnt        Score        Error  Units
FlatMap.par_iterate_double      10  thrpt   12    46354,848 ?   6372,823  ops/s
FlatMap.par_iterate_double     100  thrpt   12    15851,059 ?   2942,830  ops/s
FlatMap.par_iterate_double    1000  thrpt   12     1778,464 ?     27,042  ops/s
FlatMap.par_iterate_int         10  thrpt   12    51879,241 ?   6759,903  ops/s
FlatMap.par_iterate_int        100  thrpt   12    16458,214 ?   3206,146  ops/s
FlatMap.par_iterate_int       1000  thrpt   12     2421,501 ?      5,582  ops/s
FlatMap.par_iterate_long        10  thrpt   12    47412,155 ?   9957,661  ops/s
FlatMap.par_iterate_long       100  thrpt   12    17745,066 ?   3519,614  ops/s
FlatMap.par_iterate_long      1000  thrpt   12     2413,274 ?     27,152  ops/s
FlatMap.par_iterate_ref         10  thrpt   12    24754,662 ?   5144,389  ops/s
FlatMap.par_iterate_ref        100  thrpt   12    10535,374 ?    273,802  ops/s
FlatMap.par_iterate_ref       1000  thrpt   12      990,926 ?    153,386  ops/s
FlatMap.seq_iterate_double      10  thrpt   12   941441,571 ?  72849,560  ops/s
FlatMap.seq_iterate_double     100  thrpt   12    26116,346 ?    225,451  ops/s
FlatMap.seq_iterate_double    1000  thrpt   12      285,873 ?      1,924  ops/s
FlatMap.seq_iterate_int         10  thrpt   12  1097970,188 ? 365428,186  ops/s
FlatMap.seq_iterate_int        100  thrpt   12    28136,050 ?    136,249  ops/s
FlatMap.seq_iterate_int       1000  thrpt   12      316,555 ?      0,687  ops/s
FlatMap.seq_iterate_long        10  thrpt   12  1021716,173 ?   8729,180  ops/s
FlatMap.seq_iterate_long       100  thrpt   12    28290,057 ?    264,404  ops/s
FlatMap.seq_iterate_long      1000  thrpt   12      316,620 ?      1,906  ops/s
FlatMap.seq_iterate_ref         10  thrpt   12   820498,644 ? 167233,794  ops/s
FlatMap.seq_iterate_ref        100  thrpt   12    13583,900 ?    116,079  ops/s
FlatMap.seq_iterate_ref       1000  thrpt   12      158,580 ?      1,977  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8196106](https://bugs.openjdk.org/browse/JDK-8196106): Support nested infinite or recursive flat mapped streams (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18625/head:pull/18625` \
`$ git checkout pull/18625`

Update a local copy of the PR: \
`$ git checkout pull/18625` \
`$ git pull https://git.openjdk.org/jdk.git pull/18625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18625`

View PR using the GUI difftool: \
`$ git pr show -t 18625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18625.diff">https://git.openjdk.org/jdk/pull/18625.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18625#issuecomment-2044620346)