### PR TITLE
8330215: Trim working set for OldObjectSamples

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.hpp
@@ -85,6 +85,7 @@ class ObjectSampler : public CHeapObj<mtTracing> {
   ObjectSample* last() const;
   const ObjectSample* last_resolved() const;
   void set_last_resolved(const ObjectSample* sample);
+  static bool has_unresolved_entry();
 };
 
 #endif // SHARE_JFR_LEAKPROFILER_SAMPLING_OBJECTSAMPLER_HPP

--- a/src/hotspot/share/jfr/utilities/jfrSignal.hpp
+++ b/src/hotspot/share/jfr/utilities/jfrSignal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,13 +37,23 @@ class JfrSignal {
     Atomic::release_store(&_signaled, true);
   }
 
+  void reset() const {
+    Atomic::release_store(&_signaled, false);
+  }
+
   bool is_signaled() const {
     return Atomic::load_acquire(&_signaled);
   }
 
+  void signal_if_not_set() const {
+    if (!is_signaled()) {
+      signal();
+    }
+  }
+
   bool is_signaled_with_reset() const {
     if (is_signaled()) {
-      Atomic::release_store(&_signaled, false);
+      reset();
       return true;
     }
     return false;


### PR DESCRIPTION
Greetings,

During the investigation around a potential memory leak, initially thought to be related to JFR and OldObjectSamples, but eventually reduced to https://bugs.openjdk.org/browse/JDK-8303767, a few minor improvements were made.

There is no need to save class unload typesets if there are no new unresolved entries for the epoch in the priority queue. 

Testing: jdk_jfr, stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330215](https://bugs.openjdk.org/browse/JDK-8330215): Trim working set for OldObjectSamples (**Enhancement** - P4)


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18776/head:pull/18776` \
`$ git checkout pull/18776`

Update a local copy of the PR: \
`$ git checkout pull/18776` \
`$ git pull https://git.openjdk.org/jdk.git pull/18776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18776`

View PR using the GUI difftool: \
`$ git pr show -t 18776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18776.diff">https://git.openjdk.org/jdk/pull/18776.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18776#issuecomment-2054016827)