### PR TITLE
8330165: C2: make superword consistently use PhaseIdealLoop::register_new_node()

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -422,7 +422,7 @@ Node* IdealLoopTree::reassociate(Node* n1, PhaseIdealLoop *phase) {
   }
 
   assert(result != nullptr, "");
-  phase->register_new_node(result, phase->get_ctrl(n1));
+  phase->register_new_node_with_ctrl_of(result, n1);
   phase->_igvn.replace_node(n1, result);
   assert(phase->get_loop(phase->get_ctrl(n1)) == this, "");
   _body.yank(n1);
@@ -2251,7 +2251,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
       // Limit is not constant. Int subtraction could lead to underflow.
       // (1) Convert to long.
       Node* limit_l = new ConvI2LNode(limit);
-      register_new_node(limit_l, get_ctrl(limit));
+      register_new_node_with_ctrl_of(limit_l, limit);
       Node* stride_l = _igvn.longcon(stride_con);
       set_ctrl(stride_l, C->root());
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1673,6 +1673,9 @@ public:
   void set_created_loop_node() { _created_loop_node = true; }
   bool created_loop_node()     { return _created_loop_node; }
   void register_new_node(Node* n, Node* blk);
+  void register_new_node_with_ctrl_of(Node* new_node, Node* ctrl_of) {
+    register_new_node(new_node, get_ctrl(ctrl_of));
+  }
 
   Node* clone_and_register(Node* n, Node* ctrl) {
     n = n->clone();

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -467,7 +467,7 @@ Node* PhaseIdealLoop::remix_address_expressions_add_left_shift(Node* n, IdealLoo
       Node* zero = _igvn.integercon(0, bt);
       set_ctrl(zero, C->root());
       Node* neg = SubNode::make(zero, add->in(2), bt);
-      register_new_node(neg, get_ctrl(add->in(2)));
+      register_new_node_with_ctrl_of(neg, add->in(2));
       add = AddNode::make(add->in(1), neg, bt);
       register_new_node(add, add_ctrl);
     }
@@ -654,13 +654,13 @@ Node *PhaseIdealLoop::convert_add_to_muladd(Node* n) {
             if ((adr1->in(AddPNode::Base) == adr3->in(AddPNode::Base)) &&
                 (adr2->in(AddPNode::Base) == adr4->in(AddPNode::Base))) {
               nn = new MulAddS2INode(mul_in1, mul_in2, mul_in3, mul_in4);
-              register_new_node(nn, get_ctrl(n));
+              register_new_node_with_ctrl_of(nn, n);
               _igvn.replace_node(n, nn);
               return nn;
             } else if ((adr1->in(AddPNode::Base) == adr4->in(AddPNode::Base)) &&
                        (adr2->in(AddPNode::Base) == adr3->in(AddPNode::Base))) {
               nn = new MulAddS2INode(mul_in1, mul_in2, mul_in4, mul_in3);
-              register_new_node(nn, get_ctrl(n));
+              register_new_node_with_ctrl_of(nn, n);
               _igvn.replace_node(n, nn);
               return nn;
             }
@@ -2268,7 +2268,7 @@ void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
           // that access. If that condition is replaced by an identical dominating one, then an unpinned load would risk
           // floating above its range check.
           pinned_clone->set_req(0, phi);
-          register_new_node(pinned_clone, get_ctrl(use));
+          register_new_node_with_ctrl_of(pinned_clone, use);
           _igvn.replace_node(use, pinned_clone);
           continue;
         }
@@ -3914,7 +3914,7 @@ bool PhaseIdealLoop::partial_peel( IdealLoopTree *loop, Node_List &old_new ) {
         // floating above its range check.
         Node* pinned_clone = n_clone->pin_array_access_node();
         if (pinned_clone != nullptr) {
-          register_new_node(pinned_clone, get_ctrl(n_clone));
+          register_new_node_with_ctrl_of(pinned_clone, n_clone);
           old_new.map(n->_idx, pinned_clone);
           _igvn.replace_node(n_clone, pinned_clone);
           n_clone = pinned_clone;

--- a/src/hotspot/share/opto/split_if.cpp
+++ b/src/hotspot/share/opto/split_if.cpp
@@ -756,7 +756,7 @@ void PhaseIdealLoop::pin_array_access_nodes_dependent_on(Node* ctrl) {
     }
     Node* pinned_clone = use->pin_array_access_node();
     if (pinned_clone != nullptr) {
-      register_new_node(pinned_clone, get_ctrl(use));
+      register_new_node_with_ctrl_of(pinned_clone, use);
       _igvn.replace_node(use, pinned_clone);
       --i;
     }

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -33,6 +33,7 @@
 #include "opto/memnode.hpp"
 #include "opto/opcodes.hpp"
 #include "opto/opaquenode.hpp"
+#include "opto/rootnode.hpp"
 #include "opto/superword.hpp"
 #include "opto/vectornode.hpp"
 #include "opto/movenode.hpp"
@@ -2553,8 +2554,7 @@ bool SuperWord::output() {
         BasicType bt = velt_basic_type(cmp);
         const TypeVect* vt = TypeVect::make(bt, vlen);
         VectorNode* mask = new VectorMaskCmpNode(bol_test, cmp_in1, cmp_in2, bol_test_node, vt);
-        igvn().register_new_node_with_optimizer(mask);
-        phase()->set_ctrl(mask, phase()->get_ctrl(p->at(0)));
+        phase()->register_new_node(mask, phase()->get_ctrl(p->at(0)));
         igvn()._worklist.push(mask);
 
         // VectorBlend
@@ -2628,8 +2628,7 @@ bool SuperWord::output() {
         assert(n->req() == 2, "only one input expected");
         Node* in = vector_opd(p, 1);
         Node* longval = VectorNode::make(opc, in, nullptr, vlen, T_LONG);
-        igvn().register_new_node_with_optimizer(longval);
-        phase()->set_ctrl(longval, phase()->get_ctrl(first));
+        phase()->register_new_node(longval, phase()->get_ctrl(first));
         vn = VectorCastNode::make(Op_VectorCastL2X, longval, T_INT, vlen);
         vlen_in_bytes = vn->as_Vector()->length_in_bytes();
       } else if (VectorNode::is_convert_opcode(opc)) {
@@ -2669,8 +2668,7 @@ bool SuperWord::output() {
       }
 #endif
 
-      igvn().register_new_node_with_optimizer(vn);
-      phase()->set_ctrl(vn, phase()->get_ctrl(first));
+      phase()->register_new_node(vn, phase()->get_ctrl(first));
       for (uint j = 0; j < p->size(); j++) {
         Node* pm = p->at(j);
         igvn().replace_node(pm, vn);
@@ -2739,8 +2737,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
     const TypeVect* vt = TypeVect::make(iv_bt, vlen);
     Node* vn = new PopulateIndexNode(iv(), igvn().intcon(1), vt);
     VectorNode::trace_new_vector(vn, "SuperWord");
-    igvn().register_new_node_with_optimizer(vn);
-    phase()->set_ctrl(vn, phase()->get_ctrl(opd));
+    phase()->register_new_node(vn, phase()->get_ctrl(opd));
     return vn;
   }
 
@@ -2760,16 +2757,14 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
       if (t != nullptr && t->is_con()) {
         juint shift = t->get_con();
         if (shift > mask) { // Unsigned cmp
-          cnt = ConNode::make(TypeInt::make(shift & mask));
-          igvn().register_new_node_with_optimizer(cnt);
+          cnt = igvn().intcon(shift & mask);
+          phase()->set_ctrl(cnt, phase()->C->root());
         }
       } else {
         if (t == nullptr || t->_lo < 0 || t->_hi > (int)mask) {
-          cnt = ConNode::make(TypeInt::make(mask));
-          igvn().register_new_node_with_optimizer(cnt);
+          cnt = igvn().intcon(mask);
           cnt = new AndINode(opd, cnt);
-          igvn().register_new_node_with_optimizer(cnt);
-          phase()->set_ctrl(cnt, phase()->get_ctrl(opd));
+          phase()->register_new_node(cnt, phase()->get_ctrl(opd));
         }
         if (!opd->bottom_type()->isa_int()) {
           assert(false, "int type only");
@@ -2778,8 +2773,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
       }
       // Move shift count into vector register.
       cnt = VectorNode::shift_count(p0->Opcode(), cnt, vlen, velt_basic_type(p0));
-      igvn().register_new_node_with_optimizer(cnt);
-      phase()->set_ctrl(cnt, phase()->get_ctrl(opd));
+      phase()->register_new_node(cnt, phase()->get_ctrl(opd));
       return cnt;
     }
     if (opd->is_StoreVector()) {
@@ -2797,8 +2791,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
        if (p0->bottom_type()->isa_long()) {
          p0_t = TypeLong::LONG;
          conv = new ConvI2LNode(opd);
-         igvn().register_new_node_with_optimizer(conv);
-         phase()->set_ctrl(conv, phase()->get_ctrl(opd));
+         phase()->register_new_node(conv, phase()->get_ctrl(opd));
        }
        vn = VectorNode::scalar2vector(conv, vlen, p0_t);
     } else {
@@ -2806,8 +2799,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
        vn = VectorNode::scalar2vector(opd, vlen, p0_t);
     }
 
-    igvn().register_new_node_with_optimizer(vn);
-    phase()->set_ctrl(vn, phase()->get_ctrl(opd));
+    phase()->register_new_node(vn, phase()->get_ctrl(opd));
     VectorNode::trace_new_vector(vn, "SuperWord");
     return vn;
   }
@@ -2836,8 +2828,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
       pk->add_opd(in2);
     }
   }
-  igvn().register_new_node_with_optimizer(pk);
-  phase()->set_ctrl(pk, phase()->get_ctrl(opd));
+  phase()->register_new_node(pk, phase()->get_ctrl(opd));
   VectorNode::trace_new_vector(pk, "SuperWord");
   return pk;
 }
@@ -3640,7 +3631,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
       // safe to simply convert invar to an int and loose the upper 32
       // bit half.
       invar = new ConvL2INode(invar);
-      igvn().register_new_node_with_optimizer(invar);
+      phase()->register_new_node(invar, pre_ctrl);
       TRACE_ALIGN_VECTOR_NODE(invar);
    }
     if (is_sub) {
@@ -3648,8 +3639,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
     } else {
       xboi = new AddINode(xboi, invar);
     }
