### PR TITLE
8329997: Add MemorySegment::reinterpretate overloads for alignment constraints

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import jdk.internal.misc.Unsafe;
 import jdk.internal.misc.VM;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
 
@@ -57,14 +58,18 @@ public class SegmentFactories {
     // associated with MemorySegment::ofAddress.
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl, Runnable action) {
+    public static MemorySegment makeNativeSegmentUnchecked(long min,
+                                                           long byteSize,
+                                                           long byteAlignment,
+                                                           MemorySessionImpl sessionImpl,
+                                                           Runnable action) {
         ensureInitialized();
         if (action == null) {
             sessionImpl.checkValidState();
         } else {
             sessionImpl.addCloseAction(action);
         }
-        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
+        return new NativeMemorySegmentImpl(Utils.alignUp(min, byteAlignment), byteSize, false, sessionImpl);
     }
 
     @ForceInline

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,8 @@ public class TestNulls {
 
     static final Set<String> EXCLUDE_LIST = Set.of(
             "java.lang.foreign.MemorySegment/reinterpret(java.lang.foreign.Arena,java.util.function.Consumer)/1/0",
-            "java.lang.foreign.MemorySegment/reinterpret(long,java.lang.foreign.Arena,java.util.function.Consumer)/2/0"
+            "java.lang.foreign.MemorySegment/reinterpret(long,java.lang.foreign.Arena,java.util.function.Consumer)/2/0",
+            "java.lang.foreign.MemorySegment/reinterpret(java.lang.foreign.MemoryLayout,java.lang.foreign.Arena,java.util.function.Consumer)/2/0"
     );
 
     static final Set<String> OBJECT_METHODS = Stream.of(Object.class.getMethods())

--- a/test/jdk/java/foreign/TestRestricted.java
+++ b/test/jdk/java/foreign/TestRestricted.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,8 +85,10 @@ public class TestRestricted {
             RestrictedMethod.of(Linker.class, "downcallHandle", MethodHandle.class, MemorySegment.class, FunctionDescriptor.class, Linker.Option[].class),
             RestrictedMethod.of(Linker.class, "upcallStub", MemorySegment.class, MethodHandle.class, FunctionDescriptor.class, Arena.class, Linker.Option[].class),
             RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, long.class),
+            RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, MemoryLayout.class),
             RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, Arena.class, Consumer.class),
             RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, long.class, Arena.class, Consumer.class),
+            RestrictedMethod.of(MemorySegment.class, "reinterpret", MemorySegment.class, MemoryLayout.class, Arena.class, Consumer.class),
             RestrictedMethod.of(AddressLayout.class, "withTargetLayout", AddressLayout.class, MemoryLayout.class),
             RestrictedMethod.of(ModuleLayer.Controller.class, "enableNativeAccess", ModuleLayer.Controller.class, Module.class)
     );

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This PR proposes to add two overloads `MemorySegment::reinterpretate` to allow aligned reinterpretation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8329997](https://bugs.openjdk.org/browse/JDK-8329997)

### Issue
 * [JDK-8329997](https://bugs.openjdk.org/browse/JDK-8329997): Add MemorySegment::reinterpret overloads for alignment constraints (**Enhancement** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18717/head:pull/18717` \
`$ git checkout pull/18717`

Update a local copy of the PR: \
`$ git checkout pull/18717` \
`$ git pull https://git.openjdk.org/jdk.git pull/18717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18717`

View PR using the GUI difftool: \
`$ git pr show -t 18717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18717.diff">https://git.openjdk.org/jdk/pull/18717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18717#issuecomment-2047465652)