### PR TITLE
8323429: Missing C2 optimization for FP min/max when both inputs are same

### DIFF
--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -57,6 +57,7 @@ Node* AddNode::Identity(PhaseGVN* phase) {
   const Type *zero = add_id();  // The additive identity
   if( phase->type( in(1) )->higher_equal( zero ) ) return in(2);
   if( phase->type( in(2) )->higher_equal( zero ) ) return in(1);
+  if ( in(1) == in(2) ) return in(1);
   return this;
 }
 

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -57,7 +57,7 @@ Node* AddNode::Identity(PhaseGVN* phase) {
   const Type *zero = add_id();  // The additive identity
   if( phase->type( in(1) )->higher_equal( zero ) ) return in(2);
   if( phase->type( in(2) )->higher_equal( zero ) ) return in(1);
-  if ( in(1) == in(2) ) return in(1);
+  if ( ( this->Opcode() == this->max_opcode() || this->Opcode() == this->min_opcode() ) && in(1) == in(2) ) return in(1);
   return this;
 }
 

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -1417,7 +1417,9 @@ Node* MinLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
 }
 
 Node* MaxNode::Identity(PhaseGVN* phase) {
-  if ( in(1) == in(2) ) return in(1);
+  if (in(1) == in(2)) {
+      return in(1);
+  }
 
   return AddNode::Identity(phase);
 }

--- a/src/hotspot/share/opto/addnode.cpp
+++ b/src/hotspot/share/opto/addnode.cpp
@@ -57,7 +57,6 @@ Node* AddNode::Identity(PhaseGVN* phase) {
   const Type *zero = add_id();  // The additive identity
   if( phase->type( in(1) )->higher_equal( zero ) ) return in(2);
   if( phase->type( in(2) )->higher_equal( zero ) ) return in(1);
-  if ( ( this->Opcode() == this->max_opcode() || this->Opcode() == this->min_opcode() ) && in(1) == in(2) ) return in(1);
   return this;
 }
 
@@ -1415,6 +1414,12 @@ Node* MinLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     return fold_subI_no_underflow_pattern(this, phase);
   }
   return nullptr;
+}
+
+Node* MaxNode::Identity(PhaseGVN* phase) {
+  if ( in(1) == in(2) ) return in(1);
+
+  return AddNode::Identity(phase);
 }
 
 //------------------------------add_ring---------------------------------------

--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -269,6 +269,7 @@ public:
   virtual int max_opcode() const = 0;
   virtual int min_opcode() const = 0;
   Node* IdealI(PhaseGVN* phase, bool can_reshape);