-    igvn().register_new_node_with_optimizer(xboi);
-    phase()->set_ctrl(xboi, pre_ctrl);
+    phase()->register_new_node(xboi, pre_ctrl);
     TRACE_ALIGN_VECTOR_NODE(xboi);
   }
 
@@ -3659,11 +3649,11 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
     // When the base() is top, we have no alignment guarantee at all.
     // Hence, we must now take the base into account for the calculation.
     Node* xbase = new CastP2XNode(nullptr, base);
-    igvn().register_new_node_with_optimizer(xbase);
+    phase()->register_new_node(xbase, pre_ctrl);
     TRACE_ALIGN_VECTOR_NODE(xbase);
 #ifdef _LP64
     xbase  = new ConvL2INode(xbase);
-    igvn().register_new_node_with_optimizer(xbase);
+    phase()->register_new_node(xbase, pre_ctrl);
     TRACE_ALIGN_VECTOR_NODE(xbase);
 #endif
     if (is_sub) {
@@ -3671,8 +3661,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
     } else {
       xboi = new AddINode(xboi, xbase);
     }
-    igvn().register_new_node_with_optimizer(xboi);
-    phase()->set_ctrl(xboi, pre_ctrl);
+    phase()->register_new_node(xboi, pre_ctrl);
     TRACE_ALIGN_VECTOR_NODE(xboi);
   }
 
