### PR TITLE
8330000: ZGC: ZObjArrayAllocator may unnecessarily clear TypeArrays twice

### DIFF
--- a/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjArrayAllocator.cpp
@@ -126,7 +126,7 @@ oop ZObjArrayAllocator::initialize(HeapWord* mem) const {
       yield_for_safepoint();
 
       // Deal with safepoints
-      if (!seen_gc_safepoint && gc_safepoint_happened()) {
+      if (is_reference_type(element_type) && !seen_gc_safepoint && gc_safepoint_happened()) {
         // The first time we observe a GC safepoint in the yield point,
         // we have to restart processing with 11 remembered bits.
         seen_gc_safepoint = true;


### PR DESCRIPTION
The segmented array allocation in ZObjArrayAllocator for TypeArrays will restart the segmented clearing if it encounters a safepoint. This is unnecessary for TypeArrays.

Tested ZGC tests tier1-7

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330000](https://bugs.openjdk.org/browse/JDK-8330000): ZGC: ZObjArrayAllocator may unnecessarily clear TypeArrays twice (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18713/head:pull/18713` \
`$ git checkout pull/18713`

Update a local copy of the PR: \
`$ git checkout pull/18713` \
`$ git pull https://git.openjdk.org/jdk.git pull/18713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18713`

View PR using the GUI difftool: \
`$ git pr show -t 18713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18713.diff">https://git.openjdk.org/jdk/pull/18713.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18713#issuecomment-2047322327)