### PR TITLE
8325872: Make GuaranteedSafepointInterval default 0

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3645,6 +3645,11 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
 
   apply_debugger_ergo();
 
+  // The VMThread needs to stop now and then to execute these debug options.
+  if (HandshakeALot && SafepointALot && FLAG_IS_DEFAULT(GuaranteedSafepointInterval)) {
+    FLAG_SET_DEFAULT(GuaranteedSafepointInterval, 1000);
+  }
+
   if (log_is_enabled(Info, arguments)) {
     LogStream st(Log(arguments)::info());
     Arguments::print_on(&st);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3646,7 +3646,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   apply_debugger_ergo();
 
   // The VMThread needs to stop now and then to execute these debug options.
-  if (HandshakeALot && SafepointALot && FLAG_IS_DEFAULT(GuaranteedSafepointInterval)) {
+  if ((HandshakeALot || SafepointALot) && FLAG_IS_DEFAULT(GuaranteedSafepointInterval)) {
     FLAG_SET_DEFAULT(GuaranteedSafepointInterval, 1000);
   }
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -744,9 +744,8 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   product(int, MonitorUsedDeflationThreshold, 90, DIAGNOSTIC,               \
           "Percentage of used monitors before triggering deflation (0 is "  \
-          "off). The check is performed on GuaranteedSafepointInterval, "   \
-          "AsyncDeflationInterval or GuaranteedAsyncDeflationInterval, "    \
-          "whichever is lower.")                                            \
+          "off). The check is performed on AsyncDeflationInterval or "      \
+          "GuaranteedAsyncDeflationInterval, whichever is lower.")          \
           range(0, 100)                                                     \
                                                                             \
   product(uintx, NoAsyncDeflationProgressMax, 3, DIAGNOSTIC,                \
@@ -1277,7 +1276,7 @@ const int ObjectAlignmentInBytes = 8;
                                                                             \
   /* notice: the max range value here is max_jint, not max_intx  */         \
   /* because of overflow issue                                   */         \
-  product(intx, GuaranteedSafepointInterval, 1000, DIAGNOSTIC,              \
+  product(intx, GuaranteedSafepointInterval, 0, DIAGNOSTIC,                 \
           "Guarantee a safepoint (at least) every so many milliseconds "    \
           "(0 means none)")                                                 \
           range(0, max_jint)                                                \

--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -50,11 +50,7 @@ void MonitorDeflationThread::initialize() {
 
 void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAPS) {
 
-  // We wait for the lowest of these three intervals:
-  //  - GuaranteedSafepointInterval
-  //      While deflation is not related to safepoint anymore, this keeps compatibility with
-  //      the old behavior when deflation also happened at safepoints. Users who set this
-  //      option to get more/less frequent deflations would be served with this option.
+  // We wait for the lowest of these two intervals:
   //  - AsyncDeflationInterval
   //      Normal threshold-based deflation heuristic checks the conditions at this interval.
   //      See is_async_deflation_needed().
@@ -63,9 +59,6 @@ void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAP
   //      See is_async_deflation_needed().
   //
   intx wait_time = max_intx;
-  if (GuaranteedSafepointInterval > 0) {
-    wait_time = MIN2(wait_time, GuaranteedSafepointInterval);
-  }
   if (AsyncDeflationInterval > 0) {
     wait_time = MIN2(wait_time, AsyncDeflationInterval);
   }

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -314,14 +314,15 @@ bool VMThread::handshake_or_safepoint_alot() {
   if (!HandshakeALot && !SafepointALot) {
     return false;
   }
-  static jlong last_halot_ms = 0;
+  static jlong last_alot_ms = 0;
   jlong now_ms = nanos_to_millis(os::javaTimeNanos());
-  // If only HandshakeALot is set, but GuaranteedSafepointInterval is 0,
-  // we emit a handshake if it's been more than a second since the last one.
+  // If HandshakeALot or SafepointALot are set, but GuaranteedSafepointInterval is explicitly
+  // set to 0 on the command line, we emit the operation if it's been more than a second
+  // since the last one.
   jlong interval = GuaranteedSafepointInterval != 0 ? GuaranteedSafepointInterval : 1000;
-  jlong deadline_ms = interval + last_halot_ms;
+  jlong deadline_ms = interval + last_alot_ms;
   if (now_ms > deadline_ms) {
-    last_halot_ms = now_ms;
+    last_alot_ms = now_ms;
     return true;
   }
   return false;

--- a/src/hotspot/share/runtime/vmThread.hpp
+++ b/src/hotspot/share/runtime/vmThread.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,8 +70,7 @@ class VMThread: public NamedThread {
 
   static VMOperationTimeoutTask* _timeout_task;
 
-  static bool handshake_alot();
-  static void setup_periodic_safepoint_if_needed();
+  static bool handshake_or_safepoint_alot();
 
   void evaluate_operation(VM_Operation* op);
   void inner_execute(VM_Operation* op);


### PR DESCRIPTION
This change keeps the GuaranteedSafepointInterval option for use with -XX:+HandshakeALot and -XX:+SafepointALot and removes it from working with the MonitorDeflationThread.  The MonitorDeflation thread has it's own timers and doesn't require safepoint to trigger anymore, so the GuaranteedSafepointInterval is logically unrelated except for historical reasons.
The option AsyncDeflationInterval default is 250 so was used anyway in this code for the monitor deflation thread timer.

Tested with tier1-8.  Also performance tested this which didn't show any improvements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325872](https://bugs.openjdk.org/browse/JDK-8325872): Make GuaranteedSafepointInterval default 0 (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [d79b7616](https://git.openjdk.org/jdk/pull/18820/files/d79b7616de034141cb3596488551c9af5c115e91)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [4501dc02](https://git.openjdk.org/jdk/pull/18820/files/4501dc02d10964dba3c94784b70c275a00a1f25e)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [4501dc02](https://git.openjdk.org/jdk/pull/18820/files/4501dc02d10964dba3c94784b70c275a00a1f25e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18820/head:pull/18820` \
`$ git checkout pull/18820`

Update a local copy of the PR: \
`$ git checkout pull/18820` \
`$ git pull https://git.openjdk.org/jdk.git pull/18820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18820`

View PR using the GUI difftool: \
`$ git pr show -t 18820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18820.diff">https://git.openjdk.org/jdk/pull/18820.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18820#issuecomment-2061665195)