### PR TITLE
8330154: Serial: Remove TenuredSpace::update_for_block

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -39,6 +39,7 @@
 #include "gc/serial/serialGcRefProcProxyTask.hpp"
 #include "gc/serial/serialHeap.hpp"
 #include "gc/serial/serialStringDedup.hpp"
+#include "gc/serial/tenuredGeneration.inline.hpp"
 #include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
@@ -171,6 +172,9 @@ class Compacter {
 
   uint _index;
 
+  // Used for BOT update
+  TenuredGeneration* _old_gen;
+
   HeapWord* get_compaction_top(uint index) const {
     return _spaces[index]._compaction_top;
   }
@@ -196,7 +200,7 @@ class Compacter {
         _spaces[_index]._compaction_top += words;
         if (_index == 0) {
           // old-gen requires BOT update
-          static_cast<TenuredSpace*>(_spaces[0]._space)->update_for_block(result, result + words);
+          _old_gen->update_for_block(result, result + words);
         }
         return result;
       }
@@ -280,6 +284,7 @@ public:
       _num_spaces = 3;
     }
     _index = 0;
+    _old_gen = heap->old_gen();
   }
 
   void phase2_calculate_new_addr() {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -499,7 +499,7 @@ void TenuredGeneration::complete_loaded_archive_space(MemRegion archive_space) {
   HeapWord* start = archive_space.start();
   while (start < archive_space.end()) {
     size_t word_size = cast_to_oop(start)->size();;
-    space->update_for_block(start, start + word_size);
+    _bts->update_for_block(start, start + word_size);
     start += word_size;
   }
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -134,6 +134,7 @@ public:
   void object_iterate(ObjectClosure* blk);
 
   void complete_loaded_archive_space(MemRegion archive_space);
+  inline void update_for_block(HeapWord* start, HeapWord* end);
 
   virtual inline HeapWord* allocate(size_t word_size, bool is_tlab);
   virtual inline HeapWord* par_allocate(size_t word_size, bool is_tlab);

--- a/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.inline.hpp
@@ -45,6 +45,10 @@ inline bool TenuredGeneration::is_in(const void* p) const {
   return space()->is_in(p);
 }
 
+inline void TenuredGeneration::update_for_block(HeapWord* start, HeapWord* end) {
+  _bts->update_for_block(start, end);
+}
+
 HeapWord* TenuredGeneration::allocate(size_t word_size,
                                                  bool is_tlab) {
   assert(!is_tlab, "TenuredGeneration does not support TLAB allocation");

--- a/src/hotspot/share/gc/shared/space.hpp
+++ b/src/hotspot/share/gc/shared/space.hpp
@@ -179,8 +179,6 @@ class TenuredSpace: public ContiguousSpace {
   // Add offset table update.
   inline HeapWord* allocate(size_t word_size) override;
   inline HeapWord* par_allocate(size_t word_size) override;
-
-  inline void update_for_block(HeapWord* start, HeapWord* end);
 };
 #endif //INCLUDE_SERIALGC
 

--- a/src/hotspot/share/gc/shared/space.inline.hpp
+++ b/src/hotspot/share/gc/shared/space.inline.hpp
@@ -51,9 +51,6 @@ inline HeapWord* TenuredSpace::par_allocate(size_t size) {
   return res;
 }
 
-inline void TenuredSpace::update_for_block(HeapWord* start, HeapWord* end) {
-  _offsets->update_for_block(start, end);
-}
 #endif // INCLUDE_SERIALGC
 
 #endif // SHARE_GC_SHARED_SPACE_INLINE_HPP


### PR DESCRIPTION
Simple move an API from space to old-gen, in preparation for complete encapsulation of BOT inside old-gen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330154](https://bugs.openjdk.org/browse/JDK-8330154): Serial: Remove TenuredSpace::update_for_block (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18752/head:pull/18752` \
`$ git checkout pull/18752`

Update a local copy of the PR: \
`$ git checkout pull/18752` \
`$ git pull https://git.openjdk.org/jdk.git pull/18752/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18752`

View PR using the GUI difftool: \
`$ git pr show -t 18752`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18752.diff">https://git.openjdk.org/jdk/pull/18752.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18752#issuecomment-2051420867)