### PR TITLE
8330387: Crash with a different types patterns (primitive vs generic) in instanceof

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -2974,10 +2974,10 @@ public class Lower extends TreeTranslator {
             // preserving the side effects of the value
             VarSymbol dollar_s = new VarSymbol(FINAL | SYNTHETIC,
                     names.fromString("tmp" + tree.pos + this.target.syntheticNameChar()),
-                    tree.expr.type,
+                    types.erasure(tree.expr.type),
                     currentMethodSym);
             JCStatement var = make.at(tree.pos())
-                    .VarDef(dollar_s, instanceOfExpr).setType(dollar_s.type);
+                    .VarDef(dollar_s, instanceOfExpr);
 
             if (types.isUnconditionallyExact(tree.expr.type, tree.pattern.type)) {
                 exactnessCheck = make.Literal(BOOLEAN, 1).setType(syms.booleanType.constType(1));

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfPatternOpWithRecordPatterns.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfPatternOpWithRecordPatterns.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8304487
+ * @bug 8304487 8327683 8330387
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile PrimitiveInstanceOfPatternOpWithRecordPatterns.java
@@ -42,6 +42,7 @@ public class PrimitiveInstanceOfPatternOpWithRecordPatterns {
         assertEquals(true,  unboxingWithObject());
         assertEquals(true,  wideningReferenceConversionUnboxing());
         assertEquals(true,  wideningReferenceConversionUnboxing2());
+        assertEquals(true,  wideningReferenceConversionUnboxing3());
         assertEquals(true,  wideningReferenceConversionUnboxingAndWideningPrimitive());
         assertEquals(true,  unboxingAndWideningPrimitiveExact());
         assertEquals(false, unboxingAndWideningPrimitiveNotExact());
@@ -112,6 +113,11 @@ public class PrimitiveInstanceOfPatternOpWithRecordPatterns {
     public static boolean wideningReferenceConversionUnboxing2() {
         R_generic2<Byte> i = new R_generic2<Byte>(Byte.valueOf((byte) 42));
         return i instanceof R_generic2(byte _);
+    }
+
+    public static boolean wideningReferenceConversionUnboxing3() {
+        R_generic<Integer> i = new R_generic<Integer>(0x1000000);
+        return i instanceof R_generic(float _);
     }
 
     public static boolean wideningReferenceConversionUnboxingAndWideningPrimitive() {

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfPatternOpWithTopLevelPatterns.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfPatternOpWithTopLevelPatterns.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8304487 8325257
+ * @bug 8304487 8325257 8327683 8330387
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile PrimitiveInstanceOfPatternOpWithTopLevelPatterns.java
@@ -44,6 +44,7 @@ public class PrimitiveInstanceOfPatternOpWithTopLevelPatterns {
         assertEquals(true,  unboxingWithObject());
         assertEquals(true,  wideningReferenceConversionUnboxing(42));
         assertEquals(true,  wideningReferenceConversionUnboxing2(Byte.valueOf((byte) 42)));
+        assertEquals(true,  wideningReferenceConversionUnboxing3(0x1000000));
         assertEquals(true,  wideningReferenceConversionUnboxingAndWideningPrimitive(42));
         assertEquals(true,  unboxingAndWideningPrimitiveExact());
         assertEquals(false, unboxingAndWideningPrimitiveNotExact());
@@ -119,6 +120,10 @@ public class PrimitiveInstanceOfPatternOpWithTopLevelPatterns {
 
     public static <T extends Byte> boolean wideningReferenceConversionUnboxing2(T i) {
         return i instanceof byte bb;
+    }
+
+    public static <T extends Integer> boolean wideningReferenceConversionUnboxing3(T i) {
+        return i instanceof float ff;
     }
 
     public static <T extends Integer> boolean wideningReferenceConversionUnboxingAndWideningPrimitive(T i) {

--- a/test/langtools/tools/javac/patterns/PrimitiveInstanceOfTypeComparisonOp.java
+++ b/test/langtools/tools/javac/patterns/PrimitiveInstanceOfTypeComparisonOp.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8304487 8325257
+ * @bug 8304487 8325257 8327683 8330387
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile PrimitiveInstanceOfTypeComparisonOp.java
@@ -44,6 +44,7 @@ public class PrimitiveInstanceOfTypeComparisonOp {
         assertEquals(true,  unboxingWithObject());
         assertEquals(true,  wideningReferenceConversionUnboxing(42));
         assertEquals(true,  wideningReferenceConversionUnboxing2(Byte.valueOf((byte) 42)));
+        assertEquals(true,  wideningReferenceConversionUnboxing3(0x1000000));
         assertEquals(true,  wideningReferenceConversionUnboxingAndWideningPrimitive(42));
         assertEquals(true,  unboxingAndWideningPrimitiveExact());
         assertEquals(false, unboxingAndWideningPrimitiveNotExact());
@@ -119,6 +120,10 @@ public class PrimitiveInstanceOfTypeComparisonOp {
 
     public static <T extends Byte> boolean wideningReferenceConversionUnboxing2(T i) {
         return i instanceof byte;
+    }
+
+    public static <T extends Integer> boolean wideningReferenceConversionUnboxing3(T i) {
+        return i instanceof float;
     }
 
     public static <T extends Integer> boolean wideningReferenceConversionUnboxingAndWideningPrimitive(T i) {

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
@@ -261,4 +261,8 @@ public class PrimitivePatternsSwitchErrors {
             case char c -> c; // Error - not exhaustive and not allowed
         };
     }
+
+    public static <T extends Integer> boolean wideningReferenceConversionUnboxingAndNarrowingPrimitive(T i) {
+        return i instanceof byte b;  // not allowed as a conversion
+    }
 }

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
@@ -29,6 +29,7 @@ PrimitivePatternsSwitchErrors.java:216:18: compiler.err.prob.found.req: (compile
 PrimitivePatternsSwitchErrors.java:248:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Long, char)
 PrimitivePatternsSwitchErrors.java:255:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Long, int)
 PrimitivePatternsSwitchErrors.java:261:18: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: java.lang.Short, char)
+PrimitivePatternsSwitchErrors.java:266:16: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: T, byte)
 PrimitivePatternsSwitchErrors.java:30:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:37:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:44:16: compiler.err.not.exhaustive
@@ -43,4 +44,4 @@ PrimitivePatternsSwitchErrors.java:254:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:260:16: compiler.err.not.exhaustive
 - compiler.note.preview.filename: PrimitivePatternsSwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-43 errors
+44 errors


### PR DESCRIPTION
Prior to this PR those three tests were accepted correctly (and still do). However the conversion after unboxing was unconditionally exact so no further test was generated. The first two cover a widening reference conversion followed by unboxing and the third a widening reference conversion followed by unboxing followed by a widening primitive primitive conversion (which was unconditionally exact, notice `int` to `double`). 

```java
    public static <T extends Integer> boolean wideningReferenceConversionUnboxing(T i) {
        return i instanceof int ii;
    }

    public static <T extends Byte> boolean wideningReferenceConversionUnboxing2(T i) {
        return i instanceof byte bb;
    }

    public static <T extends Integer> boolean wideningReferenceConversionUnboxingAndWideningPrimitive(T i) {
        return i instanceof double ii;
    }
```

What was missing was a widening reference conversion followed by unboxing followed by widening primitive conversion that was not unconditionally exact. `int` to `float` is a widening primitive conversion that is possibly not exact.

```
    public static <T extends Integer> boolean wideningReferenceConversionUnboxing3(T i) {
        return i instanceof float ff;
    }
```

That reveals that the type of the synthetic variable prior to binding needed to be erased to a type. After Lowering:

```
    public static boolean wideningReferenceConversionUnboxing(Integer i) {
        return (let int ii in (let /*synthetic*/ final Integer tmp4646$ = i in tmp4646$ != null) && (let ii = (int)i.intValue(); in true));
    }
    
    public static boolean wideningReferenceConversionUnboxing2(Byte i) {
        return (let byte bb in (let /*synthetic*/ final Byte tmp4776$ = i in tmp4776$ != null) && (let bb = (byte)i.byteValue(); in true));
    }
    
    public static boolean wideningReferenceConversionUnboxing3(Integer i) {
        return (let float ff in (let /*synthetic*/ final Integer tmp4910$ = i in tmp4910$ != null && java.lang.runtime.ExactConversionsSupport.isIntToFloatExact(tmp4910$.intValue())) && (let ff = (float)i.intValue(); in true));
    }
    
    public static boolean wideningReferenceConversionUnboxingAndWideningPrimitive(Integer i) {
        return (let double ii in (let /*synthetic*/ final Integer tmp5064$ = i in tmp5064$ != null) && (let ii = (double)i.intValue(); in true));
    }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330387](https://bugs.openjdk.org/browse/JDK-8330387): Crash with a different types patterns (primitive vs generic) in instanceof (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18811/head:pull/18811` \
`$ git checkout pull/18811`

Update a local copy of the PR: \
`$ git checkout pull/18811` \
`$ git pull https://git.openjdk.org/jdk.git pull/18811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18811`

View PR using the GUI difftool: \
`$ git pr show -t 18811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18811.diff">https://git.openjdk.org/jdk/pull/18811.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18811#issuecomment-2061243006)