### PR TITLE
8328977 : JEditorPane.setPage not thread-safe, pageLoader not cancelled

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -473,20 +473,17 @@ public class JEditorPane extends JTextComponent {
             throw new IOException("invalid url");
         }
         URL loaded = getPage();
+        Object postData = getPostData();
 
         // reset scrollbar
         if (!page.equals(loaded) && page.getRef() == null) {
             scrollRectToVisible(new Rectangle(0, 0, 1, 1));
         }
-        if ((loaded != null) && loaded.sameFile(page)) {
+
+        if ((postData == null) && (page.sameFile(loaded))) {
             if (page.getRef() != null) {
                 scrollToReference(page.getRef());
             }
-            return;
-        }
-
-        Object postData = getPostData();
-        if ((postData == null) && (kit == null)) {
             return;
         }
 
@@ -495,6 +492,7 @@ public class JEditorPane extends JTextComponent {
             // we need to cancel background loading
             if (pageLoader != null) {
                 pageLoader.cancel(true);
+                pageLoader = null;
             }
         }
 
@@ -512,6 +510,10 @@ public class JEditorPane extends JTextComponent {
         // open stream synchronously
         InputStream in = getStream(page);
 
+        if ((kit == null)) {
+            return;
+        }
+
         Document doc = initializeModel(kit, page);
 
         // At this point, one could either load up the model with no
@@ -528,6 +530,7 @@ public class JEditorPane extends JTextComponent {
             }
             return;
         }
+
         read(in, doc);
         setDocument(doc);
 

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -472,24 +472,29 @@ public class JEditorPane extends JTextComponent {
         if (page == null) {
             throw new IOException("invalid url");
         }
-        URL loaded = getPage();
-        Object postData = getPostData();
 
-        // reset scrollbar
-        if (!page.equals(loaded) && page.getRef() == null) {
-            scrollRectToVisible(new Rectangle(0, 0, 1, 1));
-        }
+        final URL loaded = getPage();
+        final Object postData = getPostData();
+        final String reference = page.getRef();
 
-        if ((postData == null) && (page.sameFile(loaded))) {
-            if (page.getRef() != null) {
-                scrollToReference(page.getRef());
+        if ((postData == null) && page.sameFile(loaded)) {
+            // The same page with different reference
+            if (reference != null) {
+                scrollToReference(reference);
+            } else {
+                // Scroll to the top of the page
+                scrollRectToVisible(new Rectangle(0, 0, 1, 1));
             }
             return;
         }
 
         // different url or POST method, load the new content
+
+        // reset scrollbar
+        scrollRectToVisible(new Rectangle(0, 0, 1, 1));
+
         synchronized (this) {
-            // we need to cancel background loading
+            // Cancel background loading
             if (pageLoader != null) {
                 pageLoader.cancel(true);
                 pageLoader = null;
@@ -510,7 +515,8 @@ public class JEditorPane extends JTextComponent {
         // open stream synchronously
         InputStream in = getStream(page);
 
-        if ((kit == null)) {
+        // getStream instantiates a new kit
+        if (kit == null) {
             return;
         }
 
@@ -534,7 +540,6 @@ public class JEditorPane extends JTextComponent {
         read(in, doc);
         setDocument(doc);
 
-        final String reference = page.getRef();
         if (reference != null) {
             // Have to scroll after painted.
             SwingUtilities.invokeLater(new Runnable() {

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -545,7 +545,6 @@ public class JEditorPane extends JTextComponent {
         firePropertyChange("page", loaded, page);
     }
 
-
     /**
      * Create model and initialize document properties from page properties.
      */


### PR DESCRIPTION
Hi Reviewers,

Added pageloader cancel before new page creation along with code restructuring. Moved all page loading calls inside synchronize to make it thread safe.

Regards,
Renjith.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8328977](https://bugs.openjdk.org/browse/JDK-8328977): JEditorPane.setPage not thread-safe, pageLoader not cancelled (**Bug** - P3)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Dmitry Markov](https://openjdk.org/census#dmarkov) (@dmarkov20 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18670/head:pull/18670` \
`$ git checkout pull/18670`

Update a local copy of the PR: \
`$ git checkout pull/18670` \
`$ git pull https://git.openjdk.org/jdk.git pull/18670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18670`

View PR using the GUI difftool: \
`$ git pr show -t 18670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18670.diff">https://git.openjdk.org/jdk/pull/18670.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18670#issuecomment-2041940993)
</details>
