### PR TITLE
8330261: Clean up linking steps

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -849,7 +849,7 @@ AC_DEFUN([JDKOPT_CHECK_CODESIGN_DEBUG],
 
 AC_DEFUN([JDKOPT_SETUP_MACOSX_SIGNING],
 [
-  ENABLE_CODESIGN=false
+  MACOSX_CODESIGN_MODE=disabled
   if test "x$OPENJDK_TARGET_OS" = "xmacosx" && test "x$CODESIGN" != "x"; then
 
     UTIL_ARG_WITH(NAME: macosx-codesign, TYPE: literal, OPTIONAL: true,
@@ -859,7 +859,6 @@ AC_DEFUN([JDKOPT_SETUP_MACOSX_SIGNING],
         DESC: [set the macosx code signing mode (hardened, debug, auto)]
     )
 
-    MACOSX_CODESIGN_MODE=disabled
     if test "x$MACOSX_CODESIGN_ENABLED" = "xtrue"; then
 
       # Check for user provided code signing identity.
@@ -902,9 +901,9 @@ AC_DEFUN([JDKOPT_SETUP_MACOSX_SIGNING],
         AC_MSG_ERROR([unknown value for --with-macosx-codesign: $MACOSX_CODESIGN])
       fi
     fi
-    AC_SUBST(MACOSX_CODESIGN_IDENTITY)
-    AC_SUBST(MACOSX_CODESIGN_MODE)
   fi
+  AC_SUBST(MACOSX_CODESIGN_IDENTITY)
+  AC_SUBST(MACOSX_CODESIGN_MODE)
 ])
 
 ################################################################################

--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -229,6 +229,9 @@ endef
 ################################################################################
 # Verify that user passed arguments are valid
 define VerifyArguments
+  ifeq ($$($1_NAME), )
+    $$(error NAME must not be empty in $1)
+  endif
   ifneq ($$($1_NAME), $(basename $$($1_NAME)))
     $$(error NAME must not contain any directory path in $1)
   endif

--- a/make/common/native/DebugSymbols.gmk
+++ b/make/common/native/DebugSymbols.gmk
@@ -36,47 +36,35 @@ define CreateDebugSymbols
     $1_ZIP_EXTERNAL_DEBUG_SYMBOLS := $(ZIP_EXTERNAL_DEBUG_SYMBOLS)
   endif
 
+  $1_CREATE_DEBUGINFO := false
   ifeq ($$($1_COPY_DEBUG_SYMBOLS), true)
     ifneq ($$($1_DEBUG_SYMBOLS), false)
       $$(call SetIfEmpty, $1_SYMBOLS_DIR, $$($1_OUTPUT_DIR))
       # Only copy debug symbols for dynamic libraries and programs.
       ifneq ($$($1_TYPE), STATIC_LIBRARY)
-        # Generate debuginfo files.
+        $1_CREATE_DEBUGINFO := true
+
+        # Setup where the platform specific debuginfo files end up
+        ifeq ($(call isTargetOs, windows), true)
+          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb \
+              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).map
+          $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).diz
+        else ifeq ($(call isTargetOs, macosx), true)
+          $1_DEBUGINFO_FILES := \
+              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \
+              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
+          $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).diz
+        else ifeq ($(call isTargetOsType, unix), true)
+          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).debuginfo
+          $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).diz
+        endif
+
         ifeq ($(call isTargetOs, windows), true)
           $1_EXTRA_LDFLAGS += -debug "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb" \
               "-map:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).map"
           ifeq ($(SHIP_DEBUG_SYMBOLS), public)
             $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).stripped.pdb"
           endif
