### PR TITLE
8329962: Remove CardTable::invalidate

### DIFF
--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -202,6 +202,7 @@ void CardTable::resize_covered_region(MemRegion new_region) {
 void CardTable::dirty_MemRegion(MemRegion mr) {
   assert(align_down(mr.start(), HeapWordSize) == mr.start(), "Unaligned start");
   assert(align_up  (mr.end(),   HeapWordSize) == mr.end(),   "Unaligned end"  );
+  assert(_covered[0].contains(mr) || _covered[1].contains(mr), "precondition");
   CardValue* cur  = byte_for(mr.start());
   CardValue* last = byte_after(mr.last());
   memset(cur, dirty_card, pointer_delta(last, cur, sizeof(CardValue)));
@@ -224,15 +225,6 @@ void CardTable::clear_MemRegion(MemRegion mr) {
 uintx CardTable::ct_max_alignment_constraint() {
   // Calculate maximum alignment using GCCardSizeInBytes as card_size hasn't been set yet
   return GCCardSizeInBytes * os::vm_page_size();
-}
-
-void CardTable::invalidate(MemRegion mr) {
-  assert(align_down(mr.start(), HeapWordSize) == mr.start(), "Unaligned start");
-  assert(align_up  (mr.end(),   HeapWordSize) == mr.end(),   "Unaligned end"  );
-  for (int i = 0; i < max_covered_regions; i++) {
-    MemRegion mri = mr.intersection(_covered[i]);
-    if (!mri.is_empty()) dirty_MemRegion(mri);
-  }
 }
 
 #ifndef PRODUCT

--- a/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/src/hotspot/share/gc/shared/cardTable.hpp
@@ -131,8 +131,6 @@ public:
     return byte_for(p) + 1;
   }
 
-  void invalidate(MemRegion mr);
-
   // Provide read-only access to the card table array.
   const CardValue* byte_for_const(const void* p) const {
     return byte_for(p);

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
@@ -85,7 +85,7 @@ void CardTableBarrierSet::write_ref_array_work(MemRegion mr) {
 }
 
 void CardTableBarrierSet::invalidate(MemRegion mr) {
-  _card_table->invalidate(mr);
+  _card_table->dirty_MemRegion(mr);
 }
 
 void CardTableBarrierSet::print_on(outputStream* st) const {


### PR DESCRIPTION
Simple converting redundant if-check to assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329962](https://bugs.openjdk.org/browse/JDK-8329962): Remove CardTable::invalidate (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18696/head:pull/18696` \
`$ git checkout pull/18696`

Update a local copy of the PR: \
`$ git checkout pull/18696` \
`$ git pull https://git.openjdk.org/jdk.git pull/18696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18696`

View PR using the GUI difftool: \
`$ git pr show -t 18696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18696.diff">https://git.openjdk.org/jdk/pull/18696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18696#issuecomment-2045227948)