### PR TITLE
8329420: Java 22 (and 23) launcher calls default constructor although main() is static

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -427,10 +427,10 @@ invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
  */
 int
 invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
-    jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
-    CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jmethodID mainID = (*env)->GetMethodID(env, mainClass, "main",
                                  "([Ljava/lang/String;)V");
+    CHECK_EXCEPTION_CONTINUE_OR_FAIL();
+    jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
     CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
     if (mainObject == NULL) {
@@ -464,10 +464,10 @@ invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
  */
 int
 invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {
-    jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
-    CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jmethodID mainID = (*env)->GetMethodID(env, mainClass, "main",
                                  "()V");
+    CHECK_EXCEPTION_CONTINUE_OR_FAIL();
+    jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
     CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
     if (mainObject == NULL) {

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -396,13 +396,13 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     } while (JNI_FALSE)
 
 
-#define CHECK_EXCEPTION_NULL_FAIL(mainObject) \
+#define CHECK_EXCEPTION_NULL_PASS(mainObject) \
     do { \
         if ((*env)->ExceptionOccurred(env)) { \
-            (*env)->ExceptionClear(env); \
-            return 0; \
+            /*leave the exception pending, so that it is reported eventually*/ \
+            return 1; \
         } else if (mainObject == NULL) { \
-            return 0; \
+            return 1; \
         } \
     } while (JNI_FALSE)
 
@@ -427,11 +427,11 @@ int
 invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
     jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
     CHECK_EXCEPTION_FAIL();
-    jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
-    CHECK_EXCEPTION_NULL_FAIL(mainObject);
     jmethodID mainID = (*env)->GetMethodID(env, mainClass, "main",
                                  "([Ljava/lang/String;)V");
     CHECK_EXCEPTION_FAIL();
+    jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
+    CHECK_EXCEPTION_NULL_PASS(mainObject);
     (*env)->CallVoidMethod(env, mainObject, mainID, mainArgs);
     return 1;
  }
@@ -457,11 +457,11 @@ int
 invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {
     jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
     CHECK_EXCEPTION_FAIL();
-    jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
-    CHECK_EXCEPTION_NULL_FAIL(mainObject);
     jmethodID mainID = (*env)->GetMethodID(env, mainClass, "main",
                                  "()V");
     CHECK_EXCEPTION_FAIL();
+    jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
+    CHECK_EXCEPTION_NULL_PASS(mainObject);
     (*env)->CallVoidMethod(env, mainObject, mainID);
     return 1;
 }

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -434,9 +434,9 @@ invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs)
     CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
     if (mainObject == NULL) {
-        //new instance construction failed, don't call the main method,
-        //and don't continue with the next variant;
-        //leave any exception pending, so that it is visible to the caller:
+        // new instance construction failed, don't call the main method,
+        // and don't continue with the next variant;
+        // leave any exception pending, so that it is visible to the caller:
         return 0;
     }
     (*env)->CallVoidMethod(env, mainObject, mainID, mainArgs);