@@ -3681,8 +3670,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   //    The division is executed as shift
   Node* log2_abs_scale = igvn().intcon(exact_log2(abs(scale)));
   Node* XBOI = new URShiftINode(xboi, log2_abs_scale);
-  igvn().register_new_node_with_optimizer(XBOI);
-  phase()->set_ctrl(XBOI, pre_ctrl);
+  phase()->register_new_node(XBOI, pre_ctrl);
   TRACE_ALIGN_VECTOR_NODE(log2_abs_scale);
   TRACE_ALIGN_VECTOR_NODE(XBOI);
 
@@ -3696,8 +3684,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   } else {
     XBOI_OP_old_limit = new AddINode(XBOI, old_limit);
   }
-  igvn().register_new_node_with_optimizer(XBOI_OP_old_limit);
-  phase()->set_ctrl(XBOI_OP_old_limit, pre_ctrl);
+  phase()->register_new_node(XBOI_OP_old_limit, pre_ctrl);
   TRACE_ALIGN_VECTOR_NODE(XBOI_OP_old_limit);
 
   // 3.2: Compute:
@@ -3708,8 +3695,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   //    a bitmask operation.
   Node* mask_AW = igvn().intcon(AW-1);
   Node* adjust_pre_iter = new AndINode(XBOI_OP_old_limit, mask_AW);
