### PR TITLE
8330388: Remove invokedynamic cache index encoding

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -190,11 +190,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
   } else if (index_size == sizeof(u4)) {
     // assert(EnableInvokeDynamic, "giant index used only for JSR 292");
     ldrw(index, Address(rbcp, bcp_offset));
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    eonw(index, index, zr);  // convert to plain index
   } else if (index_size == sizeof(u1)) {
     load_unsigned_byte(index, Address(rbcp, bcp_offset));
   } else {

--- a/src/hotspot/cpu/arm/interp_masm_arm.cpp
+++ b/src/hotspot/cpu/arm/interp_masm_arm.cpp
@@ -211,11 +211,6 @@ void InterpreterMacroAssembler::get_index_at_bcp(Register index, int bcp_offset,
     orr(index, tmp_reg, AsmOperand(index, lsl, BitsPerByte));
     ldrb(tmp_reg, Address(Rbcp, bcp_offset));
     orr(index, tmp_reg, AsmOperand(index, lsl, BitsPerByte));
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    mvn_32(index, index);  // convert to plain index
   } else if (index_size == sizeof(u1)) {
     ldrb(index, Address(Rbcp, bcp_offset));
   } else {

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -444,8 +444,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register Rdst, int bcp_of
     } else {
       lwa(Rdst, bcp_offset, R14_bcp);
     }
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    nand(Rdst, Rdst, Rdst); // convert to plain index
   } else if (index_size == sizeof(u1)) {
     lbz(Rdst, bcp_offset, R14_bcp);
   } else {

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -216,13 +216,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
     }
   } else if (index_size == sizeof(u4)) {
     load_int_misaligned(index, Address(xbcp, bcp_offset), tmp, false);
-
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    xori(index, index, -1);
-    sign_extend(index, index, 32);
   } else if (index_size == sizeof(u1)) {
     load_unsigned_byte(index, Address(xbcp, bcp_offset));
   } else {

--- a/src/hotspot/cpu/s390/interp_masm_s390.cpp
+++ b/src/hotspot/cpu/s390/interp_masm_s390.cpp
@@ -324,12 +324,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index, int bcp_o
   } else if (index_size == sizeof(u4)) {
 
     load_sized_value(index, param, 4, false);
-
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    not_(index);  // Convert to plain index.
   } else if (index_size == sizeof(u1)) {
     z_llgc(index, param);
   } else {

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -463,11 +463,6 @@ void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,
     load_unsigned_short(index, Address(_bcp_register, bcp_offset));
   } else if (index_size == sizeof(u4)) {
     movl(index, Address(_bcp_register, bcp_offset));
-    // Check if the secondary index definition is still ~x, otherwise
-    // we have to change the following assembler code to calculate the
-    // plain index.
-    assert(ConstantPool::decode_invokedynamic_index(~123) == 123, "else change next line");
-    notl(index);  // convert to plain index
   } else if (index_size == sizeof(u1)) {
     load_unsigned_byte(index, Address(_bcp_register, bcp_offset));
   } else {

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1059,8 +1059,7 @@ JRT_ENTRY(void, Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_
         break;
       }
       case Bytecodes::_invokedynamic: {
-        int indy_index = pool->decode_invokedynamic_index(index);
-        appendix = Handle(current, pool->cache()->set_dynamic_call(info, indy_index));
+        appendix = Handle(current, pool->cache()->set_dynamic_call(info, index));
         break;
       }
       default: fatal("unexpected bytecode for load_appendix_patching_id");

--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -591,7 +591,7 @@ void ClassListParser::resolve_indy_impl(Symbol* class_name_symbol, TRAPS) {
           LinkResolver::resolve_invoke(info,
                                        recv,
                                        pool,
-                                       ConstantPool::encode_invokedynamic_index(indy_index),
+                                       indy_index,
                                        Bytecodes::_invokedynamic, CHECK);
           break;
         }

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -416,7 +416,6 @@ class CompileReplay : public StackObj {
       int pool_index = 0;
 
       if (bytecode.is_invokedynamic()) {
-        index = cp->decode_invokedynamic_index(index);
         cp->cache()->set_dynamic_call(callInfo, index);
 
         appendix = cp->resolved_reference_from_indy(index);

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -470,7 +470,7 @@ ciMethod* ciBytecodeStream::get_method(bool& will_link, ciSignature* *declared_s
 bool ciBytecodeStream::has_appendix() {
   VM_ENTRY_MARK;
   constantPoolHandle cpool(THREAD, _method->get_Method()->constants());
-  return ConstantPool::has_appendix_at_if_loaded(cpool, get_method_index());
+  return ConstantPool::has_appendix_at_if_loaded(cpool, get_method_index(), cur_bc());
 }
 
 // ------------------------------------------------------------------
@@ -481,7 +481,7 @@ bool ciBytecodeStream::has_appendix() {
 ciObject* ciBytecodeStream::get_appendix() {
   VM_ENTRY_MARK;
   constantPoolHandle cpool(THREAD, _method->get_Method()->constants());
-  oop appendix_oop = ConstantPool::appendix_at_if_loaded(cpool, get_method_index());
+  oop appendix_oop = ConstantPool::appendix_at_if_loaded(cpool, get_method_index(), cur_bc());
   return CURRENT_ENV->get_object(appendix_oop);
 }
 
@@ -493,7 +493,7 @@ ciObject* ciBytecodeStream::get_appendix() {
 bool ciBytecodeStream::has_local_signature() {
   GUARDED_VM_ENTRY(
     constantPoolHandle cpool(Thread::current(), _method->get_Method()->constants());
-    return ConstantPool::has_local_signature_at_if_loaded(cpool, get_method_index());
+    return ConstantPool::has_local_signature_at_if_loaded(cpool, get_method_index(), cur_bc());
   )
 }
 
@@ -543,4 +543,3 @@ int ciBytecodeStream::get_method_signature_index(const constantPoolHandle& cpool
     return cpool->signature_ref_index_at(name_and_type_index);
   )
 }
-

--- a/src/hotspot/share/classfile/resolutionErrors.hpp
+++ b/src/hotspot/share/classfile/resolutionErrors.hpp
@@ -57,7 +57,7 @@ public:
   static const int CPCACHE_INDEX_MANGLE_VALUE = 1000000;
 
   // This function is used to encode an invokedynamic index to differentiate it from a
-  // constant pool index.  It assumes it is being called with a index that is less than 0
+  // constant pool index.
   static int encode_indy_index(int index) {
     return index + CPCACHE_INDEX_MANGLE_VALUE;
   }

--- a/src/hotspot/share/classfile/resolutionErrors.hpp
+++ b/src/hotspot/share/classfile/resolutionErrors.hpp
@@ -59,7 +59,6 @@ public:
   // This function is used to encode an invokedynamic index to differentiate it from a
   // constant pool index.  It assumes it is being called with a index that is less than 0
   static int encode_indy_index(int index) {
-    assert(index < 0, "Unexpected non-negative cpCache index");
     return index + CPCACHE_INDEX_MANGLE_VALUE;
   }
 };

--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -261,7 +261,7 @@ bool AbstractInterpreter::is_not_reached(const methodHandle& method, int bci) {
     switch (code) {
       case Bytecodes::_invokedynamic: {
         assert(invoke_bc.has_index_u4(code), "sanity");
-        int method_index = cpool->decode_invokedynamic_index(invoke_bc.get_index_u4(code));
+        int method_index = invoke_bc.get_index_u4(code);
         return cpool->resolved_indy_entry_at(method_index)->is_resolved();
       }
       case Bytecodes::_invokevirtual:   // fall-through
@@ -394,8 +394,7 @@ address AbstractInterpreter::deopt_continue_after_entry(Method* method, address 
       // (NOT needed for the old calling convention)
       if (!is_top_frame) {
         int index = Bytes::get_native_u4(bcp+1);
-        int indy_index = method->constants()->decode_invokedynamic_index(index);
-        method->constants()->resolved_indy_entry_at(indy_index)->set_num_parameters(callee_parameters);
+        method->constants()->resolved_indy_entry_at(index)->set_num_parameters(callee_parameters);
       }
       break;
     }

--- a/src/hotspot/share/interpreter/bootstrapInfo.cpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.cpp
@@ -74,7 +74,7 @@ bool BootstrapInfo::resolve_previously_linked_invokedynamic(CallInfo& result, TR
     Exceptions::wrap_dynamic_exception(/* is_indy */ true, CHECK_false);
     return true;
   } else if (indy_entry->resolution_failed()) {
-    int encoded_index = ResolutionErrorTable::encode_indy_index(ConstantPool::encode_invokedynamic_index(_indy_index));
+    int encoded_index = ResolutionErrorTable::encode_indy_index(_indy_index);
     ConstantPool::throw_resolution_error(_pool, encoded_index, CHECK_false); // Doesn't necessarily need to be resolved yet
     return true;
   } else {

--- a/src/hotspot/share/interpreter/bootstrapInfo.hpp
+++ b/src/hotspot/share/interpreter/bootstrapInfo.hpp
@@ -76,7 +76,6 @@ class BootstrapInfo : public StackObj {
   // derived accessors
   InstanceKlass* caller() const         { return _pool->pool_holder(); }
   oop caller_mirror() const             { return caller()->java_mirror(); }
-  int decode_indy_index() const         { return ConstantPool::decode_invokedynamic_index(_indy_index); }
   int bsms_attr_index() const           { return _pool->bootstrap_methods_attribute_index(_bss_index); }
   int bsm_index() const                 { return _pool->bootstrap_method_ref_index_at(_bss_index); }
   //int argc() is eagerly cached in _argc

--- a/src/hotspot/share/interpreter/bytecode.cpp
+++ b/src/hotspot/share/interpreter/bytecode.cpp
@@ -179,7 +179,7 @@ int Bytecode_member_ref::pool_index() const {
 ResolvedIndyEntry* Bytecode_member_ref::resolved_indy_entry() const {
   int index = this->index();
   assert(invoke_code() == Bytecodes::_invokedynamic, "should not call this");
-  return cpcache()->resolved_indy_entry_at(ConstantPool::decode_invokedynamic_index(index));
+  return cpcache()->resolved_indy_entry_at(index);
 }
 
 ResolvedMethodEntry* Bytecode_member_ref::resolved_method_entry() const {

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -555,8 +555,7 @@ void BytecodePrinter::print_attributes(int bci, outputStream* st) {
         int indy_index;
         int cp_index;
         if (is_linked()) {
-          int i = get_native_index_u4();
-          indy_index = ConstantPool::decode_invokedynamic_index(i);
+          indy_index = get_native_index_u4();
           cp_index = constants()->resolved_indy_entry_at(indy_index)->constant_pool_index();
         } else {
           indy_index = -1;

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -959,7 +959,7 @@ void InterpreterRuntime::resolve_invokedynamic(JavaThread* current) {
                                  index, bytecode, CHECK);
   } // end JvmtiHideSingleStepping
 
-  pool->cache()->set_dynamic_call(info, pool->decode_invokedynamic_index(index));
+  pool->cache()->set_dynamic_call(info, index);
 }
 
 // This function is the interface to the assembly code. It returns the resolved

--- a/src/hotspot/share/interpreter/linkResolver.cpp
+++ b/src/hotspot/share/interpreter/linkResolver.cpp
@@ -1779,11 +1779,10 @@ void LinkResolver::resolve_handle_call(CallInfo& result,
 }
 
 void LinkResolver::resolve_invokedynamic(CallInfo& result, const constantPoolHandle& pool, int indy_index, TRAPS) {
-  int index = pool->decode_invokedynamic_index(indy_index);
-  int pool_index = pool->resolved_indy_entry_at(index)->constant_pool_index();
+  int pool_index = pool->resolved_indy_entry_at(indy_index)->constant_pool_index();
 
   // Resolve the bootstrap specifier (BSM + optional arguments).
-  BootstrapInfo bootstrap_specifier(pool, pool_index, index);
+  BootstrapInfo bootstrap_specifier(pool, pool_index, indy_index);
 
   // Check if CallSite has been bound already or failed already, and short circuit:
   {

--- a/src/hotspot/share/interpreter/rewriter.cpp
+++ b/src/hotspot/share/interpreter/rewriter.cpp
@@ -305,15 +305,14 @@ void Rewriter::rewrite_invokedynamic(address bcp, int offset, bool reverse) {
     // must have a five-byte instruction format.  (Of course, other JVM
     // implementations can use the bytes for other purposes.)
     // Note: We use native_u4 format exclusively for 4-byte indexes.
-    Bytes::put_native_u4(p, ConstantPool::encode_invokedynamic_index(_invokedynamic_index));
+    Bytes::put_native_u4(p, (u2)_invokedynamic_index);
     _invokedynamic_index++;
 
     // Collect invokedynamic information before creating ResolvedInvokeDynamicInfo array
     _initialized_indy_entries.push(ResolvedIndyEntry((u2)resolved_index, (u2)cp_index));
   } else {
     // Should do nothing since we are not patching this bytecode
-    int cache_index = ConstantPool::decode_invokedynamic_index(
-                        Bytes::get_native_u4(p));
+    int cache_index = Bytes::get_native_u4(p);
     int cp_index = _initialized_indy_entries.at(cache_index).constant_pool_index();
     assert(_pool->tag_at(cp_index).is_invoke_dynamic(), "wrong index");
     // zero out 4 bytes

--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2247,7 +2247,7 @@ run:
       }
 
       CASE(_invokedynamic): {
-        u4 index = cp->constant_pool()->decode_invokedynamic_index(Bytes::get_native_u4(pc+1)); // index is originally negative
+        u4 index = Bytes::get_native_u4(pc+1);
         ResolvedIndyEntry* indy_info = cp->resolved_indy_entry_at(index);
         if (!indy_info->is_resolved()) {
           CALL_VM(InterpreterRuntime::resolve_from_cache(THREAD, (Bytecodes::Code)opcode),

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -908,9 +908,9 @@ C2V_VMENTRY_NULL(jobject, lookupKlassInPool, (JNIEnv* env, jobject, ARGUMENT_PAI
   return JVMCIENV->get_jobject(result);
 C2V_END
 
-C2V_VMENTRY_NULL(jobject, lookupAppendixInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint which))
+C2V_VMENTRY_NULL(jobject, lookupAppendixInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint which, jint opcode))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
-  oop appendix_oop = ConstantPool::appendix_at_if_loaded(cp, which);
+  oop appendix_oop = ConstantPool::appendix_at_if_loaded(cp, which, Bytecodes::Code(opcode));
   return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(appendix_oop));
 C2V_END
 
@@ -1623,16 +1623,11 @@ C2V_VMENTRY_NULL(jobject, iterateFrames, (JNIEnv* env, jobject compilerToVM, job
   return nullptr;
 C2V_END
 
-C2V_VMENTRY_0(int, decodeIndyIndexToCPIndex, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint encoded_indy_index, jboolean resolve))
-  if (!ConstantPool::is_invokedynamic_index(encoded_indy_index)) {
-    JVMCI_THROW_MSG_0(IllegalStateException, err_msg("not an encoded indy index %d", encoded_indy_index));
-  }
-
+C2V_VMENTRY_0(int, decodeIndyIndexToCPIndex, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint indy_index, jboolean resolve))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   CallInfo callInfo;
-  int indy_index = cp->decode_invokedynamic_index(encoded_indy_index);
   if (resolve) {
-    LinkResolver::resolve_invoke(callInfo, Handle(), cp, encoded_indy_index, Bytecodes::_invokedynamic, CHECK_0);
+    LinkResolver::resolve_invoke(callInfo, Handle(), cp, indy_index, Bytecodes::_invokedynamic, CHECK_0);
     cp->cache()->set_dynamic_call(callInfo, indy_index);
   }
   return cp->resolved_indy_entry_at(indy_index)->constant_pool_index();
@@ -1665,7 +1660,7 @@ C2V_VMENTRY(void, resolveInvokeHandleInPool, (JNIEnv* env, jobject, ARGUMENT_PAI
   }
 C2V_END
 
-C2V_VMENTRY_0(jint, isResolvedInvokeHandleInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
+C2V_VMENTRY_0(jint, isResolvedInvokeHandleInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index, jint opcode))
   constantPoolHandle cp(THREAD, UNPACK_PAIR(ConstantPool, cp));
   ResolvedMethodEntry* entry = cp->cache()->resolved_method_entry_at(index);
   if (entry->is_resolved(Bytecodes::_invokehandle)) {
@@ -1699,8 +1694,8 @@ C2V_VMENTRY_0(jint, isResolvedInvokeHandleInPool, (JNIEnv* env, jobject, ARGUMEN
 
     return Bytecodes::_invokevirtual;
   }
-  if (cp->is_invokedynamic_index(index)) {
-    if (cp->resolved_indy_entry_at(cp->decode_invokedynamic_index(index))->is_resolved()) {
+  if ((Bytecodes::Code)opcode == Bytecodes::_invokedynamic) {
+    if (cp->resolved_indy_entry_at(index)->is_resolved()) {
       return Bytecodes::_invokedynamic;
     }
   }
@@ -3219,7 +3214,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "lookupSignatureInPool",                        CC "(" HS_CONSTANT_POOL2 "II)" STRING,                                                FN_PTR(lookupSignatureInPool)},
   {CC "lookupKlassRefIndexInPool",                    CC "(" HS_CONSTANT_POOL2 "II)I",                                                      FN_PTR(lookupKlassRefIndexInPool)},
   {CC "lookupKlassInPool",                            CC "(" HS_CONSTANT_POOL2 "I)Ljava/lang/Object;",                                      FN_PTR(lookupKlassInPool)},
-  {CC "lookupAppendixInPool",                         CC "(" HS_CONSTANT_POOL2 "I)" OBJECTCONSTANT,                                         FN_PTR(lookupAppendixInPool)},
+  {CC "lookupAppendixInPool",                         CC "(" HS_CONSTANT_POOL2 "II)" OBJECTCONSTANT,                                        FN_PTR(lookupAppendixInPool)},
   {CC "lookupMethodInPool",                           CC "(" HS_CONSTANT_POOL2 "IB" HS_METHOD2 ")" HS_METHOD,                               FN_PTR(lookupMethodInPool)},
   {CC "lookupConstantInPool",                         CC "(" HS_CONSTANT_POOL2 "IZ)" JAVACONSTANT,                                          FN_PTR(lookupConstantInPool)},
   {CC "resolveBootstrapMethod",                       CC "(" HS_CONSTANT_POOL2 "I)[" OBJECT,                                                FN_PTR(resolveBootstrapMethod)},
@@ -3231,7 +3226,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "decodeMethodIndexToCPIndex",                   CC "(" HS_CONSTANT_POOL2 "I)I",                                                       FN_PTR(decodeMethodIndexToCPIndex)},
   {CC "decodeIndyIndexToCPIndex",                     CC "(" HS_CONSTANT_POOL2 "IZ)I",                                                      FN_PTR(decodeIndyIndexToCPIndex)},
   {CC "resolveInvokeHandleInPool",                    CC "(" HS_CONSTANT_POOL2 "I)V",                                                       FN_PTR(resolveInvokeHandleInPool)},
-  {CC "isResolvedInvokeHandleInPool",                 CC "(" HS_CONSTANT_POOL2 "I)I",                                                       FN_PTR(isResolvedInvokeHandleInPool)},
+  {CC "isResolvedInvokeHandleInPool",                 CC "(" HS_CONSTANT_POOL2 "II)I",                                                      FN_PTR(isResolvedInvokeHandleInPool)},
   {CC "resolveMethod",                                CC "(" HS_KLASS2 HS_METHOD2 HS_KLASS2 ")" HS_METHOD,                                  FN_PTR(resolveMethod)},
   {CC "getSignaturePolymorphicHolders",               CC "()[" STRING,                                                                      FN_PTR(getSignaturePolymorphicHolders)},
   {CC "getVtableIndexForInterfaceMethod",             CC "(" HS_KLASS2 HS_METHOD2 ")I",                                                     FN_PTR(getVtableIndexForInterfaceMethod)},

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1856,9 +1856,8 @@ Method* JVMCIRuntime::get_method_by_index_impl(const constantPoolHandle& cpool,
                                                int index, Bytecodes::Code bc,
                                                InstanceKlass* accessor) {
   if (bc == Bytecodes::_invokedynamic) {
-    int indy_index = cpool->decode_invokedynamic_index(index);
-    if (cpool->resolved_indy_entry_at(indy_index)->is_resolved()) {
-      return cpool->resolved_indy_entry_at(indy_index)->method();
+    if (cpool->resolved_indy_entry_at(index)->is_resolved()) {
+      return cpool->resolved_indy_entry_at(index)->method();
     }
 
     return nullptr;

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -652,32 +652,29 @@ Method* ConstantPool::method_at_if_loaded(const constantPoolHandle& cpool,
 }
 
 
-bool ConstantPool::has_appendix_at_if_loaded(const constantPoolHandle& cpool, int which) {
+bool ConstantPool::has_appendix_at_if_loaded(const constantPoolHandle& cpool, int which, Bytecodes::Code code) {
   if (cpool->cache() == nullptr)  return false;  // nothing to load yet
-  if (is_invokedynamic_index(which)) {
-    int indy_index = decode_invokedynamic_index(which);
-    return cpool->resolved_indy_entry_at(indy_index)->has_appendix();
+  if (code == Bytecodes::_invokedynamic) {
+    return cpool->resolved_indy_entry_at(which)->has_appendix();
   } else {
     return cpool->resolved_method_entry_at(which)->has_appendix();
   }
 }
 
-oop ConstantPool::appendix_at_if_loaded(const constantPoolHandle& cpool, int which) {
+oop ConstantPool::appendix_at_if_loaded(const constantPoolHandle& cpool, int which, Bytecodes::Code code) {
   if (cpool->cache() == nullptr)  return nullptr;  // nothing to load yet
-  if (is_invokedynamic_index(which)) {
-    int indy_index = decode_invokedynamic_index(which);
-    return cpool->resolved_reference_from_indy(indy_index);
+  if (code == Bytecodes::_invokedynamic) {
+    return cpool->resolved_reference_from_indy(which);
   } else {
     return cpool->cache()->appendix_if_resolved(which);
   }
 }
 
 
-bool ConstantPool::has_local_signature_at_if_loaded(const constantPoolHandle& cpool, int which) {
+bool ConstantPool::has_local_signature_at_if_loaded(const constantPoolHandle& cpool, int which, Bytecodes::Code code) {
   if (cpool->cache() == nullptr)  return false;  // nothing to load yet
-  if (is_invokedynamic_index(which)) {
-    int indy_index = decode_invokedynamic_index(which);
-    return cpool->resolved_indy_entry_at(indy_index)->has_local_signature();
+  if (code == Bytecodes::_invokedynamic) {
+    return cpool->resolved_indy_entry_at(which)->has_local_signature();
   } else {
     return cpool->resolved_method_entry_at(which)->has_local_signature();
   }
@@ -739,8 +736,6 @@ u2 ConstantPool::uncached_klass_ref_index_at(int cp_index) {
 }
 
 u2 ConstantPool::klass_ref_index_at(int index, Bytecodes::Code code) {
-  guarantee(!ConstantPool::is_invokedynamic_index(index),
-            "an invokedynamic instruction does not have a klass");
   assert(code != Bytecodes::_invokedynamic,
             "an invokedynamic instruction does not have a klass");
   return uncached_klass_ref_index_at(to_cp_index(index, code));

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -248,14 +248,6 @@ class ConstantPool : public Metadata {
   void allocate_resolved_klasses(ClassLoaderData* loader_data, int num_klasses, TRAPS);
   void initialize_unresolved_klasses(ClassLoaderData* loader_data, TRAPS);
 
-  // Invokedynamic indexes.
-  // They must look completely different from normal indexes.
-  // The main reason is that byte swapping is sometimes done on normal indexes.
-  // Finally, it is helpful for debugging to tell the two apart.
-  static bool is_invokedynamic_index(int i) { return (i < 0); }
-  static int  decode_invokedynamic_index(int i) { assert(is_invokedynamic_index(i),  ""); return ~i; }
-  static int  encode_invokedynamic_index(int i) { assert(!is_invokedynamic_index(i), ""); return ~i; }
-
   // Given the per-instruction index of an indy instruction, report the
   // main constant pool entry for its bootstrap specifier.
   // From there, uncached_name/signature_ref_at will get the name/type.
@@ -761,9 +753,9 @@ class ConstantPool : public Metadata {
 
   // Used by compiler to prevent classloading.
   static Method*          method_at_if_loaded      (const constantPoolHandle& this_cp, int which);
-  static bool       has_appendix_at_if_loaded      (const constantPoolHandle& this_cp, int which);
-  static oop            appendix_at_if_loaded      (const constantPoolHandle& this_cp, int which);
-  static bool has_local_signature_at_if_loaded     (const constantPoolHandle& this_cp, int which);
+  static bool       has_appendix_at_if_loaded      (const constantPoolHandle& this_cp, int which, Bytecodes::Code code);
+  static oop            appendix_at_if_loaded      (const constantPoolHandle& this_cp, int which, Bytecodes::Code code);
+  static bool has_local_signature_at_if_loaded     (const constantPoolHandle& this_cp, int which, Bytecodes::Code code);
   static Klass*            klass_at_if_loaded      (const constantPoolHandle& this_cp, int which);
 
   // Routines currently used for annotations (only called by jvm.cpp) but which might be used in the

--- a/src/hotspot/share/oops/constantPool.inline.hpp
+++ b/src/hotspot/share/oops/constantPool.inline.hpp
@@ -69,7 +69,7 @@ inline oop ConstantPool::appendix_if_resolved(int method_index) const {
 }
 
 inline u2 ConstantPool::invokedynamic_bootstrap_ref_index_at(int indy_index) const {
-  return cache()->resolved_indy_entry_at(decode_invokedynamic_index(indy_index))->constant_pool_index();
+  return cache()->resolved_indy_entry_at(indy_index)->constant_pool_index();
 }
 
 inline ResolvedIndyEntry* ConstantPool::resolved_indy_entry_at(int index) {

--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -570,8 +570,7 @@ bool ConstantPoolCache::save_and_throw_indy_exc(
   Symbol* error = PENDING_EXCEPTION->klass()->name();
   Symbol* message = java_lang_Throwable::detail_message(PENDING_EXCEPTION);
 
-  int encoded_index = ResolutionErrorTable::encode_indy_index(
-                          ConstantPool::encode_invokedynamic_index(index));
+  int encoded_index = ResolutionErrorTable::encode_indy_index(index);
   SystemDictionary::add_resolution_error(cpool, encoded_index, error, message);
   resolved_indy_entry_at(index)->set_resolution_failed();
   return true;
@@ -590,8 +589,7 @@ oop ConstantPoolCache::set_dynamic_call(const CallInfo &call_info, int index) {
     // Before we got here, another thread got a LinkageError exception during
     // resolution.  Ignore our success and throw their exception.
     guarantee(index >= 0, "Invalid indy index");
-    int encoded_index = ResolutionErrorTable::encode_indy_index(
-                          ConstantPool::encode_invokedynamic_index(index));
+    int encoded_index = ResolutionErrorTable::encode_indy_index(index);
     JavaThread* THREAD = JavaThread::current(); // For exception macros.
     constantPoolHandle cp(THREAD, constant_pool());
     ConstantPool::throw_resolution_error(cp, encoded_index, THREAD);

--- a/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
+++ b/src/hotspot/share/prims/jvmtiClassFileReconstituter.cpp
@@ -1066,7 +1066,7 @@ void JvmtiClassFileReconstituter::copy_bytecodes(const methodHandle& mh,
         int pool_index;
         if (is_invokedynamic) {
           cpci = Bytes::get_native_u4(bcp+1);
-          pool_index = mh->constants()->resolved_indy_entry_at(mh->constants()->decode_invokedynamic_index(cpci))->constant_pool_index();
+          pool_index = mh->constants()->resolved_indy_entry_at(cpci)->constant_pool_index();
         } else {
           // cache cannot be pre-fetched since some classes won't have it yet
           pool_index = mh->constants()->resolved_method_entry_at(cpci)->constant_pool_index();

--- a/src/hotspot/share/prims/methodComparator.cpp
+++ b/src/hotspot/share/prims/methodComparator.cpp
@@ -120,9 +120,6 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
     int index_old = s_old->get_index_u4();
     int index_new = s_new->get_index_u4();
 
-    int indy_index_old = old_cp->decode_invokedynamic_index(index_old);
-    int indy_index_new = new_cp->decode_invokedynamic_index(index_new);
-
     // Check if the names of classes, field/method names and signatures at these indexes
     // are the same. Indices which are really into constantpool cache (rather than constant
     // pool itself) are accepted by the constantpool query routines below.
@@ -131,8 +128,8 @@ bool MethodComparator::args_same(Bytecodes::Code const c_old,  Bytecodes::Code c
         (old_cp->signature_ref_at(index_old, c_old) != new_cp->signature_ref_at(index_new, c_old)))
       return false;
 
-    int cpi_old = old_cp->cache()->resolved_indy_entry_at(indy_index_old)->constant_pool_index();
-    int cpi_new = new_cp->cache()->resolved_indy_entry_at(indy_index_new)->constant_pool_index();
+    int cpi_old = old_cp->cache()->resolved_indy_entry_at(index_old)->constant_pool_index();
+    int cpi_new = new_cp->cache()->resolved_indy_entry_at(index_new)->constant_pool_index();
     if ((old_cp->uncached_name_ref_at(cpi_old) != new_cp->uncached_name_ref_at(cpi_new)) ||
         (old_cp->uncached_signature_ref_at(cpi_old) != new_cp->uncached_signature_ref_at(cpi_new)))
       return false;

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1883,10 +1883,6 @@ WB_ENTRY(jobjectArray, WB_GetResolvedReferences(JNIEnv* env, jobject wb, jclass 
   return (jobjectArray)JNIHandles::make_local(THREAD, resolved_refs);
 WB_END
 
-WB_ENTRY(jint, WB_ConstantPoolEncodeIndyIndex(JNIEnv* env, jobject wb, jint index))
-  return ConstantPool::encode_invokedynamic_index(index);
-WB_END
-
 WB_ENTRY(jint, WB_getFieldEntriesLength(JNIEnv* env, jobject wb, jclass klass))
   InstanceKlass* ik = InstanceKlass::cast(java_lang_Class::as_Klass(JNIHandles::resolve(klass)));
   ConstantPool* cp = ik->constants();
@@ -2844,8 +2840,6 @@ static JNINativeMethod methods[] = {
   {CC"forceClassLoaderStatsSafepoint", CC"()V",       (void*)&WB_ForceClassLoaderStatsSafepoint },
   {CC"getConstantPool0",   CC"(Ljava/lang/Class;)J",  (void*)&WB_GetConstantPool    },
   {CC"getResolvedReferences0", CC"(Ljava/lang/Class;)[Ljava/lang/Object;", (void*)&WB_GetResolvedReferences},
-  {CC"encodeConstantPoolIndyIndex0",
-      CC"(I)I",                      (void*)&WB_ConstantPoolEncodeIndyIndex},
   {CC"getFieldEntriesLength0", CC"(Ljava/lang/Class;)I",  (void*)&WB_getFieldEntriesLength},
   {CC"getFieldCPIndex0",    CC"(Ljava/lang/Class;I)I", (void*)&WB_getFieldCPIndex},
   {CC"getMethodEntriesLength0", CC"(Ljava/lang/Class;)I",  (void*)&WB_getMethodEntriesLength},

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithCPIndex.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/interpreter/BytecodeWithCPIndex.java
@@ -24,8 +24,8 @@
 
 package sun.jvm.hotspot.interpreter;
 
-import sun.jvm.hotspot.oops.*;
-import sun.jvm.hotspot.runtime.*;
+import sun.jvm.hotspot.oops.ConstantPoolCache;
+import sun.jvm.hotspot.oops.Method;
 
 // any bytecode with constant pool index
 
@@ -37,12 +37,7 @@ public abstract class BytecodeWithCPIndex extends Bytecode {
   // the constant pool index for this bytecode
   public int index() {
     if (code() == Bytecodes._invokedynamic) {
-      int index = getIndexU4();
-      if (ConstantPool.isInvokedynamicIndex(index)) {
-        return ConstantPool.decodeInvokedynamicIndex(index);
-      } else {
-        return index;
-      }
+      return getIndexU4();
     } else {
       return getIndexU2(code(), false);
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/ConstantPool.java
@@ -306,18 +306,6 @@ public class ConstantPool extends Metadata implements ClassConstants {
     return getSymbolAt(signatureIndex);
   }
 
-  public static boolean isInvokedynamicIndex(int i) { return (i < 0); }
-
-  public static int  decodeInvokedynamicIndex(int i) { Assert.that(isInvokedynamicIndex(i),  ""); return ~i; }
-
-  // The invokedynamic points at a CP cache entry.  This entry points back
-  // at the original CP entry (CONSTANT_InvokeDynamic) and also (via f2) at an entry
-  // in the resolved_references array (which provides the appendix argument).
-  public int invokedynamicCPCacheIndex(int index) {
-    Assert.that(isInvokedynamicIndex(index), "should be a invokedynamic index");
-    return decodeInvokedynamicIndex(index);
-  }
-
   public int uncachedGetNameAndTypeRefIndexAt(int cp_index) {
     if (getTagAt(cp_index).isInvokeDynamic() || getTagAt(cp_index).isDynamicConstant()) {
       int poolIndex = invokeDynamicNameAndTypeRefIndexAt(cp_index);

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/jcore/ByteCodeRewriter.java
@@ -24,12 +24,16 @@
 
 package sun.jvm.hotspot.tools.jcore;
 
-import sun.jvm.hotspot.oops.*;
-import sun.jvm.hotspot.interpreter.*;
-import sun.jvm.hotspot.utilities.*;
-import sun.jvm.hotspot.runtime.*;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+
+import sun.jvm.hotspot.interpreter.Bytecodes;
+import sun.jvm.hotspot.oops.ConstantPool;
+import sun.jvm.hotspot.oops.ConstantPoolCache;
+import sun.jvm.hotspot.oops.Method;
+import sun.jvm.hotspot.runtime.Bytes;
+import sun.jvm.hotspot.runtime.VM;
+import sun.jvm.hotspot.utilities.Assert;
 
 public class ByteCodeRewriter
 {
@@ -133,8 +137,8 @@ public class ByteCodeRewriter
                 }
 
                 case Bytecodes._invokedynamic: {
-                    int cpci = method.getNativeIntArg(bci + 1);
-                    cpoolIndex = (short) cpCache.getIndyEntryAt(~cpci).getConstantPoolIndex();
+                    int indy_index = method.getNativeIntArg(bci + 1);
+                    cpoolIndex = (short) cpCache.getIndyEntryAt(indy_index).getConstantPoolIndex();
                     writeShort(code, bci + 1, cpoolIndex);
                     writeShort(code, bci + 3, (short)0);  // clear out trailing bytes
                     break;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -23,9 +23,6 @@
 
 package jdk.vm.ci.hotspot;
 
-import static jdk.vm.ci.common.InitTimer.timer;
-import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
-
 import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 
@@ -35,8 +32,10 @@ import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.code.InvalidInstalledCodeException;
 import jdk.vm.ci.code.stack.InspectedFrameVisitor;
 import jdk.vm.ci.common.InitTimer;
+import static jdk.vm.ci.common.InitTimer.timer;
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.Option;
+import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
 import jdk.vm.ci.meta.Constant;
 import jdk.vm.ci.meta.ConstantReflectionProvider;
 import jdk.vm.ci.meta.JavaConstant;
@@ -429,11 +428,10 @@ final class CompilerToVM {
                     long callerMethodPointer);
 
     /**
-     * Converts the encoded indy index operand of an invokedynamic instruction
+     * Converts the indy index operand of an invokedynamic instruction
      * to an index directly into {@code constantPool}.
      *
      * @param resolve if {@true}, then resolve the entry (which may call a bootstrap method)
-     * @throws IllegalArgumentException if {@code encoded_indy_index} is not an encoded indy index
      * @return {@code JVM_CONSTANT_InvokeDynamic} constant pool entry index for the invokedynamic
      */
     int decodeIndyIndexToCPIndex(HotSpotConstantPool constantPool, int encoded_indy_index, boolean resolve) {
@@ -535,11 +533,11 @@ final class CompilerToVM {
      * opcode of the instruction for which the resolution was performed ({@code invokedynamic} or
      * {@code invokevirtual}), or {@code -1} otherwise.
      */
-    int isResolvedInvokeHandleInPool(HotSpotConstantPool constantPool, int cpi) {
-        return isResolvedInvokeHandleInPool(constantPool, constantPool.getConstantPoolPointer(), cpi);
+    int isResolvedInvokeHandleInPool(HotSpotConstantPool constantPool, int cpi, int opcode) {
+        return isResolvedInvokeHandleInPool(constantPool, constantPool.getConstantPoolPointer(), cpi, opcode);
     }
 
-    private native int isResolvedInvokeHandleInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int cpi);
+    private native int isResolvedInvokeHandleInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int cpi, int opcode);
 
     /**
      * Gets the list of type names (in the format of {@link JavaType#getName()}) denoting the
@@ -596,11 +594,11 @@ final class CompilerToVM {
      *              Otherwise, it's treated as a constant pool cache index
      *              for INVOKE{VIRTUAL,SPECIAL,STATIC,INTERFACE}.
      */
-    HotSpotObjectConstantImpl lookupAppendixInPool(HotSpotConstantPool constantPool, int which) {
-        return lookupAppendixInPool(constantPool, constantPool.getConstantPoolPointer(), which);
+    HotSpotObjectConstantImpl lookupAppendixInPool(HotSpotConstantPool constantPool, int which, int opcode) {
+        return lookupAppendixInPool(constantPool, constantPool.getConstantPoolPointer(), which, opcode);
     }
 
-    private native HotSpotObjectConstantImpl lookupAppendixInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int which);
+    private native HotSpotObjectConstantImpl lookupAppendixInPool(HotSpotConstantPool constantPool, long constantPoolPointer, int which, int opcode);
 
     /**
      * Installs the result of a compilation into the code cache.

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -22,19 +22,16 @@
  */
 package jdk.vm.ci.hotspot;
 
-import static jdk.vm.ci.hotspot.CompilerToVM.compilerToVM;
-import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
-import static jdk.vm.ci.hotspot.HotSpotVMConfig.config;
-import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
-
 import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.common.NativeImageReinitialize;
+import static jdk.vm.ci.hotspot.CompilerToVM.compilerToVM;
+import static jdk.vm.ci.hotspot.HotSpotJVMCIRuntime.runtime;
+import static jdk.vm.ci.hotspot.HotSpotVMConfig.config;
+import static jdk.vm.ci.hotspot.UnsafeAccess.UNSAFE;
 import jdk.vm.ci.meta.ConstantPool;
 import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaField;
@@ -257,13 +254,6 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
             holder = compilerToVM().getResolvedJavaType(this, config().constantPoolHolderOffset);
         }
         return holder;
-    }
-
-    /**
-     * See {@code ConstantPool::is_invokedynamic_index}.
-     */
-    private static boolean isInvokedynamicIndex(int index) {
-        return index < 0;
     }
 
     /**
@@ -708,15 +698,7 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
         if (!Bytecodes.isInvoke(opcode)) {
             throw new IllegalArgumentException("expected an invoke bytecode for " + rawIndex + ", got " + opcode);
         }
-
-        if (opcode == Bytecodes.INVOKEDYNAMIC) {
-          if (!isInvokedynamicIndex(rawIndex)) {
-              throw new IllegalArgumentException("expected a raw index for INVOKEDYNAMIC but got " + rawIndex);
-          }
-          return compilerToVM().lookupAppendixInPool(this, rawIndex);
-        } else {
-          return compilerToVM().lookupAppendixInPool(this, rawIndex);
-        }
+        return compilerToVM().lookupAppendixInPool(this, rawIndex, opcode);
     }
 
     /**
@@ -735,15 +717,7 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
 
     @Override
     public JavaMethod lookupMethod(int rawIndex, int opcode, ResolvedJavaMethod caller) {
-        int which; // interpretation depends on opcode
-        if (opcode == Bytecodes.INVOKEDYNAMIC) {
-            if (!isInvokedynamicIndex(rawIndex)) {
-                throw new IllegalArgumentException("expected a raw index for INVOKEDYNAMIC but got " + rawIndex);
-            }
-            which = rawIndex;
-        } else {
-            which = rawIndex;
-        }
+        int which = rawIndex;
         final HotSpotResolvedJavaMethod method = compilerToVM().lookupMethodInPool(this, which, (byte) opcode, (HotSpotResolvedJavaMethodImpl) caller);
         if (method != null) {
             return method;
@@ -853,14 +827,10 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
      * @return constant pool index
      */
     private int indyIndexConstantPoolIndex(int rawIndex, int opcode) {
-        if (isInvokedynamicIndex(rawIndex)) {
-            if (opcode != Bytecodes.INVOKEDYNAMIC) {
-                throw new IllegalArgumentException("expected INVOKEDYNAMIC at " + rawIndex + ", got " + opcode);
-            }
-            return compilerToVM().decodeIndyIndexToCPIndex(this, rawIndex, false);
-        } else {
-          throw new IllegalArgumentException("expected a raw index for INVOKEDYNAMIC but got " + rawIndex);
+        if (opcode != Bytecodes.INVOKEDYNAMIC) {
+            throw new IllegalArgumentException("expected INVOKEDYNAMIC at " + rawIndex + ", got " + opcode);
         }
+        return compilerToVM().decodeIndyIndexToCPIndex(this, rawIndex, false);
     }
 
     @Override
@@ -884,10 +854,6 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
                 cpi = rawIndex;
                 break;
             case Bytecodes.INVOKEDYNAMIC: {
-                // invokedynamic indices are different from constant pool cache indices
-                if (!isInvokedynamicIndex(rawIndex)) {
-                    throw new IllegalArgumentException("must use invokedynamic index but got " + rawIndex);
-                }
                 cpi = compilerToVM().decodeIndyIndexToCPIndex(this, rawIndex, true);
                 break;
             }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotConstantPool.java
@@ -717,18 +717,17 @@ public final class HotSpotConstantPool implements ConstantPool, MetaspaceHandleO
 
     @Override
     public JavaMethod lookupMethod(int rawIndex, int opcode, ResolvedJavaMethod caller) {
-        int which = rawIndex;
-        final HotSpotResolvedJavaMethod method = compilerToVM().lookupMethodInPool(this, which, (byte) opcode, (HotSpotResolvedJavaMethodImpl) caller);
+        final HotSpotResolvedJavaMethod method = compilerToVM().lookupMethodInPool(this, rawIndex, (byte) opcode, (HotSpotResolvedJavaMethodImpl) caller);
         if (method != null) {
             return method;
         } else {
             // Get the method's name and signature.
-            String name = compilerToVM().lookupNameInPool(this, which, opcode);
-            HotSpotSignature signature = new HotSpotSignature(runtime(), compilerToVM().lookupSignatureInPool(this, which, opcode));
+            String name = compilerToVM().lookupNameInPool(this, rawIndex, opcode);
+            HotSpotSignature signature = new HotSpotSignature(runtime(), compilerToVM().lookupSignatureInPool(this, rawIndex, opcode));
             if (opcode == Bytecodes.INVOKEDYNAMIC) {
                 return new UnresolvedJavaMethod(name, signature, runtime().getMethodHandleClass());
             } else {
-                final int klassIndex = getKlassRefIndexAt(which, opcode);
+                final int klassIndex = getKlassRefIndexAt(rawIndex, opcode);
                 final Object type = compilerToVM().lookupKlassInPool(this, klassIndex);
                 return new UnresolvedJavaMethod(name, signature, getJavaType(type));
             }

--- a/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/common/patches/jdk.internal.vm.ci/jdk/vm/ci/hotspot/CompilerToVMHelper.java
@@ -144,8 +144,8 @@ public class CompilerToVMHelper {
     }
 
     public static Object lookupAppendixInPool(
-            ConstantPool constantPool, int cpi) {
-        return CTVM.lookupAppendixInPool((HotSpotConstantPool) constantPool, cpi);
+            ConstantPool constantPool, int cpi, int opcode) {
+        return CTVM.lookupAppendixInPool((HotSpotConstantPool) constantPool, cpi, opcode);
     }
 
     public static int installCode(TargetDescription target,

--- a/test/hotspot/jtreg/compiler/jvmci/compilerToVM/ConstantPoolTestsHelper.java
+++ b/test/hotspot/jtreg/compiler/jvmci/compilerToVM/ConstantPoolTestsHelper.java
@@ -80,7 +80,7 @@ public class ConstantPoolTestsHelper {
             if (constantPoolSS.getTagAt(cpi).equals(Tag.INVOKEDYNAMIC)) {
                 for (int indy_index = 0; indy_index < WB.getIndyInfoLength(this.klass); indy_index++) {
                     if (WB.getIndyCPIndex(this.klass, indy_index) == cpi) {
-                        return ~indy_index;
+                        return indy_index;
                     }
                 }
             }


### PR DESCRIPTION
Before [JDK-8307190](https://bugs.openjdk.org/browse/JDK-8307190), [JDK-8309673](https://bugs.openjdk.org/browse/JDK-8309673), and [JDK-8301995](https://bugs.openjdk.org/browse/JDK-8301995), invokedynamic operands needed to be rewritten to encoded values to better distinguish indy entries from other cp cache entries. The above changes now distinguish between entries with `to_cp_index()` using the bytecode, which is now propagated by the callers.

The encoding flips the bits of the index so the encoded index is always negative, leading to access errors if there is no matching decode call. These calls are removed with some methods adjusted to distinguish between indices with the bytecode. Verified with tier 1-5 tests. The changes show no issues when tested against libgraal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330388](https://bugs.openjdk.org/browse/JDK-8330388): Remove invokedynamic cache index encoding (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [87926aee](https://git.openjdk.org/jdk/pull/18819/files/87926aee8a297c2dbe917baf9f81c8c32568c886)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [87926aee](https://git.openjdk.org/jdk/pull/18819/files/87926aee8a297c2dbe917baf9f81c8c32568c886)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18819/head:pull/18819` \
`$ git checkout pull/18819`

Update a local copy of the PR: \
`$ git checkout pull/18819` \
`$ git pull https://git.openjdk.org/jdk.git pull/18819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18819`

View PR using the GUI difftool: \
`$ git pr show -t 18819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18819.diff">https://git.openjdk.org/jdk/pull/18819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18819#issuecomment-2061993552)