### PR TITLE
8330576: ZYoungCompactionLimit should have range check

### DIFF
--- a/src/hotspot/share/gc/z/z_globals.hpp
+++ b/src/hotspot/share/gc/z/z_globals.hpp
@@ -36,6 +36,7 @@
                                                                             \
   product(double, ZYoungCompactionLimit, 25.0,                              \
           "Maximum allowed garbage in young pages")                         \
+          range(0, 100)                                                     \
                                                                             \
   product(double, ZCollectionIntervalMinor, -1,                             \
           "Force Minor GC at a fixed time interval (in seconds)")           \


### PR DESCRIPTION
Currently any double is allowed for `ZYoungCompactionLimit`. This is wrong for two reasons, it should express the percentage of fragmentation on a page, so only [0,100] would be valid numbers. Moreover, if a user inputs a negative or larger than 100 number the method `ZHeuristics::significant_young_overhead` would return improper values leading to broken heuristics.

This patch adds a range check for `ZYoungCompactionLimit`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330576](https://bugs.openjdk.org/browse/JDK-8330576): ZYoungCompactionLimit should have range check (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18838/head:pull/18838` \
`$ git checkout pull/18838`

Update a local copy of the PR: \
`$ git checkout pull/18838` \
`$ git pull https://git.openjdk.org/jdk.git pull/18838/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18838`

View PR using the GUI difftool: \
`$ git pr show -t 18838`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18838.diff">https://git.openjdk.org/jdk/pull/18838.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18838#issuecomment-2063776449)