### PR TITLE
8289770: Remove Windows version macro from ShellFolder2.cpp

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/ShellFolder2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -118,17 +118,6 @@ static jstring lsName;
 static jstring lsSize;
 static jstring lsType;
 static jstring lsDate;
-
-// Some macros from awt.h, because it is not included in release
-#ifndef IS_WIN2000
-#define IS_WIN2000 (LOBYTE(LOWORD(::GetVersion())) >= 5)
-#endif
-#ifndef IS_WINXP
-#define IS_WINXP ((IS_WIN2000 && HIBYTE(LOWORD(::GetVersion())) >= 1) || LOBYTE(LOWORD(::GetVersion())) > 5)
-#endif
-#ifndef IS_WINVISTA
-#define IS_WINVISTA (!(::GetVersion() & 0x80000000) && LOBYTE(LOWORD(::GetVersion())) >= 6)
-#endif
 
 
 extern "C" {
@@ -1090,12 +1079,10 @@ JNIEXPORT jintArray JNICALL Java_sun_awt_shell_Win32ShellFolder2_getIconBits
                 // XP supports alpha in some icons, and depending on device.
                 // This should take precedence over the icon mask bits.
                 BOOL hasAlpha = FALSE;
-                if (IS_WINXP) {
-                    for (int i = 0; i < nBits; i++) {
-                        if ((colorBits[i] & 0xff000000) != 0) {
-                            hasAlpha = TRUE;
-                            break;
-                        }
+                for (int i = 0; i < nBits; i++) {
+                    if ((colorBits[i] & 0xff000000) != 0) {
+                        hasAlpha = TRUE;
+                        break;
                     }
                 }
                 if (!hasAlpha) {


### PR DESCRIPTION
This clean-up PR removes unused Windows version macro from `ShellFolder2.cpp`.

`IS_WINVISTA` was not used at all.

`IS_WINXP` guarded support for icons with alpha channel. It is now safe to assume Java runs on a Windows version later than Windows XP. Java launchers specify 6.0 as the minimum OS version which corresponds to Windows Vista.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289770](https://bugs.openjdk.org/browse/JDK-8289770): Remove Windows version macro from ShellFolder2.cpp (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18736/head:pull/18736` \
`$ git checkout pull/18736`

Update a local copy of the PR: \
`$ git checkout pull/18736` \
`$ git pull https://git.openjdk.org/jdk.git pull/18736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18736`

View PR using the GUI difftool: \
`$ git pr show -t 18736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18736.diff">https://git.openjdk.org/jdk/pull/18736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18736#issuecomment-2049309266)