-          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb \
-              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).map
-
-        else ifeq ($(call isTargetOs, linux), true)
-          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).debuginfo
-          # Setup the command line creating debuginfo files, to be run after linking.
-          # It cannot be run separately since it updates the original target file
-          # Creating the debuglink is done in another command rather than all at once
-          # so we can run it after strip is called, since strip can sometimes mangle the
-          # embedded debuglink, which we want to avoid.
-          $1_CREATE_DEBUGINFO_CMDS := \
-              $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES) && \
-              $$(CHMOD) -x $$($1_DEBUGINFO_FILES)
-          $1_CREATE_DEBUGLINK_CMDS := $(CD) $$($1_SYMBOLS_DIR) && \
-              $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
-
-        else ifeq ($(call isTargetOs, aix), true)
-          # AIX does not provide the equivalent of OBJCOPY to extract debug symbols,
-          # so we copy the compiled object with symbols to the .debuginfo file, which
-          # happens prior to the STRIP_CMD on the original target object file.
-          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).debuginfo
-          $1_CREATE_DEBUGINFO_CMDS := $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES)
-
-        else ifeq ($(call isTargetOs, macosx), true)
-          $1_DEBUGINFO_FILES := \
-              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Info.plist \
-              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM/Contents/Resources/DWARF/$$($1_BASENAME)
-          $1_CREATE_DEBUGINFO_CMDS := \
-              $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
         endif
 
         # Since the link rule creates more than one file that we want to track,
@@ -98,19 +86,13 @@ define CreateDebugSymbols
         $1 += $$($1_DEBUGINFO_FILES)
 
         ifeq ($$($1_ZIP_EXTERNAL_DEBUG_SYMBOLS), true)
-          ifeq ($(call isTargetOs, windows), true)
-            $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).diz
-          else
-            $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_NOSUFFIX).diz
-          endif
-          $1 += $$($1_DEBUGINFO_ZIP)
-
           # The dependency on TARGET is needed for debuginfo files
           # to be rebuilt properly.
           $$($1_DEBUGINFO_ZIP): $$($1_DEBUGINFO_FILES) $$($1_TARGET)
 		$(CD) $$($1_SYMBOLS_DIR) && \
 		    $(ZIPEXE) -q -r $$@ $$(subst $$($1_SYMBOLS_DIR)/,, $$($1_DEBUGINFO_FILES))
 
+          $1 += $$($1_DEBUGINFO_ZIP)
         endif
        endif # !STATIC_LIBRARY
     endif # $1_DEBUG_SYMBOLS != false

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -52,12 +52,9 @@ define SetupLinking
   # being copied.
   $$(call SetIfEmpty, $1_STRIP_SYMBOLS, $$($1_COPY_DEBUG_SYMBOLS))
 
-  ifneq ($$($1_STRIP_SYMBOLS), false)
-    # Default to using the global STRIPFLAGS. Allow for overriding with an
-    # empty value
-    $1_STRIPFLAGS ?= $(STRIPFLAGS)
-    $1_STRIP_CMD := $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
-  endif
+  # Default to using the global STRIPFLAGS. Allow for overriding with an
+  # empty value
+  $1_STRIPFLAGS ?= $(STRIPFLAGS)
 endef
 
 ################################################################################
@@ -135,9 +132,16 @@ define CreateDynamicLibraryOrExecutable
     $1_EXTRA_LDFLAGS += $$(call SET_SHARED_LIBRARY_NAME,$$($1_BASENAME))
   endif
 
+  ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+    $1_CODESIGN_OPTS := "$(MACOSX_CODESIGN_IDENTITY)" --timestamp \
+        --options runtime
+  else ifeq ($(MACOSX_CODESIGN_MODE), debug)
+    $1_CODESIGN_OPTS := -
+  endif
+
   $1_VARDEPS := $$($1_LD) $$($1_SYSROOT_LDFLAGS) $$($1_LDFLAGS) \
       $$($1_EXTRA_LDFLAGS) $$($1_LIBS) $$($1_EXTRA_LIBS) \
-      $$($1_CREATE_DEBUGINFO_CMDS) $$($1_STRIP_CMD) $$($1_CREATE_DEBUGLINK_CMDS)
+      $$($1_DEBUGINFO_FILES) $$($1_STRIPFLAGS)
   $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
       $$($1_OBJECT_DIR)/$$($1_NOSUFFIX).vardeps)
 
@@ -158,20 +162,36 @@ define CreateDynamicLibraryOrExecutable
 	    $$($1_LD) $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) \
 	        $$($1_SYSROOT_LDFLAGS) -o $$($1_TARGET) $$($1_LD_OBJ_ARG) \
 	        $$($1_LIBS) $$($1_EXTRA_LIBS))
