### PR TITLE
8325494: C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2013,10 +2013,10 @@ bool IdealLoopTree::is_invariant(Node* n) const {
 // to the new stride.
 void PhaseIdealLoop::update_main_loop_assertion_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init,
                                                            const int stride_con) {
-  if (init->Opcode() == Op_CastII) {
+  if (init->is_CastII()) {
     // skip over the cast added by PhaseIdealLoop::cast_incr_before_loop() when pre/post/main loops are created because
     // it can get in the way of type propagation
-    assert(((CastIINode*)init)->carry_dependency() && loop_head->skip_assertion_predicates_with_halt() == init->in(0), "casted iv phi from pre loop expected");
+    assert(init->as_CastII()->carry_dependency() && loop_head->skip_assertion_predicates_with_halt() == init->in(0), "casted iv phi from pre loop expected");
     init = init->in(1);
   }
   Node* entry = ctrl;

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2013,6 +2013,12 @@ bool IdealLoopTree::is_invariant(Node* n) const {
 // to the new stride.
 void PhaseIdealLoop::update_main_loop_assertion_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init,
                                                            const int stride_con) {
+  if (init->Opcode() == Op_CastII) {
+    // skip over the cast added by PhaseIdealLoop::cast_incr_before_loop() when pre/post/main loops are created because
+    // it can get in the way of type propagation
+    assert(((CastIINode*)init)->carry_dependency() && loop_head->skip_assertion_predicates_with_halt() == init->in(0), "casted iv phi from pre loop expected");
+    init = init->in(1);
+  }
   Node* entry = ctrl;
   Node* prev_proj = ctrl;
   LoopNode* outer_loop_head = loop_head->skip_strip_mined();

--- a/test/hotspot/jtreg/compiler/loopopts/TestAssertPredicateDoesntConstantFold.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestAssertPredicateDoesntConstantFold.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8325494
+ * @summary C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=TestAssertPredicateDoesntConstantFold::test TestAssertPredicateDoesntConstantFold
+ *
+ */
+
+public class TestAssertPredicateDoesntConstantFold {
+    static boolean bFld;
+    static int iArrFld[];
+    static long lArrFld[];
+
+    public static void main(String[] strArr) {
+        try {
+            test();
+        } catch (NullPointerException npe) {}
+    }
+
+    static long test() {
+        int i6 = 1, i7, i11;
+        do {
+            for (i7 = 1; i7 < 9; ++i7) {
+                for (i11 = 2; i6 < i11; i11 -= 2) {
+                    if (bFld) {
+                        break;
+                    }
+
+                    lArrFld[i11 + 1] = 6;
+                    iArrFld[i11 % 20] = 3;
+                }
+            }
+        } while (++i6 < 8);
+
+        return i6;
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/predicates/TestAssertionPredicateDoesntConstantFold.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestAssertionPredicateDoesntConstantFold.java
@@ -25,11 +25,11 @@
  * @test
  * @bug 8325494
  * @summary C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902
- * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=TestAssertPredicateDoesntConstantFold::test TestAssertPredicateDoesntConstantFold
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileOnly=TestAssertionPredicateDoesntConstantFold::test TestAssertionPredicateDoesntConstantFold
  *
  */
 
-public class TestAssertPredicateDoesntConstantFold {
+public class TestAssertionPredicateDoesntConstantFold {
     static boolean bFld;
     static int iArrFld[];
     static long lArrFld[];


### PR DESCRIPTION
After range check elimination, a cast in the main loop becomes top
because the type of its input (that depends on the iv phi) and the
type recorded in the cast do not intersect. This is a case that's
expected to be caught by assert predicates but, in this particular
case, no assert predicate constant folds.

The stride for the loop is -2. The iv phi type is `min+1..0`

As a consequence, the init value for the main loop has type int.

The range check that causes the issue is for array access:
```
lArrFld[i11 + 1] = 6;
```

The main loop is unrolled once. The second access in the loop is at
`i11 - 1` which has type `min..-1`. The range check cast at that
access becomes top. The assert predicates operates on an init value
that has the shape:

```
(CastII (AddI pre_loop_iv -2) int)
```

and type int.

That `CastII` is inserted by `PhaseIdealLoop::cast_incr_before_loop()`.

The assert predicate for the first iteration in the main loop is for
index:

```
(AddI (CastII (AddI pre_loop_iv -2) int) 1)
```

And for the second:

```
(AddI (CastII (AddI pre_loop_iv -2) int) -1)
```

Both have type int so the assert predicate can't constant fold.

I initially fixed this by changing the type of the cast from int to
the type of the iv phi:

```
(AddI (CastII (AddI pre_loop_iv -2) min+1..0) -1)
```

That allows the assert predicate for the second iteration to constant
fold. But I was then worried narrowing the type of the cast would
causes issues going forward so instead, I propose proceeding as in
8282592 and have assert predicates skip over the CastII (that part of
8282592 was later undone):

```
(AddI (AddI pre_loop_iv -2) 1)
```

which allows the assert predicate for the first iteration in the main
loop to constant fold.

The change from 8282592 caused issues because we used to narrow the
type of a cast based on the condition that guards it. That was removed
by 8319372.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325494](https://bugs.openjdk.org/browse/JDK-8325494): C2: Broken graph after not skipping CastII node anymore for Assertion Predicates after JDK-8309902 (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18724/head:pull/18724` \
`$ git checkout pull/18724`

Update a local copy of the PR: \
`$ git checkout pull/18724` \
`$ git pull https://git.openjdk.org/jdk.git pull/18724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18724`

View PR using the GUI difftool: \
`$ git pr show -t 18724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18724.diff">https://git.openjdk.org/jdk/pull/18724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18724#issuecomment-2047595088)