### PR TITLE
8329720: Gtest failure printing markword after JDK-8325303

### DIFF
--- a/test/hotspot/gtest/oops/test_markWord.cpp
+++ b/test/hotspot/gtest/oops/test_markWord.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,11 +88,11 @@ TEST_VM(markWord, printing) {
     ObjectLocker ol(h_obj, THREAD);
     assert_test_pattern(h_obj, "locked");
   }
-  assert_test_pattern(h_obj, "is_neutral no_hash");
+  assert_test_pattern(h_obj, "is_unlocked no_hash");
 
   // Hash the object then print it.
   intx hash = h_obj->identity_hash();
-  assert_test_pattern(h_obj, "is_neutral hash=0x");
+  assert_test_pattern(h_obj, "is_unlocked hash=0x");
 
   // Wait gets the lock inflated.
   {


### PR DESCRIPTION
Trivial test fix that changes `is_neutral` to `is_unlocked`.

Testing: locally, tier1 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329720](https://bugs.openjdk.org/browse/JDK-8329720): Gtest failure printing markword after JDK-8325303 (**Bug** - P2)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18641/head:pull/18641` \
`$ git checkout pull/18641`

Update a local copy of the PR: \
`$ git checkout pull/18641` \
`$ git pull https://git.openjdk.org/jdk.git pull/18641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18641`

View PR using the GUI difftool: \
`$ git pr show -t 18641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18641.diff">https://git.openjdk.org/jdk/pull/18641.diff</a>

</details>
