### PR TITLE
8212895: ChronoField.INSTANT_SECONDS's range doesn't match the range of Instant

### DIFF
--- a/src/java.base/share/classes/java/time/temporal/ChronoField.java
+++ b/src/java.base/share/classes/java/time/temporal/ChronoField.java
@@ -587,7 +587,7 @@ public enum ChronoField implements TemporalField {
      * This field is strictly defined to have the same meaning in all calendar systems.
      * This is necessary to ensure interoperation between calendars.
      * <p>
-     * Range of {@code InstantSeconds} is between {@link Instant#MIN} and {@link Instant#MAX}
+     * Range of InstantSeconds is between {@link Instant#MIN} and {@link Instant#MAX}
      * {@linkplain Instant#getEpochSecond() epoch second}, both inclusive.
      */
     INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, ValueRange.of(Instant.MIN.getEpochSecond(), Instant.MAX.getEpochSecond())),

--- a/src/java.base/share/classes/java/time/temporal/ChronoField.java
+++ b/src/java.base/share/classes/java/time/temporal/ChronoField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -587,7 +587,8 @@ public enum ChronoField implements TemporalField {
      * This field is strictly defined to have the same meaning in all calendar systems.
      * This is necessary to ensure interoperation between calendars.
      */
-    INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, ValueRange.of(Long.MIN_VALUE, Long.MAX_VALUE)),
+    // ValueRange matches the min and max epoch second supported by java.time.Instant
+    INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, ValueRange.of(-31557014167219200L, 31556889864403199L)),
     /**
      * The offset from UTC/Greenwich.
      * <p>

--- a/src/java.base/share/classes/java/time/temporal/ChronoField.java
+++ b/src/java.base/share/classes/java/time/temporal/ChronoField.java
@@ -586,9 +586,11 @@ public enum ChronoField implements TemporalField {
      * <p>
      * This field is strictly defined to have the same meaning in all calendar systems.
      * This is necessary to ensure interoperation between calendars.
+     * <p>
+     * Range of {@code InstantSeconds} is between {@link Instant#MIN} and {@link Instant#MAX}
+     * {@linkplain Instant#getEpochSecond() epoch second}, both inclusive.
      */
-    // ValueRange matches the min and max epoch second supported by java.time.Instant
-    INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, ValueRange.of(-31557014167219200L, 31556889864403199L)),
+    INSTANT_SECONDS("InstantSeconds", SECONDS, FOREVER, ValueRange.of(Instant.MIN.getEpochSecond(), Instant.MAX.getEpochSecond())),
     /**
      * The offset from UTC/Greenwich.
      * <p>

--- a/test/jdk/java/time/tck/java/time/temporal/TCKChronoField.java
+++ b/test/jdk/java/time/tck/java/time/temporal/TCKChronoField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -262,5 +263,15 @@ public class TCKChronoField {
         for (ChronoField field : ChronoField.values()) {
             assertEquals(ChronoField.valueOf(field.name()), field);
         }
+    }
+
+    // verify the minimum and maximum values of ChronoField.INSTANT_SECONDS
+    // matches the minimum and maximum supported epoch second by Instant.
+    @Test
+    public void testMinMaxInstantSeconds() {
+        assertEquals(ChronoField.INSTANT_SECONDS.range().getMinimum(),
+                Instant.MIN.getLong(ChronoField.INSTANT_SECONDS));
+        assertEquals(ChronoField.INSTANT_SECONDS.range().getMaximum(),
+                Instant.MAX.getLong(ChronoField.INSTANT_SECONDS));
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8212895?

As noted in that issue, the `ChronoField.INSTANT_SECONDS` currently is initialized to have a minimum and maximum values of `Long.MIN_VALUE` and `LONG.MAX_VALUE` respectively. However, `java.time.Instant` only supports `-31557014167219200L` and `31556889864403199L` as minimum and maximum values for the epoch second.

The commit in this PR updates the `ChronoField.INSTANT_SECONDS`'s value range to match the supported min and max values of `Instant` (as suggested by Stephen in that JBS issue). This commit also introduces a test to verify this change. This new test method as well as existing tests in tier1, tier2 and tier3 continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8330135](https://bugs.openjdk.org/browse/JDK-8330135) to be approved

### Issues
 * [JDK-8212895](https://bugs.openjdk.org/browse/JDK-8212895): ChronoField.INSTANT_SECONDS's range doesn't match the range of Instant (**Bug** - P4)
 * [JDK-8330135](https://bugs.openjdk.org/browse/JDK-8330135): ChronoField.INSTANT_SECONDS's range doesn't match the range of Instant (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18674/head:pull/18674` \
`$ git checkout pull/18674`

Update a local copy of the PR: \
`$ git checkout pull/18674` \
`$ git pull https://git.openjdk.org/jdk.git pull/18674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18674`

View PR using the GUI difftool: \
`$ git pr show -t 18674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18674.diff">https://git.openjdk.org/jdk/pull/18674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18674#issuecomment-2042340021)