### PR TITLE
8330280: SharedRuntime::get_resolved_entry should not return c2i entry if the callee is special native intrinsic

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -1489,7 +1489,7 @@ JRT_END
 // return verified_code_entry if interp_only_mode is not set for the current thread;
 // otherwise return c2i entry.
 address SharedRuntime::get_resolved_entry(JavaThread* current, methodHandle callee_method) {
-  if (current->is_interp_only_mode()) {
+  if (current->is_interp_only_mode() && !callee_method->is_special_native_intrinsic()) {
     // In interp_only_mode we need to go to the interpreted entry
     // The c2i won't patch in this mode -- see fixup_callers_callsite
     return callee_method->get_c2i_entry();


### PR DESCRIPTION
In https://github.com/openjdk/jdk/pull/18741 we return c2i entry for threads with interp_only_mode. This can be problematic for method handle intrinsics and continuation intrinsics, which cannot be interpreted. Consequently, we will cascade the c2i entry with an i2c entry and fail the runtime. The solution is to not return c2i entry under such circumstance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330280](https://bugs.openjdk.org/browse/JDK-8330280): SharedRuntime::get_resolved_entry should not return c2i entry if the callee is special native intrinsic (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18799/head:pull/18799` \
`$ git checkout pull/18799`

Update a local copy of the PR: \
`$ git checkout pull/18799` \
`$ git pull https://git.openjdk.org/jdk.git pull/18799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18799`

View PR using the GUI difftool: \
`$ git pr show -t 18799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18799.diff">https://git.openjdk.org/jdk/pull/18799.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18799#issuecomment-2058997279)