-	$$($1_CREATE_DEBUGINFO_CMDS)
-	$$($1_STRIP_CMD)
-	$$($1_CREATE_DEBUGLINK_CMDS)
-        # On macosx, optionally run codesign on every binary.
-        # Remove signature explicitly first to avoid warnings if the linker
-        # added a default adhoc signature.
-        ifeq ($(MACOSX_CODESIGN_MODE), hardened)
+        ifeq ($$($1_CREATE_DEBUGINFO), true)
+          ifeq ($(call isTargetOs, linux), true)
+            # This cannot be run separately since it updates the original target
+            # file.
+	    $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES)
+	    $$(CHMOD) -x $$($1_DEBUGINFO_FILES)
+          else ifeq ($(call isTargetOs, aix), true)
+            # AIX does not provide the equivalent of objcopy to extract debug
+            # symbols, so we copy unstripped library instead.
+	    $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES)
+          else ifeq ($(call isTargetOs, macosx), true)
+	    $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+          endif
+        endif
+        ifneq ($$($1_STRIP_SYMBOLS), false)
+	  $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
+        endif
+        ifeq ($$($1_CREATE_DEBUGINFO), true)
+          ifeq ($(call isTargetOs, linux), true)
+            # Run this after strip is called, since strip can sometimes mangle
+            # the embedded debuglink, which we want to avoid.
+	    $(CD) $$($1_SYMBOLS_DIR) && \
+	        $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
+          endif
+        endif
+        ifneq ($(MACOSX_CODESIGN_MODE), disabled)
+          # Remove signature explicitly first to avoid warnings if the linker
+          # added a default adhoc signature.
 	  $(CODESIGN) --remove-signature $$@
-	  $(CODESIGN) -f -s "$(MACOSX_CODESIGN_IDENTITY)" --timestamp \
-	      --options runtime --entitlements \
-	      $$(call GetEntitlementsFile, $$@) $$@
-        else ifeq ($(MACOSX_CODESIGN_MODE), debug)
-	  $(CODESIGN) --remove-signature $$@
-	  $(CODESIGN) -f -s - --entitlements \
+	  $(CODESIGN) -f -s $$($1_CODESIGN_OPTS) --entitlements \
 	      $$(call GetEntitlementsFile, $$@) $$@
         endif
 endef

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -106,13 +106,12 @@ define CreateStaticLibrary
         # Do partial linking.
         ifeq ($$($1_ENABLE_PARTIAL_LINKING), true)
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_partial_link, \
-	    $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
+	      $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	      $$($1_LD) $(LDFLAGS_CXX_PARTIAL_LINKING) $$($1_SYSROOT_LDFLAGS) \
-	        -o $$($1_TARGET_RELOCATABLE) \
-	        $$($1_LD_OBJ_ARG))
+	          -o $$($1_TARGET_RELOCATABLE) $$($1_LD_OBJ_ARG))
         endif
 	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_ar, \
-	  $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
+	    $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	    $$($1_AR) $$(ARFLAGS) -r -cs $$($1_TARGET) \
 	        $$($1_AR_OBJ_ARG) $$($1_RES))
         ifeq ($(STATIC_BUILD), true)
@@ -167,38 +166,38 @@ define CreateDynamicLibraryOrExecutable
             # This cannot be run separately since it updates the original target
             # file.
 	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
-	      $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES))
+	        $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES))
 	    $$(CHMOD) -x $$($1_DEBUGINFO_FILES)
           else ifeq ($(call isTargetOs, aix), true)
             # AIX does not provide the equivalent of objcopy to extract debug
             # symbols, so we copy unstripped library instead.
 	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
-	      $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES))
+	        $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES))
           else ifeq ($(call isTargetOs, macosx), true)
 	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
-	      $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET))
+	        $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET))
           endif
         endif
         ifneq ($$($1_STRIP_SYMBOLS), false)
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_strip, \
-	    $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET))
+	      $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET))
         endif
         ifeq ($$($1_CREATE_DEBUGINFO), true)
           ifeq ($(call isTargetOs, linux), true)
             # Run this after strip is called, since strip can sometimes mangle
             # the embedded debuglink, which we want to avoid.
 	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_add_debuginfo_link, \
