### PR TITLE
8324673: javacserver failed during build: RejectedExecutionException

### DIFF
--- a/make/langtools/tools/javacserver/server/CompilerThreadPool.java
+++ b/make/langtools/tools/javacserver/server/CompilerThreadPool.java
@@ -43,14 +43,8 @@ public class CompilerThreadPool {
         this.pool = Executors.newFixedThreadPool(POOLSIZE);
     }
 
-    public int dispatchCompilation(String[] args) {
-        Log log = Log.get();
-        try {
-            return pool.submit(() -> Server.runCompiler(log, args)).get();
-        } catch (Exception e) {
-            e.printStackTrace();
-            throw new RuntimeException("Error during compile", e);
-        }
+    public void execute(Runnable runnable) {
+        this.pool.execute(runnable);
     }
 
     public void shutdown() {


### PR DESCRIPTION
The RejectedExecutionException was thrown when the thread executing `Server.start` managed to shut down the `compilerThreadPool` before the thread executing `Server.handleRequest` submitted the compilation task.

This patch removes the extra thread used for `Server.handleRequest`, and executes that method directly in the thread pool. All `compilerThreadPool` uses happen on the `Server.start` thread now, and no new tasks are submitted after the thread pool is shut down.

In order to verify the fix, I modified `IdleMonitor.KEEPALIVE` to 1 second. With that change the problem was occasionally reproducible without the patch from this PR. With the patch, the `RejectedExecutionException` problem did not reproduce. 

No new regression test. Existing langtools tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324673](https://bugs.openjdk.org/browse/JDK-8324673): javacserver failed during build: RejectedExecutionException (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18672/head:pull/18672` \
`$ git checkout pull/18672`

Update a local copy of the PR: \
`$ git checkout pull/18672` \
`$ git pull https://git.openjdk.org/jdk.git pull/18672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18672`

View PR using the GUI difftool: \
`$ git pr show -t 18672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18672.diff">https://git.openjdk.org/jdk/pull/18672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18672#issuecomment-2042759631)