### PR TITLE
8329749: Obsolete the unused UseNeon flag

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -85,8 +85,6 @@ define_pd_global(intx, InlineSmallCode,          1000);
                                                                         \
   product(bool, NearCpool, true,                                        \
          "constant pool is close to instructions")                      \
-  product(bool, UseNeon, false,                                         \
-          "Use Neon for CRC32 computation")                             \
   product(bool, UseCRC32, false,                                        \
           "Use CRC32 instructions for CRC32 computation")               \
   product(bool, UseCryptoPmullForCRC32, false,                          \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -537,6 +537,7 @@ static SpecialFlag const special_jvm_flags[] = {
 
   { "ParallelOldDeadWoodLimiterMean",   JDK_Version::undefined(), JDK_Version::jdk(23), JDK_Version::jdk(24) },
   { "ParallelOldDeadWoodLimiterStdDev", JDK_Version::undefined(), JDK_Version::jdk(23), JDK_Version::jdk(24) },
+  { "UseNeon",                      JDK_Version::undefined(), JDK_Version::jdk(23), JDK_Version::jdk(24) },
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/aarch64/AArch64.java
@@ -190,7 +190,6 @@ public class AArch64 extends Architecture {
      */
     public enum Flag {
         UseCRC32,
-        UseNeon,
         UseSIMDForMemoryOps,
         AvoidUnalignedAccesses,
         UseLSE,

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotJVMCIBackendFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,9 +57,6 @@ public class AArch64HotSpotJVMCIBackendFactory implements HotSpotJVMCIBackendFac
 
         if (config.useCRC32) {
             flags.add(AArch64.Flag.UseCRC32);
-        }
-        if (config.useNeon) {
-            flags.add(AArch64.Flag.UseNeon);
         }
         if (config.useSIMDForMemoryOps) {
             flags.add(AArch64.Flag.UseSIMDForMemoryOps);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/aarch64/AArch64HotSpotVMConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ class AArch64HotSpotVMConfig extends HotSpotVMConfigAccess {
      * These flags are set based on the corresponding command line flags.
      */
     final boolean useCRC32 = getFlag("UseCRC32", Boolean.class);
-    final boolean useNeon = getFlag("UseNeon", Boolean.class);
     final boolean useSIMDForMemoryOps = getFlag("UseSIMDForMemoryOps", Boolean.class);
     final boolean avoidUnalignedAccesses = getFlag("AvoidUnalignedAccesses", Boolean.class);
     final boolean useLSE = getFlag("UseLSE", Boolean.class);


### PR DESCRIPTION
After [JDK-8328264](https://bugs.openjdk.org/browse/JDK-8328264), the UseNeon flag is only used by JVMCI code and @dougxc confirmed that it can be removed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8329753](https://bugs.openjdk.org/browse/JDK-8329753) to be approved

### Issues
 * [JDK-8329749](https://bugs.openjdk.org/browse/JDK-8329749): Obsolete the unused UseNeon flag (**Enhancement** - P4)
 * [JDK-8329753](https://bugs.openjdk.org/browse/JDK-8329753): Obsolete UseNeon (**CSR**)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [5d8119ab](https://git.openjdk.org/jdk/pull/18648/files/5d8119abefcc0958cce949247e8232c5319aa304)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [5d8119ab](https://git.openjdk.org/jdk/pull/18648/files/5d8119abefcc0958cce949247e8232c5319aa304)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18648/head:pull/18648` \
`$ git checkout pull/18648`

Update a local copy of the PR: \
`$ git checkout pull/18648` \
`$ git pull https://git.openjdk.org/jdk.git pull/18648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18648`

View PR using the GUI difftool: \
`$ git pr show -t 18648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18648.diff">https://git.openjdk.org/jdk/pull/18648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18648#issuecomment-2039219313)