### PR TITLE
8330076: NMT: add/make a mandatory MEMFLAGS argument to family of os::reserve/commit/uncommit memory API

### DIFF
--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -69,7 +69,7 @@ static char* reserve_at_eor_compatible_address(size_t size, bool aslr) {
     const uint64_t immediate = ((uint64_t)immediates[index]) << 32;
     assert(immediate > 0 && Assembler::operand_valid_for_logical_immediate(/*is32*/false, immediate),
            "Invalid immediate %d " UINT64_FORMAT, index, immediate);
-    result = os::attempt_reserve_memory_at((char*)immediate, size, false, mtMetaspace);
+    result = os::attempt_reserve_memory_at((char*)immediate, size, !ExecMem, mtClass);
     if (result == nullptr) {
       log_trace(metaspace, map)("Failed to attach at " UINT64_FORMAT_X, immediate);
     }
@@ -112,7 +112,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   if (result == nullptr) {
     constexpr size_t alignment = nth_bit(32);
     log_debug(metaspace, map)("Trying to reserve at a 32-bit-aligned address");
-    result = os::reserve_memory_aligned(size, alignment, false, mtMetaspace);
+    result = os::reserve_memory_aligned(size, alignment, !ExecMem, mtClass);
   }
 
   return result;

--- a/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/compressedKlass_aarch64.cpp
@@ -69,7 +69,7 @@ static char* reserve_at_eor_compatible_address(size_t size, bool aslr) {
     const uint64_t immediate = ((uint64_t)immediates[index]) << 32;
     assert(immediate > 0 && Assembler::operand_valid_for_logical_immediate(/*is32*/false, immediate),
            "Invalid immediate %d " UINT64_FORMAT, index, immediate);
-    result = os::attempt_reserve_memory_at((char*)immediate, size, false);
+    result = os::attempt_reserve_memory_at((char*)immediate, size, false, mtMetaspace);
     if (result == nullptr) {
       log_trace(metaspace, map)("Failed to attach at " UINT64_FORMAT_X, immediate);
     }
@@ -112,7 +112,7 @@ char* CompressedKlassPointers::reserve_address_space_for_compressed_classes(size
   if (result == nullptr) {
     constexpr size_t alignment = nth_bit(32);
     log_debug(metaspace, map)("Trying to reserve at a 32-bit-aligned address");
-    result = os::reserve_memory_aligned(size, alignment, false);
+    result = os::reserve_memory_aligned(size, alignment, false, mtMetaspace);
   }
 
   return result;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1848,7 +1848,7 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
 void os::pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
 }
 
-void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint) {
+void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag) {
 }
 
 size_t os::pd_pretouch_memory(void* first, void* last, size_t page_size) {

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1890,7 +1890,7 @@ bool os::numa_get_group_ids_for_range(const void** addresses, int* lgrp_ids, siz
 }
 
 // Reserves and attaches a shared memory segment.
-char* os::pd_reserve_memory(size_t bytes, bool exec) {
+char* os::pd_reserve_memory(size_t bytes, bool exec, MEMFLAGS flag) {
   // Always round to os::vm_page_size(), which may be larger than 4K.
   bytes = align_up(bytes, os::vm_page_size());
 
@@ -2039,7 +2039,7 @@ void os::large_page_init() {
   return; // Nothing to do. See query_multipage_support and friends.
 }
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec, MEMFLAGS flag) {
   fatal("os::reserve_memory_special should not be called on AIX.");
   return nullptr;
 }
@@ -2058,7 +2058,7 @@ bool os::can_commit_large_page_memory() {
   return false;
 }
 
-char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc, MEMFLAGS flag) {
   assert(file_desc >= 0, "file_desc is not valid");
   char* result = nullptr;
 
@@ -2076,7 +2076,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
-char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec, MEMFLAGS flag) {
   char* addr = nullptr;
 
   // Always round to os::vm_page_size(), which may be larger than 4K.

--- a/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
@@ -78,7 +78,7 @@ XPhysicalMemoryBacking::XPhysicalMemoryBacking(size_t max_capacity) :
     _initialized(false) {
 
   // Reserve address space for backing memory
-  _base = (uintptr_t)os::reserve_memory(max_capacity, false, mtJavaHeap);
+  _base = (uintptr_t)os::reserve_memory(max_capacity, !ExecMem, mtJavaHeap);
   if (_base == 0) {
     // Failed
     log_error_pd(gc)("Failed to reserve address space for backing memory");

--- a/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/x/xPhysicalMemoryBacking_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ XPhysicalMemoryBacking::XPhysicalMemoryBacking(size_t max_capacity) :
     _initialized(false) {
 
   // Reserve address space for backing memory
-  _base = (uintptr_t)os::reserve_memory(max_capacity);
+  _base = (uintptr_t)os::reserve_memory(max_capacity, false, mtJavaHeap);
   if (_base == 0) {
     // Failed
     log_error_pd(gc)("Failed to reserve address space for backing memory");

--- a/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
@@ -79,7 +79,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
     _initialized(false) {
 
   // Reserve address space for backing memory
-  _base = (uintptr_t)os::reserve_memory(max_capacity, false, mtJavaHeap);
+  _base = (uintptr_t)os::reserve_memory(max_capacity, !ExecMem, mtJavaHeap);
   if (_base == 0) {
     // Failed
     log_error_pd(gc)("Failed to reserve address space for backing memory");

--- a/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,7 +79,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
     _initialized(false) {
 
   // Reserve address space for backing memory
-  _base = (uintptr_t)os::reserve_memory(max_capacity);
+  _base = (uintptr_t)os::reserve_memory(max_capacity, false, mtJavaHeap);
   if (_base == 0) {
     // Failed
     log_error_pd(gc)("Failed to reserve address space for backing memory");

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1668,7 +1668,7 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size,
 void os::pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
 }
 
-void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint) {
+void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag) {
   ::madvise(addr, bytes, MADV_DONTNEED);
 }
 
@@ -1766,13 +1766,13 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  return os::commit_memory(addr, size, !ExecMem, mtThreadStack);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by
 // munmap()ping them.  If not, just call uncommit_memory().
 bool os::remove_stack_guard_pages(char* addr, size_t size) {
-  return os::uncommit_memory(addr, size);
+  return os::uncommit_memory(addr, size, mtThreadStack);
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1809,7 +1809,7 @@ static int anon_munmap(char * addr, size_t size) {
   }
 }
 
-char* os::pd_reserve_memory(size_t bytes, bool exec) {
+char* os::pd_reserve_memory(size_t bytes, bool exec, MEMFLAGS flag) {
   return anon_mmap(nullptr /* addr */, bytes, exec);
 }
 
@@ -1869,7 +1869,7 @@ void os::large_page_init() {
 }
 
 
-char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
+char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec, MEMFLAGS flag) {
   fatal("os::reserve_memory_special should not be called on BSD.");
   return nullptr;
 }
@@ -1888,9 +1888,9 @@ bool os::can_commit_large_page_memory() {
   return false;
 }
 
-char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc, MEMFLAGS flag) {
   assert(file_desc >= 0, "file_desc is not valid");
-  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes, !ExecMem);
+  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes, !ExecMem, flag);
   if (result != nullptr) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == nullptr) {
       vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
@@ -1902,7 +1902,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
 
-char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec, MEMFLAGS flag) {
   // Assert only that the size is a multiple of the page size, since
   // that's all that mmap requires, and since that's all we really know
   // about at this low abstraction level.  If we need higher alignment,

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1772,7 +1772,7 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
 // If this is a growable mapping, remove the guard pages entirely by
 // munmap()ping them.  If not, just call uncommit_memory().
 bool os::remove_stack_guard_pages(char* addr, size_t size) {
-  return os::uncommit_memory(addr, size, mtThreadStack);
+  return os::uncommit_memory(addr, size, !ExecMem, mtThreadStack);
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3660,7 +3660,7 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
     return ::munmap(addr, size) == 0;
   }
 
-  return os::uncommit_memory(addr, size, mtThreadStack);
+  return os::uncommit_memory(addr, size, !ExecMem, mtThreadStack);
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or
@@ -4681,7 +4681,7 @@ static void workaround_expand_exec_shield_cs_limit() {
    */
   char* hint = (char*)(os::Linux::initial_thread_stack_bottom() -
                        (StackOverflow::stack_guard_zone_size() + page_size));
-  char* codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtInternal);
+  char* codebuf = os::attempt_reserve_memory_at(hint, page_size, !ExecMem, mtInternal);
 
   if (codebuf == nullptr) {
     // JDK-8197429: There may be a stack gap of one megabyte between
@@ -4689,10 +4689,10 @@ static void workaround_expand_exec_shield_cs_limit() {
     // Linux kernel workaround for CVE-2017-1000364.  If we failed to
     // map our codebuf, try again at an address one megabyte lower.
     hint -= 1 * M;
-    codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtInternal);
+    codebuf = os::attempt_reserve_memory_at(hint, page_size, !ExecMem, mtInternal);
   }
 
-  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, true, mtInternal))) {
+  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, ExecMem, mtInternal))) {
     return; // No matter, we tried, best effort.
   }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3660,7 +3660,7 @@ bool os::remove_stack_guard_pages(char* addr, size_t size) {
     return ::munmap(addr, size) == 0;
   }
 
-  return os::uncommit_memory(addr, size);
+  return os::uncommit_memory(addr, size, mtThreadStack);
 }
 
 // 'requested_addr' is only treated as a hint, the return value may or

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3764,7 +3764,7 @@ static int anon_munmap(char * addr, size_t size) {
   return 1;
 }
 
-char* os::pd_reserve_memory(size_t bytes, bool exec) {
+char* os::pd_reserve_memory(size_t bytes, bool exec, MEMFLAGS flag) {
   return anon_mmap(nullptr, bytes);
 }
 
@@ -4221,7 +4221,7 @@ static char* reserve_memory_special_huge_tlbfs(size_t bytes,
 }
 
 char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size,
-                                    char* req_addr, bool exec) {
+                                    char* req_addr, bool exec, MEMFLAGS flag) {
   assert(UseLargePages, "only for large pages");
 
   char* const addr = reserve_memory_special_huge_tlbfs(bytes, alignment, page_size, req_addr, exec);
@@ -4256,9 +4256,9 @@ bool os::can_commit_large_page_memory() {
   return UseTransparentHugePages;
 }
 
-char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {
+char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc, MEMFLAGS flag) {
   assert(file_desc >= 0, "file_desc is not valid");
-  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes, !ExecMem);
+  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes, !ExecMem, flag);
   if (result != nullptr) {
     if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == nullptr) {
       vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
@@ -4270,7 +4270,7 @@ char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, i
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
 
-char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
+char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec, MEMFLAGS flag) {
   // Assert only that the size is a multiple of the page size, since
   // that's all that mmap requires, and since that's all we really know
   // about at this low abstraction level.  If we need higher alignment,

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4681,7 +4681,7 @@ static void workaround_expand_exec_shield_cs_limit() {
    */
   char* hint = (char*)(os::Linux::initial_thread_stack_bottom() -
                        (StackOverflow::stack_guard_zone_size() + page_size));
-  char* codebuf = os::attempt_reserve_memory_at(hint, page_size);
+  char* codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtThreadStack);
 
   if (codebuf == nullptr) {
     // JDK-8197429: There may be a stack gap of one megabyte between
@@ -4689,10 +4689,10 @@ static void workaround_expand_exec_shield_cs_limit() {
     // Linux kernel workaround for CVE-2017-1000364.  If we failed to
     // map our codebuf, try again at an address one megabyte lower.
     hint -= 1 * M;
-    codebuf = os::attempt_reserve_memory_at(hint, page_size);
+    codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtThreadStack);
   }
 
-  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, true))) {
+  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, true, mtThreadStack))) {
     return; // No matter, we tried, best effort.
   }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3030,14 +3030,14 @@ void os::pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
   }
 }
 
-void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint) {
+void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag) {
   // This method works by doing an mmap over an existing mmaping and effectively discarding
   // the existing pages. However it won't work for SHM-based large pages that cannot be
   // uncommitted at all. We don't do anything in this case to avoid creating a segment with
   // small pages on top of the SHM segment. This method always works for small pages, so we
   // allow that in any case.
   if (alignment_hint <= os::vm_page_size() || can_commit_large_page_memory()) {
-    commit_memory(addr, bytes, alignment_hint, !ExecMem);
+    commit_memory(addr, bytes, alignment_hint, !ExecMem, flag);
   }
 }
 
@@ -3644,7 +3644,7 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
     }
   }
 
-  return os::commit_memory(addr, size, !ExecMem);
+  return os::commit_memory(addr, size, !ExecMem, mtThreadStack);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4681,7 +4681,7 @@ static void workaround_expand_exec_shield_cs_limit() {
    */
   char* hint = (char*)(os::Linux::initial_thread_stack_bottom() -
                        (StackOverflow::stack_guard_zone_size() + page_size));
-  char* codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtThreadStack);
+  char* codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtInternal);
 
   if (codebuf == nullptr) {
     // JDK-8197429: There may be a stack gap of one megabyte between
@@ -4689,10 +4689,10 @@ static void workaround_expand_exec_shield_cs_limit() {
     // Linux kernel workaround for CVE-2017-1000364.  If we failed to
     // map our codebuf, try again at an address one megabyte lower.
     hint -= 1 * M;
-    codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtThreadStack);
+    codebuf = os::attempt_reserve_memory_at(hint, page_size, false, mtInternal);
   }
 
