### PR TITLE
8330172: G1: Consolidate update_bot_for_block and update_bot_for_obj in HeapRegion

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -720,10 +720,6 @@ void HeapRegion::mangle_unused_area() {
 }
 #endif
 
-void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
-  _bot->update_for_block(start, end);
-}
-
 void HeapRegion::object_iterate(ObjectClosure* blk) {
   HeapWord* p = bottom();
   while (p < top()) {
@@ -737,7 +733,7 @@ void HeapRegion::object_iterate(ObjectClosure* blk) {
 void HeapRegion::fill_with_dummy_object(HeapWord* address, size_t word_size, bool zap) {
   // Keep the BOT in sync for old generation regions.
   if (is_old()) {
-    update_bot_for_obj(address, word_size);
+    update_bot_for_block(address, address + word_size);
   }
   // Fill in the object.
   CollectedHeap::fill_with_object(address, word_size, zap);

--- a/src/hotspot/share/gc/g1/g1HeapRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.hpp
@@ -167,12 +167,9 @@ public:
   inline HeapWord* allocate(size_t word_size);
   inline HeapWord* allocate(size_t min_word_size, size_t desired_word_size, size_t* actual_size);
 
-  // Update BOT if this obj is the first entering a new card (i.e. crossing the card boundary).
-  inline void update_bot_for_obj(HeapWord* obj_start, size_t obj_size);
-
   // Full GC support methods.
 
-  void update_bot_for_block(HeapWord* start, HeapWord* end);
+  inline void update_bot_for_block(HeapWord* start, HeapWord* end);
 
   void prepare_for_full_gc();
   // Update heap region that has been compacted to be consistent after Full GC.

--- a/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.inline.hpp
@@ -253,17 +253,13 @@ inline void HeapRegion::update_bot() {
   assert(next_addr == top(), "Should stop the scan at the limit.");
 }
 
-inline void HeapRegion::update_bot_for_obj(HeapWord* obj_start, size_t obj_size) {
-  assert(is_old(), "should only do BOT updates for old regions");
-
-  HeapWord* obj_end = obj_start + obj_size;
-
-  assert(is_in(obj_start), "obj_start must be in this region: " HR_FORMAT
-         " obj_start " PTR_FORMAT " obj_end " PTR_FORMAT,
+inline void HeapRegion::update_bot_for_block(HeapWord* start, HeapWord* end) {
+  assert(is_in(start), "The start address must be in this region: " HR_FORMAT
+         " start " PTR_FORMAT " end " PTR_FORMAT,
          HR_FORMAT_PARAMS(this),
-         p2i(obj_start), p2i(obj_end));
+         p2i(start), p2i(end));
 
-  _bot->update_for_block(obj_start, obj_end);
+  _bot->update_for_block(start, end);
 }
 
 inline HeapWord* HeapRegion::parsable_bottom() const {

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -444,7 +444,7 @@ void G1ParScanThreadState::undo_allocation(G1HeapRegionAttr dest_attr,
 void G1ParScanThreadState::update_bot_after_copying(oop obj, size_t word_sz) {
   HeapWord* obj_start = cast_from_oop<HeapWord*>(obj);
   HeapRegion* region = _g1h->heap_region_containing(obj_start);
-  region->update_bot_for_obj(obj_start, word_sz);
+  region->update_bot_for_block(obj_start, obj_start + word_sz);
 }
 
 // Private inline function, for direct internal use and providing the


### PR DESCRIPTION
Hi all,

This patch consolidates the methods `update_bot_for_obj` and `update_bot_for_block`. The test `make test-tier1_gc` passed locally.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330172](https://bugs.openjdk.org/browse/JDK-8330172): G1: Consolidate update_bot_for_block and update_bot_for_obj in HeapRegion (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18771/head:pull/18771` \
`$ git checkout pull/18771`

Update a local copy of the PR: \
`$ git checkout pull/18771` \
`$ git pull https://git.openjdk.org/jdk.git pull/18771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18771`

View PR using the GUI difftool: \
`$ git pr show -t 18771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18771.diff">https://git.openjdk.org/jdk/pull/18771.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18771#issuecomment-2053592077)