### PR TITLE
8321014: RISC-V: C2 VectorLoadShuffle

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -76,6 +76,12 @@ source %{
       case Op_VectorCastHF2F:
       case Op_VectorCastF2HF:
         return UseZvfh;
+      case Op_VectorLoadShuffle:
+      case Op_VectorRearrange:
+        if (vlen < 4) {
+          return false;
+        }
+        break;
       default:
         break;
     }
@@ -3560,6 +3566,42 @@ instruct vmask_reinterpret_diff_esize(vRegMask dst, vRegMask_V0 src, vReg tmp) %
     BasicType to_bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(to_bt, Matcher::vector_length(this));
     __ vmseq_vi(as_VectorRegister($dst$$reg), as_VectorRegister($tmp$$reg), -1);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// ------------------------------ Vector shuffle -------------------------------
+
+instruct loadshuffleB(vReg dst) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_BYTE);
+  match(Set dst (VectorLoadShuffle dst));
+  effect(TEMP_DEF dst);
+  format %{ "loadshuffleB $dst, $dst" %}
+  ins_encode %{
+    // For T_BYTE, no need to do anything
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct loadshuffleX(vReg dst, vReg src) %{
+  predicate(Matcher::vector_element_basic_type(n) == T_DOUBLE ||
+            Matcher::vector_element_basic_type(n) == T_LONG ||
+            Matcher::vector_element_basic_type(n) == T_FLOAT ||
+            Matcher::vector_element_basic_type(n) == T_INT ||
+            Matcher::vector_element_basic_type(n) == T_SHORT);
+  match(Set dst (VectorLoadShuffle src));
+  effect(TEMP_DEF dst);
+  format %{ "loadshuffleX $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    if (bt == T_SHORT) {
+      __ vsext_vf2(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    } else if (bt == T_FLOAT || bt == T_INT) {
+      __ vsext_vf4(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    } else { // bt == T_DOUBLE || bt == T_LONG
+      __ vsext_vf8(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+    }
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Hi,
Can you help to review the patch for instrinsic VectorLoadShuffle?

BTW, without this intrinsic, some other vector api operation does not work as well (e.g. rearrange) on riscv.

Thanks

## Test
test/jdk/jdk/incubator/vector/
test/hotspot/jtreg/compiler/vectorapi
