### PR TITLE
8329674: JvmtiEnvThreadState::reset_current_location function should use JvmtiHandshake

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1997,8 +1997,11 @@ JvmtiHandshake::execute(JvmtiUnitedHandshakeClosure* hs_cl, jthread target) {
 void
 JvmtiHandshake::execute(JvmtiUnitedHandshakeClosure* hs_cl, ThreadsListHandle* tlh,
                         JavaThread* target_jt, Handle target_h) {
+  JavaThread* current = JavaThread::current();
   bool is_virtual = java_lang_VirtualThread::is_instance(target_h());
-  bool self = target_jt == JavaThread::current();
+  bool self = target_jt == current;
+
+  assert(!Continuations::enabled() || self || !is_virtual || current->is_VTMS_transition_disabler(), "sanity check");
 
   hs_cl->set_target_jt(target_jt);   // can be needed in the virtual thread case
   hs_cl->set_is_virtual(is_virtual); // can be needed in the virtual thread case

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -297,14 +297,9 @@ class GetCurrentLocationClosure : public JvmtiUnitedHandshakeClosure {
     _completed = true;
   }
   void do_vthread(Handle target_h) {
-    if (_target_jt != nullptr) {
-      assert(_target_jt->vthread() == target_h(), "sanity check");
-      do_thread(_target_jt);
-      return;
-    }
-    if (!JvmtiEnvBase::is_vthread_alive(target_h())) {
-      return; // _completed remains false.
-    }
+    assert(_target_jt == nullptr || !_target_jt->is_exiting(), "sanity check");
+    // use jvmti_vthread() as vthread() can be outdated
+    assert(_target_jt == nullptr || _target_jt->jvmti_vthread() == target_h(), "sanity check");
     ResourceMark rm;
     javaVFrame *jvf = JvmtiEnvBase::get_vthread_jvf(target_h());
 

--- a/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvThreadState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,58 +264,19 @@ bool JvmtiEnvThreadState::is_frame_pop(int cur_frame_number) {
   return get_frame_pops()->contains(fp);
 }
 
-class VM_VirtualThreadGetCurrentLocation : public VM_Operation {
- private:
-   Handle _vthread_h;
-   jmethodID _method_id;
-   int _bci;
-   bool _completed;
-
- public:
-  VM_VirtualThreadGetCurrentLocation(Handle vthread_h)
-    : _vthread_h(vthread_h),
-      _method_id(nullptr),
-      _bci(0),
-      _completed(false)
-  {}
-
-  VMOp_Type type() const { return VMOp_VirtualThreadGetCurrentLocation; }
-  void doit() {
-    if (!JvmtiEnvBase::is_vthread_alive(_vthread_h())) {
-      return; // _completed remains false.
-    }
-    ResourceMark rm;
-    javaVFrame* jvf = JvmtiEnvBase::get_vthread_jvf(_vthread_h());
-
-    if (jvf != nullptr) {
-      // jvf can be null, when the native enterSpecial frame is on the top.
-      Method* method = jvf->method();
-      _method_id = method->jmethod_id();
-      _bci = jvf->bci();
-    }
-    _completed = true;
-  }
-  void get_current_location(jmethodID *method_id, int *bci) {
-    *method_id = _method_id;
-    *bci = _bci;
-  }
-  bool completed() {
-    return _completed;
-  }
-};
-
-class GetCurrentLocationClosure : public HandshakeClosure {
+class GetCurrentLocationClosure : public JvmtiUnitedHandshakeClosure {
  private:
    jmethodID _method_id;
    int _bci;
    bool _completed;
  public:
   GetCurrentLocationClosure()
-    : HandshakeClosure("GetCurrentLocation"),
+    : JvmtiUnitedHandshakeClosure("GetCurrentLocation"),
       _method_id(nullptr),
       _bci(0),
       _completed(false) {}
-  void do_thread(Thread *target) {
+
+  void doit(Thread *target) {
     JavaThread *jt = JavaThread::cast(target);
     ResourceMark rmark; // jt != Thread::current()
     RegisterMap rm(jt,
@@ -334,6 +295,30 @@ class GetCurrentLocationClosure : public HandshakeClosure {
       }
     }
     _completed = true;
+  }
+  void doit(Handle target_h) {
+    if (!JvmtiEnvBase::is_vthread_alive(target_h())) {
+      return; // _completed remains false.
+    }
+    ResourceMark rm;
+    javaVFrame *jvf = JvmtiEnvBase::get_vthread_jvf(target_h());
+
+    if (jvf != nullptr) {
+      Method* method = jvf->method();
+      _method_id = method->jmethod_id();
+      _bci = jvf->bci();
+    }
+    _completed = true;
+  }
+  void do_thread(Thread *target) {
+    doit(target);
+  }
+  void do_vthread(Handle target_h) {
+    if (_target_jt != nullptr) {
+      doit(_target_jt);
+    } else {
+      doit(target_h);
+    }
   }
   void get_current_location(jmethodID *method_id, int *bci) {
     *method_id = _method_id;
@@ -372,41 +357,25 @@ void JvmtiEnvThreadState::reset_current_location(jvmtiEvent event_type, bool ena
   if (enabled) {
     // If enabling breakpoint, no need to reset.
     // Can't do anything if empty stack.
-
     JavaThread* thread = get_thread_or_saved();
 
-    oop thread_oop = jvmti_thread_state()->get_thread_oop();
+    if (event_type == JVMTI_EVENT_SINGLE_STEP &&
+        ((thread == nullptr && is_virtual()) || thread->has_last_Java_frame())) {
+      JavaThread* current = JavaThread::current();
+      HandleMark hm(current);
+      oop thread_oop = jvmti_thread_state()->get_thread_oop();
+      Handle thread_h(current, thread_oop);
+      ThreadsListHandle tlh(current);
 
-    if (thread == nullptr && event_type == JVMTI_EVENT_SINGLE_STEP && is_virtual()) {
-      // Handle the unmounted virtual thread case.
-      jmethodID method_id;
-      int bci;
-      JavaThread* cur_thread = JavaThread::current();
-      HandleMark hm(cur_thread);
-      VM_VirtualThreadGetCurrentLocation op(Handle(cur_thread, thread_oop));
-      VMThread::execute(&op);
+      GetCurrentLocationClosure op;
+      JvmtiHandshake::execute(&op, &tlh, thread, thread_h);
+
       if (op.completed()) {
-        // Do nothing if virtual thread has been already terminated.
+        jmethodID method_id;
+        int bci;
         op.get_current_location(&method_id, &bci);
         set_current_location(method_id, bci);
       }
-      return;
-    }
-    if (event_type == JVMTI_EVENT_SINGLE_STEP && thread->has_last_Java_frame()) {
-      jmethodID method_id;
-      int bci;
-      // The java thread stack may not be walkable for a running thread
-      // so get current location with direct handshake.
-      GetCurrentLocationClosure op;
-      Thread *current = Thread::current();
-      if (thread->is_handshake_safe_for(current)) {
-        op.do_thread(thread);
-      } else {
-        Handshake::execute(&op, thread);
-        guarantee(op.completed(), "Handshake failed. Target thread is not alive?");
-      }
-      op.get_current_location(&method_id, &bci);
-      set_current_location(method_id, bci);
     }
   } else if (event_type == JVMTI_EVENT_SINGLE_STEP || !is_enabled(JVMTI_EVENT_SINGLE_STEP)) {
     // If this is to disable breakpoint, also check if single-step is not enabled

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -83,7 +83,6 @@
   template(ChangeBreakpoints)                     \
   template(GetOrSetLocal)                         \
   template(VirtualThreadGetOrSetLocal)            \
-  template(VirtualThreadGetCurrentLocation)       \
   template(ChangeSingleStep)                      \
   template(SetNotifyJvmtiEventsMode)              \
   template(HeapWalkOperation)                     \


### PR DESCRIPTION
The internal JVM TI JvmtiHandshake and JvmtiUnitedHandshakeClosure classes were introduced in the JDK 22 to unify/simplify the JVM TI functions supporting implementation of the virtual threads. This enhancement is to refactor the JVM TI internal functions JvmtiEnvThreadState::reset_current_location on the base of JvmtiHandshake and JvmtiUnitedHandshakeClosure classes.

Testing:
 - Ran mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329674](https://bugs.openjdk.org/browse/JDK-8329674): JvmtiEnvThreadState::reset_current_location function should use JvmtiHandshake (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [39717f37](https://git.openjdk.org/jdk/pull/18630/files/39717f371a4a2429f0f4e90a407b2f67de874563)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [86775376](https://git.openjdk.org/jdk/pull/18630/files/86775376517ac8652da93cfa615b1cf8a6251813)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18630/head:pull/18630` \
`$ git checkout pull/18630`

Update a local copy of the PR: \
`$ git checkout pull/18630` \
`$ git pull https://git.openjdk.org/jdk.git pull/18630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18630`

View PR using the GUI difftool: \
`$ git pr show -t 18630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18630.diff">https://git.openjdk.org/jdk/pull/18630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18630#issuecomment-2037534916)