### PR TITLE
8329967: Build failure after JDK-8329628

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -687,7 +687,7 @@ void CodeCache::nmethods_do(void f(nmethod* nm)) {
 
 void CodeCache::nmethods_do(NMethodClosure* cl) {
   assert_locked_or_safepoint(CodeCache_lock);
-  NMethodIterator iter(NMethodIterator::all_blobs);
+  NMethodIterator iter(NMethodIterator::all);
   while(iter.next()) {
     cl->do_nmethod(iter.method());
   }


### PR DESCRIPTION
[JDK-8329629](https://bugs.openjdk.org/browse/JDK-8329629) changes added this new code to codeCache.cpp few hours before I integrated [JDK-8329628](https://bugs.openjdk.org/browse/JDK-8329628). GitHub automatic merge did not detect conflict because it was new code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329967](https://bugs.openjdk.org/browse/JDK-8329967): Build failure after JDK-8329628 (**Bug** - P1)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18700/head:pull/18700` \
`$ git checkout pull/18700`

Update a local copy of the PR: \
`$ git checkout pull/18700` \
`$ git pull https://git.openjdk.org/jdk.git pull/18700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18700`

View PR using the GUI difftool: \
`$ git pr show -t 18700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18700.diff">https://git.openjdk.org/jdk/pull/18700.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18700#issuecomment-2045553852)