### PR TITLE
8329898: Revert one use of markWord.is_unlocked back to is_neutral

### DIFF
--- a/src/hotspot/share/runtime/basicLock.cpp
+++ b/src/hotspot/share/runtime/basicLock.cpp
@@ -67,7 +67,7 @@ void BasicLock::move_to(oop obj, BasicLock* dest) {
   // we'll leave that optimization for another time.
 
   if (LockingMode == LM_LEGACY) {
-    if (displaced_header().is_unlocked()) {
+    if (displaced_header().is_neutral()) {
       // The object is locked and the resulting ObjectMonitor* will also be
       // locked so it can't be async deflated until ownership is dropped.
       ObjectSynchronizer::inflate_helper(obj);


### PR DESCRIPTION
[JDK-8325303](https://bugs.openjdk.org/browse/JDK-8325303) changed a number of occurrences of `is_neutral` to `is_unlocked`, but one change in basicLock.cpp should not have been changed as it relates to the displaced markword.

This is a trivial change.

Testing:
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329898](https://bugs.openjdk.org/browse/JDK-8329898): Revert one use of markWord.is_unlocked back to is_neutral (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18684/head:pull/18684` \
`$ git checkout pull/18684`

Update a local copy of the PR: \
`$ git checkout pull/18684` \
`$ git pull https://git.openjdk.org/jdk.git pull/18684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18684`

View PR using the GUI difftool: \
`$ git pr show -t 18684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18684.diff">https://git.openjdk.org/jdk/pull/18684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18684#issuecomment-2044131541)