### PR TITLE
8329726: Use non-short forward jumps in lightweight locking

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1008,7 +1008,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
     // Check if recursive.
     cmpptr(thread, rax_reg);
-    jcc(Assembler::notEqual, slow_path);
+    jccb(Assembler::notEqual, slow_path);
 
     // Recursive.
     increment(Address(tagged_monitor, OM_OFFSET_NO_MONITOR_VALUE_TAG(recursions)));
@@ -1022,15 +1022,18 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 #ifdef ASSERT
   // Check that locked label is reached with ZF set.
   Label zf_correct;
+  Label zf_bad_zero;
   jcc(Assembler::zero, zf_correct);
-  stop("Fast Lock ZF != 1");
+  jmp(zf_bad_zero);
 #endif
 
   bind(slow_path);
 #ifdef ASSERT
   // Check that slow_path label is reached with ZF not set.
-  jccb(Assembler::notZero, zf_correct);
+  jcc(Assembler::notZero, zf_correct);
   stop("Fast Lock ZF != 0");
+  bind(zf_bad_zero);
+  stop("Fast Lock ZF != 1");
   bind(zf_correct);
 #endif
   // C2 uses the value of ZF to determine the continuation.

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -1008,7 +1008,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 
     // Check if recursive.
     cmpptr(thread, rax_reg);
-    jccb(Assembler::notEqual, slow_path);
+    jcc(Assembler::notEqual, slow_path);
 
     // Recursive.
     increment(Address(tagged_monitor, OM_OFFSET_NO_MONITOR_VALUE_TAG(recursions)));
@@ -1022,7 +1022,7 @@ void C2_MacroAssembler::fast_lock_lightweight(Register obj, Register box, Regist
 #ifdef ASSERT
   // Check that locked label is reached with ZF set.
   Label zf_correct;
-  jccb(Assembler::zero, zf_correct);
+  jcc(Assembler::zero, zf_correct);
   stop("Fast Lock ZF != 1");
 #endif
 
@@ -1161,7 +1161,7 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
 #ifdef ASSERT
   // Check that unlocked label is reached with ZF set.
   Label zf_correct;
-  jccb(Assembler::zero, zf_correct);
+  jcc(Assembler::zero, zf_correct);
   stop("Fast Unlock ZF != 1");
 #endif
 

--- a/test/hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java
+++ b/test/hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Tests correct code generation of lightweight locking when using -XX:+ShowMessageBoxOnError; times-out on failure
+ * @bug 8329726
+ * @run main/othervm/timeout=15 -XX:+ShowMessageBoxOnError -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLWLockingCodeGen::sync TestLWLockingCodeGen
+ */
+public class TestLWLockingCodeGen {
+    private static int val = 0;
+    public static void main(String[] args) {
+        sync();
+    }
+    private static synchronized void sync() {
+        val = val + (int)(Math.random() * 42);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java
+++ b/test/hotspot/jtreg/compiler/c2/TestLWLockingCodeGen.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Tests correct code generation of lightweight locking when using -XX:+ShowMessageBoxOnError; times-out on failure
  * @bug 8329726
- * @run main/othervm/timeout=15 -XX:+ShowMessageBoxOnError -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLWLockingCodeGen::sync TestLWLockingCodeGen
+ * @run main/othervm -XX:+ShowMessageBoxOnError -Xcomp -XX:-TieredCompilation -XX:CompileOnly=TestLWLockingCodeGen::sync TestLWLockingCodeGen
  */
 public class TestLWLockingCodeGen {
     private static int val = 0;


### PR DESCRIPTION
This turns a few short-jumps to long-jumps in x86 lightweight locking code paths. When running with -XX:+ShowMessageBoxOnError, MA::stop() generates more code and jccb is not sufficient to address this.

Two of the jccb are in ASSERT path anyway. However, another is also in a product path. We *could* generate jccb or jcc conditionally on ShowMessageBoxOnError, however, I don't think it is worth the trouble. WDYT?

Unfortunately, I could not make a simple test-case, because ShowMessageBoxOnError stops and waits on error, which would make jtreg time-out.

Testing:
 - [x] manual test with dacapo as provided in the bug report
 - [ ] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329726](https://bugs.openjdk.org/browse/JDK-8329726): Use non-short forward jumps in lightweight locking (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [f6231d8f](https://git.openjdk.org/jdk/pull/18657/files/f6231d8f81dea88e1a87af6b4bb5d69c43056240)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [025755b2](https://git.openjdk.org/jdk/pull/18657/files/025755b2d834669bb54d9cf8404383ba3a5f0194)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) ⚠️ Review applies to [f6231d8f](https://git.openjdk.org/jdk/pull/18657/files/f6231d8f81dea88e1a87af6b4bb5d69c43056240)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18657/head:pull/18657` \
`$ git checkout pull/18657`

Update a local copy of the PR: \
`$ git checkout pull/18657` \
`$ git pull https://git.openjdk.org/jdk.git pull/18657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18657`

View PR using the GUI difftool: \
`$ git pr show -t 18657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18657.diff">https://git.openjdk.org/jdk/pull/18657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18657#issuecomment-2039829792)