### PR TITLE
8329875: Serial: Move preservedMarks.inline.hpp to serialFullGC.cpp

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -45,6 +45,7 @@
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/gc_globals.hpp"
 #include "gc/shared/modRefBarrierSet.hpp"
+#include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/referencePolicy.hpp"
 #include "gc/shared/referenceProcessorPhaseTimes.hpp"
 #include "gc/shared/space.inline.hpp"

--- a/src/hotspot/share/gc/serial/serialFullGC.hpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.hpp
@@ -26,7 +26,7 @@
 #define SHARE_GC_SERIAL_SERIALFULLGC_HPP
 
 #include "gc/shared/collectedHeap.hpp"
-#include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shared/preservedMarks.hpp"
 #include "gc/shared/referenceProcessor.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/taskqueue.hpp"
@@ -48,7 +48,6 @@ class STWGCTimer;
 // Class unloading will only occur when a full gc is invoked.
 
 // declared at end
-class PreservedMark;
 class MarkAndPushClosure;
 class AdjustPointerClosure;
 


### PR DESCRIPTION
Trivial moving included inline.hpp to cpp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329875](https://bugs.openjdk.org/browse/JDK-8329875): Serial: Move preservedMarks.inline.hpp to serialFullGC.cpp (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18678/head:pull/18678` \
`$ git checkout pull/18678`

Update a local copy of the PR: \
`$ git checkout pull/18678` \
`$ git pull https://git.openjdk.org/jdk.git pull/18678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18678`

View PR using the GUI difftool: \
`$ git pr show -t 18678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18678.diff">https://git.openjdk.org/jdk/pull/18678.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18678#issuecomment-2043250064)