+  virtual Node* Identity(PhaseGVN* phase);
 
   static Node* unsigned_max(Node* a, Node* b, const Type* t, PhaseGVN& gvn) {
     return build_min_max(a, b, true, true, t, gvn);

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
@@ -45,30 +45,30 @@ public class TestFpMinMaxOpt {
     }
 
     @Test
-    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @Arguments(values = {Argument.NUMBER_42})
     @IR(counts = {IRNode.MIN_F, "1"})
-    private static float testFloatMin(float a, float b) {
-        return Math.min(a, b);
+    private static float testFloatMin(float v) {
+        return Math.min(v, v);
     }
 
     @Test
-    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @Arguments(values = {Argument.NUMBER_42})
     @IR(counts = {IRNode.MAX_F, "1"})
-    private static float testFloatMax(float a, float b) {
-        return Math.max(a, b);
+    private static float testFloatMax(float v) {
+        return Math.max(v, v);
     }
 
     @Test
-    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @Arguments(values = {Argument.NUMBER_42})
     @IR(counts = {IRNode.MIN_D, "1"})
-    private static double testDoubleMin(double a, double b) {
-        return Math.min(a, b);
+    private static double testDoubleMin(double v) {
+        return Math.min(v, v);
     }
 
     @Test
-    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @Arguments(values = {Argument.NUMBER_42})
     @IR(counts = {IRNode.MAX_D, "1"})
-    private static double testDoubleMax(double a, double b) {
-        return Math.max(a, b);
+    private static double testDoubleMax(double v) {
+        return Math.max(v, v);
     }
 }

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287087
+ * @summary ...
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.intrinsics.math.TestFpMinMaxOpt
+ */
+
+package compiler.intrinsics.math;
+
+import compiler.lib.ir_framework.Argument;
+import compiler.lib.ir_framework.Arguments;
+import compiler.lib.ir_framework.IR;
+import compiler.lib.ir_framework.IRNode;
+import compiler.lib.ir_framework.Test;
+import compiler.lib.ir_framework.TestFramework;
+
+public class TestFpMinMaxOpt {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @IR(counts = {IRNode.MIN_F, "1"})
+    private static float testFloatMin(float a, float b) {
+        return Math.min(a, b);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @IR(counts = {IRNode.MAX_F, "1"})
+    private static float testFloatMax(float a, float b) {
+        return Math.max(a, b);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @IR(counts = {IRNode.MIN_D, "1"})
+    private static double testDoubleMin(double a, double b) {
+        return Math.min(a, b);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42, Argument.NUMBER_42})
+    @IR(counts = {IRNode.MAX_D, "1"})
+    private static double testDoubleMax(double a, double b) {
+        return Math.max(a, b);
+    }
+}

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestFpMinMaxOpt.java
@@ -46,28 +46,28 @@ public class TestFpMinMaxOpt {
 
     @Test
     @Arguments(values = {Argument.NUMBER_42})
-    @IR(counts = {IRNode.MIN_F, "1"})
+    @IR(counts = {IRNode.MIN_F, "0"})
     private static float testFloatMin(float v) {
         return Math.min(v, v);
     }
 
     @Test
     @Arguments(values = {Argument.NUMBER_42})
-    @IR(counts = {IRNode.MAX_F, "1"})
+    @IR(counts = {IRNode.MAX_F, "0"})
     private static float testFloatMax(float v) {
         return Math.max(v, v);
     }
 
     @Test
     @Arguments(values = {Argument.NUMBER_42})
-    @IR(counts = {IRNode.MIN_D, "1"})
+    @IR(counts = {IRNode.MIN_D, "0"})
     private static double testDoubleMin(double v) {
         return Math.min(v, v);
     }
 
     @Test
     @Arguments(values = {Argument.NUMBER_42})
-    @IR(counts = {IRNode.MAX_D, "1"})
+    @IR(counts = {IRNode.MAX_D, "0"})
     private static double testDoubleMax(double v) {
         return Math.max(v, v);
     }

--- a/test/hotspot/jtreg/compiler/intrinsics/math/TestMinMaxOpt.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/math/TestMinMaxOpt.java
@@ -27,7 +27,7 @@
  * @summary ...
  * @library /test/lib /
  * @requires vm.compiler2.enabled
- * @run driver compiler.intrinsics.math.TestFpMinMaxOpt
+ * @run driver compiler.intrinsics.math.TestMinMaxOpt
  */
 
 package compiler.intrinsics.math;
@@ -39,9 +39,37 @@ import compiler.lib.ir_framework.IRNode;
 import compiler.lib.ir_framework.Test;
 import compiler.lib.ir_framework.TestFramework;
 
-public class TestFpMinMaxOpt {
+public class TestMinMaxOpt {
     public static void main(String[] args) {
         TestFramework.run();
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42})
+    @IR(counts = {IRNode.MIN_I, "0"})
+    private static int testIntMin(int v) {
+        return Math.min(v, v);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42})
+    @IR(counts = {IRNode.MAX_I, "0"})
+    private static int testIntMax(int v) {
+        return Math.max(v, v);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42})
+    @IR(counts = {IRNode.MIN_L, "0"})
+    private static long testLongMin(long v) {
+        return Math.min(v, v);
+    }
+
+    @Test
+    @Arguments(values = {Argument.NUMBER_42})
+    @IR(counts = {IRNode.MAX_L, "0"})
+    private static long testLongMax(long v) {
+        return Math.max(v, v);
     }
 
     @Test

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -822,6 +822,11 @@ public class IRNode {
         beforeMatchingNameRegex(MAX, "Max(I|L)");
     }
 
+    public static final String MAX_D = PREFIX + "MAX_D" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(MAX_D, "MaxD");
+    }
+
     public static final String MAX_D_REDUCTION_REG = PREFIX + "MAX_D_REDUCTION_REG" + POSTFIX;
     static {
         machOnlyNameRegex(MAX_D_REDUCTION_REG, "maxD_reduction_reg");
@@ -830,6 +835,11 @@ public class IRNode {
     public static final String MAX_D_REG = PREFIX + "MAX_D_REG" + POSTFIX;
     static {
         machOnlyNameRegex(MAX_D_REG, "maxD_reg");
+    }
+
+    public static final String MAX_F = PREFIX + "MAX_F" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(MAX_F, "MaxF");
     }
 
     public static final String MAX_F_REDUCTION_REG = PREFIX + "MAX_F_REDUCTION_REG" + POSTFIX;
@@ -882,6 +892,11 @@ public class IRNode {
         beforeMatchingNameRegex(MIN, "Min(I|L)");
     }
 
+    public static final String MIN_D = PREFIX + "MIN_D" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(MIN_D, "MinD");
+    }
+
     public static final String MIN_D_REDUCTION_REG = PREFIX + "MIN_D_REDUCTION_REG" + POSTFIX;
     static {
         machOnlyNameRegex(MIN_D_REDUCTION_REG, "minD_reduction_reg");
@@ -890,6 +905,11 @@ public class IRNode {
     public static final String MIN_D_REG = PREFIX + "MIN_D_REG" + POSTFIX;
     static {
         machOnlyNameRegex(MIN_D_REG, "minD_reg");
+    }
+
+    public static final String MIN_F = PREFIX + "MIN_F" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(MIN_F, "MinF");
     }
 
     public static final String MIN_F_REDUCTION_REG = PREFIX + "MIN_F_REDUCTION_REG" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicDoubleOpTest.java
@@ -240,7 +240,7 @@ public class BasicDoubleOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "avx", "true"},
-        counts = {IRNode.MAX_VD, ">0"})
+        counts = {IRNode.MAX_VD, "0"})
     public double[] vectorMax_8322090() {
         double[] res = new double[SIZE];
         for (int i = 0; i < SIZE; i++) {


### PR DESCRIPTION
Added C2 identity optimization for min/max calls, whereby if both inputs are the same, either is returned.

It includes an IR test to verify that the optimization gets applied. The optimization applies not only to floating points, but also long and ints. The test includes tests for all of those.

`BasicDoubleOpTest.vectorMax_8322090` has also been adjusted to match expectations after implementing the optimization.

I've run hotspot compiler tests successfully on x86_64.