### PR TITLE
8329617: Update stylesheet for specs and tool documentation

### DIFF
--- a/make/data/docs-resources/resources/jdk-default.css
+++ b/make/data/docs-resources/resources/jdk-default.css
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,56 +23,62 @@
  * questions.
  */
 
+@import url('../api/resource-files/fonts/dejavu.css');
+
 body {
-  margin: 2em 2em;
   font-family: DejaVu Sans, Bitstream Vera Sans, Luxi Sans, Verdana, Arial, Helvetica, sans-serif;
   font-size: 10pt;
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  min-width: 100%;
   line-height: 1.4;
 }
 
 pre, code, tt {
-  font-family: DejaVu Sans Mono, Bitstream Vera Sans Mono, Luxi Mono,
-    Courier New, monospace;
+    font-family: DejaVu Sans Mono, Bitstream Vera Sans Mono, Luxi Mono, Courier New, monospace;
+}
+
+main, footer {
+  margin: 16px 27px;
+}
+
+/* Adjust horizontal margin for content elements outside of main element */
+:is(body, header) > :is(nav, h1, h2, h3, h4, h5, h6, p, .sub-title) {
+    margin-left: 27px;
+    margin-right: 27px;
 }
 
 blockquote {
-  margin: 1.5ex 0em 1.5ex 2em;
+  margin: 1.5ex 0 1.5ex 2em;
 }
 
 p {
-  padding: 0pt;
-  margin: 1ex 0em;
+  margin-top: 1ex;
+  margin-bottom: 1ex;
 }
 
-p:first-child, pre:first-child { margin-top: 0pt; }
-
-h1 {
-  font-weight: bold;
-  padding: 0pt;
-  margin: 2ex .5ex 1ex 0pt;
+dd > p:first-child, pre:first-child {
+  margin-top: 0;
 }
 
 h1:first-child, h2:first-child {
-  margin-top: 0ex;
+  margin-top: 0;
 }
 
-h2 {
-  font-weight: bold;
-  padding: 0pt;
-  margin: 2ex 0pt 1ex 0pt;
+h1, h2 {
+  margin-top: 2ex;
+  margin-bottom: 1ex;
 }
 
-h3 {
-  font-weight: bold;
-  padding: 0pt;
-  margin: 1.5ex 0pt 1ex 0pt;
+h3, h4, h5 {
+  margin-top: 1.5ex;
+  margin-bottom: 1ex;
 }
 
 h4, h5 {
   font-size: 100%;
-  font-weight: bold;
-  padding: 0pt;
-  margin: 1.5ex 0pt 1ex 0pt;
 }
 
 .subtitle {
@@ -100,7 +106,7 @@ a[href]:hover {
 }
 
 a img {
-  border-width: 0px;
+  border-width: 0;
 }
 
 img {
@@ -154,9 +160,9 @@ table.centered td {
 
 .draft-header {
   text-align: center;
-  font-size: 80%;
+  font-size: 11.2px;
   padding: 6px;
-  margin: -2.5em -2.5em 2.5em -2.5em;
+  line-height: initial;
 }
 
 .legal-footer {
@@ -183,29 +189,31 @@ nav#TOC ul ul li::before {
     content: " \2022  "
 }
 
-header#title-block-header {
-    margin-top:-2em;
+/* Rules below replicate sizing of navigation bar in API docs */
+header#title-block-header div.navbar {
+    padding: 0 20px 0 26px;
+    margin-bottom: 30px;
+    background-color: #4D7A97;
+    color: #FFFFFF;
+    height: 44px;
+    overflow: hidden;
+    font-size: 0.857em;
+    line-height: initial;
+    display: flex;
+    flex-direction: row-reverse;
+    align-items: center;
 }
 
-header#title-block-header div.navbar {
-    margin: 0 -2.5em 2.5em -2.5em;
-    padding: 0 2.5em;
-    background-color:#4D7A97;
-    color:#FFFFFF;
-    float:left;
-    width:100%;
-    clear:right;
-    min-height:2.8em;
-    padding-top:10px;
-    overflow:hidden;
-    font-size:12px;
+header#title-block-header div.navbar nav {
+    flex: 1 1 auto;
+    font-size: 12px;
+    white-space: nowrap;
 }
 
 header#title-block-header div.navbar div {
-    float:right;
-    font-size:11px;
-    height:2.9em;
-    margin: auto 0;
+    flex: 0 0 auto;
+    font-size: 10.978px;
+    white-space: nowrap;
 }
 
 header#title-block-header ul {


### PR DESCRIPTION
Please review an update to the `jdk-default.css` stylesheet used for specifications and tool guides. The original purpose was to make use of the Dejavu web fonts provided by the API docs and to update the navigation bar to match the one in the API docs. However, the updates include some other fixes and improvements also described below.

 - The change to use the DejaVu web fonts consists only of the `@import` statement in line 16 as the stylesheet already used DejaVu web fonts as first choice in its `font-family` rules.
 - The changes to make the navigation bar match the one in the API docs are mostly located at the end of the file (beyond line 160). However, this also includes setting the `margin` property to '0' in the `body` element and adding a `margin` in the `main` and `footer` elements instead. 
 - To set the horizontal margin for page content elements outside the `main` element which occur in some pages, a margin is set explicitly on those elements in lines 48-50. While this is a bit awkward, I think it's still better than working with negative margins in the header to offset the margin in the `body` element.
 - Most of the remaining changes (lines 53-110) are changes are to redefine the styles in simpler terms, such as leaving out declarations that are equal to browser defaults, and removing the units from `0`-length values.

The changes are intended to preserve the layout of the pages, including the body font size which is slightly different from the one used in API docs (`10pt` vs `14px`). I can provide before/after snapshots of the rendered documentation if desired.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329617](https://bugs.openjdk.org/browse/JDK-8329617): Update stylesheet for specs and tool documentation (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18694/head:pull/18694` \
`$ git checkout pull/18694`

Update a local copy of the PR: \
`$ git checkout pull/18694` \
`$ git pull https://git.openjdk.org/jdk.git pull/18694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18694`

View PR using the GUI difftool: \
`$ git pr show -t 18694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18694.diff">https://git.openjdk.org/jdk/pull/18694.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18694#issuecomment-2045154435)