### PR TITLE
8322043: HeapDumper should use parallel dump by default

### DIFF
--- a/src/hotspot/share/services/attachListener.cpp
+++ b/src/hotspot/share/services/attachListener.cpp
@@ -254,7 +254,7 @@ static jint dump_heap(AttachOperation* op, outputStream* out) {
     // This helps reduces the amount of unreachable objects in the dump
     // and makes it easier to browse.
     HeapDumper dumper(live_objects_only /* request GC */);
-    dumper.dump(path, out, level, false, HeapDumper::default_num_of_dump_threads());
+    dumper.dump(path, out, level);
   }
   return JNI_OK;
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -493,7 +493,7 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
 
 void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   jlong level = -1; // -1 means no compression.
-  jlong parallel = -1; // auto select.
+  jlong parallel = HeapDumper::default_num_of_dump_threads();
 
   if (_gzip.is_set()) {
     level = _gzip.value();
@@ -520,7 +520,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  dumper.dump(_filename.value(), output(), (int)level, _overwrite.value(), (int)parallel);
+  dumper.dump(_filename.value(), output(), (int)level, _overwrite.value(), (uint)parallel);
 }
 
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -493,7 +493,7 @@ HeapDumpDCmd::HeapDumpDCmd(outputStream* output, bool heap) :
 
 void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   jlong level = -1; // -1 means no compression.
-  jlong parallel = HeapDumper::default_num_of_dump_threads();
+  jlong parallel = -1; // auto select.
 
   if (_gzip.is_set()) {
     level = _gzip.value();
@@ -520,7 +520,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  dumper.dump(_filename.value(), output(), (int) level, _overwrite.value(), (uint)parallel);
+  dumper.dump(_filename.value(), output(), (int)level, _overwrite.value(), (int)parallel);
 }
 
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -520,7 +520,7 @@ void HeapDumpDCmd::execute(DCmdSource source, TRAPS) {
   // This helps reduces the amount of unreachable objects in the dump
   // and makes it easier to browse.
   HeapDumper dumper(!_all.value() /* request GC if _all is false*/);
-  dumper.dump(_filename.value(), output(), (int)level, _overwrite.value(), (uint)parallel);
+  dumper.dump(_filename.value(), output(), (int) level, _overwrite.value(), (uint)parallel);
 }
 
 ClassHistogramDCmd::ClassHistogramDCmd(outputStream* output, bool heap) :

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2613,7 +2613,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
       // For the OOM handling we may already be limited in memory.
       // Lets ensure we have at least 20MB per thread.
       julong max_threads = os::free_memory() / (20 * M);
-      if (num_dump_threads > max_threads) {
+      if ((uint)num_dump_threads > max_threads) {
         num_dump_threads = MAX2<int>(1, (int)max_threads);
       }
     }

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2596,7 +2596,7 @@ void VM_HeapDumper::dump_vthread(oop vt, AbstractDumpWriter* segment_writer) {
 }
 
 // dump the heap to given path.
-int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite, uint num_dump_threads) {
+int HeapDumper::dump(const char* path, outputStream* out, int compression, bool overwrite, int num_dump_threads) {
   assert(path != nullptr && strlen(path) > 0, "path missing");
 
   // print message in interactive case
@@ -2604,6 +2604,11 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
     out->print_cr("Dumping heap to %s ...", path);
     timer()->start();
   }
+
+  if (num_dump_threads < 0) {
+    num_dump_threads = default_num_of_dump_threads();
+  }
+
   // create JFR event
   EventHeapDump event;
 
@@ -2630,7 +2635,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
   }
 
   // generate the segmented heap dump into separate files
-  VM_HeapDumper dumper(&writer, _gc_before_heap_dump, _oome, num_dump_threads);
+  VM_HeapDumper dumper(&writer, _gc_before_heap_dump, _oome, (uint)num_dump_threads);
   VMThread::execute(&dumper);
 
   // record any error that the writer may have encountered

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2642,7 +2642,7 @@ int HeapDumper::dump(const char* path, outputStream* out, int compression, bool 
   }
 
   // generate the segmented heap dump into separate files
