### PR TITLE
8330006: Serial: Extract out ContiguousSpace::block_start_const

### DIFF
--- a/src/hotspot/share/gc/serial/cardTableRS.cpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.cpp
@@ -31,9 +31,9 @@
 #include "memory/iterator.inline.hpp"
 #include "utilities/align.hpp"
 
-void CardTableRS::scan_old_to_young_refs(TenuredSpace* sp, HeapWord* saved_mark_word) {
-  const MemRegion ur    = sp->used_region();
-  const MemRegion urasm = MemRegion(sp->bottom(), saved_mark_word);
+void CardTableRS::scan_old_to_young_refs(TenuredGeneration* tg, HeapWord* saved_mark_word) {
+  const MemRegion ur    = tg->used_region();
+  const MemRegion urasm = MemRegion(tg->space()->bottom(), saved_mark_word);
 
   assert(ur.contains(urasm),
          "Did you forget to call save_marks()? "
@@ -43,7 +43,7 @@ void CardTableRS::scan_old_to_young_refs(TenuredSpace* sp, HeapWord* saved_mark_
 
   if (!urasm.is_empty()) {
     OldGenScanClosure cl(SerialHeap::heap()->young_gen());
-    non_clean_card_iterate(sp, urasm, &cl);
+    non_clean_card_iterate(tg, urasm, &cl);
   }
 }
 
@@ -225,7 +225,7 @@ static void scan_obj_with_limit(oop obj,
   }
 }
 
-void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
+void CardTableRS::non_clean_card_iterate(TenuredGeneration* tg,
                                          MemRegion mr,
                                          OldGenScanClosure* cl) {
   struct {
@@ -238,7 +238,7 @@ void CardTableRS::non_clean_card_iterate(TenuredSpace* sp,
       assert(cached_obj.start_addr != nullptr, "inv");
       return cached_obj.start_addr;
     }
-    HeapWord* result = sp->block_start_const(addr);
+    HeapWord* result = tg->block_start(addr);
 
     cached_obj.start_addr = result;
     cached_obj.end_addr = result + cast_to_oop(result)->size();

--- a/src/hotspot/share/gc/serial/cardTableRS.hpp
+++ b/src/hotspot/share/gc/serial/cardTableRS.hpp
@@ -60,7 +60,7 @@ class CardTableRS : public CardTable {
 public:
   CardTableRS(MemRegion whole_heap);
 
-  void scan_old_to_young_refs(TenuredSpace* sp, HeapWord* saved_mark_word);
+  void scan_old_to_young_refs(TenuredGeneration* tg, HeapWord* saved_mark_word);
 
   void inline_write_ref_field_gc(void* field) {
     CardValue* byte = byte_for(field);
@@ -83,7 +83,7 @@ public:
   // Iterate over the portion of the card-table which covers the given
   // region mr in the given space and apply cl to any dirty sub-regions
   // of mr. Clears the dirty cards as they are processed.
-  void non_clean_card_iterate(TenuredSpace* sp,
+  void non_clean_card_iterate(TenuredGeneration* tg,
                               MemRegion mr,
                               OldGenScanClosure* cl);
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -589,7 +589,7 @@ void DefNewGeneration::object_iterate(ObjectClosure* blk) {
 }
 
 // Very general, slow implementation.
-HeapWord* DefNewGeneration::block_start_const(const ContiguousSpace* cs, const void* p) const {
+HeapWord* DefNewGeneration::block_start_const(const ContiguousSpace* cs, const void* p) {
   assert(MemRegion(cs->bottom(), cs->end()).contains(p),
          "p (" PTR_FORMAT ") not in space [" PTR_FORMAT ", " PTR_FORMAT ")",
          p2i(p), p2i(cs->bottom()), p2i(cs->end()));

--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -588,8 +588,12 @@ void DefNewGeneration::object_iterate(ObjectClosure* blk) {
   from()->object_iterate(blk);
 }
 
+// If "p" is in the space, returns the address of the start of the
+// "block" that contains "p".  We say "block" instead of "object" since
+// some heaps may not pack objects densely; a chunk may either be an
+// object or a non-object.  If "p" is not in the space, return null.
 // Very general, slow implementation.
-HeapWord* DefNewGeneration::block_start_const(const ContiguousSpace* cs, const void* p) {
+static HeapWord* block_start_const(const ContiguousSpace* cs, const void* p) {
   assert(MemRegion(cs->bottom(), cs->end()).contains(p),
          "p (" PTR_FORMAT ") not in space [" PTR_FORMAT ", " PTR_FORMAT ")",
          p2i(p), p2i(cs->bottom()), p2i(cs->end()));

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -159,7 +159,7 @@ class DefNewGeneration: public Generation {
   // "block" that contains "p".  We say "block" instead of "object" since
   // some heaps may not pack objects densely; a chunk may either be an
   // object or a non-object.  If "p" is not in the space, return null.
-  HeapWord* block_start_const(const ContiguousSpace* cs, const void* p) const;
+  static HeapWord* block_start_const(const ContiguousSpace* cs, const void* p);
 
  public:
   DefNewGeneration(ReservedSpace rs,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -155,6 +155,12 @@ class DefNewGeneration: public Generation {
     return n > alignment ? align_down(n, alignment) : alignment;
   }
 
+  // If "p" is in the space, returns the address of the start of the
+  // "block" that contains "p".  We say "block" instead of "object" since
+  // some heaps may not pack objects densely; a chunk may either be an
+  // object or a non-object.  If "p" is not in the space, return null.
+  HeapWord* block_start_const(const ContiguousSpace* cs, const void* p) const;
+
  public:
   DefNewGeneration(ReservedSpace rs,
                    size_t initial_byte_size,

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -155,12 +155,6 @@ class DefNewGeneration: public Generation {
     return n > alignment ? align_down(n, alignment) : alignment;
   }
 
-  // If "p" is in the space, returns the address of the start of the
-  // "block" that contains "p".  We say "block" instead of "object" since
-  // some heaps may not pack objects densely; a chunk may either be an
-  // object or a non-object.  If "p" is not in the space, return null.
-  static HeapWord* block_start_const(const ContiguousSpace* cs, const void* p);
-
  public:
   DefNewGeneration(ReservedSpace rs,
                    size_t initial_byte_size,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -264,11 +264,7 @@ void TenuredGeneration::compute_new_size_inner() {
   }
 }
 
-HeapWord* TenuredGeneration::block_start(const void* p) const {
-  return block_start_const(p);
-}
-
-HeapWord* TenuredGeneration::block_start_const(const void* addr) const {
+HeapWord* TenuredGeneration::block_start(const void* addr) const {
   HeapWord* cur_block = _bts->block_start_reaching_into_card(addr);
 
   while (true) {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -265,11 +265,27 @@ void TenuredGeneration::compute_new_size_inner() {
 }
 
 HeapWord* TenuredGeneration::block_start(const void* p) const {
-  return space()->block_start_const(p);
+  return block_start_const(p);
+}
+
+HeapWord* TenuredGeneration::block_start_const(const void* addr) const {
+  HeapWord* cur_block = _bts->block_start_reaching_into_card(addr);
+
+  while (true) {
+    HeapWord* next_block = cur_block + cast_to_oop(cur_block)->size();
+    if (next_block > addr) {
+      assert(cur_block <= addr, "postcondition");
+      return cur_block;
+    }
+    cur_block = next_block;
+    // Because the BOT is precise, we should never step into the next card
+    // (i.e. crossing the card boundary).
+    assert(!SerialBlockOffsetTable::is_crossing_card_boundary(cur_block, (HeapWord*)addr), "must be");
+  }
 }
 
 void TenuredGeneration::scan_old_to_young_refs() {
-  _rs->scan_old_to_young_refs(space(), saved_mark_word());
+  _rs->scan_old_to_young_refs(this, saved_mark_word());
 }
 
 TenuredGeneration::TenuredGeneration(ReservedSpace rs,

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -85,6 +85,8 @@ class TenuredGeneration: public Generation {
 
   void compute_new_size_inner();
 
+  HeapWord* block_start_const(const void* addr) const;
+
 public:
   void compute_new_size();
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -85,8 +85,6 @@ class TenuredGeneration: public Generation {
 
   void compute_new_size_inner();
 
-  HeapWord* block_start_const(const void* addr) const;
-
 public:
   void compute_new_size();
 
@@ -114,7 +112,7 @@ public:
     return _virtual_space.uncommitted_size() == 0;
   }
 
-  HeapWord* block_start(const void* p) const;
+  HeapWord* block_start(const void* addr) const;
 
   void scan_old_to_young_refs();
 

--- a/src/hotspot/share/gc/shared/space.cpp
+++ b/src/hotspot/share/gc/shared/space.cpp
@@ -125,25 +125,6 @@ void ContiguousSpace::object_iterate(ObjectClosure* blk) {
   }
 }
 
-// Very general, slow implementation.
-HeapWord* ContiguousSpace::block_start_const(const void* p) const {
-  assert(MemRegion(bottom(), end()).contains(p),
-         "p (" PTR_FORMAT ") not in space [" PTR_FORMAT ", " PTR_FORMAT ")",
-         p2i(p), p2i(bottom()), p2i(end()));
-  if (p >= top()) {
-    return top();
-  } else {
-    HeapWord* last = bottom();
-    HeapWord* cur = last;
-    while (cur <= p) {
-      last = cur;
-      cur += cast_to_oop(cur)->size();
-    }
-    assert(oopDesc::is_oop(cast_to_oop(last)), PTR_FORMAT " should be an object start", p2i(last));
-    return last;
-  }
-}
-
 // This version requires locking.
 inline HeapWord* ContiguousSpace::allocate_impl(size_t size) {
   assert(Heap_lock->owned_by_self() ||
@@ -191,22 +172,6 @@ HeapWord* ContiguousSpace::par_allocate(size_t size) {
 }
 
 #if INCLUDE_SERIALGC
-HeapWord* TenuredSpace::block_start_const(const void* addr) const {
-  HeapWord* cur_block = _offsets->block_start_reaching_into_card(addr);
-
-  while (true) {
-    HeapWord* next_block = cur_block + cast_to_oop(cur_block)->size();
-    if (next_block > addr) {
-      assert(cur_block <= addr, "postcondition");
-      return cur_block;
-    }
-    cur_block = next_block;
-    // Because the BOT is precise, we should never step into the next card
-    // (i.e. crossing the card boundary).
-    assert(!SerialBlockOffsetTable::is_crossing_card_boundary(cur_block, (HeapWord*)addr), "must be");
-  }
-}
-
 TenuredSpace::TenuredSpace(SerialBlockOffsetTable* offsets,
                            MemRegion mr) :
   _offsets(offsets)

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -169,12 +169,6 @@ public:
   // Iteration
   void object_iterate(ObjectClosure* blk);
 
-  // If "p" is in the space, returns the address of the start of the
-  // "block" that contains "p".  We say "block" instead of "object" since
-  // some heaps may not pack objects densely; a chunk may either be an
-  // object or a non-object.  If "p" is not in the space, return null.
-  virtual HeapWord* block_start_const(const void* p) const;
-
   // Addresses for inlined allocation
   HeapWord** top_addr() { return &_top; }
 
@@ -196,8 +190,6 @@ class TenuredSpace: public ContiguousSpace {
   // Constructor
   TenuredSpace(SerialBlockOffsetTable* offsets,
                MemRegion mr);
-
-  HeapWord* block_start_const(const void* addr) const override;
 
   // Add offset table update.
   inline HeapWord* allocate(size_t word_size) override;


### PR DESCRIPTION
Hi all,

This patch moves the method `ContiguousSpace::block_start_const` to `DefNewGeneration` (note: not the parent class `Generation`) and moves the method `TenuredSpace::block_start_const` to `TenuredGeneration`. These two methods don't need  the same signature so I don't add a virtual method to the parent class `Generation`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330006](https://bugs.openjdk.org/browse/JDK-8330006): Serial: Extract out ContiguousSpace::block_start_const (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18722/head:pull/18722` \
`$ git checkout pull/18722`

Update a local copy of the PR: \
`$ git checkout pull/18722` \
`$ git pull https://git.openjdk.org/jdk.git pull/18722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18722`

View PR using the GUI difftool: \
`$ git pr show -t 18722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18722.diff">https://git.openjdk.org/jdk/pull/18722.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18722#issuecomment-2047517814)