### PR TITLE
8328741: serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java failed with unexpected owner

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
@@ -55,7 +55,7 @@ public class ObjectMonitorUsage {
     native static int getRes();
     native static int setTestedMonitor(Object monitor);
     native static void ensureBlockedOnEnter(Thread thread);
-    native static void ensureWaitsToBeNotified(Thread thread);
+    native static void ensureWaitingToBeNotified(Thread thread);
     native static void check(Object obj, Thread owner,
                              int entryCount, int waiterCount, int notifyWaiterCount);
 
@@ -88,7 +88,7 @@ public class ObjectMonitorUsage {
         for (int i = 0; i < NUMBER_OF_WAITING_THREADS; i++) {
             // the WaitingTask has to wait to be notified in lockCheck.wait()
             Thread thread = startTask(i, new WaitingTask(), isVirtual, "Waiting");
-            ensureWaitsToBeNotified(thread);
+            ensureWaitingToBeNotified(thread);
             threads[i] = thread;
         }
         return threads;

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
@@ -89,7 +89,7 @@ public class ObjectMonitorUsage {
             // the WaitingTask has to wait to be notified in lockCheck.wait()
             Thread thread = startTask(i, new WaitingTask(), isVirtual, "Waiting");
             ensureWaitsToBeNotified(thread);
-            threads[i] = thread; 
+            threads[i] = thread;
         }
         return threads;
     }
@@ -100,7 +100,7 @@ public class ObjectMonitorUsage {
             // the EnteringTask has to be blocked at the lockCheck enter
             Thread thread = startTask(i, new EnteringTask(), isVirtual, "Entering");
             ensureBlockedOnEnter(thread);
-            threads[i] = thread; 
+            threads[i] = thread;
         }
         return threads;
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
@@ -53,9 +53,9 @@ public class ObjectMonitorUsage {
     static Object lockCheck = new Object();
 
     native static int getRes();
-    native static int waitsToEnter();
-    native static int waitsToBeNotified();
     native static int setTestedMonitor(Object monitor);
+    native static void ensureBlockedOnEnter(Thread thread);
+    native static void ensureWaitsToBeNotified(Thread thread);
     native static void check(Object obj, Thread owner,
                              int entryCount, int waiterCount, int notifyWaiterCount);
 
@@ -87,10 +87,9 @@ public class ObjectMonitorUsage {
         Thread[] threads = new Thread[NUMBER_OF_WAITING_THREADS];
         for (int i = 0; i < NUMBER_OF_WAITING_THREADS; i++) {
             // the WaitingTask has to wait to be notified in lockCheck.wait()
-            threads[i] = startTask(i, new WaitingTask(), isVirtual, "Waiting");
-        }
-        while (waitsToBeNotified() < NUMBER_OF_WAITING_THREADS) {
-            sleep(1);
+            Thread thread = startTask(i, new WaitingTask(), isVirtual, "Waiting");
+            ensureWaitsToBeNotified(thread);
+            threads[i] = thread; 
         }
         return threads;
     }
@@ -99,10 +98,9 @@ public class ObjectMonitorUsage {
         Thread[] threads = new Thread[NUMBER_OF_ENTERING_THREADS];
         for (int i = 0; i < NUMBER_OF_ENTERING_THREADS; i++) {
             // the EnteringTask has to be blocked at the lockCheck enter
-            threads[i] = startTask(i, new EnteringTask(), isVirtual, "Entering");
-        }
-        while (waitsToEnter() < NUMBER_OF_ENTERING_THREADS) {
-            sleep(1);
+            Thread thread = startTask(i, new EnteringTask(), isVirtual, "Entering");
+            ensureBlockedOnEnter(thread);
+            threads[i] = thread; 
         }
         return threads;
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/libObjectMonitorUsage.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/libObjectMonitorUsage.cpp
@@ -177,7 +177,7 @@ Java_ObjectMonitorUsage_ensureBlockedOnEnter(JNIEnv *jni, jclass cls, jthread th
 }
 
 JNIEXPORT void JNICALL
-Java_ObjectMonitorUsage_ensureWaitsToBeNotified(JNIEnv *jni, jclass cls, jthread thread) {
+Java_ObjectMonitorUsage_ensureWaitingToBeNotified(JNIEnv *jni, jclass cls, jthread thread) {
   wait_for_state(jvmti, jni, thread, JVMTI_THREAD_STATE_WAITING_INDEFINITELY);
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/libObjectMonitorUsage.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/libObjectMonitorUsage.cpp
@@ -35,8 +35,6 @@ static jvmtiEnv *jvmti = nullptr;
 static jrawMonitorID event_lock = nullptr;
 static jint result = PASSED;
 static int check_idx = 0;
-static int waits_to_enter = 0;
-static int waits_to_be_notified = 0;
 static jobject tested_monitor = nullptr;
 
 static bool is_tested_monitor(JNIEnv *jni, jobject monitor) {
@@ -53,47 +51,10 @@ static void log_event(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
   deallocate(jvmti, jni, (void*)tname);
 }
 
-JNIEXPORT void JNICALL
-MonitorContendedEnter(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jobject monitor) {
-  RawMonitorLocker rml(jvmti, jni, event_lock);
-  if (is_tested_monitor(jni, monitor)) {
-    waits_to_enter++;
-    log_event(jvmti, jni, thread, "MonitorContendedEnter", waits_to_enter);
-  }
-}
-
-JNIEXPORT void JNICALL
-MonitorContendedEntered(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jobject monitor) {
-  RawMonitorLocker rml(jvmti, jni, event_lock);
-  if (is_tested_monitor(jni, monitor)) {
-    waits_to_enter--;
-    log_event(jvmti, jni, thread, "MonitorContendedEntered", waits_to_enter);
-  }
-}
-
-JNIEXPORT void JNICALL
-MonitorWait(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jobject monitor, jlong timeout) {
-  RawMonitorLocker rml(jvmti, jni, event_lock);
-  if (is_tested_monitor(jni, monitor)) {
-    waits_to_be_notified++;
-    log_event(jvmti, jni, thread, "MonitorWait", waits_to_be_notified);
-  }
-}
-
-JNIEXPORT void JNICALL
-MonitorWaited(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jobject monitor, jboolean timed_out) {
-  RawMonitorLocker rml(jvmti, jni, event_lock);
-  if (is_tested_monitor(jni, monitor)) {
-    waits_to_be_notified--;
-    log_event(jvmti, jni, thread, "MonitorWaited", waits_to_be_notified);
-  }
-}
-
 jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
   jint res;
   jvmtiError err;
   jvmtiCapabilities caps;
-  jvmtiEventCallbacks callbacks;
 
   res = jvm->GetEnv((void **) &jvmti, JVMTI_VERSION_1_1);
   if (res != JNI_OK || jvmti == nullptr) {
@@ -116,15 +77,6 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     LOG("Warning: Monitor events are not implemented\n");
     return JNI_ERR;
   }
-  memset(&callbacks, 0, sizeof(callbacks));
-  callbacks.MonitorContendedEnter   = &MonitorContendedEnter;
-  callbacks.MonitorContendedEntered = &MonitorContendedEntered;
-  callbacks.MonitorWait = &MonitorWait;
-  callbacks.MonitorWaited = &MonitorWaited;
-
-  err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
-  check_jvmti_error(err, "Agent_Initialize: error in JVMTI SetEventCallbacks");
-
   event_lock = create_raw_monitor(jvmti, "Events Monitor");
 
   return JNI_OK;
@@ -225,32 +177,26 @@ Java_ObjectMonitorUsage_setTestedMonitor(JNIEnv *jni, jclass cls, jobject monito
     jni->DeleteGlobalRef(tested_monitor);
   }
   tested_monitor = (monitor != nullptr) ? jni->NewGlobalRef(monitor) : nullptr;
-  waits_to_enter = 0;
-  waits_to_be_notified = 0;
-
-  err = jvmti->SetEventNotificationMode(event_mode, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, nullptr);
-  check_jvmti_status(jni, err, "setTestedMonitor: error in JVMTI SetEventNotificationMode #1");
-
-  err = jvmti->SetEventNotificationMode(event_mode, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, nullptr);
-  check_jvmti_status(jni, err, "setTestedMonitor: error in JVMTI SetEventNotificationMode #2");
-
-  err = jvmti->SetEventNotificationMode(event_mode, JVMTI_EVENT_MONITOR_WAIT, nullptr);
-  check_jvmti_status(jni, err, "setTestedMonitor: error in JVMTI SetEventNotificationMode #3");
-
-  err = jvmti->SetEventNotificationMode(event_mode, JVMTI_EVENT_MONITOR_WAITED, nullptr);
-  check_jvmti_status(jni, err, "setTestedMonitor: error in JVMTI SetEventNotificationMode #4");
 }
 
-JNIEXPORT jint JNICALL
-Java_ObjectMonitorUsage_waitsToEnter(JNIEnv *jni, jclass cls) {
+static void wait_for_state(JNIEnv *jni, jthread thread, jint exp_state) {
   RawMonitorLocker rml(jvmti, jni, event_lock);
-  return waits_to_enter;
+  while (true) {
+    if (get_thread_state(jvmti, jni, thread) & exp_state) {
+      break;
+    }
+    rml.wait(100);
+  }
 }
 
-JNIEXPORT jint JNICALL
-Java_ObjectMonitorUsage_waitsToBeNotified(JNIEnv *jni, jclass cls) {
-  RawMonitorLocker rml(jvmti, jni, event_lock);
-  return waits_to_be_notified;
+JNIEXPORT void JNICALL
+Java_ObjectMonitorUsage_ensureBlockedOnEnter(JNIEnv *jni, jclass cls, jthread thread) {
+  wait_for_state(jni, thread, JVMTI_THREAD_STATE_BLOCKED_ON_MONITOR_ENTER);
+}
+
+JNIEXPORT void JNICALL
+Java_ObjectMonitorUsage_ensureWaitsToBeNotified(JNIEnv *jni, jclass cls, jthread thread) {
+  wait_for_state(jni, thread, JVMTI_THREAD_STATE_WAITING_INDEFINITELY);
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/libSuspendResumeAll.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResumeAll/libSuspendResumeAll.cpp
@@ -216,11 +216,7 @@ test_vthread_resume_all(JNIEnv* jni, const jthread* thread_list, int suspend_mas
   check_jvmti_status(jni, err, "test_vthread_resume_all: error in JVMTI ResumeAllVirtualThreads");
 
   // wait a second to give the breakpoints a chance to be hit.
-#ifdef WINDOWS
-  Sleep(1000);
-#else
-  sleep(1);
-#endif
+  sleep_sec(1);
 
   for (int idx = 0; idx < EXCLUDE_CNT; idx++) {
     // Disable Breakpoint events on excluded thread

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -56,7 +56,7 @@
 
 #define COMPLAIN LOG
 
-
+void sleep_ms(int millis);
 const char* TranslateState(jint flags);
 const char* TranslateError(jvmtiError err);
 
@@ -388,13 +388,11 @@ find_method(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass, const char* mname) {
 // - JVMTI_THREAD_STATE_SLEEPING
 static void
 wait_for_state(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jint exp_state) {
-  jrawMonitorID lock = create_raw_monitor(jvmti, "Waiting Monitor");
-  RawMonitorLocker rml(jvmti, jni, lock);
   while (true) {
     if (get_thread_state(jvmti, jni, thread) & exp_state) {
       break;
     }
-    rml.wait(100);
+    sleep_ms(100);
   }
 }
 

--- a/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
+++ b/test/lib/jdk/test/lib/jvmti/jvmti_common.hpp
@@ -389,7 +389,9 @@ find_method(jvmtiEnv *jvmti, JNIEnv *jni, jclass klass, const char* mname) {
 static void
 wait_for_state(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread, jint exp_state) {
   while (true) {
-    if (get_thread_state(jvmti, jni, thread) & exp_state) {
+    // Allow a bitmask to designate expected thread state. E.g., if two bits are expected
+    // than check they both are present in the state mask returned by JVMTI GetThreadState.
+    if ((get_thread_state(jvmti, jni, thread) & exp_state) == exp_state) {
       break;
     }
     sleep_ms(100);


### PR DESCRIPTION
This is the test issue. The `WaitingPT3` thread posted the `MonitorWait` event but has not released the `lockCheck` monitor yet. It has been fixed to wait for each `WaitingTask` thread to really reach the `WAITING` state. The same approach is used for `EnteringTask` threads. It has been fixed to wait for each `EnteringTask` thread to reach the `BLOCKED_ON_MONITOR` state.

Testing:
 - Reran the test `serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java` locally
 - TBD: submit the mach5 tiers 1-6 as well

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328741](https://bugs.openjdk.org/browse/JDK-8328741): serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java failed with unexpected owner (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [68cdd8c7](https://git.openjdk.org/jdk/pull/18778/files/68cdd8c7b3d6cc9683801683f86df524e4c0911d)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18778/head:pull/18778` \
`$ git checkout pull/18778`

Update a local copy of the PR: \
`$ git checkout pull/18778` \
`$ git pull https://git.openjdk.org/jdk.git pull/18778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18778`

View PR using the GUI difftool: \
`$ git pr show -t 18778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18778.diff">https://git.openjdk.org/jdk/pull/18778.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18778#issuecomment-2056614988)