### PR TITLE
8311098: Change comment in verificationType.hpp to refer to _sym

### DIFF
--- a/src/hotspot/share/classfile/verificationType.hpp
+++ b/src/hotspot/share/classfile/verificationType.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,10 +49,10 @@ class ClassVerifier;
 
 class VerificationType {
   private:
-    // Least significant bits of _handle are always 0, so we use these as
-    // the indicator that the _handle is valid.  Otherwise, the _data field
+    // Least significant 2 bits of _sym are always 0, so we use these as
+    // the indicator that _sym is a valid pointer.  Otherwise, the _data field
     // contains encoded data (as specified below).  Should the VM change
-    // and the lower bits on oops aren't 0, the assert in the constructor
+    // and the lower 2 bits of Symbol* aren't 0, the assert in the constructor
     // will catch this and we'll have to add a descriminator tag to this
     // structure.
     union {


### PR DESCRIPTION
Please review this trivial comment change.

The related code was changed during PermGen removal. Symbols used to be oops. Now they are metaspace objects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311098](https://bugs.openjdk.org/browse/JDK-8311098): Change comment in verificationType.hpp to refer to _sym (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18830/head:pull/18830` \
`$ git checkout pull/18830`

Update a local copy of the PR: \
`$ git checkout pull/18830` \
`$ git pull https://git.openjdk.org/jdk.git pull/18830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18830`

View PR using the GUI difftool: \
`$ git pr show -t 18830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18830.diff">https://git.openjdk.org/jdk/pull/18830.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18830#issuecomment-2062621240)