### PR TITLE
8329884: Serial: Fix build failure due to ‘Copy’ has not been declared

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -37,6 +37,7 @@
 #include "memory/allocation.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/java.hpp"
+#include "utilities/copy.hpp"
 #include "utilities/macros.hpp"
 
 bool TenuredGeneration::grow_by(size_t bytes) {


### PR DESCRIPTION
Please review the trivial change which fixes the build failure of serial gc (e.g., build the minimal-release).
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329884](https://bugs.openjdk.org/browse/JDK-8329884): Serial: Fix build failure due to ‘Copy’ has not been declared (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18682/head:pull/18682` \
`$ git checkout pull/18682`

Update a local copy of the PR: \
`$ git checkout pull/18682` \
`$ git pull https://git.openjdk.org/jdk.git pull/18682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18682`

View PR using the GUI difftool: \
`$ git pr show -t 18682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18682.diff">https://git.openjdk.org/jdk/pull/18682.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18682#issuecomment-2043991016)