### PR TITLE
8329351: Add runtime/Monitor/TestRecursiveLocking.java for recursive Java monitor stress testing

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -393,6 +393,8 @@ tier1_runtime = \
  -runtime/Metaspace/FragmentMetaspace.java \
  -runtime/Metaspace/FragmentMetaspaceSimple.java \
  -runtime/MirrorFrame/Test8003720.java \
+ -runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java \
+ -runtime/Monitor/TestRecursiveLocking.java \
  -runtime/modules/LoadUnloadModuleStress.java \
  -runtime/modules/ModuleStress/ExportModuleStressTest.java \
  -runtime/modules/ModuleStress/ModuleStressGC.java \
@@ -590,6 +592,7 @@ hotspot_tier2_runtime = \
  -runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java \
  -runtime/CompressedOops/UseCompressedOops.java \
  -runtime/InvocationTests \
+ -runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java \
  -runtime/Thread/TestThreadDumpMonitorContention.java \
  -:tier1_runtime \
  -:hotspot_tier2_runtime_platform_agnostic \

--- a/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
+++ b/test/hotspot/jtreg/runtime/Monitor/StressWrapper_TestRecursiveLocking_36M.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=Xint_outer_inner
+ * @requires vm.flagless
+ * @summary Tests recursive locking in -Xint in outer then inner mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ */
+
+/*
+ * @test id=Xint_alternate_AB
+ * @requires vm.flagless
+ * @summary Tests recursive locking in -Xint in alternate A and B mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ */
+
+/*
+ * @test id=C1_outer_inner
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled
+ * @summary Tests recursive locking in C1 in outer then inner mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ */
+
+/*
+ * @test id=C1_alternate_AB
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled
+ * @summary Tests recursive locking in C1 in alternate A and B mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ */
+
+/*
+ * @test id=C2_outer_inner
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled
+ * @summary Tests recursive locking in C2 in outer then inner mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 1
+ */
+
+/*
+ * @test id=C2_alternate_AB
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled
+ * @summary Tests recursive locking in C2 in alternate A and B mode.
+ * @library /testlibrary /test/lib /runtime/Monitor
+ * @build jdk.test.whitebox.WhiteBox
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=0
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=1
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ *
+ * @run main/othervm/timeout=240 -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=2
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 120 2
+ */

