### PR TITLE
8329840: Fix ZPhysicalMemorySegment::_end type

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -133,6 +133,10 @@ inline bool operator<(zoffset first, zoffset_end second) {
   return untype(first) < untype(second);
 }
 
+inline bool operator<=(zoffset_end first, zoffset second) {
+  return untype(first) <= untype(second);
+}
+
 inline bool operator>(zoffset first, zoffset_end second) {
   return untype(first) > untype(second);
 }

--- a/src/hotspot/share/gc/z/zPhysicalMemory.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.hpp
@@ -32,9 +32,9 @@
 
 class ZPhysicalMemorySegment : public CHeapObj<mtGC> {
 private:
-  zoffset _start;
+  zoffset     _start;
   zoffset_end _end;
-  bool    _committed;
+  bool        _committed;
 
 public:
   ZPhysicalMemorySegment();

--- a/src/hotspot/share/gc/z/zPhysicalMemory.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.hpp
@@ -33,7 +33,7 @@
 class ZPhysicalMemorySegment : public CHeapObj<mtGC> {
 private:
   zoffset _start;
-  zoffset _end;
+  zoffset_end _end;
   bool    _committed;
 
 public:
@@ -41,7 +41,7 @@ public:
   ZPhysicalMemorySegment(zoffset start, size_t size, bool committed);
 
   zoffset start() const;
-  zoffset end() const;
+  zoffset_end end() const;
   size_t size() const;
 
   bool is_committed() const;

--- a/src/hotspot/share/gc/z/zPhysicalMemory.inline.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.inline.hpp
@@ -31,19 +31,19 @@
 
 inline ZPhysicalMemorySegment::ZPhysicalMemorySegment()
   : _start(zoffset(UINTPTR_MAX)),
-    _end(zoffset(UINTPTR_MAX)),
+    _end(zoffset_end(UINTPTR_MAX)),
     _committed(false) {}
 
 inline ZPhysicalMemorySegment::ZPhysicalMemorySegment(zoffset start, size_t size, bool committed)
   : _start(start),
-    _end(start + size),
+    _end(to_zoffset_end(start, size)),
     _committed(committed) {}
 
 inline zoffset ZPhysicalMemorySegment::start() const {
   return _start;
 }
 
-inline zoffset ZPhysicalMemorySegment::end() const {
+inline zoffset_end ZPhysicalMemorySegment::end() const {
   return _end;
 }
 


### PR DESCRIPTION
`ZPhysicalMemorySegment::_end` should use `zoffset_end` for its type instead of `zoffset`.

Starting a debug vm with a 16TB min heap size will crash with an invalid `zoffset` assert.

Testing with ZGC tier1-tier7 on linux x64+aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329840](https://bugs.openjdk.org/browse/JDK-8329840): Fix ZPhysicalMemorySegment::_end type (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18673/head:pull/18673` \
`$ git checkout pull/18673`

Update a local copy of the PR: \
`$ git checkout pull/18673` \
`$ git pull https://git.openjdk.org/jdk.git pull/18673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18673`

View PR using the GUI difftool: \
`$ git pr show -t 18673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18673.diff">https://git.openjdk.org/jdk/pull/18673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18673#issuecomment-2042334882)