### PR TITLE
8330153: C2: dump barrier information for all Mach nodes

### DIFF
--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -548,6 +548,11 @@ void MachNode::dump_spec(outputStream *st) const {
     if( C->alias_type(t)->is_volatile() )
       st->print(" Volatile!");
   }
+  if (barrier_data() != 0) {
+    st->print(" barrier(");
+    BarrierSet::barrier_set()->barrier_set_c2()->dump_barrier_data(this, st);
+    st->print(") ");
+  }
 }
 
 //------------------------------dump_format------------------------------------
@@ -560,15 +565,11 @@ void MachNode::dump_format(PhaseRegAlloc *ra, outputStream *st) const {
 //=============================================================================
 #ifndef PRODUCT
 void MachTypeNode::dump_spec(outputStream *st) const {
+  MachNode::dump_spec(st);
   if (_bottom_type != nullptr) {
     _bottom_type->dump_on(st);
   } else {
     st->print(" null");
-  }
-  if (barrier_data() != 0) {
-    st->print(" barrier(");
-    BarrierSet::barrier_set()->barrier_set_c2()->dump_barrier_data(this, st);
-    st->print(")");
   }
 }
 #endif

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2076,6 +2076,12 @@ public class IRNode {
         machOnly(Z_STORE_P_WITH_BARRIER_FLAG, regex);
     }
 
+    public static final String Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG" + POSTFIX;
+    static {
+        String regex = START + "zCompareAndSwapP" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;
+        machOnly(Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, regex);
+    }
+
     public static final String Z_GET_AND_SET_P_WITH_BARRIER_FLAG = COMPOSITE_PREFIX + "Z_GET_AND_SET_P_WITH_BARRIER_FLAG" + POSTFIX;
     static {
         String regex = START + "(zXChgP)|(zGetAndSetP\\S*)" + MID + "barrier\\(\\s*" + IS_REPLACED + "\\s*\\)" + END;

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.examples;
+
+import compiler.lib.ir_framework.*;
+import java.lang.invoke.VarHandle;
+import java.lang.invoke.MethodHandles;
+
+/**
+ * @test
+ * @summary Example test that illustrates the use of the IR test framework for
+ *          verification of late-expanded GC barriers.
+ * @library /test/lib /
+ * @run driver ir_framework.examples.GCBarrierIRExample
+ */
+
+public class GCBarrierIRExample {
+
+    static class Outer {
+        Object f;
+    }
+
+    static final VarHandle fVarHandle;
+    static {
+        MethodHandles.Lookup l = MethodHandles.lookup();
+        try {
+            fVarHandle = l.findVarHandle(Outer.class, "f", Object.class);
+        } catch (Exception e) {
+            throw new Error(e);
+        }
+    }
+    static Outer o = new Outer();
+    static Object oldVal = new Object();
+    static Object newVal = new Object();
+
+    public static void main(String[] args) {
+        // These rules apply only to collectors that expand barriers at code
+        // emission, such as ZGC. Because the collector selection flags are not
+        // whitelisted (see IR framework's README.md file), the user (as opposed
+        // to jtreg) needs to set these flags here.
+        TestFramework.runWithFlags("-XX:+UseZGC", "-XX:+ZGenerational");
+    }
+
+    @Test
+    // IR rules can be used to verify collector-specific barrier info (in this
+    // case, that a ZGC barrier corresponds to a strong OOP reference). Barrier
+    // info can only be verified after matching, e.g. at the FINAL_CODE phase.
+    @IR(counts = {IRNode.Z_COMPARE_AND_SWAP_P_WITH_BARRIER_FLAG, "strong", "1"},
+        phase  = CompilePhase.FINAL_CODE)
+    static boolean testBarrierOfCompareAndSwap() {
+        return fVarHandle.compareAndSet(o, oldVal, newVal);
+    }
+}

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
@@ -29,6 +29,7 @@ import java.lang.invoke.MethodHandles;
 
 /**
  * @test
+ * @bug 8330153
  * @summary Example test that illustrates the use of the IR test framework for
  *          verification of late-expanded GC barriers.
  * @library /test/lib /


### PR DESCRIPTION
This debug-only changeset ensures that GC-specific barrier information is dumped (via [`BarrierSetC2::dump_barrier_data()`](https://github.com/openjdk/jdk/blob/aebfd53e9d19f5939c81fa1a2fc75716c3355900/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp#L311-L313)) for all C2 Mach nodes, not just `MachType` ones. This makes it possible to e.g. write IR tests that verify barrier properties of `CompareAndSwap`/`WeakCompareAndSwap` Mach implementations, which do not inherit from `MachTypeNode`. An example of such a test can be found [here](https://github.com/robcasloz/jdk/blob/e9b3c2a4cb5dd80d85af8320e559acea5920b2ff/test/hotspot/jtreg/compiler/gcbarriers/TestG1BarrierGeneration.java#L283-L292).

The [following program](https://bugs.openjdk.org/secure/attachment/108921/Example.java) illustrates the effect of the change:

```
import java.lang.invoke.VarHandle;
import java.lang.invoke.MethodHandles;

public class Example {
    static class Outer {
        Object f;
    }

    static final VarHandle fVarHandle;
    static {
        MethodHandles.Lookup l = MethodHandles.lookup();
        try {
            fVarHandle = l.findVarHandle(Outer.class, "f", Object.class);
        } catch (Exception e) {
            throw new Error(e);
        }
    }

    static boolean testCompareAndSwap(Outer o, Object oldVal, Object newVal) {
        return fVarHandle.compareAndSet(o, oldVal, newVal);
    }

    public static void main(String[] args) {
        for (int i = 0; i < 10_000; i++) {
            Outer o = new Outer();
            Object oldVal = new Object();
            o.f = oldVal;
            Object newVal = new Object();
            testCompareAndSwap(o, oldVal, newVal);
        }
    }
}
```

Before this changeset, issuing this command:

```
$ java -Xbatch -XX:+UseZGC -XX:+ZGenerational -XX:CompileOnly=Example::testCompareAndSwap -XX:CompileCommand=PrintIdealPhase,Example::testCompareAndSwap,FINAL_CODE Example.java | grep zCompareAndSwapP
```

gives the following dump:

```
 R10     37  zCompareAndSwapP  === 28 35 38 54 22 41  [[ 40 42 36 27 56 25 ]]  !jvms: VarHandleReferences$FieldInstanceReadWrite::compareAndSet @ bci:44 (line 180) VarHandleGuards::guard_LLL_Z @ bci:50 (line 68) Example::testCompareAndSwap @ bci:6 (line 20)
```

After this changeset, we get:

```
 R10     37  zCompareAndSwapP  === 28 35 38 54 22 41  [[ 40 42 36 27 56 25 ]]  barrier(strong )  !jvms: VarHandleReferences$FieldInstanceReadWrite::compareAndSet @ bci:44 (line 180) VarHandleGuards::guard_LLL_Z @ bci:50 (line 68) Example::testCompareAndSwap @ bci:6 (line 20)
```

Note the additional `barrier(strong )` field in the second dump.

**Testing:** tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330153](https://bugs.openjdk.org/browse/JDK-8330153): C2: dump barrier information for all Mach nodes (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [409a1ef4](https://git.openjdk.org/jdk/pull/18754/files/409a1ef4cc86b3cd591ce84c7f5e305115d3a101)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18754/head:pull/18754` \
`$ git checkout pull/18754`

Update a local copy of the PR: \
`$ git checkout pull/18754` \
`$ git pull https://git.openjdk.org/jdk.git pull/18754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18754`

View PR using the GUI difftool: \
`$ git pr show -t 18754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18754.diff">https://git.openjdk.org/jdk/pull/18754.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18754#issuecomment-2051746786)