### PR TITLE
8330061: Cleanup: follow code heaps order in CodeCache initialization and logging, code heap info in logs

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -272,10 +272,10 @@ void CodeCache::initialize_heaps() {
 
   // Validation
   // Check minimal required sizes
-  check_min_size("non-nmethod code heap", non_nmethod.size, non_nmethod_min_size);
   if (profiled.enabled) {
     check_min_size("profiled code heap", profiled.size, min_size);
   }
+  check_min_size("non-nmethod code heap", non_nmethod.size, non_nmethod_min_size);
   if (non_profiled.enabled) { // non_profiled.enabled is always ON for segmented code heap, leave it checked for clarity
     check_min_size("non-profiled code heap", non_profiled.size, min_size);
   }


### PR DESCRIPTION
This is an additional tiny cleanup after CodeCache::initialize_heaps refactoring (JDK-8311248). CodeCache::initialize_heaps: code heaps info is printed in code heaps order, final size adjustments and flags are made in code heaps order. CodeCache::allocate: assertion message contains blob type. CodeCache::print_trace: name of the heap containing the method is printed.

Testing: jtreg test/hotspot/jtreg/compiler/codecache, tier1, tier2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330061](https://bugs.openjdk.org/browse/JDK-8330061): Cleanup: follow code heaps order in CodeCache initialization and logging, code heap info in logs (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18732/head:pull/18732` \
`$ git checkout pull/18732`

Update a local copy of the PR: \
`$ git checkout pull/18732` \
`$ git pull https://git.openjdk.org/jdk.git pull/18732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18732`

View PR using the GUI difftool: \
`$ git pr show -t 18732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18732.diff">https://git.openjdk.org/jdk/pull/18732.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18732#issuecomment-2048537494)