### PR TITLE
8330464: hserr generic events - add entry for the before_exit calls

### DIFF
--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -78,6 +78,7 @@
 #include "runtime/vm_version.hpp"
 #include "sanitizers/leak.hpp"
 #include "utilities/dtrace.hpp"
+#include "utilities/events.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
 #include "utilities/vmError.hpp"
@@ -365,6 +366,8 @@ void before_exit(JavaThread* thread, bool halt) {
   #define BEFORE_EXIT_RUNNING 1
   #define BEFORE_EXIT_DONE    2
   static jint volatile _before_exit_status = BEFORE_EXIT_NOT_RUN;
+
+  Events::log(thread, "Before exit entered");
 
   // Note: don't use a Mutex to guard the entire before_exit(), as
   // JVMTI post_thread_end_event and post_vm_death_event will run native code.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -833,10 +833,10 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
 // Threads::destroy_vm() is normally called from jni_DestroyJavaVM() when
 // the program falls off the end of main(). Another VM exit path is through
-// vm_exit() when
-// there is a serious error in VM. The two shutdown paths are not exactly
-// the same, but they share Shutdown.shutdown() at Java level and before_exit()
-// and VM_Exit op at VM level.
+// vm_exit() when the program calls System.exit() to return a value, or when
+// there is a serious error in VM.
+// These two separate shutdown paths are not exactly the same, but they share
+// Shutdown.shutdown() at Java level and before_exit() and VM_Exit op at VM level.
 //
 // Shutdown sequence:
 //   + Shutdown native memory tracking if it is on

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -833,7 +833,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
 // Threads::destroy_vm() is normally called from jni_DestroyJavaVM() when
 // the program falls off the end of main(). Another VM exit path is through
-// vm_exit() when the program calls System.exit() to return a value or when
+// vm_exit() when
 // there is a serious error in VM. The two shutdown paths are not exactly
 // the same, but they share Shutdown.shutdown() at Java level and before_exit()
 // and VM_Exit op at VM level.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -833,7 +833,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 
 // Threads::destroy_vm() is normally called from jni_DestroyJavaVM() when
 // the program falls off the end of main(). Another VM exit path is through
-// vm_exit() when the program calls System.exit() to return a value, or when
+// vm_exit(), when the program calls System.exit() to return a value, or when
 // there is a serious error in VM.
 // These two separate shutdown paths are not exactly the same, but they share
 // Shutdown.shutdown() at Java level and before_exit() and VM_Exit op at VM level.


### PR DESCRIPTION
We currently miss a hs_err file generic event entry for before_exit calls. Those would be helpful to see clearly that a crash happened in a shutdown phase (we had this case recently and would have liked to have a hserr event log entry showing this more clearly).

Additionally while testing the event I called System.exit(0)  to check the event.
This showed a native backtrace like this 

 Stack: [0x00007f1cfe825000,0x00007f1cfe926000],  sp=0x00007f1cfe924530,  free space=1021k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x8fb21b]  before_exit(JavaThread*, bool)+0x4bb  (java.cpp:376)
V  [libjvm.so+0x9da27c]  JVM_Halt+0x6c  (jvm.cpp:442)
j  java.lang.Shutdown.halt0(I)V+0 java.base@23.0.0.1-internal
j  java.lang.Shutdown.halt(I)V+7 java.base@23.0.0.1-internal
j  java.lang.Shutdown.exit(I)V+16 java.base@23.0.0.1-internal
j  java.lang.Runtime.exit(I)V+14 java.base@23.0.0.1-internal
j  java.lang.System.exit(I)V+4 java.base@23.0.0.1-internal

So the comment in thread.cpp seems to be outdated, Threads::destroy_vm()  is not in the callstack  and vm_exit() is not seen as well in the callstack so probably the comment needs adjustment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330464](https://bugs.openjdk.org/browse/JDK-8330464): hserr generic events - add entry for the before_exit calls (**Enhancement** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18809/head:pull/18809` \
`$ git checkout pull/18809`

Update a local copy of the PR: \
`$ git checkout pull/18809` \
`$ git pull https://git.openjdk.org/jdk.git pull/18809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18809`

View PR using the GUI difftool: \
`$ git pr show -t 18809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18809.diff">https://git.openjdk.org/jdk/pull/18809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18809#issuecomment-2060690438)