### PR TITLE
8322992: Javac fails with StackOverflowError when compiling deeply nested synchronized blocks

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1075,9 +1075,9 @@ public class Gen extends JCTree.Visitor {
 
     public void visitBlock(JCBlock tree) {
         /* this method is heavily invoked, as expected, for deeply nested blocks, if blocks doesn't happen to have
-         * patterns there will be an unnecessary tax on memory consumption for these blocks, for this reason we have
-         * created helper methods and here at a higher level we just discriminate depending on the presence, or not,
-         * of patterns in a given block
+         * patterns there will be an unnecessary tax on memory consumption every time this method is executed, for this
+         * reason we have created helper methods and here at a higher level we just discriminate depending on the
+         * presence, or not, of patterns in a given block
          */
         if (tree.patternMatchingCatch != null) {
             visitBlockWithPatterns(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -1074,6 +1074,11 @@ public class Gen extends JCTree.Visitor {
     }
 
     public void visitBlock(JCBlock tree) {
+        /* this method is heavily invoked, as expected, for deeply nested blocks, if blocks doesn't happen to have
+         * patterns there will be an unnecessary tax on memory consumption for these blocks, for this reason we have
+         * created helper methods and here at a higher level we just discriminate depending on the presence, or not,
+         * of patterns in a given block
+         */
         if (tree.patternMatchingCatch != null) {
             visitBlockWithPatterns(tree);
         } else {

--- a/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
+++ b/test/langtools/tools/javac/patterns/SOEDeeplyNestedBlocksTest.java
@@ -1,0 +1,1187 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8322992
+ * @summary Javac fails with StackOverflowError when compiling deeply nested synchronized blocks
+ * @compile SOEDeeplyNestedBlocksTest.java
+ */
+
+public class SOEDeeplyNestedBlocksTest {
+
+    public static void test() {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        synchronized (SOEDeeplyNestedBlocksTest.class) {
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+        }
+    }
+}


### PR DESCRIPTION
This is a fix to a memory issue but I'm not totally sure we should apply it. Basically the issue here is that javac is failing because of lack of resources for a very deeply nested sequence of blocks. I was tracing the root cause and I found the fix for: [JDK-8291769](https://bugs.openjdk.org/browse/JDK-8291769) to be the one starting from which the stack overflow issue started to happen. Basically method Gen::visitBlock as refactored by fix for [JDK-8291769](https://bugs.openjdk.org/browse/JDK-8291769) occupies more memory than before, at execution time space for local variables is reserved regardless and after the mentioned fix the method has more local variables.

This refactoring proposed here fixes the stack overflow for the reproductor provided in the bug entry but it could be that if we add more nested blocks then we can make the compiler fail at some point. So the merit of this fix is arguable. Still the bug could be valid for the reporter so let's discuss if this fix should be pushed or not.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322992](https://bugs.openjdk.org/browse/JDK-8322992): Javac fails with StackOverflowError when compiling deeply nested synchronized blocks (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [24c7e37c](https://git.openjdk.org/jdk/pull/18832/files/24c7e37c3c6e5d633f9fc3f9112257a4be457272)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18832/head:pull/18832` \
`$ git checkout pull/18832`

Update a local copy of the PR: \
`$ git checkout pull/18832` \
`$ git pull https://git.openjdk.org/jdk.git pull/18832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18832`

View PR using the GUI difftool: \
`$ git pr show -t 18832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18832.diff">https://git.openjdk.org/jdk/pull/18832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18832#issuecomment-2062832095)