### PR TITLE
8330272: Wrong javadoc for ValueLayout.JAVA_LONG/JAVA_DOUBLE on x86 32bit

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -446,8 +446,7 @@ public sealed interface ValueLayout extends MemoryLayout
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code long},
-     * (platform-dependent) byte alignment set to {@code ADDRESS.byteSize()},
-     * and byte order set to {@link ByteOrder#nativeOrder()}.
+     * byte alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfLong JAVA_LONG = ValueLayouts.OfLongImpl.of(ByteOrder.nativeOrder());
 
@@ -459,8 +458,7 @@ public sealed interface ValueLayout extends MemoryLayout
 
     /**
      * A value layout constant whose size is the same as that of a Java {@code double},
-     * (platform-dependent) byte alignment set to {@code ADDRESS.byteSize()},
-     * and byte order set to {@link ByteOrder#nativeOrder()}.
+     * byte alignment set to 8, and byte order set to {@link ByteOrder#nativeOrder()}.
      */
     OfDouble JAVA_DOUBLE = ValueLayouts.OfDoubleImpl.of(ByteOrder.nativeOrder());
 


### PR DESCRIPTION
This PR proposes to update the javadocs for `ValueLayout.JAVA_LONG` and `ValueLayout.JAVA_DOUBLE` to reflect the changes made in https://bugs.openjdk.org/browse/JDK-8326172  (we forgot to update the docs when that issue was fixed)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8330333](https://bugs.openjdk.org/browse/JDK-8330333) to be approved

### Issues
 * [JDK-8330272](https://bugs.openjdk.org/browse/JDK-8330272): Wrong javadoc for ValueLayout.JAVA_LONG/JAVA_DOUBLE on x86 32bit (**Bug** - P4)
 * [JDK-8330333](https://bugs.openjdk.org/browse/JDK-8330333): Wrong javadoc for ValueLayout.JAVA_LONG/JAVA_DOUBLE on x86 32bit (**CSR**)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18791/head:pull/18791` \
`$ git checkout pull/18791`

Update a local copy of the PR: \
`$ git checkout pull/18791` \
`$ git pull https://git.openjdk.org/jdk.git pull/18791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18791`

View PR using the GUI difftool: \
`$ git pr show -t 18791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18791.diff">https://git.openjdk.org/jdk/pull/18791.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18791#issuecomment-2058396401)