### PR TITLE
8330158: C2: Loop strip mining uses ABS with min int

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2352,7 +2352,8 @@ Node* PhaseIdealLoop::exact_limit( IdealLoopTree *loop ) {
   CountedLoopNode *cl = loop->_head->as_CountedLoop();
   assert(cl->is_valid_counted_loop(T_INT), "");
 
-  if (ABS(cl->stride_con()) == 1 ||
+  if (cl->stride_con() == 1 ||
+      cl->stride_con() == -1 ||
       cl->limit()->Opcode() == Op_LoopLimit) {
     // Old code has exact limit (it could be incorrect in case of int overflow).
     // Loop limit is exact with stride == 1. And loop may already have exact limit.
@@ -2962,14 +2963,19 @@ void OuterStripMinedLoopNode::adjust_strip_mined_loop(PhaseIterGVN* igvn) {
   CountedLoopEndNode* inner_cle = inner_cl->loopexit();
 
   int stride = inner_cl->stride_con();
-  jlong scaled_iters_long = ((jlong)LoopStripMiningIter) * ABS(stride);
+  jlong scaled_iters_long = ((jlong)LoopStripMiningIter) * ABS((jlong)stride);
   int scaled_iters = (int)scaled_iters_long;
-  int short_scaled_iters = LoopStripMiningIterShortLoop* ABS(stride);
+  if ((jlong)scaled_iters != scaled_iters_long) {
+    // Remove outer loop and safepoint (too few iterations)
+    remove_outer_loop_and_safepoint(igvn);
+    return;
+  }
+  int short_scaled_iters = LoopStripMiningIterShortLoop * ABS(stride);
   const TypeInt* inner_iv_t = igvn->type(inner_iv_phi)->is_int();
   jlong iter_estimate = (jlong)inner_iv_t->_hi - (jlong)inner_iv_t->_lo;
   assert(iter_estimate > 0, "broken");
-  if ((jlong)scaled_iters != scaled_iters_long || iter_estimate <= short_scaled_iters) {
-    // Remove outer loop and safepoint (too few iterations)
+  if (iter_estimate <= short_scaled_iters) {
+    // Remove outer loop and safepoint: loop executes less than LoopStripMiningIterShortLoop
     remove_outer_loop_and_safepoint(igvn);
     return;
   }

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2963,6 +2963,9 @@ void OuterStripMinedLoopNode::adjust_strip_mined_loop(PhaseIterGVN* igvn) {
   CountedLoopEndNode* inner_cle = inner_cl->loopexit();
 
   int stride = inner_cl->stride_con();
+  // For a min int stride, LoopStripMiningIter * stride overflows the int range for all values of LoopStripMiningIter
+  // except 0 or 1. Those values are handled early on in this method and causes the method to return. So for a min int
+  // stride, the method is guaranteed to return at the next check below.
   jlong scaled_iters_long = ((jlong)LoopStripMiningIter) * ABS((jlong)stride);
   int scaled_iters = (int)scaled_iters_long;
   if ((jlong)scaled_iters != scaled_iters_long) {
@@ -2970,7 +2973,7 @@ void OuterStripMinedLoopNode::adjust_strip_mined_loop(PhaseIterGVN* igvn) {
     remove_outer_loop_and_safepoint(igvn);
     return;
   }
-  int short_scaled_iters = LoopStripMiningIterShortLoop * ABS(stride);
+  jlong short_scaled_iters = LoopStripMiningIterShortLoop * ABS(stride);
   const TypeInt* inner_iv_t = igvn->type(inner_iv_phi)->is_int();
   jlong iter_estimate = (jlong)inner_iv_t->_hi - (jlong)inner_iv_t->_lo;
   assert(iter_estimate > 0, "broken");


### PR DESCRIPTION
This fixes 3 calls to ABS with a min int argument. I think all of them
are harmless:

- in `PhaseIdealLoop::exact_limit()`, I removed the call to ABS. The
  check is for a stride of 1 or -1.
  
- in `OuterStripMinedLoopNode::adjust_strip_mined_loop()`, for the
  computation of `scaled_iters_long`, the stride is passed to `ABS()`
  and then implicitly casted to long. I now cast the stride to long
  before `ABS()`. For a min int stride, `LoopStripMiningIter * stride`
  overflows the int range for all values of `LoopStripMiningIter`
  except 0 or 1. Those values are handled early on in that method. So
  for a min in stride:
  ```
  (jlong)scaled_iters != scaled_iters_long
  ```
  is always true and the method returns early.
  
- in `OuterStripMinedLoopNode::adjust_strip_mined_loop()`, the
  computation of `short_scaled_iters` also calls `ABS()` with the
  stride as argument. But the result of that computation is only used
  if the test for:
  ```
  (jlong)scaled_iters != scaled_iters_long
  ```
  doesn't cause an early return of the method. I reordered statements
  so the `ABS()` calls happens after that test which will cause an early
  return if the stride is min int.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330158](https://bugs.openjdk.org/browse/JDK-8330158): C2: Loop strip mining uses ABS with min int (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [ecd940f3](https://git.openjdk.org/jdk/pull/18813/files/ecd940f38175bf68ba462170d6e7c887a4aac437)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [ecd940f3](https://git.openjdk.org/jdk/pull/18813/files/ecd940f38175bf68ba462170d6e7c887a4aac437)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18813/head:pull/18813` \
`$ git checkout pull/18813`

Update a local copy of the PR: \
`$ git checkout pull/18813` \
`$ git pull https://git.openjdk.org/jdk.git pull/18813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18813`

View PR using the GUI difftool: \
`$ git pr show -t 18813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18813.diff">https://git.openjdk.org/jdk/pull/18813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18813#issuecomment-2060975944)