### PR TITLE
8330161: RISC-V: Don't use C for Labels jumps

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -922,6 +922,8 @@ void MacroAssembler::li(Register Rd, int64_t imm) {
   }                                                                                   \
   void MacroAssembler::NAME(Register Rd, Label &L, Register temp) {                   \
     assert_different_registers(Rd, temp);                                             \
+    /* We can't patch C, i.e. if Label wasn't bound we need to patch this jump.*/     \
+    IncompressibleRegion ir(this);                                                    \
     wrap_label(Rd, L, temp, &MacroAssembler::NAME);                                   \
   }
 


### PR DESCRIPTION
Hi please consider!

jal do not have C switch, we always use the full length instructions.
But jalr have, in case of an unbound Label which is to far for jal we can emit c_jalr.
When we bind the Label we can't patch the c_jalr.

Sanity tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330161](https://bugs.openjdk.org/browse/JDK-8330161): RISC-V: Don't use C for Labels jumps (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18761/head:pull/18761` \
`$ git checkout pull/18761`

Update a local copy of the PR: \
`$ git checkout pull/18761` \
`$ git pull https://git.openjdk.org/jdk.git pull/18761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18761`

View PR using the GUI difftool: \
`$ git pr show -t 18761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18761.diff">https://git.openjdk.org/jdk/pull/18761.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18761#issuecomment-2051729929)