### PR TITLE
8330095: RISC-V: Remove obsolete vandn_vi instruction

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1870,7 +1870,6 @@ enum Nf {
   // Vector Bit-manipulation used in Cryptography (Zvkb) Extension
   INSN(vandn_vv,   0b1010111, 0b000, 0b000001);
   INSN(vandn_vx,   0b1010111, 0b100, 0b000001);
-  INSN(vandn_vi,   0b1010111, 0b011, 0b000001);
   INSN(vclmul_vv,  0b1010111, 0b010, 0b001100);
   INSN(vclmul_vx,  0b1010111, 0b110, 0b001100);
   INSN(vclmulh_vv, 0b1010111, 0b010, 0b001101);


### PR DESCRIPTION
Hi, We notice that the `vandn_vi` instruction is defined in the current code and is not used anywhere, it is not available in the riscv-crypto Release-1.0.0 manual. The `vandn_vi` instruction is present in earlier riscv-crypto manual, but the `vandnvi` has been removed from the https://github.com/riscv/riscv-crypto/commit/82a02f09668adb18dfee5dfc45a0ce7d3af10103 commit.

### Testing
- [x]  fastdebug build successfully

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330095](https://bugs.openjdk.org/browse/JDK-8330095): RISC-V: Remove obsolete vandn_vi instruction (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18737/head:pull/18737` \
`$ git checkout pull/18737`

Update a local copy of the PR: \
`$ git checkout pull/18737` \
`$ git pull https://git.openjdk.org/jdk.git pull/18737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18737`

View PR using the GUI difftool: \
`$ git pr show -t 18737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18737.diff">https://git.openjdk.org/jdk/pull/18737.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18737#issuecomment-2049477233)