### PR TITLE
8330002: Remove redundant public keyword in BarrierSet

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSet.hpp
+++ b/src/hotspot/share/gc/shared/barrierSet.hpp
@@ -142,7 +142,6 @@ public:
 
   virtual void make_parsable(JavaThread* thread) {}
 
-public:
   // Print a description of the memory for the barrier set
   virtual void print_on(outputStream* st) const = 0;
 


### PR DESCRIPTION
Trivial removing redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330002](https://bugs.openjdk.org/browse/JDK-8330002): Remove redundant public keyword in BarrierSet (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18708/head:pull/18708` \
`$ git checkout pull/18708`

Update a local copy of the PR: \
`$ git checkout pull/18708` \
`$ git pull https://git.openjdk.org/jdk.git pull/18708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18708`

View PR using the GUI difftool: \
`$ git pr show -t 18708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18708.diff">https://git.openjdk.org/jdk/pull/18708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18708#issuecomment-2046933599)