### PR TITLE
8329533: TestCDSVMCrash fails on libgraal

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
+++ b/test/hotspot/jtreg/runtime/cds/TestCDSVMCrash.java
@@ -25,6 +25,7 @@
  * @test TestCDSVMCrash
  * @summary Verify that an exception is thrown when the VM crashes during executeAndLog
  * @requires vm.cds
+ * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @run driver TestCDSVMCrash
@@ -37,19 +38,21 @@ import jdk.test.lib.process.ProcessTools;
 
 public class TestCDSVMCrash {
 
+    static Object[] oa;
+
     public static void main(String[] args) throws Exception {
         if (args.length == 1) {
             // This should guarantee to throw:
             // java.lang.OutOfMemoryError: Requested array size exceeds VM limit
             try {
-                Object[] oa = new Object[Integer.MAX_VALUE];
+                oa = new Object[Integer.MAX_VALUE];
                 throw new Error("OOME not triggered");
             } catch (OutOfMemoryError err) {
                 throw new Error("OOME didn't abort JVM!");
             }
         }
         // else this is the main test
-        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+CrashOnOutOfMemoryError",
                                                                       "-XX:-CreateCoredumpOnCrash", "-Xmx128m",
                                                                       "-Xshare:on", TestCDSVMCrash.class.getName(),
                                                                       "throwOOME");


### PR DESCRIPTION
After [JDK-8321550](https://bugs.openjdk.org/browse/JDK-8321550), `TestCDSVMCrash.java` fails on libgraal likely due to the allocated array being optimized out. Part of the aforementioned patch was reverted, `vm.flagless` was added as intended to prevent it from running, and the array was made static to future-proof the test. Verified in tier1-4 and in local testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329533](https://bugs.openjdk.org/browse/JDK-8329533): TestCDSVMCrash fails on libgraal (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18660/head:pull/18660` \
`$ git checkout pull/18660`

Update a local copy of the PR: \
`$ git checkout pull/18660` \
`$ git pull https://git.openjdk.org/jdk.git pull/18660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18660`

View PR using the GUI difftool: \
`$ git pr show -t 18660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18660.diff">https://git.openjdk.org/jdk/pull/18660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18660#issuecomment-2040235092)