### PR TITLE
8329555: Crash in intrinsifying heap-based MemorySegment Vector store/loads

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1036,8 +1036,10 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   const bool needs_cpu_membar = is_mixed_access || is_mismatched_access;
 
-  bool mismatched_ms = from_ms->get_con() && !is_mask && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
-  BasicType mem_elem_bt = LITTLE_ENDIAN_ONLY(elem_bt) BIG_ENDIAN_ONLY(arr_type->elem()->array_element_basic_type());
+  bool mismatched_ms = LITTLE_ENDIAN_ONLY(false)
+      BIG_ENDIAN_ONLY(from_ms->get_con() && !is_mask && arr_type != nullptr &&
+                      arr_type->elem()->array_element_basic_type() != elem_bt);
+  BasicType mem_elem_bt = mismatched_ms ? arr_type->elem()->array_element_basic_type() : elem_bt;
   if (!is_java_primitive(mem_elem_bt)) {
     if (C->print_intrinsics()) {
       tty->print_cr("  ** non-primitive array element type");

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1037,7 +1037,13 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
   const bool needs_cpu_membar = is_mixed_access || is_mismatched_access;
 
   bool mismatched_ms = from_ms->get_con() && !is_mask && arr_type != nullptr && arr_type->elem()->array_element_basic_type() != elem_bt;
-  BasicType mem_elem_bt = mismatched_ms ? arr_type->elem()->array_element_basic_type() : elem_bt;
+  BasicType mem_elem_bt = LITTLE_ENDIAN_ONLY(elem_bt) BIG_ENDIAN_ONLY(arr_type->elem()->array_element_basic_type());
+  if (!is_java_primitive(mem_elem_bt)) {
+    if (C->print_intrinsics()) {
+      tty->print_cr("  ** non-primitive array element type");
+    }
+    return false;
+  }
   int mem_num_elem = mismatched_ms ? (num_elem * type2aelembytes(elem_bt)) / type2aelembytes(mem_elem_bt) : num_elem;
   if (arr_type != nullptr && !is_mask && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
     if (C->print_intrinsics()) {

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -1036,6 +1036,10 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   const bool needs_cpu_membar = is_mixed_access || is_mismatched_access;
 
+  // For non-masked mismatched memory segment vector read/write accesses, intrinsification can continue
+  // with unknown backing storage type and compiler can skip inserting explicit reinterpretation IR after
+  // loading from or before storing to backing storage which is mandatory for semantic correctness of
+  // big-endian memory layout.
   bool mismatched_ms = LITTLE_ENDIAN_ONLY(false)
       BIG_ENDIAN_ONLY(from_ms->get_con() && !is_mask && arr_type != nullptr &&
                       arr_type->elem()->array_element_basic_type() != elem_bt);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestBiMorphicMismatchedMemSegment.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestBiMorphicMismatchedMemSegment.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+/*
+ * @test
+ * @bug 8329555
+ * @modules jdk.incubator.vector
+ *
+ * @run main/othervm -Xbatch -XX:+TieredCompilation compiler.vectorapi.TestBiMorphicMismatchedMemSegment
+ */
+
+
+import jdk.incubator.vector.ByteVector;
+
+import java.lang.foreign.MemorySegment;
+import java.nio.ByteOrder;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
+
+public class TestBiMorphicMismatchedMemSegment {
+    public static void main(String[] args) {
+        AtomicLong aLong = new AtomicLong();
+
+        IntStream.range(0, 10000).forEach(j -> {
+            byte[] bytes = new byte[64];
+            ThreadLocalRandom.current().nextBytes(bytes);
+            var byteSegment = MemorySegment.ofArray(bytes);
+            var byteFragment = ByteVector.SPECIES_PREFERRED.fromMemorySegment(byteSegment, 0, ByteOrder.LITTLE_ENDIAN);
+            float[] floats = new float[128];
+            byte[] targetBytes = new byte[512];
+            var floatSegment = MemorySegment.ofArray(floats);
+            var targetByteSegment = MemorySegment.ofArray(targetBytes);
+            byteFragment.intoMemorySegment(floatSegment, ThreadLocalRandom.current().nextInt(0, 448), ByteOrder.LITTLE_ENDIAN);
+            byteFragment.intoMemorySegment(targetByteSegment, ThreadLocalRandom.current().nextInt(0, 448), ByteOrder.LITTLE_ENDIAN);
+            var l = 0;
+            for (int i = 0; i < floats.length; i++) {
+                l += (int) floats[i];
+            }
+            aLong.addAndGet(l);
+        });
+
+        System.out.println(aLong.get());
+    }
+}


### PR DESCRIPTION
- Problem is related to bi-morphic inlining of ms.unsafeBase() in presence of multiple receiver type profiles (OfFloat, OfByte) which results into formation of an abstract type phi node at JVM state convergence points.
- Due to this, for mismatched memory segment access, inline expander is unable to infer the element type of array wrapped within the memory segment and this results into an assertion failure while computing the source lane count.
- For non-masked mismatched memory segment vector read/write accesses, intrinsification can continue with unknown backing storage type and compiler can skip inserting explicit reinterpretation IR after loading from or before storing to backing storage which is mandatory for semantic correctness of big-endian memory layout.
- For vector write access, this may prevent value forwarding, which may result into subsequent redundant vector loads from same address, but preventing intensification failure will offset that cost.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329555](https://bugs.openjdk.org/browse/JDK-8329555): Crash in intrinsifying heap-based MemorySegment Vector store/loads (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18749/head:pull/18749` \
`$ git checkout pull/18749`

Update a local copy of the PR: \
`$ git checkout pull/18749` \
`$ git pull https://git.openjdk.org/jdk.git pull/18749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18749`

View PR using the GUI difftool: \
`$ git pr show -t 18749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18749.diff">https://git.openjdk.org/jdk/pull/18749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18749#issuecomment-2050927348)