### PR TITLE
8330351: Remove the SHARED_LIBRARY and STATIC_LIBRARY macros

### DIFF
--- a/make/RunTestsPrebuiltSpec.gmk
+++ b/make/RunTestsPrebuiltSpec.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,3 @@ ULIMIT := ulimit
 ifeq ($(OPENJDK_BUILD_OS), windows)
   PATHTOOL := cygpath
 endif
-
-################################################################################
-# Simple macros from spec.gmk.in
-SHARED_LIBRARY=$(LIBRARY_PREFIX)$1$(SHARED_LIBRARY_SUFFIX)

--- a/make/autoconf/spec.gmk.template
+++ b/make/autoconf/spec.gmk.template
@@ -625,13 +625,6 @@ SHARED_LIBRARY_FLAGS := @SHARED_LIBRARY_FLAGS@
 SET_SHARED_LIBRARY_ORIGIN = @SET_SHARED_LIBRARY_ORIGIN@
 SET_EXECUTABLE_ORIGIN = @SET_EXECUTABLE_ORIGIN@
 
-# Different OS:es have different ways of naming shared libraries.
-# The SHARED_LIBRARY and STATIC_LIBRARY macros takes "verify" as and argument and returns:
-#    "libverify.so" or "libverify.dylib" or "verify.dll" depending on platform.
-# (Note absence of := assignment, because we do not want to evaluate the macro body here)
-SHARED_LIBRARY = @SHARED_LIBRARY@
-STATIC_LIBRARY = @STATIC_LIBRARY@
-
 LIBRARY_PREFIX := @LIBRARY_PREFIX@
 SHARED_LIBRARY_SUFFIX := @SHARED_LIBRARY_SUFFIX@
 STATIC_LIBRARY_SUFFIX := @STATIC_LIBRARY_SUFFIX@

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -174,30 +174,24 @@ AC_DEFUN([TOOLCHAIN_SETUP_FILENAME_PATTERNS],
     LIBRARY_PREFIX=
     SHARED_LIBRARY_SUFFIX='.dll'
     STATIC_LIBRARY_SUFFIX='.lib'
-    SHARED_LIBRARY='[$]1.dll'
-    STATIC_LIBRARY='[$]1.lib'
     OBJ_SUFFIX='.obj'
     EXECUTABLE_SUFFIX='.exe'
   else
     LIBRARY_PREFIX=lib
     SHARED_LIBRARY_SUFFIX='.so'
     STATIC_LIBRARY_SUFFIX='.a'
-    SHARED_LIBRARY='lib[$]1.so'
-    STATIC_LIBRARY='lib[$]1.a'
     OBJ_SUFFIX='.o'
     EXECUTABLE_SUFFIX=''
     if test "x$OPENJDK_TARGET_OS" = xmacosx; then
-      # For full static builds, we're overloading the SHARED_LIBRARY
-      # variables in order to limit the amount of changes required.
+      # For full static builds, we're overloading the shared library suffix
+      # in order to limit the amount of changes required.
       # It would be better to remove SHARED and just use LIBRARY and
       # LIBRARY_SUFFIX for libraries that can be built either
       # shared or static and use STATIC_* for libraries that are
       # always built statically.
       if test "x$STATIC_BUILD" = xtrue; then
-        SHARED_LIBRARY='lib[$]1.a'
         SHARED_LIBRARY_SUFFIX='.a'
       else
-        SHARED_LIBRARY='lib[$]1.dylib'
         SHARED_LIBRARY_SUFFIX='.dylib'
       fi
     fi
@@ -206,8 +200,6 @@ AC_DEFUN([TOOLCHAIN_SETUP_FILENAME_PATTERNS],
   AC_SUBST(LIBRARY_PREFIX)
   AC_SUBST(SHARED_LIBRARY_SUFFIX)
   AC_SUBST(STATIC_LIBRARY_SUFFIX)
-  AC_SUBST(SHARED_LIBRARY)
-  AC_SUBST(STATIC_LIBRARY)
   AC_SUBST(OBJ_SUFFIX)
   AC_SUBST(EXECUTABLE_SUFFIX)
 ])

--- a/make/hotspot/test/GtestImage.gmk
+++ b/make/hotspot/test/GtestImage.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ $(foreach v, $(JVM_VARIANTS), \
   $(eval $(call SetupCopyFiles, COPY_GTEST_$v, \
       SRC := $(HOTSPOT_OUTPUTDIR)/variant-$v/libjvm/gtest, \
       DEST := $(TEST_IMAGE_DIR)/hotspot/gtest/$v, \
-      FILES := $(call SHARED_LIBRARY,jvm) gtestLauncher$(EXECUTABLE_SUFFIX), \
+      FILES := $(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX) gtestLauncher$(EXECUTABLE_SUFFIX), \
   )) \
   $(eval TARGETS += $$(COPY_GTEST_$v)) \
 )

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -126,17 +126,18 @@ ifeq ($(call isTargetOsType, unix)+$(STATIC_BUILD), true+false)
   # Create symlinks to libjsig in each JVM variant sub dir
   ifneq ($(STATIC_LIBS), true)
     LIB_OUTPUTDIR := $(call FindLibDirForModule, java.base)
+    LIBJSIG_NAME := $(LIBRARY_PREFIX)jsig$(SHARED_LIBRARY_SUFFIX)
 
     # $1 variant subdir
     define CreateSymlinks
       # Always symlink from libdir/variant/libjsig.so -> ../libjsig.so.
-      $(LIB_OUTPUTDIR)/$1/$(call SHARED_LIBRARY,jsig): \
-          $(LIB_OUTPUTDIR)/$(call SHARED_LIBRARY,jsig)
+      $(LIB_OUTPUTDIR)/$1/$(LIBJSIG_NAME): \
+          $(LIB_OUTPUTDIR)/$(LIBJSIG_NAME)
 		$$(call MakeDir, $$(@D))
 		$(RM) $$@
 		$(LN) -s ../$$(@F) $$@
 
-      TARGETS += $(LIB_OUTPUTDIR)/$1/$(call SHARED_LIBRARY,jsig)
+      TARGETS += $(LIB_OUTPUTDIR)/$1/$(LIBJSIG_NAME)
     endef
 
     # The subdir is the same as the variant


### PR DESCRIPTION
The macros SHARED_LIBRARY and STATIC_LIBRARY are weird (they do not fit in with naming and placement of other macros), and almost never used. We should just get rid of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330351](https://bugs.openjdk.org/browse/JDK-8330351): Remove the SHARED_LIBRARY and STATIC_LIBRARY macros (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18793/head:pull/18793` \
`$ git checkout pull/18793`

Update a local copy of the PR: \
`$ git checkout pull/18793` \
`$ git pull https://git.openjdk.org/jdk.git pull/18793/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18793`

View PR using the GUI difftool: \
`$ git pr show -t 18793`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18793.diff">https://git.openjdk.org/jdk/pull/18793.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18793#issuecomment-2058817876)