### PR TITLE
8329864: TestLibGraal.java still crashes with assert(_stack_base != nullptr)

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1579,9 +1579,11 @@ void JavaThread::print_on_error(outputStream* st, char *buf, int buflen) const {
   if (osthread()) {
     st->print(", id=%d", osthread()->thread_id());
   }
+  // Use raw field members for stack base/size as this could be
+  // called before a thread has run enough to initialize them.
   st->print(", stack(" PTR_FORMAT "," PTR_FORMAT ") (" PROPERFMT ")",
-            p2i(stack_end()), p2i(stack_base()),
-            PROPERFMTARGS(stack_size()));
+            p2i(_stack_base - _stack_size), p2i(_stack_base),
+            PROPERFMTARGS(_stack_size));
   st->print("]");
 
   ThreadsSMRSupport::print_info_on(this, st);


### PR DESCRIPTION
The changes to `JavaThread::print_on_error` were overlooked when `Thread::print_on_error` was fixed by https://github.com/openjdk/jdk/pull/18615. The fix is identical: access the `_stack_base` and `_stack_size` fields directly, not through the accessors with the assert.

Testing:
- tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329864](https://bugs.openjdk.org/browse/JDK-8329864): TestLibGraal.java still crashes with assert(_stack_base != nullptr) (**Bug** - P3)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18683/head:pull/18683` \
`$ git checkout pull/18683`

Update a local copy of the PR: \
`$ git checkout pull/18683` \
`$ git pull https://git.openjdk.org/jdk.git pull/18683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18683`

View PR using the GUI difftool: \
`$ git pr show -t 18683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18683.diff">https://git.openjdk.org/jdk/pull/18683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18683#issuecomment-2044115571)