### PR TITLE
8330008: [s390x] Test bit "in-memory" in case of DiagnoseSyncOnValueBasedClasses

### DIFF
--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3207,10 +3207,8 @@ void MacroAssembler::compiler_fast_lock_object(Register oop, Register box, Regis
 
   if (DiagnoseSyncOnValueBasedClasses != 0) {
     load_klass(temp, oop);
-    z_l(temp, Address(temp, Klass::access_flags_offset()));
-    assert((JVM_ACC_IS_VALUE_BASED_CLASS & 0xFFFF) == 0, "or change following instruction");
-    z_nilh(temp, JVM_ACC_IS_VALUE_BASED_CLASS >> 16);
-    z_brne(done);
+    testbit(Address(temp, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
+    z_btrue(done);
   }
 
   // Handle existing monitor.

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1712,8 +1712,6 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
     // Try fastpath for locking.
     // Fast_lock kills r_temp_1, r_temp_2.
-    // in case of DiagnoseSyncOnValueBasedClasses content for Z_R1_scratch
-    // will be destroyed, So avoid using Z_R1 as temp here.
     __ compiler_fast_lock_object(r_oop, r_box, r_tmp1, r_tmp2);
     __ z_bre(done);
 


### PR DESCRIPTION
It's trivial update to use `testbit` method to test the bit "in-memory"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330008](https://bugs.openjdk.org/browse/JDK-8330008): [s390x] Test bit "in-memory" in case of DiagnoseSyncOnValueBasedClasses (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [127ea97d](https://git.openjdk.org/jdk/pull/18709/files/127ea97db17fdb8a167754da87abc70544f19e49)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18709/head:pull/18709` \
`$ git checkout pull/18709`

Update a local copy of the PR: \
`$ git checkout pull/18709` \
`$ git pull https://git.openjdk.org/jdk.git pull/18709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18709`

View PR using the GUI difftool: \
`$ git pr show -t 18709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18709.diff">https://git.openjdk.org/jdk/pull/18709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18709#issuecomment-2048929480)