### PR TITLE
8329850: [AIX] Allow loading of different members of same shared library archive

### DIFF
--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1161,6 +1161,7 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
         // so delete entry from array (do not forget to free member-string space if member exists)
         if ((p_handletable + i)->member) {
           os::free((p_handletable + i)->member);
+          (p_handletable + i)->member = nullptr;
         }
         g_handletable_used--;
         // If the entry was the last one of the array, the previous g_handletable_used--

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1066,7 +1066,7 @@ void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
       if ((p_handletable + i)->handle &&
           (p_handletable + i)->inode == libstat.st_ino &&
           (p_handletable + i)->devid == libstat.st_dev &&
-          (((p_handletable + i)->member == nullptr && member == nullptr) ||
+          (((p_handletable + i)->member == member) ||
            ((p_handletable + i)->member != nullptr && member != nullptr &&
            strcmp((p_handletable + i)->member, member) == 0))) {
         (p_handletable + i)->refcount++;
@@ -1159,8 +1159,8 @@ bool os::pd_dll_unload(void* libhandle, char* ebuf, int ebuflen) {
       if (res) {
         // First case: libhandle was found (with refcount == 0) and ::dlclose successful,
         // so delete entry from array (do not forget to free member-string space if member exists)
-		if ((p_handletable + i)->member) {
-		  os::free((p_handletable + i)->member);
+        if ((p_handletable + i)->member) {
+          os::free((p_handletable + i)->member);
         }
         g_handletable_used--;
         // If the entry was the last one of the array, the previous g_handletable_used--

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1066,7 +1066,7 @@ void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
       if ((p_handletable + i)->handle &&
           (p_handletable + i)->inode == libstat.st_ino &&
           (p_handletable + i)->devid == libstat.st_dev &&
-          (((p_handletable + i)->member == member) ||
+          (((p_handletable + i)->member == nullptr && member == nullptr) ||
            ((p_handletable + i)->member != nullptr && member != nullptr &&
            strcmp((p_handletable + i)->member, member) == 0))) {
         (p_handletable + i)->refcount++;


### PR DESCRIPTION
With [JDK-8320890](https://bugs.openjdk.org/browse/JDK-8320890) we introduced the capability not to load shared libraries twice if the application wants to do that. Instead we just rise a ref counter. Unfortunately this also suppresses the loading of a second member of a shared library.
This fix introduces an additionally stored hash value for each loaded member and only suppresses duplicate loading if the same member is loaded twice.
If a shared library has no member a hash value of 0 is used to make the code orthogonal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329850](https://bugs.openjdk.org/browse/JDK-8329850): [AIX] Allow loading of different members of same shared library archive (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [b1ec5ed3](https://git.openjdk.org/jdk/pull/18676/files/b1ec5ed33d3812e38ee39d7828445f9a5c05d45a)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18676/head:pull/18676` \
`$ git checkout pull/18676`

Update a local copy of the PR: \
`$ git checkout pull/18676` \
`$ git pull https://git.openjdk.org/jdk.git pull/18676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18676`

View PR using the GUI difftool: \
`$ git pr show -t 18676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18676.diff">https://git.openjdk.org/jdk/pull/18676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18676#issuecomment-2042629843)