### PR TITLE
8329784: Run MaxMetaspaceSizeTest.java with -Xshare:off

### DIFF
--- a/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeTest.java
+++ b/test/hotspot/jtreg/runtime/Metaspace/MaxMetaspaceSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,14 +36,14 @@ import jdk.test.lib.process.OutputAnalyzer;
 public class MaxMetaspaceSizeTest {
     public static void main(String... args) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-Xshare:off",
             "-Xmx1g",
             "-XX:MaxMetaspaceSize=4K",
             "-XX:+UseCompressedClassPointers",
             "-XX:CompressedClassSpaceSize=1g",
             "--version");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        // We do not explicitly limit MaxMetaspaceSize to a lower minimum. User can get as low as he wants.
-        // However, you most certainly will hit either one of
+        // -Xshare:off --version loads hundreds of classes and will hit either one of
         // "OutOfMemoryError: Metaspace" or
         // "OutOfMemoryError: Compressed class space"
         output.shouldMatch("OutOfMemoryError.*(Compressed class space|Metaspace)");


### PR DESCRIPTION
Please review this trivial fix.

MaxMetaspaceSizeTest.java should be run with -Xshare:off to ensure that OOM is thrown. Please see [bug report](https://bugs.openjdk.org/browse/JDK-8329784) for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329784](https://bugs.openjdk.org/browse/JDK-8329784): Run MaxMetaspaceSizeTest.java with -Xshare:off (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18658/head:pull/18658` \
`$ git checkout pull/18658`

Update a local copy of the PR: \
`$ git checkout pull/18658` \
`$ git pull https://git.openjdk.org/jdk.git pull/18658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18658`

View PR using the GUI difftool: \
`$ git pr show -t 18658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18658.diff">https://git.openjdk.org/jdk/pull/18658.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18658#issuecomment-2040146116)