### PR TITLE
8329745: Update the documentation of ServerSocket and Socket to refer to StandardSocketOptions instead of legacy SocketOptions

### DIFF
--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -855,22 +855,22 @@ public class ServerSocket implements java.io.Closeable {
      * {@code SocketAddress} if there is a connection in the
      * timeout state involving the socket address or port.
      * <p>
-     * Enabling {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} prior to
-     * binding the socket using {@link #bind(SocketAddress)} allows the socket
-     * to be bound even though a previous connection is in a timeout state.
+     * Enabling {@code SO_REUSEADDR} prior to binding the socket using
+     * {@link #bind(SocketAddress)} allows the socket to be bound even
+     * though a previous connection is in a timeout state.
      * <p>
      * When a {@code ServerSocket} is created the initial setting
-     * of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is not defined.
-     * Applications can use {@link #getReuseAddress()} to determine the initial
-     * setting of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}.
+     * of {@code SO_REUSEADDR} is not defined. Applications can use
+     * {@link #getReuseAddress()} to determine the initial
+     * setting of {@code SO_REUSEADDR}.
      * <p>
-     * The behaviour when {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is
-     * enabled or disabled after a socket is bound (See {@link #isBound()})
+     * The behaviour when {@code SO_REUSEADDR} is enabled or disabled
+     * after a socket is bound (See {@link #isBound()})
      * is not defined.
      *
      * @param on  whether to enable or disable the socket option
      * @throws    SocketException if an error occurs enabling or
-     *            disabling the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     *            disabling the {@code SO_REUSEADDR}
      *            socket option, or the socket is closed.
      * @since 1.4
      * @see #getReuseAddress()
@@ -888,7 +888,7 @@ public class ServerSocket implements java.io.Closeable {
      * Tests if {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     *         {@code SO_REUSEADDR} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.4
@@ -987,8 +987,8 @@ public class ServerSocket implements java.io.Closeable {
      * {@link Socket#getReceiveBufferSize()} after the socket
      * is returned by {@link #accept()}.
      * <p>
-     * The value of {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is used both to
-     * set the size of the internal socket receive buffer, and to set the size
+     * The value of {@code SO_RCVBUF} is used both to set the size of
+     * the internal socket receive buffer, and to set the size
      * of the TCP receive window that is advertised to the remote peer.
      * <p>
      * It is possible to change the value subsequently, by calling
@@ -1030,8 +1030,7 @@ public class ServerSocket implements java.io.Closeable {
      *
      * <p>Note, the value actually set in the accepted socket is determined by
      * calling {@link Socket#getReceiveBufferSize()}.
-     * @return the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF}
-     *         option for this {@code Socket}.
+     * @return the value of the {@code SO_RCVBUF} option for this {@code Socket}.
      * @throws    SocketException if there is an error
      *            in the underlying protocol, such as a TCP error.
      * @see #setReceiveBufferSize(int)

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -140,10 +140,10 @@ public class ServerSocket implements java.io.Closeable {
      * request to connect) is set to {@code 50}. If a connection
      * indication arrives when the queue is full, the connection is refused.
      * <p>
-     * If the application has specified a server socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
+     * If the application has specified a {@linkplain SocketImplFactory server
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl} method
+     * is called to create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
      * If there is a security manager,
@@ -183,10 +183,10 @@ public class ServerSocket implements java.io.Closeable {
      * a connection indication arrives when the queue is full, the
      * connection is refused.
      * <p>
-     * If the application has specified a server socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to create
-     * the actual socket implementation. Otherwise a system-default
+     * If the application has specified a {@linkplain SocketImplFactory server
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl} method
+     * is called to create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
      * If there is a security manager,

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -141,7 +141,8 @@ public class ServerSocket implements java.io.Closeable {
      * indication arrives when the queue is full, the connection is refused.
      * <p>
      * If the application has specified a server socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
@@ -163,7 +164,6 @@ public class ServerSocket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      *
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkListen
      */
     public ServerSocket(int port) throws IOException {
@@ -184,8 +184,9 @@ public class ServerSocket implements java.io.Closeable {
      * connection is refused.
      * <p>
      * If the application has specified a server socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
-     * create the actual socket implementation. Otherwise a system-default
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to create
+     * the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
      * If there is a security manager,
@@ -214,7 +215,6 @@ public class ServerSocket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      *
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkListen
      */
     public ServerSocket(int port, int backlog) throws IOException {
@@ -261,8 +261,6 @@ public class ServerSocket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      *
-     * @see StandardSocketOptions
-     * @see SocketImpl
      * @see SecurityManager#checkListen
      * @since   1.1
      */

--- a/src/java.base/share/classes/java/net/ServerSocket.java
+++ b/src/java.base/share/classes/java/net/ServerSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,7 +261,7 @@ public class ServerSocket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      *
-     * @see SocketOptions
+     * @see StandardSocketOptions
      * @see SocketImpl
      * @see SecurityManager#checkListen
      * @since   1.1
@@ -801,7 +801,7 @@ public class ServerSocket implements java.io.Closeable {
      * specified timeout, in milliseconds.  With this option set to a positive
      * timeout value, a call to accept() for this ServerSocket
      * will block for only this amount of time.  If the timeout expires,
-     * a <B>java.net.SocketTimeoutException</B> is raised, though the
+     * a {@link java.net.SocketTimeoutException} is raised, though the
      * ServerSocket is still valid. A timeout of zero is interpreted as an
      * infinite timeout.
      * The option <B>must</B> be enabled prior to entering the blocking
@@ -843,7 +843,7 @@ public class ServerSocket implements java.io.Closeable {
     }
 
     /**
-     * Enable/disable the {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     * Enable/disable the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
      * socket option.
      * <p>
      * When a TCP connection is closed the connection may remain
@@ -855,22 +855,22 @@ public class ServerSocket implements java.io.Closeable {
      * {@code SocketAddress} if there is a connection in the
      * timeout state involving the socket address or port.
      * <p>
-     * Enabling {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} prior to
+     * Enabling {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} prior to
      * binding the socket using {@link #bind(SocketAddress)} allows the socket
      * to be bound even though a previous connection is in a timeout state.
      * <p>
      * When a {@code ServerSocket} is created the initial setting
-     * of {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is not defined.
+     * of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is not defined.
      * Applications can use {@link #getReuseAddress()} to determine the initial
-     * setting of {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}.
+     * setting of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}.
      * <p>
-     * The behaviour when {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is
+     * The behaviour when {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is
      * enabled or disabled after a socket is bound (See {@link #isBound()})
      * is not defined.
      *
      * @param on  whether to enable or disable the socket option
      * @throws    SocketException if an error occurs enabling or
-     *            disabling the {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     *            disabling the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
      *            socket option, or the socket is closed.
      * @since 1.4
      * @see #getReuseAddress()
@@ -885,10 +885,10 @@ public class ServerSocket implements java.io.Closeable {
     }
 
     /**
-     * Tests if {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     * Tests if {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     *         {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.4
@@ -981,13 +981,13 @@ public class ServerSocket implements java.io.Closeable {
 
     /**
      * Sets a default proposed value for the
-     * {@link SocketOptions#SO_RCVBUF SO_RCVBUF} option for sockets
+     * {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option for sockets
      * accepted from this {@code ServerSocket}. The value actually set
      * in the accepted socket must be determined by calling
      * {@link Socket#getReceiveBufferSize()} after the socket
      * is returned by {@link #accept()}.
      * <p>
-     * The value of {@link SocketOptions#SO_RCVBUF SO_RCVBUF} is used both to
+     * The value of {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is used both to
      * set the size of the internal socket receive buffer, and to set the size
      * of the TCP receive window that is advertised to the remote peer.
      * <p>
@@ -1024,13 +1024,13 @@ public class ServerSocket implements java.io.Closeable {
     }
 
     /**
-     * Gets the value of the {@link SocketOptions#SO_RCVBUF SO_RCVBUF} option
+     * Gets the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option
      * for this {@code ServerSocket}, that is the proposed buffer size that
      * will be used for Sockets accepted from this {@code ServerSocket}.
      *
      * <p>Note, the value actually set in the accepted socket is determined by
      * calling {@link Socket#getReceiveBufferSize()}.
-     * @return the value of the {@link SocketOptions#SO_RCVBUF SO_RCVBUF}
+     * @return the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF}
      *         option for this {@code Socket}.
      * @throws    SocketException if there is an error
      *            in the underlying protocol, such as a TCP error.

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1244,7 +1244,7 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Enable/disable {@link SocketOptions#TCP_NODELAY TCP_NODELAY}
+     * Enable/disable {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY}
      * (disable/enable Nagle's algorithm).
      *
      * @param on {@code true} to enable TCP_NODELAY,
@@ -1264,10 +1264,10 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Tests if {@link SocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
+     * Tests if {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link SocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
+     *         {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.1
@@ -1280,7 +1280,7 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Enable/disable {@link SocketOptions#SO_LINGER SO_LINGER} with the
+     * Enable/disable {@link StandardSocketOptions#SO_LINGER SO_LINGER} with the
      * specified linger time in seconds. The maximum timeout value is platform
      * specific.
      *
@@ -1310,13 +1310,13 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Returns setting for {@link SocketOptions#SO_LINGER SO_LINGER}.
+     * Returns setting for {@link StandardSocketOptions#SO_LINGER SO_LINGER}.
      * -1 returns implies that the
      * option is disabled.
      *
      * The setting only affects socket close.
      *
-     * @return the setting for {@link SocketOptions#SO_LINGER SO_LINGER}.
+     * @return the setting for {@link StandardSocketOptions#SO_LINGER SO_LINGER}.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.1
@@ -1447,13 +1447,13 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Sets the {@link SocketOptions#SO_SNDBUF SO_SNDBUF} option to the
+     * Sets the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option to the
      * specified value for this {@code Socket}.
-     * The {@link SocketOptions#SO_SNDBUF SO_SNDBUF} option is used by the
+     * The {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option is used by the
      * platform's networking code as a hint for the size to set the underlying
      * network I/O buffers.
      *
-     * <p>Because {@link SocketOptions#SO_SNDBUF SO_SNDBUF} is a hint,
+     * <p>Because {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} is a hint,
      * applications that want to verify what size the buffers were set to
      * should call {@link #getSendBufferSize()}.
      *
@@ -1478,10 +1478,10 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Get value of the {@link SocketOptions#SO_SNDBUF SO_SNDBUF} option
+     * Get value of the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option
      * for this {@code Socket}, that is the buffer size used by the platform
      * for output on this {@code Socket}.
-     * @return the value of the {@link SocketOptions#SO_SNDBUF SO_SNDBUF}
+     * @return the value of the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF}
      *         option for this {@code Socket}.
      *
      * @throws    SocketException if there is an error
@@ -1502,9 +1502,9 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Sets the {@link SocketOptions#SO_RCVBUF SO_RCVBUF} option to the
+     * Sets the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option to the
      * specified value for this {@code Socket}. The
-     * {@link SocketOptions#SO_RCVBUF SO_RCVBUF} option is
+     * {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option is
      * used by the platform's networking code as a hint for the size to set
      * the underlying network I/O buffers.
      *
@@ -1512,11 +1512,11 @@ public class Socket implements java.io.Closeable {
      * network I/O for high-volume connection, while decreasing it can
      * help reduce the backlog of incoming data.
      *
-     * <p>Because {@link SocketOptions#SO_RCVBUF SO_RCVBUF} is a hint,
+     * <p>Because {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is a hint,
      * applications that want to verify what size the buffers were set to
      * should call {@link #getReceiveBufferSize()}.
      *
-     * <p>The value of {@link SocketOptions#SO_RCVBUF SO_RCVBUF} is also used
+     * <p>The value of {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is also used
      * to set the TCP receive window that is advertised to the remote peer.
      * Generally, the window size can be modified at any time when a socket is
      * connected. However, if a receive window larger than 64K is required then
@@ -1550,11 +1550,11 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Gets the value of the {@link SocketOptions#SO_RCVBUF SO_RCVBUF} option
+     * Gets the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option
      * for this {@code Socket}, that is the buffer size used by the platform
      * for input on this {@code Socket}.
      *
-     * @return the value of the {@link SocketOptions#SO_RCVBUF SO_RCVBUF}
+     * @return the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF}
      *         option for this {@code Socket}.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
@@ -1573,7 +1573,7 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Enable/disable {@link SocketOptions#SO_KEEPALIVE SO_KEEPALIVE}.
+     * Enable/disable {@link StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE}.
      *
      * @param on  whether or not to have socket keep alive turned on.
      * @throws    SocketException if there is an error
@@ -1588,10 +1588,10 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Tests if {@link SocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
+     * Tests if {@link StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link SocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
+     *         {@link StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.3
@@ -1647,7 +1647,7 @@ public class Socket implements java.io.Closeable {
      * traffic class or type-of-service
      * @since 1.4
      * @see #getTrafficClass
-     * @see SocketOptions#IP_TOS
+     * @see StandardSocketOptions#IP_TOS
      */
     public void setTrafficClass(int tc) throws SocketException {
         if (tc < 0 || tc > 255)
@@ -1671,14 +1671,14 @@ public class Socket implements java.io.Closeable {
      * traffic class or type-of-service value.
      * @since 1.4
      * @see #setTrafficClass(int)
-     * @see SocketOptions#IP_TOS
+     * @see StandardSocketOptions#IP_TOS
      */
     public int getTrafficClass() throws SocketException {
         return ((Integer) (getImpl().getOption(SocketOptions.IP_TOS))).intValue();
     }
 
     /**
-     * Enable/disable the {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     * Enable/disable the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
      * socket option.
      * <p>
      * When a TCP connection is closed the connection may remain
@@ -1690,21 +1690,21 @@ public class Socket implements java.io.Closeable {
      * {@code SocketAddress} if there is a connection in the
      * timeout state involving the socket address or port.
      * <p>
-     * Enabling {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     * Enabling {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
      * prior to binding the socket using {@link #bind(SocketAddress)} allows
      * the socket to be bound even though a previous connection is in a timeout
      * state.
      * <p>
      * When a {@code Socket} is created the initial setting
-     * of {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is disabled.
+     * of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is disabled.
      * <p>
-     * The behaviour when {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is
+     * The behaviour when {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is
      * enabled or disabled after a socket is bound (See {@link #isBound()})
      * is not defined.
      *
      * @param on  whether to enable or disable the socket option
      * @throws    SocketException if an error occurs enabling or
-     *            disabling the {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     *            disabling the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
      *            socket option, or the socket is closed.
      * @since 1.4
      * @see #getReuseAddress()
@@ -1719,10 +1719,10 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Tests if {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     * Tests if {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link SocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     *         {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.4

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -173,7 +173,8 @@ public class Socket implements java.io.Closeable {
      * Creates an unconnected Socket.
      * <p>
      * If the application has specified a client socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      *
@@ -296,7 +297,8 @@ public class Socket implements java.io.Closeable {
      * loopback interface. </p>
      * <p>
      * If the application has specified a client socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
@@ -317,7 +319,6 @@ public class Socket implements java.io.Closeable {
      * @throws     IllegalArgumentException if the port parameter is outside
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkConnect
      */
     @SuppressWarnings("this-escape")
@@ -334,7 +335,8 @@ public class Socket implements java.io.Closeable {
      * number at the specified IP address.
      * <p>
      * If the application has specified a client socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
@@ -352,7 +354,6 @@ public class Socket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      * @throws     NullPointerException if {@code address} is null.
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkConnect
      */
     @SuppressWarnings("this-escape")
@@ -462,7 +463,8 @@ public class Socket implements java.io.Closeable {
      * creates a datagram socket.
      * <p>
      * If the application has specified a client socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      * <p>
@@ -483,7 +485,6 @@ public class Socket implements java.io.Closeable {
      * @throws     IllegalArgumentException if the port parameter is outside
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkConnect
      * @deprecated Use DatagramSocket instead for UDP transport.
      */
@@ -504,7 +505,8 @@ public class Socket implements java.io.Closeable {
      * creates a datagram socket.
      * <p>
      * If the application has specified a client socket implementation
-     * factory, that factory's {@code createSocketImpl} method is called to
+     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
+     * factory's createSocketImpl method} is called to
      * create the actual socket implementation. Otherwise a system-default
      * socket implementation is created.
      *
@@ -526,7 +528,6 @@ public class Socket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      * @throws     NullPointerException if {@code host} is null.
-     * @see        java.net.SocketImpl
      * @see        SecurityManager#checkConnect
      * @deprecated Use DatagramSocket instead for UDP transport.
      */

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -172,11 +172,11 @@ public class Socket implements java.io.Closeable {
     /**
      * Creates an unconnected Socket.
      * <p>
-     * If the application has specified a client socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
-     * socket implementation is created.
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
      *
      * @since   1.1
      */
@@ -296,11 +296,11 @@ public class Socket implements java.io.Closeable {
      * In other words, it is equivalent to specifying an address of the
      * loopback interface. </p>
      * <p>
-     * If the application has specified a client socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
-     * socket implementation is created.
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
      * <p>
      * If there is a security manager, its
      * {@code checkConnect} method is called
@@ -334,11 +334,11 @@ public class Socket implements java.io.Closeable {
      * Creates a stream socket and connects it to the specified port
      * number at the specified IP address.
      * <p>
-     * If the application has specified a client socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
-     * socket implementation is created.
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
      * <p>
      * If there is a security manager, its
      * {@code checkConnect} method is called
@@ -462,11 +462,11 @@ public class Socket implements java.io.Closeable {
      * stream socket. If the stream argument is {@code false}, it
      * creates a datagram socket.
      * <p>
-     * If the application has specified a client socket implementation
-     * factory, {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
-     * socket implementation is created.
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
      * <p>
      * If there is a security manager, its
      * {@code checkConnect} method is called
@@ -504,11 +504,11 @@ public class Socket implements java.io.Closeable {
      * stream socket. If the stream argument is {@code false}, it
      * creates a datagram socket.
      * <p>
-     * If the application has specified a client socket implementation
-     * factory, that {@linkplain SocketImplFactory#createSocketImpl()
-     * factory's createSocketImpl method} is called to
-     * create the actual socket implementation. Otherwise a system-default
-     * socket implementation is created.
+     * If the application has specified a {@linkplain SocketImplFactory client
+     * socket implementation factory}, that factory's
+     * {@linkplain SocketImplFactory#createSocketImpl() createSocketImpl}
+     * method is called to create the actual socket implementation. Otherwise
+     * a system-default socket implementation is created.
      *
      * <p>If there is a security manager, its
      * {@code checkConnect} method is called

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -1247,7 +1247,7 @@ public class Socket implements java.io.Closeable {
      * Enable/disable {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY}
      * (disable/enable Nagle's algorithm).
      *
-     * @param on {@code true} to enable TCP_NODELAY,
+     * @param on {@code true} to enable {@code TCP_NODELAY},
      * {@code false} to disable.
      *
      * @throws    SocketException if there is an error
@@ -1267,7 +1267,7 @@ public class Socket implements java.io.Closeable {
      * Tests if {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link StandardSocketOptions#TCP_NODELAY TCP_NODELAY} is enabled.
+     *         {@code TCP_NODELAY} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.1
@@ -1316,7 +1316,7 @@ public class Socket implements java.io.Closeable {
      *
      * The setting only affects socket close.
      *
-     * @return the setting for {@link StandardSocketOptions#SO_LINGER SO_LINGER}.
+     * @return the setting for {@code SO_LINGER}.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.1
@@ -1364,8 +1364,7 @@ public class Socket implements java.io.Closeable {
      * and there is no capability to distinguish between normal data and urgent
      * data unless provided by a higher level protocol.
      *
-     * @param on {@code true} to enable
-     *           {@link SocketOptions#SO_OOBINLINE SO_OOBINLINE},
+     * @param on {@code true} to enable {@code SO_OOBINLINE},
      *           {@code false} to disable.
      *
      * @throws    SocketException if there is an error
@@ -1385,7 +1384,7 @@ public class Socket implements java.io.Closeable {
      * Tests if {@link SocketOptions#SO_OOBINLINE SO_OOBINLINE} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link SocketOptions#SO_OOBINLINE SO_OOBINLINE} is enabled.
+     *         {@code SO_OOBINLINE} is enabled.
      *
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
@@ -1427,7 +1426,7 @@ public class Socket implements java.io.Closeable {
      * Returns setting for {@link SocketOptions#SO_TIMEOUT SO_TIMEOUT}.
      * 0 returns implies that the option is disabled (i.e., timeout of infinity).
      *
-     * @return the setting for {@link SocketOptions#SO_TIMEOUT SO_TIMEOUT}
+     * @return the setting for {@code SO_TIMEOUT}
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      *
@@ -1449,13 +1448,11 @@ public class Socket implements java.io.Closeable {
     /**
      * Sets the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option to the
      * specified value for this {@code Socket}.
-     * The {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option is used by the
-     * platform's networking code as a hint for the size to set the underlying
-     * network I/O buffers.
+     * The {@code SO_SNDBUF} option is used by the platform's networking code
+     * as a hint for the size to set the underlying network I/O buffers.
      *
-     * <p>Because {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} is a hint,
-     * applications that want to verify what size the buffers were set to
-     * should call {@link #getSendBufferSize()}.
+     * <p>Because {@code SO_SNDBUF} is a hint, applications that want to verify
+     * what size the buffers were set to should call {@link #getSendBufferSize()}.
      *
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
@@ -1481,8 +1478,7 @@ public class Socket implements java.io.Closeable {
      * Get value of the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF} option
      * for this {@code Socket}, that is the buffer size used by the platform
      * for output on this {@code Socket}.
-     * @return the value of the {@link StandardSocketOptions#SO_SNDBUF SO_SNDBUF}
-     *         option for this {@code Socket}.
+     * @return the value of the {@code SO_SNDBUF} option for this {@code Socket}.
      *
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
@@ -1504,20 +1500,18 @@ public class Socket implements java.io.Closeable {
     /**
      * Sets the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option to the
      * specified value for this {@code Socket}. The
-     * {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} option is
-     * used by the platform's networking code as a hint for the size to set
-     * the underlying network I/O buffers.
+     * {@code SO_RCVBUF} option is used by the platform's networking code
+     * as a hint for the size to set the underlying network I/O buffers.
      *
      * <p>Increasing the receive buffer size can increase the performance of
      * network I/O for high-volume connection, while decreasing it can
      * help reduce the backlog of incoming data.
      *
-     * <p>Because {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is a hint,
-     * applications that want to verify what size the buffers were set to
-     * should call {@link #getReceiveBufferSize()}.
+     * <p>Because {@code SO_RCVBUF} is a hint, applications that want to verify
+     * what size the buffers were set to should call {@link #getReceiveBufferSize()}.
      *
-     * <p>The value of {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF} is also used
-     * to set the TCP receive window that is advertised to the remote peer.
+     * <p>The value of {@code SO_RCVBUF} is also used to set the TCP receive window
+     * that is advertised to the remote peer.
      * Generally, the window size can be modified at any time when a socket is
      * connected. However, if a receive window larger than 64K is required then
      * this must be requested <B>before</B> the socket is connected to the
@@ -1554,8 +1548,7 @@ public class Socket implements java.io.Closeable {
      * for this {@code Socket}, that is the buffer size used by the platform
      * for input on this {@code Socket}.
      *
-     * @return the value of the {@link StandardSocketOptions#SO_RCVBUF SO_RCVBUF}
-     *         option for this {@code Socket}.
+     * @return the value of the {@code SO_RCVBUF} option for this {@code Socket}.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @see #setReceiveBufferSize(int)
@@ -1591,7 +1584,7 @@ public class Socket implements java.io.Closeable {
      * Tests if {@link StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link StandardSocketOptions#SO_KEEPALIVE SO_KEEPALIVE} is enabled.
+     *         {@code SO_KEEPALIVE} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.3
@@ -1690,21 +1683,19 @@ public class Socket implements java.io.Closeable {
      * {@code SocketAddress} if there is a connection in the
      * timeout state involving the socket address or port.
      * <p>
-     * Enabling {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
-     * prior to binding the socket using {@link #bind(SocketAddress)} allows
-     * the socket to be bound even though a previous connection is in a timeout
-     * state.
+     * Enabling {@code SO_REUSEADDR} prior to binding the socket using
+     * {@link #bind(SocketAddress)} allows the socket to be bound even
+     * though a previous connection is in a timeout state.
      * <p>
      * When a {@code Socket} is created the initial setting
-     * of {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is disabled.
+     * of {@code SO_REUSEADDR} is disabled.
      * <p>
-     * The behaviour when {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is
-     * enabled or disabled after a socket is bound (See {@link #isBound()})
-     * is not defined.
+     * The behaviour when {@code SO_REUSEADDR} is enabled or disabled after
+     * a socket is bound (See {@link #isBound()}) is not defined.
      *
      * @param on  whether to enable or disable the socket option
      * @throws    SocketException if an error occurs enabling or
-     *            disabling the {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR}
+     *            disabling the {@code SO_REUSEADDR}
      *            socket option, or the socket is closed.
      * @since 1.4
      * @see #getReuseAddress()
@@ -1722,7 +1713,7 @@ public class Socket implements java.io.Closeable {
      * Tests if {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
      *
      * @return a {@code boolean} indicating whether or not
-     *         {@link StandardSocketOptions#SO_REUSEADDR SO_REUSEADDR} is enabled.
+     *         {@code SO_REUSEADDR} is enabled.
      * @throws    SocketException if there is an error
      * in the underlying protocol, such as a TCP error.
      * @since   1.4


### PR DESCRIPTION
Can I please get a review of this doc-only changes to java.net.ServerSocket and java.net.Socket classes?

As noted in https://bugs.openjdk.org/browse/JDK-8329745, these classes currently refer to the legacy `java.net.SocketOptions` interface and instead should be refering to the newer `java.net.StandardSocketOptions` class. The commit in this PR updates such references. This change intentionally doesn't do any code changes to use the `StandardSocketOptions` class - that can be done separately if desired at a later point (after testing for any compatibility issues). Finally, there are a few places in ServerSocket and Socket documentation which will continue to refer to java.net.SocketOptions legacy interface because few of the options aren't available in StandardSocketOptions class (for example, `SO_TIMEOUT`).

I ran `make docs-image` locally with this change and the generated doc looks OK to me.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329745](https://bugs.openjdk.org/browse/JDK-8329745): Update the documentation of ServerSocket and Socket to refer to StandardSocketOptions instead of legacy SocketOptions (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18646/head:pull/18646` \
`$ git checkout pull/18646`

Update a local copy of the PR: \
`$ git checkout pull/18646` \
`$ git pull https://git.openjdk.org/jdk.git pull/18646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18646`

View PR using the GUI difftool: \
`$ git pr show -t 18646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18646.diff">https://git.openjdk.org/jdk/pull/18646.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18646#issuecomment-2039152187)