### PR TITLE
8329665: fatal error: memory leak: allocating without ResourceMark

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -181,18 +181,6 @@ InterpreterOopMap::InterpreterOopMap() {
 #endif
 }
 
-InterpreterOopMap::~InterpreterOopMap() {
-  // The expectation is that the bit mask was allocated
-  // last in this resource area.  That would make the free of the
-  // bit_mask effective (see how FREE_RESOURCE_ARRAY does a free).
-  // If it was not allocated last, there is not a correctness problem
-  // but the space for the bit_mask is not freed.
-  assert(_resource_allocate_bit_mask, "Trying to free C heap space");
-  if (mask_size() > small_mask_limit) {
-    FREE_RESOURCE_ARRAY(uintptr_t, _bit_mask[0], mask_word_size());
-  }
-}
-
 bool InterpreterOopMap::is_empty() const {
   bool result = _method == nullptr;
   assert(_method != nullptr || (_bci == 0 &&

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -128,7 +128,6 @@ class InterpreterOopMap: ResourceObj {
 
  public:
   InterpreterOopMap();
-  ~InterpreterOopMap();
 
   // Copy the OopMapCacheEntry in parameter "from" into this
   // InterpreterOopMap.  If the _bit_mask[0] in "from" points to

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -885,6 +885,7 @@ oop frame::interpreter_callee_receiver(Symbol* signature) {
 void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   Thread *thread = Thread::current();
+  DEBUG_ONLY(ResourceMark rm(thread);) // ~InterpreterOopMap already handles possible deallocation of bitmask
   methodHandle m (thread, interpreter_frame_method());
   jint      bci = interpreter_frame_bci();
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -885,7 +885,6 @@ oop frame::interpreter_callee_receiver(Symbol* signature) {
 void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool query_oop_map_cache) const {
   assert(is_interpreted_frame(), "Not an interpreted frame");
   Thread *thread = Thread::current();
-  DEBUG_ONLY(ResourceMark rm(thread);) // ~InterpreterOopMap already handles possible deallocation of bitmask
   methodHandle m (thread, interpreter_frame_method());
   jint      bci = interpreter_frame_bci();
 
@@ -953,6 +952,7 @@ void frame::oops_interpreted_do(OopClosure* f, const RegisterMap* map, bool quer
   InterpreterFrameClosure blk(this, max_locals, m->max_stack(), f);
 
   // process locals & expression stack
+  ResourceMark rm(thread);
   InterpreterOopMap mask;
   if (query_oop_map_cache) {
     m->mask_for(bci, &mask);


### PR DESCRIPTION
There are two places in Loom code that call f.oops_interpreted_do() to process oops in the stackChunk. Although not obvious this method seem to require to have a ResourceMark on scope and there are several contexts where these two are call where we don't have one. The reason why a ResourceMark is needed is because OopMapCache::compute_one_oop_map() might allocate from the resource area if _mask_size is > 4 * BitsPerWord, which depends on the amount of locals + expression stack of the corresponding method. But ~InterpreterOopMap already checks if the _bit_mask was allocated in the resource area and in that case it will free it. So the ResourceMark is not strictly needed except that in debug mode we will actually hit the assert if there is not one in scope when trying to allocate the _bit_mask.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329665](https://bugs.openjdk.org/browse/JDK-8329665): fatal error: memory leak: allocating without ResourceMark (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [33354c7c](https://git.openjdk.org/jdk/pull/18632/files/33354c7c554b9cba91bb549f4f502580b0b5cdfd)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18632/head:pull/18632` \
`$ git checkout pull/18632`

Update a local copy of the PR: \
`$ git checkout pull/18632` \
`$ git pull https://git.openjdk.org/jdk.git pull/18632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18632`

View PR using the GUI difftool: \
`$ git pr show -t 18632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18632.diff">https://git.openjdk.org/jdk/pull/18632.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18632#issuecomment-2038084790)