### PR TITLE
8330033: com/sun/net/httpserver/bugs/B6431193.java fails in AssertionError after JDK-8326568

### DIFF
--- a/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
+++ b/test/jdk/com/sun/net/httpserver/bugs/B6431193.java
@@ -50,10 +50,9 @@ public class B6431193 {
                     is.readAllBytes();
                     // .. read the request body
                     String response = "This is the response";
+                    handlerIsDaemon = Thread.currentThread().isDaemon();
                     t.sendResponseHeaders(200, response.length());
                     os.write(response.getBytes());
-                } finally {
-                    handlerIsDaemon = Thread.currentThread().isDaemon();
                 }
             }
         }


### PR DESCRIPTION
After integrating [JDK-8326568](https://bugs.openjdk.org/browse/JDK-8326568), B6431193 has been failing due to a suspected race condition on whether the `handlerIsDaemon` is set.

- Moved setting `handlerIsDaemon` from the finally block to before the response is sent