@@ -471,9 +471,9 @@ invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {
     CHECK_EXCEPTION_CONTINUE_OR_FAIL();
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
     if (mainObject == NULL) {
-        //new instance construction failed, don't call the main method,
-        //and don't continue with the next variant;
-        //leave any exception pending, so that it is visible to the caller:
+        // new instance construction failed, don't call the main method,
+        // and don't continue with the next variant;
+        // leave any exception pending, so that it is visible to the caller:
         return 1;
     }
     (*env)->CallVoidMethod(env, mainObject, mainID);

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -474,7 +474,7 @@ invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {
         // new instance construction failed, don't call the main method,
         // and don't continue with the next variant;
         // leave any exception pending, so that it is visible to the caller:
-        return 1;
+        return 0;
     }
     (*env)->CallVoidMethod(env, mainObject, mainID);
     return 0;

--- a/test/jdk/tools/launcher/InstanceMainTest.java
+++ b/test/jdk/tools/launcher/InstanceMainTest.java
@@ -181,7 +181,7 @@ public class InstanceMainTest extends TestHelper {
 
     private static void testMethodOrder() throws Exception {
         for (String source : SOURCES) {
-            performTest(source, tr -> {
+            performTest(source, true, tr -> {
                 if (!tr.isOK()) {
                     System.err.println(source);
                     System.err.println(tr);
@@ -191,7 +191,13 @@ public class InstanceMainTest extends TestHelper {
         }
     }
 
-    record TestCase(String sourceCode, List<String> expectedOutput) {}
+    record TestCase(String sourceCode, boolean enablePreview, List<String> expectedOutput) {
+
+        public TestCase(String sourceCode, List<String> expectedOutput) {
+            this(sourceCode, true, expectedOutput);
+        }
+
+    }
 
     private static final TestCase[] EXECUTION_ORDER = new TestCase[] {
         new TestCase("""
@@ -220,7 +226,7 @@ public class InstanceMainTest extends TestHelper {
 
     private static void testExecutionOrder() throws Exception {
         for (TestCase testCase : EXECUTION_ORDER) {
-            performTest(testCase.sourceCode, tr -> {
+            performTest(testCase.sourceCode, testCase.enablePreview(), tr -> {
                 if (!Objects.equals(testCase.expectedOutput, tr.testOutput)) {
                     throw new AssertionError("Unexpected output, " +
                                              "expected: " + testCase.expectedOutput +
@@ -276,12 +282,57 @@ public class InstanceMainTest extends TestHelper {
                      """,
                      List.of("Constructor called!",
                              "Exception in thread \"main\" java.lang.Error",
-                             "\tat MainClass.<init>(MainClass.java:5)"))
+                             "\tat MainClass.<init>(MainClass.java:5)")),
+        new TestCase("""
+                     public class MainClass {
+                         static {
+                             System.out.println("static init called!");
+                             if (true) throw new Error();
+                         }
+                         public static void main(String... args) {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     false,
+                     List.of("static init called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<clinit>(MainClass.java:4)")),
+        new TestCase("""
+                     public class MainClass {
+                         static {
+                             System.out.println("static init called!");
+                             if (true) throw new Error();
+                         }
+                         public static void main(String... args) {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     true,
+                     List.of("static init called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<clinit>(MainClass.java:4)")),
+        new TestCase("""
+                     public class MainClass {
+                         static {
+                             System.out.println("static init called!");
+                             if (true) throw new Error();
+                         }
+                         public void main(String... args) {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     true,
+                     List.of("static init called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<clinit>(MainClass.java:4)")),
     };
 
     private static void testExecutionErrors() throws Exception {
         for (TestCase testCase : EXECUTION_ERRORS) {
-            performTest(testCase.sourceCode, tr -> {
+            performTest(testCase.sourceCode, testCase.enablePreview(), tr -> {
                 for (int i = 0; i < testCase.expectedOutput.size(); i++) {
                     if (i >= tr.testOutput.size() ||
                         !Objects.equals(testCase.expectedOutput.get(i),
@@ -296,15 +347,17 @@ public class InstanceMainTest extends TestHelper {
         }
     }
 
-    private static void performTest(String source, Consumer<TestResult> validator) throws Exception {
+    private static void performTest(String source, boolean enablePreview, Consumer<TestResult> validator) throws Exception {
         Path mainClass = Path.of("MainClass.java");
         Files.writeString(mainClass, source);
         var version = System.getProperty("java.specification.version");
-        var trSource = doExec(javaCmd, "--enable-preview", "--source", version, "MainClass.java");
+        var previewRuntime = enablePreview ? "--enable-preview" : "-DtestNoPreview";
+        var previewCompile = enablePreview ? "--enable-preview" : "-XDtestNoPreview";
+        var trSource = doExec(javaCmd, previewRuntime, "--source", version, "MainClass.java");
         validator.accept(trSource);
-        compile("--enable-preview", "--source", version, "MainClass.java");
+        compile(previewCompile, "--source", version, "MainClass.java");
         String cp = mainClass.toAbsolutePath().getParent().toString();
-        var trCompile = doExec(javaCmd, "--enable-preview", "--class-path", cp, "MainClass");
+        var trCompile = doExec(javaCmd, previewRuntime, "--class-path", cp, "MainClass");
         validator.accept(trCompile);
     }
 

--- a/test/jdk/tools/launcher/InstanceMainTest.java
+++ b/test/jdk/tools/launcher/InstanceMainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,14 @@
  */
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 
 /**
  * @test
- * @summary test execution priority of main methods
+ * @bug 8329420
+ * @summary test execution priority and behavior of main methods
  * @run main InstanceMainTest
  */
 public class InstanceMainTest extends TestHelper {
@@ -175,16 +179,138 @@ public class InstanceMainTest extends TestHelper {
             """
     };
 
-    public static void main(String... args) throws Exception {
+    private static void testMethodOrder() throws Exception {
         for (String source : SOURCES) {
-            Files.writeString(Path.of("MainClass.java"), source);
-            var version = System.getProperty("java.specification.version");
-            var tr = doExec(javaCmd, "--enable-preview", "--source", version, "MainClass.java");
-            if (!tr.isOK()) {
-                System.err.println(source);
-                System.err.println(tr);
-                throw new AssertionError();
-            }
+            performTest(source, tr -> {
+                if (!tr.isOK()) {
+                    System.err.println(source);
+                    System.err.println(tr);
+                    throw new AssertionError();
+                }
+            });
         }
+    }
+
+    record TestCase(String sourceCode, List<String> expectedOutput) {}
+
+    private static final TestCase[] EXECUTION_ORDER = new TestCase[] {
+        new TestCase("""
+                     public class MainClass {
+                         public MainClass() {
+                             System.out.println("Constructor called!");
+                         }
+                         public static void main() {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     List.of("main called!")),
+        new TestCase("""
+                     public class MainClass {
+                         public MainClass() {
+                             System.out.println("Constructor called!");
+                         }
+                         public void main() {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     List.of("Constructor called!", "main called!"))
+    };
+
+    private static void testExecutionOrder() throws Exception {
+        for (TestCase testCase : EXECUTION_ORDER) {
+            performTest(testCase.sourceCode, tr -> {
+                if (!Objects.equals(testCase.expectedOutput, tr.testOutput)) {
+                    throw new AssertionError("Unexpected output, " +
+                                             "expected: " + testCase.expectedOutput +
+                                             ", actual: " + tr.testOutput);
+                }
+            });
+        }
+    }
+
+    private static final TestCase[] EXECUTION_ERRORS = new TestCase[] {
+        new TestCase("""
+                     public class MainClass {
+                         public MainClass() {
+                             System.out.println("Constructor called!");
+                             if (true) throw new Error();
+                         }
+                         public void main(String... args) {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     List.of("Constructor called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<init>(MainClass.java:4)")),
+        new TestCase("""
+                     public class MainClass {
+                         public MainClass() {
+                             System.out.println("Constructor called!");
+                             if (true) throw new Error();
+                         }
+                         public void main() {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     List.of("Constructor called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<init>(MainClass.java:4)")),
+        new TestCase("""
+                     public class MainClass {
+                         static int idx;
+                         public MainClass() {
+                             System.out.println("Constructor called!");
+                             if (idx++ == 0) throw new Error();
+                         }
+                         public void main(String... args) {
+                             System.out.println("main called!");
+                         }
+                         public void main() {
+                             System.out.println("main called!");
+                         }
+                     }
+                     """,
+                     List.of("Constructor called!",
+                             "Exception in thread \"main\" java.lang.Error",
+                             "\tat MainClass.<init>(MainClass.java:5)"))
+    };
+
+    private static void testExecutionErrors() throws Exception {
+        for (TestCase testCase : EXECUTION_ERRORS) {
+            performTest(testCase.sourceCode, tr -> {
+                for (int i = 0; i < testCase.expectedOutput.size(); i++) {
+                    if (i >= tr.testOutput.size() ||
+                        !Objects.equals(testCase.expectedOutput.get(i),
+                                    tr.testOutput.get(i))) {
+                        throw new AssertionError("Unexpected output, " +
+                                                 "expected: " + testCase.expectedOutput +
+                                                 ", actual: " + tr.testOutput +
+                                                 ", failed comparison at index: " + i);
+                    }
+                }
+            });
+        }
+    }
+
+    private static void performTest(String source, Consumer<TestResult> validator) throws Exception {
+        Path mainClass = Path.of("MainClass.java");
+        Files.writeString(mainClass, source);
+        var version = System.getProperty("java.specification.version");
+        var trSource = doExec(javaCmd, "--enable-preview", "--source", version, "MainClass.java");
+        validator.accept(trSource);
+        compile("--enable-preview", "--source", version, "MainClass.java");
+        String cp = mainClass.toAbsolutePath().getParent().toString();
+        var trCompile = doExec(javaCmd, "--enable-preview", "--class-path", cp, "MainClass");
+        validator.accept(trCompile);
+    }
+
+    public static void main(String... args) throws Exception {
+        testMethodOrder();
+        testExecutionOrder();
+        testExecutionErrors();
     }
 }


### PR DESCRIPTION
Consider code like:
```
public class MainClass {
    public MainClass() {
        System.out.println("Constructor called!");
    }
    public static void main() {
        System.out.println("main called!");
    }
}
```
and compile and run it, with preview enabled, like:
```
$ javac /tmp/MainClass.java 
$ java --enable-preview -classpath /tmp MainClass
Constructor called!
main called!
```

That is wrong, as the `main` method is static, and there is no need to create a new instance of the class.

The reason is that as launcher attempts to invoke the main method, it goes in the following order: 1) static-main-with-args; 2) instance-main-with-args; 3) static-main-without-args; 4) instance-main-without-args. But, for the instance variants, the code first creates a new instance of the given class, and only then attempts to lookup the `main` method, and will pass to the next option when the `main` method lookup fails. So, when invoking static-main-without-args, the current class instance may be created for instance-main-with-args, which will then fail due to the missing `main(String[])` method.

The proposed solution to this problem is to simply first do a lookup for the `main` method (skipping to the next variant when the given main method does not exist, without instantiating the current class).

There is also a relatively closely related problem: what happens when the constructor throws an exception?
```
public class MainClass {
    public MainClass() {
        if (true) throw new RuntimeException();
    }
    public void main() {
        System.out.println("main called!");
    }
}
```

when compiled an run, this produces no output whatsoever:
```
$ javac /tmp/MainClass.java 
$ java --enable-preview -classpath /tmp MainClass
$
```

This is because any exceptions thrown from the constructor are effectively ignored, and the launcher will continue with the next variant. This seems wrong - the exception should be printed for the user, like:
```
$ java --enable-preview -classpath /tmp/ MainClass 
Exception in thread "main" java.lang.RuntimeException
        at MainClass.<init>(MainClass.java:3)
```

This patch proposes to do that by not consuming the exceptions thrown from the constructor, and stop the propagation to the next variant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329420](https://bugs.openjdk.org/browse/JDK-8329420): Java 22 (and 23) launcher calls default constructor although main() is static (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [2022aa5a](https://git.openjdk.org/jdk/pull/18753/files/2022aa5a0d21f930d9b49d1bb0b91ecf7e60ead2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18753/head:pull/18753` \
`$ git checkout pull/18753`

Update a local copy of the PR: \
`$ git checkout pull/18753` \
`$ git pull https://git.openjdk.org/jdk.git pull/18753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18753`

View PR using the GUI difftool: \
`$ git pr show -t 18753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18753.diff">https://git.openjdk.org/jdk/pull/18753.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18753#issuecomment-2051482569)