### PR TITLE
8330262: C2: simplify transfer of GC barrier data from Ideal to Mach nodes

### DIFF
--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -1890,11 +1890,7 @@ MachNode *Matcher::ReduceInst( State *s, int rule, Node *&mem ) {
   }
 
   // Have mach nodes inherit GC barrier data
-  if (leaf->is_LoadStore()) {
-    mach->set_barrier_data(leaf->as_LoadStore()->barrier_data());
-  } else if (leaf->is_Mem()) {
-    mach->set_barrier_data(leaf->as_Mem()->barrier_data());
-  }
+  mach->set_barrier_data(MemNode::barrier_data(leaf));
 
   return ex;
 }


### PR DESCRIPTION
This (trivial?) cleanup reuses `MemNode::barrier_data()` (added recently by [JDK-8322692](https://bugs.openjdk.org/browse/JDK-8322692)) to compute the GC barrier data to be transferred from Ideal nodes to their corresponding Mach nodes in `Matcher::ReduceInst()`.

**Testing:** tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64; release and debug mode).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330262](https://bugs.openjdk.org/browse/JDK-8330262): C2: simplify transfer of GC barrier data from Ideal to Mach nodes (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18784/head:pull/18784` \
`$ git checkout pull/18784`

Update a local copy of the PR: \
`$ git checkout pull/18784` \
`$ git pull https://git.openjdk.org/jdk.git pull/18784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18784`

View PR using the GUI difftool: \
`$ git pr show -t 18784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18784.diff">https://git.openjdk.org/jdk/pull/18784.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18784#issuecomment-2057012151)