### PR TITLE
8329659: Serial: Extract allowed_dead_ratio from ContiguousSpace

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -96,8 +96,10 @@ class DeadSpacer : StackObj {
   ContiguousSpace* _space;
 
 public:
-  DeadSpacer(ContiguousSpace* space, size_t allowed_dead_ratio) : _allowed_deadspace_words(0), _space(space) {
-    _active = allowed_dead_ratio > 0;
+  DeadSpacer(ContiguousSpace* space) : _allowed_deadspace_words(0), _space(space) {
+    size_t ratio = (_space == SerialHeap::heap()->old_gen()->space())
+                   ? MarkSweepDeadRatio : 0;
+    _active = ratio > 0;
 
     if (_active) {
       // We allow some amount of garbage towards the bottom of the space, so
@@ -105,7 +107,7 @@ public:
       // Occasionally, we want to ensure a full compaction, which is determined
       // by the MarkSweepAlwaysCompactCount parameter.
       if ((SerialFullGC::total_invocations() % MarkSweepAlwaysCompactCount) != 0) {
-        _allowed_deadspace_words = (space->capacity() * allowed_dead_ratio / 100) / HeapWordSize;
+        _allowed_deadspace_words = (space->capacity() * ratio / 100) / HeapWordSize;
       } else {
         _active = false;
       }
@@ -149,15 +151,11 @@ class Compacter {
     // The first dead word in this contiguous space. It's an optimization to
     // skip large chunk of live objects at the beginning.
     HeapWord* _first_dead;
-    // The maximum percentage of objects that can be dead in the compacted
-    // live part of a compacted space.
-    size_t _allowed_dead_ratio;
 
-    void init(ContiguousSpace* space, size_t allowed_dead_ratio) {
+    void init(ContiguousSpace* space) {
       _space = space;
       _compaction_top = space->bottom();
       _first_dead = nullptr;
-      _allowed_dead_ratio = allowed_dead_ratio;
     }
   };
 
@@ -177,10 +175,6 @@ class Compacter {
 
   ContiguousSpace* get_space(uint index) const {
     return _spaces[index]._space;
-  }
-
-  size_t get_allowed_dead_ratio(uint index) const {
-    return _spaces[index]._allowed_dead_ratio;
   }
 
   void record_first_dead(uint index, HeapWord* first_dead) {
@@ -268,13 +262,13 @@ class Compacter {
 public:
   explicit Compacter(SerialHeap* heap) {
     // In this order so that heap is compacted towards old-gen.
-    _spaces[0].init(heap->old_gen()->space(), MarkSweepDeadRatio);
-    _spaces[1].init(heap->young_gen()->eden(), 0);
-    _spaces[2].init(heap->young_gen()->from(), 0);
+    _spaces[0].init(heap->old_gen()->space());
+    _spaces[1].init(heap->young_gen()->eden());
+    _spaces[2].init(heap->young_gen()->from());
 
     bool is_promotion_failed = (heap->young_gen()->from()->next_compaction_space() != nullptr);
     if (is_promotion_failed) {
-      _spaces[3].init(heap->young_gen()->to(), 0);
+      _spaces[3].init(heap->young_gen()->to());
       _num_spaces = 4;
     } else {
       _num_spaces = 3;
@@ -290,7 +284,7 @@ public:
 
       bool record_first_dead_done = false;
 
-      DeadSpacer dead_spacer(space, get_allowed_dead_ratio(i));
+      DeadSpacer dead_spacer(space);
 
       while (cur_addr < top) {
         oop obj = cast_to_oop(cur_addr);

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -213,8 +213,4 @@ TenuredSpace::TenuredSpace(SerialBlockOffsetTable* offsets,
 {
   initialize(mr, SpaceDecorator::Clear, SpaceDecorator::Mangle);
 }
-
-size_t TenuredSpace::allowed_dead_ratio() const {
-  return MarkSweepDeadRatio;
-}
 #endif // INCLUDE_SERIALGC

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -135,10 +135,6 @@ public:
     _next_compaction_space = csp;
   }
 
-  // The maximum percentage of objects that can be dead in the compacted
-  // live part of a compacted space ("deadwood" support.)
-  virtual size_t allowed_dead_ratio() const { return 0; };
-
   // Accessors
   HeapWord* top() const            { return _top;    }
   void set_top(HeapWord* value)    { _top = value; }
@@ -196,8 +192,6 @@ class TenuredSpace: public ContiguousSpace {
  protected:
   SerialBlockOffsetTable* _offsets;
 
-  // Mark sweep support
-  size_t allowed_dead_ratio() const override;
  public:
   // Constructor
   TenuredSpace(SerialBlockOffsetTable* offsets,


### PR DESCRIPTION
Hi all,

This patch moves the `allowed_dead_ratio` related content from `ContiguousSpace` to `DeadSpacer`.

The tests `make test-tier1_gc` passed locally. Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329659](https://bugs.openjdk.org/browse/JDK-8329659): Serial: Extract allowed_dead_ratio from ContiguousSpace (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18661/head:pull/18661` \
`$ git checkout pull/18661`

Update a local copy of the PR: \
`$ git checkout pull/18661` \
`$ git pull https://git.openjdk.org/jdk.git pull/18661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18661`

View PR using the GUI difftool: \
`$ git pr show -t 18661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18661.diff">https://git.openjdk.org/jdk/pull/18661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18661#issuecomment-2040239519)