### PR TITLE
Add input streams that correspond to Hotspot's output streams.

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.hpp
+++ b/src/hotspot/share/compiler/compilerOracle.hpp
@@ -28,6 +28,7 @@
 #include "memory/allStatic.hpp"
 #include "oops/oopsHierarchy.hpp"
 
+class BlockInput;
 class methodHandle;
 
 
@@ -114,10 +115,17 @@ enum class OptionType {
 };
 
 class CompilerOracle : AllStatic {
+ public:
+  typedef void parse_from_line_fn_t(char*);
+
  private:
   static bool _quiet;
   static void print_parse_error(char* error_msg, char* original_line);
   static void print_command(enum CompileCommand option, const char* name, enum OptionType type);
+
+  // The core parser.
+  static void parse_from_input(BlockInput* input,
+                               parse_from_line_fn_t* parse_from_line);
 
  public:
   // True if the command file has been specified or is implicit
@@ -167,7 +175,8 @@ class CompilerOracle : AllStatic {
   static bool option_matches_type(enum CompileCommand option, T& value);
 
   // Reads from string instead of file
-  static void parse_from_string(const char* option_string, void (*parser)(char*));
+  static void parse_from_string(const char* option_string,
+                                parse_from_line_fn_t* parser);
   static void parse_from_line(char* line);
   static void parse_compile_only(char* line);
 

--- a/src/hotspot/share/utilities/istream.cpp
+++ b/src/hotspot/share/utilities/istream.cpp
@@ -1,0 +1,675 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "memory/allocation.inline.hpp"
+#include "runtime/orderAccess.hpp"
+#include "utilities/istream.hpp"
+#include "utilities/ostream.hpp"
+#include "utilities/xmlstream.hpp"
+
+#ifndef ASSERT
+#define COV(casen) {}
+#else //ASSERT
+// Support for coverage testing.  Used by the gtest.
+/* $ sed < istream.cpp '/^.* COV(\([A-Z][^)]*\)).*$/!d;s//COV_FN(\1)/' |
+     tr '\12' ' ' | fold -sw72 | sed 's| $||;s|.*|  & \\|'
+  */
+#define DO_COV_CASES(COV_FN) \
+  COV_FN(NXT_L) COV_FN(NXT_N) COV_FN(FIB_P) COV_FN(FIB_E) COV_FN(FIB_N) \
+  COV_FN(FIB_L) COV_FN(PFB_X) COV_FN(PFB_C) COV_FN(PFB_P) COV_FN(PFB_A) \
+  COV_FN(PFB_G) COV_FN(PFB_H) COV_FN(SBC_C) COV_FN(SBC_B) COV_FN(SBC_N) \
+  COV_FN(SBC_L) COV_FN(EXB_S) COV_FN(EXB_R) COV_FN(EXB_A) COV_FN(XCL_Z) \
+  COV_FN(XCL_S) COV_FN(XCL_E) COV_FN(XCL_X) COV_FN(XCL_N) COV_FN(RCL_S) \
+  COV_FN(RCL_E) COV_FN(RCL_Z) \
+  /**/
+#define COV_COUNT(casename) coverage_case_##casename
+#define DECLARE_COV_CASE(casename) static int COV_COUNT(casename);
+DO_COV_CASES(DECLARE_COV_CASE)
+#undef DECLARE_COV_CASE
+
+static int current_coverage_mode = 0;
+#define COV(casename) {                                 \
+    if (current_coverage_mode != 0) {                   \
+      COV_COUNT(casename)++;                            \
+    }                                                  }
+#endif //ASSERT
+
+bool inputStream::next() {
+  // We have to look at the current line first, just in case nobody
+  // actually called current_line() or done().
+  preload();
+  if (definitely_done()) {
+    return false;         // OK to call this->next() after done is true
+  }
+  // current line is at buffer[beg..end]; now skip past its '\0'
+  assert(have_current_line(), "");
+
+  set_buffer_content(_next, _content_end);
+  if (!need_to_read()) {  // any next line was already in the buffer
+    COV(NXT_L);
+    assert(have_current_line(), "");
+    return true;
+  } else {                // go back to the source for more
+    COV(NXT_N);
+    return fill_buffer();
+  }
+}
+
+void inputStream::set_done() {
+  size_t end = _beg = _end = _content_end;
+  _next = end + NEXT_PHANTOM;
+  _line_ending = 0;
+  assert(definitely_done(), "");
+}
+
+void inputStream::set_error(bool error_condition) {
+  if (error_condition) {
+    set_done();
+    _input_state = ERR_STATE;
+    assert(error(), "");
+  } else if (error()) {
+    _input_state = definitely_done() ? EOF_STATE : NTR_STATE;
+  }
+}
+
+void inputStream::clear_buffer() {
+  _content_end = _beg = _end = _next = 0;
+  _line_ending = 0;
+  _clean_read_position = _expected_read_position;
+}
+
+const char* inputStream::next_content(size_t& next_content_length) const {
+  assert(is_sane(), "");
+  size_t len = buffered_content_length(false);
+  next_content_length = len;
+  return len == 0 ? "" : &_buffer[_next];
+}
+
+void inputStream::set_input(BlockInput* input) {
+  clear_buffer();
+  if (_input != nullptr && _input != input) {
+    _input->close();
+  }
+  _input = input;
+  _input_state = NTR_STATE;
+  _clean_read_position = _expected_read_position = 0;
+  if (input != nullptr) {
+    size_t ip = input->position();
+    if (ip != (size_t)-1) {
+      _expected_read_position = ip;
+    }
+  }
+}
+
+bool inputStream::fill_buffer() {
+  assert(!definitely_done(), "");  // caller responsibility
+  while (need_to_read()) {
+    size_t fill_offset, fill_length;
+    prepare_to_fill_buffer(fill_offset, fill_length);
+    if (error())  return false;
+    assert(fill_offset >= 0 && fill_length > 0, "");
+    assert(fill_offset < _buffer_size, "");
+    assert(fill_offset + fill_length <= _buffer_size, "");
+    size_t nr = 0;
+    if (_input != nullptr && _input_state == NTR_STATE) {
+      nr = _input->read(&_buffer[fill_offset], fill_length);
+      if (nr == 0)  _input_state = EOF_STATE;  // do not get EOF twice
+      // do not expect _input to track its own position, but track mine
+      _expected_read_position += nr;
+      // _clean_read_position lags behind unless disturbed by edits
+    }
+    bool last_partial = false;
+    if (nr > 0) {
+      fill_offset += nr;
+    } else if (_beg == _end) {  // no partial line, so end it now
+      // we hit the end of the file (or there was never anything there)
+      COV(FIB_P);
+      assert(!definitely_done(), "");
+      set_done();
+      assert(definitely_done(), "");
+      return false;
+    } else {
+      // pretend to read a newline, to complete the last partial line
+      COV(FIB_E);
+      _buffer[fill_offset++] = '\n';  // insert phantom newline
+      last_partial = true;
+    }
+    set_buffer_content(_beg, fill_offset);
+    assert(!definitely_done(), "");
+    if (need_to_read()) { COV(FIB_N); }
+    else                { COV(FIB_L); }
+    if (last_partial) {
+      assert(have_current_line(), "");
+      _line_ending = 0;
+      _content_end -= 1;  // reverse insertion of phantom newline
+      assert(_next == _content_end + NEXT_PHANTOM, "");
+      assert(have_current_line(), "");
+    }
+  }
+  return true;
+}
+
+// Find some space in the buffer for reading.  If there is already a
+// partial line in the buffer, new space must follow it immediately.
+// The partial line is between _beg and _end, and no other parts of
+// the buffer are in use.
+void inputStream::prepare_to_fill_buffer(size_t& fill_offset,
+                                         size_t& fill_length) {
+  assert(need_to_read(), "");  // _next pointer out of the way
+  if (_buffer_size == 0) {
+    COV(PFB_X);
+    expand_buffer(sizeof(_small_buffer));
+    assert(_buffer_size > 0, "");
+    // and continue with at least a little buffer
+  }
+  size_t end = _content_end;
+  if (_beg == end) { // if no partial line present...
+    COV(PFB_C);
+    clear_buffer();
+    fill_offset = 0;
+    fill_length = _buffer_size;
+    return;   // use the whole buffer
+  }
+  // at this point we have a pending line that needs more input
+  if (_beg > 0 && (_input != nullptr || end == _buffer_size)) {
+    COV(PFB_P);
+    // compact the buffer by overwriting characters from previous lines
+    size_t shift_left = _beg;
+    ::memmove(_buffer, _buffer + shift_left, _content_end - _beg);
+    _beg -= shift_left;
+    _end -= shift_left;
+    _next -= shift_left;
+    _content_end -= shift_left;
+    end = _content_end;
+  }
+  if (end < _buffer_size) {
+    COV(PFB_A);
+    fill_offset = end;
+    fill_length = _buffer_size - end;
+    return;   // use the whole buffer except partial line at the beginning
+  }
+  // the whole buffer contains a partial line, which means we must expand
+  COV(PFB_G);
+  size_t new_size = (_buffer_size < BIG_SIZE ? BIG_SIZE
+                     : _buffer_size + _buffer_size / 2);
+  assert(new_size > _buffer_size, "");
+  if (expand_buffer(new_size)) {
+    COV(PFB_H);
+    fill_offset = end;
+    fill_length = _buffer_size - end;
+    return;   // use the expanded buffer, except the partial line
+  }
+  // no recovery from failed allocation; just set the error state and bail
+  set_error();
+}
+
+// The only buffer content is between the given offsets.
+// Set _beg, _end, _next, and _content_end appropriately.
+void inputStream::set_buffer_content(size_t content_start,
+                                     size_t content_end) {
+  assert(content_start >= 0 && content_end <= _buffer_size, "");
+  assert(content_start <= content_end + NEXT_PHANTOM, "");
+  if (content_start >= content_end) {   // empty content; clear buffer
+    COV(SBC_C);
+    clear_buffer();
+    return;
+  }
+  COV(SBC_B);
+  size_t content_len = content_end - content_start;
+  _beg = content_start;
+  _content_end = content_end;
+
+  // this is where we scan for newlines
+  char* nl = (char*) memchr(&_buffer[content_start], '\n', content_len);
+  if (nl == nullptr) {
+    COV(SBC_N);
+    _next = _end = content_end;
+    _line_ending = 0;
+    assert(need_to_read(), "");
+  } else {
+    COV(SBC_L);
+    *nl = '\0';  // so that this->current_line() will work
+    ++_line_count;
+    size_t end = nl - &_buffer[0];
+    _next = end + 1;
+    assert(_next != _content_end + NEXT_PHANTOM, "");
+    if (end > content_start && nl[-1] == '\r') { // yuck
+      // again, for this->current_line(), remove '\r' before '\n'
+      nl[-1] = '\0';
+      --end;
+      // Note: we could treat '\r' alone as a line ending on some
+      // platforms, but that is way too much work.  Newline '\n' is
+      // supported everywhere, and some tools insist on accompanying
+      // it with return as well, so we remove that.  But return '\r'
+      // by itself is an obsolete format, and also inconsistent with
+      // outputStream, which standarizes on '\n' and never emits '\r'.
+      // Postel's law suggests that we write '\n' only and grudgingly
+      // accept '\r' before '\n'.
+    }
+    _end = end;  // now this->current_line() points to buf[beg..end]
+    _line_ending = (int)(_next - end);
+    assert(have_current_line(), "");
+    assert(current_line() == &_buffer[_beg], "");
+    assert(current_line_length() == _end - _beg, "");
+  }
+}
+
+// Return true iff we expanded the buffer to the given length.
+bool inputStream::expand_buffer(size_t new_length) {
+  assert(new_length > _buffer_size, "");
+  char* new_buf = nullptr;
+  if (new_length <= sizeof(_small_buffer)) {
+    COV(EXB_S);
+    new_buf = &_small_buffer[0];
+    new_length = sizeof(_small_buffer);
+  } else if (_buffer != nullptr && _buffer == _must_free) {
+    COV(EXB_R);
+    new_buf = REALLOC_C_HEAP_ARRAY(char, _buffer, new_length, mtInternal);
+    if (new_buf != nullptr) {
+      _must_free = new_buf;
+    }
+  } else {  // fresh allocation
+    COV(EXB_A);
+    new_buf = NEW_C_HEAP_ARRAY(char, new_length, mtInternal);
+    if (new_buf != nullptr) {
+      assert(_must_free == nullptr, "dropped free");
+      _must_free = new_buf;
+      if (_content_end > 0) {
+        assert(_content_end <= _buffer_size, "");
+        ::memcpy(new_buf, _buffer, _content_end);  // copy only the active content
+      }
+    }
+  }
+  if (new_buf == nullptr) {
+    return false;   // do not further update _buffer etc.
+  }
+  _buffer = new_buf;
+  _buffer_size = new_length;
+  return true;
+}
+
+void inputStream::handle_free() {
+  void* to_free = _must_free;
+  if (to_free == nullptr)  return;
+  _must_free = nullptr;
+  FreeHeap(to_free);
+}
+
+#ifdef ASSERT
+void inputStream::dump(const char* what) {
+  int diff = (int)(_end - _beg);
+  if (!_buffer || _beg > _buffer_size || _end > _buffer_size)
+    diff = 0;
+
+  bool ntr = (_next == _end),
+       hcl = (_beg < _content_end && _end < _next),
+       ddn = (_beg == _content_end && _next > _content_end);
+  tty->print_cr("%s%sistream %s%s%s%s%s [%d<%.*s>%d/%d..%d] LE=%d,"
+                " B=%llx%s[%d], LN=%d%+d, C..ERP=%d..%d, MF=%llx",
+                what ? what : "", what ? ": " : "",
+                _buffer == nullptr ? "U" : "",
+                ntr ? "R" : "",
+                hcl ? "L" : "",
+                ddn ? "D" : "",
+                (_next < _content_end ? "" :
+                 _next == _content_end ? "N" : "P"),
+                (int)_beg,
+                diff < 0 ? 0 : diff > 10 ? 10 : diff,
+                _buffer ? &_buffer[_beg] : "",
+                (int)_end, (int)_next, (int)_content_end,
+                _line_ending,
+                (unsigned long long)(intptr_t)_buffer,
+                _buffer == _small_buffer ? "(SB)" : "",
+                (int)_buffer_size,
+                (int)_line_count, (int)_adjust_count,
+                (int)_clean_read_position,
+                (int)_expected_read_position,
+                (unsigned long long)(intptr_t)_must_free);
+  assert(is_sane(), "");
+}
+#endif
+
+char* inputStream::save_line(bool c_heap) const {
+  size_t len;
+  char* line = current_line(len);
+  size_t alloc_len = len + 1;
+  char* copy = (c_heap
+                ? NEW_C_HEAP_ARRAY(char, alloc_len, mtInternal)
+                : NEW_RESOURCE_ARRAY(char, alloc_len));
+  if (copy == nullptr) {
+    return (char*)"";  // recover by returning a valid string
+  }
+  ::memcpy(copy, line, len);
+  copy[len] = '\0';  // terminating null
+  // Note: There may also be embedded nulls in the line.  The caller
+  // must deal with this by saving a count as well, or else previously
+  // testing for nulls.
+  if (c_heap) {
+    // Need to ensure our content is written to memory before we return
+    // the pointer to it.
+    OrderAccess::storestore();
+  }
+  return copy;
+}
+
+const char* inputStream::current_line_ending() const {
+  assert(is_sane(), "");
+  preload();
+  switch (_line_ending) {
+  case 1: return "\n";
+  case 2: return "\r\n";
+  default: return "";
+  }
+  // If we were to support more kinds of newline, such as '\r' or
+  // Unicode line ends, we could add more state and logic here.
+}
+
+char* inputStream::prepare_to_expand_current_line(size_t increase, bool at_start) {
+  assert(is_sane(), "");
+  size_t llen = current_line_length();
+  size_t nlen = llen + increase;
+  if (nlen <= llen) {
+    // It could be that nlen < llen, if somebody requested a ridiculous increase.
+    COV(XCL_Z);
+    return (nlen == llen) ? &_buffer[at_start ? _beg : _end] : nullptr;
+  }
+
+  // Find out if we are sharing the buffer with any pending input.
+  int next_phantom = (_next == _content_end + NEXT_PHANTOM) ? NEXT_PHANTOM : 0;
+  size_t pending_beg = _next - next_phantom;
+
+  // If dirtying the current line, advance clean position to next line.
+  if (position_is_clean(pending_beg)) {
+    _clean_read_position = _expected_read_position - (_content_end - pending_beg);
+    assert(position_is_clean(pending_beg), "");  //still clean, just barely
+  }
+
+  // See if we have room for an O(1) fast path, otherwise moves stuff around.
+  size_t fillp;
+  if (at_start && increase <= _beg) {
+    COV(XCL_S);
+    _beg -= increase;
+    fillp = _beg;
+  } else if (!at_start && _end + increase < pending_beg) {
+    COV(XCL_E);
+    fillp = _end;
+    _end += increase;
+  } else {
+    size_t pending_len = (_content_end + next_phantom) - pending_beg;
+    size_t current_need = nlen + 1;  // nlen, plus space for final \0
+    if (current_need > pending_beg) {
+      COV(XCL_X);
+      // This is where the buffer expansion happens.
+      size_t total_need = current_need + pending_len;
+      if (_buffer_size < total_need && !expand_buffer(total_need)) {
+        set_error();
+        return nullptr;
+      }
+      // Shift everything after the current line as high as possible.
+      size_t fillp = _buffer_size - pending_len;
+      if (fillp != pending_beg && pending_len != 0) {
+        ::memmove(&_buffer[fillp], &_buffer[pending_beg], pending_len);
+      }
+      pending_beg = fillp;
+      assert(current_need <= pending_beg, "");
+      _next        = pending_beg + next_phantom;
+      _content_end = pending_beg + pending_len - next_phantom;
+    } else {
+      COV(XCL_N);
+    }
+    // We might not need to reallocate the buffer if we just shift the line.
+    // Whether we allocated or not, shift the line to make space at both ends.
+    size_t spare_room = pending_beg - current_need;
+    // We are free to position the line anywhere in {beg=0,...beg=spare_room].
+    // Put more spare room near the start or end, based on the request.
+    size_t new_beg = (at_start ? spare_room - spare_room / 4 : spare_room / 4);
+    size_t copy_pos = new_beg + (at_start ? increase : 0);
+    fillp =           new_beg + (at_start ? 0 : llen);
+    ::memmove(&_buffer[copy_pos], &_buffer[_beg], llen);
+    _beg = new_beg;
+    _end = new_beg + nlen;
+  }
+  assert(_end < _next, "");
+  _buffer[_end] = '\0';
+  return &_buffer[fillp];
+  // caller responsibility: memset(&_buffer[fillp], ' ', increase)
+}
+
+char* inputStream::reduce_current_line(size_t decrease, bool at_start) {
+  assert(is_sane(), "");
+  size_t llen = current_line_length();
+  size_t nlen = (llen >= decrease) ? llen - decrease : 0;
+  if (nlen < llen) {
+    if (at_start) {
+      COV(RCL_S);
+      _beg = _end - nlen;
+    } else {
+      COV(RCL_E);
+      _end = _beg + nlen;
+      assert(_end < _next, "");
+      _buffer[_end] = '\0';
+    }
+    // If dirtying the current line, advance clean position to next line.
+    size_t still_clean = _next < _content_end ? _next : _content_end;
+    if (position_is_clean(still_clean)) {
+      _clean_read_position = _expected_read_position - (_content_end - still_clean);
+      assert(position_is_clean(still_clean), "");  //still clean, just barely
+    }
+  } else {
+    COV(RCL_Z);
+  }
+  return &_buffer[at_start ? _beg : _end];
+}
+
+// Forces the given data into the buffer, before the current line
+// or overwriting the current line, depending on the flag.
+void inputStream::push_back_input(const char* chars, size_t length,
+                                  bool overwrite_current_line) {
+  assert(is_sane(), "");
+  bool was_done = (_buffer_size == 0) || definitely_done();
+  if (overwrite_current_line) {
+    preload();   // we need to know how much to overwrite...
+  }
+  if (!have_current_line()) {
+    overwrite_current_line = false;  // nothing to overwrite
+  }
+  if (length == 0) {
+    if (overwrite_current_line)  next();
+    return;  // there is nothing else to do here
+  }
+  prepare_to_push_back(length, chars, overwrite_current_line);
+  if (was_done) {
+    // set things up so that the position of line 1 is zero:
+    _clean_read_position = 0;
+    _expected_read_position = length;
+  }
+}
+
+size_t inputStream::prepare_to_push_back(size_t length,
+                                         const char* chars,
+                                         bool overwrite_current_line) {
+  assert(chars != nullptr, "");
+  const bool current_line_only = (chars == nullptr);  // two use cases
+
+  // Some decisions are different if the pushback does not end in \n
+  const int partial_line = (length > 0 && chars[length-1] != '\n' ? 1 : 0);
+
+  // The logic below requires current line (_end+LE) to fit into _next exactly.
+  size_t required_end = (_next <= _content_end
+                         ? _next - _line_ending
+                         : _content_end - _line_ending);
+  if (_end != required_end && _content_end > 0) {
+    size_t llen = _end - _beg;
+    assert(llen + _line_ending <= required_end, "");
+    size_t new_beg = required_end - llen;
+    if (llen > 0)  ::memmove(&_buffer[new_beg], &_buffer[_beg], llen);
+    _beg = new_beg;
+    _end = new_beg + llen;
+    _buffer[_end] = '\0';
+  }
+
+  // Decide exactly which pending bytes we will leave undisturbed in buffer.
+  int next_phantom = (_next == _content_end + NEXT_PHANTOM) ? NEXT_PHANTOM : 0;
+  size_t pending_beg = !overwrite_current_line ? _beg : _next - next_phantom;
+  size_t pending_len = (_content_end + next_phantom) - pending_beg;
+
+  // If dirtying the current line, advance clean position to next line.
+  // Otherwise, advance clean position to current line, but not any earlier.
+  size_t still_clean = partial_line == 0 ? pending_beg : _next - next_phantom;
+  if (position_is_clean(still_clean)) {
+    _clean_read_position = _expected_read_position - (_content_end - still_clean);
+    assert(position_is_clean(still_clean), "");  //still clean, just barely
+  }
+
+  // We may need to recompute line boundaries after this operation
+  if (have_current_line()) {
+    add_to_lineno(-1);     // we will see some \n again, or we are deleting it
+    if (pending_beg <= _end && _end < _content_end) {
+      assert(!overwrite_current_line, "");
+      // Prepare to recognize the current line ending a second time.
+      assert(_buffer[_end] == '\0', "");
+      const char* le = current_line_ending();
+      strncpy(&_buffer[_end], le, _next - _end);
+      // set_buffer_content will see the line ending again
+    }
+  }
+
+  // How much space do we need?  New stuff + pending stuff + maybe a new phantom.
+  size_t buflen = length + pending_len + (pending_len == 0 ? partial_line : 0);
+  if (_buffer_size < buflen && !expand_buffer(buflen)) {
+    set_error();
+    return (size_t)-1;
+  }
+  assert(length + pending_len <= _buffer_size, "");
+  size_t fillp = _buffer_size;
+  if (pending_len == 0) {
+    // Welcome a phantom \n, since we are going to need one.
+    fillp -= partial_line;
+    if (DEBUG_ONLY(partial_line)+0 == 1)  _buffer[fillp] = '#';
+  } else if (length <= pending_beg) {
+    fillp = pending_beg;   // avoid the memmove in the next paragraph
+  } else {
+    fillp -= pending_len;
+    if (fillp != pending_beg) {
+      assert(fillp + pending_len <= _buffer_size, "");
+      ::memmove(&_buffer[fillp], &_buffer[pending_beg], pending_len);
+      // We will rely on set_buffer_content to fix up beg/end/next/content_end.
+    }
+  }
+  assert(fillp >= length, "");
+  fillp -= length;
+  ::memcpy(&_buffer[fillp], chars, length);
+  set_buffer_content(fillp, fillp + length + pending_len - next_phantom);
+  if (_next == _content_end && next_phantom != 0) {
+    assert(_next < _buffer_size, "");
+    _buffer[_next++] = '\0';
+  }
+  preload();
+  return fillp;
+}
+
+size_t inputStream::current_line_position() const {
+  size_t buflen = definitely_done() ? 0 : buffered_content_length(true);
+  size_t content_end_pos = _expected_read_position;
+  return (position_is_clean(_content_end - buflen)
+          ? content_end_pos - buflen
+          : (size_t)-1);
+}
+
+size_t inputStream::set_current_line_position(size_t position,
+                                              julong lineno) {
+  bool do_set_lineno = (lineno != 0);
+  if (position == current_line_position()) {
+    if (do_set_lineno)  set_lineno(lineno);
+    return position;  // nop
+  }
+  size_t nclen = buffered_content_length(false);
+  // is new pos in the same buffer?  if so, just bump pointers forward
+  if (_expected_read_position < nclen) {
+    nclen = 0;  // should not happen, but recover
+  }
+  size_t next_pos = _expected_read_position - nclen;
+  if (position >= next_pos && position <= _expected_read_position) {
+    size_t new_next = _next + (position - next_pos);
+    set_buffer_content(new_next, _content_end);
+  } else {
+    if (_input == nullptr) {
+      set_error();
+      return (size_t)-1;
+    }
+    position = _input->set_position(position);
+    if (position == (size_t)-1)  return position;
+    // the next call sets _expected_read_position and _clean_read_position:
+    set_input(_input);
+  }
+  preload();
+  if (do_set_lineno)  set_lineno(lineno);
+  return current_line_position();
+}
+
+#ifdef ASSERT
+// More support for coverage testing.
+int inputStream::coverage_mode(int start,
+                               int& cases, int& total, int& zeroes) {
+  int old_mode = current_coverage_mode;
+  current_coverage_mode = start;
+  int num_cases = 0, zero_count = 0, case_count = 0;
+#define COUNT_COV_CASE(casename) {              \
+    int tem = COV_COUNT(casename);              \
+    case_count += tem;                          \
+    if (tem == 0)  ++zero_count;                \
+    num_cases++;                                \
+  }
+  DO_COV_CASES(COUNT_COV_CASE)
+#undef COUNT_COV_CASE
+  if (start < 0) {
+    tty->print("istream coverage:");
+    #define PRINT_COV_CASE(casename) \
+      tty->print(" %s:%d", #casename, COV_COUNT(casename));
+    DO_COV_CASES(PRINT_COV_CASE)
+    tty->cr();
+    #undef PRINT_COV_CASE
+    if (zero_count != 0) {
+      case_count = -case_count;
+      #define ZERO_COV_CASE(casename)                  \
+        if (COV_COUNT(casename) == 0)                  \
+          tty->print_cr("%s: no coverage for %s",      \
+                        __FILE__, #casename);          \
+      DO_COV_CASES(ZERO_COV_CASE)
+      #undef ZERO_COV_CASE
+    }
+  }
+  if (start >= 2 || start < 0) {
+    #define CLEAR_COV_CASE(casename) \
+       COV_COUNT(casename) = 0;
+    DO_COV_CASES(CLEAR_COV_CASE)
+    #undef CLEAR_COV_CASE
+  }
+  cases  = num_cases;
+  total  = case_count;
+  zeroes = zero_count;
+  return old_mode;
+}
+#endif //ASSERT

--- a/src/hotspot/share/utilities/istream.hpp
+++ b/src/hotspot/share/utilities/istream.hpp
@@ -1,0 +1,600 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_UTILITIES_ISTREAM_HPP
+#define SHARE_UTILITIES_ISTREAM_HPP
+
+#include "memory/allocation.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
+
+// Input streams for reading line-oriented textual data These streams
+// treat newline '\n' very differently from all other bytes.  Carriage
+// return '\r' is just another bit of whitespace, although it is
+// removed just before newline.
+//
+// Null '\0' is just a data byte, although it also terminates C
+// strings; the `current_line` function adds a null after removing any
+// line terminator but does not specially process any nulls embedded
+// in the line.
+//
+// There are sizing access functions which allow lines to contain
+// null, but the simpler function assumes null termination, and thus
+// lines containing null will "look" shorter when viewed as C strings.
+// Use the sizing access functions if you care about this.
+//
+// Formatting guidelines:
+//
+// Configuration data should be line-oriented.  It should be readable
+// by humans (though perhaps with difficulty).  It should be easily
+// processed by text editors and by widely available text processing
+// tools such as grep, sed, and awk.
+//
+// Configuration data should not require "compilers" to generate, if
+// possible.  It should be editable by hand, if possible.  In cases
+// where binary data is strongly required, pick a binary format
+// already native to Hotspot, such as classfile, jar, or jmod.
+//
+// Each line should be separately parseable; the parsing can be ad
+// hoc.  For constructs inherently larger than single lines (such as
+// complex method configuration information), try to use a structuring
+// principle that allows "leaf" data to be line-oriented, and delimits
+// that data with markup lines of some sort.  Try to pick a
+// line-friendly version of a standard format like XML or Markdown.
+// JSON is somewhat problematic because there is no line-friendly leaf
+// syntax: everything at the leaves must be a quoted string in JSON.
+//
+// Use simple parsing via scanf-like formats for simple applications.
+// But, keep in mind that these formats may lose data when applied to
+// unusual strings, such as class names that contain spaces, or method
+// names that contain punctuation.  For more robust transmission of
+// potentially unusual names, consider wrapping them in XML-flavored
+// lines like <tag attr='pay load'/>.
+//
+// See xmlstream.hpp for the details of XML flavoring.
+//
+// Note: Input streams are never MT-safe.
+
+class BlockInput;
+
+class inputStream : public CHeapObjBase {
+ private:
+  NONCOPYABLE(inputStream);
+
+  static constexpr size_t SMALL_SIZE =  240 DEBUG_ONLY(*0 + 10);
+  static constexpr size_t BIG_SIZE   = 2048 DEBUG_ONLY(*0 + 20);
+
+ protected:
+  // Values for _input_state, to distinguish some phases of history:
+  // Do we need to read more input (NTR)?  Did we see EOF already?
+  // Was there an error getting input or allocating buffer space?
+  enum IState { NTR_STATE, EOF_STATE, ERR_STATE };
+
+  // Named offset for _next relative to _content_end, of phantom '\n'.
+  static const int NEXT_PHANTOM = 1;
+
+  BlockInput* _input;   // where the input comes from or else nullptr
+  IState _input_state;  // one of {NTR,EOF,ERR}_STATE
+  char   _line_ending;  // one of {0,1,2} for "", "\n", "\r\n"
+  char*  _buffer;       // scratch buffer holding at least the current line
+  size_t _buffer_size;  // allocated size of buffer
+  size_t _content_end;  // offset to end of valid contents of buffer
+  size_t _beg;          // offset in buffer to start of current line
+  size_t _end;          // offset to end of known current line (else content_end)
+  size_t _next;         // offset to known start of next line (else =end)
+  void*  _must_free;    // unless null, a malloc pointer which we must free
+  size_t _line_count;   // increasing non-resettable count of lines read
+  jlong  _adjust_count; // adjustment to lineno accessor
+  size_t _clean_read_position;     // lowest position not dirtied by pushback
+  size_t _expected_read_position;  // where we expect the next read to happen
+  char   _small_buffer[SMALL_SIZE];  // buffer for holding lines
+
+  void handle_free();
+
+  // Buffer states
+  //
+  // The current line (less any line ending) is always [beg..end).
+  // It is always the case that 0 <= beg <= end <= con_end <= buffer_size.
+  // When there is a current line buffered, end < next <= 1+con_end.
+  // In that case, the value of next is end + max(1, strlen(lend)),
+  // where lend is "\n", "\r\n", or (for a last partial line) "".
+  // But if next == end, we need to read more input, or observe an EOF.
+  //
+  //   beg ==end ==next ==  con_end => nothing buffered, we need to read
+  //   beg <=end < next <=  con_end => have current line, with terminator
+  //   beg < end < next ==1+con_end => have partial current line (saw EOF)
+  //   beg < end ==next ==  con_end => partial line, we need to read
+  //   beg ==end < next ==1+con_end => definitely done; no more I/O
+  //
+  // These states are in three mutually exclusive groups:
+  //   need_to_read()      <= nothing or partial line in buffer
+  //   have_current_line() <= beg/end point to valid line (partial only if EOF)
+  //   definitely_done()   <= consumed all lines && (hit EOF || hit error)
+  // These states are internal; the user can only look at next/done/error.
+  //
+  // A call to set_current_line_position (re-)fetches the indicated line.
+  //
+  // Relative to these states, everything already read from the input
+  // before the first byte of the current line is logically present
+  // (but not accessible) before _beg, while everything not yet read
+  // from the input is after _content_end.  The difference between
+  // these two pointers is constant, except when characters change
+  // from being in the current line to being (logically) before it,
+  // when next is called.
+
+  bool is_sane() const {
+    assert((_buffer == nullptr) == (_buffer_size == 0), "");
+    assert(_content_end >= 0 && _content_end <= _buffer_size, "");
+    assert(0 <= _beg && _beg <= _end && _end <= _content_end, "");
+    assert(_end <= _next && _next <= _content_end + NEXT_PHANTOM, "");
+    assert(_buffer_size == 0 || _next <= _buffer_size, "");
+    return true;
+  }
+
+  bool need_to_read() const {
+    assert(is_sane(), "");
+    return _next == _end;
+  }
+  bool have_current_line() const {
+    assert(is_sane(), "");
+    // _beg < _content_end because there is an \0 (was \n) at _end,
+    // or else it is a non-empty partial line and the \0 is at
+    // _content_end.  In either case, if _end == _next we are
+    // still searching for more input.
+    return (_beg < _content_end && _end < _next);
+  }
+  bool definitely_done() const {
+    assert(is_sane(), "");
+    // If _beg < _content_end we still have a line of some sort.
+    // Otherwise, if _next > _content_end, we have seen EOF or error.
+    return (_beg == _content_end && _next > _content_end);
+  }
+
+  // Reset indexes within the buffer to point to no content.
+  void clear_buffer();
+
+  // Reset indexes within the buffer to point to the given content.
+  // This is where we scan for newlines as well.
+  void set_buffer_content(size_t content_start, size_t content_end);
+
+  // Try to make the buffer bigger.  This may be necessary in order to
+  // buffer a very long line.  Returns false if there was an
+  // allocation failure.
+  //
+  // On allocation failure, just make do with whatever buffer there
+  // was to start with; the caller must check for this condition and
+  // avoid buffering more data in the non-expanded buffer.  However,
+  // the buffer will always be non-null, so at least one line can be
+  // buffered, if it is of normal size.
+  bool expand_buffer(size_t new_length);
+
+  // Make sure there is at least one line in the buffer, and set
+  // _beg/_end to indicate where it is.  Any content before _beg can
+  // be overwritten to make more room in the buffer.  If there is no
+  // more input, set the state up to indicate we are done.
+  bool fill_buffer();
+
+  // Find some room in the buffer so we call read on it.
+  // This might call expand_buffer but will try not to.
+  // The assumption is that read already buffers slow I/O calls.
+  // The purpose for the small buffer managed here is to store whole lines,
+  // and perhaps edit them in-place.
+  void prepare_to_fill_buffer(size_t& fill_offset, size_t& fill_length);
+
+  // Quick check for an initially incomplete buffer...
+  void preload() const {
+    if (need_to_read()) {
+      const_cast<inputStream*>(this)->fill_buffer();
+    }
+  }
+
+  // Get extra space in the current line, store chars there (if not null).
+  // Return internal buffer offset insertion point, or (size_t)-1 on error.
+  size_t prepare_to_push_back(size_t length,
+                              const char* chars = nullptr,
+                              bool overwrite_current_line = false);
+
+  // Expand the current line, without storing anything in the opened space.
+  char* prepare_to_expand_current_line(size_t increase, bool at_start);
+
+  // How much content is buffered (if any) after the current line?
+  size_t buffered_content_length(bool include_current) const {
+    return (include_current       ? _content_end - _beg :
+            _content_end >= _next ? _content_end - _next : 0);
+  }
+
+  // If a line were to begin at the given point, does it fall on or
+  // after the _clean_read_position?  Setting _clean_read_position to
+  // a high value means that earlier positions in the buffer are not
+  // regarded as cleanly associated with an external position.
+  bool position_is_clean(size_t beg) const {
+    if (beg > _content_end)  return false;  // outside buffered content
+    size_t content_end_pos = _expected_read_position;
+    size_t clean_pos       = _clean_read_position;
+    size_t pending_len     = _content_end - beg;
+    return (pending_len == 0 ||
+            (clean_pos + pending_len > clean_pos &&   // no overflow please
+             clean_pos + pending_len <= content_end_pos));
+  }
+
+  // Returns a pointer and count to characters buffered after the
+  // current line, but not yet read from my input source.  Only useful
+  // if you are trying to stack input streams on top of each other
+  // somehow.  You can also ask the input source if it thinks it has
+  // more bytes.
+  const char* next_content(size_t& next_content_length) const;
+
+ public:
+  // Create an empty input stream.
+  // Call push_back_input or set_input to configure.
+  inputStream() {
+    _input = nullptr;
+    _buffer = nullptr;
+    _must_free = nullptr;
+    _buffer_size = 0;
+    _adjust_count = _line_count = 0;
+    _clean_read_position = _expected_read_position = 0;
+    _beg = _end = _next = _content_end = 0;
+    _line_ending = 0;
+    _input_state = NTR_STATE;
+  }
+
+  // Take input from the given source.  Buffer only a modest amount.
+  inputStream(BlockInput* input)
+    : inputStream()
+  {
+    set_input(input);
+  }
+
+  // For reading lines directly from strings or other shared memory.
+  // This constructor inhales the whole string into its buffer, as if
+  // by push_back_input.  The first current_line_position will be zero.
+  //
+  // If you have large shared memory, and don't want to make a large
+  // private copy, consider using MemoryInput instead.
+  inputStream(const char* chars, size_t length)
+    : inputStream()
+  {
+    push_back_input(chars, length);
+  }
+
+  inputStream(const char* chars)
+    : inputStream(chars, strlen(chars))
+  { }
+
+  virtual ~inputStream() {
+    if (_must_free)         handle_free();
+    if (_input != nullptr)  set_input(nullptr);
+  }
+
+  // Discards any previous input and sets the given input source.
+  void set_input(BlockInput* input);
+
+  // Forces the given data into the buffer, before the current line.
+  // If overwrite_current_line is true, the current line is removed.
+  // Normally, an input stream tries not to do a "big inhale", but
+  // this will cause all of the given data into my buffer.
+  void push_back_input(const char* chars, size_t length,
+                       bool overwrite_current_line = false);
+
+  void push_back_input(const char* chars) {
+    push_back_input(chars, strlen(chars));
+  }
+
+  // Returns a pointer to a null terminated mutable copy of the current line.
+  // Note that embedded nulls may make the line appear shorter than it really is.
+  // This may trigger input activity if there is not enough data buffered.
+  // If there are no more lines, return an empty line, statically allocated.
+  char* current_line() const {
+    preload();
+    if (definitely_done())
+      return (char*)"";
+    return &_buffer[_beg];
+  }
+
+  // Returns a pointer to a null terminated mutable copy of the current line.
+  // The size of the line (which may contain nulls) is reported via line_length.
+  // This may trigger input activity if there is not enough data buffered.
+  char* current_line(size_t& line_length) const {
+    char* line = current_line();
+    line_length = _end - _beg;
+    return line;
+  }
+
+  // Return the size of the current line, exclusive of any line terminator.
+  // If no lines have been read yet, or there are none remaining, return zero.
+  size_t current_line_length() const {
+    preload();
+    return _end - _beg;
+  }
+
+  // These functions adjust the beginning and end of the storage of
+  // the current line.  They work by inserting or deleting characters
+  // at the left or right boundary of the line.  Underflow causes the
+  // line to become empty; there is no overflow per se but allocation
+  // failure will put the stream into an error state.  If new
+  // characters are added, to either the beginning or the end, they
+  // are initialized to space ' '.
+  //
+  // You can use these functions to trim or add leading or trailing
+  // spaces from a line, or to remove other decorations from either
+  // end, or to expand the line in place if some other post-processing
+  // is required.  If you need to edit the interior of the line, you
+  // are responsible for moving around the interior parts yourself,
+  // and also adjusting the length as appropriate.  The return value
+  // is a pointer into the line to the left of where the change
+  // happened, or else null if an expansion failed to allocate.
+  //
+  // The point of these functions is to enable light postprocessing
+  // without recopying the current line into a new buffer.  It is
+  // generally an O(1) operation to add or subtract a little space at
+  // either the start or the end of the line, except for a one-time
+  // line relocation in the buffer when space is added at the end.
+  char* reduce_current_line(size_t decrease, bool at_start = false);
+  void clear_current_line() { reduce_current_line(current_line_length()); }
+  char* expand_current_line(size_t increase, bool at_start = false) {
+    char* fillp = prepare_to_expand_current_line(increase, at_start);
+    if (fillp != nullptr && increase > 0) {
+      ::memset(fillp, ' ', increase);
+    }
+    return fillp;
+  }
+  // Expand the current line and copy the given chars in.
+  // The increase defaults to strlen(chars).
+  // Returns null if chars is null.
+  char* expand_current_line_with(const char* chars,
+                                 size_t increase = (size_t)-1,
+                                 bool at_start = false) {
+    if (chars == nullptr && increase != 0)  return nullptr;
+    if (increase == (size_t)-1)  increase = strlen(chars);
+    char* fillp = prepare_to_expand_current_line(increase, at_start);
+    if (fillp != nullptr && increase > 0) {
+      ::memcpy(fillp, chars, increase);
+    }
+    return fillp;
+  }
+
+  // Return the number of characters read from input to the beginning
+  // of the current line if any.  If the current line contains
+  // pushback characters, or if the current line length has been
+  // adjusted, the position is undefined and (size_t)-1 is returned.
+  size_t current_line_position() const;
+
+  // Attempt to seek to some line position relevant to the input source.
+  // This can fail in many ways; return (size_t)-1 on failure.
+  // Also set lineno, if it is given and not zero; otherwise, reads
+  // will continue to increment the current value of lineno.
+  // On success, advance to the indicated line and return its position.
+  size_t set_current_line_position(size_t position, julong lineno = 0);
+
+  // Returns a C string for exactly the line-ending sequence which was
+  // stripped from the current line.  This is the sequence, pulled
+  // from the underlying block input, that delimited the current line.
+  // If there are no more lines, or if we are at a partial final line,
+  // return an empty string.  Otherwise return "\n" or "\r\n" as the
+  // case may be.
+  const char* current_line_ending() const;
+
+  // Reports my current input source, if any, else a null pointer.
+  BlockInput* input() const { return _input; }
+
+  // Discards the current line, gets ready to report the next line.
+  // Returns true if there is one, which is always the opposite of done().
+  // Fetches input if necessary.
+  bool next();
+
+  // Reports if there are no more lines.  Fetches input if necessary.
+  bool done() const  {
+    preload();
+    return definitely_done();
+  }
+
+  // Discard pending input and do not read any more.
+  // Takes no action if already done, whether in an error state or not.
+  void set_done();
+
+  // Reports if this stream has had an error was reported on it.
+  bool error() const {
+    return _input_state == ERR_STATE;
+  }
+
+  // Set this stream done with an error, if the argument is true.
+  // If it is false but there is an error condition, clear the error.
+  // Otherwise do nothing.
+  void set_error(bool error_condition = true);
+
+  // lineno is the 1-based ordinal of the current line; it starts at one
+  size_t lineno() const         { preload(); return _line_count + _adjust_count; }
+  void set_lineno(size_t line)  { preload(); _adjust_count = line - _line_count; }
+  void add_to_lineno(jlong del) { preload(); _adjust_count += del; }
+
+  // returns a count of the number of lines seen; it is not resettable
+  size_t line_count() const      { return _line_count; }
+
+  // Copy to a resource or C-heap array as requested.
+  // Add a terminating null, and also keep any embedded nulls.
+  char* save_line(bool c_heap = false) const;
+
+  // Copy to a resource or C-heap array, doing the actual work with a
+  // copy-function which can perform arbitrary operations on this
+  // input stream, copying arbitrary data into a temporary
+  // string-stream that collects the output.  The copy function is
+  // called on two pointers, as if it by the expression
+  // `this->print_on(out)`.  Note that multiple lines can be saved, if
+  // desired, by calling `this->next()` inside the copy function.
+  template<typename WFN>
+  char* save_data(WFN copy_in_to_out, bool c_heap = false) {
+    stringStream out(current_line_length() + 10);
+    copy_in_to_out(this, &out);
+    return out.as_string(c_heap);
+  }
+
+  // Copy the current line to the given output stream.
+  void print_on(outputStream* out);
+
+  // Copy the current line to the given output stream, and also call cr().
+  void print_cr_on(outputStream* out) {
+    print_on(out); out->cr();
+  }
+
+#ifdef ASSERT
+  void dump(const char* what = nullptr);
+  static int coverage_mode(int mode, int& cases, int& total, int& zeroes);
+#else
+  void dump(const char* what = nullptr) { }
+#endif
+};
+
+// Block-oriented input, which treats all bytes equally.
+class BlockInput : public CHeapObjBase {
+ public:
+  // Read some characters from an external source into the line buffer.
+  // If there are no more, return zero, otherwise return non-zero.
+  // It must be OK to call read even after it returns zero.
+  virtual size_t read(char* buf, size_t size) = 0;
+  // Example: read(b,s) { return fread(b, 1, s, _my_fp); }
+  // Example: read(b,s) { return 0; } // never more than the initial buffer
+
+  // Give the current number of bytes already produced by the source.
+  // Give (size_t)-1 if this source does have a tracked position.
+  // A tracked position increments by the result of every call to read.
+  virtual size_t position() { return -1; }
+
+  // Give the remaining number of bytes which might be produced in the future.
+  // Give (size_t)-1 if this source does not keep track of that number.
+  virtual size_t remaining() { return -1; }
+
+  // Rewind so that the position appears to be the given one.
+  // Return the new position, or else (size_t)-1 if the request fails.
+  virtual size_t set_position(size_t position) { return -1; }
+
+  // If it is backed by a resource that needs closing, do so.
+  virtual void close() { }
+};
+
+template<typename BlockClass>
+class BlockInputStream : public inputStream {
+  BlockClass _input;
+ public:
+  template<typename... Arg>
+  BlockInputStream(Arg... arg)
+    : _input(arg...) {
+    set_input(&_input);
+  }
+};
+
+// for reading lines from files
+class FileInput : public BlockInput {
+  NONCOPYABLE(FileInput);
+
+ protected:
+  fileStream& _fs;
+  fileStream _private_fs;
+
+  // it does not seem likely there are such file streams around
+  FileInput(fileStream& fs)
+    : _fs(fs)
+  { }
+
+ public:
+  // just forward all the constructor arguments to the wrapped line-input class
+  template<typename... Arg>
+  FileInput(Arg... arg)
+    : _fs(_private_fs), _private_fs(arg...)
+  {
+  }
+
+  FileInput(const char* file_name)
+    : FileInput(file_name, "rt")
+  { }
+
+  bool is_open() const { return _fs.is_open(); }
+
+ protected:
+  virtual size_t read(char* buf, size_t size) {
+    return _fs.read(buf, size);
+  }
+  virtual size_t position() {
+    return _fs.position();
+  }
+  virtual size_t remaining() {
+    return _fs.remaining();
+  }
+  virtual size_t set_position(size_t position) {
+    return _fs.set_position(position);
+  }
+  virtual void close() {
+    _fs.close();
+  }
+};
+
+class MemoryInput : public BlockInput {
+  const void* _base;
+  size_t      _limit;
+  size_t      _offset;
+  const void* _must_free;  // unless null, a malloc pointer which we must free
+
+ public:
+  MemoryInput(const void* base, size_t size,
+              bool must_free = false,
+              size_t offset = 0)
+    : _base(base), _limit(size), _offset(offset)
+  {
+    _must_free = must_free ? base : nullptr;
+  }
+
+  MemoryInput(const char* start)
+    : MemoryInput(start, 0, strlen(start))
+  { }
+
+ protected:
+  virtual size_t read(char* buf, size_t size) {
+    size_t nr = size;
+    if (nr > _limit - _offset) {
+      nr = _limit - _offset;
+    }
+    if (nr > 0) {
+      ::memcpy(buf, (char*)_base + _offset, nr);
+      _offset += nr;
+    }
+    return nr;
+  }
+  virtual size_t position() {
+    return _offset;
+  }
+  virtual size_t remaining() {
+    return _limit - _offset;
+  }
+  virtual size_t set_position(size_t position) {
+    if (position >= 0 && position <= _limit) {
+      _offset = position;
+    } else {
+      position = (size_t)-1;
+    }
+    return position;
+  }
+};
+
+#endif // SHARE_UTILITIES_ISTREAM_HPP

--- a/src/hotspot/share/utilities/xmlstream.cpp
+++ b/src/hotspot/share/utilities/xmlstream.cpp
@@ -37,6 +37,35 @@
 #include "utilities/vmError.hpp"
 #include "utilities/xmlstream.hpp"
 
+// The LogFile (default hotspot_%p.log) contains XML-flavored text.
+// It is a superset of whatever might be displayed on the tty.
+// You can get to it by calls of the form xtty->...
+// Normal calls to tty->... just embed plain text among any markup
+// produced via the xtty API.
+// The xtty has sub-streams called xtty->text() and xtty->log_long().
+// These are ordinary output streams for writing unstructured text.
+// The format of this log file is both unstructured and constrained.
+//
+// Apart from possible race conditions, every line in the log file
+// is either an XML element (<tag ...>, or </tag>, or <tag .../>)
+// or is unstructured text.  See xmlstream.hpp for more details.
+//
+// The net effect is that you may select a range of tools to process
+// the marked-up logs, including XML parsers and simple line-oriented
+// Java or Unix tools.  The main concession you have to make to XML
+// is to convert the above five XML entities to single ASCII chars,
+// as you process attribute strings or unstructured text.
+//
+// It would be wise to ignore any XML tags that you do not recognize.
+// This can be done with grep, if you choose, because the log file
+// is line-structured.
+//
+// The log file collects the output from many contributing threads.
+// You should expect that an element of the form <writer thread='NNN'>
+// could appear almost anywhere, as the lines interleave.
+// It is straightforward to write a script to tease the log file
+// into thread-specific substreams.
+
 // Do not assert this condition if there's already another error reported.
 #define assert_if_no_error(cond, msg) \
   vmassert((cond) || VMError::is_error_reported(), msg)
@@ -87,41 +116,185 @@ void xmlStream::write(const char* s, size_t len) {
 void xmlStream::write_text(const char* s, size_t len) {
   if (!is_open())  return;
 
+  const char* pass_these_through = "\n";
+  if (inside_attrs())  pass_these_through = nullptr;
+  write_escaped(s, len, out(), pass_these_through);
+
+}
+
+// ------------------------------------------------------------------
+// Means of escape
+
+// The chars ' and " are attribute delimiters, but we do them in all
+// contexts, for consistency.  The characters < & > should be escaped
+// everywhere.  Newlines need escaping inside attribute strings.
+#define XML_ESCAPES_DO(FN)                      \
+  FN('\'', "&apos;")                            \
+  FN('"' , "&quot;")                            \
+  FN('<' , "&lt;"  )                            \
+  FN('>' , "&gt;"  )                            \
+  FN('&' , "&amp;" )                            \
+  FN('\n', "&#10;" )                            \
+  /*END*/
+
+#define MAX_ESCAPE_LEN xmlStream::MAX_ESCAPE_LEN
+
+#define ESC_LEN_BIT(ch, esc)  | (1 << (sizeof(esc)-1))
+static_assert( ((0 XML_ESCAPES_DO(ESC_LEN_BIT)) | ((1 << MAX_ESCAPE_LEN) - 1))
+               == ((2 << MAX_ESCAPE_LEN) - 1),
+               "max strlen of escape sequence must be as indicated");
+#undef ESC_LEN_BIT
+
+template<typename FN>
+inline size_t scan_for_escaping(const char* s, size_t len, FN fn,
+                                const char* *first_esc = nullptr,
+                                const char* pass_these_through = nullptr) {
   size_t written = 0;
-  // All normally printed material goes inside XML quotes.
+  size_t extra = 0;
+  // All normally printed material uses XML escapes.
   // This leaves the output free to include markup also.
   // Scan the string looking for inadvertent "<&>" chars
   for (size_t i = 0; i < len; i++) {
     char ch = s[i];
-    // Escape special chars.
+    // Escape the Special Six characters.
     const char* esc = nullptr;
+    size_t esc_len = 0;
     switch (ch) {
-      // These are important only in attrs, but we do them always:
-    case '\'': esc = "&apos;"; break;
-    case '"':  esc = "&quot;"; break;
-    case '<':  esc = "&lt;";   break;
-    case '&':  esc = "&amp;";  break;
-      // This is a freebie.
-    case '>':  esc = "&gt;";   break;
+      #define DO_SWITCH_CASE(chr,str) \
+        case chr: esc_len = strlen(esc = str); break;
+      XML_ESCAPES_DO(DO_SWITCH_CASE)
+      #undef DO_SWITCH_CASE
+    }
+    if (esc != nullptr && pass_these_through && strchr(pass_these_through, ch)) {
+      esc = nullptr;
     }
     if (esc != nullptr) {
+      if (first_esc != nullptr) { *first_esc = esc; return i; }
       if (written < i) {
-        out()->write(&s[written], i - written);
-        written = i;
+        fn(&s[written], i - written);
       }
-      out()->print_raw(esc);
-      written++;
+      fn(esc, esc_len);
+      written = i + 1;   // amount of raw input processed so far
+      extra += esc_len - 1;
     }
   }
+
+  if (first_esc != nullptr)  return len;
 
   // Print the clean remainder.  Usually, it is all of s.
   if (written < len) {
-    out()->write(&s[written], len - written);
+    fn(&s[written], len - written);
   }
+
+  return written + extra;
+}
+
+size_t xmlStream::escaped_length(const char* s, size_t len) {
+  return scan_for_escaping(s, len, [](const char* ig1, size_t ig2) { });
+}
+  
+// Return len if there is no escape sequence.
+size_t xmlStream::find_to_escape(const char* s, size_t len, const char* &esc) {
+  return scan_for_escaping(s, len, [](const char* ig1, size_t ig2) { }, &esc);
+}
+
+size_t xmlStream::write_escaped(const char* s, size_t len, outputStream* out,
+                                const char* pass_these_through) {
+  auto out_writer = [&](const char* c, size_t n) { out->write(c, n); };
+  return scan_for_escaping(s, len, out_writer, nullptr, pass_these_through);
+}
+
+static size_t find_next_escape(const char* s, size_t len,
+                               int& esc_len, char& unesc_char) {
+  for (size_t i = 0; i < len; i++) {
+    if (s[i] != '&')   continue;
+    int qlen = 0;
+    size_t jlimit = MAX_ESCAPE_LEN; //== strlen("&quot;")
+    if (jlimit > len - i)  jlimit = len - i;
+    // find terminating ';'
+    for (size_t j = 2; j < jlimit; j++) {
+      if (s[i+j] == ';') { qlen = j + 1; break; }
+      // (could do more pattern matching here, but not worth it)
+    }
+    if (qlen == 0)  continue;
+    int found = -1;
+    #define DO_CHECK_CASE(chr,str) \
+      { if (!strncmp(str, &s[i], qlen))  found = chr; }
+    XML_ESCAPES_DO(DO_CHECK_CASE);
+    #undef DO_CHECK_CASE
+    if (found >= 0) {
+      unesc_char = (char) found;
+      esc_len = qlen;  // caller should use esc_len to skip over next ';'
+      return i;
+    }
+  }
+  return len;
+}
+
+// Return len if there is no escape sequence.
+size_t xmlStream::find_escape(const char* s, size_t len,
+                              int &esc_len, char &unesc) {
+  return find_next_escape(s, len, esc_len, unesc);
+}
+
+size_t xmlStream::write_unescaped(const char* s, size_t len, outputStream* out) {
+  size_t processed = 0;
+  size_t removed = 0;
+  for (;;) {
+    int esc_len = 0;
+    char unesc_char = 0;
+    size_t i = find_next_escape(&s[processed], len - processed,
+                                esc_len, unesc_char);
+    if (i == len - processed)  break;
+    if (processed < i) {
+      out->write(&s[processed], i - processed);
+    }
+    out->write(&unesc_char, 1);
+    processed = i + esc_len;
+    removed += esc_len - 1;
+  }
+
+  // Print the clean remainder.  Usually, it is all of s.
+  if (processed < len) {
+    out->write(&s[processed], len - processed);
+  }
+
+  return len - removed;
+}
+
+// Return the new length, which will be shorter if there were escapes.
+size_t xmlStream::unescape_in_place(char* buf, size_t len) {
+  size_t processed = 0;  // in-place read pointer
+  size_t copied = 0;     // in-place write pointer, copied <= processed <= len
+  for (;;) {
+    int esc_len = 0;
+    char unesc_char = 0;
+    size_t i = find_next_escape(&buf[processed], len - processed,
+                                esc_len, unesc_char) + processed;
+    if (i == len) {
+      if (processed == 0)  return len;  // usual case, of no escapes found
+      break;
+    }
+    if (processed < i && copied != processed) {
+      memmove(&buf[copied], &buf[processed], i - processed);
+    }
+    copied += i - processed;
+    buf[copied++] = unesc_char;
+    processed = i + esc_len;
+  }
+
+  // Shift the clean remainder.
+  if (processed < len) {
+    memmove(&buf[copied], &buf[processed], len - processed);
+    copied += len - processed;
+  }
+
+  buf[copied] = '\0';  // if it shrinks, reset a null terminator as a courtesy
+  return copied;
 }
 
 // ------------------------------------------------------------------
-// Outputs XML text, with special characters quoted.
+// Outputs XML text, with special characters escaped.
 void xmlStream::text(const char* format, ...) {
   va_list ap;
   va_start(ap, format);

--- a/src/hotspot/share/utilities/xmlstream.hpp
+++ b/src/hotspot/share/utilities/xmlstream.hpp
@@ -31,9 +31,138 @@
 class xmlStream;
 class defaultStream;
 
-// Sub-stream for writing quoted text, as opposed to markup.
-// Characters written to this stream are subject to quoting,
-// as '<' => "&lt;", etc.
+// If you need structuring beyond the level of single lines, or robust
+// quoting of arbitrary strings, consider XML-flavored syntax.
+//
+// If a Hotspot-related file uses XML syntax to organize data, we
+// call it "XML-flavored".  General XML is not read or written by
+// Hotspot, but only a limited form.  (See, for example, the output
+// of -XX:+LogCompilation.)  Every line in an XML-flavored file
+// is either unmarked text no XML syntax except possibly escapes
+// of the form "&lt;", etc, or else the line is a "markup line",
+// an XML element or tag (enclosed in '<' and '>') which occupies
+// the entire line.
+//
+// XML-flavored files can encapsulate marked bundles of flat text
+// by wrapping them in XML tags like this:
+//
+//   <some_dependencies klass='foo/Bar'>
+//   something about the first dependency
+//   something about the second dependency
+//   </some_dependencies>
+//
+// The other trick they can do is XML encapsulated small record-like
+// items with multiple fields like this:
+//
+//   <my_favorite klass='foo/Bar' reason='I prefer foo bars'/>
+//
+// Hotspots reader for XML-flavored text makes it easy to pick apart
+// such records.
+//
+// Note that XML requires that attribute names never be repeated, and
+// that it reserves the right to reorder attributes.  Therefore, do
+// not repeat attributes, and do not use their order to convey
+// information.
+//
+// Although general XML allows a rich syntax for tag and attribute
+// names, XML-flavored text must not use any names other than C-like
+// identifiers composed of ASCII letters, numbers, and underscore.
+//
+// In XML-flavored text, character escaping more restricted than in
+// general XML.  Necessarily, the characters in "&<>" are escaped,
+// using exactly the sequences in "&amp;&lt;&gt;" and no other
+// sequences (not "&#60;" or "&GT;" for "<", for example).  In
+// addition, both single and double quotes are escaped, as
+// "&apos;&quot;".  Finally, the sequence "&#10;" may stand in for a
+// hidden newline; such hidden newlines may be useful in XML attribute
+// strings, or even hidden in a physical line; otherwise there would
+// be no way to talk about string constants or class names which
+// contain the newline character.  Most importantly, apart from the
+// Special Six characters "&<>'\"\n", no other character escapes will
+// ever used in XML-flavored text used by Hotspot.  (If such escapes
+// appear, different processing tools may observe different texts; a
+// fully compliant XML parser will decode all escapes, while a
+// Unix-based tool may only decode the Special Six.)
+//
+// Hotspot will not encode or decode any other escapes.  If it finds
+// XML syntax in a place it does not expect, or of a kind it does not
+// expect, it will just treat it as plain text on input, and on output
+// add escapes, but just to the Special Six.
+//
+// The escaping of the double quote character (as "&quot;") is a
+// historical artifact from the design of the Hotspot log (the first
+// XML-flavored file).  There are no current uses of double-quote '"'
+// to delimit text in XML flavored files.
+//
+// As a concession to general XML parsers, processing instructions
+// (like "<?xml version='1.0' encoding='UTF-8'?>" as found in the main
+// Hotspot log) will be skipped at the top of an XML-flavored input
+// file.  But they must be alone on single lines, not accompanied
+// even by whitespace at the beginning or end of the line.
+//
+// Some input files (like compiler command files) auto-detect XML
+// flavoring, and apply XML escapes after unambiguously XML-flavored
+// input has already been seen.  Until a line of the form /<.*>/ has
+// been read, a reader in auto-detect mode will not expand escapes
+// like "&amp;".  After such a line, all escapes will be expanded.  To
+// allow real XML parsers to read it, or to trigger auto-detection
+// immediately, such a file can look like this:
+//
+//    <?xml version='1.0' encoding='UTF-8'?>
+//    <my_file>
+//    ... rest of file comes here ...
+//    </my_file>
+//
+// The body of the file should be enclosed in a matching pair of
+// top-level tags, again just so that a real XML parser can handle it.
+// (But many readers, including Hotspot, do not require this.  It is
+// easy for Unix-like tools to add these trimmings to a file if it
+// must be passed to a real XML parser.)
+//
+// Nearly any flat-text input can be enclosed tags, passed as
+// attribute values, or passed to an auto-detecting stream, and
+// the possibility of additional XML syntax will not affect the
+// validity of the text.  But, necessarily, there are caveats.
+//
+//  - any line of the form /^<.*>$/ needs to be valid XML syntax
+//  - other lines need not escape '<' and '>' (until real XML is needed)
+//  - quotes and newlines in attribute strings need to be escaped
+//  - the Special Six in attribute strings should be escaped (for real XML)
+//  - lines with "&" need special care if they seem to contain escapes
+//  - the Special Six in text lines should be escaped (for real XML)
+//
+// To be as interoperable as possible, XML-flavored files should
+// always escape the Special Six "&<>'\"\n", using exactly the
+// supported escapes "&amp;", unless those characters are used for
+// XML-flavored markup.  Also, no other XML features should be used,
+// to stay within the subset of XML understood by Hotspot.
+//
+// Here is a grammar that summarizes these rules:
+//
+//   xml_flavored_file = xml_compliant_file | [content NL]* [content]?
+//   content = [looks_like_markup => markup] | text
+//   text = [ escape | NOTNL ]*             -- real XML has more constraints
+//   escape = /&lt;/ | /&gt;/ | /&amp;/ | /&apos/ | /&quot/ | /&#10;/
+//   looks_like_markup = /^[<].*[>]$/
+//   markup = elem | head NL [content NL]* tail
+//   elem = "<" NAME [attr]* "/>"
+//   head = "<" NAME [attr]* ">"
+//   tail = "</" NAME ">"                   -- real XML requires names to match
+//   attr = SP NAME "=" SQ attrstring SQ
+//   attrstring = [ escape | NOTSQNL ]*     -- real XML has more constraints
+//   xml_compliant_file = [xml_header]* markup
+//   xml_header = [ /^[<][?].*[>]$/ NL ]*   -- real XML has more constraints
+//   NAME = /[a-zA-Z_][a-zA-Z_0-9]*/        -- real XML allows additional names
+//   NL = '\n'
+//   NOTNL = /[^\n]/
+//   NOTSQNL = /[^'\n]/
+//   SP = / /  -- exactly one space
+//   SQ = /'/  -- exactly this quote
+//   ATOZ = //
+
+// Sub-stream for writing regular text, as opposed to markup.
+// Any "Special Six" characters written to this stream will be
+// escaped, as '<' => "&lt;", etc.
 class xmlTextStream : public outputStream {
   friend class xmlStream;
   friend class defaultStream; // tty
@@ -52,7 +181,7 @@ class xmlTextStream : public outputStream {
 // Output stream for writing XML-structured logs.
 // To write markup, use special calls elem, head/tail, etc.
 // Use the xmlStream::text() stream to write unmarked text.
-// Text written that way will be quoted as necessary using '&lt;', etc.
+// Text written that way will be escaped as necessary using '&lt;', etc.
 // Characters written directly to an xmlStream via print_cr, etc.,
 // are directly written to the encapsulated stream, xmlStream::out().
 // This can be used to produce markup directly, character by character.
@@ -105,8 +234,18 @@ class xmlStream : public outputStream {
   // flushing
   virtual void flush();  // flushes out, sets _last_flush = count()
   virtual void write(const char* s, size_t len);
-  void    write_text(const char* s, size_t len);  // used by xmlTextStream
+  void    write_text(const char* s, size_t len);
   int unflushed_count() { return (int)(out()->count() - _last_flush); }
+
+  // handling escaped XML content, limited to only the Special Six
+  static const int MAX_ESCAPE_LEN = 6;  //strlen("&apos;")
+  static size_t find_escape(      const char* s, size_t len, int &esc_len, char& unesc);
+  static size_t find_to_escape(   const char* s, size_t len, const char*& esc);
+  static size_t escaped_length(   const char* s, size_t len);
+  static size_t write_escaped(    const char* s, size_t len, outputStream* out,
+                                  const char* pass_these_through = nullptr);
+  static size_t write_unescaped(  const char* s, size_t len, outputStream* out);
+  static size_t unescape_in_place( char* buffer, size_t len);
 
   // writing complete XML elements
   void          elem(const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
@@ -178,6 +317,8 @@ class xmlStream : public outputStream {
    */
 
 };
+
+#define XML_SPECIAL_SIX "&<>'\"\n"
 
 // Standard log file, null if no logging is happening.
 extern xmlStream* xtty;

--- a/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
+++ b/test/hotspot/gtest/gc/shared/test_memset_with_concurrent_readers.cpp
@@ -28,6 +28,7 @@
 #include "utilities/vmassert_uninstall.hpp"
 #include <string.h>
 #include <sstream>
+#include <iomanip>
 #include "utilities/vmassert_reinstall.hpp"
 
 #include "unittest.hpp"

--- a/test/hotspot/gtest/utilities/test_istream.cpp
+++ b/test/hotspot/gtest/utilities/test_istream.cpp
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "jvm.h"
+#include "memory/allocation.inline.hpp"
+#include "memory/resourceArea.hpp"
+#include "runtime/os.hpp"
+#include "utilities/istream.hpp"
+#include "unittest.hpp"
+
+#define EXPECT_MEMEQ(s1, s2, len) \
+  EXPECT_PRED_FORMAT3(CmpHelperMEMEQ, s1, s2, len)
+// cf. ::testing::internal::CmpHelperSTREQ
+
+testing::AssertionResult CmpHelperMEMEQ(const char* s1_expression,
+                                        const char* s2_expression,
+                                        const char* len_expression,
+                                        const char* s1, const char* s2,
+                                        size_t len) {
+  if (s1 == nullptr || s2 == nullptr) {
+    return testing::internal::CmpHelperEQ(s1_expression, s2_expression,
+                                          s1, s2);
+  }
+  int c = ::memcmp(s1, s2, len);
+  if (c == 0) {
+    return testing::AssertionSuccess();
+  }
+  ::std::string str1, str2;
+  for (auto which = 0; which <= 1; which++) {
+    auto  s   = which ? s1   : s2;
+    auto &str = which ? str1 : str2;
+    std::stringstream buf;
+    buf << "{";
+    for (size_t i = 0; i < len; i++) {
+      char c = s[i];
+      switch (c) {
+      case '\0':  buf << "\\0"; break;
+      case '\n':  buf << "\\n"; break;
+      case '\\':  buf << "\\\\"; break;
+      default:    buf << c; break;
+      }
+    }
+    buf << "}[" << len_expression << "=" << len << "]";
+    str = buf.str();
+  }
+  return testing::internal::CmpHelperSTREQ(s1_expression, s2_expression,
+                                           str1.c_str(), str2.c_str());
+}
+
+static int firstdiff(char* b1, char* b2, int blen) {
+  for (int i = 0; i < blen; i++) {
+    if (b1[i] != b2[i])  return i;
+  }
+  return -1;
+}
+
+static char* get_temp_file(bool VERBOSE, const char* filename) {
+  const char* tmp_dir = os::get_temp_directory();
+  const char* file_sep = os::file_separator();
+  size_t temp_file_len = strlen(tmp_dir) + strlen(file_sep) + strlen(filename) + 28;
+  char* temp_file = NEW_C_HEAP_ARRAY(char, temp_file_len, mtInternal);
+  int ret = jio_snprintf(temp_file, temp_file_len, "%s%spid%d.%s",
+                         tmp_dir, file_sep,
+                         os::current_process_id(), filename);
+  if (VERBOSE)  tty->print_cr("temp_file = %s", temp_file);
+  return temp_file;
+}
+
+static const char* get_temp_file(bool VERBOSE) {
+  static const char* temp_file = get_temp_file(VERBOSE, "test_istream");
+  return temp_file;
+}
+
+#define EIGHTY 80
+#define LC0(x)     ('/' + (((unsigned)(x)+1) % EIGHTY))
+#define LC(line,col)  LC0((col) * (line))
+
+#define COLS 30
+
+static int cases, total, zeroes;
+#ifdef ASSERT
+#define istream_coverage_mode(mode, a,b,c) \
+  inputStream::coverage_mode(mode, a,b,c)
+#else
+#define istream_coverage_mode(mode, a,b,c)
+#endif
+
+// Fill in a test pattern of ascii characters.
+// Each line is ncols long, plus a line termination of lelen (1 or 2).
+// Each character is a fixed, static function of the line and column.
+// This enables test logic to predict exactly what will be read in each line.
+static void fill_pattern(bool VERBOSE,
+                         char* pat, int patlen, int ncols, int lelen,
+                         int& full_lines, int& partial_line,
+                         const char* &line_end,
+                         const char* &partial_line_end) {
+  full_lines = partial_line = 0;
+  for (int i = 0; i < patlen; i++) {
+    int line = (i / (ncols+lelen)) + 1;  // 1-based line number
+    int col  = (i % (ncols+lelen)) + 1;  // 1-based column number
+    if (col <= ncols) {
+      pat[i] = LC(line, col);
+      partial_line = 1;
+    } else if (col < ncols+lelen) {
+      pat[i] = i == patlen - 1 ? '!' : '%';
+      partial_line = 1;
+    } else {
+      assert(col == ncols+lelen, "");
+      pat[i] = '!';
+      full_lines++;
+      partial_line = 0;
+    }
+  }
+  pat[patlen] = '\0';
+  if (VERBOSE)  tty->print_cr("PATTERN=%d+%d[%s]",
+                              full_lines, partial_line, pat);
+  for (int i = 0; i < patlen; i++) {
+    assert(pat[i] != '%' || i+1 < patlen && pat[i+1] == '!', "");
+    if (pat[i] == '!')  pat[i] = '\n';
+    if (pat[i] == '%')  pat[i] = '\r';
+  }
+  assert(pat[patlen-1] != '\r', "");
+
+  line_end = (lelen == 2 ? "\r\n" : "\n");
+  int partial_line_bytes = patlen - (full_lines * (ncols + lelen));
+  assert(partial_line_bytes < ncols + lelen, "");
+  partial_line_end = (partial_line_bytes == ncols + 1) ? "\n" : "";
+}
+
+static const int MAX_PATLEN = COLS * (COLS-1);
+
+static void istream_test_driver(const bool VERBOSE,
+                                const int patlen,
+                                const int ncols,
+                                const int lelen,
+                                const bool TEST_SET_POSITION,
+                                const bool TEST_PUSH_BACK,
+                                const bool TEST_EXPAND_REDUCE) {
+  DEBUG_ONLY( istream_coverage_mode(VERBOSE ? 2 : 1, cases, total, zeroes) );
+  const char* temp_file = get_temp_file(VERBOSE);
+  unlink(temp_file);
+  char pat[MAX_PATLEN+1];
+  int full_lines = 0, partial_line = 0;
+  const char* line_end = "\n";
+  const char* partial_line_end = "";
+  fill_pattern(VERBOSE, pat, patlen, ncols, lelen,
+               full_lines, partial_line,
+               line_end, partial_line_end);
+
+  char pat2[sizeof(pat)];  // copy of pat to help detect scribbling
+  memcpy(pat2, pat, sizeof(pat));
+  // Make three kinds of stream and test them all.
+  inputStream sin(pat2, patlen);
+  if (VERBOSE) {
+    tty->print("at %llx ", (unsigned long long)(intptr_t)&sin);
+    sin.dump("sin");
+  }
+  {
+    fileStream tfs(temp_file);
+    guarantee(tfs.is_open(), "cannot open temp file");
+    tfs.write(pat, patlen);
+    //tfs.print_cr("googly");  //this fault would get caught
+  }
+  //FileInput fin_block(temp_file);
+  //inputStream fin(&fin_block);
+  BlockInputStream<FileInput> fin(temp_file);
+  if (VERBOSE) {
+    tty->print("at %llx ", (unsigned long long)(intptr_t)&fin);
+    fin.dump("fin");
+  }
+  BlockInputStream<MemoryInput> min(&pat2[0], patlen);
+  if (VERBOSE) {
+    tty->print("at %llx ", (unsigned long long)(intptr_t)&min);
+    sin.dump("min");
+  }
+  inputStream* ins[] = { &sin, &fin, &min };
+  const char* in_names[] = { "sin", "fin", "min" };
+  const char* test_mode = (TEST_SET_POSITION
+                           ? (!TEST_PUSH_BACK ? "(seek)" : "(seek/push)")
+                           : TEST_EXPAND_REDUCE
+                           ? (!TEST_PUSH_BACK ? "(exp/red)" : "(exp/red/push)")
+                           : (!TEST_PUSH_BACK ? "(plain)" : "(push)"));
+  for (int which = 0; which < 3; which++) {
+    inputStream& in = *ins[which];
+    const char* in_name = in_names[which];
+    int lineno;
+    char* lp = (char*)"--";
+#define LPEQ                                                    \
+    in_name << test_mode                                        \
+            << " ncols=" << ncols << " lelen=" << lelen         \
+            << " full=" << full_lines << " lineno=" << lineno   \
+            << " [" << lp << "]" << (in.dump("expect"), "")
+    if (VERBOSE)
+      tty->print_cr("testing %s%s patlen=%d ncols=%d full_lines=%d partial_line=%d",
+                    in_name, test_mode,
+                    patlen, ncols, full_lines, partial_line);
+    int pos_to_set = 0, line_to_set = 1;  // for TEST_SET_POSITION only
+    for (int phase = 0; phase <= (TEST_SET_POSITION ? 1 : 0); phase++) {
+      lineno = 1;
+      if (phase > 0 && (&in == &sin)) {
+        if (VERBOSE)  in.dump("push");
+        in.push_back_input(pat, patlen);
+        in.set_lineno(lineno);
+        if (VERBOSE)  in.dump("push");
+        EXPECT_EQ((int)in.current_line_position(), 0)  <<LPEQ;
+      }
+      if (TEST_SET_POSITION) {
+        if (VERBOSE) { tty->print("seek %d/%d ", (int)pos_to_set, line_to_set); in.dump("seek"); }
+        lineno = line_to_set;
+        size_t res = in.set_current_line_position(pos_to_set, line_to_set);
+        if (VERBOSE)  tty->print_cr("seek res = %d", (int)res);
+        EXPECT_EQ((int)in.current_line_position(), pos_to_set)  <<LPEQ;
+        if (VERBOSE) { tty->print("seek %d/%d ", (int)pos_to_set, line_to_set); in.dump("seek"); }
+      }
+      for (; lineno <= full_lines + partial_line; lineno++) {
+        if (TEST_SET_POSITION &&
+            phase == 0 && lineno == (full_lines + partial_line)/2) {
+          pos_to_set = (int)in.current_line_position();
+          EXPECT_NE(pos_to_set, -1)  <<LPEQ;
+          line_to_set = lineno;
+          if (VERBOSE) { tty->print("tell %d/%d ", (int)pos_to_set, line_to_set); in.dump("tell"); }
+        }
+        EXPECT_EQ(-1, firstdiff(pat, pat2, patlen + 1));
+        if (VERBOSE)  in.dump("!done?");
+        bool done = in.done();
+        EXPECT_TRUE(!done)  <<LPEQ;
+        if (done)  break;
+        lp = in.current_line();
+        const char* expect_endl =
+          (lineno <= full_lines) ? line_end : partial_line_end;
+        if (TEST_PUSH_BACK && (lineno ^ (lineno>>3)) % 3 > 0) {
+          // test additional state changes here
+          bool test_pushback_lineno = false;  //FIXME
+          const char* copy = in.save_line();
+          int oldcll = (int) in.current_line_length();
+          EXPECT_STREQ(lp, copy)  <<LPEQ;
+          const char* endl = in.current_line_ending();
+          EXPECT_STREQ(endl, expect_endl)  <<LPEQ;
+          const bool overwrite = (lineno % 7 > 3);
+          const bool charwise = (lineno % 14 < 7);
+          if (VERBOSE) {
+            tty->print("pushback %s%s %d: [%s]",
+                       overwrite ? "overwriting" : "before next",
+                       charwise ? "/charwise" : "",
+                       lineno, copy);
+            in.dump("");
+          }
+          if (!overwrite) {
+            bool saw_next = in.next();
+            if (VERBOSE)  in.dump(saw_next ? "PB-N" : "PB-D");
+          }
+          if (!charwise) {
+            in.push_back_input(endl, strlen(endl), overwrite);
+            in.push_back_input(copy);
+          } else {
+            bool oflag = overwrite;
+            const char* cp;
+            for (cp = endl + strlen(endl); --cp >= endl; cp) {
+              in.push_back_input(cp, 1, oflag);
+              oflag = false;
+            }
+            for (cp = copy + strlen(copy); --cp >= copy; cp) {
+              in.push_back_input(cp, 1, oflag);
+              oflag = false;
+            }
+          }
+          if (test_pushback_lineno) {
+            if (!overwrite || !*endl)  in.add_to_lineno(-1);
+          }
+          // paper over irregular lineno/pushback interactions:
+          if (!test_pushback_lineno)  in.set_lineno(lineno);
+          lp = in.current_line();
+          EXPECT_STREQ(lp, copy)  <<LPEQ;
+          int newcll = (int) in.current_line_length();
+          EXPECT_EQ(newcll, oldcll)  <<LPEQ << " newcll:" << newcll;
+        }
+        bool verify_lp = true;
+        if (TEST_EXPAND_REDUCE && (lineno ^ (lineno>>3)) % 7 > 2) {
+          // test additional state changes here
+          const char* copy = in.save_line();
+          int oldcll = (int) in.current_line_length();
+          EXPECT_STREQ(lp, copy)  <<LPEQ;
+          const char* endl = in.current_line_ending();
+          EXPECT_STREQ(endl, expect_endl)  <<LPEQ;
+          const bool expand = (lineno % 7 > 3);
+          const bool start  = (lineno % 14 < 7);
+          const char* xrstr = "ASDF";
+          const int  xrlen_arg = (lineno % 5);
+          const int  xrlen = (!expand && xrlen_arg > oldcll) ? oldcll : xrlen_arg;
+          assert(xrlen >= 0, "");
+          const int expcll = oldcll + (expand ? xrlen : -xrlen);
+          assert(expcll >= 0, "");
+          if (VERBOSE) {
+            tty->print("%s%s/arg%d %d: [%s]",
+                       expand ? "expand" : "reduce",
+                       start ? "/start" : "/end",
+                       xrlen_arg,
+                       lineno, copy);
+            in.dump("");
+          }
+          if (expand) {
+            in.expand_current_line_with(xrstr, xrlen_arg, start);
+            if (VERBOSE)  in.dump("expand");
+          } else {
+            in.reduce_current_line(xrlen_arg, start);
+            if (VERBOSE)  in.dump("reduce");
+          }
+          lp = in.current_line();
+          int newcll = (int) in.current_line_length();
+          EXPECT_EQ(newcll, expcll)  <<LPEQ << " expcll:" << expcll;
+          if (expand) {
+            if (start) {
+              // lp = xrstr + oldcopy
+              EXPECT_MEMEQ(lp, xrstr, xrlen) <<LPEQ;
+              EXPECT_STREQ(lp+xrlen, copy) <<LPEQ;
+            } else {
+              // lp = oldcopy + xrstr
+              EXPECT_MEMEQ(lp, copy, oldcll) <<LPEQ;
+              EXPECT_MEMEQ(lp+oldcll, xrstr, xrlen) <<LPEQ;
+            }
+          } else {
+            if (start) {
+              EXPECT_STREQ(lp, copy+xrlen) <<LPEQ;
+            } else {
+              EXPECT_MEMEQ(lp, copy, expcll) <<LPEQ;
+            }
+          }
+          if (xrlen > 0)  verify_lp = false;  // do not bother
+        }
+        if (verify_lp) {
+          int actual_lineno = in.lineno();
+          if (VERBOSE)  in.dump("CL    ");
+          EXPECT_EQ(actual_lineno, lineno)  <<LPEQ;
+          int len = (int) in.current_line_length();
+          EXPECT_EQ(len, (int) strlen(lp))  <<LPEQ;
+          int expect_len = ncols;
+          if (lineno > full_lines)
+            expect_len = MIN2(ncols, patlen % (ncols+lelen));
+          EXPECT_EQ(len, expect_len)  <<LPEQ;
+          for (int j = 0; j < len; j++) {
+            int lc = LC(lineno, j+1);   // 1-based column
+            EXPECT_EQ(lc, lp[j])  <<LPEQ;
+          }
+          if (len != expect_len || len != (int)strlen(lp)) {
+            return;  // no error cascades please
+          }
+        }
+        const char* endl = in.current_line_ending();
+        EXPECT_EQ(strlen(expect_endl), strlen(endl))  <<LPEQ << " endl=" << endl;
+        EXPECT_STREQ(expect_endl, endl);
+        if (VERBOSE)  in.dump("next  ");
+        in.next();
+      }
+
+      for (int done_test = 0; done_test <= 3; done_test++) {
+        if (done_test == 2)  in.set_done();
+        lp = in.current_line();  // should be empty line
+        if (VERBOSE)  in.dump("done!!");
+        EXPECT_TRUE(lp != nullptr);
+        EXPECT_TRUE(in.done())  <<LPEQ;
+        if (!in.done())  break;
+        EXPECT_EQ((int)in.current_line_length(), 0)   <<LPEQ;
+        EXPECT_EQ(strlen(lp), in.current_line_length())  <<LPEQ;
+        const char* endl = in.current_line_ending();
+        EXPECT_EQ(0, (int)strlen(endl))  <<LPEQ << " endl=" << endl;
+        bool extra_next = in.next();
+        EXPECT_TRUE(!extra_next)  <<LPEQ;
+      }
+
+      // no memory side effects
+      EXPECT_EQ(-1, firstdiff(pat, pat2, patlen + 1));
+    }
+  }
+  unlink(temp_file);
+}
+
+static void istream_test_driver(const bool VERBOSE,
+                                const bool TEST_SET_POSITION,
+                                const bool TEST_PUSH_BACK,
+                                const bool TEST_EXPAND_REDUCE) {
+  ResourceMark rm;
+  int patlen = MAX_PATLEN;
+  const bool SHORT_TEST = false;
+  const int SHORT_NCOLS = 1, SHORT_PATLEN = 37;
+  if (SHORT_TEST)  patlen = SHORT_PATLEN;
+  for (int ncols = 0; ncols <= patlen; ncols++) {
+    if (SHORT_TEST) {
+      if (ncols < SHORT_NCOLS)  ncols = SHORT_NCOLS;
+      if (ncols > SHORT_NCOLS)  break;
+    } else if (ncols > COLS && ncols < patlen - COLS) {
+      ncols += ncols / 7;
+      if (ncols > patlen - COLS)  ncols = (patlen - COLS);
+    }
+    for (int lelen = 1; lelen <= 2; lelen++) {  // try both kinds of newline
+      //if (ncols > 0) ncols = (ncols == 1) ? (2*patlen)/3 : patlen;
+      istream_test_driver(VERBOSE,
+                          patlen, ncols, lelen,
+                          TEST_SET_POSITION, TEST_PUSH_BACK, TEST_EXPAND_REDUCE);
+    }
+  }
+}
+
+TEST_VM(istream, basic) {
+  const bool VERBOSE = false;
+  istream_test_driver(VERBOSE, false, false, false);
+}
+
+TEST_VM(istream, push_back) {
+  const bool VERBOSE = false;
+  const bool TEST_PUSH_BACK = true;
+  istream_test_driver(VERBOSE, false, TEST_PUSH_BACK, false);
+}
+
+TEST_VM(istream, set_position) {
+  const bool VERBOSE = false;
+  const bool TEST_SET_POSITION = true;
+  istream_test_driver(VERBOSE, TEST_SET_POSITION, false, false);
+  istream_test_driver(VERBOSE, TEST_SET_POSITION, true, false);
+}
+
+TEST_VM(istream, expand_reduce) {
+  const bool VERBOSE = false;
+  const bool TEST_EXPAND_REDUCE = true;
+  istream_test_driver(VERBOSE, false, false, TEST_EXPAND_REDUCE);
+  istream_test_driver(VERBOSE, true, false, TEST_EXPAND_REDUCE);
+}
+
+TEST_VM(istream, coverage) {
+  const bool VERBOSE = false;
+#ifdef ASSERT
+  istream_coverage_mode(0, cases, total, zeroes);
+  if (cases == 0)  return;
+  if (VERBOSE || zeroes != 0)
+    istream_coverage_mode(-1, cases, total, zeroes);
+  EXPECT_EQ(zeroes, 0) << "zeroes: " << zeroes << "/" << cases;
+#endif //ASSERT
+}


### PR DESCRIPTION
An inputStream buffers a whole line at a time, no matter how long the line. The buffer starts on stack, but uses malloc if the line size overflows.

If you use fgets or have static input buffers of fixed size, switch to this. It is more robust and probably also more efficient.

Both newline formats of \n and \r\n are recognized.  Lines may contain nulls. A truncated line at the end of the data is handled correctly. There is a reliable line number counter.

The line you get back is mutable, but the stream always owns the memory. Therefore, when you call inputStream::next, the old line is gone. Until you call next, you can edit the line in place, and even lengthen it.

The source of data can be memory or a file or some other virtualized thing. The input stream is seekable, if its data source is seekable.

If you need non-line-oriented input, you can still use fileStream.read. But fileStream.readln has been removed; it is fails silently on long lines.

Line parsing over blocked input is tricky to make both efficient and correct. This code has a gtest suite that tests all the corner cases, and tests as correct.

Possible future work:  Add format-sensitive scanning to inputStream, so that os::print[_cr] is matched with a counterpart is::scan[_cr]. Also, if we ever use xml-log streams for input, add xml-input streams.

This line of work assumes that text files will continue to be a useful carrier of configuration data for the HotSpot VM.  At least, it supports the compiler oracle and CDS configuration files.  As those use cases scale up, or for new use cases, we need a solid line reader foundation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Patch contains a binary file (test/jdk/javax/xml/jaxp/datatype/8033980/JDK9_XMLGregorianCalendar.ser)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18773/head:pull/18773` \
`$ git checkout pull/18773`

Update a local copy of the PR: \
`$ git checkout pull/18773` \
`$ git pull https://git.openjdk.org/jdk.git pull/18773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18773`

View PR using the GUI difftool: \
`$ git pr show -t 18773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18773.diff">https://git.openjdk.org/jdk/pull/18773.diff</a>

</details>
