### PR TITLE
8329750: Change Universe functions to return more specific Klass* types

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -368,7 +368,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
     }
   } else {
     k = Universe::typeArrayKlass(t);
-    k = TypeArrayKlass::cast(k)->array_klass(ndims, CHECK_NULL);
+    k = k->array_klass(ndims, CHECK_NULL);
   }
   return k;
 }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -367,8 +367,7 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
       k = k->array_klass(ndims, CHECK_NULL);
     }
   } else {
-    TypeArrayKlass* tak = Universe::typeArrayKlass(t);
-    k = tak->array_klass(ndims, CHECK_NULL);
+    k = Universe::typeArrayKlass(t);
     k = k->array_klass(ndims, CHECK_NULL);
   }
   return k;

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -367,7 +367,8 @@ Klass* SystemDictionary::resolve_array_class_or_null(Symbol* class_name,
       k = k->array_klass(ndims, CHECK_NULL);
     }
   } else {
-    k = Universe::typeArrayKlass(t);
+    TypeArrayKlass* tak = Universe::typeArrayKlass(t);
+    k = tak->array_klass(ndims, CHECK_NULL);
     k = k->array_klass(ndims, CHECK_NULL);
   }
   return k;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -636,7 +636,7 @@ C2V_VMENTRY_NULL(jobject, lookupType, (JNIEnv* env, jobject, jstring jname, ARGU
           resolved_klass = resolved_klass->array_klass(ndim, CHECK_NULL);
         }
       } else {
-        resolved_klass = TypeArrayKlass::cast(Universe::typeArrayKlass(ss.type()))->array_klass(ndim, CHECK_NULL);
+        resolved_klass = Universe::typeArrayKlass(ss.type())->array_klass(ndim, CHECK_NULL);
       }
     } else {
       resolved_klass = SystemDictionary::find_instance_klass(THREAD, class_name,

--- a/src/hotspot/share/memory/oopFactory.cpp
+++ b/src/hotspot/share/memory/oopFactory.cpp
@@ -41,41 +41,41 @@
 #include "utilities/utf8.hpp"
 
 typeArrayOop oopFactory::new_boolArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::boolArrayKlass())->allocate(length, THREAD);
+  return Universe::boolArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_charArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::charArrayKlass())->allocate(length, THREAD);
+  return Universe::charArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_floatArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::floatArrayKlass())->allocate(length, THREAD);
+  return Universe::floatArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_doubleArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::doubleArrayKlass())->allocate(length, THREAD);
+  return Universe::doubleArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_byteArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::byteArrayKlass())->allocate(length, THREAD);
+  return Universe::byteArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_shortArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::shortArrayKlass())->allocate(length, THREAD);
+  return Universe::shortArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_intArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::intArrayKlass())->allocate(length, THREAD);
+  return Universe::intArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_longArray(int length, TRAPS) {
-  return TypeArrayKlass::cast(Universe::longArrayKlass())->allocate(length, THREAD);
+  return Universe::longArrayKlass()->allocate(length, THREAD);
 }
 
 // create java.lang.Object[]
 objArrayOop oopFactory::new_objectArray(int length, TRAPS)  {
   assert(Universe::objectArrayKlass() != nullptr, "Too early?");
-  return ObjArrayKlass::cast(Universe::objectArrayKlass())->allocate(length, THREAD);
+  return Universe::objectArrayKlass()->allocate(length, THREAD);
 }
 
 typeArrayOop oopFactory::new_charArray(const char* utf8_str, TRAPS) {
@@ -88,10 +88,8 @@ typeArrayOop oopFactory::new_charArray(const char* utf8_str, TRAPS) {
 }
 
 typeArrayOop oopFactory::new_typeArray(BasicType type, int length, TRAPS) {
-  Klass* klass = Universe::typeArrayKlass(type);
-  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
-  typeArrayOop result = typeArrayKlass->allocate(length, THREAD);
-  return result;
+  TypeArrayKlass* klass = Universe::typeArrayKlass(type);
+  return klass->allocate(length, THREAD);
 }
 
 // Create a Java array that points to Symbol.
@@ -100,17 +98,12 @@ typeArrayOop oopFactory::new_typeArray(BasicType type, int length, TRAPS) {
 // this.  They cast Symbol* into this type.
 typeArrayOop oopFactory::new_symbolArray(int length, TRAPS) {
   BasicType type = LP64_ONLY(T_LONG) NOT_LP64(T_INT);
-  Klass* klass = Universe::typeArrayKlass(type);
-  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
-  typeArrayOop result = typeArrayKlass->allocate(length, THREAD);
-  return result;
+  return new_typeArray(type, length, THREAD);
 }
 
 typeArrayOop oopFactory::new_typeArray_nozero(BasicType type, int length, TRAPS) {
-  Klass* klass = Universe::typeArrayKlass(type);
-  TypeArrayKlass* typeArrayKlass = TypeArrayKlass::cast(klass);
-  typeArrayOop result = typeArrayKlass->allocate_common(length, false, THREAD);
-  return result;
+  TypeArrayKlass* klass = Universe::typeArrayKlass(type);
+  return klass->allocate_common(length, false, THREAD);
 }
 
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -111,9 +111,9 @@ static LatestMethodCache _throw_no_such_method_error_cache; // Unsafe.throwNoSuc
 static LatestMethodCache _do_stack_walk_cache;              // AbstractStackWalker.doStackWalk()
 
 // Known objects
-Klass* Universe::_typeArrayKlasses[T_LONG+1]        = { nullptr /*, nullptr...*/ };
-Klass* Universe::_objectArrayKlass                  = nullptr;
-Klass* Universe::_fillerArrayKlass                  = nullptr;
+TypeArrayKlass* Universe::_typeArrayKlasses[T_LONG+1] = { nullptr /*, nullptr...*/ };
+ObjArrayKlass* Universe::_objectArrayKlass            = nullptr;
+Klass* Universe::_fillerArrayKlass                    = nullptr;
 OopHandle Universe::_basic_type_mirrors[T_VOID+1];
 #if INCLUDE_CDS_JAVA_HEAP
 int Universe::_archived_basic_type_mirror_indices[T_VOID+1];
@@ -472,8 +472,10 @@ void Universe::genesis(TRAPS) {
   // ordinary object arrays, _objectArrayKlass will be loaded when
   // SystemDictionary::initialize(CHECK); is run. See the extra check
   // for Object_klass_loaded in objArrayKlassKlass::allocate_objArray_klass_impl.
-  _objectArrayKlass = InstanceKlass::
-    cast(vmClasses::Object_klass())->array_klass(1, CHECK);
+  {
+    Klass* oak = vmClasses::Object_klass()->array_klass(CHECK);
+    _objectArrayKlass = ObjArrayKlass::cast(oak);
+  }
   // OLD
   // Add the class to the class hierarchy manually to make sure that
   // its vtable is initialized after core bootstrapping is completed.

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -65,8 +65,8 @@ class Universe: AllStatic {
 
  private:
   // Known classes in the VM
-  static Klass* _typeArrayKlasses[T_LONG+1];
-  static Klass* _objectArrayKlass;
+  static TypeArrayKlass* _typeArrayKlasses[T_LONG+1];
+  static ObjArrayKlass* _objectArrayKlass;
   // Special int-Array that represents filler objects that are used by GC to overwrite
   // dead objects. References to them are generally an error.
   static Klass* _fillerArrayKlass;
@@ -174,20 +174,20 @@ class Universe: AllStatic {
   static void set_verify_data(uintptr_t mask, uintptr_t bits) PRODUCT_RETURN;
 
   // Known classes in the VM
-  static Klass* boolArrayKlass()                 { return typeArrayKlass(T_BOOLEAN); }
-  static Klass* byteArrayKlass()                 { return typeArrayKlass(T_BYTE); }
-  static Klass* charArrayKlass()                 { return typeArrayKlass(T_CHAR); }
-  static Klass* intArrayKlass()                  { return typeArrayKlass(T_INT); }
-  static Klass* shortArrayKlass()                { return typeArrayKlass(T_SHORT); }
-  static Klass* longArrayKlass()                 { return typeArrayKlass(T_LONG); }
-  static Klass* floatArrayKlass()                { return typeArrayKlass(T_FLOAT); }
-  static Klass* doubleArrayKlass()               { return typeArrayKlass(T_DOUBLE); }
+  static TypeArrayKlass* boolArrayKlass()        { return typeArrayKlass(T_BOOLEAN); }
+  static TypeArrayKlass* byteArrayKlass()        { return typeArrayKlass(T_BYTE); }
+  static TypeArrayKlass* charArrayKlass()        { return typeArrayKlass(T_CHAR); }
+  static TypeArrayKlass* intArrayKlass()         { return typeArrayKlass(T_INT); }
+  static TypeArrayKlass* shortArrayKlass()       { return typeArrayKlass(T_SHORT); }
+  static TypeArrayKlass* longArrayKlass()        { return typeArrayKlass(T_LONG); }
+  static TypeArrayKlass* floatArrayKlass()       { return typeArrayKlass(T_FLOAT); }
+  static TypeArrayKlass* doubleArrayKlass()      { return typeArrayKlass(T_DOUBLE); }
 
-  static Klass* objectArrayKlass()               { return _objectArrayKlass; }
+  static ObjArrayKlass* objectArrayKlass()       { return _objectArrayKlass; }
 
   static Klass* fillerArrayKlass()               { return _fillerArrayKlass; }
 
-  static Klass* typeArrayKlass(BasicType t) {
+  static TypeArrayKlass* typeArrayKlass(BasicType t) {
     assert((uint)t >= T_BOOLEAN, "range check for type: %s", type2name(t));
     assert((uint)t < T_LONG+1,   "range check for type: %s", type2name(t));
     assert(_typeArrayKlasses[t] != nullptr, "domain check");

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -138,7 +138,7 @@ Handle VectorSupport::allocate_vector_payload_helper(InstanceKlass* ik, frame* f
   int elem_size = type2aelembytes(elem_bt);
 
   // On-heap vector values are represented as primitive arrays.
-  TypeArrayKlass* tak = TypeArrayKlass::cast(Universe::typeArrayKlass(elem_bt));
+  TypeArrayKlass* tak = Universe::typeArrayKlass(elem_bt);
 
   typeArrayOop arr = tak->allocate(num_elem, CHECK_NH); // safepoint
 


### PR DESCRIPTION
We have various functions in Universe that returns Klass* where they could be returning TypeArrayKlass* and ObjArrayKlass* instead. If we change these functions we could get rid of some casts in the code. Does this seem like a reasonable change?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329750](https://bugs.openjdk.org/browse/JDK-8329750): Change Universe functions to return more specific Klass* types (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18652/head:pull/18652` \
`$ git checkout pull/18652`

Update a local copy of the PR: \
`$ git checkout pull/18652` \
`$ git pull https://git.openjdk.org/jdk.git pull/18652/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18652`

View PR using the GUI difftool: \
`$ git pr show -t 18652`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18652.diff">https://git.openjdk.org/jdk/pull/18652.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18652#issuecomment-2039622227)