### PR TITLE
8329862: libjli GetApplicationHome cleanups and enhance jli tracing

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -495,7 +495,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     char libjava[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JRE location from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
@@ -518,7 +518,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         }
     }
 
-    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JRE location from shared lib of the image\n");
 
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
@@ -527,8 +527,6 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
             return JNI_TRUE;
         }
     }
-
-    JLI_TraceLauncher("GetJREPath - attempts to get JRE location did not succeed\n");
 
     if (!speculative)
       JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -495,7 +495,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     char libjava[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("Attempt to get JRE location from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JRE path from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
@@ -518,7 +518,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         }
     }
 
-    JLI_TraceLauncher("Attempt to get JRE location from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");
 
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -495,6 +495,8 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     char libjava[MAXPATHLEN];
     struct stat s;
 
+    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from launcher executable path\n");
+
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
@@ -516,6 +518,8 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         }
     }
 
+    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from shared lib of the image\n");
+
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (stat(libjava, &s) == 0) {
@@ -523,6 +527,8 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
             return JNI_TRUE;
         }
     }
+
+    JLI_TraceLauncher("GetJREPath - attempts to get JRE location did not succeed\n");
 
     if (!speculative)
       JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -504,18 +504,6 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
             JLI_TraceLauncher("JRE path is %s\n", path);
             return JNI_TRUE;
         }