-  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, true, mtThreadStack))) {
+  if ((codebuf == nullptr) || (!os::commit_memory(codebuf, page_size, true, mtInternal))) {
     return; // No matter, we tried, best effort.
   }
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4696,8 +4696,6 @@ static void workaround_expand_exec_shield_cs_limit() {
     return; // No matter, we tried, best effort.
   }
 
-  MemTracker::record_virtual_memory_type((address)codebuf, mtInternal);
-
   log_info(os)("[CS limit NX emulation work-around, exec code at: %p]", codebuf);
 
   // Some code to exec: the 'ret' instruction

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -395,9 +395,9 @@ static char* chop_extra_memory(size_t size, size_t alignment, char* extra_base, 
 // Multiple threads can race in this code, and can remap over each other with MAP_FIXED,
 // so on posix, unmap the section at the start and at the end of the chunk that we mapped
 // rather than unmapping and remapping the whole chunk to get requested alignment.
-char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec) {
+char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec, MEMFLAGS flag) {
   size_t extra_size = calculate_aligned_extra_size(size, alignment);
-  char* extra_base = os::reserve_memory(extra_size, exec);
+  char* extra_base = os::reserve_memory(extra_size, exec, flag);
   if (extra_base == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2052,7 +2052,6 @@ const char* os::path_separator() { return ":"; }
 // Returns address to mapped memory, nullptr on error
 char* os::pd_map_memory(int fd, const char* unused,
                         size_t file_offset, char *addr, size_t bytes,
-                        MEMFLAGS flag,
                         bool read_only, bool allow_exec) {
 
   assert(fd != -1, "Specify a valid file descriptor");

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -421,7 +421,7 @@ char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int file_des
   if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc) == nullptr) {
     vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
   }
-  MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC);
+  MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC, flag);
   return aligned_base;
 }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -2052,6 +2052,7 @@ const char* os::path_separator() { return ":"; }
 // Returns address to mapped memory, nullptr on error
 char* os::pd_map_memory(int fd, const char* unused,
                         size_t file_offset, char *addr, size_t bytes,
+                        MEMFLAGS flag,
                         bool read_only, bool allow_exec) {
 
   assert(fd != -1, "Specify a valid file descriptor");

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -65,7 +65,7 @@ static char* backing_store_file_name = nullptr;  // name of the backing store
 static char* create_standard_memory(size_t size) {
 
   // allocate an aligned chuck of memory
-  char* mapAddress = os::reserve_memory(size, false, mtInternal);
+  char* mapAddress = os::reserve_memory(size, !ExecMem, mtInternal);
 
   if (mapAddress == nullptr) {
     return nullptr;

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -72,7 +72,7 @@ static char* create_standard_memory(size_t size) {
   }
 
   // commit memory
-  if (!os::commit_memory(mapAddress, size, !ExecMem)) {
+  if (!os::commit_memory(mapAddress, size, !ExecMem, mtInternal)) {
     if (PrintMiscellaneous && Verbose) {
       warning("Could not commit PerfData memory\n");
     }

--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -65,7 +65,7 @@ static char* backing_store_file_name = nullptr;  // name of the backing store
 static char* create_standard_memory(size_t size) {
 
   // allocate an aligned chuck of memory
-  char* mapAddress = os::reserve_memory(size);
+  char* mapAddress = os::reserve_memory(size, false, mtInternal);
 
   if (mapAddress == nullptr) {
     return nullptr;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3769,7 +3769,7 @@ bool os::protect_memory(char* addr, size_t bytes, ProtType prot,
   // memory, not a big deal anyway, as bytes less or equal than 64K
   if (!is_committed) {
     commit_memory_or_exit(addr, bytes, prot == MEM_PROT_RWX,
-                          "cannot commit protection page", mtInternal);
+                          mtInternal, "cannot commit protection page");
   }
   // One cannot use os::guard_memory() here, as on Win32 guard page
   // have different (one-shot) semantics, from MSDN on PAGE_GUARD:
@@ -5065,7 +5065,6 @@ void os::funlockfile(FILE* fp) {
 // Map a block of memory.
 char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
                         char *addr, size_t bytes,
-                        MEMFLAGS flag,
                         bool read_only,
                         bool allow_exec) {
 
@@ -5105,9 +5104,6 @@ char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
       CloseHandle(hFile);
       return nullptr;
     }
-
-    // Record virtual memory allocation
-    MemTracker::record_virtual_memory_reserve_and_commit((address)addr, bytes, CALLER_PC, flag);
 
     DWORD bytes_read;
     OVERLAPPED overlapped;

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3398,7 +3398,7 @@ char* os::pd_reserve_memory(size_t bytes, bool exec, MEMFLAGS flag) {
 
 // Reserve memory at an arbitrary address, only if that area is
 // available (and not reserved for something else).
-char* os::pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool exec, MEMFLAGS nmt_flag) {
+char* os::pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool exec, MEMFLAGS flag) {
   assert((size_t)addr % os::vm_allocation_granularity() == 0,
          "reserve alignment");
   assert(bytes % os::vm_page_size() == 0, "reserve page size");
@@ -3413,7 +3413,7 @@ char* os::pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool exec, MEMF
     if (Verbose && PrintMiscellaneous) reserveTimer.start();
     // in numa interleaving, we have to allocate pages individually
     // (well really chunks of NUMAInterleaveGranularity size)
-    res = allocate_pages_individually(bytes, addr, MEM_RESERVE, PAGE_READWRITE, nmt_flag);
+    res = allocate_pages_individually(bytes, addr, MEM_RESERVE, PAGE_READWRITE, flag);
     if (res == nullptr) {
       warning("NUMA page allocation failed");
     }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5064,8 +5064,7 @@ void os::funlockfile(FILE* fp) {
 
 // Map a block of memory.
 char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
-                        char *addr, size_t bytes,
-                        bool read_only,
+                        char *addr, size_t bytes, bool read_only,
                         bool allow_exec) {
 
   errno_t err;

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -55,7 +55,7 @@ typedef BOOL (WINAPI *SetSecurityDescriptorControlFnPtr)(
 static char* create_standard_memory(size_t size) {
 
   // allocate an aligned chuck of memory
-  char* mapAddress = os::reserve_memory(size, false, mtInternal);
+  char* mapAddress = os::reserve_memory(size, !ExecMem, mtInternal);
 
   if (mapAddress == nullptr) {
     return nullptr;

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -55,7 +55,7 @@ typedef BOOL (WINAPI *SetSecurityDescriptorControlFnPtr)(
 static char* create_standard_memory(size_t size) {
 
   // allocate an aligned chuck of memory
-  char* mapAddress = os::reserve_memory(size);
+  char* mapAddress = os::reserve_memory(size, false, mtInternal);
 
   if (mapAddress == nullptr) {
     return nullptr;

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ static char* create_standard_memory(size_t size) {
   }
 
   // commit memory
-  if (!os::commit_memory(mapAddress, size, !ExecMem)) {
+  if (!os::commit_memory(mapAddress, size, !ExecMem, mtInternal)) {
     if (PrintMiscellaneous && Verbose) {
       warning("Could not commit PerfData memory\n");
     }

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -311,7 +311,7 @@ size_t ArchiveBuilder::estimate_archive_size() {
 
 address ArchiveBuilder::reserve_buffer() {
   size_t buffer_size = estimate_archive_size();
-  ReservedSpace rs(buffer_size, MetaspaceShared::core_region_alignment(), os::vm_page_size());
+  ReservedSpace rs(buffer_size, MetaspaceShared::core_region_alignment(), os::vm_page_size(), mtClassShared);
   if (!rs.is_reserved()) {
     log_error(cds)("Failed to reserve " SIZE_FORMAT " bytes of output buffer.", buffer_size);
     MetaspaceShared::unrecoverable_writing_error();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1721,9 +1721,9 @@ bool FileMapInfo::remap_shared_readonly_as_readwrite() {
   // This path should not be reached for Windows; see JDK-8222379.
   assert(WINDOWS_ONLY(false) NOT_WINDOWS(true), "Don't call on Windows");
   // Replace old mapping with new one that is writable.
-  char *base = os::map_memory(_fd, _full_path, r->file_offset(),                      //file info
-                              addr, size,                                             //memory info
-                              false /* !read_only */, r->allow_exec(), mtClassShared); // flags
+  char *base = os::map_memory(_fd, _full_path, r->file_offset(),
+                              addr, size, false /* !read_only */,
+                              r->allow_exec(), mtClassShared);
   close();
   // These have to be errors because the shared region is now unmapped.
   if (base == nullptr) {

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1782,7 +1782,7 @@ bool FileMapInfo::read_region(int i, char* base, size_t size, bool do_commit) {
     log_info(cds)("Commit %s region #%d at base " INTPTR_FORMAT " top " INTPTR_FORMAT " (%s)%s",
                   is_static() ? "static " : "dynamic", i, p2i(base), p2i(base + size),
                   shared_region_name[i], r->allow_exec() ? " exec" : "");
-    if (!os::commit_memory(base, size, r->allow_exec())) {
+    if (!os::commit_memory(base, size, r->allow_exec(), mtClassShared)) {
       log_error(cds)("Failed to commit %s region #%d (%s)", is_static() ? "static " : "dynamic",
                      i, shared_region_name[i]);
       return false;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1693,12 +1693,11 @@ void FileMapInfo::close() {
  * Same as os::map_memory() but also pretouches if AlwaysPreTouch is enabled.
  */
 static char* map_and_pretouch_memory(int fd, const char* file_name, size_t file_offset,
-                        char *addr, size_t bytes, bool read_only,
-                        bool allow_exec, MEMFLAGS flags) {
+                                     char *addr, size_t bytes, bool read_only,
+                                     bool allow_exec, MEMFLAGS flags) {
   char* mem = os::map_memory(fd, file_name, file_offset, addr, bytes,
                              AlwaysPreTouch ? false : read_only,
-                             allow_exec,
-                             flags);
+                             allow_exec, flags);
   if (mem != nullptr && AlwaysPreTouch) {
     os::pretouch_memory(mem, mem + bytes);
   }
@@ -1722,11 +1721,9 @@ bool FileMapInfo::remap_shared_readonly_as_readwrite() {
   // This path should not be reached for Windows; see JDK-8222379.
   assert(WINDOWS_ONLY(false) NOT_WINDOWS(true), "Don't call on Windows");
   // Replace old mapping with new one that is writable.
-  char *base = os::map_memory(_fd, _full_path, r->file_offset(),
-                              addr, size,
-                              false /* !read_only */,
-                              r->allow_exec(),
-                              mtClassShared);
+  char *base = os::map_memory(_fd, _full_path, r->file_offset(),                      //file info
+                              addr, size,                                             //memory info
+                              false /* !read_only */, r->allow_exec(), mtClassShared); // flags
   close();
   // These have to be errors because the shared region is now unmapped.
   if (base == nullptr) {

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1274,8 +1274,6 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
     if (archive_space_rs.is_reserved()) {
       assert(base_address == nullptr ||
              (address)archive_space_rs.base() == base_address, "Sanity");
-      // Register archive space with NMT.
-      MemTracker::record_virtual_memory_type(archive_space_rs.base(), mtClassShared);
       return archive_space_rs.base();
     }
     return nullptr;
@@ -1327,9 +1325,6 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
       release_reserved_spaces(total_space_rs, archive_space_rs, class_space_rs);
       return nullptr;
     }
-    // NMT: fix up the space tags
-    MemTracker::record_virtual_memory_type(archive_space_rs.base(), mtClassShared);
-    MemTracker::record_virtual_memory_type(class_space_rs.base(), mtClass);
   } else {
     if (use_archive_base_addr && base_address != nullptr) {
       total_space_rs = ReservedSpace(total_range_size, archive_space_alignment,

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -269,7 +269,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   SharedBaseAddress = (size_t)_requested_base_address;
 
   size_t symbol_rs_size = LP64_ONLY(3 * G) NOT_LP64(128 * M);
-  _symbol_rs = ReservedSpace(symbol_rs_size);
+  _symbol_rs = ReservedSpace(symbol_rs_size, mtClassShared);
   if (!_symbol_rs.is_reserved()) {
     log_error(cds)("Unable to reserve memory for symbols: " SIZE_FORMAT " bytes.", symbol_rs_size);
     MetaspaceShared::unrecoverable_writing_error();
@@ -1270,7 +1270,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
     // Get the simple case out of the way first:
     // no compressed class space, simple allocation.
     archive_space_rs = ReservedSpace(archive_space_size, archive_space_alignment,
-                                     os::vm_page_size(), (char*)base_address);
+                                     os::vm_page_size(), mtClassShared, (char*)base_address);
     if (archive_space_rs.is_reserved()) {
       assert(base_address == nullptr ||
              (address)archive_space_rs.base() == base_address, "Sanity");
@@ -1319,9 +1319,9 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
       // via sequential file IO.
       address ccs_base = base_address + archive_space_size + gap_size;
       archive_space_rs = ReservedSpace(archive_space_size, archive_space_alignment,
-                                       os::vm_page_size(), (char*)base_address);
+                                       os::vm_page_size(), mtClassShared, (char*)base_address);
       class_space_rs   = ReservedSpace(class_space_size, class_space_alignment,
-                                       os::vm_page_size(), (char*)ccs_base);
+                                       os::vm_page_size(), mtClass, (char*)ccs_base);
     }
     if (!archive_space_rs.is_reserved() || !class_space_rs.is_reserved()) {
       release_reserved_spaces(total_space_rs, archive_space_rs, class_space_rs);
@@ -1333,7 +1333,7 @@ char* MetaspaceShared::reserve_address_space_for_archives(FileMapInfo* static_ma
   } else {
     if (use_archive_base_addr && base_address != nullptr) {
       total_space_rs = ReservedSpace(total_range_size, archive_space_alignment,
-                                     os::vm_page_size(), (char*) base_address);
+                                     os::vm_page_size(), mtClassShared, (char*) base_address);
     } else {
       // We did not manage to reserve at the preferred address, or were instructed to relocate. In that
       // case we reserve wherever possible, but the start address needs to be encodable as narrow Klass

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,7 +240,7 @@ HashtableTextDump::HashtableTextDump(const char* filename) : _fd(-1) {
   if (_fd < 0) {
     quit("Unable to open hashtable dump file", filename);
   }
-  _base = os::map_memory(_fd, filename, 0, nullptr, _size, true, false);
+  _base = os::map_memory(_fd, filename, 0, nullptr, _size, mtInternal, true, false);
   if (_base == nullptr) {
     quit("Unable to map hashtable dump file", filename);
   }

--- a/src/hotspot/share/classfile/compactHashtable.cpp
+++ b/src/hotspot/share/classfile/compactHashtable.cpp
@@ -240,7 +240,7 @@ HashtableTextDump::HashtableTextDump(const char* filename) : _fd(-1) {
   if (_fd < 0) {
     quit("Unable to open hashtable dump file", filename);
   }
-  _base = os::map_memory(_fd, filename, 0, nullptr, _size, mtInternal, true, false);
+  _base = os::map_memory(_fd, filename, 0, nullptr, _size, true, false, mtClassShared);
   if (_base == nullptr) {
     quit("Unable to map hashtable dump file", filename);
   }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1213,7 +1213,7 @@ G1RegionToSpaceMapper* G1CollectedHeap::create_aux_memory_mapper(const char* des
                                                                  size_t translation_factor) {
   size_t preferred_page_size = os::page_size_for_region_unaligned(size, 1);
   // Allocate a new reserved space, preferring to use large pages.
-  ReservedSpace rs(size, preferred_page_size);
+  ReservedSpace rs(size, preferred_page_size, mtGC);
   size_t page_size = rs.page_size();
   G1RegionToSpaceMapper* result  =
     G1RegionToSpaceMapper::create_mapper(rs,

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,14 +135,14 @@ void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pa
   char* start_addr = page_start(start);
   size_t size = num_pages * _page_size;
 
-  os::commit_memory_or_exit(start_addr, size, _page_size, false, "G1 virtual space");
+  os::commit_memory_or_exit(start_addr, size, _page_size, false, "G1 virtual space", mtGC);
 }
 
 void G1PageBasedVirtualSpace::commit_tail() {
   vmassert(_tail_size > 0, "The size of the tail area must be > 0 when reaching here");
 
   char* const aligned_end_address = align_down(_high_boundary, _page_size);
-  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), false, "G1 virtual space");
+  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), false, "G1 virtual space", mtGC);
 }
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -135,14 +135,14 @@ void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pa
   char* start_addr = page_start(start);
   size_t size = num_pages * _page_size;
 
-  os::commit_memory_or_exit(start_addr, size, _page_size, !ExecMem, "G1 virtual space", mtGC);
+  os::commit_memory_or_exit(start_addr, size, _page_size, !ExecMem, mtGC, "G1 virtual space");
 }
 
 void G1PageBasedVirtualSpace::commit_tail() {
   vmassert(_tail_size > 0, "The size of the tail area must be > 0 when reaching here");
 
   char* const aligned_end_address = align_down(_high_boundary, _page_size);
-  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), !ExecMem, "G1 virtual space", mtGC);
+  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), !ExecMem, mtGC, "G1 virtual space");
 }
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -135,14 +135,14 @@ void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pa
   char* start_addr = page_start(start);
   size_t size = num_pages * _page_size;
 
-  os::commit_memory_or_exit(start_addr, size, _page_size, false, "G1 virtual space", mtGC);
+  os::commit_memory_or_exit(start_addr, size, _page_size, !ExecMem, "G1 virtual space", mtGC);
 }
 
 void G1PageBasedVirtualSpace::commit_tail() {
   vmassert(_tail_size > 0, "The size of the tail area must be > 0 when reaching here");
 
   char* const aligned_end_address = align_down(_high_boundary, _page_size);
-  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), false, "G1 virtual space", mtGC);
+  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), !ExecMem, "G1 virtual space", mtGC);
 }
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {
@@ -201,7 +201,7 @@ void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_pa
             "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
 
   char* start_addr = page_start(start_page);
-  os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)), mtGC);
+  os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)), !ExecMem, mtGC);
 }
 
 void G1PageBasedVirtualSpace::uncommit(size_t start_page, size_t size_in_pages) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -201,7 +201,7 @@ void G1PageBasedVirtualSpace::uncommit_internal(size_t start_page, size_t end_pa
             "Given start page " SIZE_FORMAT " is larger or equal to end page " SIZE_FORMAT, start_page, end_page);
 
   char* start_addr = page_start(start_page);
-  os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)));
+  os::uncommit_memory(start_addr, pointer_delta(bounded_end_addr(end_page), start_addr, sizeof(char)), mtGC);
 }
 
 void G1PageBasedVirtualSpace::uncommit(size_t start_page, size_t size_in_pages) {

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,8 +47,6 @@ G1RegionToSpaceMapper::G1RegionToSpaceMapper(ReservedSpace rs,
   _memory_type(type) {
   guarantee(is_power_of_2(page_size), "must be");
   guarantee(is_power_of_2(region_granularity), "must be");
-
-  MemTracker::record_virtual_memory_type((address)rs.base(), type);
 }
 
 // Used to manually signal a mapper to handle a set of regions as committed.

--- a/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
+++ b/src/hotspot/share/gc/g1/g1RegionToSpaceMapper.cpp
@@ -43,7 +43,7 @@ G1RegionToSpaceMapper::G1RegionToSpaceMapper(ReservedSpace rs,
                                              MEMFLAGS type) :
   _listener(nullptr),
   _storage(rs, used_size, page_size),
-  _region_commit_map(rs.size() * commit_factor / region_granularity, mtGC),
+  _region_commit_map(rs.size() * commit_factor / region_granularity, type),
   _memory_type(type) {
   guarantee(is_power_of_2(page_size), "must be");
   guarantee(is_power_of_2(region_granularity), "must be");

--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ void MutableNUMASpace::bias_region(MemRegion mr, uint lgrp_id) {
     // Then we uncommit the pages in the range.
     // The alignment_hint argument must be less than or equal to the small page
     // size if not using large pages or else this function does nothing.
-    os::free_memory((char*)aligned_region.start(), aligned_region.byte_size(), os_align);
+    os::free_memory((char*)aligned_region.start(), aligned_region.byte_size(), os_align, mtGC);
     // And make them local/first-touch biased.
     os::numa_make_local((char*)aligned_region.start(), aligned_region.byte_size(), checked_cast<int>(lgrp_id));
   }

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ void MutableSpace::numa_setup_pages(MemRegion mr, size_t page_size, bool clear_s
       size_t size = pointer_delta(end, start, sizeof(char));
       if (clear_space) {
         // Prefer page reallocation to migration.
-        os::free_memory((char*)start, size, page_size);
+        os::free_memory((char*)start, size, page_size, mtGC);
       }
       os::numa_make_global((char*)start, size);
     }

--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -60,7 +60,7 @@ void MutableSpace::numa_setup_pages(MemRegion mr, size_t page_size, bool clear_s
       size_t size = pointer_delta(end, start, sizeof(char));
       if (clear_space) {
         // Prefer page reallocation to migration.
-        os::free_memory((char*)start, size, page_size, mtGC);
+        os::free_memory((char*)start, size, page_size, mtJavaHeap);
       }
       os::numa_make_global((char*)start, size);
     }

--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -47,7 +47,7 @@ void ObjectStartArray::initialize(MemRegion reserved_region) {
 
   // Do not use large-pages for the backing store. The one large page region
   // will be used for the heap proper.
-  ReservedSpace backing_store(bytes_to_reserve);
+  ReservedSpace backing_store(bytes_to_reserve, mtGC);
   if (!backing_store.is_reserved()) {
     vm_exit_during_initialization("Could not reserve space for ObjectStartArray");
   }

--- a/src/hotspot/share/gc/parallel/objectStartArray.cpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.cpp
@@ -51,7 +51,6 @@ void ObjectStartArray::initialize(MemRegion reserved_region) {
   if (!backing_store.is_reserved()) {
     vm_exit_during_initialization("Could not reserve space for ObjectStartArray");
   }
-  MemTracker::record_virtual_memory_type(backing_store.base(), mtGC);
 
   // We do not commit any memory initially
   _virtual_space.initialize(backing_store);

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ ParMarkBitMap::initialize(MemRegion covered_region)
 
   const size_t rs_align = page_sz == os::vm_page_size() ? 0 :
     MAX2(page_sz, granularity);
-  ReservedSpace rs(_reserved_byte_size, rs_align, page_sz);
+  ReservedSpace rs(_reserved_byte_size, rs_align, page_sz, mtGC);
   const size_t used_page_sz = rs.page_size();
   os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes,
                        rs.base(), rs.size(), used_page_sz);

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -54,8 +54,6 @@ ParMarkBitMap::initialize(MemRegion covered_region)
   os::trace_page_sizes("Mark Bitmap", raw_bytes, raw_bytes,
                        rs.base(), rs.size(), used_page_sz);
 
-  MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
-
   _virtual_space = new PSVirtualSpace(rs, page_sz);
   if (_virtual_space != nullptr && _virtual_space->expand_by(_reserved_byte_size)) {
     _region_start = covered_region.start();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -440,7 +440,7 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
 
   const size_t rs_align = page_sz == os::vm_page_size() ? 0 :
     MAX2(page_sz, granularity);
-  ReservedSpace rs(_reserved_byte_size, rs_align, page_sz);
+  ReservedSpace rs(_reserved_byte_size, rs_align, page_sz, mtGC);
   os::trace_page_sizes("Parallel Compact Data", raw_bytes, raw_bytes, rs.base(),
                        rs.size(), page_sz);
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -444,8 +444,6 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
   os::trace_page_sizes("Parallel Compact Data", raw_bytes, raw_bytes, rs.base(),
                        rs.size(), page_sz);
 
-  MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
-
   PSVirtualSpace* vspace = new PSVirtualSpace(rs, page_sz);
   if (vspace != 0) {
     if (vspace->expand_by(_reserved_byte_size)) {

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -95,7 +95,7 @@ bool PSVirtualSpace::shrink_by(size_t bytes) {
   }
 
   char* const base_addr = committed_high_addr() - bytes;
-  bool result = special() || os::uncommit_memory(base_addr, bytes);
+  bool result = special() || os::uncommit_memory(base_addr, bytes, mtGC);
   if (result) {
     _committed_high_addr -= bytes;
   }

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -95,7 +95,7 @@ bool PSVirtualSpace::shrink_by(size_t bytes) {
   }
 
   char* const base_addr = committed_high_addr() - bytes;
-  bool result = special() || os::uncommit_memory(base_addr, bytes, mtGC);
+  bool result = special() || os::uncommit_memory(base_addr, bytes, !ExecMem, mtGC);
   if (result) {
     _committed_high_addr -= bytes;
   }

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -78,7 +78,7 @@ bool PSVirtualSpace::expand_by(size_t bytes) {
 
   char* const base_addr = committed_high_addr();
   bool result = special() ||
-         os::commit_memory(base_addr, bytes, alignment(), !ExecMem);
+         os::commit_memory(base_addr, bytes, alignment(), !ExecMem, mtGC);
   if (result) {
     _committed_high_addr += bytes;
   }

--- a/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
@@ -37,7 +37,7 @@ SerialBlockOffsetTable::SerialBlockOffsetTable(MemRegion reserved,
                                                size_t init_word_size):
   _reserved(reserved) {
   size_t size = compute_size(reserved.word_size());
-  ReservedSpace rs(size);
+  ReservedSpace rs(size, mtGC);
   if (!rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for heap offset array");
   }

--- a/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/serial/serialBlockOffsetTable.cpp
@@ -42,8 +42,6 @@ SerialBlockOffsetTable::SerialBlockOffsetTable(MemRegion reserved,
     vm_exit_during_initialization("Could not reserve enough space for heap offset array");
   }
 
-  MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
-
   if (!_vs.initialize(rs, 0)) {
     vm_exit_during_initialization("Could not reserve enough space for heap offset array");
   }

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -84,9 +84,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
     MAX2(_page_size, os::vm_allocation_granularity());
   ReservedSpace heap_rs(_byte_map_size, rs_align, _page_size, mtGC);
 
-  MemTracker::record_virtual_memory_type((address)heap_rs.base(), mtGC);
-
-  os::trace_page_sizes("Card Table", num_bytes, num_bytes,
+    os::trace_page_sizes("Card Table", num_bytes, num_bytes,
                        heap_rs.base(), heap_rs.size(), _page_size);
   if (!heap_rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for the "

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -164,8 +164,8 @@ void CardTable::resize_covered_region(MemRegion new_region) {
                               delta.byte_size(),
                               _page_size,
                               !ExecMem,
-                              "card table expansion",
-                              mtGCCardSet);
+                              mtGCCardSet,
+                              "card table expansion");
 
     memset(delta.start(), clean_card, delta.byte_size());
   } else {

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -84,7 +84,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
     MAX2(_page_size, os::vm_allocation_granularity());
   ReservedSpace heap_rs(_byte_map_size, rs_align, _page_size, mtGC);
 
-    os::trace_page_sizes("Card Table", num_bytes, num_bytes,
+  os::trace_page_sizes("Card Table", num_bytes, num_bytes,
                        heap_rs.base(), heap_rs.size(), _page_size);
   if (!heap_rs.is_reserved()) {
     vm_exit_during_initialization("Could not reserve enough space for the "
@@ -173,7 +173,9 @@ void CardTable::resize_covered_region(MemRegion new_region) {
     MemRegion delta = MemRegion(new_committed.end(),
                                 old_committed.word_size() - new_committed.word_size());
     bool res = os::uncommit_memory((char*)delta.start(),
-                                   delta.byte_size(), !ExecMem, mtGCCardSet);
+                                   delta.byte_size(),
+                                   !ExecMem,
+                                   mtGCCardSet);
     assert(res, "uncommit should succeed");
   }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -173,7 +173,7 @@ void CardTable::resize_covered_region(MemRegion new_region) {
     MemRegion delta = MemRegion(new_committed.end(),
                                 old_committed.word_size() - new_committed.word_size());
     bool res = os::uncommit_memory((char*)delta.start(),
-                                   delta.byte_size(), mtGCCardSet);
+                                   delta.byte_size(), !ExecMem, mtGCCardSet);
     assert(res, "uncommit should succeed");
   }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -167,7 +167,7 @@ void CardTable::resize_covered_region(MemRegion new_region) {
                               _page_size,
                               !ExecMem,
                               "card table expansion",
-                              mtGC);
+                              mtGCCardSet);
 
     memset(delta.start(), clean_card, delta.byte_size());
   } else {
@@ -175,7 +175,7 @@ void CardTable::resize_covered_region(MemRegion new_region) {
     MemRegion delta = MemRegion(new_committed.end(),
                                 old_committed.word_size() - new_committed.word_size());
     bool res = os::uncommit_memory((char*)delta.start(),
-                                   delta.byte_size());
+                                   delta.byte_size(), mtGCCardSet);
     assert(res, "uncommit should succeed");
   }
 

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -82,7 +82,7 @@ void CardTable::initialize(void* region0_start, void* region1_start) {
 
   const size_t rs_align = _page_size == os::vm_page_size() ? 0 :
     MAX2(_page_size, os::vm_allocation_granularity());
-  ReservedSpace heap_rs(_byte_map_size, rs_align, _page_size);
+  ReservedSpace heap_rs(_byte_map_size, rs_align, _page_size, mtGC);
 
   MemTracker::record_virtual_memory_type((address)heap_rs.base(), mtGC);
 
@@ -166,7 +166,8 @@ void CardTable::resize_covered_region(MemRegion new_region) {
                               delta.byte_size(),
                               _page_size,
                               !ExecMem,
-                              "card table expansion");
+                              "card table expansion",
+                              mtGC);
 
     memset(delta.start(), clean_card, delta.byte_size());
   } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -64,12 +64,12 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
     char* bot_addr = align_down(_cset_map, page_size);
     char* top_addr = align_up(_cset_map + _map_size, page_size);
     os::commit_memory_or_exit(bot_addr, pointer_delta(top_addr, bot_addr, 1), !ExecMem,
-                              "Unable to commit collection set bitmap: heap", mtGC);
+                              mtGC, "Unable to commit collection set bitmap: heap");
 
     // Commit the zero page, if not yet covered by heap cset map.
     if (bot_addr != _biased_cset_map) {
       os::commit_memory_or_exit(_biased_cset_map, page_size, !ExecMem,
-                                "Unable to commit collection set bitmap: zero page", mtGC);
+                                mtGC, "Unable to commit collection set bitmap: zero page");
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -63,12 +63,12 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
     // Commit entire pages that cover the heap cset map.
     char* bot_addr = align_down(_cset_map, page_size);
     char* top_addr = align_up(_cset_map + _map_size, page_size);
-    os::commit_memory_or_exit(bot_addr, pointer_delta(top_addr, bot_addr, 1), false,
+    os::commit_memory_or_exit(bot_addr, pointer_delta(top_addr, bot_addr, 1), !ExecMem,
                               "Unable to commit collection set bitmap: heap", mtGC);
 
     // Commit the zero page, if not yet covered by heap cset map.
     if (bot_addr != _biased_cset_map) {
-      os::commit_memory_or_exit(_biased_cset_map, page_size, false,
+      os::commit_memory_or_exit(_biased_cset_map, page_size, !ExecMem,
                                 "Unable to commit collection set bitmap: zero page", mtGC);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -57,8 +57,6 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
   // subsystem for mapping not-yet-written-to pages to a single physical backing page,
   // but this is not guaranteed, and would confuse NMT and other memory accounting tools.
 
-  MemTracker::record_virtual_memory_type(_map_space.base(), mtGC);
-
   size_t page_size = os::vm_page_size();
 
   if (!_map_space.special()) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCollectionSet.cpp
@@ -66,12 +66,12 @@ ShenandoahCollectionSet::ShenandoahCollectionSet(ShenandoahHeap* heap, ReservedS
     char* bot_addr = align_down(_cset_map, page_size);
     char* top_addr = align_up(_cset_map + _map_size, page_size);
     os::commit_memory_or_exit(bot_addr, pointer_delta(top_addr, bot_addr, 1), false,
-                              "Unable to commit collection set bitmap: heap");
+                              "Unable to commit collection set bitmap: heap", mtGC);
 
     // Commit the zero page, if not yet covered by heap cset map.
     if (bot_addr != _biased_cset_map) {
       os::commit_memory_or_exit(_biased_cset_map, page_size, false,
-                                "Unable to commit collection set bitmap: zero page");
+                                "Unable to commit collection set bitmap: zero page", mtGC);
     }
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -252,7 +252,6 @@ jint ShenandoahHeap::initialize() {
                                           bitmap_size_orig, bitmap_page_size,
                                           bitmap.base(),
                                           bitmap.size(), bitmap.page_size());
-  MemTracker::record_virtual_memory_type(bitmap.base(), mtGC);
   _bitmap_region = MemRegion((HeapWord*) bitmap.base(), bitmap.size() / HeapWordSize);
   _bitmap_region_special = bitmap.special();
 
@@ -297,7 +296,6 @@ jint ShenandoahHeap::initialize() {
                                           bitmap_size_orig, aux_bitmap_page_size,
                                           aux_bitmap.base(),
                                           aux_bitmap.size(), aux_bitmap.page_size());
-  MemTracker::record_virtual_memory_type(aux_bitmap.base(), mtGC);
   _aux_bitmap_region = MemRegion((HeapWord*) aux_bitmap.base(), aux_bitmap.size() / HeapWordSize);
   _aux_bitmap_region_special = aux_bitmap.special();
   _aux_bit_map.initialize(_heap_region, _aux_bitmap_region);
@@ -315,7 +313,6 @@ jint ShenandoahHeap::initialize() {
                                           region_storage_size_orig, region_page_size,
                                           region_storage.base(),
                                           region_storage.size(), region_storage.page_size());
-  MemTracker::record_virtual_memory_type(region_storage.base(), mtGC);
   if (!region_storage.special()) {
     os::commit_memory_or_exit(region_storage.base(), region_storage_size, region_page_size, false,
                               "Cannot commit region memory", mtGC);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -2261,7 +2261,7 @@ bool ShenandoahHeap::commit_bitmap_slice(ShenandoahHeapRegion* r) {
   size_t len = _bitmap_bytes_per_slice;
   char* start = (char*) _bitmap_region.start() + off;
 
-  if (!os::commit_memory(start, len, false)) {
+  if (!os::commit_memory(start, len, false, mtJavaHeap)) {
     return false;
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1434,7 +1434,7 @@ void ShenandoahHeap::scan_roots_for_iteration(ShenandoahScanObjectStack* oop_sta
 }
 
 void ShenandoahHeap::reclaim_aux_bitmap_for_iteration() {
-  if (!_aux_bitmap_region_special && !os::uncommit_memory((char*)_aux_bitmap_region.start(), _aux_bitmap_region.byte_size())) {
+  if (!_aux_bitmap_region_special && !os::uncommit_memory((char*)_aux_bitmap_region.start(), _aux_bitmap_region.byte_size(), mtGC)) {
     log_warning(gc)("Could not uncommit native memory for auxiliary marking bitmap for heap iteration");
   }
 }
@@ -2293,7 +2293,7 @@ bool ShenandoahHeap::uncommit_bitmap_slice(ShenandoahHeapRegion *r) {
   size_t slice = r->index() / _bitmap_regions_per_slice;
   size_t off = _bitmap_bytes_per_slice * slice;
   size_t len = _bitmap_bytes_per_slice;
-  if (!os::uncommit_memory((char*)_bitmap_region.start() + off, len)) {
+  if (!os::uncommit_memory((char*)_bitmap_region.start() + off, len, mtGC)) {
     return false;
   }
   return true;

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1411,7 +1411,7 @@ void ShenandoahHeap::object_iterate(ObjectClosure* cl) {
 bool ShenandoahHeap::prepare_aux_bitmap_for_iteration() {
   assert(SafepointSynchronize::is_at_safepoint(), "safe iteration is only available during safepoints");
 
-  if (!_aux_bitmap_region_special && !os::commit_memory((char*)_aux_bitmap_region.start(), _aux_bitmap_region.byte_size(), false)) {
+  if (!_aux_bitmap_region_special && !os::commit_memory((char*)_aux_bitmap_region.start(), _aux_bitmap_region.byte_size(), false, mtJavaHeap)) {
     log_warning(gc)("Could not commit native memory for auxiliary marking bitmap for heap iteration");
     return false;
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -273,7 +273,7 @@ jint ShenandoahHeap::initialize() {
                                             verify_bitmap.size(), verify_bitmap.page_size());
     if (!verify_bitmap.special()) {
       os::commit_memory_or_exit(verify_bitmap.base(), verify_bitmap.size(), bitmap_page_size, !ExecMem,
-                                "Cannot commit verification bitmap memory", mtGC);
+                                mtGC, "Cannot commit verification bitmap memory");
     }
     MemTracker::record_virtual_memory_type(verify_bitmap.base(), mtGC);
     MemRegion verify_bitmap_region = MemRegion((HeapWord *) verify_bitmap.base(), verify_bitmap.size() / HeapWordSize);
@@ -315,7 +315,7 @@ jint ShenandoahHeap::initialize() {
                                           region_storage.size(), region_storage.page_size());
   if (!region_storage.special()) {
     os::commit_memory_or_exit(region_storage.base(), region_storage_size, region_page_size, !ExecMem,
-                              "Cannot commit region memory", mtGC);
+                              mtGC, "Cannot commit region memory");
   }
 
   // Try to fit the collection set bitmap at lower addresses. This optimizes code generation for cset checks.

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -214,7 +214,7 @@ jint ShenandoahHeap::initialize() {
   ReservedSpace sh_rs = heap_rs.first_part(max_byte_size);
   if (!_heap_region_special) {
     os::commit_memory_or_exit(sh_rs.base(), _initial_size, heap_alignment, !ExecMem,
-                              "Cannot commit heap memory", mtGC);
+                              mtGC, "Cannot commit heap memory");
   }
 
   //
@@ -260,7 +260,7 @@ jint ShenandoahHeap::initialize() {
   bitmap_init_commit = MIN2(_bitmap_size, bitmap_init_commit);
   if (!_bitmap_region_special) {
     os::commit_memory_or_exit((char *) _bitmap_region.start(), bitmap_init_commit, bitmap_page_size, !ExecMem,
-                              "Cannot commit bitmap memory", mtGC);
+                              mtGC, "Cannot commit bitmap memory");
   }
 
   _marking_context = new ShenandoahMarkingContext(_heap_region, _bitmap_region, _num_regions, _max_workers);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -275,7 +275,6 @@ jint ShenandoahHeap::initialize() {
       os::commit_memory_or_exit(verify_bitmap.base(), verify_bitmap.size(), bitmap_page_size, !ExecMem,
                                 mtGC, "Cannot commit verification bitmap memory");
     }
-    MemTracker::record_virtual_memory_type(verify_bitmap.base(), mtGC);
     MemRegion verify_bitmap_region = MemRegion((HeapWord *) verify_bitmap.base(), verify_bitmap.size() / HeapWordSize);
     _verification_bit_map.initialize(_heap_region, verify_bitmap_region);
     _verifier = new ShenandoahVerifier(this, &_verification_bit_map);

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -620,7 +620,7 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
 
 void ShenandoahHeapRegion::do_commit() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (!heap->is_heap_region_special() && !os::commit_memory((char *) bottom(), RegionSizeBytes, false, mtJavaHeap)) {
+  if (!heap->is_heap_region_special() && !os::commit_memory((char *) bottom(), RegionSizeBytes, !ExecMem, mtJavaHeap)) {
     report_java_out_of_memory("Unable to commit region");
   }
   if (!heap->commit_bitmap_slice(this)) {
@@ -634,7 +634,7 @@ void ShenandoahHeapRegion::do_commit() {
 
 void ShenandoahHeapRegion::do_uncommit() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (!heap->is_heap_region_special() && !os::uncommit_memory((char *) bottom(), RegionSizeBytes, mtJavaHeap)) {
+  if (!heap->is_heap_region_special() && !os::uncommit_memory((char *) bottom(), RegionSizeBytes, !ExecMem, mtJavaHeap)) {
     report_java_out_of_memory("Unable to uncommit region");
   }
   if (!heap->uncommit_bitmap_slice(this)) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
@@ -620,7 +620,7 @@ size_t ShenandoahHeapRegion::setup_sizes(size_t max_heap_size) {
 
 void ShenandoahHeapRegion::do_commit() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (!heap->is_heap_region_special() && !os::commit_memory((char *) bottom(), RegionSizeBytes, false)) {
+  if (!heap->is_heap_region_special() && !os::commit_memory((char *) bottom(), RegionSizeBytes, false, mtJavaHeap)) {
     report_java_out_of_memory("Unable to commit region");
   }
   if (!heap->commit_bitmap_slice(this)) {
@@ -634,7 +634,7 @@ void ShenandoahHeapRegion::do_commit() {
 
 void ShenandoahHeapRegion::do_uncommit() {
   ShenandoahHeap* heap = ShenandoahHeap::heap();
-  if (!heap->is_heap_region_special() && !os::uncommit_memory((char *) bottom(), RegionSizeBytes)) {
+  if (!heap->is_heap_region_special() && !os::uncommit_memory((char *) bottom(), RegionSizeBytes, mtJavaHeap)) {
     report_java_out_of_memory("Unable to uncommit region");
   }
   if (!heap->uncommit_bitmap_slice(this)) {

--- a/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ size_t XMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space");
+  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space", mtGC);
 
   return expand_size;
 }

--- a/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
@@ -105,7 +105,7 @@ size_t XMarkStackSpace::shrink_space() {
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;
-    os::uncommit_memory((char*)shrink_start, shrink_size, false /* executable */);
+    os::uncommit_memory((char*)shrink_start, shrink_size, mtGC, false /* executable */);
   }
 
   return shrink_size;

--- a/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
@@ -88,7 +88,7 @@ size_t XMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space", mtGC);
+  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem /* executable */, "Mark stack space", mtGC);
 
   return expand_size;
 }
@@ -105,7 +105,7 @@ size_t XMarkStackSpace::shrink_space() {
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;
-    os::uncommit_memory((char*)shrink_start, shrink_size, mtGC, false /* executable */);
+    os::uncommit_memory((char*)shrink_start, shrink_size, !ExecMem, mtGC);
   }
 
   return shrink_size;

--- a/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/x/xMarkStackAllocator.cpp
@@ -88,7 +88,7 @@ size_t XMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem /* executable */, "Mark stack space", mtGC);
+  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem, mtGC, "Mark stack space");
 
   return expand_size;
 }

--- a/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -279,7 +279,7 @@ void XPhysicalMemoryManager::try_enable_uncommit(size_t min_capacity, size_t max
 void XPhysicalMemoryManager::nmt_commit(uintptr_t offset, size_t size) const {
   // From an NMT point of view we treat the first heap view (marked0) as committed
   const uintptr_t addr = XAddress::marked0(offset);
-  MemTracker::record_virtual_memory_commit((void*)addr, size, CALLER_PC);
+  MemTracker::record_virtual_memory_commit((void*)addr, size, CALLER_PC, mtGC);
 }
 
 void XPhysicalMemoryManager::nmt_uncommit(uintptr_t offset, size_t size) const {

--- a/src/hotspot/share/gc/x/xPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/x/xPhysicalMemory.cpp
@@ -285,7 +285,7 @@ void XPhysicalMemoryManager::nmt_commit(uintptr_t offset, size_t size) const {
 void XPhysicalMemoryManager::nmt_uncommit(uintptr_t offset, size_t size) const {
   const uintptr_t addr = XAddress::marked0(offset);
   ThreadCritical tc;
-  MemTracker::record_virtual_memory_uncommit((address)addr, size);
+  MemTracker::record_virtual_memory_uncommit((address)addr, size, mtGC);
 }
 
 void XPhysicalMemoryManager::alloc(XPhysicalMemory& pmem, size_t size) {

--- a/src/hotspot/share/gc/x/xVirtualMemory.cpp
+++ b/src/hotspot/share/gc/x/xVirtualMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,8 +181,7 @@ bool XVirtualMemoryManager::reserve(size_t max_capacity) {
 }
 
 void XVirtualMemoryManager::nmt_reserve(uintptr_t start, size_t size) {
-  MemTracker::record_virtual_memory_reserve((void*)start, size, CALLER_PC);
-  MemTracker::record_virtual_memory_type((void*)start, mtJavaHeap);
+  MemTracker::record_virtual_memory_reserve((void*)start, size, CALLER_PC, mtJavaHeap);
 }
 
 bool XVirtualMemoryManager::is_initialized() const {

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -104,7 +104,7 @@ size_t ZMarkStackSpace::shrink_space() {
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;
-    os::uncommit_memory((char*)shrink_start, shrink_size, false /* executable */);
+    os::uncommit_memory((char*)shrink_start, shrink_size, mtGC, false /* executable */);
   }
 
   return shrink_size;

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -87,7 +87,7 @@ size_t ZMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem /* executable */, "Mark stack space", mtGC);
+  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem, mtGC, "Mark stack space");
 
   return expand_size;
 }

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ size_t ZMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space");
+  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space", mtGC);
 
   return expand_size;
 }

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -87,7 +87,7 @@ size_t ZMarkStackSpace::expand_space() {
                          old_size / M, new_size / M);
 
   // Expand
-  os::commit_memory_or_exit((char*)_end, expand_size, false /* executable */, "Mark stack space", mtGC);
+  os::commit_memory_or_exit((char*)_end, expand_size, !ExecMem /* executable */, "Mark stack space", mtGC);
 
   return expand_size;
 }
@@ -104,7 +104,7 @@ size_t ZMarkStackSpace::shrink_space() {
                            old_size / M, new_size / M);
 
     const uintptr_t shrink_start = _end - shrink_size;
-    os::uncommit_memory((char*)shrink_start, shrink_size, mtGC, false /* executable */);
+    os::uncommit_memory((char*)shrink_start, shrink_size, !ExecMem, mtGC);
   }
 
   return shrink_size;

--- a/src/hotspot/share/gc/z/zNMT.cpp
+++ b/src/hotspot/share/gc/z/zNMT.cpp
@@ -74,7 +74,7 @@ void ZNMT::process_fake_mapping(zoffset offset, size_t size, bool commit) {
       MemTracker::record_virtual_memory_commit((void*)sub_range_addr, sub_range_size, CALLER_PC, mtGC);
     } else {
       ThreadCritical tc;
-      MemTracker::record_virtual_memory_uncommit((address)sub_range_addr, sub_range_size);
+      MemTracker::record_virtual_memory_uncommit((address)sub_range_addr, sub_range_size, mtGC);
     }
 
     left_to_process -= sub_range_size;

--- a/src/hotspot/share/gc/z/zNMT.cpp
+++ b/src/hotspot/share/gc/z/zNMT.cpp
@@ -71,7 +71,7 @@ void ZNMT::process_fake_mapping(zoffset offset, size_t size, bool commit) {
 
     // commit / uncommit memory
     if (commit) {
-      MemTracker::record_virtual_memory_commit((void*)sub_range_addr, sub_range_size, CALLER_PC);
+      MemTracker::record_virtual_memory_commit((void*)sub_range_addr, sub_range_size, CALLER_PC, mtGC);
     } else {
       ThreadCritical tc;
       MemTracker::record_virtual_memory_uncommit((address)sub_range_addr, sub_range_size);

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -117,7 +117,6 @@ bool JfrVirtualMemorySegment::initialize(size_t reservation_size_request_bytes) 
                               _rs.base(),
                               _rs.size(),
                               os::vm_page_size());
-  MemTracker::record_virtual_memory_type((address)_rs.base(), mtTracing);
   assert(is_aligned(_rs.base(), os::vm_page_size()), "invariant");
   assert(is_aligned(_rs.size(), os::vm_page_size()), "invariant");
 

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,7 @@ bool JfrVirtualMemorySegment::initialize(size_t reservation_size_request_bytes) 
   assert(is_aligned(reservation_size_request_bytes, os::vm_allocation_granularity()), "invariant");
   _rs = ReservedSpace(reservation_size_request_bytes,
                       os::vm_allocation_granularity(),
-                      os::vm_page_size());
+                      os::vm_page_size(), mtTracing);
   if (!_rs.is_reserved()) {
     return false;
   }

--- a/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrVirtualMemory.cpp
@@ -104,7 +104,8 @@ bool JfrVirtualMemorySegment::initialize(size_t reservation_size_request_bytes) 
   assert(is_aligned(reservation_size_request_bytes, os::vm_allocation_granularity()), "invariant");
   _rs = ReservedSpace(reservation_size_request_bytes,
                       os::vm_allocation_granularity(),
-                      os::vm_page_size(), mtTracing);
+                      os::vm_page_size(),
+                      mtTracing);
   if (!_rs.is_reserved()) {
     return false;
   }

--- a/src/hotspot/share/memory/allocation.inline.hpp
+++ b/src/hotspot/share/memory/allocation.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ E* MmapArrayAllocator<E>::allocate_or_null(size_t length, MEMFLAGS flags) {
     return nullptr;
   }
 
-  if (os::commit_memory(addr, size, !ExecMem)) {
+  if (os::commit_memory(addr, size, !ExecMem, flags)) {
     return (E*)addr;
   } else {
     os::release_memory(addr, size);
@@ -80,7 +80,7 @@ E* MmapArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "Allocator (reserve)");
   }
 
-  os::commit_memory_or_exit(addr, size, !ExecMem, "Allocator (commit)");
+  os::commit_memory_or_exit(addr, size, !ExecMem, "Allocator (commit)", flags);
 
   return (E*)addr;
 }

--- a/src/hotspot/share/memory/allocation.inline.hpp
+++ b/src/hotspot/share/memory/allocation.inline.hpp
@@ -80,7 +80,7 @@ E* MmapArrayAllocator<E>::allocate(size_t length, MEMFLAGS flags) {
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "Allocator (reserve)");
   }
 
-  os::commit_memory_or_exit(addr, size, !ExecMem, "Allocator (commit)", flags);
+  os::commit_memory_or_exit(addr, size, !ExecMem, flags, "Allocator (commit)");
 
   return (E*)addr;
 }

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
   const size_t committed_segments_size = align_to_page_size(_number_of_committed_segments);
 
   // reserve space for _segmap
-  ReservedSpace seg_rs(reserved_segments_size);
+  ReservedSpace seg_rs(reserved_segments_size, mtCode);
   if (!_segmap.initialize(seg_rs, committed_segments_size)) {
     return false;
   }

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -232,8 +232,6 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
     return false;
   }
 
-  MemTracker::record_virtual_memory_type((address)_segmap.low_boundary(), mtCode);
-
   assert(_segmap.committed_size() >= (size_t) _number_of_committed_segments, "could not commit  enough space for segment map");
   assert(_segmap.reserved_size()  >= (size_t) _number_of_reserved_segments , "could not reserve enough space for segment map");
   assert(_segmap.reserved_size()  >= _segmap.committed_size()     , "just checking");

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -589,7 +589,7 @@ ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t siz
   if (result == nullptr) {
     // Fallback: reserve anywhere
     log_debug(metaspace, map)("Trying anywhere...");
-    result = os::reserve_memory_aligned(size, Metaspace::reserve_alignment(), false, mtMetaspace);
+    result = os::reserve_memory_aligned(size, Metaspace::reserve_alignment(), !ExecMem, mtClass);
   }
 
   // Wrap resulting range in ReservedSpace
@@ -598,7 +598,7 @@ ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t siz
     log_debug(metaspace, map)("Mapped at " PTR_FORMAT, p2i(result));
     assert(is_aligned(result, Metaspace::reserve_alignment()), "Alignment too small for metaspace");
     rs = ReservedSpace::space_for_range(result, size, Metaspace::reserve_alignment(),
-                                                      os::vm_page_size(), false, false, mtMetaspace);
+                                                      os::vm_page_size(), false, false, mtClass);
   } else {
     log_debug(metaspace, map)("Failed to map.");
     rs = ReservedSpace();
@@ -739,7 +739,7 @@ void Metaspace::global_initialize() {
                     CompressedClassSpaceBaseAddress, Metaspace::reserve_alignment()));
       }
       rs = ReservedSpace(size, Metaspace::reserve_alignment(),
-                         os::vm_page_size() /* large */, mtMetaspace, (char*)base);
+                         os::vm_page_size() /* large */, mtClass, (char*)base);
       if (rs.is_reserved()) {
         log_info(metaspace)("Successfully forced class space address to " PTR_FORMAT, p2i(base));
       } else {

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -598,7 +598,7 @@ ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t siz
     log_debug(metaspace, map)("Mapped at " PTR_FORMAT, p2i(result));
     assert(is_aligned(result, Metaspace::reserve_alignment()), "Alignment too small for metaspace");
     rs = ReservedSpace::space_for_range(result, size, Metaspace::reserve_alignment(),
-                                                      os::vm_page_size(), false, false);
+                                                      os::vm_page_size(), false, false, mtMetaspace);
   } else {
     log_debug(metaspace, map)("Failed to map.");
     rs = ReservedSpace();
@@ -739,7 +739,7 @@ void Metaspace::global_initialize() {
                     CompressedClassSpaceBaseAddress, Metaspace::reserve_alignment()));
       }
       rs = ReservedSpace(size, Metaspace::reserve_alignment(),
-                         os::vm_page_size() /* large */, (char*)base);
+                         os::vm_page_size() /* large */, mtMetaspace, (char*)base);
       if (rs.is_reserved()) {
         log_info(metaspace)("Successfully forced class space address to " PTR_FORMAT, p2i(base));
       } else {

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -589,7 +589,7 @@ ReservedSpace Metaspace::reserve_address_space_for_compressed_classes(size_t siz
   if (result == nullptr) {
     // Fallback: reserve anywhere
     log_debug(metaspace, map)("Trying anywhere...");
-    result = os::reserve_memory_aligned(size, Metaspace::reserve_alignment(), false);
+    result = os::reserve_memory_aligned(size, Metaspace::reserve_alignment(), false, mtMetaspace);
   }
 
   // Wrap resulting range in ReservedSpace
@@ -768,7 +768,7 @@ void Metaspace::global_initialize() {
     }
 
     // Mark class space as such
-    MemTracker::record_virtual_memory_type((address)rs.base(), mtClass);
+    MemTracker::record_virtual_memory_type((address)rs.base(), rs.nmt_flag());
 
     // Initialize space
     Metaspace::initialize_class_space(rs);

--- a/src/hotspot/share/memory/metaspace.cpp
+++ b/src/hotspot/share/memory/metaspace.cpp
@@ -767,9 +767,6 @@ void Metaspace::global_initialize() {
                    CompressedClassSpaceSize));
     }
 
-    // Mark class space as such
-    MemTracker::record_virtual_memory_type((address)rs.base(), rs.nmt_flag());
-
     // Initialize space
     Metaspace::initialize_class_space(rs);
 

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -78,7 +78,7 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
                     reserve_limit, Metaspace::reserve_alignment_words());
   if (reserve_limit > 0) {
     // have reserve limit -> non-expandable context
-    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size(), mtTest);
+    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size(), mtMetaspace);
     _context = MetaspaceContext::create_nonexpandable_context(name, _rs, &_commit_limiter);
   } else {
     // no reserve limit -> expandable vslist

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -78,7 +78,7 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
                     reserve_limit, Metaspace::reserve_alignment_words());
   if (reserve_limit > 0) {
     // have reserve limit -> non-expandable context
-    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size());
+    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size(), mtTest);
     _context = MetaspaceContext::create_nonexpandable_context(name, _rs, &_commit_limiter);
   } else {
     // no reserve limit -> expandable vslist

--- a/src/hotspot/share/memory/metaspace/testHelpers.cpp
+++ b/src/hotspot/share/memory/metaspace/testHelpers.cpp
@@ -78,7 +78,7 @@ MetaspaceTestContext::MetaspaceTestContext(const char* name, size_t commit_limit
                     reserve_limit, Metaspace::reserve_alignment_words());
   if (reserve_limit > 0) {
     // have reserve limit -> non-expandable context
-    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size(), mtMetaspace);
+    _rs = ReservedSpace(reserve_limit * BytesPerWord, Metaspace::reserve_alignment(), os::vm_page_size(), mtTest);
     _context = MetaspaceContext::create_nonexpandable_context(name, _rs, &_commit_limiter);
   } else {
     // no reserve limit -> expandable vslist

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -109,7 +109,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   }
 
   // Commit...
-  if (os::commit_memory((char*)p, word_size * BytesPerWord, false, _rs.nmt_flag()) == false) {
+  if (os::commit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to commit metaspace.");
   }
 
@@ -188,7 +188,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   }
 
   // Uncommit...
-  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, _rs.nmt_flag()) == false) {
+  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
     // Note: this can actually happen, since uncommit may increase the number of mappings.
     fatal("Failed to uncommit metaspace.");
   }

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -259,7 +259,6 @@ VirtualSpaceNode* VirtualSpaceNode::create_node(size_t word_size,
   if (!rs.is_reserved()) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to reserve memory for metaspace");
   }
-  MemTracker::record_virtual_memory_type(rs.base(), mtMetaspace);
   assert_is_aligned(rs.base(), chunklevel::MAX_CHUNK_BYTE_SIZE);
   InternalStats::inc_num_vsnodes_births();
   return new VirtualSpaceNode(rs, true, limiter, reserve_words_counter, commit_words_counter);

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -188,7 +188,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   }
 
   // Uncommit...
-  if (os::uncommit_memory((char*)p, word_size * BytesPerWord) == false) {
+  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, _rs.nmt_flag()) == false) {
     // Note: this can actually happen, since uncommit may increase the number of mappings.
     fatal("Failed to uncommit metaspace.");
   }

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -109,7 +109,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   }
 
   // Commit...
-  if (os::commit_memory((char*)p, word_size * BytesPerWord, false) == false) {
+  if (os::commit_memory((char*)p, word_size * BytesPerWord, false, _rs.nmt_flag()) == false) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to commit metaspace.");
   }
 
@@ -255,7 +255,7 @@ VirtualSpaceNode* VirtualSpaceNode::create_node(size_t word_size,
   DEBUG_ONLY(assert_is_aligned(word_size, chunklevel::MAX_CHUNK_WORD_SIZE);)
   ReservedSpace rs(word_size * BytesPerWord,
                    Settings::virtual_space_node_reserve_alignment_words() * BytesPerWord,
-                   os::vm_page_size());
+                   os::vm_page_size(), mtMetaspace);
   if (!rs.is_reserved()) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to reserve memory for metaspace");
   }

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -109,7 +109,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   }
 
   // Commit...
-  if (os::commit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
+  if (os::commit_memory((char*)p, word_size * BytesPerWord, !ExecMem, mtMetaspace) == false) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to commit metaspace.");
   }
 
@@ -188,7 +188,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   }
 
   // Uncommit...
-  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
+  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, !ExecMem, mtMetaspace) == false) {
     // Note: this can actually happen, since uncommit may increase the number of mappings.
     fatal("Failed to uncommit metaspace.");
   }

--- a/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceNode.cpp
@@ -109,7 +109,7 @@ bool VirtualSpaceNode::commit_range(MetaWord* p, size_t word_size) {
   }
 
   // Commit...
-  if (os::commit_memory((char*)p, word_size * BytesPerWord, !ExecMem, mtMetaspace) == false) {
+  if (os::commit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
     vm_exit_out_of_memory(word_size * BytesPerWord, OOM_MMAP_ERROR, "Failed to commit metaspace.");
   }
 
@@ -188,7 +188,7 @@ void VirtualSpaceNode::uncommit_range(MetaWord* p, size_t word_size) {
   }
 
   // Uncommit...
-  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, !ExecMem, mtMetaspace) == false) {
+  if (os::uncommit_memory((char*)p, word_size * BytesPerWord, !ExecMem, _rs.nmt_flag()) == false) {
     // Note: this can actually happen, since uncommit may increase the number of mappings.
     fatal("Failed to uncommit metaspace.");
   }

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -706,7 +706,6 @@ bool VirtualSpace::initialize_with_granularity(ReservedSpace rs, size_t committe
   assert(_low_boundary == nullptr, "VirtualSpace already initialized");
   assert(max_commit_granularity > 0, "Granularity must be non-zero.");
 
-
   _low_boundary  = rs.base();
   _high_boundary = low_boundary() + rs.size();
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -1015,7 +1015,7 @@ void VirtualSpace::shrink_by(size_t size) {
     assert(middle_high_boundary() <= aligned_upper_new_high &&
            aligned_upper_new_high + upper_needs <= upper_high_boundary(),
            "must not shrink beyond region");
-    if (!os::uncommit_memory(aligned_upper_new_high, upper_needs, _executable)) {
+    if (!os::uncommit_memory(aligned_upper_new_high, upper_needs, _nmt_flag, _executable)) {
       debug_only(warning("os::uncommit_memory failed"));
       return;
     } else {
@@ -1026,7 +1026,7 @@ void VirtualSpace::shrink_by(size_t size) {
     assert(lower_high_boundary() <= aligned_middle_new_high &&
            aligned_middle_new_high + middle_needs <= middle_high_boundary(),
            "must not shrink beyond region");
-    if (!os::uncommit_memory(aligned_middle_new_high, middle_needs, _executable)) {
+    if (!os::uncommit_memory(aligned_middle_new_high, middle_needs, _nmt_flag, _executable)) {
       debug_only(warning("os::uncommit_memory failed"));
       return;
     } else {
@@ -1037,7 +1037,7 @@ void VirtualSpace::shrink_by(size_t size) {
     assert(low_boundary() <= aligned_lower_new_high &&
            aligned_lower_new_high + lower_needs <= lower_high_boundary(),
            "must not shrink beyond region");
-    if (!os::uncommit_memory(aligned_lower_new_high, lower_needs, _executable)) {
+    if (!os::uncommit_memory(aligned_lower_new_high, lower_needs, _nmt_flag, _executable)) {
       debug_only(warning("os::uncommit_memory failed"));
       return;
     } else {

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -692,7 +692,7 @@ VirtualSpace::VirtualSpace() {
   _upper_alignment        = 0;
   _special                = false;
   _executable             = false;
-  _nmt_flag                = mtNone;
+  _nmt_flag               = mtNone;
 }
 
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -42,7 +42,7 @@
 
 // Dummy constructor
 ReservedSpace::ReservedSpace() : _base(nullptr), _size(0), _noaccess_prefix(0),
-    _alignment(0), _special(false), _fd_for_heap(-1), _executable(false), _nmt_flag(mtNone) {
+    _alignment(0), _fd_for_heap(-1), _special(false), _executable(false), _nmt_flag(mtNone) {
 }
 
 ReservedSpace::ReservedSpace(size_t size, MEMFLAGS flag) : _fd_for_heap(-1), _nmt_flag(flag) {
@@ -715,7 +715,6 @@ bool VirtualSpace::initialize_with_granularity(ReservedSpace rs, size_t committe
 
   _special = rs.special();
   _executable = rs.executable();
-
   _nmt_flag = rs.nmt_flag();
 
   // When a VirtualSpace begins life at a large size, make all future expansion
@@ -775,6 +774,7 @@ void VirtualSpace::release() {
   _upper_alignment        = 0;
   _special                = false;
   _executable             = false;
+  _nmt_flag               = mtNone;
 }
 
 

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -81,19 +81,19 @@ ReservedSpace::ReservedSpace(char* base, size_t size, size_t alignment, size_t p
 }
 
 // Helper method
-static char* attempt_map_or_reserve_memory_at(char* base, size_t size, int fd, bool executable) {
+static char* attempt_map_or_reserve_memory_at(char* base, size_t size, int fd, bool executable, MEMFLAGS flag) {
   if (fd != -1) {
     return os::attempt_map_memory_to_file_at(base, size, fd);
   }
-  return os::attempt_reserve_memory_at(base, size, executable);
+  return os::attempt_reserve_memory_at(base, size, executable, flag);
 }
 
 // Helper method
-static char* map_or_reserve_memory(size_t size, int fd, bool executable) {
+static char* map_or_reserve_memory(size_t size, int fd, bool executable, MEMFLAGS flag) {
   if (fd != -1) {
     return os::map_memory_to_file(size, fd);
   }
-  return os::reserve_memory(size, executable);
+  return os::reserve_memory(size, executable, flag);
 }
 
 // Helper method
@@ -101,7 +101,7 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fd
   if (fd != -1) {
     return os::map_memory_to_file_aligned(size, alignment, fd, flag);
   }
-  return os::reserve_memory_aligned(size, alignment, executable);
+  return os::reserve_memory_aligned(size, alignment, executable, flag);
 }
 
 // Helper method
@@ -163,12 +163,12 @@ static char* reserve_memory(char* requested_address, const size_t size,
     assert(is_aligned(requested_address, alignment),
            "Requested address " PTR_FORMAT " must be aligned to " SIZE_FORMAT,
            p2i(requested_address), alignment);
-    base = attempt_map_or_reserve_memory_at(requested_address, size, fd, exec);
+    base = attempt_map_or_reserve_memory_at(requested_address, size, fd, exec, flag);
   } else {
     // Optimistically assume that the OS returns an aligned base pointer.
     // When reserving a large address range, most OSes seem to align to at
     // least 64K.
-    base = map_or_reserve_memory(size, fd, exec);
+    base = map_or_reserve_memory(size, fd, exec, flag);
     // Check alignment constraints. This is only needed when there is
     // no requested address.
     if (!is_aligned(base, alignment)) {

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -670,7 +670,6 @@ ReservedCodeSpace::ReservedCodeSpace(size_t r_size,
                                      size_t rs_page_size) : ReservedSpace() {
   set_nmt_flag(mtCode);
   initialize(r_size, rs_align, rs_page_size, /*requested address*/ nullptr, /*executable*/ true);
-  MemTracker::record_virtual_memory_type((address)base(), mtCode);
 }
 
 // VirtualSpace

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -42,10 +42,10 @@
 
 // Dummy constructor
 ReservedSpace::ReservedSpace() : _base(nullptr), _size(0), _noaccess_prefix(0),
-    _alignment(0), _special(false), _fd_for_heap(-1), _executable(false) {
+    _alignment(0), _special(false), _fd_for_heap(-1), _nmt_flag(mtNone), _executable(false) {
 }
 
-ReservedSpace::ReservedSpace(size_t size) : _fd_for_heap(-1) {
+ReservedSpace::ReservedSpace(size_t size, MEMFLAGS flag) : _fd_for_heap(-1), _nmt_flag(flag) {
   // Want to use large pages where possible. If the size is
   // not large page aligned the mapping will be a mix of
   // large and normal pages.
@@ -54,7 +54,7 @@ ReservedSpace::ReservedSpace(size_t size) : _fd_for_heap(-1) {
   initialize(size, alignment, page_size, nullptr, false);
 }
 
-ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size) : _fd_for_heap(-1) {
+ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size, MEMFLAGS flag) : _fd_for_heap(-1), _nmt_flag(flag) {
   // When a page size is given we don't want to mix large
   // and normal pages. If the size is not a multiple of the
   // page size it will be aligned up to achieve this.
@@ -68,13 +68,13 @@ ReservedSpace::ReservedSpace(size_t size, size_t preferred_page_size) : _fd_for_
 
 ReservedSpace::ReservedSpace(size_t size,
                              size_t alignment,
-                             size_t page_size,
-                             char* requested_address) : _fd_for_heap(-1) {
+                             size_t page_size, MEMFLAGS flag,
+                             char* requested_address) : _fd_for_heap(-1), _nmt_flag(flag) {
   initialize(size, alignment, page_size, requested_address, false);
 }
 
 ReservedSpace::ReservedSpace(char* base, size_t size, size_t alignment, size_t page_size,
-                             bool special, bool executable) : _fd_for_heap(-1) {
+                             bool special, bool executable, MEMFLAGS flag) : _fd_for_heap(-1), _nmt_flag(flag) {
   assert((size % os::vm_allocation_granularity()) == 0,
          "size not allocation aligned");
   initialize_members(base, size, alignment, page_size, special, executable);
@@ -97,9 +97,9 @@ static char* map_or_reserve_memory(size_t size, int fd, bool executable) {
 }
 
 // Helper method
-static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fd, bool executable) {
+static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fd, bool executable, MEMFLAGS flag) {
   if (fd != -1) {
-    return os::map_memory_to_file_aligned(size, alignment, fd);
+    return os::map_memory_to_file_aligned(size, alignment, fd, flag);
   }
   return os::reserve_memory_aligned(size, alignment, executable);
 }
@@ -154,7 +154,7 @@ static void log_on_large_pages_failure(char* req_addr, size_t bytes) {
 }
 
 static char* reserve_memory(char* requested_address, const size_t size,
-                            const size_t alignment, int fd, bool exec) {
+                            const size_t alignment, int fd, bool exec, MEMFLAGS flag) {
   char* base;
   // If the memory was requested at a particular address, use
   // os::attempt_reserve_memory_at() to avoid mapping over something
@@ -175,7 +175,7 @@ static char* reserve_memory(char* requested_address, const size_t size,
       // Base not aligned, retry.
       unmap_or_release_memory(base, size, fd != -1 /*is_file_mapped*/);
       // Map using the requested alignment.
-      base = map_or_reserve_memory_aligned(size, alignment, fd, exec);
+      base = map_or_reserve_memory_aligned(size, alignment, fd, exec, flag);
     }
   }
 
@@ -235,7 +235,7 @@ void ReservedSpace::reserve(size_t size,
     // When there is a backing file directory for this space then whether
     // large pages are allocated is up to the filesystem of the backing file.
     // So UseLargePages is not taken into account for this reservation.
-    char* base = reserve_memory(requested_address, size, alignment, _fd_for_heap, executable);
+    char* base = reserve_memory(requested_address, size, alignment, _fd_for_heap, executable, _nmt_flag);
     if (base != nullptr) {
       initialize_members(base, size, alignment, os::vm_page_size(), true, executable);
     }
@@ -266,7 +266,7 @@ void ReservedSpace::reserve(size_t size,
   }
 
   // == Case 3 ==
-  char* base = reserve_memory(requested_address, size, alignment, -1, executable);
+  char* base = reserve_memory(requested_address, size, alignment, -1, executable, _nmt_flag);
   if (base != nullptr) {
     // Successful mapping.
     initialize_members(base, size, alignment, page_size, false, executable);
@@ -310,7 +310,7 @@ void ReservedSpace::initialize(size_t size,
 
 ReservedSpace ReservedSpace::first_part(size_t partition_size, size_t alignment) {
   assert(partition_size <= size(), "partition failed");
-  ReservedSpace result(base(), partition_size, alignment, page_size(), special(), executable());
+  ReservedSpace result(base(), partition_size, alignment, page_size(), special(), executable(), nmt_flag());
   return result;
 }
 
@@ -319,7 +319,7 @@ ReservedSpace
 ReservedSpace::last_part(size_t partition_size, size_t alignment) {
   assert(partition_size <= size(), "partition failed");
   ReservedSpace result(base() + partition_size, size() - partition_size,
-                       alignment, page_size(), special(), executable());
+                       alignment, page_size(), special(), executable(), nmt_flag());
   return result;
 }
 
@@ -357,12 +357,13 @@ void ReservedSpace::release() {
 
 // Put a ReservedSpace over an existing range
 ReservedSpace ReservedSpace::space_for_range(char* base, size_t size, size_t alignment,
-                                             size_t page_size, bool special, bool executable) {
+                                             size_t page_size, bool special, bool executable, MEMFLAGS flag) {
   assert(is_aligned(base, os::vm_allocation_granularity()), "Unaligned base");
   assert(is_aligned(size, os::vm_page_size()), "Unaligned size");
   assert(os::page_sizes().contains(page_size), "Invalid pagesize");
   ReservedSpace space;
   space.initialize_members(base, size, alignment, page_size, special, executable);
+  space.set_nmt_flag(flag);
   return space;
 }
 
@@ -610,7 +611,7 @@ void ReservedHeapSpace::initialize_compressed_heap(const size_t size, size_t ali
 }
 
 ReservedHeapSpace::ReservedHeapSpace(size_t size, size_t alignment, size_t page_size, const char* heap_allocation_directory) : ReservedSpace() {
-
+  set_nmt_flag(mtJavaHeap);
   if (size == 0) {
     return;
   }
@@ -668,6 +669,7 @@ ReservedCodeSpace::ReservedCodeSpace(size_t r_size,
                                      size_t rs_align,
                                      size_t rs_page_size) : ReservedSpace() {
   initialize(r_size, rs_align, rs_page_size, /*requested address*/ nullptr, /*executable*/ true);
+  set_nmt_flag(mtCode);
   MemTracker::record_virtual_memory_type((address)base(), mtCode);
 }
 
@@ -689,6 +691,7 @@ VirtualSpace::VirtualSpace() {
   _upper_alignment        = 0;
   _special                = false;
   _executable             = false;
+  _nmt_flag                = mtNone;
 }
 
 
@@ -702,6 +705,7 @@ bool VirtualSpace::initialize_with_granularity(ReservedSpace rs, size_t committe
   assert(_low_boundary == nullptr, "VirtualSpace already initialized");
   assert(max_commit_granularity > 0, "Granularity must be non-zero.");
 
+  _nmt_flag = rs.nmt_flag();
   _low_boundary  = rs.base();
   _high_boundary = low_boundary() + rs.size();
 
@@ -833,8 +837,8 @@ static void pretouch_expanded_memory(void* start, void* end) {
   os::pretouch_memory(start, end);
 }
 
-static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre_touch, bool executable) {
-  if (os::commit_memory(start, size, alignment, executable)) {
+static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre_touch, bool executable, MEMFLAGS flag) {
+  if (os::commit_memory(start, size, alignment, executable, flag)) {
     if (pre_touch || AlwaysPreTouch) {
       pretouch_expanded_memory(start, start + size);
     }
@@ -923,7 +927,7 @@ bool VirtualSpace::expand_by(size_t bytes, bool pre_touch) {
   // Commit regions
   if (lower_needs > 0) {
     assert(lower_high() + lower_needs <= lower_high_boundary(), "must not expand beyond region");
-    if (!commit_expanded(lower_high(), lower_needs, _lower_alignment, pre_touch, _executable)) {
+    if (!commit_expanded(lower_high(), lower_needs, _lower_alignment, pre_touch, _executable, _nmt_flag)) {
       return false;
     }
     _lower_high += lower_needs;
@@ -931,7 +935,7 @@ bool VirtualSpace::expand_by(size_t bytes, bool pre_touch) {
 
   if (middle_needs > 0) {
     assert(middle_high() + middle_needs <= middle_high_boundary(), "must not expand beyond region");
-    if (!commit_expanded(middle_high(), middle_needs, _middle_alignment, pre_touch, _executable)) {
+    if (!commit_expanded(middle_high(), middle_needs, _middle_alignment, pre_touch, _executable, _nmt_flag)) {
       return false;
     }
     _middle_high += middle_needs;
@@ -939,7 +943,7 @@ bool VirtualSpace::expand_by(size_t bytes, bool pre_touch) {
 
   if (upper_needs > 0) {
     assert(upper_high() + upper_needs <= upper_high_boundary(), "must not expand beyond region");
-    if (!commit_expanded(upper_high(), upper_needs, _upper_alignment, pre_touch, _executable)) {
+    if (!commit_expanded(upper_high(), upper_needs, _upper_alignment, pre_touch, _executable, _nmt_flag)) {
       return false;
     }
     _upper_high += upper_needs;

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -668,8 +668,8 @@ MemRegion ReservedHeapSpace::region() const {
 ReservedCodeSpace::ReservedCodeSpace(size_t r_size,
                                      size_t rs_align,
                                      size_t rs_page_size) : ReservedSpace() {
-  initialize(r_size, rs_align, rs_page_size, /*requested address*/ nullptr, /*executable*/ true);
   set_nmt_flag(mtCode);
+  initialize(r_size, rs_align, rs_page_size, /*requested address*/ nullptr, /*executable*/ true);
   MemTracker::record_virtual_memory_type((address)base(), mtCode);
 }
 

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -42,9 +42,9 @@ class ReservedSpace {
   size_t   _page_size;
   bool     _special;
   int      _fd_for_heap;
+  bool     _executable;
   MEMFLAGS _nmt_flag;
  private:
-  bool   _executable;
 
   // ReservedSpace
   ReservedSpace(char* base, size_t size, size_t alignment,
@@ -69,7 +69,6 @@ class ReservedSpace {
  public:
 
   MEMFLAGS nmt_flag() { return _nmt_flag; }
-  void set_nmt_flag(MEMFLAGS flag) { _nmt_flag = flag; }
 
   // Constructor
   ReservedSpace();

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -178,6 +178,7 @@ class VirtualSpace {
   bool   _executable;
 
   MEMFLAGS _nmt_flag;
+
   // MPSS Support
   // Each virtualspace region has a lower, middle, and upper region.
   // Each region has an end boundary and a high pointer which is the
@@ -195,7 +196,6 @@ class VirtualSpace {
   size_t _lower_alignment;
   size_t _middle_alignment;
   size_t _upper_alignment;
-
 
   // MPSS Accessors
   char* lower_high() const { return _lower_high; }

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -62,7 +62,7 @@ class ReservedSpace {
                           size_t page_size, bool special, bool executable, MEMFLAGS flag);
 
   void initialize(size_t size, size_t alignment, size_t page_size,
-                  char* requested_address, bool executable);
+                  char* requested_address, bool executable, MEMFLAGS flag);
 
   void reserve(size_t size, size_t alignment, size_t page_size,
                char* requested_address, bool executable);

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,12 +42,13 @@ class ReservedSpace {
   size_t _page_size;
   bool   _special;
   int    _fd_for_heap;
+  MEMFLAGS _nmt_flag;
  private:
   bool   _executable;
 
   // ReservedSpace
   ReservedSpace(char* base, size_t size, size_t alignment,
-                size_t page_size, bool special, bool executable);
+                size_t page_size, bool special, bool executable, MEMFLAGS flag);
  protected:
   // Helpers to clear and set members during initialization. Two members
   // require special treatment:
@@ -66,17 +67,21 @@ class ReservedSpace {
   void reserve(size_t size, size_t alignment, size_t page_size,
                char* requested_address, bool executable);
  public:
+
+  inline MEMFLAGS nmt_flag() { return _nmt_flag; }
+  inline void set_nmt_flag(MEMFLAGS flag) { _nmt_flag = flag; }
+
   // Constructor
   ReservedSpace();
   // Initialize the reserved space with the given size. Depending on the size
   // a suitable page size and alignment will be used.
-  explicit ReservedSpace(size_t size);
+  explicit ReservedSpace(size_t size, MEMFLAGS flag);
   // Initialize the reserved space with the given size. The preferred_page_size
   // is used as the minimum page size/alignment. This may waste some space if
   // the given size is not aligned to that value, as the reservation will be
   // aligned up to the final alignment in this case.
-  ReservedSpace(size_t size, size_t preferred_page_size);
-  ReservedSpace(size_t size, size_t alignment, size_t page_size,
+  ReservedSpace(size_t size, size_t preferred_page_size, MEMFLAGS flag);
+  ReservedSpace(size_t size, size_t alignment, size_t page_size, MEMFLAGS flag,
                 char* requested_address = nullptr);
 
   // Accessors
@@ -110,7 +115,7 @@ class ReservedSpace {
 
   // Put a ReservedSpace over an existing range
   static ReservedSpace space_for_range(char* base, size_t size, size_t alignment,
-                                       size_t page_size, bool special, bool executable);
+                                       size_t page_size, bool special, bool executable, MEMFLAGS flag);
 };
 
 ReservedSpace
@@ -190,6 +195,8 @@ class VirtualSpace {
   size_t _lower_alignment;
   size_t _middle_alignment;
   size_t _upper_alignment;
+
+  MEMFLAGS _nmt_flag;
 
   // MPSS Accessors
   char* lower_high() const { return _lower_high; }

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -35,13 +35,13 @@ class outputStream;
 class ReservedSpace {
   friend class VMStructs;
  protected:
-  char*  _base;
-  size_t _size;
-  size_t _noaccess_prefix;
-  size_t _alignment;
-  size_t _page_size;
-  bool   _special;
-  int    _fd_for_heap;
+  char*    _base;
+  size_t   _size;
+  size_t   _noaccess_prefix;
+  size_t   _alignment;
+  size_t   _page_size;
+  bool     _special;
+  int      _fd_for_heap;
   MEMFLAGS _nmt_flag;
  private:
   bool   _executable;
@@ -59,7 +59,7 @@ class ReservedSpace {
   //                       0 during initialization.
   void clear_members();
   void initialize_members(char* base, size_t size, size_t alignment,
-                          size_t page_size, bool special, bool executable);
+                          size_t page_size, bool special, bool executable, MEMFLAGS flag);
 
   void initialize(size_t size, size_t alignment, size_t page_size,
                   char* requested_address, bool executable);
@@ -68,8 +68,8 @@ class ReservedSpace {
                char* requested_address, bool executable);
  public:
 
-  inline MEMFLAGS nmt_flag() { return _nmt_flag; }
-  inline void set_nmt_flag(MEMFLAGS flag) { _nmt_flag = flag; }
+  MEMFLAGS nmt_flag() { return _nmt_flag; }
+  void set_nmt_flag(MEMFLAGS flag) { _nmt_flag = flag; }
 
   // Constructor
   ReservedSpace();

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -40,8 +40,8 @@ class ReservedSpace {
   size_t   _noaccess_prefix;
   size_t   _alignment;
   size_t   _page_size;
-  bool     _special;
   int      _fd_for_heap;
+  bool     _special;
   bool     _executable;
   MEMFLAGS _nmt_flag;
  private:
@@ -177,6 +177,7 @@ class VirtualSpace {
   // Need to know if commit should be executable.
   bool   _executable;
 
+  MEMFLAGS _nmt_flag;
   // MPSS Support
   // Each virtualspace region has a lower, middle, and upper region.
   // Each region has an end boundary and a high pointer which is the
@@ -195,7 +196,6 @@ class VirtualSpace {
   size_t _middle_alignment;
   size_t _upper_alignment;
 
-  MEMFLAGS _nmt_flag;
 
   // MPSS Accessors
   char* lower_high() const { return _lower_high; }

--- a/src/hotspot/share/memory/virtualspace.hpp
+++ b/src/hotspot/share/memory/virtualspace.hpp
@@ -43,7 +43,7 @@ class ReservedSpace {
   int      _fd_for_heap;
   bool     _special;
   bool     _executable;
-  MEMFLAGS _nmt_flag;
+  MEMFLAGS _flag;
  private:
 
   // ReservedSpace
@@ -68,7 +68,7 @@ class ReservedSpace {
                char* requested_address, bool executable);
  public:
 
-  MEMFLAGS nmt_flag() { return _nmt_flag; }
+  MEMFLAGS nmt_flag() const { return _flag; }
 
   // Constructor
   ReservedSpace();
@@ -177,7 +177,7 @@ class VirtualSpace {
   // Need to know if commit should be executable.
   bool   _executable;
 
-  MEMFLAGS _nmt_flag;
+  MEMFLAGS _flag;
 
   // MPSS Support
   // Each virtualspace region has a lower, middle, and upper region.

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -146,7 +146,7 @@ class MemTracker : AllStatic {
   }
 
   static inline void record_virtual_memory_reserve_and_commit(void* addr, size_t size,
-    const NativeCallStack& stack, MEMFLAGS flag = mtNone) {
+    const NativeCallStack& stack, MEMFLAGS flag) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -141,7 +141,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      VirtualMemoryTracker::remove_uncommitted_region((address)addr, size);
+      VirtualMemoryTracker::remove_uncommitted_region((address)addr, size, flag);
     }
   }
 
@@ -152,7 +152,7 @@ class MemTracker : AllStatic {
     if (addr != nullptr) {
       ThreadCritical tc;
       VirtualMemoryTracker::add_reserved_region((address)addr, size, stack, flag);
-      VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
+      VirtualMemoryTracker::add_committed_region((address)addr, size, stack, flag);
     }
   }
 
@@ -162,7 +162,7 @@ class MemTracker : AllStatic {
     if (!enabled()) return;
     if (addr != nullptr) {
       ThreadCritical tc;
-      VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
+      VirtualMemoryTracker::add_committed_region((address)addr, size, stack, flag);
     }
   }
 

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -120,7 +120,7 @@ class MemTracker : AllStatic {
   //  (we do not do any reservations before that).
 
   static inline void record_virtual_memory_reserve(void* addr, size_t size, const NativeCallStack& stack,
-    MEMFLAGS flag = mtNone) {
+    MEMFLAGS flag) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ class MemTracker : AllStatic {
   }
 
   static inline void record_virtual_memory_commit(void* addr, size_t size,
-    const NativeCallStack& stack) {
+    const NativeCallStack& stack, MEMFLAGS flag) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -137,7 +137,7 @@ class MemTracker : AllStatic {
     }
   }
 
-  static inline void record_virtual_memory_uncommit(address addr, size_t size) {
+  static inline void record_virtual_memory_uncommit(address addr, size_t size, MEMFLAGS flag) {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -424,8 +424,8 @@ void VirtualMemoryTracker::set_reserved_region_type(address addr, MEMFLAGS flag)
   if (reserved_rgn != nullptr) {
     assert(reserved_rgn->contain_address(addr), "Containment");
     if (reserved_rgn->flag() != flag) {
-      assert(reserved_rgn->flag() == mtNone, "Overwrite memory type (should be mtNone, is: \"%s\")",
-             NMTUtil::flag_to_name(reserved_rgn->flag()));
+      assert(reserved_rgn->flag() == mtNone, "Overwrite memory type (should be mtNone, is: \"%s\") wants to change to \"%s\"",
+             NMTUtil::flag_to_name(reserved_rgn->flag()), NMTUtil::flag_to_name(flag));
       reserved_rgn->set_flag(flag);
     }
   }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -432,12 +432,12 @@ void VirtualMemoryTracker::set_reserved_region_type(address addr, MEMFLAGS flag)
 }
 
 bool VirtualMemoryTracker::add_committed_region(address addr, size_t size,
-  const NativeCallStack& stack) {
+  const NativeCallStack& stack, MEMFLAGS flag) {
   assert(addr != nullptr, "Invalid address");
   assert(size > 0, "Invalid size");
   assert(_reserved_regions != nullptr, "Sanity check");
 
-  ReservedMemoryRegion  rgn(addr, size);
+  ReservedMemoryRegion  rgn(addr, size, stack, flag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
 
   if (reserved_rgn == nullptr) {
@@ -452,12 +452,12 @@ bool VirtualMemoryTracker::add_committed_region(address addr, size_t size,
   return result;
 }
 
-bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size) {
+bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size, MEMFLAGS flag) {
   assert(addr != nullptr, "Invalid address");
   assert(size > 0, "Invalid size");
   assert(_reserved_regions != nullptr, "Sanity check");
 
-  ReservedMemoryRegion  rgn(addr, size);
+  ReservedMemoryRegion  rgn(addr, size, NativeCallStack::empty_stack(), flag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
   assert(reserved_rgn != nullptr, "No reserved region (" INTPTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), size);
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -457,7 +457,7 @@ bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size, 
   assert(size > 0, "Invalid size");
   assert(_reserved_regions != nullptr, "Sanity check");
 
-  ReservedMemoryRegion  rgn(addr, size, NativeCallStack::empty_stack(), flag);
+  ReservedMemoryRegion  rgn(addr, size, flag);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
   assert(reserved_rgn != nullptr, "No reserved region (" INTPTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), size);
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -457,7 +457,7 @@ bool VirtualMemoryTracker::remove_uncommitted_region(address addr, size_t size, 
   assert(size > 0, "Invalid size");
   assert(_reserved_regions != nullptr, "Sanity check");
 
-  ReservedMemoryRegion  rgn(addr, size, flag);
+  ReservedMemoryRegion  rgn(addr, size);
   ReservedMemoryRegion* reserved_rgn = _reserved_regions->find(rgn);
   assert(reserved_rgn != nullptr, "No reserved region (" INTPTR_FORMAT ", " SIZE_FORMAT ")", p2i(addr), size);
   assert(reserved_rgn->contain_region(addr, size), "Not completely contained");

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -296,7 +296,7 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
 
  public:
   ReservedMemoryRegion(address base, size_t size, const NativeCallStack& stack,
-    MEMFLAGS flag = mtNone) :
+    MEMFLAGS flag) :
     VirtualMemoryRegion(base, size), _stack(stack), _flag(flag) { }
 
 
@@ -382,7 +382,7 @@ class VirtualMemoryTracker : AllStatic {
  public:
   static bool initialize(NMT_TrackingLevel level);
 
-  static bool add_reserved_region (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag = mtNone);
+  static bool add_reserved_region (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag);
 
   static bool add_committed_region      (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag);
   static bool remove_uncommitted_region (address base_addr, size_t size, MEMFLAGS flag);

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -381,8 +381,8 @@ class VirtualMemoryTracker : AllStatic {
 
   static bool add_reserved_region (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag = mtNone);
 
-  static bool add_committed_region      (address base_addr, size_t size, const NativeCallStack& stack);
-  static bool remove_uncommitted_region (address base_addr, size_t size);
+  static bool add_committed_region      (address base_addr, size_t size, const NativeCallStack& stack, MEMFLAGS flag);
+  static bool remove_uncommitted_region (address base_addr, size_t size, MEMFLAGS flag);
   static bool remove_released_region    (address base_addr, size_t size);
   static bool remove_released_region    (ReservedMemoryRegion* rgn);
   static void set_reserved_region_type  (address addr, MEMFLAGS flag);

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,6 +302,9 @@ class ReservedMemoryRegion : public VirtualMemoryRegion {
 
   ReservedMemoryRegion(address base, size_t size) :
     VirtualMemoryRegion(base, size), _stack(NativeCallStack::empty_stack()), _flag(mtNone) { }
+
+  ReservedMemoryRegion(address base, size_t size, MEMFLAGS flag) :
+    VirtualMemoryRegion(base, size), _stack(NativeCallStack::empty_stack()), _flag(flag) { }
 
   // Copy constructor
   ReservedMemoryRegion(const ReservedMemoryRegion& rr) :

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t
 
 char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr) {
   alignment = MAX2(Metaspace::reserve_alignment(), alignment);
-  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr);
+  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtMetaspace);
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -69,7 +69,7 @@ void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t
 
 char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr) {
   alignment = MAX2(Metaspace::reserve_alignment(), alignment);
-  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtClass);
+  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtMetaspace);
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -69,7 +69,7 @@ void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t
 
 char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr) {
   alignment = MAX2(Metaspace::reserve_alignment(), alignment);
-  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtMetaspace);
+  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtClass);
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2400,7 +2400,6 @@ static char* get_bad_address() {
     if (bad_address != nullptr) {
       os::protect_memory(bad_address, size, os::MEM_PROT_READ,
                          /*is_committed*/false);
-      MemTracker::record_virtual_memory_type((void*)bad_address, mtInternal);
     }
   }
   return bad_address;

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012 Red Hat, Inc.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -2396,7 +2396,7 @@ static char* get_bad_address() {
   static char* bad_address = nullptr;
   if (bad_address == nullptr) {
     size_t size = os::vm_allocation_granularity();
-    bad_address = os::reserve_memory(size);
+    bad_address = os::reserve_memory(size, false, mtInternal);
     if (bad_address != nullptr) {
       os::protect_memory(bad_address, size, os::MEM_PROT_READ,
                          /*is_committed*/false);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -2396,7 +2396,7 @@ static char* get_bad_address() {
   static char* bad_address = nullptr;
   if (bad_address == nullptr) {
     size_t size = os::vm_allocation_granularity();
-    bad_address = os::reserve_memory(size, false, mtInternal);
+    bad_address = os::reserve_memory(size, !ExecMem, mtInternal);
     if (bad_address != nullptr) {
       os::protect_memory(bad_address, size, os::MEM_PROT_READ,
                          /*is_committed*/false);

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -696,12 +696,12 @@ WB_END
 
 WB_ENTRY(jlong, WB_NMTReserveMemory(JNIEnv* env, jobject o, jlong size))
   jlong addr = 0;
-  addr = (jlong)(uintptr_t)os::reserve_memory(size, false, mtTest);
+  addr = (jlong)(uintptr_t)os::reserve_memory(size, !ExecMem, mtTest);
   return addr;
 WB_END
 
 WB_ENTRY(jlong, WB_NMTAttemptReserveMemoryAt(JNIEnv* env, jobject o, jlong addr, jlong size))
-  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size, false, mtTest);
+  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size, !ExecMem, mtTest);
   return addr;
 WB_END
 
@@ -710,7 +710,7 @@ WB_ENTRY(void, WB_NMTCommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size
 WB_END
 
 WB_ENTRY(void, WB_NMTUncommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
-  os::uncommit_memory((char *)(uintptr_t)addr, size, mtTest);
+  os::uncommit_memory((char *)(uintptr_t)addr, size, !ExecMem, mtTest);
 WB_END
 
 WB_ENTRY(void, WB_NMTReleaseMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
@@ -1478,7 +1478,7 @@ WB_ENTRY(void, WB_ReadReservedMemory(JNIEnv* env, jobject o))
   static char c;
   static volatile char* p;
 
-  p = os::reserve_memory(os::vm_allocation_granularity(), false, mtTest);
+  p = os::reserve_memory(os::vm_allocation_granularity(), !ExecMem, mtTest);
   if (p == nullptr) {
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Failed to reserve memory");
   }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -716,7 +716,7 @@ WB_ENTRY(void, WB_NMTCommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size
 WB_END
 
 WB_ENTRY(void, WB_NMTUncommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
-  os::uncommit_memory((char *)(uintptr_t)addr, size);
+  os::uncommit_memory((char *)(uintptr_t)addr, size, mtTest);
 WB_END
 
 WB_ENTRY(void, WB_NMTReleaseMemory(JNIEnv* env, jobject o, jlong addr, jlong size))

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -696,23 +696,17 @@ WB_END
 
 WB_ENTRY(jlong, WB_NMTReserveMemory(JNIEnv* env, jobject o, jlong size))
   jlong addr = 0;
-
   addr = (jlong)(uintptr_t)os::reserve_memory(size, false, mtTest);
-  MemTracker::record_virtual_memory_type((address)addr, mtTest);
-
   return addr;
 WB_END
 
 WB_ENTRY(jlong, WB_NMTAttemptReserveMemoryAt(JNIEnv* env, jobject o, jlong addr, jlong size))
   addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size, false, mtTest);
-  MemTracker::record_virtual_memory_type((address)addr, mtTest);
-
   return addr;
 WB_END
 
 WB_ENTRY(void, WB_NMTCommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
   os::commit_memory((char *)(uintptr_t)addr, size, !ExecMem, mtTest);
-  MemTracker::record_virtual_memory_type((address)(uintptr_t)addr, mtTest);
 WB_END
 
 WB_ENTRY(void, WB_NMTUncommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -697,14 +697,14 @@ WB_END
 WB_ENTRY(jlong, WB_NMTReserveMemory(JNIEnv* env, jobject o, jlong size))
   jlong addr = 0;
 
-  addr = (jlong)(uintptr_t)os::reserve_memory(size);
+  addr = (jlong)(uintptr_t)os::reserve_memory(size, false, mtTest);
   MemTracker::record_virtual_memory_type((address)addr, mtTest);
 
   return addr;
 WB_END
 
 WB_ENTRY(jlong, WB_NMTAttemptReserveMemoryAt(JNIEnv* env, jobject o, jlong addr, jlong size))
-  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size);
+  addr = (jlong)(uintptr_t)os::attempt_reserve_memory_at((char*)(uintptr_t)addr, (size_t)size, false, mtTest);
   MemTracker::record_virtual_memory_type((address)addr, mtTest);
 
   return addr;
@@ -1484,7 +1484,7 @@ WB_ENTRY(void, WB_ReadReservedMemory(JNIEnv* env, jobject o))
   static char c;
   static volatile char* p;
 
-  p = os::reserve_memory(os::vm_allocation_granularity());
+  p = os::reserve_memory(os::vm_allocation_granularity(), false, mtTest);
   if (p == nullptr) {
     THROW_MSG(vmSymbols::java_lang_OutOfMemoryError(), "Failed to reserve memory");
   }

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -711,7 +711,7 @@ WB_ENTRY(jlong, WB_NMTAttemptReserveMemoryAt(JNIEnv* env, jobject o, jlong addr,
 WB_END
 
 WB_ENTRY(void, WB_NMTCommitMemory(JNIEnv* env, jobject o, jlong addr, jlong size))
-  os::commit_memory((char *)(uintptr_t)addr, size, !ExecMem);
+  os::commit_memory((char *)(uintptr_t)addr, size, !ExecMem, mtTest);
   MemTracker::record_virtual_memory_type((address)(uintptr_t)addr, mtTest);
 WB_END
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2180,9 +2180,9 @@ char* os::attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc,
   return result;
 }
 
-char* os::map_memory(int fd, const char* file_name, size_t file_offset,  // file info
-                     char *addr, size_t bytes,                           // memory info
-                     bool read_only, bool allow_exec, MEMFLAGS flags) {  // flags
+char* os::map_memory(int fd, const char* file_name, size_t file_offset,
+                     char *addr, size_t bytes, bool read_only,
+                     bool allow_exec, MEMFLAGS flags) {
   char* result = pd_map_memory(fd, file_name, file_offset, addr, bytes, read_only, allow_exec);
   if (result != nullptr) {
     MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC, flags);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2082,7 +2082,7 @@ void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
   MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC, flag);
 }
 
-bool os::uncommit_memory(char* addr, size_t bytes, MEMFLAGS flag, bool executable) {
+bool os::uncommit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
@@ -2213,14 +2213,14 @@ void os::realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
 }
 
 char* os::reserve_memory_special(size_t size, size_t alignment, size_t page_size,
-                                 char* addr, bool executable) {
+                                 char* addr, bool executable, MEMFLAGS flag) {
 
   assert(is_aligned(addr, alignment), "Unaligned request address");
 
   char* result = pd_reserve_memory_special(size, alignment, page_size, addr, executable);
   if (result != nullptr) {
     // The memory is committed
-    MemTracker::record_virtual_memory_reserve_and_commit((address)result, size, CALLER_PC);
+    MemTracker::record_virtual_memory_reserve_and_commit((address)result, size, CALLER_PC, flag);
     log_debug(os, map)("Reserved and committed " RANGEFMT, RANGEFMTARGS(result, size));
   } else {
     log_info(os, map)("Reserve and commit failed (%zu bytes)", size);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1872,7 +1872,7 @@ static void hemi_split(T* arr, unsigned num) {
 
 // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
 // If randomize is true, the location will be randomized.
-char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize) {
+char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize, MEMFLAGS flag) {
 
   // Please keep the following constants in sync with the companion gtests:
 
@@ -2027,7 +2027,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     assert(is_aligned(result, alignment), "alignment invalid (" ERRFMT ")", ERRFMTARGS);
     log_trace(os, map)(ERRFMT, ERRFMTARGS);
     log_debug(os, map)("successfully attached at " PTR_FORMAT, p2i(result));
-    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC, flag);
   } else {
     log_debug(os, map)("failed to attach anywhere in [" PTR_FORMAT "-" PTR_FORMAT ")", p2i(min), p2i(max));
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2082,14 +2082,14 @@ void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
   MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC, flag);
 }
 
-bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
+bool os::uncommit_memory(char* addr, size_t bytes, MEMFLAGS flag, bool executable) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
     ThreadCritical tc;
     res = pd_uncommit_memory(addr, bytes, executable);
     if (res) {
-      MemTracker::record_virtual_memory_uncommit((address)addr, bytes);
+      MemTracker::record_virtual_memory_uncommit((address)addr, bytes, flag);
     }
   } else {
     res = pd_uncommit_memory(addr, bytes, executable);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2043,11 +2043,11 @@ static void assert_nonempty_range(const char* addr, size_t bytes) {
          p2i(addr), p2i(addr) + bytes);
 }
 
-bool os::commit_memory(char* addr, size_t bytes, bool executable) {
+bool os::commit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag) {
   assert_nonempty_range(addr, bytes);
   bool res = pd_commit_memory(addr, bytes, executable);
   if (res) {
-    MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
+    MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC, flag);
     log_debug(os, map)("Committed " RANGEFMT, RANGEFMTARGS(addr, bytes));
   } else {
     log_info(os, map)("Failed to commit " RANGEFMT, RANGEFMTARGS(addr, bytes));
@@ -2056,11 +2056,11 @@ bool os::commit_memory(char* addr, size_t bytes, bool executable) {
 }
 
 bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
-                              bool executable) {
+                              bool executable, MEMFLAGS flag) {
   assert_nonempty_range(addr, size);
   bool res = os::pd_commit_memory(addr, size, alignment_hint, executable);
   if (res) {
-    MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
+    MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC, flag);
     log_debug(os, map)("Committed " RANGEFMT, RANGEFMTARGS(addr, size));
   } else {
     log_info(os, map)("Failed to commit " RANGEFMT, RANGEFMTARGS(addr, size));
@@ -2069,17 +2069,17 @@ bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
 }
 
 void os::commit_memory_or_exit(char* addr, size_t bytes, bool executable,
-                               const char* mesg) {
+                               const char* mesg, MEMFLAGS flag) {
   assert_nonempty_range(addr, bytes);
   pd_commit_memory_or_exit(addr, bytes, executable, mesg);
-  MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
+  MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC, flag);
 }
 
 void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
-                               bool executable, const char* mesg) {
+                               bool executable, const char* mesg, MEMFLAGS flag) {
   assert_nonempty_range(addr, size);
   os::pd_commit_memory_or_exit(addr, size, alignment_hint, executable, mesg);
-  MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
+  MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC, flag);
 }
 
 bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
@@ -2204,8 +2204,8 @@ bool os::unmap_memory(char *addr, size_t bytes) {
   return result;
 }
 
-void os::free_memory(char *addr, size_t bytes, size_t alignment_hint) {
-  pd_free_memory(addr, bytes, alignment_hint);
+void os::free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag) {
+  pd_free_memory(addr, bytes, alignment_hint, flag);
 }
 
 void os::realign_memory(char *addr, size_t bytes, size_t alignment_hint) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2180,9 +2180,9 @@ char* os::attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc,
   return result;
 }
 
-char* os::map_memory(int fd, const char* file_name, size_t file_offset,
-                     char *addr, size_t bytes,
-                     bool read_only, bool allow_exec, MEMFLAGS flags) {
+char* os::map_memory(int fd, const char* file_name, size_t file_offset,  // file info
+                     char *addr, size_t bytes,                           // memory info
+                     bool read_only, bool allow_exec, MEMFLAGS flags) {  // flags
   char* result = pd_map_memory(fd, file_name, file_offset, addr, bytes, read_only, allow_exec);
   if (result != nullptr) {
     MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC, flags);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2069,14 +2069,14 @@ bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
 }
 
 void os::commit_memory_or_exit(char* addr, size_t bytes, bool executable,
-                               const char* mesg, MEMFLAGS flag) {
+                               MEMFLAGS flag, const char* mesg) {
   assert_nonempty_range(addr, bytes);
   pd_commit_memory_or_exit(addr, bytes, executable, mesg);
   MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC, flag);
 }
 
 void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
-                               bool executable, const char* mesg, MEMFLAGS flag) {
+                               bool executable, MEMFLAGS flag, const char* mesg) {
   assert_nonempty_range(addr, size);
   os::pd_commit_memory_or_exit(addr, size, alignment_hint, executable, mesg);
   MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC, flag);
@@ -2182,10 +2182,8 @@ char* os::attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc,
 
 char* os::map_memory(int fd, const char* file_name, size_t file_offset,
                      char *addr, size_t bytes,
-                     MEMFLAGS flags,
-                     bool read_only,
-                     bool allow_exec) {
-  char* result = pd_map_memory(fd, file_name, file_offset, addr, bytes, flags, read_only, allow_exec);
+                     bool read_only, bool allow_exec, MEMFLAGS flags) {
+  char* result = pd_map_memory(fd, file_name, file_offset, addr, bytes, read_only, allow_exec);
   if (result != nullptr) {
     MemTracker::record_virtual_memory_reserve_and_commit((address)result, bytes, CALLER_PC, flags);
   }

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -471,7 +471,7 @@ class os: AllStatic {
   static void   commit_memory_or_exit(char* addr, size_t size,
                                       size_t alignment_hint,
                                       bool executable, const char* mesg, MEMFLAGS flag);
-  static bool   uncommit_memory(char* addr, size_t bytes, MEMFLAGS flag, bool executable = false);
+  static bool   uncommit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
   static bool   release_memory(char* addr, size_t bytes);
 
   // Does the platform support trimming the native heap?
@@ -540,7 +540,7 @@ class os: AllStatic {
   static char*  non_memory_address_word();
   // reserve, commit and pin the entire memory region
   static char*  reserve_memory_special(size_t size, size_t alignment, size_t page_size,
-                                       char* addr, bool executable);
+                                       char* addr, bool executable, MEMFLAGS flag);
   static bool   release_memory_special(char* addr, size_t bytes);
   static void   large_page_init();
   static size_t large_page_size();

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -228,8 +228,8 @@ class os: AllStatic {
   static char*  pd_attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc, MEMFLAGS flag);
 
   static char*  pd_map_memory(int fd, const char* file_name, size_t file_offset,
-                              char *addr, size_t bytes,
-                              bool read_only = false, bool allow_exec = false);
+                              char *addr, size_t bytes, bool read_only = false,
+                              bool allow_exec = false);
   static bool   pd_unmap_memory(char *addr, size_t bytes);
   static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint);
@@ -513,9 +513,9 @@ class os: AllStatic {
   // Replace existing reserved memory with file mapping
   static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd);
 
-  static char*  map_memory(int fd, const char* file_name, size_t file_offset, // file info
-                           char *addr, size_t bytes,                          // memory info
-                           bool read_only, bool allow_exec, MEMFLAGS flag);   // flags
+  static char*  map_memory(int fd, const char* file_name, size_t file_offset,
+                           char *addr, size_t bytes, bool read_only,
+                           bool allow_exec, MEMFLAGS flag);
   static bool   unmap_memory(char *addr, size_t bytes);
   static void   free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -513,11 +513,9 @@ class os: AllStatic {
   // Replace existing reserved memory with file mapping
   static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd);
 
-  static char*  map_memory(int fd, const char* file_name, size_t file_offset,
-                           char *addr, size_t bytes,
-                           bool read_only,
-                           bool allow_exec,
-                           MEMFLAGS flag);
+  static char*  map_memory(int fd, const char* file_name, size_t file_offset, // file info
+                           char *addr, size_t bytes,                          // memory info
+                           bool read_only, bool allow_exec, MEMFLAGS flag);   // flags
   static bool   unmap_memory(char *addr, size_t bytes);
   static void   free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -471,7 +471,7 @@ class os: AllStatic {
   static void   commit_memory_or_exit(char* addr, size_t size,
                                       size_t alignment_hint,
                                       bool executable, const char* mesg, MEMFLAGS flag);
-  static bool   uncommit_memory(char* addr, size_t bytes, bool executable = false);
+  static bool   uncommit_memory(char* addr, size_t bytes, MEMFLAGS flag, bool executable = false);
   static bool   release_memory(char* addr, size_t bytes);
 
   // Does the platform support trimming the native heap?

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -231,7 +231,7 @@ class os: AllStatic {
                            char *addr, size_t bytes, bool read_only = false,
                            bool allow_exec = false);
   static bool   pd_unmap_memory(char *addr, size_t bytes);
-  static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint);
+  static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint);
 
   // Returns 0 if pretouch is done via platform dependent method, or otherwise
@@ -461,16 +461,16 @@ class os: AllStatic {
   // If randomize is true, the location will be randomized.
   static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize);
 
-  static bool   commit_memory(char* addr, size_t bytes, bool executable);
+  static bool   commit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
   static bool   commit_memory(char* addr, size_t size, size_t alignment_hint,
-                              bool executable);
+                              bool executable, MEMFLAGS flag);
   // Same as commit_memory() that either succeeds or calls
   // vm_exit_out_of_memory() with the specified mesg.
   static void   commit_memory_or_exit(char* addr, size_t bytes,
-                                      bool executable, const char* mesg);
+                                      bool executable, const char* mesg, MEMFLAGS flag);
   static void   commit_memory_or_exit(char* addr, size_t size,
                                       size_t alignment_hint,
-                                      bool executable, const char* mesg);
+                                      bool executable, const char* mesg, MEMFLAGS flag);
   static bool   uncommit_memory(char* addr, size_t bytes, bool executable = false);
   static bool   release_memory(char* addr, size_t bytes);
 
@@ -508,7 +508,7 @@ class os: AllStatic {
   // Map memory to the file referred by fd. This function is slightly different from map_memory()
   // and is added to be used for implementation of -XX:AllocateHeapAt
   static char* map_memory_to_file(size_t size, int fd, MEMFLAGS flag = mtNone);
-  static char* map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MEMFLAGS flag = mtNone);
+  static char* map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MEMFLAGS flag);
   static char* map_memory_to_file(char* base, size_t size, int fd);
   static char* attempt_map_memory_to_file_at(char* base, size_t size, int fd, MEMFLAGS flag = mtNone);
   // Replace existing reserved memory with file mapping
@@ -518,7 +518,7 @@ class os: AllStatic {
                            char *addr, size_t bytes, bool read_only = false,
                            bool allow_exec = false, MEMFLAGS flags = mtNone);
   static bool   unmap_memory(char *addr, size_t bytes);
-  static void   free_memory(char *addr, size_t bytes, size_t alignment_hint);
+  static void   free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);
 
   // NUMA-specific interface

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -208,9 +208,9 @@ class os: AllStatic {
   // low enough to leave most of the valuable low-4gb address space open.
   static constexpr size_t _vm_min_address_default = 16 * M;
 
-  static char*  pd_reserve_memory(size_t bytes, bool executable);
+  static char*  pd_reserve_memory(size_t bytes, bool executable, MEMFLAGS flag);
 
-  static char*  pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool executable);
+  static char*  pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
 
   static bool   pd_commit_memory(char* addr, size_t bytes, bool executable);
   static bool   pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
@@ -225,10 +225,12 @@ class os: AllStatic {
   static bool   pd_uncommit_memory(char* addr, size_t bytes, bool executable);
   static bool   pd_release_memory(char* addr, size_t bytes);
 
-  static char*  pd_attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc);
+  static char*  pd_attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc, MEMFLAGS flag);
 
   static char*  pd_map_memory(int fd, const char* file_name, size_t file_offset,
-                           char *addr, size_t bytes, bool read_only = false,
+                           char *addr, size_t bytes,
+                           MEMFLAGS flag,
+                           bool read_only = false,
                            bool allow_exec = false);
   static bool   pd_unmap_memory(char *addr, size_t bytes);
   static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
@@ -239,8 +241,7 @@ class os: AllStatic {
   static size_t pd_pretouch_memory(void* first, void* last, size_t page_size);
 
   static char*  pd_reserve_memory_special(size_t size, size_t alignment, size_t page_size,
-
-                                          char* addr, bool executable);
+                                          char* addr, bool executable, MEMFLAGS flag);
   static bool   pd_release_memory_special(char* addr, size_t bytes);
 
   static size_t page_size_for_region(size_t region_size, size_t min_pages, bool must_be_aligned);
@@ -507,16 +508,18 @@ class os: AllStatic {
   static int create_file_for_heap(const char* dir);
   // Map memory to the file referred by fd. This function is slightly different from map_memory()
   // and is added to be used for implementation of -XX:AllocateHeapAt
-  static char* map_memory_to_file(size_t size, int fd, MEMFLAGS flag = mtNone);
+  static char* map_memory_to_file(size_t size, int fd, MEMFLAGS flag);
   static char* map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MEMFLAGS flag);
   static char* map_memory_to_file(char* base, size_t size, int fd);
-  static char* attempt_map_memory_to_file_at(char* base, size_t size, int fd, MEMFLAGS flag = mtNone);
+  static char* attempt_map_memory_to_file_at(char* base, size_t size, int fd, MEMFLAGS flag);
   // Replace existing reserved memory with file mapping
   static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd);
 
   static char*  map_memory(int fd, const char* file_name, size_t file_offset,
-                           char *addr, size_t bytes, bool read_only = false,
-                           bool allow_exec = false, MEMFLAGS flags = mtNone);
+                           char *addr, size_t bytes,
+                           MEMFLAGS flag,
+                           bool read_only = false,
+                           bool allow_exec = false);
   static bool   unmap_memory(char *addr, size_t bytes);
   static void   free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -448,18 +448,18 @@ class os: AllStatic {
   inline static size_t cds_core_region_alignment();
 
   // Reserves virtual memory.
-  static char*  reserve_memory(size_t bytes, bool executable = false, MEMFLAGS flags = mtNone);
+  static char*  reserve_memory(size_t bytes, bool executable, MEMFLAGS flags);
 
   // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
-  static char*  reserve_memory_aligned(size_t size, size_t alignment, bool executable = false);
+  static char*  reserve_memory_aligned(size_t size, size_t alignment, bool executable, MEMFLAGS flag);
 
   // Attempts to reserve the virtual memory at [addr, addr + bytes).
   // Does not overwrite existing mappings.
-  static char*  attempt_reserve_memory_at(char* addr, size_t bytes, bool executable = false, MEMFLAGS flag = mtNone);
+  static char*  attempt_reserve_memory_at(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
 
   // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
   // If randomize is true, the location will be randomized.
-  static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize);
+  static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize, MEMFLAGS flag);
 
   static bool   commit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
   static bool   commit_memory(char* addr, size_t size, size_t alignment_hint,

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -228,10 +228,8 @@ class os: AllStatic {
   static char*  pd_attempt_map_memory_to_file_at(char* addr, size_t bytes, int file_desc, MEMFLAGS flag);
 
   static char*  pd_map_memory(int fd, const char* file_name, size_t file_offset,
-                           char *addr, size_t bytes,
-                           MEMFLAGS flag,
-                           bool read_only = false,
-                           bool allow_exec = false);
+                              char *addr, size_t bytes,
+                              bool read_only = false, bool allow_exec = false);
   static bool   pd_unmap_memory(char *addr, size_t bytes);
   static void   pd_free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint);
@@ -468,10 +466,10 @@ class os: AllStatic {
   // Same as commit_memory() that either succeeds or calls
   // vm_exit_out_of_memory() with the specified mesg.
   static void   commit_memory_or_exit(char* addr, size_t bytes,
-                                      bool executable, const char* mesg, MEMFLAGS flag);
+                                      bool executable, MEMFLAGS flag, const char* mesg);
   static void   commit_memory_or_exit(char* addr, size_t size,
                                       size_t alignment_hint,
-                                      bool executable, const char* mesg, MEMFLAGS flag);
+                                      bool executable, MEMFLAGS flag, const char* mesg);
   static bool   uncommit_memory(char* addr, size_t bytes, bool executable, MEMFLAGS flag);
   static bool   release_memory(char* addr, size_t bytes);
 
@@ -517,9 +515,9 @@ class os: AllStatic {
 
   static char*  map_memory(int fd, const char* file_name, size_t file_offset,
                            char *addr, size_t bytes,
-                           MEMFLAGS flag,
-                           bool read_only = false,
-                           bool allow_exec = false);
+                           bool read_only,
+                           bool allow_exec,
+                           MEMFLAGS flag);
   static bool   unmap_memory(char *addr, size_t bytes);
   static void   free_memory(char *addr, size_t bytes, size_t alignment_hint, MEMFLAGS flag);
   static void   realign_memory(char *addr, size_t bytes, size_t alignment_hint);

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -59,7 +59,7 @@ void SafepointMechanism::default_initialize() {
     const size_t page_size = os::vm_page_size();
     const size_t allocation_size = 2 * page_size;
     char* polling_page = os::reserve_memory(allocation_size, !ExecMem, mtSafepoint);
-    os::commit_memory_or_exit(polling_page, allocation_size, !ExecMem, "Unable to commit Safepoint polling page", mtSafepoint);
+    os::commit_memory_or_exit(polling_page, allocation_size, !ExecMem, mtSafepoint, "Unable to commit Safepoint polling page");
 
     char* bad_page  = polling_page;
     char* good_page = polling_page + page_size;

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -58,7 +58,7 @@ void SafepointMechanism::default_initialize() {
     // Polling page
     const size_t page_size = os::vm_page_size();
     const size_t allocation_size = 2 * page_size;
-    char* polling_page = os::reserve_memory(allocation_size);
+    char* polling_page = os::reserve_memory(allocation_size, false, mtSafepoint);
     os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page", mtSafepoint);
     MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
 

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -58,8 +58,8 @@ void SafepointMechanism::default_initialize() {
     // Polling page
     const size_t page_size = os::vm_page_size();
     const size_t allocation_size = 2 * page_size;
-    char* polling_page = os::reserve_memory(allocation_size, false, mtSafepoint);
-    os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page", mtSafepoint);
+    char* polling_page = os::reserve_memory(allocation_size, !ExecMem, mtSafepoint);
+    os::commit_memory_or_exit(polling_page, allocation_size, !ExecMem, "Unable to commit Safepoint polling page", mtSafepoint);
 
     char* bad_page  = polling_page;
     char* good_page = polling_page + page_size;

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -60,7 +60,6 @@ void SafepointMechanism::default_initialize() {
     const size_t allocation_size = 2 * page_size;
     char* polling_page = os::reserve_memory(allocation_size, false, mtSafepoint);
     os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page", mtSafepoint);
-    MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
 
     char* bad_page  = polling_page;
     char* good_page = polling_page + page_size;

--- a/src/hotspot/share/runtime/safepointMechanism.cpp
+++ b/src/hotspot/share/runtime/safepointMechanism.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ void SafepointMechanism::default_initialize() {
     const size_t page_size = os::vm_page_size();
     const size_t allocation_size = 2 * page_size;
     char* polling_page = os::reserve_memory(allocation_size);
-    os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page");
+    os::commit_memory_or_exit(polling_page, allocation_size, false, "Unable to commit Safepoint polling page", mtSafepoint);
     MemTracker::record_virtual_memory_type((address)polling_page, mtSafepoint);
 
     char* bad_page  = polling_page;

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -709,9 +709,9 @@ struct TestMultipleStaticAssertFormsInClassScope {
 static ucontext_t g_stored_assertion_context;
 
 void initialize_assert_poison() {
-  char* page = os::reserve_memory(os::vm_page_size(), false, mtInternal);
+  char* page = os::reserve_memory(os::vm_page_size(), !ExecMem, mtInternal);
   if (page) {
-    if (os::commit_memory(page, os::vm_page_size(), false, mtInternal) &&
+    if (os::commit_memory(page, os::vm_page_size(), !ExecMem, mtInternal) &&
         os::protect_memory(page, os::vm_page_size(), os::MEM_PROT_NONE)) {
       g_assert_poison = page;
     }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -709,7 +709,7 @@ struct TestMultipleStaticAssertFormsInClassScope {
 static ucontext_t g_stored_assertion_context;
 
 void initialize_assert_poison() {
-  char* page = os::reserve_memory(os::vm_page_size());
+  char* page = os::reserve_memory(os::vm_page_size(), false, mtInternal);
   if (page) {
     MemTracker::record_virtual_memory_type(page, mtInternal);
     if (os::commit_memory(page, os::vm_page_size(), false, mtInternal) &&

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -711,7 +711,6 @@ static ucontext_t g_stored_assertion_context;
 void initialize_assert_poison() {
   char* page = os::reserve_memory(os::vm_page_size(), false, mtInternal);
   if (page) {
-    MemTracker::record_virtual_memory_type(page, mtInternal);
     if (os::commit_memory(page, os::vm_page_size(), false, mtInternal) &&
         os::protect_memory(page, os::vm_page_size(), os::MEM_PROT_NONE)) {
       g_assert_poison = page;

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -712,7 +712,7 @@ void initialize_assert_poison() {
   char* page = os::reserve_memory(os::vm_page_size());
   if (page) {
     MemTracker::record_virtual_memory_type(page, mtInternal);
-    if (os::commit_memory(page, os::vm_page_size(), false) &&
+    if (os::commit_memory(page, os::vm_page_size(), false, mtInternal) &&
         os::protect_memory(page, os::vm_page_size(), os::MEM_PROT_NONE)) {
       g_assert_poison = page;
     }

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -50,7 +50,7 @@ TEST_VM(FreeRegionList, length) {
   // the BOT.
   size_t bot_size = G1BlockOffsetTable::compute_size(heap.word_size());
   HeapWord* bot_data = NEW_C_HEAP_ARRAY(HeapWord, bot_size, mtGC);
-  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()), mtTest);
+  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()), mtGC);
   G1RegionToSpaceMapper* bot_storage =
     G1RegionToSpaceMapper::create_mapper(bot_rs,
                                          bot_rs.size(),

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -50,7 +50,7 @@ TEST_VM(FreeRegionList, length) {
   // the BOT.
   size_t bot_size = G1BlockOffsetTable::compute_size(heap.word_size());
   HeapWord* bot_data = NEW_C_HEAP_ARRAY(HeapWord, bot_size, mtGC);
-  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()));
+  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()), mtTest);
   G1RegionToSpaceMapper* bot_storage =
     G1RegionToSpaceMapper::create_mapper(bot_rs,
                                          bot_rs.size(),

--- a/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
+++ b/test/hotspot/gtest/gc/g1/test_freeRegionList.cpp
@@ -50,7 +50,7 @@ TEST_VM(FreeRegionList, length) {
   // the BOT.
   size_t bot_size = G1BlockOffsetTable::compute_size(heap.word_size());
   HeapWord* bot_data = NEW_C_HEAP_ARRAY(HeapWord, bot_size, mtGC);
-  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()), mtGC);
+  ReservedSpace bot_rs(G1BlockOffsetTable::compute_size(heap.word_size()), mtTest);
   G1RegionToSpaceMapper* bot_storage =
     G1RegionToSpaceMapper::create_mapper(bot_rs,
                                          bot_rs.size(),

--- a/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
+++ b/test/hotspot/gtest/gc/g1/test_stressCommitUncommit.cpp
@@ -81,7 +81,7 @@ TEST_VM(G1RegionToSpaceMapper, smallStressAdjacent) {
   size_t size = G1BlockOffsetTable::compute_size(num_regions * region_size / HeapWordSize);
   size_t page_size = os::vm_page_size();
 
-  ReservedSpace rs(size, os::vm_page_size());
+  ReservedSpace rs(size, os::vm_page_size(), mtTest);
 
   G1RegionToSpaceMapper* small_mapper  =
     G1RegionToSpaceMapper::create_mapper(rs,
@@ -105,7 +105,7 @@ TEST_VM(G1RegionToSpaceMapper, largeStressAdjacent) {
   size_t size = G1BlockOffsetTable::compute_size(num_regions * region_size / HeapWordSize);
   size_t page_size = os::vm_page_size();
 
-  ReservedSpace rs(size, page_size);
+  ReservedSpace rs(size, page_size, mtTest);
 
   G1RegionToSpaceMapper* large_mapper  =
     G1RegionToSpaceMapper::create_mapper(rs,

--- a/test/hotspot/gtest/gc/z/test_zForwarding.cpp
+++ b/test/hotspot/gtest/gc/z/test_zForwarding.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public:
 
     _reserved = reserved;
 
-    os::commit_memory((char*)_reserved, ZGranuleSize, false /* executable */);
+    os::commit_memory((char*)_reserved, ZGranuleSize, false /* executable */, mtGC);
 
     _page_offset = uintptr_t(_reserved) - ZAddressHeapBase;
   }

--- a/test/hotspot/gtest/gc/z/test_zForwarding.cpp
+++ b/test/hotspot/gtest/gc/z/test_zForwarding.cpp
@@ -100,7 +100,7 @@ public:
 
     _reserved = reserved;
 
-    os::commit_memory((char*)_reserved, ZGranuleSize, !ExecMem /* executable */, mtGC);
+    os::commit_memory((char*)_reserved, ZGranuleSize, !ExecMem /* executable */, mtTest);
 
     _page_offset = uintptr_t(_reserved) - ZAddressHeapBase;
   }
@@ -111,7 +111,7 @@ public:
     ZGeneration::_old = _old_old;
     ZGeneration::_young = _old_young;
     if (_reserved != nullptr) {
-      os::uncommit_memory((char*)_reserved, ZGranuleSize, !ExecMem, mtGC);
+      os::uncommit_memory((char*)_reserved, ZGranuleSize, !ExecMem, mtTest);
       os::release_memory((char*)_reserved, ZGranuleSize);
     }
   }

--- a/test/hotspot/gtest/gc/z/test_zForwarding.cpp
+++ b/test/hotspot/gtest/gc/z/test_zForwarding.cpp
@@ -111,7 +111,7 @@ public:
     ZGeneration::_old = _old_old;
     ZGeneration::_young = _old_young;
     if (_reserved != nullptr) {
-      os::uncommit_memory((char*)_reserved, ZGranuleSize, false /* executable */);
+      os::uncommit_memory((char*)_reserved, ZGranuleSize, mtGC, false /* executable */);
       os::release_memory((char*)_reserved, ZGranuleSize);
     }
   }

--- a/test/hotspot/gtest/gc/z/test_zForwarding.cpp
+++ b/test/hotspot/gtest/gc/z/test_zForwarding.cpp
@@ -56,7 +56,7 @@ public:
     const size_t increment = MAX2(align_up(unused / 100, ZGranuleSize), ZGranuleSize);
 
     for (uintptr_t start = 0; start + ZGranuleSize <= ZAddressOffsetMax; start += increment) {
-      char* const reserved = os::attempt_reserve_memory_at((char*)ZAddressHeapBase + start, ZGranuleSize, false /* executable */, mtTest);
+      char* const reserved = os::attempt_reserve_memory_at((char*)ZAddressHeapBase + start, ZGranuleSize, !ExecMem /* executable */, mtTest);
       if (reserved != nullptr) {
         // Success
         return reserved;
@@ -100,7 +100,7 @@ public:
 
     _reserved = reserved;
 
-    os::commit_memory((char*)_reserved, ZGranuleSize, false /* executable */, mtGC);
+    os::commit_memory((char*)_reserved, ZGranuleSize, !ExecMem /* executable */, mtGC);
 
     _page_offset = uintptr_t(_reserved) - ZAddressHeapBase;
   }
@@ -111,7 +111,7 @@ public:
     ZGeneration::_old = _old_old;
     ZGeneration::_young = _old_young;
     if (_reserved != nullptr) {
-      os::uncommit_memory((char*)_reserved, ZGranuleSize, mtGC, false /* executable */);
+      os::uncommit_memory((char*)_reserved, ZGranuleSize, !ExecMem, mtGC);
       os::release_memory((char*)_reserved, ZGranuleSize);
     }
   }

--- a/test/hotspot/gtest/gc/z/test_zForwarding.cpp
+++ b/test/hotspot/gtest/gc/z/test_zForwarding.cpp
@@ -56,7 +56,7 @@ public:
     const size_t increment = MAX2(align_up(unused / 100, ZGranuleSize), ZGranuleSize);
 
     for (uintptr_t start = 0; start + ZGranuleSize <= ZAddressOffsetMax; start += increment) {
-      char* const reserved = os::attempt_reserve_memory_at((char*)ZAddressHeapBase + start, ZGranuleSize, false /* executable */);
+      char* const reserved = os::attempt_reserve_memory_at((char*)ZAddressHeapBase + start, ZGranuleSize, false /* executable */, mtTest);
       if (reserved != nullptr) {
         // Success
         return reserved;

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -220,7 +220,8 @@ namespace {
       case Commit:
         return ReservedSpace(reserve_size_aligned,
                              os::vm_allocation_granularity(),
-                             os::vm_page_size(), mtTest);
+                             os::vm_page_size(),
+                             mtTest);
     }
   }
 

--- a/test/hotspot/gtest/memory/test_virtualspace.cpp
+++ b/test/hotspot/gtest/memory/test_virtualspace.cpp
@@ -64,7 +64,7 @@ namespace {
   static void test_reserved_size(size_t size) {
     ASSERT_PRED2(is_size_aligned, size, os::vm_allocation_granularity());
 
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
     MemoryReleaser releaser(&rs);
 
     EXPECT_TRUE(rs.base() != nullptr) << "rs.special: " << rs.special();
@@ -78,7 +78,7 @@ namespace {
   static void test_reserved_size_alignment(size_t size, size_t alignment) {
     ASSERT_PRED2(is_size_aligned, size, alignment) << "Incorrect input parameters";
     size_t page_size = UseLargePages ? os::large_page_size() : os::vm_page_size();
-    ReservedSpace rs(size, alignment, page_size, (char *) nullptr);
+    ReservedSpace rs(size, alignment, page_size, mtTest, (char *) nullptr);
 
     ASSERT_TRUE(rs.base() != nullptr) << "rs.special = " << rs.special();
     ASSERT_EQ(size, rs.size()) << "rs.special = " << rs.special();
@@ -106,7 +106,7 @@ namespace {
     bool large = maybe_large && UseLargePages && size >= os::large_page_size();
     size_t page_size = large ? os::large_page_size() : os::vm_page_size();
 
-    ReservedSpace rs(size, alignment, page_size);
+    ReservedSpace rs(size, alignment, page_size, mtTest);
     MemoryReleaser releaser(&rs);
 
     EXPECT_TRUE(rs.base() != nullptr) << "rs.special: " << rs.special();
@@ -215,12 +215,12 @@ namespace {
       default:
       case Default:
       case Reserve:
-        return ReservedSpace(reserve_size_aligned);
+        return ReservedSpace(reserve_size_aligned, mtTest);
       case Disable:
       case Commit:
         return ReservedSpace(reserve_size_aligned,
                              os::vm_allocation_granularity(),
-                             os::vm_page_size());
+                             os::vm_page_size(), mtTest);
     }
   }
 
@@ -299,7 +299,7 @@ TEST_VM(VirtualSpace, actual_committed_space_one_large_page) {
 
   size_t large_page_size = os::large_page_size();
 
-  ReservedSpace reserved(large_page_size, large_page_size, large_page_size);
+  ReservedSpace reserved(large_page_size, large_page_size, large_page_size, mtTest);
   ReservedSpaceReleaser releaser(&reserved);
   ASSERT_TRUE(reserved.is_reserved());
 
@@ -369,6 +369,7 @@ class TestReservedSpace : AllStatic {
     ReservedSpace rs(size,          // size
                      alignment,     // alignment
                      page_size, // page size
+                     mtTest, // NMT MEM Flag
                      (char *)nullptr); // requested_address
 
     EXPECT_TRUE(rs.base() != nullptr);
@@ -387,7 +388,7 @@ class TestReservedSpace : AllStatic {
   static void test_reserved_space2(size_t size) {
     ASSERT_TRUE(is_aligned(size, os::vm_allocation_granularity())) << "Must be at least AG aligned";
 
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
 
     EXPECT_TRUE(rs.base() != nullptr);
     EXPECT_EQ(rs.size(), size) <<  "rs.size: " << rs.size();
@@ -412,7 +413,7 @@ class TestReservedSpace : AllStatic {
     bool large = maybe_large && UseLargePages && size >= os::large_page_size();
     size_t page_size = large ? os::large_page_size() : os::vm_page_size();
 
-    ReservedSpace rs(size, alignment, page_size);
+    ReservedSpace rs(size, alignment, page_size, mtTest);
 
     EXPECT_TRUE(rs.base() != nullptr);
     EXPECT_EQ(rs.size(), size) <<  "rs.size: " << rs.size();
@@ -516,12 +517,12 @@ class TestVirtualSpace : AllStatic {
     default:
     case Default:
     case Reserve:
-      return ReservedSpace(reserve_size_aligned);
+      return ReservedSpace(reserve_size_aligned, mtTest);
     case Disable:
     case Commit:
       return ReservedSpace(reserve_size_aligned,
                            os::vm_allocation_granularity(),
-                           os::vm_page_size());
+                           os::vm_page_size(), mtTest);
     }
   }
 
@@ -576,7 +577,7 @@ class TestVirtualSpace : AllStatic {
 
     size_t large_page_size = os::large_page_size();
 
-    ReservedSpace reserved(large_page_size, large_page_size, large_page_size);
+    ReservedSpace reserved(large_page_size, large_page_size, large_page_size, mtTest);
 
     EXPECT_TRUE(reserved.is_reserved());
 

--- a/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_locationprinting.cpp
@@ -114,7 +114,7 @@ TEST_VM(NMT, DISABLED_location_printing_cheap_dead_7) { test_for_dead_c_heap_blo
 #endif
 
 static void test_for_mmap(size_t sz, ssize_t offset) {
-  char* addr = os::reserve_memory(sz, false, mtTest);
+  char* addr = os::reserve_memory(sz, !ExecMem, mtTest);
   if (MemTracker::enabled()) {
     test_pointer(addr + offset, true, "in mmap'd memory region");
   } else {

--- a/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
+++ b/test/hotspot/gtest/runtime/test_committed_virtualmemory.cpp
@@ -93,7 +93,7 @@ public:
     const size_t page_sz = os::vm_page_size();
     const size_t size = num_pages * page_sz;
     char* base = os::reserve_memory(size, !ExecMem, mtThreadStack);
-    bool result = os::commit_memory(base, size, !ExecMem);
+    bool result = os::commit_memory(base, size, !ExecMem, mtThreadStack);
     size_t index;
     ASSERT_NE(base, (char*)nullptr);
     for (index = 0; index < touch_pages; index ++) {
@@ -132,7 +132,7 @@ public:
     }
 
     // Cleanup
-    os::free_memory(base, size, page_sz);
+    os::free_memory(base, size, page_sz, mtThreadStack);
     VirtualMemoryTracker::remove_released_region((address)base, size);
 
     rmr = VirtualMemoryTracker::_reserved_regions->find(ReservedMemoryRegion((address)base, size));
@@ -162,7 +162,7 @@ public:
     const size_t size = num_pages * page_sz;
     char* base = os::reserve_memory(size, !ExecMem, mtTest);
     ASSERT_NE(base, (char*)nullptr);
-    result = os::commit_memory(base, size, !ExecMem);
+    result = os::commit_memory(base, size, !ExecMem, mtTest);
 
     ASSERT_TRUE(result);
     // touch all pages

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -367,7 +367,7 @@ TEST_VM(os, jio_snprintf) {
 static inline bool can_reserve_executable_memory(void) {
   bool executable = true;
   size_t len = 128;
-  char* p = os::reserve_memory(len, executable);
+  char* p = os::reserve_memory(len, executable, mtTest);
   bool exec_supported = (p != nullptr);
   if (exec_supported) {
     os::release_memory(p, len);
@@ -405,7 +405,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
   for (int tries = 0; tries < 256 && p == nullptr; tries ++) {
     size_t total_range_len = num_stripes * stripe_len;
     // Reserve a large contiguous area to get the address space...
-    p = (address)os::reserve_memory(total_range_len);
+    p = (address)os::reserve_memory(total_range_len, false, mtTest);
     EXPECT_NE(p, (address)nullptr);
     // .. release it...
     EXPECT_TRUE(os::release_memory((char*)p, total_range_len));
@@ -419,7 +419,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
 #else
       const bool executable = stripe % 2 == 0;
 #endif
-      q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, executable);
+      q = (address)os::attempt_reserve_memory_at((char*)q, stripe_len, executable, mtTest);
       if (q == nullptr) {
         // Someone grabbed that area concurrently. Cleanup, then retry.
         tty->print_cr("reserve_multiple: retry (%d)...", stripe);
@@ -439,7 +439,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
 static address reserve_one_commit_multiple(int num_stripes, size_t stripe_len) {
   assert(is_aligned(stripe_len, os::vm_allocation_granularity()), "Sanity");
   size_t total_range_len = num_stripes * stripe_len;
-  address p = (address)os::reserve_memory(total_range_len);
+  address p = (address)os::reserve_memory(total_range_len, false, mtTest);
   EXPECT_NE(p, (address)nullptr);
   for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
@@ -506,7 +506,7 @@ TEST_VM(os, release_multi_mappings) {
   PRINT_MAPPINGS("B");
 
   // ...re-reserve the middle stripes. This should work unless release silently failed.
-  address p2 = (address)os::attempt_reserve_memory_at((char*)p_middle_stripes, middle_stripe_len);
+  address p2 = (address)os::attempt_reserve_memory_at((char*)p_middle_stripes, middle_stripe_len, false, mtTest);
 
   ASSERT_EQ(p2, p_middle_stripes);
 
@@ -529,7 +529,7 @@ TEST_VM_ASSERT_MSG(os, release_bad_ranges, ".*bad release") {
 #else
 TEST_VM(os, release_bad_ranges) {
 #endif
-  char* p = os::reserve_memory(4 * M);
+  char* p = os::reserve_memory(4 * M, false, mtTest);
   ASSERT_NE(p, (char*)nullptr);
   // Release part of range
   ASSERT_FALSE(os::release_memory(p, M));
@@ -564,7 +564,7 @@ TEST_VM(os, release_one_mapping_multi_commits) {
 
   // // make things even more difficult by trying to reserve at the border of the region
   address border = p + num_stripes * stripe_len;
-  address p2 = (address)os::attempt_reserve_memory_at((char*)border, stripe_len);
+  address p2 = (address)os::attempt_reserve_memory_at((char*)border, stripe_len, false, mtTest);
   PRINT_MAPPINGS("B");
 
   ASSERT_TRUE(p2 == nullptr || p2 == border);
@@ -629,7 +629,7 @@ TEST_VM(os, find_mapping_simple) {
 
   // A simple allocation
   {
-    address p = (address)os::reserve_memory(total_range_len);
+    address p = (address)os::reserve_memory(total_range_len, false, mtTest);
     ASSERT_NE(p, (address)nullptr);
     PRINT_MAPPINGS("A");
     for (size_t offset = 0; offset < total_range_len; offset += 4711) {
@@ -936,7 +936,7 @@ TEST_VM(os, open_O_CLOEXEC) {
 TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_smallpages) {
   char* p1 = os::reserve_memory(M, false, mtTest);
   ASSERT_NE(p1, nullptr);
-  char* p2 = os::attempt_reserve_memory_at(p1, M);
+  char* p2 = os::attempt_reserve_memory_at(p1, M, false, mtTest);
   ASSERT_EQ(p2, nullptr); // should have failed
   os::release_memory(p1, M);
 }
@@ -944,7 +944,7 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_smallpages) {
 TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
   if (UseLargePages && !os::can_commit_large_page_memory()) { // aka special
     const size_t lpsz = os::large_page_size();
-    char* p1 = os::reserve_memory_aligned(lpsz, lpsz, false);
+    char* p1 = os::reserve_memory_aligned(lpsz, lpsz, false, mtTest);
     ASSERT_NE(p1, nullptr);
     char* p2 = os::reserve_memory_special(lpsz, lpsz, lpsz, p1, false);
     ASSERT_EQ(p2, nullptr); // should have failed
@@ -958,9 +958,9 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
 // On Aix, we should fail attach attempts not aligned to segment boundaries (256m)
 TEST_VM(os, aix_reserve_at_non_shmlba_aligned_address) {
   if (Use64KPages) {
-    char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
+    char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M, false, mtTest);
     ASSERT_EQ(p, nullptr); // should have failed
-    p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);
+    p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M, false, mtTest);
     ASSERT_EQ(p, nullptr); // should have failed
   }
 }

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -426,7 +426,7 @@ static address reserve_multiple(int num_stripes, size_t stripe_len) {
         carefully_release_multiple(p, stripe, stripe_len);
         p = nullptr;
       } else {
-        EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, executable));
+        EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, executable, mtTest));
       }
     }
   }
@@ -444,7 +444,7 @@ static address reserve_one_commit_multiple(int num_stripes, size_t stripe_len) {
   for (int stripe = 0; stripe < num_stripes; stripe++) {
     address q = p + (stripe * stripe_len);
     if (stripe % 2 == 0) {
-      EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, false));
+      EXPECT_TRUE(os::commit_memory((char*)q, stripe_len, false, mtTest));
     }
   }
   return p;
@@ -607,7 +607,7 @@ TEST_VM(os, show_mappings_full_range) {
   // on implementations displaying range snippets
   char* p = os::reserve_memory(1 * M, false, mtInternal);
   if (p != nullptr) {
-    if (os::commit_memory(p, 1 * M, false)) {
+    if (os::commit_memory(p, 1 * M, false, mtTest)) {
       strcpy(p, "ABCDEFGHIJKLMNOPQRSTUVWXYZ");
     }
   }

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -54,7 +54,7 @@ namespace {
     const size_t _size;
    public:
     static char* reserve_memory_special_huge_tlbfs(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
-      return os::reserve_memory_special(bytes, alignment, page_size, req_addr, exec);
+      return os::reserve_memory_special(bytes, alignment, page_size, req_addr, exec, mtTest);
     }
     HugeTlbfsMemory(char* const ptr, size_t size) : _ptr(ptr), _size(size) { }
     ~HugeTlbfsMemory() {
@@ -224,7 +224,7 @@ class TestReserveMemorySpecial : AllStatic {
     if (!using_explicit_hugepages()) {
       return;
     }
-    char* addr = os::reserve_memory_special(size, alignment, page_size, nullptr, false);
+    char* addr = os::reserve_memory_special(size, alignment, page_size, nullptr, !ExecMem, mtTest);
     if (addr != nullptr) {
       small_page_write(addr, size);
       os::release_memory_special(addr, size);
@@ -281,7 +281,7 @@ class TestReserveMemorySpecial : AllStatic {
     for (int i = 0; i < num_sizes; i++) {
       const size_t size = sizes[i];
       for (size_t alignment = ag; is_aligned(size, alignment); alignment *= 2) {
-        char* p = os::reserve_memory_special(size, alignment, lp, nullptr, false);
+        char* p = os::reserve_memory_special(size, alignment, lp, nullptr, !ExecMem, mtTest);
         if (p != nullptr) {
           EXPECT_TRUE(is_aligned(p, alignment));
           small_page_write(p, size);
@@ -296,7 +296,7 @@ class TestReserveMemorySpecial : AllStatic {
       for (size_t alignment = ag; is_aligned(size, alignment); alignment *= 2) {
         // req_addr must be at least large page aligned.
         char* const req_addr = align_up(mapping1, MAX2(alignment, lp));
-        char* p = os::reserve_memory_special(size, alignment, lp, req_addr, false);
+        char* p = os::reserve_memory_special(size, alignment, lp, req_addr, !ExecMem, mtTest);
         if (p != nullptr) {
           EXPECT_EQ(p, req_addr);
           small_page_write(p, size);
@@ -311,7 +311,7 @@ class TestReserveMemorySpecial : AllStatic {
       for (size_t alignment = ag; is_aligned(size, alignment); alignment *= 2) {
         // req_addr must be at least large page aligned.
         char* const req_addr = align_up(mapping2, MAX2(alignment, lp));
-        char* p = os::reserve_memory_special(size, alignment, lp, req_addr, false);
+        char* p = os::reserve_memory_special(size, alignment, lp, req_addr, !ExecMem, mtTest);
         // as the area around req_addr contains already existing mappings, the API should always
         // return nullptr (as per contract, it cannot return another address)
         EXPECT_TRUE(p == nullptr);
@@ -355,9 +355,9 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   const size_t size = 1 * G;
   const bool useThp = UseTransparentHugePages;
   UseTransparentHugePages = true;
-  char* const heap = os::reserve_memory(size, false, mtInternal);
+  char* const heap = os::reserve_memory(size, !ExecMem, mtInternal);
   EXPECT_NE(heap, nullptr);
-  EXPECT_TRUE(os::commit_memory(heap, size, false, mtInternal));
+  EXPECT_TRUE(os::commit_memory(heap, size, !ExecMem, mtInternal));
 
   {
     auto pretouch = [heap, size](Thread*, int) {
@@ -379,7 +379,7 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   for (int i = 0; i < 1000; i++)
     EXPECT_EQ(*iptr++, i);
 
-  EXPECT_TRUE(os::uncommit_memory(heap, size, mtInternal, false));
+  EXPECT_TRUE(os::uncommit_memory(heap, size, !ExecMem, mtInternal));
   EXPECT_TRUE(os::release_memory(heap, size));
   UseTransparentHugePages = useThp;
 }

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -379,7 +379,7 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   for (int i = 0; i < 1000; i++)
     EXPECT_EQ(*iptr++, i);
 
-  EXPECT_TRUE(os::uncommit_memory(heap, size, false));
+  EXPECT_TRUE(os::uncommit_memory(heap, size, mtInternal, false));
   EXPECT_TRUE(os::release_memory(heap, size));
   UseTransparentHugePages = useThp;
 }

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -357,7 +357,7 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   UseTransparentHugePages = true;
   char* const heap = os::reserve_memory(size, false, mtInternal);
   EXPECT_NE(heap, nullptr);
-  EXPECT_TRUE(os::commit_memory(heap, size, false));
+  EXPECT_TRUE(os::commit_memory(heap, size, false, mtInternal));
 
   {
     auto pretouch = [heap, size](Thread*, int) {

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -158,7 +158,7 @@ public:
       // the hole.
       const uintptr_t candidate = nth_bit(i);
       if ((candidate + _len) <= ARMB_constants::absolute_max) {
-        _base = os::attempt_reserve_memory_at((char*)candidate, _len, false, mtTest);
+        _base = os::attempt_reserve_memory_at((char*)candidate, _len, !ExecMem, mtTest);
       }
     }
     if (_base == nullptr) {
@@ -166,8 +166,8 @@ public:
     }
     // Release total mapping, remap the individual non-holy parts
     os::release_memory(_base, _len);
-    _p1 = os::attempt_reserve_memory_at(_base + _p1_offset, _p1_size, false, mtTest);
-    _p2 = os::attempt_reserve_memory_at(_base + _p2_offset, _p2_size, false, mtTest);
+    _p1 = os::attempt_reserve_memory_at(_base + _p1_offset, _p1_size, !ExecMem, mtTest);
+    _p2 = os::attempt_reserve_memory_at(_base + _p2_offset, _p2_size, !ExecMem, mtTest);
     if (_p1 == nullptr || _p2 == nullptr) {
       return false;
     }

--- a/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
+++ b/test/hotspot/gtest/runtime/test_os_reserve_between.cpp
@@ -66,7 +66,7 @@ static size_t allocation_granularity() {
                  << " bytes: " << bytes << " alignment: " << alignment << " randomized: " << randomized
 
 static char* call_attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomized) {
-  char* const  addr = os::attempt_reserve_memory_between(min, max, bytes, alignment, randomized);
+  char* const  addr = os::attempt_reserve_memory_between(min, max, bytes, alignment, randomized, mtTest);
   if (addr != nullptr) {
     EXPECT_TRUE(is_aligned(addr, alignment)) << ERRINFO;
     EXPECT_TRUE(is_aligned(addr, allocation_granularity())) << ERRINFO;
@@ -158,7 +158,7 @@ public:
       // the hole.
       const uintptr_t candidate = nth_bit(i);
       if ((candidate + _len) <= ARMB_constants::absolute_max) {
-        _base = os::attempt_reserve_memory_at((char*)candidate, _len);
+        _base = os::attempt_reserve_memory_at((char*)candidate, _len, false, mtTest);
       }
     }
     if (_base == nullptr) {
@@ -166,8 +166,8 @@ public:
     }
     // Release total mapping, remap the individual non-holy parts
     os::release_memory(_base, _len);
-    _p1 = os::attempt_reserve_memory_at(_base + _p1_offset, _p1_size);
-    _p2 = os::attempt_reserve_memory_at(_base + _p2_offset, _p2_size);
+    _p1 = os::attempt_reserve_memory_at(_base + _p1_offset, _p1_size, false, mtTest);
+    _p2 = os::attempt_reserve_memory_at(_base + _p2_offset, _p2_size, false, mtTest);
     if (_p1 == nullptr || _p2 == nullptr) {
       return false;
     }

--- a/test/hotspot/gtest/runtime/test_os_windows.cpp
+++ b/test/hotspot/gtest/runtime/test_os_windows.cpp
@@ -67,7 +67,7 @@ void TestReserveMemorySpecial_test() {
   FLAG_SET_CMDLINE(UseNUMAInterleaving, false);
 
   const size_t large_allocation_size = os::large_page_size() * 4;
-  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), nullptr, false);
+  char* result = os::reserve_memory_special(large_allocation_size, os::large_page_size(), os::large_page_size(), nullptr, !ExecMem, mtTest);
   if (result == nullptr) {
       // failed to allocate memory, skipping the test
       return;
@@ -77,12 +77,12 @@ void TestReserveMemorySpecial_test() {
   // Reserve another page within the recently allocated memory area. This should fail
   const size_t expected_allocation_size = os::large_page_size();
   char* expected_location = result + os::large_page_size();
-  char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
+  char* actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, !ExecMem, mtTest);
   EXPECT_TRUE(actual_location == nullptr) << "Should not be allowed to reserve within present reservation";
 
   // Instead try reserving after the first reservation.
   expected_location = result + large_allocation_size;
-  actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, false);
+  actual_location = os::reserve_memory_special(expected_allocation_size, os::large_page_size(), os::large_page_size(), expected_location, !ExecMem, mtTest);
   EXPECT_TRUE(actual_location != nullptr) << "Unexpected reservation failure, can’t verify correct location";
   EXPECT_TRUE(actual_location == expected_location) << "Reservation must be at requested location";
   MemoryReleaser m2(actual_location, os::large_page_size());
@@ -90,7 +90,7 @@ void TestReserveMemorySpecial_test() {
   // Now try to do a reservation with a larger alignment.
   const size_t alignment = os::large_page_size() * 2;
   const size_t new_large_size = alignment * 4;
-  char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), nullptr, false);
+  char* aligned_request = os::reserve_memory_special(new_large_size, alignment, os::large_page_size(), nullptr, !ExecMem, mtTest);
   EXPECT_TRUE(aligned_request != nullptr) << "Unexpected reservation failure, can’t verify correct alignment";
   EXPECT_TRUE(is_aligned(aligned_request, alignment)) << "Returned address must be aligned";
   MemoryReleaser m3(aligned_request, new_large_size);

--- a/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
+++ b/test/hotspot/gtest/runtime/test_virtualMemoryTracker.cpp
@@ -93,7 +93,7 @@ public:
   static void test_add_committed_region_adjacent() {
 
     size_t size  = 0x01000000;
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
     address addr = (address)rs.base();
 
     address frame1 = (address)0x1234;
@@ -167,7 +167,7 @@ public:
   static void test_add_committed_region_adjacent_overlapping() {
 
     size_t size  = 0x01000000;
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
     address addr = (address)rs.base();
 
     address frame1 = (address)0x1234;
@@ -254,7 +254,7 @@ public:
   static void test_add_committed_region_overlapping() {
 
     size_t size  = 0x01000000;
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
     address addr = (address)rs.base();
 
     address frame1 = (address)0x1234;
@@ -425,7 +425,7 @@ public:
   static void test_remove_uncommitted_region() {
 
     size_t size  = 0x01000000;
-    ReservedSpace rs(size);
+    ReservedSpace rs(size, mtTest);
     address addr = (address)rs.base();
 
     address frame1 = (address)0x1234;


### PR DESCRIPTION
`MEMFLAGS flag` is used to hold/show the type of the memory regions in NMT. Each call of NMT API requires a search through the list of memory regions.
The Hotspot code reserves/commits/uncommits memory regions and later calls explicitly NMT API with a specific memory type (e.g., `mtGC`, `mtJavaHeap`) for that region.  Therefore, there are two search in the list of regions per reserve/commit/uncommit operations, one for the operation and another for setting the type of the region.  
When the memory type is passed in during reserve/commit/uncommit operations, NMT can use it and avoid the extra search for setting the memory type.

Tests: tiers1-5 passed on linux-x64, macosx-aarch64 and windows-x64 for debug and non-debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330076](https://bugs.openjdk.org/browse/JDK-8330076): NMT: add/make a mandatory MEMFLAGS argument to family of os::reserve/commit/uncommit memory API (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [fa350261](https://git.openjdk.org/jdk/pull/18745/files/fa3502618532e73fdc8a79ecd99b6474089c4ed3)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [fa350261](https://git.openjdk.org/jdk/pull/18745/files/fa3502618532e73fdc8a79ecd99b6474089c4ed3)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [72467f68](https://git.openjdk.org/jdk/pull/18745/files/72467f682e8bba1eddce36ab067f243315506fe9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18745/head:pull/18745` \
`$ git checkout pull/18745`

Update a local copy of the PR: \
`$ git checkout pull/18745` \
`$ git pull https://git.openjdk.org/jdk.git pull/18745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18745`

View PR using the GUI difftool: \
`$ git pr show -t 18745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18745.diff">https://git.openjdk.org/jdk/pull/18745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18745#issuecomment-2050026160)