### PR TITLE
8330053: JFR: Use LocalDateTime instead ZonedDateTime

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -28,7 +28,6 @@ package jdk.jfr.internal;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -81,7 +80,7 @@ public final class Repository {
     }
 
     synchronized RepositoryChunk newChunk() {
-        ZonedDateTime timestamp = ZonedDateTime.now();
+        LocalDateTime timestamp = LocalDateTime.now();
         try {
             if (!SecuritySupport.existDirectory(repository)) {
                 this.repository = createRepository(baseLocation);
@@ -93,7 +92,7 @@ public final class Repository {
             if (chunkFilename == null) {
                 chunkFilename = ChunkFilename.newPriviliged(repository.toPath());
             }
-            String filename = chunkFilename.next(timestamp.toLocalDateTime());
+            String filename = chunkFilename.next(timestamp);
             return new RepositoryChunk(new SafePath(filename));
         } catch (Exception e) {
             String errorMsg = String.format("Could not create chunk in repository %s, %s: %s", repository, e.getClass(), e.getMessage());


### PR DESCRIPTION
Could I have a review of PR that changes so LocalDateTime instead of ZonedDateTime is used when naming chunk files. Problem is that a java.time.DateTimeException occurs when ZonedDateTime.now() is used and the time zone is invalid. This happens in a JCK test.

Testing: jdk/jdk/jfr + applicable test in JCK.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330053](https://bugs.openjdk.org/browse/JDK-8330053): JFR: Use LocalDateTime instead ZonedDateTime (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [830de986](https://git.openjdk.org/jdk/pull/18729/files/830de9868606ce3c560724a71a9cebfb25cc7701)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18729/head:pull/18729` \
`$ git checkout pull/18729`

Update a local copy of the PR: \
`$ git checkout pull/18729` \
`$ git pull https://git.openjdk.org/jdk.git pull/18729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18729`

View PR using the GUI difftool: \
`$ git pr show -t 18729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18729.diff">https://git.openjdk.org/jdk/pull/18729.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18729#issuecomment-2049685626)