-        /* ensure storage for path + /jre + NULL */
-        if ((JLI_StrLen(path) + 4  + 1) > (size_t) pathsize) {
-            JLI_TraceLauncher("Insufficient space to store JRE path\n");
-            return JNI_FALSE;
-        }
-        /* Does the app ship a private JRE in <apphome>/jre directory? */
-        JLI_Snprintf(libjava, sizeof(libjava), "%s/jre/lib/" JAVA_DLL, path);
-        if (access(libjava, F_OK) == 0) {
-            JLI_StrCat(path, "/jre");
-            JLI_TraceLauncher("JRE path is %s\n", path);
-            return JNI_TRUE;
-        }
     }
 
     JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,6 @@ GetApplicationHome(char *buf, jint bufsize)
 {
     const char *execname = GetExecName();
     if (execname != NULL) {
-        JLI_TraceLauncher("Launcher executable path is %s\n", execname);
-
         JLI_Snprintf(buf, bufsize, "%s", execname);
         buf[bufsize-1] = '\0';
     } else {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,6 +82,8 @@ GetApplicationHome(char *buf, jint bufsize)
 {
     const char *execname = GetExecName();
     if (execname != NULL) {
+        JLI_TraceLauncher("GetApplicationHome - launcher executable path is %s\n", execname);
+
         JLI_Snprintf(buf, bufsize, "%s", execname);
         buf[bufsize-1] = '\0';
     } else {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -82,7 +82,7 @@ GetApplicationHome(char *buf, jint bufsize)
 {
     const char *execname = GetExecName();
     if (execname != NULL) {
-        JLI_TraceLauncher("GetApplicationHome - launcher executable path is %s\n", execname);
+        JLI_TraceLauncher("Launcher executable path is %s\n", execname);
 
         JLI_Snprintf(buf, bufsize, "%s", execname);
         buf[bufsize-1] = '\0';

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -49,10 +49,6 @@ static jboolean GetJVMPath(const char *jrepath, const char *jvmtype,
                            char *jvmpath, jint jvmpathsize);
 static jboolean GetJREPath(char *path, jint pathsize);
 
-#ifdef USE_REGISTRY_LOOKUP
-jboolean GetPublicJREHome(char *buf, jint bufsize);
-#endif
-
 /* We supports warmup for UI stack that is performed in parallel
  * to VM initialization.
  * This helps to improve startup of UI application as warmup phase
@@ -333,14 +329,6 @@ GetJREPath(char *path, jint pathsize)
             return JNI_TRUE;
         }
     }
-
-#ifdef USE_REGISTRY_LOOKUP
-    /* Lookup public JRE using Windows registry. */
-    if (GetPublicJREHome(path, pathsize)) {
-        JLI_TraceLauncher("JRE path is %s\n", path);
-        return JNI_TRUE;
-    }
-#endif
 
     JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
     return JNI_FALSE;

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -296,7 +296,7 @@ GetJREPath(char *path, jint pathsize)
     char javadll[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("Attempt to get JRE location from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JRE path from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
@@ -319,7 +319,7 @@ GetJREPath(char *path, jint pathsize)
         }
     }
 
-    JLI_TraceLauncher("Attempt to get JRE location from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");
 
     /* Try getting path to JRE from path to JLI.DLL */
     if (GetApplicationHomeFromDll(path, pathsize)) {

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -422,7 +422,6 @@ jboolean
 GetApplicationHome(char *buf, jint bufsize)
 {
     GetModuleFileName(NULL, buf, bufsize);
-    JLI_TraceLauncher("Launcher executable path is %s\n", buf);
     return TruncatePath(buf);
 }
 

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -300,6 +300,8 @@ GetJREPath(char *path, jint pathsize)
     char javadll[MAXPATHLEN];
     struct stat s;
 
+    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from launcher executable path\n");
+
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
         JLI_Snprintf(javadll, sizeof(javadll), "%s\\bin\\" JAVA_DLL, path);
@@ -321,6 +323,8 @@ GetJREPath(char *path, jint pathsize)
         }
     }
 
+    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from shared lib of the image\n");
+
     /* Try getting path to JRE from path to JLI.DLL */
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(javadll, sizeof(javadll), "%s\\bin\\" JAVA_DLL, path);
@@ -337,6 +341,8 @@ GetJREPath(char *path, jint pathsize)
         return JNI_TRUE;
     }
 #endif
+
+    JLI_TraceLauncher("GetJREPath - attempts to get JRE location did not succeed\n");
 
     JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
     return JNI_FALSE;
@@ -430,6 +436,7 @@ jboolean
 GetApplicationHome(char *buf, jint bufsize)
 {
     GetModuleFileName(NULL, buf, bufsize);
+    JLI_TraceLauncher("GetApplicationHome - launcher executable path is %s\n", buf);
     return TruncatePath(buf);
 }
 

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -300,7 +300,7 @@ GetJREPath(char *path, jint pathsize)
     char javadll[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JRE location from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
@@ -323,7 +323,7 @@ GetJREPath(char *path, jint pathsize)
         }
     }
 
-    JLI_TraceLauncher("GetJREPath - attempt to get JRE location from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JRE location from shared lib of the image\n");
 
     /* Try getting path to JRE from path to JLI.DLL */
     if (GetApplicationHomeFromDll(path, pathsize)) {
@@ -341,8 +341,6 @@ GetJREPath(char *path, jint pathsize)
         return JNI_TRUE;
     }
 #endif
-
-    JLI_TraceLauncher("GetJREPath - attempts to get JRE location did not succeed\n");
 
     JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
     return JNI_FALSE;
@@ -436,7 +434,7 @@ jboolean
 GetApplicationHome(char *buf, jint bufsize)
 {
     GetModuleFileName(NULL, buf, bufsize);
-    JLI_TraceLauncher("GetApplicationHome - launcher executable path is %s\n", buf);
+    JLI_TraceLauncher("Launcher executable path is %s\n", buf);
     return TruncatePath(buf);
 }
 

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -305,18 +305,6 @@ GetJREPath(char *path, jint pathsize)
             JLI_TraceLauncher("JRE path is %s\n", path);
             return JNI_TRUE;
         }
-        /* ensure storage for path + \jre + NULL */
-        if ((JLI_StrLen(path) + 4 + 1) > (size_t) pathsize) {
-            JLI_TraceLauncher("Insufficient space to store JRE path\n");
-            return JNI_FALSE;
-        }
-        /* Does this app ship a private JRE in <apphome>\jre directory? */
-        JLI_Snprintf(javadll, sizeof (javadll), "%s\\jre\\bin\\" JAVA_DLL, path);
-        if (stat(javadll, &s) == 0) {
-            JLI_StrCat(path, "\\jre");
-            JLI_TraceLauncher("JRE path is %s\n", path);
-            return JNI_TRUE;
-        }
     }
 
     JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");


### PR DESCRIPTION
We have already good JLI tracing capabilities. But GetApplicationHome and GetApplicationHomeFromDll lack some tracing and should be enhanced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8329862](https://bugs.openjdk.org/browse/JDK-8329862): libjli GetApplicationHome cleanups and enhance jli tracing (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [4d998244](https://git.openjdk.org/jdk/pull/18699/files/4d99824469cb6206aa1a06888d0d7361dc6c1c0e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18699/head:pull/18699` \
`$ git checkout pull/18699`

Update a local copy of the PR: \
`$ git checkout pull/18699` \
`$ git pull https://git.openjdk.org/jdk.git pull/18699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18699`

View PR using the GUI difftool: \
`$ git pr show -t 18699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18699.diff">https://git.openjdk.org/jdk/pull/18699.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18699#issuecomment-2045494980)