### PR TITLE
8328879: G1: Some gtests modify global state crashing the JVM during GC after JDK-8289822

### DIFF
--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -34,7 +34,7 @@
 #include "unittest.hpp"
 
 // @requires UseG1GC
-TEST_VM(FreeRegionList, length) {
+TEST_OTHER_VM(FreeRegionList, length) {
   if (!UseG1GC) {
     return;
   }

--- a/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
+++ b/test/hotspot/gtest/gc/g1/test_heapRegion.cpp
@@ -122,7 +122,7 @@ void VM_HeapRegionApplyToMarkedObjectsTest::doit() {
   region->set_top(old_top);
 }
 
-TEST_VM(HeapRegion, apply_to_marked_object) {
+TEST_OTHER_VM(HeapRegion, apply_to_marked_object) {
   if (!UseG1GC) {
     return;
   }


### PR DESCRIPTION
Hi all,

  please review this change that modifies two gtests to use `TEST_OTHER_VM` because they modify global state. It adds like 50ms each to test execution here, but modifying either the test or the VM seems too complicated.

Testing: local gtest runs

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328879](https://bugs.openjdk.org/browse/JDK-8328879): G1: Some gtests modify global state crashing the JVM during GC after JDK-8289822 (**Bug** - P3)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18691/head:pull/18691` \
`$ git checkout pull/18691`

Update a local copy of the PR: \
`$ git checkout pull/18691` \
`$ git pull https://git.openjdk.org/jdk.git pull/18691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18691`

View PR using the GUI difftool: \
`$ git pr show -t 18691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18691.diff">https://git.openjdk.org/jdk/pull/18691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18691#issuecomment-2045096966)