### PR TITLE
8294880: Review running time of jdk/internal/shellsupport/doc/JavadocHelperTest.java

### DIFF
--- a/test/langtools/TEST.groups
+++ b/test/langtools/TEST.groups
@@ -53,8 +53,7 @@ langtools_jshell_unstable = \
     jdk/jshell/ToolLocaleMessageTest.java \
     jdk/jshell/ToolReloadTest.java \
     jdk/jshell/UserInputTest.java \
-    jdk/jshell/UserJdiUserRemoteTest.java \
-    jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
+    jdk/jshell/UserJdiUserRemoteTest.java
 
 langtools_jdeprscan = \
     tools/all \
@@ -63,6 +62,9 @@ langtools_jdeprscan = \
 langtools_jdeps = \
     tools/all \
     tools/jdeps
+
+langtools_slow = \
+    jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
 
 # All tests
 
@@ -79,11 +81,13 @@ tier1 = \
     :langtools_all \
     lib \
     tools \
-    -:langtools_jshell_unstable
+    -:langtools_jshell_unstable \
+    -:langtools_slow
 
 # (Almost) no langtools tests are tier 2.
 tier2 = \
-    :langtools_jshell_unstable
+    :langtools_jshell_unstable \
+    :langtools_slow
 
 # No langtools tests are tier 3 either.
 tier3 =

--- a/test/langtools/TEST.groups
+++ b/test/langtools/TEST.groups
@@ -1,4 +1,4 @@
-#  Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+#  Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 #  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 #  This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,8 @@ langtools_jshell_unstable = \
     jdk/jshell/ToolLocaleMessageTest.java \
     jdk/jshell/ToolReloadTest.java \
     jdk/jshell/UserInputTest.java \
-    jdk/jshell/UserJdiUserRemoteTest.java
+    jdk/jshell/UserJdiUserRemoteTest.java \
+    jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
 
 langtools_jdeprscan = \
     tools/all \

