### PR TITLE
8330475: Remove unused default value for ModRefBarrierSet::write_ref_array_pre

### DIFF
--- a/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
@@ -61,9 +61,9 @@ public:
 
   // Below length is the # array elements being written
   virtual void write_ref_array_pre(oop* dst, size_t length,
-                                   bool dest_uninitialized = false) {}
+                                   bool dest_uninitialized) {}
   virtual void write_ref_array_pre(narrowOop* dst, size_t length,
-                                   bool dest_uninitialized = false) {}
+                                   bool dest_uninitialized) {}
   // Below count is the # array elements being written, starting
   // at the address "start", which may not necessarily be HeapWord-aligned
   inline void write_ref_array(HeapWord* start, size_t count);


### PR DESCRIPTION
Trivial removing unnecessary code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330475](https://bugs.openjdk.org/browse/JDK-8330475): Remove unused default value for ModRefBarrierSet::write_ref_array_pre (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18812/head:pull/18812` \
`$ git checkout pull/18812`

Update a local copy of the PR: \
`$ git checkout pull/18812` \
`$ git pull https://git.openjdk.org/jdk.git pull/18812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18812`

View PR using the GUI difftool: \
`$ git pr show -t 18812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18812.diff">https://git.openjdk.org/jdk/pull/18812.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18812#issuecomment-2060866102)