### PR TITLE
8329805: Deprecate for removal ObjectOutputStream.PutField.write

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectOutputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectOutputStream.java
@@ -1027,7 +1027,7 @@ public class ObjectOutputStream
          *         calling the {@link java.io.ObjectOutputStream#writeFields()}
          *         method.
          */
-        @Deprecated
+        @Deprecated(forRemoval = true, since = "1.4")
         public abstract void write(ObjectOutput out) throws IOException;
     }
 


### PR DESCRIPTION
The method `java.io.ObjectOutputStream.PutField.write` has been deprecated since 1.4 and should be deprecated for removal. The Deprecation annotation is updated to indicate the intention to remov the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8330413](https://bugs.openjdk.org/browse/JDK-8330413) to be approved

### Issues
 * [JDK-8329805](https://bugs.openjdk.org/browse/JDK-8329805): Deprecate for removal ObjectOutputStream.PutField.write (**Bug** - P4)
 * [JDK-8330413](https://bugs.openjdk.org/browse/JDK-8330413): Deprecate for removal java.io.ObjectOutputStream.PutField.write (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18802/head:pull/18802` \
`$ git checkout pull/18802`

Update a local copy of the PR: \
`$ git checkout pull/18802` \
`$ git pull https://git.openjdk.org/jdk.git pull/18802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18802`

View PR using the GUI difftool: \
`$ git pr show -t 18802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18802.diff">https://git.openjdk.org/jdk/pull/18802.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18802#issuecomment-2059814814)