### PR TITLE
8330520: linux clang build fails in os_linux.cpp with static_assert with no message is a C++17 extension

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2972,7 +2972,7 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
   #define MADV_POPULATE_WRITE MADV_POPULATE_WRITE_value
 #else
   // Sanity-check our assumed default value if we build with a new enough libc.
-  static_assert(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value, "MADV_POPULATE_WRITE != MADV_POPULATE_WRITE_value");
+  STATIC_ASSERT(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value);
 #endif
 
 // Note that the value for MAP_FIXED_NOREPLACE differs between architectures, but all architectures
@@ -2982,7 +2982,7 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
   #define MAP_FIXED_NOREPLACE MAP_FIXED_NOREPLACE_value
 #else
   // Sanity-check our assumed default value if we build with a new enough libc.
-  static_assert(MAP_FIXED_NOREPLACE == MAP_FIXED_NOREPLACE_value, "MAP_FIXED_NOREPLACE != MAP_FIXED_NOREPLACE_value");
+  STATIC_ASSERT(MAP_FIXED_NOREPLACE == MAP_FIXED_NOREPLACE_value);
 #endif
 
 int os::Linux::commit_memory_impl(char* addr, size_t size,

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -2972,7 +2972,7 @@ void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
   #define MADV_POPULATE_WRITE MADV_POPULATE_WRITE_value
 #else
   // Sanity-check our assumed default value if we build with a new enough libc.
-  static_assert(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value);
+  static_assert(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value, "MADV_POPULATE_WRITE != MADV_POPULATE_WRITE_value");
 #endif
 
 // Note that the value for MAP_FIXED_NOREPLACE differs between architectures, but all architectures


### PR DESCRIPTION
We run into the following build error when compiling on Linux ppc64le with the clang toolchain

```
jdk/src/hotspot/os/linux/os_linux.cpp:2975:65: error: 'static_assert' with no message is a C++17 extension [-Werror,-Wc++17-extensions]
static_assert(MADV_POPULATE_WRITE == MADV_POPULATE_WRITE_value);
```

Currently it is not clear when "8314488: Compile the JDK as C++17" will be in the codebase so better fix the static_assert .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330520](https://bugs.openjdk.org/browse/JDK-8330520): linux clang build fails in os_linux.cpp with static_assert with no message is a C++17 extension (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18816/head:pull/18816` \
`$ git checkout pull/18816`

Update a local copy of the PR: \
`$ git checkout pull/18816` \
`$ git pull https://git.openjdk.org/jdk.git pull/18816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18816`

View PR using the GUI difftool: \
`$ git pr show -t 18816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18816.diff">https://git.openjdk.org/jdk/pull/18816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18816#issuecomment-2061425375)