### PR TITLE
8329258: TailCall should not use frame pointer register for jump target

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16190,7 +16190,7 @@ instruct CallLeafNoFPDirect(method meth)
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use rfp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset rfp to the caller state.
+// emitted just above the TailCall which has reset rfp to the caller state.
 instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -695,8 +695,8 @@ reg_class no_special_ptr_reg %{
 %}
 
 // Class for all non_special pointer registers (excluding rfp)
-reg_class no_special_or_rfp_ptr_reg %{
-  return _NO_SPECIAL_OR_RFP_PTR_REG_mask;
+reg_class no_special_no_rfp_ptr_reg %{
+  return _NO_SPECIAL_NO_RFP_PTR_REG_mask;
 %}
 
 // Class for all float registers
@@ -1130,7 +1130,7 @@ extern RegMask _PTR_REG_mask;
 extern RegMask _NO_SPECIAL_REG32_mask;
 extern RegMask _NO_SPECIAL_REG_mask;
 extern RegMask _NO_SPECIAL_PTR_REG_mask;
-extern RegMask _NO_SPECIAL_OR_RFP_PTR_REG_mask;
+extern RegMask _NO_SPECIAL_NO_RFP_PTR_REG_mask;
 
 class CallStubImpl {
 
@@ -1219,7 +1219,7 @@ source %{
   RegMask _NO_SPECIAL_REG32_mask;
   RegMask _NO_SPECIAL_REG_mask;
   RegMask _NO_SPECIAL_PTR_REG_mask;
-  RegMask _NO_SPECIAL_OR_RFP_PTR_REG_mask;
+  RegMask _NO_SPECIAL_NO_RFP_PTR_REG_mask;
 
   void reg_mask_init() {
     // We derive below RegMask(s) from the ones which are auto-generated from
@@ -1257,8 +1257,8 @@ source %{
       _NO_SPECIAL_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
     }
 
-    _NO_SPECIAL_OR_RFP_PTR_REG_mask = _NO_SPECIAL_PTR_REG_mask;
-    _NO_SPECIAL_OR_RFP_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
+    _NO_SPECIAL_NO_RFP_PTR_REG_mask = _NO_SPECIAL_PTR_REG_mask;
+    _NO_SPECIAL_NO_RFP_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
   }
 
   // Optimizaton of volatile gets and puts
@@ -4784,7 +4784,7 @@ operand iRegPNoSp()
 // rfp is not used to hold the frame pointer.
 operand iRegPNoSpNoRfp()
 %{
-  constraint(ALLOC_IN_RC(no_special_or_rfp_ptr_reg));
+  constraint(ALLOC_IN_RC(no_special_no_rfp_ptr_reg));
   match(RegP);
   match(iRegPNoSp);
   op_cost(0);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4788,9 +4788,7 @@ operand iRegPNoSp()
 operand iRegPNoSpNoRfp()
 %{
   constraint(ALLOC_IN_RC(no_special_or_rfp_ptr_reg));
-  //match(RegP);
-  // TODO these list "who matches me as well"
-  // match(iRegP);
+  match(RegP);
   match(iRegPNoSp);
   op_cost(0);
   format %{ %}
@@ -16207,7 +16205,7 @@ instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr
   ins_pipe(pipe_class_call);
 %}
 
-instruct TailjmpInd(iRegPNoSp jump_target, iRegP_R0 ex_oop)
+instruct TailjmpInd(iRegPNoSpNoRfp jump_target, iRegP_R0 ex_oop)
 %{
   match(TailJump jump_target ex_oop);
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16189,8 +16189,8 @@ instruct CallLeafNoFPDirect(method meth)
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-// Don't use rfp for the jump_target because the
-// MachEpilogNode that is inserted above will kill it.
+// Don't use rfp for 'jump_target' because a MachEpilogNode has already been
+// emitted just above the TailCall and it will reset rbp to the caller state.
 instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16190,7 +16190,7 @@ instruct CallLeafNoFPDirect(method meth)
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use rfp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset rbp to the caller state.
+// emitted just above the TailCall and it will reset rfp to the caller state.
 instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -1234,7 +1234,6 @@ source %{
 
     _PTR_REG_mask = _ALL_REG_mask;
 
-    // Exclude non allocatable: r18 (tls), r28 (thread), r30 (lr), r31 (sp)
     _NO_SPECIAL_REG32_mask = _ALL_REG32_mask;
     _NO_SPECIAL_REG32_mask.SUBTRACT(_NON_ALLOCATABLE_REG32_mask);
 
@@ -4756,7 +4755,6 @@ operand iRegP()
   constraint(ALLOC_IN_RC(ptr_reg));
   match(RegP);
   match(iRegPNoSp);
-  match(iRegPNoSpNoRfp);
   match(iRegP_R0);
   //match(iRegP_R2);
   //match(iRegP_R4);
@@ -4783,8 +4781,8 @@ operand iRegPNoSp()
   interface(REG_INTER);
 %}
 
-// This operand is not allowed to use RFP even if
-// RFP is not used to hold the frame pointer.
+// This operand is not allowed to use rfp even if
+// rfp is not used to hold the frame pointer.
 operand iRegPNoSpNoRfp()
 %{
   constraint(ALLOC_IN_RC(no_special_or_rfp_ptr_reg));

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -136,7 +136,6 @@ reg_def R27     ( SOC, SOE, Op_RegI, 27, r27->as_VMReg()        ); // heapbase
 reg_def R27_H   ( SOC, SOE, Op_RegI, 27, r27->as_VMReg()->next());
 reg_def R28     (  NS, SOE, Op_RegI, 28, r28->as_VMReg()        ); // thread
 reg_def R28_H   (  NS, SOE, Op_RegI, 28, r28->as_VMReg()->next());
-// TODO R29 is callee-save (SOE) as well
 reg_def R29     (  NS,  NS, Op_RegI, 29, r29->as_VMReg()        ); // fp
 reg_def R29_H   (  NS,  NS, Op_RegI, 29, r29->as_VMReg()->next());
 reg_def R30     (  NS,  NS, Op_RegI, 30, r30->as_VMReg()        ); // lr

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -136,6 +136,7 @@ reg_def R27     ( SOC, SOE, Op_RegI, 27, r27->as_VMReg()        ); // heapbase
 reg_def R27_H   ( SOC, SOE, Op_RegI, 27, r27->as_VMReg()->next());
 reg_def R28     (  NS, SOE, Op_RegI, 28, r28->as_VMReg()        ); // thread
 reg_def R28_H   (  NS, SOE, Op_RegI, 28, r28->as_VMReg()->next());
+// TODO R29 is callee-save (SOE) as well
 reg_def R29     (  NS,  NS, Op_RegI, 29, r29->as_VMReg()        ); // fp
 reg_def R29_H   (  NS,  NS, Op_RegI, 29, r29->as_VMReg()->next());
 reg_def R30     (  NS,  NS, Op_RegI, 30, r30->as_VMReg()        ); // lr
@@ -694,6 +695,11 @@ reg_class no_special_ptr_reg %{
   return _NO_SPECIAL_PTR_REG_mask;
 %}
 
+// Class for all non_special pointer registers (excluding rfp)
+reg_class no_special_or_rfp_ptr_reg %{
+  return _NO_SPECIAL_OR_RFP_PTR_REG_mask;
+%}
+
 // Class for all float registers
 reg_class float_reg(
     V0,
@@ -1125,6 +1131,7 @@ extern RegMask _PTR_REG_mask;
 extern RegMask _NO_SPECIAL_REG32_mask;
 extern RegMask _NO_SPECIAL_REG_mask;
 extern RegMask _NO_SPECIAL_PTR_REG_mask;
+extern RegMask _NO_SPECIAL_OR_RFP_PTR_REG_mask;
 
 class CallStubImpl {
 
@@ -1213,6 +1220,7 @@ source %{
   RegMask _NO_SPECIAL_REG32_mask;
   RegMask _NO_SPECIAL_REG_mask;
   RegMask _NO_SPECIAL_PTR_REG_mask;
+  RegMask _NO_SPECIAL_OR_RFP_PTR_REG_mask;
 
   void reg_mask_init() {
     // We derive below RegMask(s) from the ones which are auto-generated from
@@ -1226,6 +1234,7 @@ source %{
 
     _PTR_REG_mask = _ALL_REG_mask;
 
+    // Exclude non allocatable: r18 (tls), r28 (thread), r30 (lr), r31 (sp)
     _NO_SPECIAL_REG32_mask = _ALL_REG32_mask;
     _NO_SPECIAL_REG32_mask.SUBTRACT(_NON_ALLOCATABLE_REG32_mask);
 
@@ -1249,6 +1258,9 @@ source %{
       _NO_SPECIAL_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
       _NO_SPECIAL_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
     }
+
+    _NO_SPECIAL_OR_RFP_PTR_REG_mask = _NO_SPECIAL_PTR_REG_mask;
+    _NO_SPECIAL_OR_RFP_PTR_REG_mask.Remove(OptoReg::as_OptoReg(r29->as_VMReg()));
   }
 
   // Optimizaton of volatile gets and puts
@@ -4744,6 +4756,7 @@ operand iRegP()
   constraint(ALLOC_IN_RC(ptr_reg));
   match(RegP);
   match(iRegPNoSp);
+  match(iRegPNoSpNoRfp);
   match(iRegP_R0);
   //match(iRegP_R2);
   //match(iRegP_R4);
@@ -4765,6 +4778,20 @@ operand iRegPNoSp()
   // match(iRegP_R4);
   // match(iRegP_R5);
   // match(thread_RegP);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// This operand is not allowed to use RFP even if
+// RFP is not used to hold the frame pointer.
+operand iRegPNoSpNoRfp()
+%{
+  constraint(ALLOC_IN_RC(no_special_or_rfp_ptr_reg));
+  //match(RegP);
+  // TODO these list "who matches me as well"
+  // match(iRegP);
+  match(iRegPNoSp);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);
@@ -16167,7 +16194,7 @@ instruct CallLeafNoFPDirect(method meth)
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-instruct TailCalljmpInd(iRegPNoSp jump_target, inline_cache_RegP method_ptr)
+instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);
 

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16189,6 +16189,8 @@ instruct CallLeafNoFPDirect(method meth)
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
+// Don't use rfp for the jump_target because the
+// MachEpilogNode that is inserted above will kill it.
 instruct TailCalljmpInd(iRegPNoSpNoRfp jump_target, inline_cache_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -10509,7 +10509,7 @@ instruct cmpFastUnlockLightweight(rFlagsReg cr, iRegP object, iRegP_R10 box, iRe
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use fp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset fp to the caller state.
+// emitted just above the TailCall which has reset fp to the caller state.
 instruct TailCalljmpInd(iRegPNoSpNoFp jump_target, inline_cache_RegP method_oop)
 %{
   match(TailCall jump_target method_oop);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -649,10 +649,12 @@ reg_class non_allocatable_reg(
     R23, R23_H                // java thread
 );
 
+// Class for all non-special integer registers
 reg_class no_special_reg32 %{
   return _NO_SPECIAL_REG32_mask;
 %}
 
+// Class for all non-special long integer registers
 reg_class no_special_reg %{
   return _NO_SPECIAL_REG_mask;
 %}
@@ -661,8 +663,14 @@ reg_class ptr_reg %{
   return _PTR_REG_mask;
 %}
 
+// Class for all non_special pointer registers
 reg_class no_special_ptr_reg %{
   return _NO_SPECIAL_PTR_REG_mask;
+%}
+
+// Class for all non_special pointer registers (excluding fp)
+reg_class no_special_no_fp_ptr_reg %{
+  return _NO_SPECIAL_NO_FP_PTR_REG_mask;
 %}
 
 // Class for 64 bit register r10
@@ -1037,6 +1045,7 @@ extern RegMask _PTR_REG_mask;
 extern RegMask _NO_SPECIAL_REG32_mask;
 extern RegMask _NO_SPECIAL_REG_mask;
 extern RegMask _NO_SPECIAL_PTR_REG_mask;
+extern RegMask _NO_SPECIAL_NO_FP_PTR_REG_mask;
 
 class CallStubImpl {
 
@@ -1099,6 +1108,7 @@ RegMask _PTR_REG_mask;
 RegMask _NO_SPECIAL_REG32_mask;
 RegMask _NO_SPECIAL_REG_mask;
 RegMask _NO_SPECIAL_PTR_REG_mask;
+RegMask _NO_SPECIAL_NO_FP_PTR_REG_mask;
 
 void reg_mask_init() {
 
@@ -1133,6 +1143,9 @@ void reg_mask_init() {
     _NO_SPECIAL_REG_mask.Remove(OptoReg::as_OptoReg(x8->as_VMReg()));
     _NO_SPECIAL_PTR_REG_mask.Remove(OptoReg::as_OptoReg(x8->as_VMReg()));
   }
+
+  _NO_SPECIAL_NO_FP_PTR_REG_mask = _NO_SPECIAL_PTR_REG_mask;
+  _NO_SPECIAL_NO_FP_PTR_REG_mask.Remove(OptoReg::as_OptoReg(x8->as_VMReg()));
 }
 
 void PhaseOutput::pd_perform_mach_node_analysis() {
@@ -3215,6 +3228,18 @@ operand iRegPNoSp()
 %{
   constraint(ALLOC_IN_RC(no_special_ptr_reg));
   match(RegP);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+// This operand is not allowed to use fp even if
+// fp is not used to hold the frame pointer.
+operand iRegPNoSpNoFp()
+%{
+  constraint(ALLOC_IN_RC(no_special_no_fp_ptr_reg));
+  match(RegP);
+  match(iRegPNoSp);
   op_cost(0);
   format %{ %}
   interface(REG_INTER);
@@ -10483,7 +10508,9 @@ instruct cmpFastUnlockLightweight(rFlagsReg cr, iRegP object, iRegP_R10 box, iRe
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-instruct TailCalljmpInd(iRegPNoSp jump_target, inline_cache_RegP method_oop)
+// Don't use fp for 'jump_target' because a MachEpilogNode has already been
+// emitted just above the TailCall and it will reset fp to the caller state.
+instruct TailCalljmpInd(iRegPNoSpNoFp jump_target, inline_cache_RegP method_oop)
 %{
   match(TailCall jump_target method_oop);
 
@@ -10496,7 +10523,7 @@ instruct TailCalljmpInd(iRegPNoSp jump_target, inline_cache_RegP method_oop)
   ins_pipe(pipe_class_call);
 %}
 
-instruct TailjmpInd(iRegPNoSp jump_target, iRegP_R10 ex_oop)
+instruct TailjmpInd(iRegPNoSpNoFp jump_target, iRegP_R10 ex_oop)
 %{
   match(TailJump jump_target ex_oop);
 

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13598,7 +13598,7 @@ instruct Ret() %{
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use ebp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset rbp to the caller state.
+// emitted just above the TailCall and it will reset ebp to the caller state.
 instruct TailCalljmpInd(eRegP_no_EBP jump_target, eBXRegP method_ptr) %{
   match(TailCall jump_target method_ptr);
   ins_cost(300);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13597,6 +13597,8 @@ instruct Ret() %{
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
+// Don't use ebp for the jump_target because the
+// MachEpilogNode that is inserted above will kill it.
 instruct TailCalljmpInd(eRegP_no_EBP jump_target, eBXRegP method_ptr) %{
   match(TailCall jump_target method_ptr);
   ins_cost(300);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13597,8 +13597,8 @@ instruct Ret() %{
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-// Don't use ebp for the jump_target because the
-// MachEpilogNode that is inserted above will kill it.
+// Don't use ebp for 'jump_target' because a MachEpilogNode has already been
+// emitted just above the TailCall and it will reset rbp to the caller state.
 instruct TailCalljmpInd(eRegP_no_EBP jump_target, eBXRegP method_ptr) %{
   match(TailCall jump_target method_ptr);
   ins_cost(300);

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13598,7 +13598,7 @@ instruct Ret() %{
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use ebp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset ebp to the caller state.
+// emitted just above the TailCall which has reset ebp to the caller state.
 instruct TailCalljmpInd(eRegP_no_EBP jump_target, eBXRegP method_ptr) %{
   match(TailCall jump_target method_ptr);
   ins_cost(300);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12467,6 +12467,8 @@ instruct Ret()
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
+// Don't use rbp for the jump_target because the
+// MachEpilogNode that is inserted above will kill it.
 instruct TailCalljmpInd(no_rbp_RegP jump_target, rbx_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12467,8 +12467,8 @@ instruct Ret()
 // Also known as an 'interprocedural jump'.
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
-// Don't use rbp for the jump_target because the
-// MachEpilogNode that is inserted above will kill it.
+// Don't use rbp for 'jump_target' because a MachEpilogNode has already been
+// emitted just above the TailCall and it will reset rbp to the caller state.
 instruct TailCalljmpInd(no_rbp_RegP jump_target, rbx_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12468,7 +12468,7 @@ instruct Ret()
 // Target of jump will eventually return to caller.
 // TailJump below removes the return address.
 // Don't use rbp for 'jump_target' because a MachEpilogNode has already been
-// emitted just above the TailCall and it will reset rbp to the caller state.
+// emitted just above the TailCall which has reset rbp to the caller state.
 instruct TailCalljmpInd(no_rbp_RegP jump_target, rbx_RegP method_ptr)
 %{
   match(TailCall jump_target method_ptr);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -979,6 +979,21 @@ Compile::Compile( ciEnv* ci_env,
   _igvn_worklist = new (comp_arena()) Unique_Node_List(comp_arena());
   _types = new (comp_arena()) Type_Array(comp_arena());
   _node_hash = new (comp_arena()) NodeHash(comp_arena(), 255);
+
+ // If any phase is randomized for stress testing, seed random number
+ // generation and log the seed for repeatability.
+ if (StressLCM || StressGCM || StressIGVN || StressCCP || StressIncrementalInlining || StressMacroExpansion) {
+ if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
+ _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
+ FLAG_SET_ERGO(StressSeed, _stress_seed);
+ } else {
+ _stress_seed = StressSeed;
+ }
+ if (_log != nullptr) {
+ _log->elem("stress_test seed='%u'", _stress_seed);
+ }
+ }
+
   {
     PhaseGVN gvn;
     set_initial_gvn(&gvn);    // not significant, but GraphKit guys use it pervasively

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -979,21 +979,6 @@ Compile::Compile( ciEnv* ci_env,
   _igvn_worklist = new (comp_arena()) Unique_Node_List(comp_arena());
   _types = new (comp_arena()) Type_Array(comp_arena());
   _node_hash = new (comp_arena()) NodeHash(comp_arena(), 255);
-
- // If any phase is randomized for stress testing, seed random number
- // generation and log the seed for repeatability.
- if (StressLCM || StressGCM || StressIGVN || StressCCP || StressIncrementalInlining || StressMacroExpansion) {
- if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
- _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
- FLAG_SET_ERGO(StressSeed, _stress_seed);
- } else {
- _stress_seed = StressSeed;
- }
- if (_log != nullptr) {
- _log->elem("stress_test seed='%u'", _stress_seed);
- }
- }
-
   {
     PhaseGVN gvn;
     set_initial_gvn(&gvn);    // not significant, but GraphKit guys use it pervasively

--- a/test/hotspot/jtreg/compiler/arraycopy/TestTailCallInArrayCopyStub.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestTailCallInArrayCopyStub.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8329258
+ * @summary Test correct execution of the tail call at the end of the arraycopy stub.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation
+ *                   -XX:+StressGCM -XX:+StressLCM
+ *                   -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test
+ *                   compiler.arraycopy.TestTailCallInArrayCopyStub
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation 
+ *                   -XX:+StressGCM -XX:+StressLCM -XX:StressSeed=75451718
+ *                   -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test
+ *                   compiler.arraycopy.TestTailCallInArrayCopyStub
+ */
+
+package compiler.arraycopy;
+
+public class TestTailCallInArrayCopyStub {
+
+    public static void test(byte[] src, byte[] dst) {
+        try {
+            System.arraycopy(src, -1, dst, 0, src.length);
+        } catch (Exception e) {
+            // Expected
+        }
+    }
+
+    public static void main(String[] args) {
+        byte[] array = new byte[5];
+        for (int i = 0; i < 10_000; ++i) {
+            test(array, array);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/arraycopy/TestTailCallInArrayCopyStub.java
+++ b/test/hotspot/jtreg/compiler/arraycopy/TestTailCallInArrayCopyStub.java
@@ -31,7 +31,7 @@
  *                   -XX:+StressGCM -XX:+StressLCM
  *                   -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test
  *                   compiler.arraycopy.TestTailCallInArrayCopyStub
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation 
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation
  *                   -XX:+StressGCM -XX:+StressLCM -XX:StressSeed=75451718
  *                   -XX:CompileCommand=quiet -XX:CompileCommand=compileonly,*::test
  *                   compiler.arraycopy.TestTailCallInArrayCopyStub


### PR DESCRIPTION
Applying @danielogh's patch (see description of [JDK-8329258](https://bugs.openjdk.org/browse/JDK-8329258)) to enable `StressGCM` / `StressLCM` for stub compilations triggers a crash on AArch64. The problem is that the register allocator uses `R29` (`rfp`) which is usually used for the frame pointer to hold the `TailCall` `exc_target` when generating the `_slow_arraycopy_Java` stub:
https://github.com/openjdk/jdk/blob/6dfb8120c270a76fcba5a5c3c9ad91da3282d5fa/src/hotspot/share/opto/generateOptoStub.cpp#L258-L264

With `StressGCM` / `StressLCM` the register initialization is scheduled early and `R29` is corrupted by the `MachEpilogNode` which is opaque to the register allocator and inserted right before the `TailCall`:
https://github.com/openjdk/jdk/blob/b49ba426a721db5926ac1b45d573d468389d479c/src/hotspot/share/opto/output.cpp#L320-L326 

```
028 mov R29, 0x0000ffff78cc0080 # ptr

[...]

098     # pop frame 16
        ldp  lr, rfp, [sp,#0]              <- Epilog kills rfp (and lr + sp)
        add  sp, sp, #16

[...]

0a0 br R29 # R12 holds method
```

As a result, we jump to a "garbage" location. See [bad code](https://bugs.openjdk.org/secure/attachment/108835/BAD_slow_arraycopy_Java.txt) vs. [good code](https://bugs.openjdk.org/secure/attachment/108834/GOOD_slow_arraycopy_Java.txt).

On x86, we use `no_rbp_RegP` instead:
https://github.com/openjdk/jdk/blob/b49ba426a721db5926ac1b45d573d468389d479c/src/hotspot/cpu/x86/x86_64.ad#L2564-L2566 https://github.com/openjdk/jdk/blob/b49ba426a721db5926ac1b45d573d468389d479c/src/hotspot/cpu/x86/x86_64.ad#L12470

I implemented the same on AArch64.

I think other platforms are affected as well but I don't have the hardware to test there. @offamitkumar (S390), @TheRealMDoerr (PPC), @RealFYang (RISC-V), @bulasevich (ARM32), could you please have a look?

I also wondered if `R29` shouldn't be a callee-save (SOE) register in the C calling convention?
https://github.com/openjdk/jdk/blob/b49ba426a721db5926ac1b45d573d468389d479c/src/hotspot/cpu/aarch64/aarch64.ad#L139-L140 On x86_64, `RBP` is SOE:
https://github.com/openjdk/jdk/blob/b49ba426a721db5926ac1b45d573d468389d479c/src/hotspot/cpu/x86/x86_64.ad#L86-L87

`TestTailCallInArrayCopyStub.java` will only work once [JDK-8330016](https://bugs.openjdk.org/browse/JDK-8330016) is integrated.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329258](https://bugs.openjdk.org/browse/JDK-8329258): TailCall should not use frame pointer register for jump target (**Bug** - P2)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**) ⚠️ Review applies to [160ea006](https://git.openjdk.org/jdk/pull/18716/files/160ea00692a41806ce590a99b84a84de39c43f92)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18716/head:pull/18716` \
`$ git checkout pull/18716`

Update a local copy of the PR: \
`$ git checkout pull/18716` \
`$ git pull https://git.openjdk.org/jdk.git pull/18716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18716`

View PR using the GUI difftool: \
`$ git pr show -t 18716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18716.diff">https://git.openjdk.org/jdk/pull/18716.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18716#issuecomment-2047454787)