-	      $(CD) $$($1_SYMBOLS_DIR) && \
-	          $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET))
+	        $(CD) $$($1_SYMBOLS_DIR) && \
+	            $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET))
           endif
         endif
         ifneq ($(MACOSX_CODESIGN_MODE), disabled)
           # Remove signature explicitly first to avoid warnings if the linker
           # added a default adhoc signature.
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_codesign_clear, \
-	    $(CODESIGN) --remove-signature $$@)
+	      $(CODESIGN) --remove-signature $$@)
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_codesign_add, \
-	    $(CODESIGN) -f -s $$($1_CODESIGN_OPTS) --entitlements \
-	        $$(call GetEntitlementsFile, $$@) $$@)
+	      $(CODESIGN) -f -s $$($1_CODESIGN_OPTS) --entitlements \
+	          $$(call GetEntitlementsFile, $$@) $$@)
         endif
 endef

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -181,7 +181,7 @@ define CreateDynamicLibraryOrExecutable
         endif
         ifneq ($$($1_STRIP_SYMBOLS), false)
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_strip, \
-	    $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
+	    $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET))
         endif
         ifeq ($$($1_CREATE_DEBUGINFO), true)
           ifeq ($(call isTargetOs, linux), true)

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -111,7 +111,7 @@ define CreateStaticLibrary
 	        -o $$($1_TARGET_RELOCATABLE) \
 	        $$($1_LD_OBJ_ARG))
         endif
-	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
+	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_ar, \
 	  $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	    $$($1_AR) $$(ARFLAGS) -r -cs $$($1_TARGET) \
 	        $$($1_AR_OBJ_ARG) $$($1_RES))
@@ -157,7 +157,7 @@ define CreateDynamicLibraryOrExecutable
         endif
 	$$(call LogInfo, Linking $$($1_BASENAME))
 	$$(call MakeDir, $$($1_OUTPUT_DIR) $$($1_SYMBOLS_DIR))
-	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
+	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_ld, \
 	    $$(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	    $$($1_LD) $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) \
 	        $$($1_SYSROOT_LDFLAGS) -o $$($1_TARGET) $$($1_LD_OBJ_ARG) \
@@ -166,32 +166,39 @@ define CreateDynamicLibraryOrExecutable
           ifeq ($(call isTargetOs, linux), true)
             # This cannot be run separately since it updates the original target
             # file.
-	    $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES)
+	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
+	      $$($1_OBJCOPY) --only-keep-debug $$($1_TARGET) $$($1_DEBUGINFO_FILES))
 	    $$(CHMOD) -x $$($1_DEBUGINFO_FILES)
           else ifeq ($(call isTargetOs, aix), true)
             # AIX does not provide the equivalent of objcopy to extract debug
             # symbols, so we copy unstripped library instead.
-	    $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES)
+	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
+	      $(CP) $$($1_TARGET) $$($1_DEBUGINFO_FILES))
           else ifeq ($(call isTargetOs, macosx), true)
-	    $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET)
+	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_create_debuginfo, \
+	      $(DSYMUTIL) --out $$($1_SYMBOLS_DIR)/$$($1_BASENAME).dSYM $$($1_TARGET))
           endif
         endif
         ifneq ($$($1_STRIP_SYMBOLS), false)
-	  $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_strip, \
+	    $$($1_STRIP) $$($1_STRIPFLAGS) $$($1_TARGET)
         endif
         ifeq ($$($1_CREATE_DEBUGINFO), true)
           ifeq ($(call isTargetOs, linux), true)
             # Run this after strip is called, since strip can sometimes mangle
             # the embedded debuglink, which we want to avoid.
-	    $(CD) $$($1_SYMBOLS_DIR) && \
-	        $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET)
+	    $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_add_debuginfo_link, \
+	      $(CD) $$($1_SYMBOLS_DIR) && \
+	          $$($1_OBJCOPY) --add-gnu-debuglink=$$($1_DEBUGINFO_FILES) $$($1_TARGET))
           endif
         endif
         ifneq ($(MACOSX_CODESIGN_MODE), disabled)
           # Remove signature explicitly first to avoid warnings if the linker
           # added a default adhoc signature.
