### PR TITLE
8330163: C2: improve CMoveNode::Value() when condition is always true or false

### DIFF
--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -170,10 +170,10 @@ const Type* CMoveNode::Value(PhaseGVN* phase) const {
     return Type::TOP;
   }
   if (phase->type(in(Condition)) == TypeInt::ZERO) {
-    return phase->type(in(IfFalse))->filter(_type); // Always pick left(false) input
+    return phase->type(in(IfFalse))->filter(_type); // Always pick left (false) input
   }
   if (phase->type(in(Condition)) == TypeInt::ONE) {
-    return phase->type(in(IfTrue))->filter(_type);  // Always pick right(true) input
+    return phase->type(in(IfTrue))->filter(_type);  // Always pick right (true) input
   }
 
   const Type* t = phase->type(in(IfFalse))->meet_speculative(phase->type(in(IfTrue)));

--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -169,6 +169,13 @@ const Type* CMoveNode::Value(PhaseGVN* phase) const {
   if (phase->type(in(IfTrue)) == Type::TOP || phase->type(in(IfFalse)) == Type::TOP) {
     return Type::TOP;
   }
+  if (phase->type(in(Condition)) == TypeInt::ZERO) {
+    return phase->type(in(IfFalse))->filter(_type); // Always pick left(false) input
+  }
+  if (phase->type(in(Condition)) == TypeInt::ONE) {
+    return phase->type(in(IfTrue))->filter(_type);  // Always pick right(true) input
+  }
+
   const Type* t = phase->type(in(IfFalse))->meet_speculative(phase->type(in(IfTrue)));
   return t->filter(_type);
 }

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestCMoveCCP.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestCMoveCCP.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Red Hat and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8330163
+ * @summary C2: improve CMoveNode::Value() when condition is always true or false
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestCMoveCCP
+ */
+
+
+public class TestCMoveCCP {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.LOOP })
+    private static void test1() {
+        int i = -1;
+        testHelper1(i);
+    }
+
+    @ForceInline
+    private static void testHelper1(int i) {
+        do {
+            if (i != 1) {
+                if (i < 0) { // Converted to CMoveI
+                    i = 50;
+                }
+                volatileField = 42;
+            }
+            i *= 2;
+            // i = 100 on first iteration when called from test1
+        } while (i != 100);
+    }
+
+    @Run(test = "test1")
+    @Warmup(10000)
+    private static void testRunner1() {
+        test1();
+        testHelper1(1);
+    }
+}


### PR DESCRIPTION
This is another small change from something I ran into while working
on 8275202. `CMoveNode::Value` can be improved when the condition is
known to be always true or false. That doesn't affect IGVN (as the
`CMove` is removed in that case) but it can be useful for passes that
propagates types such as CCP. In the IR tests, the backbranch of the
loop is never taken when the root of the compilation is `test1`. With
the change, CCP can eliminate it. Without, it can't.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330163](https://bugs.openjdk.org/browse/JDK-8330163): C2: improve CMoveNode::Value() when condition is always true or false (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18757/head:pull/18757` \
`$ git checkout pull/18757`

Update a local copy of the PR: \
`$ git checkout pull/18757` \
`$ git pull https://git.openjdk.org/jdk.git pull/18757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18757`

View PR using the GUI difftool: \
`$ git pr show -t 18757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18757.diff">https://git.openjdk.org/jdk/pull/18757.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18757#issuecomment-2051609350)