### PR TITLE
8310072: JComboBox/DisabledComboBoxFontTestAuto: Enabled and disabled ComboBox does not match in these LAFs: GTK+

### DIFF
--- a/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
+++ b/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
@@ -48,7 +48,6 @@ import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
 public class DisabledComboBoxFontTestAuto {
     private static JComboBox combo, combo2;
     private static BufferedImage enabledImage, disabledImage, enabledImage2, disabledImage2;
-    private static Path testDir;
     private static String lafName;
     private static StringBuffer failingLafs;
     private static int COMBO_HEIGHT, COMBO_WIDTH, COMBO2_HEIGHT, COMBO2_WIDTH;
@@ -94,6 +93,7 @@ public class DisabledComboBoxFontTestAuto {
 
     private static void testMethod() throws IOException {
         Color eColor1, eColor2, dColor1, dColor2;
+        Path testDir = Path.of(System.getProperty("test.classes", "."));
 
         // Use center line to compare RGB values
         int y = enabledImage.getHeight() / 2;
@@ -150,7 +150,6 @@ public class DisabledComboBoxFontTestAuto {
     public static void main(String[] args) throws Exception {
         lafName = "null";
         failingLafs = new StringBuffer();
-        testDir = Path.of(System.getProperty("test.classes", "."));
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             // Change Motif LAF name to avoid using slash in saved image file path
             lafName = laf.getName().equals("CDE/Motif") ? "Motif" : laf.getName();

--- a/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
+++ b/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
@@ -52,14 +52,15 @@ public class DisabledComboBoxFontTestAuto {
     private static String lafName;
     private static StringBuffer failingLafs;
     private static int COMBO_HEIGHT, COMBO_WIDTH, COMBO2_HEIGHT, COMBO2_WIDTH;
-    private static final int TOLERANCE = 20;
 
     private static void createCombo() {
         combo = new JComboBox();
-        combo.addItem("Simple JComboBox");
+        combo.addItem("\u2588".repeat(5));
+        combo.setFont(combo.getFont().deriveFont(50.0f));
         combo.setRenderer(new DefaultListCellRenderer());
         combo2 = new JComboBox();
-        combo2.addItem("Simple JComboBox");
+        combo2.addItem("\u2588".repeat(5));
+        combo2.setFont(combo2.getFont().deriveFont(50.0f));
         COMBO_WIDTH = (int) combo.getPreferredSize().getWidth();
         COMBO_HEIGHT = (int) combo.getPreferredSize().getHeight();
         COMBO2_WIDTH = (int) combo2.getPreferredSize().getWidth();
@@ -92,50 +93,27 @@ public class DisabledComboBoxFontTestAuto {
     }
 
     private static void testMethod() throws IOException {
-        ImageIO.write(enabledImage, "png", new File(testDir
-                + "/" + lafName + "Enabled.png"));
-        ImageIO.write(disabledImage, "png", new File(testDir
-                + "/" + lafName + "Disabled.png"));
-        ImageIO.write(enabledImage2, "png", new File(testDir
-                + "/" + lafName + "EnabledDLCR.png"));
-        ImageIO.write(disabledImage2, "png", new File(testDir
-                + "/" + lafName + "DisabledDLCR.png"));
-
         Color eColor1, eColor2, dColor1, dColor2;
 
         // Use center line to compare RGB values
         int y = enabledImage.getHeight() / 2;
         for (int x = (enabledImage.getWidth() / 2) - 20;
              x < (enabledImage.getWidth() / 2) + 20; x++) {
-            // Nimbus has a pixel offset in coordinates since Nimbus is 2px
-            // smaller in width than other L&F's
-            if (lafName.equals("Nimbus")) {
-                eColor1 = new Color(enabledImage.getRGB(x + 1, y));
-                eColor2 = new Color(enabledImage2.getRGB(x, y));
-                dColor1 = new Color(disabledImage.getRGB(x + 1, y));
-                dColor2 = new Color(disabledImage2.getRGB(x, y));
-            } else if (lafName.equals("Windows")) {
-                // In Windows LAF, the ComboBox sizes are different and
-                // that results in pixel offset of 1px for width and 1px for height.
-                eColor1 = new Color(enabledImage.getRGB(x, y));
-                eColor2 = new Color(enabledImage2.getRGB(x + 1, y - 1));
-                dColor1 = new Color(disabledImage.getRGB(x, y));
-                dColor2 = new Color(disabledImage2.getRGB(x + 1, y - 1));
-            } else if (lafName.equals("GTK+")) {
-                // In GTK LAF, the ComboBox sizes are different and
-                // that results in pixel offset of 10px for width and 2px for height.
-                eColor1 = new Color(enabledImage.getRGB(x, y));
-                eColor2 = new Color(enabledImage2.getRGB(x + 10, y + 2));
-                dColor1 = new Color(disabledImage.getRGB(x, y));
-                dColor2 = new Color(disabledImage2.getRGB(x + 10, y + 2));
-            } else {
-                eColor1 = new Color(enabledImage.getRGB(x, y));
-                eColor2 = new Color(enabledImage2.getRGB(x, y));
-                dColor1 = new Color(disabledImage.getRGB(x, y));
-                dColor2 = new Color(disabledImage2.getRGB(x, y));
-            }
+            eColor1 = new Color(enabledImage.getRGB(x, y));
+            eColor2 = new Color(enabledImage2.getRGB(x, y));
+            dColor1 = new Color(disabledImage.getRGB(x, y));
+            dColor2 = new Color(disabledImage2.getRGB(x, y));
+
             if ((!isColorMatching(eColor1, eColor2)) || (!isColorMatching(dColor1, dColor2))) {
                 failingLafs.append(lafName + ", ");
+                ImageIO.write(enabledImage, "png", new File(testDir
+                        + "/" + lafName + "Enabled.png"));
+                ImageIO.write(disabledImage, "png", new File(testDir
+                        + "/" + lafName + "Disabled.png"));
+                ImageIO.write(enabledImage2, "png", new File(testDir
+                        + "/" + lafName + "EnabledDLCR.png"));
+                ImageIO.write(disabledImage2, "png", new File(testDir
+                        + "/" + lafName + "DisabledDLCR.png"));
                 return;
             }
         }
@@ -143,14 +121,9 @@ public class DisabledComboBoxFontTestAuto {
     }
 
     private static boolean isColorMatching(Color c1, Color c2) {
-        int redDiff = Math.abs(c1.getRed() - c2.getRed());
-        int blueDiff = Math.abs(c1.getBlue() - c2.getBlue());
-        int greenDiff = Math.abs(c1.getGreen() - c2.getGreen());
-
-        // Added TOLERANCE for pixel color difference. In Windows LAF the
-        // background color between disabled and disabled DLCR image is slightly
-        // different (240, 240, 240 vs 255, 255, 255).
-        if ((redDiff > TOLERANCE) || (blueDiff > TOLERANCE) || (greenDiff > TOLERANCE)) {
+        if ((c1.getRed() != c2.getRed())
+            || (c1.getBlue() != c2.getBlue())
+            || (c1.getGreen() != c2.getGreen())) {
             System.out.println(lafName + " Enabled RGB failure: "
                     + c1.getRed() + ", "
                     + c1.getBlue() + ", "

--- a/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
+++ b/test/jdk/javax/swing/JComboBox/DisabledComboBoxFontTestAuto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,14 +21,6 @@
  * questions.
  */
 
-/*
- * @test
- * @bug 7093691 8310072
- * @summary Tests if JComboBox has correct font color when disabled/enabled
- * @key headful
- * @run main/othervm -Dsun.java2d.uiScale=1 DisabledComboBoxFontTestAuto
- */
-
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -44,6 +36,14 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
 import static java.awt.image.BufferedImage.TYPE_INT_ARGB;
+
+/*
+ * @test
+ * @bug 7093691 8310072
+ * @summary Tests if JComboBox has correct font color when disabled/enabled
+ * @key headful
+ * @run main/othervm -Dsun.java2d.uiScale=1 DisabledComboBoxFontTestAuto
+ */
 
 public class DisabledComboBoxFontTestAuto {
     private static JComboBox combo, combo2;
@@ -115,16 +115,14 @@ public class DisabledComboBoxFontTestAuto {
                 dColor1 = new Color(disabledImage.getRGB(x + 1, y));
                 dColor2 = new Color(disabledImage2.getRGB(x, y));
             } else if (lafName.equals("Windows")) {
-                // In Windows LAF, the ComboBox sizes are different.
-                // Combo size is 116 x 22 where as Combo2 size is 115 X 20 and
+                // In Windows LAF, the ComboBox sizes are different and
                 // that results in pixel offset of 1px for width and 1px for height.
                 eColor1 = new Color(enabledImage.getRGB(x, y));
                 eColor2 = new Color(enabledImage2.getRGB(x + 1, y - 1));
                 dColor1 = new Color(disabledImage.getRGB(x, y));
                 dColor2 = new Color(disabledImage2.getRGB(x + 1, y - 1));
             } else if (lafName.equals("GTK+")) {
-                // In GTK LAF, the ComboBox sizes are different.
-                // Combo size is 159 x 30 where as Combo2 size is 179 X 34 and
+                // In GTK LAF, the ComboBox sizes are different and
                 // that results in pixel offset of 10px for width and 2px for height.
                 eColor1 = new Color(enabledImage.getRGB(x, y));
                 eColor2 = new Color(enabledImage2.getRGB(x + 10, y + 2));
@@ -141,13 +139,13 @@ public class DisabledComboBoxFontTestAuto {
                 return;
             }
         }
-        System.out.println("Test Passed: "+lafName);
+        System.out.println("Test Passed: " + lafName);
     }
 
     private static boolean isColorMatching(Color c1, Color c2) {
-        int redDiff = c1.getRed() - c2.getRed();
-        int blueDiff = c1.getBlue() - c2.getBlue();
-        int greenDiff = c1.getGreen() - c2.getGreen();
+        int redDiff = Math.abs(c1.getRed() - c2.getRed());
+        int blueDiff = Math.abs(c1.getBlue() - c2.getBlue());
+        int greenDiff = Math.abs(c1.getGreen() - c2.getGreen());
 
         // Added TOLERANCE for pixel color difference. In Windows LAF the
         // background color between disabled and disabled DLCR image is slightly


### PR DESCRIPTION
Test was failing on GTK and Windows LAF due to pixel color mismatch. Th reason behind this issue was the size of image which is different and that results in incorrect pixel comparison. Fix is to ensure that correct pixel is matched and the pixel color should remain within tolerance. 
For windows LAF the background color is not an exact match and thus added a TOLERANCE field to check if the RGB difference is within limits.

`@key headful` added in jtreg tag to ensure that test run for GTK LAF as well which was not the case before as it is mentioned in JBS `It does not fail in mach5 because on linux + headless mode the gtk L&F is not supported.`

CI testing is green for the modified test. Link attached in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310072](https://bugs.openjdk.org/browse/JDK-8310072): JComboBox/DisabledComboBoxFontTestAuto: Enabled and disabled ComboBox does not match in these LAFs: GTK+ (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18644/head:pull/18644` \
`$ git checkout pull/18644`

Update a local copy of the PR: \
`$ git checkout pull/18644` \
`$ git pull https://git.openjdk.org/jdk.git pull/18644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18644`

View PR using the GUI difftool: \
`$ git pr show -t 18644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18644.diff">https://git.openjdk.org/jdk/pull/18644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18644#issuecomment-2039090280)