### PR TITLE
8321543: Update NSS to version 3.96

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -82,7 +82,7 @@ public abstract class PKCS11Test {
 
     // Version of the NSS artifact. This coincides with the version of
     // the NSS version
-    private static final String NSS_BUNDLE_VERSION = "3.91";
+    private static final String NSS_BUNDLE_VERSION = "3.96";
     private static final String NSSLIB = "jpg.tests.jdk.nsslib";
 
     static double nss_version = -1;


### PR DESCRIPTION
In this PR, I updated the version of the NSS libraries used in PKCS11Test to 3.96.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321543](https://bugs.openjdk.org/browse/JDK-8321543): Update NSS to version 3.96 (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18636/head:pull/18636` \
`$ git checkout pull/18636`

Update a local copy of the PR: \
`$ git checkout pull/18636` \
`$ git pull https://git.openjdk.org/jdk.git pull/18636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18636`

View PR using the GUI difftool: \
`$ git pr show -t 18636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18636.diff">https://git.openjdk.org/jdk/pull/18636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18636#issuecomment-2038074433)