### PR TITLE
8330176: Typo in Linker javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/Linker.java
+++ b/src/java.base/share/classes/java/lang/foreign/Linker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -598,7 +598,7 @@ public sealed interface Linker permits AbstractLinker {
      * <p>
      * Calling this method is equivalent to the following code:
      * {@snippet lang=java :
-     * linker.downcallHandle(function).bindTo(symbol);
+     * linker.downcallHandle(function, options).bindTo(address);
      * }
      *
      * @param address  the native memory segment whose


### PR DESCRIPTION
This PR fixes a typo in the `Linker` documentation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330176](https://bugs.openjdk.org/browse/JDK-8330176): Typo in Linker javadoc (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18781/head:pull/18781` \
`$ git checkout pull/18781`

Update a local copy of the PR: \
`$ git checkout pull/18781` \
`$ git pull https://git.openjdk.org/jdk.git pull/18781/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18781`

View PR using the GUI difftool: \
`$ git pr show -t 18781`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18781.diff">https://git.openjdk.org/jdk/pull/18781.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18781#issuecomment-2056147121)