-  igvn().register_new_node_with_optimizer(adjust_pre_iter);
-  phase()->set_ctrl(adjust_pre_iter, pre_ctrl);
+  phase()->register_new_node(adjust_pre_iter, pre_ctrl);
   TRACE_ALIGN_VECTOR_NODE(mask_AW);
   TRACE_ALIGN_VECTOR_NODE(adjust_pre_iter);
 
@@ -3722,8 +3708,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   } else {
     new_limit = new AddINode(old_limit, adjust_pre_iter);
   }
-  igvn().register_new_node_with_optimizer(new_limit);
-  phase()->set_ctrl(new_limit, pre_ctrl);
+  phase()->register_new_node(new_limit, pre_ctrl);
   TRACE_ALIGN_VECTOR_NODE(new_limit);
 
   // 5: Compute (15a, b):
@@ -3731,8 +3716,7 @@ void SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors() {
   Node* constrained_limit =
     (stride > 0) ? (Node*) new MinINode(new_limit, orig_limit)
                  : (Node*) new MaxINode(new_limit, orig_limit);
-  igvn().register_new_node_with_optimizer(constrained_limit);
-  phase()->set_ctrl(constrained_limit, pre_ctrl);
+  phase()->register_new_node(constrained_limit, pre_ctrl);
   TRACE_ALIGN_VECTOR_NODE(constrained_limit);
 
   // 6: Hack the pre-loop limit

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2554,7 +2554,7 @@ bool SuperWord::output() {
         BasicType bt = velt_basic_type(cmp);
         const TypeVect* vt = TypeVect::make(bt, vlen);
         VectorNode* mask = new VectorMaskCmpNode(bol_test, cmp_in1, cmp_in2, bol_test_node, vt);
-        phase()->register_new_node(mask, phase()->get_ctrl(p->at(0)));
+        phase()->register_new_node_with_ctrl_of(mask, p->at(0));
         igvn()._worklist.push(mask);
 
         // VectorBlend
@@ -2628,7 +2628,7 @@ bool SuperWord::output() {
         assert(n->req() == 2, "only one input expected");
         Node* in = vector_opd(p, 1);
         Node* longval = VectorNode::make(opc, in, nullptr, vlen, T_LONG);
-        phase()->register_new_node(longval, phase()->get_ctrl(first));
+        phase()->register_new_node_with_ctrl_of(longval, first);
         vn = VectorCastNode::make(Op_VectorCastL2X, longval, T_INT, vlen);
         vlen_in_bytes = vn->as_Vector()->length_in_bytes();
       } else if (VectorNode::is_convert_opcode(opc)) {
@@ -2668,7 +2668,7 @@ bool SuperWord::output() {
       }
 #endif
 
-      phase()->register_new_node(vn, phase()->get_ctrl(first));
+      phase()->register_new_node_with_ctrl_of(vn, first);
       for (uint j = 0; j < p->size(); j++) {
         Node* pm = p->at(j);
         igvn().replace_node(pm, vn);
@@ -2737,7 +2737,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
     const TypeVect* vt = TypeVect::make(iv_bt, vlen);
     Node* vn = new PopulateIndexNode(iv(), igvn().intcon(1), vt);
     VectorNode::trace_new_vector(vn, "SuperWord");
-    phase()->register_new_node(vn, phase()->get_ctrl(opd));
+    phase()->register_new_node_with_ctrl_of(vn, opd);
     return vn;
   }
 
@@ -2764,7 +2764,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
         if (t == nullptr || t->_lo < 0 || t->_hi > (int)mask) {
           cnt = igvn().intcon(mask);
           cnt = new AndINode(opd, cnt);
-          phase()->register_new_node(cnt, phase()->get_ctrl(opd));
+          phase()->register_new_node_with_ctrl_of(cnt, opd);
         }
         if (!opd->bottom_type()->isa_int()) {
           assert(false, "int type only");
@@ -2773,7 +2773,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
       }
       // Move shift count into vector register.
       cnt = VectorNode::shift_count(p0->Opcode(), cnt, vlen, velt_basic_type(p0));
-      phase()->register_new_node(cnt, phase()->get_ctrl(opd));
+      phase()->register_new_node_with_ctrl_of(cnt, opd);
       return cnt;
     }
     if (opd->is_StoreVector()) {
@@ -2791,7 +2791,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
        if (p0->bottom_type()->isa_long()) {
          p0_t = TypeLong::LONG;
          conv = new ConvI2LNode(opd);
-         phase()->register_new_node(conv, phase()->get_ctrl(opd));
+         phase()->register_new_node_with_ctrl_of(conv, opd);
        }
        vn = VectorNode::scalar2vector(conv, vlen, p0_t);
     } else {
@@ -2799,7 +2799,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
        vn = VectorNode::scalar2vector(opd, vlen, p0_t);
     }
 
-    phase()->register_new_node(vn, phase()->get_ctrl(opd));
+    phase()->register_new_node_with_ctrl_of(vn, opd);
     VectorNode::trace_new_vector(vn, "SuperWord");
     return vn;
   }
@@ -2828,7 +2828,7 @@ Node* SuperWord::vector_opd(Node_List* p, int opd_idx) {
       pk->add_opd(in2);
     }
   }
-  phase()->register_new_node(pk, phase()->get_ctrl(opd));
+  phase()->register_new_node_with_ctrl_of(pk, opd);
   VectorNode::trace_new_vector(pk, "SuperWord");
   return pk;
 }


### PR DESCRIPTION
Another set of changes from 8275202. There are cases in superword
where new nodes are not assigned control. I believe they are harmless
currently because superword is the last pass of optimizations. I also
cleaned up the code so it always uses `register_new_node()`. There are
a couple places where `intcon()` should be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330165](https://bugs.openjdk.org/browse/JDK-8330165): C2: make superword consistently use PhaseIdealLoop::register_new_node() (**Enhancement** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18760/head:pull/18760` \
`$ git checkout pull/18760`

Update a local copy of the PR: \
`$ git checkout pull/18760` \
`$ git pull https://git.openjdk.org/jdk.git pull/18760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18760`

View PR using the GUI difftool: \
`$ git pr show -t 18760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18760.diff">https://git.openjdk.org/jdk/pull/18760.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18760#issuecomment-2051671597)