-  VM_HeapDumper dumper(&writer, _gc_before_heap_dump, _oome, (uint)num_dump_threads);
+  VM_HeapDumper dumper(&writer, _gc_before_heap_dump, _oome, num_dump_threads);
   VMThread::execute(&dumper);
 
   // record any error that the writer may have encountered

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -60,8 +60,8 @@ class HeapDumper : public StackObj {
   // dumps the heap to the specified file, returns 0 if success.
   // additional info is written to out if not null.
   // compression >= 0 creates a gzipped file with the given compression level.
-  // parallel_thread_num >= 0 indicates thread numbers of parallel object dump, -1 means "auto select".
-  int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, int parallel_thread_num = -1);
+  // parallel_thread_num >= 0 indicates thread numbers of parallel object dump.
+  int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, uint parallel_thread_num = default_num_of_dump_threads());
 
   // returns error message (resource allocated), or null if no error
   char* error_as_C_string() const;
@@ -71,8 +71,8 @@ class HeapDumper : public StackObj {
   static void dump_heap_from_oome()    NOT_SERVICES_RETURN;
 
   // Parallel thread number for heap dump, initialize based on active processor count.
-  static int default_num_of_dump_threads() {
-    return MAX2<int>(1, os::initial_active_processor_count() * 3 / 8);
+  static uint default_num_of_dump_threads() {
+    return MAX2<uint>(1, (uint)os::initial_active_processor_count() * 3 / 8);
   }
 };
 

--- a/src/hotspot/share/services/heapDumper.hpp
+++ b/src/hotspot/share/services/heapDumper.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,8 @@ class HeapDumper : public StackObj {
   // dumps the heap to the specified file, returns 0 if success.
   // additional info is written to out if not null.
   // compression >= 0 creates a gzipped file with the given compression level.
-  // parallel_thread_num >= 0 indicates thread numbers of parallel object dump
-  int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, uint parallel_thread_num = 1);
+  // parallel_thread_num >= 0 indicates thread numbers of parallel object dump, -1 means "auto select".
+  int dump(const char* path, outputStream* out = nullptr, int compression = -1, bool overwrite = false, int parallel_thread_num = -1);
 
   // returns error message (resource allocated), or null if no error
   char* error_as_C_string() const;
@@ -71,8 +71,8 @@ class HeapDumper : public StackObj {
   static void dump_heap_from_oome()    NOT_SERVICES_RETURN;
 
   // Parallel thread number for heap dump, initialize based on active processor count.
-  static uint default_num_of_dump_threads() {
-    return MAX2<uint>(1, (uint)os::initial_active_processor_count() * 3 / 8);
+  static int default_num_of_dump_threads() {
+    return MAX2<int>(1, os::initial_active_processor_count() * 3 / 8);
   }
 };
 


### PR DESCRIPTION
The fix makes VM heap dumping parallel by default.
`jcmd GC.heap_dump` and `jmap -dump` had parallel dumping by default, the fix affects `HotSpotDiagnosticMXBean.dumpHeap()`, `-XX:+HeapDumpBeforeFullGC`, `-XX:+HeapDumpAfterFullGC` and `-XX:+HeapDumpOnOutOfMemoryError`.

Testing:
  - manually tested different heap dump scenarios with `-Xlog:heapdump`;
  - tier1,tier2,hs-tier5-svc;
  - all reg.tests that use heap dump.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322043](https://bugs.openjdk.org/browse/JDK-8322043): HeapDumper should use parallel dump by default (**Enhancement** - P4)


### Reviewers
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer) ⚠️ Review applies to [f6db604f](https://git.openjdk.org/jdk/pull/18748/files/f6db604fb483899211d8183a9a5cb524265dfbaa)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [641bedc5](https://git.openjdk.org/jdk/pull/18748/files/641bedc581be46f43a57b9f6936798e2a31c16fb)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [641bedc5](https://git.openjdk.org/jdk/pull/18748/files/641bedc581be46f43a57b9f6936798e2a31c16fb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18748/head:pull/18748` \
`$ git checkout pull/18748`

Update a local copy of the PR: \
`$ git checkout pull/18748` \
`$ git pull https://git.openjdk.org/jdk.git pull/18748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18748`

View PR using the GUI difftool: \
`$ git pr show -t 18748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18748.diff">https://git.openjdk.org/jdk/pull/18748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18748#issuecomment-2050849296)