### PR TITLE
8330064: JFR: Incorrect function declarations for register/unregister_stack_filter

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -161,9 +161,9 @@ jlong JNICALL jfr_host_total_swap_memory(JNIEnv* env, jclass jvm);
 
 void JNICALL jfr_emit_data_loss(JNIEnv* env, jclass jvm, jlong bytes);
 
-jlong JNICALL jfr_register_stack_filter(JNIEnv* env, jobject classes, jobject methods);
+jlong JNICALL jfr_register_stack_filter(JNIEnv* env, jclass jvm, jobjectArray classes, jobjectArray methods);
 
-jlong JNICALL jfr_unregister_stack_filter(JNIEnv* env, jlong start_filter_id);
+jlong JNICALL jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The commit from [JDK-8314745](https://bugs.openjdk.org/browse/JDK-8314745) contains
```
jlong JNICALL jfr_register_stack_filter(JNIEnv* env, jobject classes, jobject methods);
jlong JNICALL jfr_unregister_stack_filter(JNIEnv* env, jlong start_filter_id);
```
in `jfrJniMethod.hpp`, but the definitions have different signatures:
```
JVM_ENTRY_NO_ENV(jlong, jfr_register_stack_filter(JNIEnv* env, jclass jvm, jobjectArray classes, jobjectArray methods))
  return JfrStackFilterRegistry::add(classes, methods, thread);
JVM_END

JVM_ENTRY_NO_ENV(void, jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id))
  JfrStackFilterRegistry::remove(id);
JVM_END
```

This fixes the declarations to match the definitions.

The issue was detected attempting a 32-bit Windows built. Unclear why our main toolchains have not complained about this.

Testing: 
  - tiers 1-3 (sanity)
  - GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330064](https://bugs.openjdk.org/browse/JDK-8330064): JFR: Incorrect function declarations for register/unregister_stack_filter (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18733/head:pull/18733` \
`$ git checkout pull/18733`

Update a local copy of the PR: \
`$ git checkout pull/18733` \
`$ git pull https://git.openjdk.org/jdk.git pull/18733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18733`

View PR using the GUI difftool: \
`$ git pr show -t 18733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18733.diff">https://git.openjdk.org/jdk/pull/18733.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18733#issuecomment-2048710681)