### PR TITLE
8329767: G1: Move G1BlockOffsetTable::set_for_starts_humongous to HeapRegion

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -263,10 +263,3 @@ void G1BlockOffsetTable::verify(const HeapRegion* hr) const {
     }
   }
 }
-
-void G1BlockOffsetTable::set_for_starts_humongous(HeapRegion* hr, HeapWord* obj_top, size_t fill_size) {
-  update_for_block(hr->bottom(), obj_top);
-  if (fill_size > 0) {
-    update_for_block(obj_top, fill_size);
-  }
-}

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -123,10 +123,6 @@ public:
       update_for_block_work(blk_start, blk_end);
     }
   }
-
-  void update_for_block(HeapWord* blk_start, size_t size) {
-    update_for_block(blk_start, blk_start + size);
-  }
 };
 
 #endif // SHARE_GC_G1_G1BLOCKOFFSETTABLE_HPP

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -81,10 +81,6 @@ private:
     return align_up(addr, CardTable::card_size());
   }
 
-  void update_for_block(HeapWord* blk_start, size_t size) {
-    update_for_block(blk_start, blk_start + size);
-  }
-
 public:
 
   // Return the number of slots needed for an offset array
@@ -128,7 +124,9 @@ public:
     }
   }
 
-  void set_for_starts_humongous(HeapRegion* hr, HeapWord* obj_top, size_t fill_size);
+  void update_for_block(HeapWord* blk_start, size_t size) {
+    update_for_block(blk_start, blk_start + size);
+  }
 };
 
 #endif // SHARE_GC_G1_G1BLOCKOFFSETTABLE_HPP

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -188,7 +188,10 @@ void HeapRegion::set_starts_humongous(HeapWord* obj_top, size_t fill_size) {
   _type.set_starts_humongous();
   _humongous_start_region = this;
 
-  _bot->set_for_starts_humongous(this, obj_top, fill_size);
+  _bot->update_for_block(bottom(), obj_top);
+  if (fill_size > 0) {
+    _bot->update_for_block(obj_top, fill_size);
+  }
 }
 
 void HeapRegion::set_continues_humongous(HeapRegion* first_hr) {

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -190,7 +190,7 @@ void HeapRegion::set_starts_humongous(HeapWord* obj_top, size_t fill_size) {
 
   _bot->update_for_block(bottom(), obj_top);
   if (fill_size > 0) {
-    _bot->update_for_block(obj_top, fill_size);
+    _bot->update_for_block(obj_top, obj_top + fill_size);
   }
 }
 


### PR DESCRIPTION
Hi all,

This patch moves the method `G1BlockOffsetTable::set_for_starts_humongous` into `HeapRegion::set_starts_humongous` and marks `G1BlockOffsetTable::update_for_block(HeapWord* blk_start, size_t size)` as public (because it delegates to another public method which has the same name).

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329767](https://bugs.openjdk.org/browse/JDK-8329767): G1: Move G1BlockOffsetTable::set_for_starts_humongous to HeapRegion (**Enhancement** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18701/head:pull/18701` \
`$ git checkout pull/18701`

Update a local copy of the PR: \
`$ git checkout pull/18701` \
`$ git pull https://git.openjdk.org/jdk.git pull/18701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18701`

View PR using the GUI difftool: \
`$ git pr show -t 18701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18701.diff">https://git.openjdk.org/jdk/pull/18701.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18701#issuecomment-2045654819)