### PR TITLE
8330108: Increase CipherInputStream buffer size

### DIFF
--- a/src/java.base/share/classes/javax/crypto/CipherInputStream.java
+++ b/src/java.base/share/classes/javax/crypto/CipherInputStream.java
@@ -84,8 +84,8 @@ public class CipherInputStream extends FilterInputStream {
 
     /* the buffer holding data that have been read in from the
        underlying stream, but have not been processed by the cipher
-       engine. the size 512 bytes is somewhat randomly chosen */
-    private final byte[] ibuffer = new byte[512];
+       engine. */
+    private final byte[] ibuffer = new byte[8192512];
 
     // having reached the end of the underlying input stream
     private boolean done = false;

--- a/src/java.base/share/classes/javax/crypto/CipherInputStream.java
+++ b/src/java.base/share/classes/javax/crypto/CipherInputStream.java
@@ -85,7 +85,7 @@ public class CipherInputStream extends FilterInputStream {
     /* the buffer holding data that have been read in from the
        underlying stream, but have not been processed by the cipher
        engine. */
-    private final byte[] ibuffer = new byte[8192512];
+    private final byte[] ibuffer = new byte[8192];
 
     // having reached the end of the underlying input stream
     private boolean done = false;


### PR DESCRIPTION
Increase buffer size in CipherInputStream from 512 bytes to 8192 bytes.

I have seen applications where this small buffer size significantly reduces throughput, and I've even seen applications which use reflection to modify the buffer size to work around the issue.

Using the existing `AESGCMCipherInputStream` benchmark, we can see that 8192 performs better in all the explored cases than 512. Sometimes other sizes beat 8192, but it seems a good compromise of performance across encrypt/decrypt and memory usage, plus it's in line with other JDK classes like ChannelInputStream and FileInputStream.

### Benchmark results

```
make test TEST=micro:org.openjdk.bench.javax.crypto.full.AESGCMCipherInputStream
```

These are the results just comparing 512 and 8192. 8192 wins in every case, especially decrypt.

```
# decrypt
 (bufSize)  (dataSize)        Score      Error  Units
       512       16384    41800.053 +-  674.761  ops/s
      8192       16384    45023.512 +-  351.284  ops/s
       512     1048576      219.218 +- 4509.696  ops/s
      8192     1048576      217.506 +- 4498.711  ops/s

# encrypt
 (bufSize)  (dataSize)        Score      Error  Units
       512       16384    59481.957 +- 2297.546  ops/s
      8192       16384    71678.424 +- 1731.105  ops/s
       512     1048576     1030.822 +-   48.273  ops/s
      8192     1048576     1562.457 +-   50.944  ops/s
```

These are the full results including other candidate buffer sizes.

```
# decrypt
 (bufSize)  (dataSize)        Score      Error  Units
       128       16384    36282.200 +- 3827.690  ops/s
       512       16384    41800.053 +-  674.761  ops/s
      2048       16384    44411.579 +- 2452.429  ops/s
      8192       16384    45023.512 +-  351.284  ops/s
     32768       16384    51004.362 +- 3147.855  ops/s
    131702       16384    32111.911 +-  766.159  ops/s
       128     1048576      200.096 +- 3972.338  ops/s
       512     1048576      219.218 +- 4509.696  ops/s
      2048     1048576      224.036 +- 4582.988  ops/s
      8192     1048576      217.506 +- 4498.711  ops/s
     32768     1048576      205.818 +- 4233.473  ops/s
    131702     1048576      247.852 +- 5533.972  ops/s


# encrypt
 (bufSize)  (dataSize)        Score      Error  Units
       128       16384    38352.717 +- 5030.671  ops/s
       512       16384    59481.957 +- 2297.546  ops/s
      2048       16384    65907.313 +- 2678.562  ops/s
      8192       16384    71678.424 +- 1731.105  ops/s
     32768       16384    58716.428 +-  269.514  ops/s
    131702       16384    34678.424 +- 1869.548  ops/s
       128     1048576      671.195 +-   84.134  ops/s
       512     1048576     1030.822 +-   48.273  ops/s
      2048     1048576     1232.242 +-   53.233  ops/s
      8192     1048576     1562.457 +-   50.944  ops/s
     32768     1048576     1564.075 +-   43.732  ops/s
    131702     1048576     1399.952 +-  181.188  ops/s
    ```