### PR TITLE
8330133: libj2pkcs11.so crashes on some pkcs#11 v3.0 libraries

### DIFF
--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -162,7 +162,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
             rv = (C_GetInterface)(NULL, NULL, &interface, 0L);
             // don't use ckAssertReturnValueOK as we want to continue trying
             // C_GetFunctionList() or method named by "getFunctionListStr"
-            if (rv == CKR_OK) {
+            if (rv == CKR_OK && interface != NULL) {
                 goto setModuleData;
             }
         }
@@ -218,7 +218,8 @@ setModuleData:
         p11ThrowIOException(env, "ERROR: No function list ptr found");
         goto cleanup;
     }
-    if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3) {
+    if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3 &&
+            interface != NULL) {
         moduleData->ckFunctionList30Ptr = interface->pFunctionList;
     } else {
         moduleData->ckFunctionList30Ptr = NULL;

--- a/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/unix/native/libj2pkcs11/p11_md.c
@@ -210,9 +210,6 @@ setModuleData:
         }
     } else if (interface != NULL) {
         moduleData->ckFunctionListPtr = interface->pFunctionList;
-        if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3) {
-            moduleData->ckFunctionList30Ptr = interface->pFunctionList;
-        }
     } else {
         // should never happen
         p11ThrowIOException(env, "ERROR: No function list ptr found");

--- a/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
+++ b/src/jdk.crypto.cryptoki/windows/native/libj2pkcs11/p11_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  */
 
 /* Copyright  (c) 2002 Graz University of Technology. All rights reserved.
@@ -186,7 +186,7 @@ JNIEXPORT jobject JNICALL Java_sun_security_pkcs11_wrapper_PKCS11_connect
         if (C_GetInterface != NULL) {
             TRACE0("Connect: Found C_GetInterface func\n");
             rv = (C_GetInterface)(NULL, NULL, &interface, 0);
-            if (ckAssertReturnValueOK(env, rv) == CK_ASSERT_OK) {
+            if (rv == CKR_OK && interface != NULL) {
                 goto setModuleData;
             }
         }
@@ -234,7 +234,8 @@ setModuleData:
         p11ThrowIOException(env, "ERROR: No function list ptr found");
         goto cleanup;
     }
-    if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3) {
+    if (((CK_VERSION *)moduleData->ckFunctionListPtr)->major == 3 &&
+            interface != NULL) {
         moduleData->ckFunctionList30Ptr = interface->pFunctionList;
     } else {
         moduleData->ckFunctionList30Ptr = NULL;


### PR DESCRIPTION
It is reported that some PKCS#11 library/vendor reports major version 3, but doesn't implement the C_GetInterface function and the resulting 'interface' variable value may be NULL and cause unexpected crash later.

This PR would check the 'interface' variable value to be non-NULL.
Reproducing this would require certain 3rd party PKCS#11 library, and thus the noreg-hard label.

Thanks~
FYI, I will be on vacation starting 4/17 and will address the review comments upon return. 
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330133](https://bugs.openjdk.org/browse/JDK-8330133): libj2pkcs11.so crashes on some pkcs#11 v3.0 libraries (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18789/head:pull/18789` \
`$ git checkout pull/18789`

Update a local copy of the PR: \
`$ git checkout pull/18789` \
`$ git pull https://git.openjdk.org/jdk.git pull/18789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18789`

View PR using the GUI difftool: \
`$ git pr show -t 18789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18789.diff">https://git.openjdk.org/jdk/pull/18789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18789#issuecomment-2058022754)