--- a/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8189778
+ * @summary Test JavadocHelper
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/jdk.internal.shellsupport.doc
+ * @build toolbox.ToolBox toolbox.JarTask toolbox.JavacTask
+ * @run testng/timeout=900/othervm -Xmx1024m FullJavadocHelperTest
+ */
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ModuleElement;
+import javax.lang.model.element.ModuleElement.ExportsDirective;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticListener;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+
+import com.sun.source.util.JavacTask;
+import jdk.internal.shellsupport.doc.JavadocHelper;
+import org.testng.annotations.Test;
+
+@Test
+public class FullJavadocHelperTest {
+
+    /*
+     * Long-running test to retrieve doc comments for enclosed elements of all JDK classes.
+     */
+    public void testAllDocs() throws IOException {
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        DiagnosticListener<? super JavaFileObject> noErrors = d -> {
+            if (d.getKind() == Kind.ERROR) {
+                throw new AssertionError(d.getMessage(null));
+            }
+        };
+
+        List<Path> sources = new ArrayList<>();
+        Path home = Paths.get(System.getProperty("java.home"));
+        Path srcZip = home.resolve("lib").resolve("src.zip");
+        if (Files.isReadable(srcZip)) {
+            URI uri = URI.create("jar:" + srcZip.toUri());
+            try (FileSystem zipFO = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
+                Path root = zipFO.getRootDirectories().iterator().next();
+
+                //modular format:
+                try (DirectoryStream<Path> ds = Files.newDirectoryStream(root)) {
+                    for (Path p : ds) {
+                        if (Files.isDirectory(p)) {
+                            sources.add(p);
+                        }
+                    }
+                }
+                try (StandardJavaFileManager fm =
+                             compiler.getStandardFileManager(null, null, null)) {
+                    JavacTask task =
+                            (JavacTask) compiler.getTask(null, fm, noErrors, null, null, null);
+                    task.getElements().getTypeElement("java.lang.Object");
+                    for (ModuleElement me : task.getElements().getAllModuleElements()) {
+                        List<ExportsDirective> exports =
+                                ElementFilter.exportsIn(me.getDirectives());
+                        for (ExportsDirective ed : exports) {
+                            try (JavadocHelper helper = JavadocHelper.create(task, sources)) {
+                                List<? extends Element> content =
+                                        ed.getPackage().getEnclosedElements();
+                                for (TypeElement clazz : ElementFilter.typesIn(content)) {
+                                    for (Element el : clazz.getEnclosedElements()) {
+                                        helper.getResolvedDocComment(el);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
+++ b/test/langtools/jdk/internal/shellsupport/doc/FullJavadocHelperTest.java
@@ -34,32 +34,7 @@
  */
 
 import java.io.IOException;
-import java.net.URI;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
-
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ModuleElement;
-import javax.lang.model.element.ModuleElement.ExportsDirective;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.ElementFilter;
-import javax.tools.Diagnostic.Kind;
-import javax.tools.DiagnosticListener;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
-import javax.tools.ToolProvider;
-
-import com.sun.source.util.JavacTask;
-import jdk.internal.shellsupport.doc.JavadocHelper;
 import org.testng.annotations.Test;
 
 @Test
@@ -69,51 +44,6 @@ public class FullJavadocHelperTest {
      * Long-running test to retrieve doc comments for enclosed elements of all JDK classes.
      */
     public void testAllDocs() throws IOException {
-        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        DiagnosticListener<? super JavaFileObject> noErrors = d -> {
-            if (d.getKind() == Kind.ERROR) {
-                throw new AssertionError(d.getMessage(null));
-            }
-        };
-
-        List<Path> sources = new ArrayList<>();
-        Path home = Paths.get(System.getProperty("java.home"));
-        Path srcZip = home.resolve("lib").resolve("src.zip");
-        if (Files.isReadable(srcZip)) {
-            URI uri = URI.create("jar:" + srcZip.toUri());
-            try (FileSystem zipFO = FileSystems.newFileSystem(uri, Collections.emptyMap())) {
-                Path root = zipFO.getRootDirectories().iterator().next();
-
-                //modular format:
-                try (DirectoryStream<Path> ds = Files.newDirectoryStream(root)) {
-                    for (Path p : ds) {
-                        if (Files.isDirectory(p)) {
-                            sources.add(p);
-                        }
-                    }
-                }
-                try (StandardJavaFileManager fm =
-                             compiler.getStandardFileManager(null, null, null)) {
-                    JavacTask task =
-                            (JavacTask) compiler.getTask(null, fm, noErrors, null, null, null);
-                    task.getElements().getTypeElement("java.lang.Object");
-                    for (ModuleElement me : task.getElements().getAllModuleElements()) {
-                        List<ExportsDirective> exports =
-                                ElementFilter.exportsIn(me.getDirectives());
-                        for (ExportsDirective ed : exports) {
-                            try (JavadocHelper helper = JavadocHelper.create(task, sources)) {
-                                List<? extends Element> content =
-                                        ed.getPackage().getEnclosedElements();
-                                for (TypeElement clazz : ElementFilter.typesIn(content)) {
-                                    for (Element el : clazz.getEnclosedElements()) {
-                                        helper.getResolvedDocComment(el);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+        new JavadocHelperTest().retrieveDocComments(Boolean.TRUE::booleanValue);
     }
 }


### PR DESCRIPTION
Please review a change to move a long-running shellsupport test from langtools tier1 to tier2, while modifying the tier1 test to only retrieve doc comments for members of `java.lang.StringBuilder`, which is where [the original bug](https://bugs.openjdk.org/browse/JDK-8189778) occurred.  This reduces the running time in the tier1 test from around 90 seconds to 2 seconds on my computer. The tier1 test also adds a non-null check for retrieved doc comments.

I used the existing `langtools_jshell_unstable` test group to add the new test in langtools tier2, which is not a perfect match for the test, but close enough and helps to keep langtools `TEST.groups` file simple.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294880](https://bugs.openjdk.org/browse/JDK-8294880): Review running time of jdk/internal/shellsupport/doc/JavadocHelperTest.java (**Sub-task** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18837/head:pull/18837` \
`$ git checkout pull/18837`

Update a local copy of the PR: \
`$ git checkout pull/18837` \
`$ git pull https://git.openjdk.org/jdk.git pull/18837/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18837`

View PR using the GUI difftool: \
`$ git pr show -t 18837`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18837.diff">https://git.openjdk.org/jdk/pull/18837.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18837#issuecomment-2063730147)