### PR TITLE
8330572: jdk.internal.net.http.HttpConnection calls an expensive checkOpen() when returning a HTTP/1.1 connection to the pool

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/HttpConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -409,7 +409,7 @@ abstract class HttpConnection implements Closeable {
                 .map((s) -> !s.equalsIgnoreCase("close"))
                 .orElse(true);
 
-        if (keepAlive && checkOpen()) {
+        if (keepAlive && isOpen()) {
             Log.logTrace("Returning connection to the pool: {0}", this);
             pool.returnToPool(this);
         } else {


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue reported in https://bugs.openjdk.org/browse/JDK-8330572?

As noted in that issue, the internal method `checkOpen()` should only be called when picking a non-TLS HTTP/1.1 connection from the pool and before handing it out. That method should not be called in any other places.

The commit in this PR addresses that by removing the call to `checkOpen()` when the connection is being returned back to the pool. The `checkOpen()` call which does a socket channel read is now replaced with a `isOpen()` call which is just a state check.

Existing tests in tier2 continue to pass with this change. A test repeat of 50 of test/jdk/java/net/httpclient tests too passes without any regressions. No new test has been added given the nature of this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330572](https://bugs.openjdk.org/browse/JDK-8330572): jdk.internal.net.http.HttpConnection calls an expensive checkOpen() when returning a HTTP/1.1 connection to the pool (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18840/head:pull/18840` \
`$ git checkout pull/18840`

Update a local copy of the PR: \
`$ git checkout pull/18840` \
`$ git pull https://git.openjdk.org/jdk.git pull/18840/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18840`

View PR using the GUI difftool: \
`$ git pr show -t 18840`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18840.diff">https://git.openjdk.org/jdk/pull/18840.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18840#issuecomment-2063920315)