### PR TITLE
8330533: JFR: LocalDateTime should not use milliseconds since epoch

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -109,7 +109,11 @@ public final class Repository {
             return LocalDateTime.now();
         } catch (DateTimeException d) {
             Logger.log(LogTag.JFR, LogLevel.INFO, "Could not create LocalDateTime with the default time zone. Using UTC time zone for chunk filename.");
-            return LocalDateTime.ofEpochSecond(System.currentTimeMillis(), 0, ZoneOffset.UTC);
+            long epochMillis = System.currentTimeMillis();
+            long epochSeconds = epochMillis / 1000;
+            int millis = (int) (epochMillis % 1000);
+            int nanos = 1_000_000 * millis;
+            return LocalDateTime.ofEpochSecond(epochSeconds, nanos, ZoneOffset.UTC);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -28,6 +28,7 @@ package jdk.jfr.internal;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.DateTimeException;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.HashSet;
@@ -109,11 +110,7 @@ public final class Repository {
             return LocalDateTime.now();
         } catch (DateTimeException d) {
             Logger.log(LogTag.JFR, LogLevel.INFO, "Could not create LocalDateTime with the default time zone. Using UTC time zone for chunk filename.");
-            long epochMillis = System.currentTimeMillis();
-            long epochSeconds = epochMillis / 1000;
-            int millis = (int) (epochMillis % 1000);
-            int nanos = 1_000_000 * millis;
-            return LocalDateTime.ofEpochSecond(epochSeconds, nanos, ZoneOffset.UTC);
+            return LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Repository.java
@@ -28,7 +28,6 @@ package jdk.jfr.internal;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.DateTimeException;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.HashSet;
@@ -110,7 +109,7 @@ public final class Repository {
             return LocalDateTime.now();
         } catch (DateTimeException d) {
             Logger.log(LogTag.JFR, LogLevel.INFO, "Could not create LocalDateTime with the default time zone. Using UTC time zone for chunk filename.");
-            return LocalDateTime.ofInstant(Instant.now(), ZoneOffset.UTC);
+            return LocalDateTime.now(ZoneOffset.UTC);
         }
     }
 


### PR DESCRIPTION
Could I have a review of a bug fix that changes the parameter passed to LocalDateTime to an Instant.

Testing: jdk/jdk/jfr + manual inspection of -Xlog:jfr to ensure filenames use UTC when an incorrect time zone is used.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330533](https://bugs.openjdk.org/browse/JDK-8330533): JFR: LocalDateTime should not use milliseconds since epoch (**Bug** - P4)


### Reviewers
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18827/head:pull/18827` \
`$ git checkout pull/18827`

Update a local copy of the PR: \
`$ git checkout pull/18827` \
`$ git pull https://git.openjdk.org/jdk.git pull/18827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18827`

View PR using the GUI difftool: \
`$ git pr show -t 18827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18827.diff">https://git.openjdk.org/jdk/pull/18827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18827#issuecomment-2063066281)