-	  $(CODESIGN) --remove-signature $$@
-	  $(CODESIGN) -f -s $$($1_CODESIGN_OPTS) --entitlements \
-	      $$(call GetEntitlementsFile, $$@) $$@
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_codesign_clear, \
+	    $(CODESIGN) --remove-signature $$@)
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_codesign_add, \
+	    $(CODESIGN) -f -s $$($1_CODESIGN_OPTS) --entitlements \
+	        $$(call GetEntitlementsFile, $$@) $$@)
         endif
 endef

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -52,7 +52,7 @@ define CreateStaticLibraryMicrosoft
         endif
 	$$(call LogInfo, Building static library $$($1_BASENAME))
 	$$(call MakeDir, $$($1_OUTPUT_DIR) $$($1_SYMBOLS_DIR))
-	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
+	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_lib, \
 	    $$($1_LIB) -nologo $$(LIBFLAGS) -out:$$($1_TARGET) \
 	        $$($1_LD_OBJ_ARG) $$($1_RES))
 endef
@@ -98,7 +98,7 @@ define CreateDynamicLibraryOrExecutableMicrosoft
         endif
 	$$(call LogInfo, Linking $$($1_BASENAME))
 	$$(call MakeDir, $$($1_OUTPUT_DIR) $$($1_SYMBOLS_DIR))
-	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_link, \
+	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_ld, \
 	    $$($1_LD) -nologo $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) \
 	        $$($1_SYSROOT_LDFLAGS) -out:$$($1_TARGET) $$($1_LD_OBJ_ARG) \
 	        $$($1_RES) $$($1_LIBS) $$($1_EXTRA_LIBS)) \
@@ -108,8 +108,9 @@ define CreateDynamicLibraryOrExecutableMicrosoft
 	  $$(CHMOD) +x $$($1_TARGET)
         endif
         ifneq ($$($1_MANIFEST), )
-	  $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_manifest, \
+	    $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
 	      -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
-	      -outputresource:$$@;#1
+	      -outputresource:$$@;#1)
         endif
 endef

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -108,8 +108,8 @@ define CreateDynamicLibraryOrExecutableMicrosoft
 	  $$(CHMOD) +x $$($1_TARGET)
         endif
         ifneq ($$($1_MANIFEST), )
-	    $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
-	        -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
-	        -outputresource:$$@;#1
+	  $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
+	      -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
+	      -outputresource:$$@;#1
         endif
 endef

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -108,9 +108,8 @@ define CreateDynamicLibraryOrExecutableMicrosoft
 	  $$(CHMOD) +x $$($1_TARGET)
         endif
         ifneq ($$($1_MANIFEST), )
-	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_manifest, \
-	      $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
-	          -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
-	          -outputresource:$$@;#1)
+	    $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
+	        -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
+	        -outputresource:$$@;#1
         endif
 endef

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -109,8 +109,8 @@ define CreateDynamicLibraryOrExecutableMicrosoft
         endif
         ifneq ($$($1_MANIFEST), )
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_manifest, \
-	    $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
-	      -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
-	      -outputresource:$$@;#1)
+	      $$($1_MT) -nologo -manifest $$($1_MANIFEST) \
+	          -identity:"$$($1_NAME).exe, version=$$($1_MANIFEST_VERSION)" \
+	          -outputresource:$$@;#1)
         endif
 endef


### PR DESCRIPTION
Instead of executing code directly in Link.gmk, we set variables that are then evaluated to get the code we want. This is non-transparent and makes it unnecessarily hard to work with the linking code base. 

This PR also contains some additional code cleanup/fixes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330261](https://bugs.openjdk.org/browse/JDK-8330261): Clean up linking steps (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18783/head:pull/18783` \
`$ git checkout pull/18783`

Update a local copy of the PR: \
`$ git checkout pull/18783` \
`$ git pull https://git.openjdk.org/jdk.git pull/18783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18783`

View PR using the GUI difftool: \
`$ git pr show -t 18783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18783.diff">https://git.openjdk.org/jdk/pull/18783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18783#issuecomment-2056757933)