### PR TITLE
8330419: Unused code in ConnectionGraph::specialize_castpp

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -697,10 +697,9 @@ Node* ConnectionGraph::specialize_cmp(Node* base, Node* curr_ctrl) {
 //
 Node* ConnectionGraph::specialize_castpp(Node* castpp, Node* base, Node* current_control) {
   Node* control_successor  = current_control->unique_ctrl_out();
-  Node* minus_one          = _igvn->transform(ConINode::make(-1));
   Node* cmp                = _igvn->transform(specialize_cmp(base, castpp->in(0)));
-  Node* boll               = _igvn->transform(new BoolNode(cmp, BoolTest::ne));
-  IfNode* if_ne            = _igvn->transform(new IfNode(current_control, boll, PROB_MIN, COUNT_UNKNOWN))->as_If();
+  Node* bol                = _igvn->transform(new BoolNode(cmp, BoolTest::ne));
+  IfNode* if_ne            = _igvn->transform(new IfNode(current_control, bol, PROB_MIN, COUNT_UNKNOWN))->as_If();
   Node* not_eq_control     = _igvn->transform(new IfTrueNode(if_ne));
   Node* yes_eq_control     = _igvn->transform(new IfFalseNode(if_ne));
   Node* end_region         = _igvn->transform(new RegionNode(3));
@@ -964,8 +963,8 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
       Node* ncmp = _igvn->transform(cmp->clone());
       ncmp->set_req(1, ophi_input);
       ncmp->set_req(2, other);
-      Node* boll = _igvn->transform(new BoolNode(ncmp, mask));
-      res_phi_input = boll->as_Bool()->as_int_value(_igvn);
+      Node* bol = _igvn->transform(new BoolNode(ncmp, mask));
+      res_phi_input = bol->as_Bool()->as_int_value(_igvn);
     }
 
     res_phi->set_req(i, res_phi_input);


### PR DESCRIPTION
Please review this small code cleanup change.

Noticed that `minus_one` local created in `ConnectionGraph::specialize_castpp` which is introduced by [JDK-8316991](https://bugs.openjdk.org/browse/JDK-8316991) is never used. I think it should be safe to remove this. Also renamed `boll` to `bol` to be consistent in naming with other places where we create a `BoolNode`.

Tersting: tier1 tested on linux-aarch64 (release & fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330419](https://bugs.openjdk.org/browse/JDK-8330419): Unused code in ConnectionGraph::specialize_castpp (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18805/head:pull/18805` \
`$ git checkout pull/18805`

Update a local copy of the PR: \
`$ git checkout pull/18805` \
`$ git pull https://git.openjdk.org/jdk.git pull/18805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18805`

View PR using the GUI difftool: \
`$ git pr show -t 18805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18805.diff">https://git.openjdk.org/jdk/pull/18805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18805#issuecomment-2060098532)