### PR TITLE
8330467: NoClassDefFoundError when lambda is in a hidden class

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -176,10 +176,10 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         // If the target class invokes a protected method inherited from a
         // superclass in a different package, or does 'invokespecial', the
         // lambda class has no access to the resolved method, or does
-        // 'invokestatic' on a hidden class. Instead, we need to pass the
-        // live implementation method handle to the proxy class to invoke
-        // directly. (javac prefers to avoid this situation by generating
-        // bridges in the target class)
+        // 'invokestatic' on a hidden class which cannot be resolved by name.
+        // Instead, we need to pass the live implementation method handle to
+        // the proxy class to invoke directly. (javac prefers to avoid this
+        // situation by generating bridges in the target class)
         useImplMethodHandle = (Modifier.isProtected(implInfo.getModifiers()) &&
                                !VerifyAccess.isSamePackage(targetClass, implInfo.getDeclaringClass())) ||
                                implKind == H_INVOKESPECIAL ||

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -175,13 +175,15 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         lambdaClassName = lambdaClassName(targetClass);
         // If the target class invokes a protected method inherited from a
         // superclass in a different package, or does 'invokespecial', the
-        // lambda class has no access to the resolved method. Instead, we need
-        // to pass the live implementation method handle to the proxy class
-        // to invoke directly. (javac prefers to avoid this situation by
-        // generating bridges in the target class)
+        // lambda class has no access to the resolved method, or the
+        // target class is hidden and could not be referenced as constant.
+        // Instead, we need to pass the live implementation method handle
+        // to the proxy class to invoke directly. (javac prefers to avoid
+        // this situation by generating bridges in the target class)
         useImplMethodHandle = (Modifier.isProtected(implInfo.getModifiers()) &&
                                !VerifyAccess.isSamePackage(targetClass, implInfo.getDeclaringClass())) ||
-                               implKind == H_INVOKESPECIAL;
+                               implKind == H_INVOKESPECIAL ||
+                               implInfo.getDeclaringClass().isHidden();
         cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         int parameterCount = factoryType.parameterCount();
         if (parameterCount > 0) {

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -175,15 +175,15 @@ import static jdk.internal.org.objectweb.asm.Opcodes.*;
         lambdaClassName = lambdaClassName(targetClass);
         // If the target class invokes a protected method inherited from a
         // superclass in a different package, or does 'invokespecial', the
-        // lambda class has no access to the resolved method, or the
-        // target class is hidden and could not be referenced as constant.
-        // Instead, we need to pass the live implementation method handle
-        // to the proxy class to invoke directly. (javac prefers to avoid
-        // this situation by generating bridges in the target class)
+        // lambda class has no access to the resolved method, or does
+        // 'invokestatic' on a hidden class. Instead, we need to pass the
+        // live implementation method handle to the proxy class to invoke
+        // directly. (javac prefers to avoid this situation by generating
+        // bridges in the target class)
         useImplMethodHandle = (Modifier.isProtected(implInfo.getModifiers()) &&
                                !VerifyAccess.isSamePackage(targetClass, implInfo.getDeclaringClass())) ||
                                implKind == H_INVOKESPECIAL ||
-                               implInfo.getDeclaringClass().isHidden();
+                               implKind == H_INVOKESTATIC && implClass.isHidden();
         cw = new ClassWriter(ClassWriter.COMPUTE_MAXS);
         int parameterCount = factoryType.parameterCount();
         if (parameterCount > 0) {

--- a/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
@@ -182,7 +182,7 @@ public class BasicTest {
         }
     }
 
-    // Define a hidden class that uses contains lambda implementation
+    // Define a hidden class that uses lambda and contains its implementation
     // This verifies LambdaMetaFactory supports the caller which is a hidden class
     @Test
     public void testHiddenLambda() throws Throwable {

--- a/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/BasicTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8330467
  * @modules jdk.compiler
  * @library /test/lib
  * @enablePreview
@@ -172,6 +173,20 @@ public class BasicTest {
     @Test
     public void testLambda() throws Throwable {
         HiddenTest t = (HiddenTest)defineHiddenClass("Lambda").newInstance();
+        try {
+            t.test();
+        } catch (Error e) {
+            if (!e.getMessage().equals("thrown by " + t.getClass().getName())) {
+                throw e;
+            }
+        }
+    }
+
+    // Define a hidden class that uses contains lambda implementation
+    // This verifies LambdaMetaFactory supports the caller which is a hidden class
+    @Test
+    public void testHiddenLambda() throws Throwable {
+        HiddenTest t = (HiddenTest)defineHiddenClass("HiddenLambda").newInstance();
         try {
             t.test();
         } catch (Error e) {

--- a/test/jdk/java/lang/invoke/defineHiddenClass/src/HiddenLambda.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/src/HiddenLambda.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,9 @@
 
 import java.util.function.Function;
 
-public class Lambda implements HiddenTest {
+public class HiddenLambda implements HiddenTest {
      public void test() {
-         Function<Object, String> f = Object::toString;
+         Function<Object, String> f = o -> o.toString();
          String s = f.apply(this);
          throw new Error("thrown by " + s);
      }

--- a/test/jdk/java/lang/invoke/defineHiddenClass/src/Lambda.java
+++ b/test/jdk/java/lang/invoke/defineHiddenClass/src/Lambda.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
 
 public class Lambda implements HiddenTest {
      public void test() {
-         Function<Object, String> f = Object::toString;
+         Function<Object, String> f = o -> o.toString();
          String s = f.apply(this);
          throw new Error("thrown by " + s);
      }


### PR DESCRIPTION
Current implementation of `LambdaMetafactory` does not allow to use lambdas in hidden classes. Invocation throws `NoClassDefFoundError` instead.

This patch includes lambda implementation in a hidden class under the special handling of `useImplMethodHandle`.
The patch also fixes `j/l/i/defineHiddenClass/BasicTest::testLambda` to correctly cover this test case.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8330467](https://bugs.openjdk.org/browse/JDK-8330467): NoClassDefFoundError when lambda is in a hidden class (**Bug** - P3)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [e8eb1752](https://git.openjdk.org/jdk/pull/18810/files/e8eb17523db585805dec6e5ea3d3aeb949cb6c9c)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**) ⚠️ Review applies to [e8eb1752](https://git.openjdk.org/jdk/pull/18810/files/e8eb17523db585805dec6e5ea3d3aeb949cb6c9c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18810/head:pull/18810` \
`$ git checkout pull/18810`

Update a local copy of the PR: \
`$ git checkout pull/18810` \
`$ git pull https://git.openjdk.org/jdk.git pull/18810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18810`

View PR using the GUI difftool: \
`$ git pr show -t 18810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18810.diff">https://git.openjdk.org/jdk/pull/18810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18810#issuecomment-2060741656)