### PR TITLE
8330339: G1: Move some public methods to private in G1BlockOffsetTable APIs

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -43,6 +43,30 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
                      p2i(bot_reserved.start()), bot_reserved.byte_size(), p2i(bot_reserved.end()));
 }
 
+void G1BlockOffsetTable::set_offset_array_raw(uint8_t* addr, uint8_t offset) {
+  Atomic::store(addr, offset);
+}
+
+void G1BlockOffsetTable::set_offset_array(uint8_t* addr, uint8_t offset) {
+  check_address(addr, "Block offset table address out of range");
+  set_offset_array_raw(addr, offset);
+}
+
+void G1BlockOffsetTable::set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low) {
+  check_address(addr, "Block offset table address out of range");
+  assert(high >= low, "addresses out of order");
+  size_t offset = pointer_delta(high, low);
+  check_offset(offset, "offset too large");
+  set_offset_array(addr, (uint8_t)offset);
+}
+
+void G1BlockOffsetTable::set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset) {
+  check_address(right, "Right block offset table address out of range");
+  assert(left <= right, "indexes out of order");
+  size_t num_cards = right - left + 1;
+  memset_with_concurrent_readers(left, offset, num_cards);
+}
+
 #ifdef ASSERT
 void G1BlockOffsetTable::check_address(uint8_t* addr, const char* msg) const {
   uint8_t* start_addr = const_cast<uint8_t*>(_offset_base + (uintptr_t(_reserved.start()) >> CardTable::card_shift()));

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -67,10 +67,10 @@ private:
   inline void set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset);
 
   // Mapping from address to object start array entry
-  uint8_t* entry_for_addr(const void* const p) const;
+  inline uint8_t* entry_for_addr(const void* const p) const;
 
   // Mapping from object start array entry to address of first word
-  HeapWord* addr_for_entry(const uint8_t* const p) const;
+  inline HeapWord* addr_for_entry(const uint8_t* const p) const;
 
   void check_address(uint8_t* addr, const char* msg) const NOT_DEBUG_RETURN;
 

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -66,6 +66,12 @@ private:
 
   inline void set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset);
 
+  // Mapping from address to object start array entry
+  uint8_t* entry_for_addr(const void* const p) const;
+
+  // Mapping from object start array entry to address of first word
+  HeapWord* addr_for_entry(const uint8_t* const p) const;
+
   void check_address(uint8_t* addr, const char* msg) const NOT_DEBUG_RETURN;
 
   // Sets the entries corresponding to the cards starting at "start" and ending
@@ -76,6 +82,9 @@ private:
   void update_for_block_work(HeapWord* blk_start, HeapWord* blk_end);
 
   void check_all_cards(uint8_t* left_card, uint8_t* right_card) const NOT_DEBUG_RETURN;
+
+  void verify_offset(uint8_t* card_index, uint8_t upper) const NOT_DEBUG_RETURN;
+  void verify_for_block(HeapWord* blk_start, HeapWord* blk_end) const NOT_DEBUG_RETURN;
 
   static HeapWord* align_up_by_card_size(HeapWord* const addr) {
     return align_up(addr, CardTable::card_size());
@@ -99,21 +108,12 @@ public:
   // in the heap parameter.
   G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* storage);
 
-  // Mapping from address to object start array entry
-  uint8_t* entry_for_addr(const void* const p) const;
-
-  // Mapping from object start array entry to address of first word
-  HeapWord* addr_for_entry(const uint8_t* const p) const;
-
   static bool is_crossing_card_boundary(HeapWord* const obj_start,
                                         HeapWord* const obj_end) {
     HeapWord* cur_card_boundary = align_up_by_card_size(obj_start);
     // strictly greater-than
     return obj_end > cur_card_boundary;
   }
-
-  void verify_offset(uint8_t* card_index, uint8_t upper) const NOT_DEBUG_RETURN;
-  void verify_for_block(HeapWord* blk_start, HeapWord* blk_end) const NOT_DEBUG_RETURN;
 
   // Returns the address of the start of the block reaching into the card containing
   // "addr".

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -54,30 +54,6 @@ uint8_t G1BlockOffsetTable::offset_array(uint8_t* addr) const {
   return Atomic::load(addr);
 }
 
-void G1BlockOffsetTable::set_offset_array_raw(uint8_t* addr, uint8_t offset) {
-  Atomic::store(addr, offset);
-}
-
-void G1BlockOffsetTable::set_offset_array(uint8_t* addr, uint8_t offset) {
-  check_address(addr, "Block offset table address out of range");
-  set_offset_array_raw(addr, offset);
-}
-
-void G1BlockOffsetTable::set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low) {
-  check_address(addr, "Block offset table address out of range");
-  assert(high >= low, "addresses out of order");
-  size_t offset = pointer_delta(high, low);
-  check_offset(offset, "offset too large");
-  set_offset_array(addr, (uint8_t)offset);
-}
-
-void G1BlockOffsetTable::set_offset_array(uint8_t* left, uint8_t* right, uint8_t offset) {
-  check_address(right, "Right block offset table address out of range");
-  assert(left <= right, "indexes out of order");
-  size_t num_cards = right - left + 1;
-  memset_with_concurrent_readers(left, offset, num_cards);
-}
-
 inline uint8_t* G1BlockOffsetTable::entry_for_addr(const void* const p) const {
   assert(_reserved.contains(p),
          "out of bounds access to block offset table");


### PR DESCRIPTION
Hi all,

This patch moves several methods to the `private` part.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330339](https://bugs.openjdk.org/browse/JDK-8330339): G1: Move some public methods to private in G1BlockOffsetTable APIs (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18800/head:pull/18800` \
`$ git checkout pull/18800`

Update a local copy of the PR: \
`$ git checkout pull/18800` \
`$ git pull https://git.openjdk.org/jdk.git pull/18800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18800`

View PR using the GUI difftool: \
`$ git pr show -t 18800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18800.diff">https://git.openjdk.org/jdk/pull/18800.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18800#issuecomment-2059106678)