### PR TITLE
8329787: Fix typo in CLDRConverter

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -97,7 +97,7 @@ public class CLDRConverter {
     private static final String DST = "dst";
     private static final String NO_SUBST = "-";
 
-    private static SupplementDataParseHandler handlerSuppl;
+    private static SupplementalDataParseHandler handlerSuppl;
     private static LikelySubtagsParseHandler handlerLikelySubtags;
     private static WinZonesParseHandler handlerWinZones;
     static PluralsParseHandler handlerPlurals;
@@ -471,7 +471,7 @@ public class CLDRConverter {
         // SupplementalData file also provides the "parent" locales which
         // are othrwise not to be fallen back. Process them here as well.
         //
-        handlerSuppl = new SupplementDataParseHandler();
+        handlerSuppl = new SupplementalDataParseHandler();
         parseLDMLFile(new File(SPPL_SOURCE_FILE), handlerSuppl);
         Map<String, Object> parentData = handlerSuppl.getData("root");
         parentData.keySet().stream()

--- a/make/jdk/src/classes/build/tools/cldrconverter/SupplementalDataParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/SupplementalDataParseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,11 @@ import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
 /**
- * Handles parsing of files in Locale Data Markup Language for SupplementData.xml
+ * Handles parsing of files in Locale Data Markup Language for supplementalData.xml
  * and produces a map that uses the keys and values of JRE locale data.
  */
 
-class SupplementDataParseHandler extends AbstractLDMLHandler<Object> {
+class SupplementalDataParseHandler extends AbstractLDMLHandler<Object> {
     //UNM49 region and composition code used in supplementalData.xml
     private static final String WORLD = "001";
 
@@ -73,7 +73,7 @@ class SupplementDataParseHandler extends AbstractLDMLHandler<Object> {
     // "component" specific to this parent locale chain
     private String currentParentLocaleComponent;
 
-    SupplementDataParseHandler() {
+    SupplementalDataParseHandler() {
         firstDayMap = new HashMap<>();
         minDaysMap = new HashMap<>();
         parentLocalesMap = new HashMap<>();
@@ -132,32 +132,15 @@ class SupplementDataParseHandler extends AbstractLDMLHandler<Object> {
         switch (qName) {
         case "firstDay":
             if (!isIgnored(attributes)) {
-                String fd;
-
-                switch (attributes.getValue("day")) {
-                    case "sun":
-                        fd = "1";
-                        break;
-                    default:
-                    case "mon":
-                        fd = "2";
-                        break;
-                    case "tue":
-                        fd = "3";
-                        break;
-                    case "wed":
-                        fd = "4";
-                        break;
-                    case "thu":
-                        fd = "5";
-                        break;
-                    case "fri":
-                        fd = "6";
-                        break;
-                    case "sat":
-                        fd = "7";
-                        break;
-                }
+                String fd = switch (attributes.getValue("day")) {
+                    case "sun" -> "1";
+                    case "tue" -> "3";
+                    case "wed" -> "4";
+                    case "thu" -> "5";
+                    case "fri" -> "6";
+                    case "sat" -> "7";
+                    default -> "2"; // Mon
+                };
                 firstDayMap.put(attributes.getValue("territories"), fd);
             }
             break;

--- a/make/jdk/src/classes/build/tools/cldrconverter/SupplementalMetadataParseHandler.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/SupplementalMetadataParseHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Handles parsing of files in Locale Data Markup Language for
- * SupplementalMetadata.xml
+ * supplementalMetadata.xml
  */
 
 class SupplementalMetadataParseHandler extends AbstractLDMLHandler<Object> {


### PR DESCRIPTION
Fix a file/class name in the `CLDRConverter` build tool, with some clean-up for a switch statement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329787](https://bugs.openjdk.org/browse/JDK-8329787): Fix typo in CLDRConverter (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18662/head:pull/18662` \
`$ git checkout pull/18662`

Update a local copy of the PR: \
`$ git checkout pull/18662` \
`$ git pull https://git.openjdk.org/jdk.git pull/18662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18662`

View PR using the GUI difftool: \
`$ git pr show -t 18662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18662.diff">https://git.openjdk.org/jdk/pull/18662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18662#issuecomment-2040303019)