### PR TITLE
JDK-8329658

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -376,24 +376,12 @@ void DefNewGeneration::compute_space_boundaries(uintx minimum_eden_size,
   }
   from()->initialize(fromMR, clear_space, mangle_space);
   to()->initialize(toMR, clear_space, mangle_space);
-
-  // Set next compaction spaces.
-  eden()->set_next_compaction_space(from());
-  // The to-space is normally empty before a compaction so need
-  // not be considered.  The exception is during promotion
-  // failure handling when to-space can contain live objects.
-  from()->set_next_compaction_space(nullptr);
 }
 
 void DefNewGeneration::swap_spaces() {
   ContiguousSpace* s = from();
   _from_space        = to();
   _to_space          = s;
-  eden()->set_next_compaction_space(from());
-  // The to-space is normally empty before a compaction so need
-  // not be considered.  The exception is during promotion
-  // failure handling when to-space can contain live objects.
-  from()->set_next_compaction_space(nullptr);
 
   if (UsePerfData) {
     CSpaceCounters* c = _from_counters;
@@ -774,7 +762,6 @@ void DefNewGeneration::collect(bool   full,
     // as a result of a partial evacuation of eden
     // and from-space.
     swap_spaces();   // For uniformity wrt ParNewGeneration.
-    from()->set_next_compaction_space(to());
     heap->set_incremental_collection_failed();
 
     _gc_tracer->report_promotion_failed(_promotion_failed_info);
@@ -795,7 +782,6 @@ void DefNewGeneration::collect(bool   full,
 void DefNewGeneration::init_assuming_no_promotion_failure() {
   _promotion_failed = false;
   _promotion_failed_info.reset();
-  from()->set_next_compaction_space(nullptr);
 }
 
 void DefNewGeneration::remove_forwarding_pointers() {

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -71,7 +71,6 @@ class DefNewGeneration: public Generation {
   void   init_assuming_no_promotion_failure();
   // True iff a promotion has failed in the current collection.
   bool   _promotion_failed;
-  bool   promotion_failed() { return _promotion_failed; }
   PromotionFailedInfo _promotion_failed_info;
 
   // Handling promotion failure.  A young generation collection
@@ -161,6 +160,8 @@ class DefNewGeneration: public Generation {
                    size_t min_byte_size,
                    size_t max_byte_size,
                    const char* policy="Serial young collection pauses");
+
+  bool promotion_failed() { return _promotion_failed; }
 
   // allocate and initialize ("weak") refs processing support
   void ref_processor_init();

--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -265,8 +265,7 @@ public:
     _spaces[1].init(heap->young_gen()->eden());
     _spaces[2].init(heap->young_gen()->from());
 
-    bool is_promotion_failed = (heap->young_gen()->from()->next_compaction_space() != nullptr);
-    if (is_promotion_failed) {
+    if (heap->young_gen()->promotion_failed()) {
       _spaces[3].init(heap->young_gen()->to());
       _num_spaces = 4;
     } else {

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -43,7 +43,6 @@
 ContiguousSpace::ContiguousSpace():
   _bottom(nullptr),
   _end(nullptr),
-  _next_compaction_space(nullptr),
   _top(nullptr) {
   _mangler = new GenSpaceMangler(this);
 }
@@ -64,7 +63,6 @@ void ContiguousSpace::initialize(MemRegion mr,
   if (clear_space) {
     clear(mangle_space);
   }
-  _next_compaction_space = nullptr;
 }
 
 void ContiguousSpace::clear(bool mangle_space) {

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -64,9 +64,6 @@ class ContiguousSpace: public CHeapObj<mtGC> {
 private:
   HeapWord* _bottom;
   HeapWord* _end;
-
-  ContiguousSpace* _next_compaction_space;
-
   HeapWord* _top;
   // A helper for mangling the unused area of the space in debug builds.
   GenSpaceMangler* _mangler;
@@ -122,18 +119,6 @@ public:
   // The "clear" method must be called on a region that may have
   // had allocation performed in it, but is now to be considered empty.
   void clear(bool mangle_space);
-
-  // Returns the next space (in the current generation) to be compacted in
-  // the global compaction order.  Also is used to select the next
-  // space into which to compact.
-
-  ContiguousSpace* next_compaction_space() const {
-    return _next_compaction_space;
-  }
-
-  void set_next_compaction_space(ContiguousSpace* csp) {
-    _next_compaction_space = csp;
-  }
 
   // The maximum percentage of objects that can be dead in the compacted
   // live part of a compacted space ("deadwood" support.)


### PR DESCRIPTION
Hi all,

This patch removes the uncessary `ContiguousSpace::_next_compaction_space` and uses `DefNewGeneration::_promotion_failed` instead.

The tests `make test-tier1_gc` passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong