### PR TITLE
8330110: AIX build fails after JDK-8329704 - issue with libjli.a

### DIFF
--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -118,6 +118,8 @@ define ResolveLibPath
       else
         ifeq ($(STATIC_LIBS), true)
           $1_$2_LIBPATH := $$(SUPPORT_OUTPUTDIR)/native/$$($1_$2_MODULE)/lib$$($1_$2_NAME)/static
+        else ifeq ($$($1_$2_STATIC_LIBRARY), true)
+          $1_$2_LIBPATH := $$(SUPPORT_OUTPUTDIR)/native/$$($1_$2_MODULE)
         else
           $1_$2_LIBPATH := $$(SUPPORT_OUTPUTDIR)/modules_libs/$$($1_$2_MODULE)
         endif


### PR DESCRIPTION
Unfortunately, after [JDK-8329704](https://bugs.openjdk.org/browse/JDK-8329704) AIX fails to build. The reason is that libjli is specially treated on AIX, and built like a static library. I tried to compensate for this (and had tested on an earlier draft), but some late-minute changes in JDK-8329704 made this check fail.

At this point, I will not add any more checks for `$1_$2_STATIC_LIBRARY` in `ResolveLibPath`. From reading the code, it become apparent that building with `STATIC_BUILD` (n.b. -- not `STATIC_LIBS`!) will likely fail. This has on the other hand not been tested for a long time, and is likely bit-rotten anyway. Also, I will very soon address all of these shortcomings in the upcoming rewrite for proper static builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330110](https://bugs.openjdk.org/browse/JDK-8330110): AIX build fails after JDK-8329704 - issue with libjli.a (**Bug** - P2)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18759/head:pull/18759` \
`$ git checkout pull/18759`

Update a local copy of the PR: \
`$ git checkout pull/18759` \
`$ git pull https://git.openjdk.org/jdk.git pull/18759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18759`

View PR using the GUI difftool: \
`$ git pr show -t 18759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18759.diff">https://git.openjdk.org/jdk/pull/18759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18759#issuecomment-2051671477)