--- a/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
+++ b/test/hotspot/jtreg/runtime/Monitor/TestRecursiveLocking.java
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test id=Xint_outer_inner
+ * @requires vm.flagless
+ * @summary Tests recursive locking in -Xint in outer then inner mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ */
+
+/*
+ * @test id=Xint_alternate_AB
+ * @requires vm.flagless
+ * @summary Tests recursive locking in -Xint in alternate A and B mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -Xint
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ */
+
+/*
+ * @test id=C1_outer_inner
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled
+ * @summary Tests recursive locking in C1 in outer then inner mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:TieredStopAtLevel=1
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ */
+
+/*
+ * @test id=C1_alternate_AB
+ * @requires vm.flagless
+ * @requires vm.compiler1.enabled
+ * @summary Tests recursive locking in C1 in alternate A and B mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ */
+
+/*
+ * @test id=C2_outer_inner
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled
+ * @summary Tests recursive locking in C2 in outer then inner mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=0
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=1
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:-EliminateNestedLocks
+ *     -XX:LockingMode=2
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 1
+ */
+
+/*
+ * @test id=C2_alternate_AB
+ * @requires vm.flagless
+ * @requires vm.compiler2.enabled
+ * @summary Tests recursive locking in C2 in alternate A and B mode.
+ * @library /testlibrary /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ *
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=0
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=1
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ *
+ * @run main/othervm -Xbootclasspath/a:.
+ *     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *     -XX:LockingMode=2
+ *     -XX:-EliminateNestedLocks
+ *     -ms256m -mx256m
+ *     TestRecursiveLocking 5 2
+ */
+
+import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
+
+public class TestRecursiveLocking {
+    static final WhiteBox WB = WhiteBox.getWhiteBox();
+    static final int LockingMode = WB.getIntVMFlag("LockingMode").intValue();
+    static final int LockStackCapacity = WB.getLockStackCapacity();
+    static final int LM_MONITOR = 0;
+    static final int LM_LEGACY = 1;
+    static final int LM_LIGHTWEIGHT = 2;
+    static final SyncThread syncThread = new SyncThread();
+
+    // This SynchronizedObject class and the OUTER followed by INNER testing
+    // model is adapted from runtime/lockStack/TestLockStackCapacity.java.
+    static class SynchronizedObject {
+        private int counter;
+
+        synchronized void runInner(int depth, SynchronizedObject outer) {
+            counter++;
+
+            if (LockingMode != LM_LEGACY) {
+                outer.assertInflated();
+            }
+
+            if (LockingMode != LM_MONITOR) {
+                assertNotInflated();
+            }
+            if (depth == 1) {
+                return;
+            } else {
+                runInner(depth - 1, outer);
+            }
+            if (LockingMode != LM_MONITOR) {
+                assertNotInflated();
+            }
+        }
+
+        synchronized void runOuter(int depth, SynchronizedObject inner) {
+            counter++;
+            if (LockingMode != LM_MONITOR) {
+                assertNotInflated();
+            }
+            if (depth == 1) {
+                inner.runInner(LockStackCapacity, this);
+            } else {
+                runOuter(depth - 1, inner);
+            }
+            if (LockingMode != LM_LEGACY) {
+                assertInflated();
+            }
+        }
+
+        public void runOuterInnerTest() {
+            final SynchronizedObject OUTER = new SynchronizedObject();
+            final SynchronizedObject INNER = new SynchronizedObject();
+
+            // Just checking since they are new objects:
+            OUTER.assertNotInflated();
+            INNER.assertNotInflated();
+
+            synchronized(OUTER) {
+                OUTER.counter++;
+
+                if (LockingMode != LM_MONITOR) {
+                    OUTER.assertNotInflated();
+                }
+                INNER.assertNotInflated();
+                OUTER.runOuter(LockStackCapacity - 1, INNER);
+
+                if (LockingMode != LM_LEGACY) {
+                    OUTER.assertInflated();
+                }
+                if (LockingMode != LM_MONITOR) {
+                    INNER.assertNotInflated();
+                }
+            }
+
+            // Verify that the nested monitors have been properly released:
+            syncThread.verifyCanBeSynced(OUTER);
+            syncThread.verifyCanBeSynced(INNER);
+
+            Asserts.assertEquals(OUTER.counter, LockStackCapacity);
+            Asserts.assertEquals(INNER.counter, LockStackCapacity);
+        }
+
+        synchronized void runA(int depth, SynchronizedObject B) {
+            counter++;
+
+            if (LockingMode == LM_LIGHTWEIGHT) {
+                if (counter > LockStackCapacity / 2) {
+                    assertInflated();
+                }
+            } else if (LockingMode == LM_MONITOR) {
+                assertInflated();
+            }
+
+            // Call runB() at the same depth as runA's depth:
+            B.runB(depth, this);
+        }
+
+        synchronized void runB(int depth, SynchronizedObject A) {
+            counter++;
+
+            if (LockingMode != LM_MONITOR) {
+                assertNotInflated();
+            } else {
+                assertInflated();
+            }
+
+            if (depth == 1) {
+                // Reached LockStackCapacity in depth so we're done.
+                return;
+            } else {
+                A.runA(depth - 1, this);
+            }
+        }
+
+        public void runAlternateABTest() {
+            final SynchronizedObject A = new SynchronizedObject();
+            final SynchronizedObject B = new SynchronizedObject();
+
+            // Just checking since they are new objects:
+            A.assertNotInflated();
+            B.assertNotInflated();
+
+            A.runA(LockStackCapacity, B);
+
+            // Verify that the nested monitors have been properly released:
+            syncThread.verifyCanBeSynced(A);
+            syncThread.verifyCanBeSynced(B);
+
+            Asserts.assertEquals(A.counter, LockStackCapacity);
+            Asserts.assertEquals(B.counter, LockStackCapacity);
+            if (LockingMode == LM_LEGACY) {
+                A.assertNotInflated();
+            }
+            // Implied else: for LM_MONITOR or LM_LIGHTWEIGHT it can be
+            // either inflated or not point because A is not locked anymore
+            // and subject to deflation.
+
+            if (LockingMode != LM_MONITOR) {
+                B.assertNotInflated();
+            }
+        }
+
+        void assertNotInflated() {
+            Asserts.assertFalse(WB.isMonitorInflated(this));
+        }
+
+        void assertInflated() {
+            Asserts.assertTrue(WB.isMonitorInflated(this));
+        }
+    }
+
+    static void usage() {
+        System.err.println();
+        System.err.println("Usage: java TestRecursiveLocking [n_secs]");
+        System.err.println("       java TestRecursiveLocking n_secs [mode]");
+        System.err.println();
+        System.err.println("where:");
+        System.err.println("    n_secs  ::= > 0");
+        System.err.println("            Default n_secs is 15.");
+        System.err.println("    mode    ::= 1 - outer and inner");
+        System.err.println("            ::= 2 - alternate A and B");
+        System.err.println("            Default mode is 1.");
+        System.exit(1);
+    }
+
+    public static void main(String... argv) throws Exception {
+        int mode = 2;
+        int n_secs = 30;
+
+        if (argv.length != 0 && argv.length != 1 && argv.length != 2) {
+            usage();
+        } else if (argv.length > 0) {
+            try {
+                n_secs = Integer.parseInt(argv[0]);
+                if (n_secs <= 0) {
+                    throw new NumberFormatException("Not > 0: '" + argv[0]
+                                                    + "'");
+                }
+            } catch (NumberFormatException nfe) {
+                System.err.println();
+                System.err.println(nfe);
+                System.err.println("ERROR: '" + argv[0]
+                                   + "': invalid n_secs value.");
+                usage();
+            }
+
+            if (argv.length > 1) {
+                try {
+                    mode = Integer.parseInt(argv[1]);
+                    if (mode != 1 && mode != 2) {
+                        throw new NumberFormatException("Not 1 -> 2: '"
+                                                        + argv[1] + "'");
+                    }
+                } catch (NumberFormatException nfe) {
+                    System.err.println();
+                    System.err.println(nfe);
+                    System.err.println("ERROR: '" + argv[1]
+                                       + "': invalid mode value.");
+                    usage();
+                }
+            }
+        }
+
+        System.out.println("INFO: LockingMode=" + LockingMode);
+        System.out.println("INFO: LockStackCapacity=" + LockStackCapacity);
+        System.out.println("INFO: n_secs=" + n_secs);
+        System.out.println("INFO: mode=" + mode);
+
+        long loopCount = 0;
+        long endTime = System.currentTimeMillis() + n_secs * 1000;
+
+        syncThread.waitForStart();
+
+        while (System.currentTimeMillis() < endTime) {
+            loopCount++;
+            SynchronizedObject syncObj = new SynchronizedObject();
+            switch (mode) {
+            case 1:
+                syncObj.runOuterInnerTest();
+                break;
+
+            case 2:
+                syncObj.runAlternateABTest();
+                break;
+
+            default:
+                throw new RuntimeException("bad mode parameter: " + mode);
+            }
+        }
+
+        syncThread.setDone();
+        try {
+            syncThread.join();
+        } catch (InterruptedException ie) {
+            // This should not happen.
+            ie.printStackTrace();
+        }
+
+        System.out.println("INFO: main executed " + loopCount + " loops in "
+                           + n_secs + " seconds.");
+    }
+}
+
+class SyncThread extends Thread {
+    static final boolean verbose = false;  // set to true for debugging
+    private boolean done = false;
+    private boolean haveWork = false;
+    private Object obj;
+    private Object waiter = new Object();
+
+    public void run() {
+        if (verbose) System.out.println("SyncThread: running.");
+        synchronized(waiter) {
+            // Let main know that we are running:
+            if (verbose) System.out.println("SyncThread: notify main running.");
+            waiter.notify();
+
+            while (!done) {
+                if (verbose) System.out.println("SyncThread: waiting.");
+                try {
+                    waiter.wait();
+                } catch (InterruptedException ie) {
+                }
+                if (haveWork) {
+                    if (verbose) System.out.println("SyncThread: working.");
+                    synchronized(obj) {
+                    }
+                    if (verbose) System.out.println("SyncThread: worked.");
+                    haveWork = false;
+                    waiter.notify();
+                    if (verbose) System.out.println("SyncThread: notified.");
+                }
+                else if (verbose) {
+                    System.out.println("SyncThread: notified without work.");
+                }
+            }
+        }
+        if (verbose) System.out.println("SyncThread: exiting.");
+    }
+
+    public void setDone() {
+        synchronized(waiter) {
+            if (verbose) System.out.println("main: set done.");
+            done = true;
+            waiter.notify();
+        }
+    }
+
+    public void verifyCanBeSynced(Object obj) {
+        synchronized(waiter) {
+            if (verbose) System.out.println("main: queueing up work.");
+            this.obj = obj;
+            haveWork = true;
+            if (verbose) System.out.println("main: notifying SyncThread.");
+            waiter.notify();
+            if (verbose) System.out.println("main: waiting for SyncThread.");
+            while (haveWork) {
+                try {
+                    waiter.wait();
+                } catch (InterruptedException ie) {
+                }
+            }
+            if (verbose) System.out.println("main: waited for SyncThread.");
+        }
+    }
+
+    public void waitForStart() {
+        synchronized(waiter) {
+            this.start();
+
+            // Wait for SyncThread to actually get running:
+            if (verbose) System.out.println("main: wait for SyncThread start.");
+            try {
+                waiter.wait();
+            } catch (InterruptedException ie) {
+            }
+            if (verbose) System.out.println("main: waited for SyncThread start.");
+        }
+    }
+}


### PR DESCRIPTION
The first stress test to be added is:

runtime/Monitor/TestRecursiveLocking.java

It has been tested with a couple of 12 hour runs on my MBP13:
  - 3 build configs: release, fastdebug, slowdebug, 4 hours each, total 12 hours
  - 18 test configs, 800 seconds each, total 4 hours

The default configuration has been tested in Mach5 Tier2 and the
StressWrapper_TestRecursiveLocking_36M.java version has been
tested in Mach5 Tier3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8329351](https://bugs.openjdk.org/browse/JDK-8329351): Add runtime/Monitor/TestRecursiveLocking.java for recursive Java monitor stress testing (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18664/head:pull/18664` \
`$ git checkout pull/18664`

Update a local copy of the PR: \
`$ git checkout pull/18664` \
`$ git pull https://git.openjdk.org/jdk.git pull/18664/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18664`

View PR using the GUI difftool: \
`$ git pr show -t 18664`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18664.diff">https://git.openjdk.org/jdk/pull/18664.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18664#issuecomment-2040506029)
</details>
