### PR TITLE
8329190: (ch) DatagramChannel.receive should throw ClosedChannelException when called on closed channel

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -573,6 +573,7 @@ class DatagramChannelImpl
             throw new IllegalArgumentException("Read-only buffer");
         readLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             SocketAddress sender = null;
             try {
@@ -851,6 +852,7 @@ class DatagramChannelImpl
 
         writeLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             int n;
             boolean completed = false;
@@ -1039,6 +1041,7 @@ class DatagramChannelImpl
 
         readLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             int n = 0;
             try {
@@ -1069,6 +1072,7 @@ class DatagramChannelImpl
 
         readLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             long n = 0;
             try {
@@ -1152,6 +1156,7 @@ class DatagramChannelImpl
 
         writeLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             int n = 0;
             try {
@@ -1182,6 +1187,7 @@ class DatagramChannelImpl
 
         writeLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             long n = 0;
             try {

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -392,6 +392,7 @@ class ServerSocketChannelImpl
 
         acceptLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             try {
                 begin(blocking);

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -955,6 +955,7 @@ class SocketChannelImpl
             try {
                 writeLock.lock();
                 try {
+                    ensureOpen();
                     boolean blocking = isBlocking();
                     boolean connected = false;
                     try {
@@ -1053,6 +1054,7 @@ class SocketChannelImpl
                     if (isConnected())
                         return true;
 
+                    ensureOpen();
                     boolean blocking = isBlocking();
                     boolean connected = false;
                     try {

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -306,6 +306,7 @@ class SinkChannelImpl
 
         writeLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             int n = 0;
             try {
@@ -334,6 +335,7 @@ class SinkChannelImpl
 
         writeLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             long n = 0;
             try {

--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -306,6 +306,7 @@ class SourceChannelImpl
 
         readLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             int n = 0;
             try {
@@ -334,6 +335,7 @@ class SourceChannelImpl
 
         readLock.lock();
         try {
+            ensureOpen();
             boolean blocking = isBlocking();
             long n = 0;
             try {

--- a/test/jdk/java/nio/channels/Channels/ClosedNetworkChannels.java
+++ b/test/jdk/java/nio/channels/Channels/ClosedNetworkChannels.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+ * @bug 8329190
+ * @summary Test that I/O operations on a closed network channel throw ClosedChannelException
+ *    and not AsynchronousCloseException
+ * @run junit ClosedNetworkChannels
+ */
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousCloseException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.DatagramChannel;
+import java.nio.channels.NotYetConnectedException;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClosedNetworkChannels {
+
+    /**
+     * An operation that does not return a result but may throw an exception.
+     */
+    @FunctionalInterface
+    interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    /**
+     * Assert that the given operation throws ClosedChannelException.
+     */
+    private void assertThrowsCCE(ThrowingRunnable op) throws Exception {
+        try {
+            op.run();
+            fail();
+        } catch (AsynchronousCloseException e) {
+            fail(e + " thrown");
+        } catch (ClosedChannelException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Closes the given SocketChannel and checks that I/O ops throw ClosedChannelException.
+     */
+    private void testSocketChannel(SocketChannel sc) throws Exception {
+        sc.close();
+
+        InetAddress lb = InetAddress.getLoopbackAddress();
+        SocketAddress target = new InetSocketAddress(lb, 7777);  // any port will do
+
+        ByteBuffer bb = ByteBuffer.allocate(100);
+        ByteBuffer[] bufs = new ByteBuffer[] { bb };
+
+        assertThrowsCCE(() -> sc.connect(target));
+        assertThrowsCCE(() -> sc.finishConnect());
+        assertThrowsCCE(() -> sc.read(bb));
+        assertThrowsCCE(() -> sc.read(bufs));
+        assertThrowsCCE(() -> sc.read(bufs, 0, 1));
+        assertThrowsCCE(() -> sc.write(bb));
+        assertThrowsCCE(() -> sc.write(bufs));
+        assertThrowsCCE(() -> sc.write(bufs, 0, 1));
+    }
+
+    /**
+     * Test that I/O operations on a closed (but previously unconnected) SocketChannel
+     * throw ClosedChannelException.
+     */
+    @Test
+    void testUnconnectedSocketChannel() throws Exception {
+        SocketChannel sc = SocketChannel.open();
+        testSocketChannel(sc);
+    }
+
+    /**
+     * Test that I/O operations on a closed (but previously connected) SocketChannel
+     * throw ClosedChannelException.
+     */
+    @Test
+    void testConnectedSocketChannel() throws Exception {
+        try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+            ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            try (SocketChannel sc = SocketChannel.open(ssc.getLocalAddress());
+                 SocketChannel peer = ssc.accept()) {
+                testSocketChannel(sc);
+            }
+        }
+    }
+
+    /**
+     * Test that the accept operation on a closed (but previously unbound) ServerSocketChannel
+     * throws ClosedChannelException.
+     */
+    @Test
+    void testUnboundServerSocketChannel() throws Exception {
+        ServerSocketChannel ssc = ServerSocketChannel.open();
+        ssc.close();
+        assertThrowsCCE(() -> ssc.accept());
+    }
+
+    /**
+     * Test that the accept operation on a closed (but previously bound) ServerSocketChannel
+     * throws ClosedChannelException.
+     */
+    @Test
+    void testBoundServerSocketChannel() throws Exception {
+        try (ServerSocketChannel ssc = ServerSocketChannel.open()) {
+            ssc.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            ssc.close();
+            assertThrowsCCE(() -> ssc.accept());
+        }
+    }
+
+    /**
+     * Test that I/O operations on a closed Pipe.SourceChannel and Pipe.SinkChannel
+     * throw ClosedChannelException.
+     */
+    @Test
+    void testSourceAndSinkChannels() throws Exception {
+        Pipe p = Pipe.open();
+        try (Pipe.SourceChannel source = p.source();
+             Pipe.SinkChannel sink = p.sink()) {
+            source.close();
+            sink.close();
+
+            ByteBuffer bb = ByteBuffer.allocate(100);
+            ByteBuffer[] bufs = new ByteBuffer[]{bb};
+
+            assertThrowsCCE(() -> source.read(bb));
+            assertThrowsCCE(() -> source.read(bufs));
+            assertThrowsCCE(() -> source.read(bufs, 0, 1));
+            assertThrowsCCE(() -> sink.write(bb));
+            assertThrowsCCE(() -> sink.write(bufs));
+            assertThrowsCCE(() -> sink.write(bufs, 0, 1));
+        }
+    }
+
+    /**
+     * Closes the given DatagramChannel and checks that I/O ops throw ClosedChannelException.
+     */
+    private void testDatagramChannel(DatagramChannel dc) throws Exception {
+        dc.close();
+
+        InetAddress lb = InetAddress.getLoopbackAddress();
+        SocketAddress target = new InetSocketAddress(lb, 7777);  // any port will do
+
+        ByteBuffer bb = ByteBuffer.allocate(100);
+        ByteBuffer[] bufs = new ByteBuffer[] { bb };
+
+        assertThrowsCCE(() -> dc.send(bb, target));
+        assertThrowsCCE(() -> dc.receive(bb));
+        assertThrowsCCE(() -> dc.read(bb));
+        assertThrowsCCE(() -> dc.read(bufs));
+        assertThrowsCCE(() -> dc.read(bufs, 0, 1));
+        assertThrowsCCE(() -> dc.write(bb));
+        assertThrowsCCE(() -> dc.write(bufs));
+        assertThrowsCCE(() -> dc.write(bufs, 0, 1));
+    }
+
+    /**
+     * Test that I/O operations on a closed (but previously unconnected) DatagramChannel
+     * throw ClosedChannelException.
+     */
+    @Test
+    void testUnconnectedDatagramChannel() throws Exception {
+        DatagramChannel dc = DatagramChannel.open();
+        testDatagramChannel(dc);
+    }
+
+    /**
+     * Test that I/O operations on a closed (but previously connected) DatagramChannel
+     * throw ClosedChannelException.
+     */
+    @Test
+    void testConnectedDatagramChannel() throws Exception {
+        try (DatagramChannel dc = DatagramChannel.open()) {
+            InetAddress lb = InetAddress.getLoopbackAddress();
+            dc.bind(new InetSocketAddress(lb, 0));
+            dc.connect(new InetSocketAddress(lb, 7777));  // any port will do
+            testDatagramChannel(dc);
+        }
+    }
+}


### PR DESCRIPTION
Please oblige and review the following changes (provided by Alan Bateman) which addresses the issue outlined in
JDK-8329190: DatagramChannel.receive should throw ClosedChannelException when called on closed channel 

This ensures that a ClosedChannelException is consistently thrown from DatagramChannel send and receive methods, especially in the context of asynchronous closure and calling thread interruption.

The change is to move the ensureOpen() method call, which checks that a channel has not been closed, to the start of read/write send/receive methods on the DatagramChannel

The regression suites for jdk_nio and jdk_net and the JCK tests for api/java_nio api/java_net have been executed in repeat mode, multiple times, without any observed relevant failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329190](https://bugs.openjdk.org/browse/JDK-8329190): (ch) DatagramChannel.receive should throw ClosedChannelException when called on closed channel (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Contributors
 * Alan Bateman `<alanb@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18796/head:pull/18796` \
`$ git checkout pull/18796`

Update a local copy of the PR: \
`$ git checkout pull/18796` \
`$ git pull https://git.openjdk.org/jdk.git pull/18796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18796`

View PR using the GUI difftool: \
`$ git pr show -t 18796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18796.diff">https://git.openjdk.org/jdk/pull/18796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18796#issuecomment-2058939461)