### PR TITLE
8330266: RISC-V: Restore frm to RoundingMode::rne after JNI

### DIFF
--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -279,7 +279,7 @@ void DowncallLinker::StubGenerator::generate() {
   Label L_after_reguard;
   if (_needs_transition) {
     // Restore cpu control state after JNI call
-    __ restore_cpu_control_state_after_jni(t0, t1);
+    __ restore_cpu_control_state_after_jni(t0);
 
     __ block_comment("{ thread native2java");
     __ mv(t0, _thread_in_native_trans);

--- a/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/downcallLinker_riscv.cpp
@@ -278,6 +278,9 @@ void DowncallLinker::StubGenerator::generate() {
   Label L_reguard;
   Label L_after_reguard;
   if (_needs_transition) {
+    // Restore cpu control state after JNI call
+    __ restore_cpu_control_state_after_jni(t0, t1);
+
     __ block_comment("{ thread native2java");
     __ mv(t0, _thread_in_native_trans);
     __ sw(t0, Address(xthread, JavaThread::thread_state_offset()));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1167,14 +1167,14 @@ void MacroAssembler::fsflagsi(Register Rd, unsigned imm) {
 
 #undef INSN
 
-void MacroAssembler::restore_cpu_control_state_after_jni(Register tmp1, Register tmp2) {
+void MacroAssembler::restore_cpu_control_state_after_jni(Register tmp) {
   if (RestoreMXCSROnJNICalls) {
     Label skip_fsrmi;
-    frrm(tmp1);
-    mv(tmp2, RoundingMode::rne);
+    frrm(tmp);
     // Set FRM to the state we need. We do want Round to Nearest. We
     // don't want non-IEEE rounding modes.
-    beq(tmp1, tmp2, skip_fsrmi);        // Only reset FRM if it's wrong
+    guarantee(RoundingMode::rne == 0, "must be");
+    beq(tmp, zr, skip_fsrmi);        // Only reset FRM if it's wrong
     fsrmi(RoundingMode::rne);
     bind(skip_fsrmi);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1169,14 +1169,14 @@ void MacroAssembler::fsflagsi(Register Rd, unsigned imm) {
 
 void MacroAssembler::restore_cpu_control_state_after_jni(Register tmp1, Register tmp2) {
   if (RestoreMXCSROnJNICalls) {
-    Label skip_csrw;
+    Label skip_fsrmi;
     frrm(tmp1);
     mv(tmp2, RoundingMode::rne);
     // Set FRM to the state we need. We do want Round to Nearest. We
     // don't want non-IEEE rounding modes.
     beq(tmp1, tmp2, skip_fsrmi);        // Only reset FRM if it's wrong
     fsrmi(RoundingMode::rne);
-    bind(skip_csrw);
+    bind(skip_fsrmi);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1167,6 +1167,19 @@ void MacroAssembler::fsflagsi(Register Rd, unsigned imm) {
 
 #undef INSN
 
+void MacroAssembler::restore_cpu_control_state_after_jni(Register tmp1, Register tmp2) {
+  if (RestoreMXCSROnJNICalls) {
+    Label skip_csrw;
+    frrm(tmp1);
+    mv(tmp2, RoundingMode::rne);
+    // Set FRM to the state we need. We do want Round to Nearest. We
+    // don't want non-IEEE rounding modes.
+    beq(tmp1, tmp2, skip_fsrmi);        // Only reset FRM if it's wrong
+    fsrmi(RoundingMode::rne);
+    bind(skip_csrw);
+  }
+}
+
 void MacroAssembler::push_reg(Register Rs)
 {
   addi(esp, esp, 0 - wordSize);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1171,10 +1171,10 @@ void MacroAssembler::restore_cpu_control_state_after_jni(Register tmp) {
   if (RestoreMXCSROnJNICalls) {
     Label skip_fsrmi;
     frrm(tmp);
-    // Set FRM to the state we need. We do want Round to Nearest. We
-    // don't want non-IEEE rounding modes.
+    // Set FRM to the state we need. We do want Round to Nearest.
+    // We don't want non-IEEE rounding modes.
     guarantee(RoundingMode::rne == 0, "must be");
-    beq(tmp, zr, skip_fsrmi);        // Only reset FRM if it's wrong
+    beqz(tmp, skip_fsrmi);        // Only reset FRM if it's wrong
     fsrmi(RoundingMode::rne);
     bind(skip_fsrmi);
   }

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -582,7 +582,7 @@ class MacroAssembler: public Assembler {
   void fsflagsi(unsigned imm);
 
   // Restore cpu control state after JNI call
-  void restore_cpu_control_state_after_jni();
+  void restore_cpu_control_state_after_jni(Register tmp1, Register tmp2);
 
   // Control transfer pseudo instructions
   void beqz(Register Rs, const address dest);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -581,6 +581,9 @@ class MacroAssembler: public Assembler {
   void fsflagsi(Register Rd, unsigned imm);
   void fsflagsi(unsigned imm);
 
+  // Restore cpu control state after JNI call
+  void restore_cpu_control_state_after_jni();
+
   // Control transfer pseudo instructions
   void beqz(Register Rs, const address dest);
   void bnez(Register Rs, const address dest);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -582,7 +582,7 @@ class MacroAssembler: public Assembler {
   void fsflagsi(unsigned imm);
 
   // Restore cpu control state after JNI call
-  void restore_cpu_control_state_after_jni(Register tmp1, Register tmp2);
+  void restore_cpu_control_state_after_jni(Register tmp);
 
   // Control transfer pseudo instructions
   void beqz(Register Rs, const address dest);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1709,6 +1709,9 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   intptr_t return_pc = (intptr_t) __ pc();
   oop_maps->add_gc_map(return_pc - start, map);
 
+  // Verify or restore cpu control state after JNI call
+  __ restore_cpu_control_state_after_jni(t0, t1);
+
   // Unpack native results.
   if (ret_type != T_OBJECT && ret_type != T_ARRAY) {
     __ cast_primitive_type(ret_type, x10);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1710,7 +1710,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   oop_maps->add_gc_map(return_pc - start, map);
 
   // Verify or restore cpu control state after JNI call
-  __ restore_cpu_control_state_after_jni(t0, t1);
+  __ restore_cpu_control_state_after_jni(t0);
 
   // Unpack native results.
   if (ret_type != T_OBJECT && ret_type != T_ARRAY) {

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1158,7 +1158,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // result potentially in x10 or f10
 
   // Restore cpu control state after JNI call
-  __ restore_cpu_control_state_after_jni(t0, t1);
+  __ restore_cpu_control_state_after_jni(t0);
 
   // make room for the pushes we're about to do
   __ sub(t0, esp, 4 * wordSize);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1157,6 +1157,9 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   __ get_method(xmethod);
   // result potentially in x10 or f10
 
+  // Restore cpu control state after JNI call
+  __ restore_cpu_control_state_after_jni(t0, t1);
+
   // make room for the pushes we're about to do
   __ sub(t0, esp, 4 * wordSize);
   __ andi(sp, t0, -16);


### PR DESCRIPTION
Hi,
Can you help to review this patch?
It's exactly the same as https://github.com/openjdk/jdk/pull/18785 which is withdrawn, the reason could be that I deleted the branch `restore-frm-after-jni` after I `/integrate` the pr, but in fact the deletion happened before it's indeed integrated by github, so it caused the withdraw.
Sorry for the inconvenience.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330266](https://bugs.openjdk.org/browse/JDK-8330266): RISC-V: Restore frm to RoundingMode::rne after JNI (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18839/head:pull/18839` \
`$ git checkout pull/18839`

Update a local copy of the PR: \
`$ git checkout pull/18839` \
`$ git pull https://git.openjdk.org/jdk.git pull/18839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18839`

View PR using the GUI difftool: \
`$ git pr show -t 18839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18839.diff">https://git.openjdk.org/jdk/pull/18839.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18839#issuecomment-2063878941)