### PR TITLE
8330185: Potential uncaught unsafe memory copy exception

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -728,7 +728,8 @@ address StubGenerator::generate_disjoint_copy_avx3_masked(address* entry, const 
 
   if (MaxVectorSize == 64) {
     __ BIND(L_copy_large);
-    arraycopy_avx3_large(to, from, temp1, temp2, temp3, temp4, count, xmm1, xmm2, xmm3, xmm4, shift);
+      UnsafeCopyMemoryMark ucmm(this, !is_oop && !aligned, false, ucme_exit_pc);
+      arraycopy_avx3_large(to, from, temp1, temp2, temp3, temp4, count, xmm1, xmm2, xmm3, xmm4, shift);
     __ jmp(L_finish);
   }
   return start;


### PR DESCRIPTION
Adding an `UnsafeCopyMemoryMark` in `generate_disjoint_copy_avx3_masked()` to protect against SIGBUS in `arraycopy_avx3_large()`.  I discovered this by code inspection, and the missing memory mark is inconsistent with all other generators.  I do not have a testcase to generate such an exception.  I think this may have been a copy/paste error by the original contributor as evidenced by the variable `ucme_exit_pc` having been set but never used.

I have not seen a VM crash that can be attributed to this, but adding the mark is the correct behavior for its prevention.