### PR TITLE
8329717: Missing `@since` tags in elements in DocumentationTool and Taglet

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/DocumentationTool.java
+++ b/src/java.compiler/share/classes/javax/tools/DocumentationTool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,6 +188,8 @@ public interface DocumentationTool extends Tool, OptionChecker {
 
         /**
          * Location to search for snippets.
+         *
+         * @since 18
          */
         SNIPPET_PATH;
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
@@ -96,6 +96,7 @@ public interface Taglet {
      * @return true if this taglet supports block tags
      * @implSpec This implementation returns the inverse
      * result to {@code isInlineTag}.
+     *
      * @since 15
      */
     default boolean isBlockTag() {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/Taglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,6 +96,7 @@ public interface Taglet {
      * @return true if this taglet supports block tags
      * @implSpec This implementation returns the inverse
      * result to {@code isInlineTag}.
+     * @since 15
      */
     default boolean isBlockTag() {
         return !isInlineTag();


### PR DESCRIPTION
In this PR I added an `@since` tag to SNIPPET_PATH and isBlockTag() as they were added in later versions

- SNIPPET_PATH was added in JDK 18 [here](https://github.com/openjdk/jdk/commit/0fc47e99d20a1ee886df878f1302769bdd913aab#diff-8f73114f8b0d0d5229231541d5583382c8e8d33147e285f3d90ed8801ce9228bR192)

- isBlockTag() was added in JDK 15 [here](https://github.com/openjdk/jdk/commit/3c0e2b4e16d8fb2f96741bc8d4188aa47f58dd15#diff-3ee1b6e2a11b201a39ce3f2ac14ea9832900d8a3a581bf26577064173d0c9082R101)

This is similar to #18032

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329717](https://bugs.openjdk.org/browse/JDK-8329717): Missing `@<!---->since` tags in elements in DocumentationTool and Taglet (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18640/head:pull/18640` \
`$ git checkout pull/18640`

Update a local copy of the PR: \
`$ git checkout pull/18640` \
`$ git pull https://git.openjdk.org/jdk.git pull/18640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18640`

View PR using the GUI difftool: \
`$ git pr show -t 18640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18640.diff">https://git.openjdk.org/jdk/pull/18640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18640#issuecomment-2038476977)