### PR TITLE
8327741: JVM crash in hotspot/share/opto/compile.cpp - failed: missing inlining msg

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -554,6 +554,10 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
                                         true /*allow_intrinsics*/);
 
   if (cg != nullptr) {
+    if (!allow_inline && (C->print_inlining() || C->print_intrinsics())) {
+      C->print_inlining(method(), jvms->depth()-1, call_node()->jvms()->bci(), InliningResult::FAILURE,
+                        "late call devirtualization");
+    }
     assert(!cg->is_late_inline() || cg->is_mh_late_inline() || AlwaysIncrementalInline || StressIncrementalInlining, "we're doing late inlining");
     _inline_cg = cg;
     return true;

--- a/test/hotspot/jtreg/compiler/print/TestPrintInliningLateVirtualCall.java
+++ b/test/hotspot/jtreg/compiler/print/TestPrintInliningLateVirtualCall.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8327741
  * @summary JVM crash in hotspot/share/opto/compile.cpp - failed: missing inlining msg
- * @run main/othervm -XX:-BackgroundCompilation -XX:+PrintCompilation -XX:+PrintInlining TestPrintInliningLateVirtualCall
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-BackgroundCompilation -XX:+PrintCompilation -XX:+PrintInlining TestPrintInliningLateVirtualCall
  */
 
 public class TestPrintInliningLateVirtualCall {

--- a/test/hotspot/jtreg/compiler/print/TestPrintInliningLateVirtualCall.java
+++ b/test/hotspot/jtreg/compiler/print/TestPrintInliningLateVirtualCall.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, Red Hat and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8327741
+ * @summary JVM crash in hotspot/share/opto/compile.cpp - failed: missing inlining msg
+ * @run main/othervm -XX:-BackgroundCompilation -XX:+PrintCompilation -XX:+PrintInlining TestPrintInliningLateVirtualCall
+ */
+
+public class TestPrintInliningLateVirtualCall {
+    static final A fieldA = new A();
+    static final B fieldB = new B();
+    static final C fieldC = new C();
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            testHelper(0);
+            testHelper(10);
+            testHelper(100);
+            test();
+        }
+    }
+
+    private static void testHelper(int i) {
+        A a;
+        if (i == 10) {
+            a = fieldA;
+        } else if (i > 10) {
+            a = fieldB;
+        } else {
+            a = fieldC;
+        }
+        a.m();
+    }
+
+    private static void test() {
+        int i;
+        for (i = 0; i < 10; i++) {
+
+        }
+        testHelper(i);
+    }
+
+    static class A {
+        void m() {
+
+        }
+    }
+
+    static class B extends A {
+        void m() {
+
+        }
+    }
+
+    static class C extends A {
+        void m() {
+
+        }
+    }
+}


### PR DESCRIPTION
The crash occurs when a virtual call is devirtualized late. Inlining
is not attempted then. So no new inlining diagnostic message is
produced which causes the assert failure. There's some valuable
information that can be reported though (the call is
devirtualized).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327741](https://bugs.openjdk.org/browse/JDK-8327741): JVM crash in hotspot/share/opto/compile.cpp - failed: missing inlining msg (**Bug** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18685/head:pull/18685` \
`$ git checkout pull/18685`

Update a local copy of the PR: \
`$ git checkout pull/18685` \
`$ git pull https://git.openjdk.org/jdk.git pull/18685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18685`

View PR using the GUI difftool: \
`$ git pr show -t 18685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18685.diff">https://git.openjdk.org/jdk/pull/18685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18685#issuecomment-2044607540)