### PR TITLE
8329995: Restricted access to `/proc` can cause JFR initialization to crash

### DIFF
--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -847,7 +847,7 @@ SystemProcessInterface::SystemProcesses::ProcessIterator::ProcessIterator() {
 bool SystemProcessInterface::SystemProcesses::ProcessIterator::initialize() {
   _dir = os::opendir("/proc");
   _entry = nullptr;
-  _valid = true;
+  _valid = _dir != nullptr;
   next_process();
 
   return true;

--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -847,7 +847,7 @@ SystemProcessInterface::SystemProcesses::ProcessIterator::ProcessIterator() {
 bool SystemProcessInterface::SystemProcesses::ProcessIterator::initialize() {
   _dir = os::opendir("/proc");
   _entry = nullptr;
-  _valid = _dir != nullptr;
+  _valid = _dir != nullptr; // May be null if /proc is not accessible.
   next_process();
 
   return true;


### PR DESCRIPTION
Please, review this trivial change to make using `ProcessIterator` more robust in the presence of SELinux or a similar system.

The call to `os::opendir("/proc")` may return `nulltptr` if the `/proc` is not accessible due to restrictions placed by the SELinux. In that case the `ProcessIterator` will SIGSEG because it assumes the `_dir`, which is the variable storing the result  of the `os::opendir("/proc")` call to be non-null.

The patch is missing regression test because it is very hard to simulate `/proc` not being accessible to the test process.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329995](https://bugs.openjdk.org/browse/JDK-8329995): Restricted access to `/proc` can cause JFR initialization to crash (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18775/head:pull/18775` \
`$ git checkout pull/18775`

Update a local copy of the PR: \
`$ git checkout pull/18775` \
`$ git pull https://git.openjdk.org/jdk.git pull/18775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18775`

View PR using the GUI difftool: \
`$ git pr show -t 18775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18775.diff">https://git.openjdk.org/jdk/pull/18775.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18775#issuecomment-2053974163)