### PR TITLE
8330077: Allow max number of events to be buffered to be configurable to avoid OVERFLOW_EVENT

### DIFF
--- a/src/java.base/share/classes/java/nio/file/WatchKey.java
+++ b/src/java.base/share/classes/java/nio/file/WatchKey.java
@@ -99,6 +99,15 @@ public interface WatchKey {
      *
      * <p> Note that this method does not wait if there are no events pending.
      *
+     * @implNote
+     * In the reference implementation, the maximum size of the returned list of
+     * events is controlled by the system property
+     * {@code jdk.nio.file.WatchService.maxEventsPerPoll}. If the property is
+     * not set or is not an integer, the maximum size will be set to 512. The
+     * maximum size is always at least 1. If more events occur than the maximum
+     * size, the pending events are cleared and replaced with a single
+     * {@link StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
+     *
      * @return  the list of the events retrieved; may be empty
      */
     List<WatchEvent<?>> pollEvents();

--- a/src/java.base/share/classes/java/nio/file/WatchKey.java
+++ b/src/java.base/share/classes/java/nio/file/WatchKey.java
@@ -99,15 +99,6 @@ public interface WatchKey {
      *
      * <p> Note that this method does not wait if there are no events pending.
      *
-     * @implNote
-     * In the reference implementation, the maximum size of the returned list of
-     * events is controlled by the system property
-     * {@code jdk.nio.file.WatchService.maxEventsPerPoll}. If the property is
-     * not set or is not an integer, the maximum size will be set to 512. The
-     * maximum size is always at least 1. If more events occur than the maximum
-     * size, the pending events are cleared and replaced with a single
-     * {@link StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
-     *
      * @return  the list of the events retrieved; may be empty
      */
     List<WatchEvent<?>> pollEvents();

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -100,13 +100,14 @@ import java.util.concurrent.TimeUnit;
  *
  * @implNote
  * In the reference implementation, the maximum size of the list of events
- * returned by a key's {@link WatchKey#pollEvents() pollEvents} method is
- * controlled by the system property {@code
- * jdk.nio.file.WatchService.maxEventsPerPoll}. If the property is not set or
- * is not an integer, the maximum size will be set to 512. The maximum size is
- * always at least 1. If more events occur than the maximum size, the pending
- * events are cleared and replaced with a single {@link
- * StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
+ * returned by {@link WatchKey#pollEvents() WatchKey.pollEvents} is controlled
+ * by the system property {@code jdk.nio.file.WatchService.maxEventsPerPoll}.
+ * If this property is not set or cannot be parsed as an integer, then the
+ * maximum event list size will be set to 512; if the property is parsed as a
+ * non-positive integer, then the maximum event size will be {@code 1} (unity).
+ * If more events occur than the maximum size of the event list, the pending
+ * events are cleared and replaced with a single
+ * {@link StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
  *
  * @since 1.7
  *

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -99,15 +99,17 @@ import java.util.concurrent.TimeUnit;
  * detected.
  *
  * @implNote
- * In the reference implementation, the maximum size of the list of events
- * returned by {@link WatchKey#pollEvents() WatchKey.pollEvents} is controlled
- * by the system property {@code jdk.nio.file.WatchService.maxEventsPerPoll}.
- * If this property is not set or cannot be parsed as an integer, then the
- * maximum event list size will be set to 512; if the property is parsed as a
- * non-positive integer, then the maximum event size will be {@code 1} (unity).
- * If more events occur than the maximum size of the event list, the pending
- * events are cleared and replaced with a single
- * {@link StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
+ * The JDK's {@code WatchService} implementations buffer up to 512 pending
+ * events for each registered watchable object. If this limit is exceeded,
+ * pending events are discarded and the special
+ * {@link StandardWatchEventKind#OVERFLOW OVERFLOW} event is queued. This
+ * special event is the trigger to re-examine the state of the object, e.g.
+ * scan a watched directory to get an updated list of the files in the
+ * directory. The limit for the pending events can be changed from its default
+ * with the system property {@code jdk.nio.file.WatchService.maxEventsPerPoll}
+ * set to a value that parses as a positive integer. This may be useful in
+ * environments where there is a high volume of changes and where the impact
+ * of discarded events is high.
  *
  * @since 1.7
  *

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -106,10 +106,11 @@ import java.util.concurrent.TimeUnit;
  * special event is the trigger to re-examine the state of the object, e.g.
  * scan a watched directory to get an updated list of the files in the
  * directory. The limit for the pending events can be changed from its default
- * with the system property {@systemProperty
- * jdk.nio.file.WatchService.maxEventsPerPoll} set to a value that parses as a
- * positive integer. This may be useful in environments where there is a high
- * volume of changes and where the impact of discarded events is high.
+ * with the system property
+ * {@systemProperty jdk.nio.file.WatchService.maxEventsPerPoll}
+ * set to a value that parses as a positive integer. This may be useful in
+ * environments where there is a high volume of changes and where the impact
+ * of discarded events is high.
  *
  * @since 1.7
  *

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -106,10 +106,10 @@ import java.util.concurrent.TimeUnit;
  * special event is the trigger to re-examine the state of the object, e.g.
  * scan a watched directory to get an updated list of the files in the
  * directory. The limit for the pending events can be changed from its default
- * with the system property {@code jdk.nio.file.WatchService.maxEventsPerPoll}
- * set to a value that parses as a positive integer. This may be useful in
- * environments where there is a high volume of changes and where the impact
- * of discarded events is high.
+ * with the system property {@systemProperty
+ * jdk.nio.file.WatchService.maxEventsPerPoll} set to a value that parses as a
+ * positive integer. This may be useful in environments where there is a high
+ * volume of changes and where the impact of discarded events is high.
  *
  * @since 1.7
  *

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -98,6 +98,16 @@ import java.util.concurrent.TimeUnit;
  * it is not required that changes to files carried out on remote systems be
  * detected.
  *
+ * @implNote
+ * In the reference implementation, the maximum size of the list of events
+ * returned by a key's {@link WatchKey#pollEvents() pollEvents} method is
+ * controlled by the system property {@code
+ * jdk.nio.file.WatchService.maxEventsPerPoll}. If the property is not set or
+ * is not an integer, the maximum size will be set to 512. The maximum size is
+ * always at least 1. If more events occur than the maximum size, the pending
+ * events are cleared and replaced with a single {@link
+ * StandardWatchEventKinds#OVERFLOW OVERFLOW} event.
+ *
  * @since 1.7
  *
  * @see FileSystem#newWatchService

--- a/src/java.base/share/classes/java/nio/file/WatchService.java
+++ b/src/java.base/share/classes/java/nio/file/WatchService.java
@@ -102,7 +102,7 @@ import java.util.concurrent.TimeUnit;
  * The JDK's {@code WatchService} implementations buffer up to 512 pending
  * events for each registered watchable object. If this limit is exceeded,
  * pending events are discarded and the special
- * {@link StandardWatchEventKind#OVERFLOW OVERFLOW} event is queued. This
+ * {@link StandardWatchEventKinds#OVERFLOW OVERFLOW} event is queued. This
  * special event is the trigger to re-examine the state of the object, e.g.
  * scan a watched directory to get an updated list of the files in the
  * directory. The limit for the pending events can be changed from its default

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -26,8 +26,9 @@
 package sun.nio.fs;
 
 import java.nio.file.*;
-import java.security.*;
 import java.util.*;
+
+import sun.security.action.GetPropertyAction;
 
 /**
  * Base implementation class for watch keys.
@@ -39,9 +40,18 @@ abstract class AbstractWatchKey implements WatchKey {
      * Maximum size of event list
      */
     @SuppressWarnings("removal")
-    static final int MAX_EVENT_LIST_SIZE =
-        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-                Integer.getInteger("sun.nio.fs.maxWatchEvents", 512));
+    static final int MAX_EVENT_LIST_SIZE;
+    static {
+        String rawValue = GetPropertyAction.privilegedGetProperty(
+            "jdk.nio.file.maxWatchEvents", "512");
+        int intValue;
+        try {
+            intValue = Integer.decode(rawValue);
+        } catch (NumberFormatException e) {
+            intValue = 512;
+        }
+        MAX_EVENT_LIST_SIZE = intValue;
+    }
 
     /**
      * Special event to signal overflow

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -28,6 +28,7 @@ package sun.nio.fs;
 import java.nio.file.*;
 import java.util.*;
 
+import jdk.internal.util.ArraysSupport;
 import sun.security.action.GetPropertyAction;
 
 /**
@@ -49,12 +50,12 @@ abstract class AbstractWatchKey implements WatchKey {
             String.valueOf(DEFAULT_MAX_EVENT_LIST_SIZE));
         int intValue;
         try {
-            // Clamp to Integer.MAX_VALUE - 1 to signal OVERFLOW and drop events
+            // Clamp to max array length to signal OVERFLOW and drop events
             // before OOMing.
             intValue = Math.clamp(
                 Long.decode(rawValue),
                 DEFAULT_MAX_EVENT_LIST_SIZE,
-                Integer.MAX_VALUE - 1);
+                ArraysSupport.SOFT_MAX_ARRAY_LENGTH);
         } catch (NumberFormatException e) {
             intValue = DEFAULT_MAX_EVENT_LIST_SIZE;
         }

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -39,7 +39,7 @@ abstract class AbstractWatchKey implements WatchKey {
     private static final int DEFAULT_MAX_EVENT_LIST_SIZE = 512;
 
     /**
-     * Maximum size of event list
+     * Maximum size of event list before dropping events and signalling OVERFLOW
      */
     @SuppressWarnings("removal")
     static final int MAX_EVENT_LIST_SIZE;
@@ -49,8 +49,12 @@ abstract class AbstractWatchKey implements WatchKey {
             String.valueOf(DEFAULT_MAX_EVENT_LIST_SIZE));
         int intValue;
         try {
+            // Clamp to Integer.MAX_VALUE - 1 to signal OVERFLOW and drop events
+            // before OOMing.
             intValue = Math.clamp(
-                Long.decode(rawValue), DEFAULT_MAX_EVENT_LIST_SIZE, Integer.MAX_VALUE);
+                Long.decode(rawValue),
+                DEFAULT_MAX_EVENT_LIST_SIZE,
+                Integer.MAX_VALUE - 1);
         } catch (NumberFormatException e) {
             intValue = DEFAULT_MAX_EVENT_LIST_SIZE;
         }

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -46,7 +46,7 @@ abstract class AbstractWatchKey implements WatchKey {
     static final int MAX_EVENT_LIST_SIZE;
     static {
         String rawValue = GetPropertyAction.privilegedGetProperty(
-            "jdk.nio.file.maxWatchEvents",
+            "jdk.nio.file.WatchService.maxEventsPerPoll",
             String.valueOf(DEFAULT_MAX_EVENT_LIST_SIZE));
         int intValue;
         try {
@@ -54,7 +54,7 @@ abstract class AbstractWatchKey implements WatchKey {
             // before OOMing.
             intValue = Math.clamp(
                 Long.decode(rawValue),
-                DEFAULT_MAX_EVENT_LIST_SIZE,
+                1,
                 ArraysSupport.SOFT_MAX_ARRAY_LENGTH);
         } catch (NumberFormatException e) {
             intValue = DEFAULT_MAX_EVENT_LIST_SIZE;

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -42,7 +42,6 @@ abstract class AbstractWatchKey implements WatchKey {
     /**
      * Maximum size of event list before dropping events and signalling OVERFLOW
      */
-    @SuppressWarnings("removal")
     static final int MAX_EVENT_LIST_SIZE;
     static {
         String rawValue = GetPropertyAction.privilegedGetProperty(

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -26,6 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.file.*;
+import java.security.*;
 import java.util.*;
 
 /**
@@ -35,9 +36,12 @@ import java.util.*;
 abstract class AbstractWatchKey implements WatchKey {
 
     /**
-     * Maximum size of event list (in the future this may be tunable)
+     * Maximum size of event list
      */
-    static final int MAX_EVENT_LIST_SIZE    = 512;
+    @SuppressWarnings("removal")
+    static final int MAX_EVENT_LIST_SIZE =
+        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+                Integer.getInteger("sun.nio.fs.maxWatchEvents", 512));
 
     /**
      * Special event to signal overflow

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -36,6 +36,8 @@ import sun.security.action.GetPropertyAction;
 
 abstract class AbstractWatchKey implements WatchKey {
 
+    private static final int DEFAULT_MAX_EVENT_LIST_SIZE = 512;
+
     /**
      * Maximum size of event list
      */
@@ -43,12 +45,14 @@ abstract class AbstractWatchKey implements WatchKey {
     static final int MAX_EVENT_LIST_SIZE;
     static {
         String rawValue = GetPropertyAction.privilegedGetProperty(
-            "jdk.nio.file.maxWatchEvents", "512");
+            "jdk.nio.file.maxWatchEvents",
+            String.valueOf(DEFAULT_MAX_EVENT_LIST_SIZE));
         int intValue;
         try {
-            intValue = Integer.decode(rawValue);
+            intValue = Math.clamp(
+                Long.decode(rawValue), DEFAULT_MAX_EVENT_LIST_SIZE, Integer.MAX_VALUE);
         } catch (NumberFormatException e) {
-            intValue = 512;
+            intValue = DEFAULT_MAX_EVENT_LIST_SIZE;
         }
         MAX_EVENT_LIST_SIZE = intValue;
     }

--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -27,10 +27,12 @@
  *     than the default event limit
  * @library ..
  * @run main/othervm LotsOfEntries 600 fail
- * @run main/othervm -Djdk.nio.file.maxWatchEvents=invalid LotsOfEntries 600 fail
- * @run main/othervm -Djdk.nio.file.maxWatchEvents=-5 LotsOfEntries 400 pass
- * @run main/othervm -Djdk.nio.file.maxWatchEvents=700 LotsOfEntries 600 pass
- * @run main/othervm -Djdk.nio.file.maxWatchEvents=3000000000 LotsOfEntries 600 pass
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=invalid LotsOfEntries 600 fail
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=-5 LotsOfEntries 5 fail
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 5 pass
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 6 fail
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=700 LotsOfEntries 600 pass
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=3000000000 LotsOfEntries 600 pass
  */
 
 import java.nio.file.*;

--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8330077
+ * @summary Tests WatchService behavior with more entries in a watched directory
+ *     than the default event limit
+ * @library ..
+ * @run main/othervm LotsOfEntries 600 fail
+ * @run main/othervm -Dsun.nio.fs.maxWatchEvents=700 LotsOfEntries 600 pass
+ */
+
+import java.nio.file.*;
+import static java.nio.file.StandardWatchEventKinds.*;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class LotsOfEntries {
+
+    static void testCreateLotsOfEntries(Path dir, int numEvents, boolean fail) throws Exception {
+        try (WatchService watcher = FileSystems.getDefault().newWatchService()) {
+            System.out.format("register %s for events\n", dir);
+            WatchKey key = dir.register(watcher, ENTRY_CREATE);
+
+            System.out.format("create %d entries\n", numEvents);
+            Set<Path> entries = new HashSet<>();
+            for (int i = 0; i < numEvents; i++) {
+                Path entry = dir.resolve("entry" + i);
+                entries.add(entry);
+                Files.createFile(entry);
+            }
+
+            // wait for key to be signalled - the timeout is long to allow for
+            // polling implementations
+            System.out.println("poll watcher...");
+            WatchKey signalledKey = watcher.poll(15, TimeUnit.SECONDS);
+            if (key != signalledKey) {
+                throw new RuntimeException("Unexpected key returned from poll");
+            }
+
+            if (fail) {
+                System.out.println("poll expecting overflow...");
+                var events = key.pollEvents();
+                if (events.size() != 1) {
+                    throw new RuntimeException("Expected a single event");
+                }
+                if (!events.getFirst().kind().equals(OVERFLOW)) {
+                    throw new RuntimeException("Expected overflow event");
+                }
+            } else {
+                System.out.println("poll not expecting overflow...");
+                Set<Path> contexts = key.pollEvents().stream()
+                    .map(WatchEvent::context)
+                    .map(Path.class::cast)
+                    .map(entry -> dir.resolve(entry))
+                    .collect(Collectors.toSet());
+                if (!entries.equals(contexts)) {
+                    throw new RuntimeException(
+                        "Expected events on: " + entries + ", got: " + contexts);
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path dir = TestUtil.createTemporaryDirectory();
+        int numEvents = Integer.parseInt(args[0]);
+        boolean fail = args[1].equals("fail");
+        try {
+            testCreateLotsOfEntries(dir, numEvents, fail);
+        } finally {
+            TestUtil.removeAll(dir);
+        }
+    }
+}

--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -27,7 +27,8 @@
  *     than the default event limit
  * @library ..
  * @run main/othervm LotsOfEntries 600 fail
- * @run main/othervm -Dsun.nio.fs.maxWatchEvents=700 LotsOfEntries 600 pass
+ * @run main/othervm -Djdk.nio.file.maxWatchEvents=invalid LotsOfEntries 600 fail
+ * @run main/othervm -Djdk.nio.file.maxWatchEvents=700 LotsOfEntries 600 pass
  */
 
 import java.nio.file.*;

--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -28,7 +28,9 @@
  * @library ..
  * @run main/othervm LotsOfEntries 600 fail
  * @run main/othervm -Djdk.nio.file.maxWatchEvents=invalid LotsOfEntries 600 fail
+ * @run main/othervm -Djdk.nio.file.maxWatchEvents=-5 LotsOfEntries 400 pass
  * @run main/othervm -Djdk.nio.file.maxWatchEvents=700 LotsOfEntries 600 pass
+ * @run main/othervm -Djdk.nio.file.maxWatchEvents=3000000000 LotsOfEntries 600 pass
  */
 
 import java.nio.file.*;

--- a/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
+++ b/test/jdk/java/nio/file/WatchService/LotsOfEntries.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,8 @@
  * @run main/othervm LotsOfEntries 600 fail
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=invalid LotsOfEntries 600 fail
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=-5 LotsOfEntries 5 fail
- * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 5 pass
- * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 6 fail
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 3 pass
+ * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=5 LotsOfEntries 7 fail
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=700 LotsOfEntries 600 pass
  * @run main/othervm -Djdk.nio.file.WatchService.maxEventsPerPoll=3000000000 LotsOfEntries 600 pass
  */


### PR DESCRIPTION
The limit on the number of events buffered for a single `j.n.f.WatchKey` is now configurable via the `jdk.nio.file.WatchService.maxEventsPerPoll`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331162](https://bugs.openjdk.org/browse/JDK-8331162) to be approved

### Issues
 * [JDK-8330077](https://bugs.openjdk.org/browse/JDK-8330077): Allow max number of events to be buffered to be configurable to avoid OVERFLOW_EVENT (**Enhancement** - P4)
 * [JDK-8331162](https://bugs.openjdk.org/browse/JDK-8331162): Allow max number of events to be buffered to be configurable to avoid OVERFLOW_EVENT (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18739/head:pull/18739` \
`$ git checkout pull/18739`

Update a local copy of the PR: \
`$ git checkout pull/18739` \
`$ git pull https://git.openjdk.org/jdk.git pull/18739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18739`

View PR using the GUI difftool: \
`$ git pr show -t 18739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18739.diff">https://git.openjdk.org/jdk/pull/18739.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18739#issuecomment-2049585968)