### PR TITLE
8307818: Convert Indify tool to Classfile API

### DIFF
--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -74,12 +74,12 @@ MICROBENCHMARK_MANIFEST := Build: $(FULL_VERSION)\n\
 #### Compile Indify tool
 
 $(eval $(call SetupJavaCompilation, BUILD_INDIFY, \
-    TARGET_RELEASE := $(TARGET_RELEASE_BOOTJDK), \
+    TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SRC := $(TOPDIR)/test/jdk/java/lang/invoke, \
     INCLUDE_FILES := indify/Indify.java, \
-    DISABLED_WARNINGS := this-escape rawtypes serial options, \
+    DISABLED_WARNINGS := this-escape rawtypes serial options preview, \
     BIN := $(MICROBENCHMARK_TOOLS_CLASSES), \
-    JAVAC_FLAGS := -XDstringConcat=inline -Xprefer:newer, \
+    JAVAC_FLAGS := -XDstringConcat=inline -Xprefer:newer --enable-preview, \
 ))
 
 #### Compile Targets
@@ -123,7 +123,8 @@ $(BUILD_JDK_MICROBENCHMARK): $(JMH_COMPILE_JARS)
 # Run Indify
 $(MICROBENCHMARK_INDIFY_DONE): $(BUILD_INDIFY) $(BUILD_JDK_MICROBENCHMARK)
 	$(call LogWarn, Running Indify on microbenchmark classes)
-	$(JAVA_SMALL) -cp $(MICROBENCHMARK_TOOLS_CLASSES) \
+	$(BUILD_JAVA_SMALL) -cp $(MICROBENCHMARK_TOOLS_CLASSES) \
+            --enable-preview \
 	    indify.Indify --overwrite $(MICROBENCHMARK_CLASSES) \
 	    $(LOG_DEBUG) 2>&1
 	$(TOUCH) $@

--- a/test/jdk/java/lang/invoke/CallSiteTest.java
+++ b/test/jdk/java/lang/invoke/CallSiteTest.java
@@ -93,7 +93,7 @@ public class CallSiteTest {
         }
     }
 
-    public static class MyCCS extends ConstantCallSite {
+    static class MyCCS extends ConstantCallSite {
         public MyCCS(MethodType targetType, MethodHandle createTargetHook) throws Throwable {
             super(targetType, createTargetHook);
         }

--- a/test/jdk/java/lang/invoke/CallSiteTest.java
+++ b/test/jdk/java/lang/invoke/CallSiteTest.java
@@ -93,7 +93,7 @@ public class CallSiteTest {
         }
     }
 
-    static class MyCCS extends ConstantCallSite {
+    public static class MyCCS extends ConstantCallSite {
         public MyCCS(MethodType targetType, MethodHandle createTargetHook) throws Throwable {
             super(targetType, createTargetHook);
         }

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -150,7 +150,7 @@ public class CallStaticInitOrder {
     }
 
     private static int runFoo() throws Throwable {
-        assertEquals(Init1Tick, 0); // Init1 not initialized yet
+        assertEquals(Init1Tick, 0);  // Init1 not initialized yet
         int t1 = tick("runFoo");
         int t2 = (int) INDY_foo().invokeExact();
         int t3 = tick("runFoo done");

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -51,39 +51,39 @@ public class CallStaticInitOrder {
     }
 
     static int Init1Tick;
-    private static class Init1 {
+    public static class Init1 {
         static { Init1Tick = tick("foo -> Init1.<clinit>"); }
-        static int foo() { return Init1Tick; }
+        public static int foo() { return Init1Tick; }
     }
 
     static int Init2Tick;
-    private static class Init2 {
+    public static class Init2 {
         static { Init2Tick = tick("bar -> Init2.<clinit>"); }
-        static int bar() { return Init2Tick; }
+        public static int bar() { return Init2Tick; }
     }
 
     static int Init3Tick;
-    private static class Init3 {
+    public static class Init3 {
         static { Init3Tick = tick("baz -> Init3.<clinit>"); }
-        static int baz() { return Init3Tick; }
+        public static int baz() { return Init3Tick; }
     }
 
     static int Init4Tick;
-    private static class Init4 {
+    public static class Init4 {
         static { Init4Tick = tick("bat -> Init4.<clinit>"); }
-        static int bat() { return Init4Tick; }
+        public static int bat() { return Init4Tick; }
     }
 
     static int Init5Tick;
-    private static class Init5 {
+    public static class Init5 {
         static { Init5Tick = tick("read bang -> Init5.<clinit>"); }
-        static int bang = Init5Tick;
+        public static int bang = Init5Tick;
     }
 
-    static int Init6Tick;
-    private static class Init6 {
+    public static int Init6Tick;
+    public static class Init6 {
         static { Init6Tick = tick("write pong -> Init6.<clinit>"); }
-        static int pong;
+        public static int pong;
     }
 
     private static final MutableCallSite CONSTANT_CS_baz;
@@ -125,7 +125,7 @@ public class CallStaticInitOrder {
 
     private static Throwable LAST_LOSER;
 
-    private static void assertEquals(int expected, int actual) {
+    public static void assertEquals(int expected, int actual) {
         if (expected != actual) {
             Throwable loser = new AssertionError("expected: " + expected + ", actual: " + actual);
             if (LAST_LOSER != null)
@@ -134,7 +134,7 @@ public class CallStaticInitOrder {
         }
     }
 
-    private static void testInit() throws Throwable {
+    public static void testInit() throws Throwable {
         System.out.println("runFoo = "+runFoo());
         System.out.println("runBar = "+runBar());
         try {
@@ -164,7 +164,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "foo", methodType(int.class))).dynamicInvoker();
     }
 
-    private static int runBar() throws Throwable {
+    public static int runBar() throws Throwable {
         assertEquals(Init2Tick, 0);  // Init2 not initialized yet
         int t1 = tick("runBar");
         int t2 = (int) INDY_bar().invokeExact();
@@ -179,7 +179,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bar", methodType(int.class))).dynamicInvoker();
     }
 
-    private static int runBaz() throws Throwable {
+    public static int runBaz() throws Throwable {
         assertEquals(Init3Tick, 0);  // Init3 not initialized yet
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
@@ -194,7 +194,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "baz", methodType(int.class))).dynamicInvoker();
     }
 
-    private static int runBat() throws Throwable {
+    public static int runBat() throws Throwable {
         assertEquals(Init4Tick, 0);  // Init4 not initialized yet
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
@@ -209,7 +209,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bat", methodType(int.class))).dynamicInvoker();
     }
 
-    private static int runBang() throws Throwable {
+    public static int runBang() throws Throwable {
         assertEquals(Init5Tick, 0);  // Init5 not initialized yet
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
@@ -224,7 +224,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bang", methodType(int.class))).dynamicInvoker();
     }
 
-    private static int runPong() throws Throwable {
+    public static int runPong() throws Throwable {
         assertEquals(Init6Tick, 0);  // Init6 not initialized yet
         int t1 = tick("runPong");
         int t2 = (int) INDY_pong().invokeExact();

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -112,7 +112,7 @@ public class CallStaticInitOrder {
                 CONSTANT_MH_pongSetter = filterReturnValue(insertArguments(pongSetter, 0, -99), tickGetter);
             }
             int t2 = tick("CallStaticInitOrder.<clinit> done");
-            assertEquals(t1+1, t2);  // no ticks in between
+            assertEquals(t1+1, t2);  // No other static initializations should have occurred in between
         } catch (Exception ex) {
             throw new InternalError(ex.toString());
         }
@@ -150,13 +150,18 @@ public class CallStaticInitOrder {
     }
 
     private static int runFoo() throws Throwable {
-        assertEquals(Init1Tick, 0);  // Init1 not initialized yet
+        assertEquals(Init1Tick, 0);// Init1 has not been initialized before invoking INDY_foo
         int t1 = tick("runFoo");
         int t2 = (int) INDY_foo().invokeExact();
         int t3 = tick("runFoo done");
-        assertEquals(Init1Tick, t2);  // when Init1 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        /**
+         * tick("runFoo") increments TICK once
+         * INDY_foo() increments TICK during Init1's static block.
+         * tick("runFoo done") increments TICK again.
+         */
+        assertEquals(Init1Tick + 3, t2);
+        assertEquals(t1+1, t3); // one tick in between runFoo and runFoo done
+        assertEquals(t1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_foo() throws Throwable {
@@ -169,9 +174,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBar");
         int t2 = (int) INDY_bar().invokeExact();
         int t3 = tick("runBar done");
-        assertEquals(Init2Tick, t2);  // when Init2 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        assertEquals(Init2Tick +4 , t2);  // when Init2 was initialized (Init1Tick + 3) + 1
+        assertEquals(t1+1, t3);  // 1 tick in between runBar and runBar done
+        assertEquals(t1, t2 +1);
         return t2;
     }
     private static MethodHandle INDY_bar() throws Throwable {
@@ -184,9 +189,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
         int t3 = tick("runBaz done");
-        assertEquals(Init3Tick, t2);  // when Init3 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        assertEquals(Init3Tick + 5, t2);  //
+        assertEquals(t1+1, t3);
+        assertEquals(t1, t2+4);
         return t2;
     }
     private static MethodHandle INDY_baz() throws Throwable {
@@ -199,9 +204,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
         int t3 = tick("runBat done");
-        assertEquals(Init4Tick, t2);  // when Init4 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        assertEquals(Init4Tick + 6, t2);
+        assertEquals(t1+1, t3);
+        assertEquals(t1, t2+5);
         return t2;
     }
     private static MethodHandle INDY_bat() throws Throwable {
@@ -214,9 +219,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
         int t3 = tick("runBang done");
-        assertEquals(Init5Tick, t2);  // when Init5 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        assertEquals(Init5Tick + 7, t2);
+        assertEquals(t1+1, t3);
+        assertEquals(t1, t2+6);
         return t2;
     }
     private static MethodHandle INDY_bang() throws Throwable {
@@ -230,8 +235,8 @@ public class CallStaticInitOrder {
         int t2 = (int) INDY_pong().invokeExact();
         int t3 = tick("runPong done");
         assertEquals(Init6Tick, t2);  // when Init6 was initialized
-        assertEquals(t1+2, t3);  // exactly two ticks in between
-        assertEquals(t1+1, t2);  // init happened inside
+        assertEquals(t1+1, t3);
+        assertEquals(t1, t2 + 15);
         return t2;
     }
     private static MethodHandle INDY_pong() throws Throwable {

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -53,37 +53,37 @@ public class CallStaticInitOrder {
     static int Init1Tick;
     private static class Init1 {
         static { Init1Tick = tick("foo -> Init1.<clinit>"); }
-        private static int foo() { return Init1Tick; }
+         static int foo() { return Init1Tick; }
     }
 
     static int Init2Tick;
     private static class Init2 {
         static { Init2Tick = tick("bar -> Init2.<clinit>"); }
-        private static int bar() { return Init2Tick; }
+        static int bar() { return Init2Tick; }
     }
 
     static int Init3Tick;
     private static class Init3 {
         static { Init3Tick = tick("baz -> Init3.<clinit>"); }
-        private static int baz() { return Init3Tick; }
+        static int baz() { return Init3Tick; }
     }
 
     static int Init4Tick;
     private static class Init4 {
         static { Init4Tick = tick("bat -> Init4.<clinit>"); }
-        private static int bat() { return Init4Tick; }
+        static int bat() { return Init4Tick; }
     }
 
     static int Init5Tick;
     private static class Init5 {
         static { Init5Tick = tick("read bang -> Init5.<clinit>"); }
-        private static int bang = Init5Tick;
+        static int bang = Init5Tick;
     }
 
     static int Init6Tick;
     private static class Init6 {
         static { Init6Tick = tick("write pong -> Init6.<clinit>"); }
-        private static int pong;
+        static int pong;
     }
 
     private static final MutableCallSite CONSTANT_CS_baz;
@@ -112,7 +112,7 @@ public class CallStaticInitOrder {
                 CONSTANT_MH_pongSetter = filterReturnValue(insertArguments(pongSetter, 0, -99), tickGetter);
             }
             int t2 = tick("CallStaticInitOrder.<clinit> done");
-            assertEquals(t1+1, t2);  // No other static initializations should have occurred in between
+            assertEquals(t1+1, t2);  // no ticks in between
         } catch (Exception ex) {
             throw new InternalError(ex.toString());
         }
@@ -150,14 +150,14 @@ public class CallStaticInitOrder {
     }
 
     private static int runFoo() throws Throwable {
-        assertEquals(Init1Tick, 0);// Init1 has not been initialized before invoking INDY_foo
+        assertEquals(Init1Tick, 0); // Init1 not initialized yet
 
         int t1 = tick("runFoo");
         int t2 = (int) INDY_foo().invokeExact();
         int t3 = tick("runFoo done");
-        assertEquals(Init1Tick, t2);
+        assertEquals(Init1Tick, t2); // when Init1 was initialized
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2);
+        assertEquals(t1+1, t2); // init happened inside
         return t2;
     }
     private static MethodHandle INDY_foo() throws Throwable {
@@ -172,7 +172,7 @@ public class CallStaticInitOrder {
         int t3 = tick("runBar done");
         assertEquals(Init2Tick , t2);
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2);
+        assertEquals(t1+1, t2); // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bar() throws Throwable {
@@ -185,9 +185,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
         int t3 = tick("runBaz done");
-        assertEquals(Init3Tick, t2);
+        assertEquals(Init3Tick, t2); // when Init3 was initialized
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2);
+        assertEquals(t1+1, t2); // init happened inside
         return t2;
     }
     private static MethodHandle INDY_baz() throws Throwable {
@@ -200,9 +200,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
         int t3 = tick("runBat done");
-        assertEquals(Init4Tick, t2);
+        assertEquals(Init4Tick, t2); // when Init4 was initialized
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1,t2);
+        assertEquals(t1+1,t2); // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bat() throws Throwable {
@@ -215,9 +215,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
         int t3 = tick("runBang done");
-        assertEquals(Init5Tick, t2);
+        assertEquals(Init5Tick, t2); // when Init5 was initialized
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2);
+        assertEquals(t1+1, t2); // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bang() throws Throwable {
@@ -232,7 +232,7 @@ public class CallStaticInitOrder {
         int t3 = tick("runPong done");
         assertEquals(Init6Tick, t2);  // when Init6 was initialized
         assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2);
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_pong() throws Throwable {

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -125,7 +125,7 @@ public class CallStaticInitOrder {
 
     private static Throwable LAST_LOSER;
 
-    public static void assertEquals(int expected, int actual) {
+    private static void assertEquals(int expected, int actual) {
         if (expected != actual) {
             Throwable loser = new AssertionError("expected: " + expected + ", actual: " + actual);
             if (LAST_LOSER != null)
@@ -134,7 +134,7 @@ public class CallStaticInitOrder {
         }
     }
 
-    public static void testInit() throws Throwable {
+    private static void testInit() throws Throwable {
         System.out.println("runFoo = "+runFoo());
         System.out.println("runBar = "+runBar());
         try {
@@ -164,7 +164,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "foo", methodType(int.class))).dynamicInvoker();
     }
 
-    public static int runBar() throws Throwable {
+    private static int runBar() throws Throwable {
         assertEquals(Init2Tick, 0);  // Init2 not initialized yet
         int t1 = tick("runBar");
         int t2 = (int) INDY_bar().invokeExact();
@@ -179,7 +179,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bar", methodType(int.class))).dynamicInvoker();
     }
 
-    public static int runBaz() throws Throwable {
+    private static int runBaz() throws Throwable {
         assertEquals(Init3Tick, 0);  // Init3 not initialized yet
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
@@ -194,7 +194,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "baz", methodType(int.class))).dynamicInvoker();
     }
 
-    public static int runBat() throws Throwable {
+    private static int runBat() throws Throwable {
         assertEquals(Init4Tick, 0);  // Init4 not initialized yet
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
@@ -209,7 +209,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bat", methodType(int.class))).dynamicInvoker();
     }
 
-    public static int runBang() throws Throwable {
+    private static int runBang() throws Throwable {
         assertEquals(Init5Tick, 0);  // Init5 not initialized yet
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
@@ -224,7 +224,7 @@ public class CallStaticInitOrder {
         return ((CallSite) MH_bsm().invoke(lookup(), "bang", methodType(int.class))).dynamicInvoker();
     }
 
-    public static int runPong() throws Throwable {
+    private static int runPong() throws Throwable {
         assertEquals(Init6Tick, 0);  // Init6 not initialized yet
         int t1 = tick("runPong");
         int t2 = (int) INDY_pong().invokeExact();

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -80,7 +80,7 @@ public class CallStaticInitOrder {
         public static int bang = Init5Tick;
     }
 
-    public static int Init6Tick;
+    static int Init6Tick;
     public static class Init6 {
         static { Init6Tick = tick("write pong -> Init6.<clinit>"); }
         public static int pong;

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -51,39 +51,39 @@ public class CallStaticInitOrder {
     }
 
     static int Init1Tick;
-    public static class Init1 {
+    private static class Init1 {
         static { Init1Tick = tick("foo -> Init1.<clinit>"); }
-        public static int foo() { return Init1Tick; }
+        private static int foo() { return Init1Tick; }
     }
 
     static int Init2Tick;
-    public static class Init2 {
+    private static class Init2 {
         static { Init2Tick = tick("bar -> Init2.<clinit>"); }
-        public static int bar() { return Init2Tick; }
+        private static int bar() { return Init2Tick; }
     }
 
     static int Init3Tick;
-    public static class Init3 {
+    private static class Init3 {
         static { Init3Tick = tick("baz -> Init3.<clinit>"); }
-        public static int baz() { return Init3Tick; }
+        private static int baz() { return Init3Tick; }
     }
 
     static int Init4Tick;
-    public static class Init4 {
+    private static class Init4 {
         static { Init4Tick = tick("bat -> Init4.<clinit>"); }
-        public static int bat() { return Init4Tick; }
+        private static int bat() { return Init4Tick; }
     }
 
     static int Init5Tick;
-    public static class Init5 {
+    private static class Init5 {
         static { Init5Tick = tick("read bang -> Init5.<clinit>"); }
-        public static int bang = Init5Tick;
+        private static int bang = Init5Tick;
     }
 
     static int Init6Tick;
-    public static class Init6 {
+    private static class Init6 {
         static { Init6Tick = tick("write pong -> Init6.<clinit>"); }
-        public static int pong;
+        private static int pong;
     }
 
     private static final MutableCallSite CONSTANT_CS_baz;
@@ -151,17 +151,13 @@ public class CallStaticInitOrder {
 
     private static int runFoo() throws Throwable {
         assertEquals(Init1Tick, 0);// Init1 has not been initialized before invoking INDY_foo
+
         int t1 = tick("runFoo");
         int t2 = (int) INDY_foo().invokeExact();
         int t3 = tick("runFoo done");
-        /**
-         * tick("runFoo") increments TICK once
-         * INDY_foo() increments TICK during Init1's static block.
-         * tick("runFoo done") increments TICK again.
-         */
-        assertEquals(Init1Tick + 3, t2);
-        assertEquals(t1+1, t3); // one tick in between runFoo and runFoo done
-        assertEquals(t1, t2);  // init happened inside
+        assertEquals(Init1Tick, t2);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1, t2);
         return t2;
     }
     private static MethodHandle INDY_foo() throws Throwable {
@@ -174,9 +170,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBar");
         int t2 = (int) INDY_bar().invokeExact();
         int t3 = tick("runBar done");
-        assertEquals(Init2Tick +4 , t2);  // when Init2 was initialized (Init1Tick + 3) + 1
-        assertEquals(t1+1, t3);  // 1 tick in between runBar and runBar done
-        assertEquals(t1, t2 +1);
+        assertEquals(Init2Tick , t2);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1, t2);
         return t2;
     }
     private static MethodHandle INDY_bar() throws Throwable {
@@ -189,9 +185,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
         int t3 = tick("runBaz done");
-        assertEquals(Init3Tick + 5, t2);  //
-        assertEquals(t1+1, t3);
-        assertEquals(t1, t2+4);
+        assertEquals(Init3Tick, t2);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1, t2);
         return t2;
     }
     private static MethodHandle INDY_baz() throws Throwable {
@@ -204,9 +200,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
         int t3 = tick("runBat done");
-        assertEquals(Init4Tick + 6, t2);
-        assertEquals(t1+1, t3);
-        assertEquals(t1, t2+5);
+        assertEquals(Init4Tick, t2);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1,t2);
         return t2;
     }
     private static MethodHandle INDY_bat() throws Throwable {
@@ -219,9 +215,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
         int t3 = tick("runBang done");
-        assertEquals(Init5Tick + 7, t2);
-        assertEquals(t1+1, t3);
-        assertEquals(t1, t2+6);
+        assertEquals(Init5Tick, t2);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1, t2);
         return t2;
     }
     private static MethodHandle INDY_bang() throws Throwable {
@@ -235,8 +231,8 @@ public class CallStaticInitOrder {
         int t2 = (int) INDY_pong().invokeExact();
         int t3 = tick("runPong done");
         assertEquals(Init6Tick, t2);  // when Init6 was initialized
-        assertEquals(t1+1, t3);
-        assertEquals(t1, t2 + 15);
+        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+1, t2);
         return t2;
     }
     private static MethodHandle INDY_pong() throws Throwable {

--- a/test/jdk/java/lang/invoke/CallStaticInitOrder.java
+++ b/test/jdk/java/lang/invoke/CallStaticInitOrder.java
@@ -53,7 +53,7 @@ public class CallStaticInitOrder {
     static int Init1Tick;
     private static class Init1 {
         static { Init1Tick = tick("foo -> Init1.<clinit>"); }
-         static int foo() { return Init1Tick; }
+        static int foo() { return Init1Tick; }
     }
 
     static int Init2Tick;
@@ -151,13 +151,12 @@ public class CallStaticInitOrder {
 
     private static int runFoo() throws Throwable {
         assertEquals(Init1Tick, 0); // Init1 not initialized yet
-
         int t1 = tick("runFoo");
         int t2 = (int) INDY_foo().invokeExact();
         int t3 = tick("runFoo done");
-        assertEquals(Init1Tick, t2); // when Init1 was initialized
-        assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2); // init happened inside
+        assertEquals(Init1Tick, t2);  // when Init1 was initialized
+        assertEquals(t1+2, t3);  // exactly two ticks in between
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_foo() throws Throwable {
@@ -170,9 +169,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBar");
         int t2 = (int) INDY_bar().invokeExact();
         int t3 = tick("runBar done");
-        assertEquals(Init2Tick , t2);
-        assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2); // init happened inside
+        assertEquals(Init2Tick, t2);  // when Init2 was initialized
+        assertEquals(t1+2, t3);  // exactly two ticks in between
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bar() throws Throwable {
@@ -185,9 +184,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBaz");
         int t2 = (int) INDY_baz().invokeExact();
         int t3 = tick("runBaz done");
-        assertEquals(Init3Tick, t2); // when Init3 was initialized
-        assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2); // init happened inside
+        assertEquals(Init3Tick, t2);  // when Init3 was initialized
+        assertEquals(t1+2, t3);  // exactly two ticks in between
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_baz() throws Throwable {
@@ -200,9 +199,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBat");
         int t2 = (int) INDY_bat().invokeExact();
         int t3 = tick("runBat done");
-        assertEquals(Init4Tick, t2); // when Init4 was initialized
-        assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1,t2); // init happened inside
+        assertEquals(Init4Tick, t2);  // when Init4 was initialized
+        assertEquals(t1+2, t3);  // exactly two ticks in between
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bat() throws Throwable {
@@ -215,9 +214,9 @@ public class CallStaticInitOrder {
         int t1 = tick("runBang");
         int t2 = (int) INDY_bang().invokeExact();
         int t3 = tick("runBang done");
-        assertEquals(Init5Tick, t2); // when Init5 was initialized
-        assertEquals(t1+2, t3); // exactly two ticks in between
-        assertEquals(t1+1, t2); // init happened inside
+        assertEquals(Init5Tick, t2);  // when Init5 was initialized
+        assertEquals(t1+2, t3);  // exactly two ticks in between
+        assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }
     private static MethodHandle INDY_bang() throws Throwable {
@@ -231,7 +230,7 @@ public class CallStaticInitOrder {
         int t2 = (int) INDY_pong().invokeExact();
         int t3 = tick("runPong done");
         assertEquals(Init6Tick, t2);  // when Init6 was initialized
-        assertEquals(t1+2, t3); // exactly two ticks in between
+        assertEquals(t1+2, t3);  // exactly two ticks in between
         assertEquals(t1+1, t2);  // init happened inside
         return t2;
     }

--- a/test/jdk/java/lang/invoke/InvokeDynamicPrintArgs.java
+++ b/test/jdk/java/lang/invoke/InvokeDynamicPrintArgs.java
@@ -235,11 +235,11 @@ public class InvokeDynamicPrintArgs {
         throw new AssertionError("this code should be statically transformed away by Indify");
     }
 
-    public static class TestPolicy extends Policy {
+    static class TestPolicy extends Policy {
         static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
         final PermissionCollection permissions = new Permissions();
-        public TestPolicy() {
+        TestPolicy() {
             permissions.add(new java.io.FilePermission("<<ALL FILES>>", "read"));
         }
         public PermissionCollection getPermissions(ProtectionDomain domain) {

--- a/test/jdk/java/lang/invoke/InvokeDynamicPrintArgs.java
+++ b/test/jdk/java/lang/invoke/InvokeDynamicPrintArgs.java
@@ -235,11 +235,11 @@ public class InvokeDynamicPrintArgs {
         throw new AssertionError("this code should be statically transformed away by Indify");
     }
 
-    static class TestPolicy extends Policy {
+    public static class TestPolicy extends Policy {
         static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
         final PermissionCollection permissions = new Permissions();
-        TestPolicy() {
+        public TestPolicy() {
             permissions.add(new java.io.FilePermission("<<ALL FILES>>", "read"));
         }
         public PermissionCollection getPermissions(ProtectionDomain domain) {

--- a/test/jdk/java/lang/invoke/MethodHandleConstants.java
+++ b/test/jdk/java/lang/invoke/MethodHandleConstants.java
@@ -170,11 +170,11 @@ public class MethodHandleConstants {
         throw new AssertionError("this code should be statically transformed away by Indify");
     }
 
-    static class TestPolicy extends Policy {
+    public static class TestPolicy extends Policy {
         static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
         final PermissionCollection permissions = new Permissions();
-        TestPolicy() {
+        public TestPolicy() {
             permissions.add(new java.io.FilePermission("<<ALL FILES>>", "read"));
         }
         public PermissionCollection getPermissions(ProtectionDomain domain) {

--- a/test/jdk/java/lang/invoke/MethodHandleConstants.java
+++ b/test/jdk/java/lang/invoke/MethodHandleConstants.java
@@ -170,11 +170,11 @@ public class MethodHandleConstants {
         throw new AssertionError("this code should be statically transformed away by Indify");
     }
 
-    public static class TestPolicy extends Policy {
+    static class TestPolicy extends Policy {
         static final Policy DEFAULT_POLICY = Policy.getPolicy();
 
         final PermissionCollection permissions = new Permissions();
-        public TestPolicy() {
+        TestPolicy() {
             permissions.add(new java.io.FilePermission("<<ALL FILES>>", "read"));
         }
         public PermissionCollection getPermissions(ProtectionDomain domain) {

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -27,7 +27,6 @@ import java.lang.classfile.*;
 import java.lang.classfile.constantpool.*;
 import java.lang.classfile.instruction.*;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.*;
 import java.io.*;
 import java.lang.reflect.Modifier;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -197,8 +197,8 @@ public class Indify {
                 if (!keepgoing) {
                     break;
                 } else if (ex != err) {
-                err.addSuppressed(ex);
-            }
+                    err.addSuppressed(ex);
+                }
             }
         }
 

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -944,24 +944,8 @@ public class Indify {
                                 String rtype = null;
                                 for(Object typeArg : args) {
                                     if (typeArg instanceof Class<?> argClass) {
-                                        if (argClass.isPrimitive()) {
-                                            char tchar = switch (argClass.getName()) {
-                                                case "void" -> 'V';
-                                                case "boolean" -> 'Z';
-                                                case "byte" -> 'B';
-                                                case "char" -> 'C';
-                                                case "short" -> 'S';
-                                                case "int" -> 'I';
-                                                case "long" -> 'J';
-                                                case "float" -> 'F';
-                                                case "double" -> 'D';
-                                                default -> throw new InternalError(argClass.toString());
-                                            };
-                                            buf.append(tchar);
-                                        } else {
-                                            buf.append('L').append(argClass.getName().replace('.','/')).append(';');
-                                        }
-                                    } else if (typeArg instanceof PoolEntry argCon) {
+                                        buf.append(argClass.descriptorString());
+                                    }else if (typeArg instanceof PoolEntry argCon) {
                                         if(argCon.tag() == TAG_CLASS) {
                                             String cn = ((ClassEntry) argCon).name().stringValue();
                                             if (cn.endsWith(";"))

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -198,7 +198,9 @@ public class Indify {
                 System.err.println("Failure on " + a);
                 if (!keepgoing) {
                     break;
-                }
+                } else if (ex != err) {
+                err.addSuppressed(ex);
+            }
             }
         }
 

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -94,22 +94,21 @@ import static java.lang.constant.DirectMethodHandleDesc.Kind.*;
  * <p>
  * Example usage:
  * <blockquote><pre>
- $ JAVA_HOME=(some recent OpenJDK 7 build)
- $ ant
- $ $JAVA_HOME/bin/java -cp build/classes indify.Indify --overwrite --dest build/testout build/classes/indify/Example.class
- $ $JAVA_HOME/bin/java -cp build/classes indify.Example
- MT = (java.lang.Object)java.lang.Object
- MH = adder(int,int)java.lang.Integer
- adder(1,2) = 3
- calling indy:  42
- $ $JAVA_HOME/bin/java -cp build/testout indify.Example
- (same output as above)
+$ JAVA_HOME=(some recent OpenJDK 7 build)
+$ ant
+$ $JAVA_HOME/bin/java -cp build/classes indify.Indify --overwrite --dest build/testout build/classes/indify/Example.class
+$ $JAVA_HOME/bin/java -cp build/classes indify.Example
+MT = (java.lang.Object)java.lang.Object
+MH = adder(int,int)java.lang.Integer
+adder(1,2) = 3
+calling indy:  42
+$ $JAVA_HOME/bin/java -cp build/testout indify.Example
+(same output as above)
  * </pre></blockquote>
  * <p>
  * A version of this transformation built on top of <a href="http://asm.ow2.org/">http://asm.ow2.org/</a> would be welcome.
  * @author John Rose
  */
-
 public class Indify {
     public static void main(String... av) throws IOException {
         new Indify().run(av);

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -1042,6 +1042,8 @@ public class Indify {
                             PoolEntry indyCon = makeInvokeDynamicCon(bsmArgs);
                             if (indyCon != null) {
                                 return indyCon;
+                            }else {
+                                System.err.println("Failed to create invokedynamic instruction for the method: " + method.methodName());
                             }
                             System.err.println(method+": inscrutable bsm arguments: "+bsmArgs);
                             break decode;
@@ -1055,8 +1057,9 @@ public class Indify {
                     }
                     default:
                         if(jvm.stackMotion(instruction.opcode().bytecode())) break;
-                        if (bc >= ICONST_M1 && bc <= DCONST_1)
-                        { jvm.push(INSTRUCTION_CONSTANTS[bc - ICONST_M1]); break; }
+                        if (bc >= ICONST_M1 && bc <= DCONST_1) {
+                            jvm.push(instruction.opcode().constantValue()); break;
+                        }
                         if (patternMark == 'I') {
                             if (bc == ALOAD || bc >= ALOAD_0 && bc <= ALOAD_3)
                             { jvm.push(UNKNOWN_CON); break; }
@@ -1222,98 +1225,6 @@ public class Indify {
         }
 
         return ClassFile.of().parse(bytes);
-    }
-
-    private static final Object[] INSTRUCTION_CONSTANTS = {
-        -1, 0, 1, 2, 3, 4, 5, 0L, 1L, 0.0F, 1.0F, 2.0F, 0.0D, 1.0D
-    };
-
-    private static final String INSTRUCTION_FORMATS =
-        "nop$ aconst_null$L iconst_m1$I iconst_0$I iconst_1$I "+
-        "iconst_2$I iconst_3$I iconst_4$I iconst_5$I lconst_0$J_ "+
-        "lconst_1$J_ fconst_0$F fconst_1$F fconst_2$F dconst_0$D_ "+
-        "dconst_1$D_ bipush=bx$I sipush=bxx$I ldc=bk$X ldc_w=bkk$X "+
-        "ldc2_w=bkk$X_ iload=bl/wbll$I lload=bl/wbll$J_ fload=bl/wbll$F "+
-        "dload=bl/wbll$D_ aload=bl/wbll$L iload_0$I iload_1$I "+
-        "iload_2$I iload_3$I lload_0$J_ lload_1$J_ lload_2$J_ "+
-        "lload_3$J_ fload_0$F fload_1$F fload_2$F fload_3$F dload_0$D_ "+
-        "dload_1$D_ dload_2$D_ dload_3$D_ aload_0$L aload_1$L "+
-        "aload_2$L aload_3$L iaload$LI$I laload$LI$J_ faload$LI$F "+
-        "daload$LI$D_ aaload$LI$L baload$LI$I caload$LI$I saload$LI$I "+
-        "istore=bl/wbll$I$ lstore=bl/wbll$J_$ fstore=bl/wbll$F$ "+
-        "dstore=bl/wbll$D_$ astore=bl/wbll$L$ istore_0$I$ istore_1$I$ "+
-        "istore_2$I$ istore_3$I$ lstore_0$J_$ lstore_1$J_$ "+
-        "lstore_2$J_$ lstore_3$J_$ fstore_0$F$ fstore_1$F$ fstore_2$F$ "+
-        "fstore_3$F$ dstore_0$D_$ dstore_1$D_$ dstore_2$D_$ "+
-        "dstore_3$D_$ astore_0$L$ astore_1$L$ astore_2$L$ astore_3$L$ "+
-        "iastore$LII$ lastore$LIJ_$ fastore$LIF$ dastore$LID_$ "+
-        "aastore$LIL$ bastore$LII$ castore$LII$ sastore$LII$ pop$X$ "+
-        "pop2$XX$ dup$X$XX dup_x1$XX$XXX dup_x2$XXX$XXXX dup2$XX$XXXX "+
-        "dup2_x1$XXX$XXXXX dup2_x2$XXXX$XXXXXX swap$XX$XX "+
-        "iadd$II$I ladd$J_J_$J_ fadd$FF$F dadd$D_D_$D_ isub$II$I "+
-        "lsub$J_J_$J_ fsub$FF$F dsub$D_D_$D_ imul$II$I lmul$J_J_$J_ "+
-        "fmul$FF$F dmul$D_D_$D_ idiv$II$I ldiv$J_J_$J_ fdiv$FF$F "+
-        "ddiv$D_D_$D_ irem$II$I lrem$J_J_$J_ frem$FF$F drem$D_D_$D_ "+
-        "ineg$I$I lneg$J_$J_ fneg$F$F dneg$D_$D_ ishl$II$I lshl$J_I$J_ "+
-        "ishr$II$I lshr$J_I$J_ iushr$II$I lushr$J_I$J_ iand$II$I "+
-        "land$J_J_$J_ ior$II$I lor$J_J_$J_ ixor$II$I lxor$J_J_$J_ "+
-        "iinc=blx/wbllxx$ i2l$I$J_ i2f$I$F i2d$I$D_ l2i$J_$I l2f$J_$F "+
-        "l2d$J_$D_ f2i$F$I f2l$F$J_ f2d$F$D_ d2i$D_$I d2l$D_$J_ "+
-        "d2f$D_$F i2b$I$I i2c$I$I i2s$I$I lcmp fcmpl fcmpg dcmpl dcmpg "+
-        "ifeq=boo ifne=boo iflt=boo ifge=boo ifgt=boo ifle=boo "+
-        "if_icmpeq=boo if_icmpne=boo if_icmplt=boo if_icmpge=boo "+
-        "if_icmpgt=boo if_icmple=boo if_acmpeq=boo if_acmpne=boo "+
-        "goto=boo jsr=boo ret=bl/wbll tableswitch=* lookupswitch=* "+
-        "ireturn lreturn freturn dreturn areturn return "+
-        "getstatic=bkf$Q putstatic=bkf$Q$ getfield=bkf$L$Q "+
-        "putfield=bkf$LQ$ invokevirtual=bkm$LQ$Q "+
-        "invokespecial=bkm$LQ$Q invokestatic=bkm$Q$Q "+
-        "invokeinterface=bkixx$LQ$Q invokedynamic=bkd__$Q$Q new=bkc$L "+
-        "newarray=bx$I$L anewarray=bkc$I$L arraylength$L$I athrow "+
-        "checkcast=bkc$L$L instanceof=bkc$L$I monitorenter$L "+
-        "monitorexit$L wide=* multianewarray=bkcx ifnull=boo "+
-        "ifnonnull=boo goto_w=boooo jsr_w=boooo ";
-    private static final String[] INSTRUCTION_POPS;
-    static {
-        String[] insns = INSTRUCTION_FORMATS.split(" ");
-        assert(insns[LOOKUPSWITCH].startsWith("lookupswitch"));
-        assert(insns[TABLESWITCH].startsWith("tableswitch"));
-        assert(insns[WIDE].startsWith("wide"));
-        assert(insns[INVOKEDYNAMIC].startsWith("invokedynamic"));
-        int[] info = new int[256];
-        String[] names = new String[256];
-        String[] pops = new String[256];
-        for (int i = 0; i < insns.length; i++) {
-            String insn = insns[i];
-            int dl = insn.indexOf('$');
-            if (dl > 0) {
-                String p = insn.substring(dl+1);
-                if (p.indexOf('$') < 0)  p = "$" + p;
-                pops[i] = p;
-                insn = insn.substring(0, dl);
-            }
-            int eq = insn.indexOf('=');
-            if (eq < 0) {
-                info[i] = 1;
-                names[i] = insn;
-                continue;
-            }
-            names[i] = insn.substring(0, eq);
-            String fmt = insn.substring(eq+1);
-            if (fmt.equals("*")) {
-                info[i] = 0;
-                continue;
-            }
-            int sl = fmt.indexOf('/');
-            if (sl < 0) {
-                info[i] = (char) fmt.length();
-            } else {
-                String wfmt = fmt.substring(sl+1);
-                fmt = fmt.substring(0, sl);
-                info[i] = (char)( fmt.length() + (wfmt.length() * 16) );
-            }
-        }
-        INSTRUCTION_POPS = pops;
     }
 
     static String simplifyType(String type) {

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -349,7 +349,7 @@ public class Indify {
         return new File(pathDir, qualname);
     }
 
-    public void indifyJar(File f, Object dest){
+    public void indifyJar(File f, Object dest) {
         throw new UnsupportedOperationException("Not yet implemented");
     }
 

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -506,12 +506,10 @@ public class Indify {
 
                 Predicate<MethodModel> filter = method -> Objects.equals(method.methodName().stringValue(), m.methodName().stringValue());
 
-                Iterator<Instruction> instructionIterator =getInstructions(m).iterator();
                 final Stack<Boolean> shouldProceedAfterIndyAdded = new Stack<>();
 
-                while (instructionIterator.hasNext()){
+                for (Instruction i : getInstructions(m)){
                     shouldProceedAfterIndyAdded.push(true);
-                    Instruction i = instructionIterator.next();
 
                     if(i.opcode().bytecode() != INVOKESTATIC) continue;  //this is not an invokestatic instruction
                     int methodIndex = ((InvokeInstruction) i).method().index();
@@ -564,8 +562,6 @@ public class Indify {
                         classModel = of().parse(
                                of().transform(classModel, classTransform)
                         );
-
-                        System.out.println();
                     } else {
                         assert(i.sizeInBytes() == 3);
                         MethodModel finalConm = patternMethod;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -351,7 +351,7 @@ public class Indify {
         ClassModel model = parseClassFile(f);
         Logic logic = new Logic(model);
         ClassModel newClassModel = logic.transform();
-        assert newClassModel != null;
+        if(newClassModel == null) throw new IOException("No transformation has been done when transforming the class file: " + f.getName());
         logic.reportPatternMethods(quiet, keepgoing);
         writeNewClassFile(newClassModel);
     }

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -23,17 +23,21 @@
 
 package indify;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.classfile.*;
 import java.lang.classfile.constantpool.*;
-import java.lang.classfile.instruction.*;
+import java.lang.classfile.instruction.ConstantInstruction;
+import java.lang.classfile.instruction.FieldInstruction;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.NewObjectInstruction;
 import java.lang.constant.ConstantDesc;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.util.*;
-import java.io.*;
-import java.lang.reflect.Modifier;
 import java.util.function.Predicate;
-import java.util.regex.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static java.lang.classfile.ClassFile.*;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -152,8 +152,6 @@ public class Indify {
      */
     public int verifySpecifierCount = -1;
 
-    public ClassModel classModel;
-
     /**
      * Processes command-line arguments to transform class files by incorporating JSR 292 features.
      * <p>
@@ -1399,7 +1397,7 @@ public class Indify {
             System.err.println(e.getMessage());
         }
 
-        return classModel = of().parse(bytes);
+        return ClassFile.of().parse(bytes);
     }
 
     private static final Object[] INSTRUCTION_CONSTANTS = {

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -558,11 +558,9 @@ public class Indify {
                             }
                             if (e instanceof InvokeInstruction && Objects.equals(a1, a2)) {
                                 System.err.println(">> Removing instruction invokestatic for Method: " + ((InvokeInstruction) e).name());
-                                b.andThen(b);
                             } else if (shouldProceed.peek() && e instanceof InvokeInstruction && ((InvokeInstruction) e).method().equals(((InvokeInstruction) i2).method())) {
                                 System.err.println(">> Removing instruction invokevirtual for Method: " + ((InvokeInstruction) e).name());
-                                b.andThen(b);
-                                System.out.println(">> Adding invokedynamic instruction and nop instead of invoke virtual: " + ((InvokeDynamicEntry) con).name());
+                                System.err.println(">> Adding invokedynamic instruction and nop instead of invoke virtual: " + ((InvokeDynamicEntry) con).name());
                                 b.invokeDynamicInstruction((InvokeDynamicEntry) con).nop();
 
                                 shouldProceed.pop();

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -210,7 +210,14 @@ public class Indify {
         }
     }
 
-    /** Execute the given application under a class loader which indifies all application classes. */
+    /**
+     *  Execute the given application under a class loader which indifies all application classes.
+     *
+     * @param av an array of strings where the first element is the fully qualified name
+     *           of the main class to be executed, and the remaining elements are arguments
+     *           to be passed to the main method of the specified class.
+     * @throws Exception if there is an error during class loading, method retrieval, or invocation.
+     */
     public void runApplication(String... av) throws Exception {
         List<String> avl = new ArrayList<>(Arrays.asList(av));
         String mainClassName = avl.removeFirst();
@@ -221,6 +228,16 @@ public class Indify {
         main.invoke(null, (Object) av);
     }
 
+    /**
+     * Parses a list of options and arguments, configuring the application's settings based on the provided options.
+     *
+     * @param av a list of strings representing the options and arguments to be parsed.
+     *           Options are expected to start with a hyphen ('-') or double hyphen ('--').
+     *           Arguments that do not start with a hyphen are considered as positional arguments and terminate the options parsing.
+     * @throws IOException if an I/O error occurs during the processing of options.
+     * @throws IllegalArgumentException if an unrecognized flag is encountered.
+     * @throws RuntimeException if no output destination is specified and the overwrite option is not enabled.
+     */
     public void parseOptions(List<String> av) throws IOException {
         for (; !av.isEmpty(); av.remove(0)) {
             String a = av.getFirst();
@@ -276,6 +293,15 @@ public class Indify {
         }
     }
 
+    /**
+     * Converts a string representation of a boolean option to its boolean value.
+     * If the input string is null, it returns true by default.
+     *
+     * @param s the string representation of the boolean option. Accepted values for true are "true", "yes", "on", and "1".
+     *          Accepted values for false are "false", "no", "off", and "0".
+     * @return the boolean value corresponding to the input string.
+     * @throws IllegalArgumentException if the input string is not recognized as a valid boolean option.
+     */
     private boolean booleanOption(String s) {
         if (s == null)  return true;
         return switch (s) {

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -904,7 +904,7 @@ public class Indify {
                             case "Long.valueOf":
                             case "Double.valueOf":
                                 removeEmptyJVMSlots(args);
-                                if(args.size() == 1 ) {
+                                if (args.size() == 1) {
                                     arg = args.removeFirst();
                                     if (arg instanceof Number) {
                                         args.add(arg); continue;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -480,7 +480,7 @@ public class Indify {
         ConstantPoolBuilder poolBuilder;  //Builder for the new constant pool
         final char[] poolMarks;
         final Map<String, PoolEntry> constants = new HashMap<>();
-        Logic(ClassModel classModel){
+        Logic(ClassModel classModel) {
             this.classModel = classModel;
             poolBuilder = ConstantPoolBuilder.of(classModel);
             poolMarks = new char[classModel.constantPool().size()];

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -655,7 +655,7 @@ public class Indify {
                 case 'T': requiredType = "()Ljava/lang/invoke/MethodType;";    break;
                 default:  return 0;
             }
-            if(matchType(descriptor, requiredType)) return mark;
+            if (matchType(descriptor, requiredType)) return mark;
             return 0;
         }
 

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -934,7 +934,7 @@ public class Indify {
                     case ARETURN:
                     {
                         ++branchCount;
-                        if(bsmArgs != null){
+                        if (bsmArgs != null) {
                             // parse bsmArgs as (MH, lookup, String, MT, [extra])
                             PoolEntry indyCon = makeInvokeDynamicCon(bsmArgs);
                             if (indyCon != null) {

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -368,7 +368,6 @@ public class Indify {
         ClassModel model = parseClassFile(f);
         Logic logic = new Logic(model);
         Boolean changed = logic.transform();
-        System.err.println("Class file transformation: " + changed);
         logic.reportPatternMethods(quiet, keepgoing);
         if (changed || all) {
             File outfile;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -616,19 +616,19 @@ public class Indify {
                 char mark = 0;
                 if (poolMarks[entry.index()] != 0) continue;
 
-                if(entry instanceof Utf8Entry utf8Entry){
+                if (entry instanceof Utf8Entry utf8Entry) {
                     mark = nameMark(utf8Entry.stringValue());
                 }
-                if(entry instanceof ClassEntry classEntry){
+                if (entry instanceof ClassEntry classEntry) {
                     mark = nameMark(classEntry.asInternalName());
                 }
-                if(entry instanceof StringEntry stringEntry){
+                if (entry instanceof StringEntry stringEntry) {
                     mark = nameMark(stringEntry.stringValue());
                 }
-                if(entry instanceof NameAndTypeEntry nameAndTypeEntry){
+                if (entry instanceof NameAndTypeEntry nameAndTypeEntry) {
                     mark = nameAndTypeMark(nameAndTypeEntry.name(), nameAndTypeEntry.type());
                 }
-                if(entry instanceof MemberRefEntry memberRefEntry){
+                if (entry instanceof MemberRefEntry memberRefEntry) {
                     poolMarks[memberRefEntry.owner().index()] = nameMark(memberRefEntry.owner().asInternalName());
                     if(poolMarks[memberRefEntry.owner().index()] != 0){
                         mark = poolMarks[memberRefEntry.owner().index()];

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -728,7 +728,7 @@ public class Indify {
             List<Object> args;
             List<Object> bsmArgs = null;  // args to invokeGeneric
         decode:
-            for(Instruction instruction : instructions){
+            for (Instruction instruction : instructions) {
 
                 int bc = instruction.opcode().bytecode();
                 String UNKNOWN_CON = "<unknown>";

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -276,26 +276,26 @@ public class Indify {
                     classpath = maybeExpandProperties(av.remove(1)).split("["+File.pathSeparatorChar+"]");
                     break;
                 case "-k": case "--keepgoing": case "--keepgoing=":
-                    keepgoing = booleanOption(a2);
+                    keepgoing = booleanOption(a2);  // print errors but keep going
                     break;
                 case "--expand-properties": case "--expand-properties=":
-                    expandProperties = booleanOption(a2);
+                    expandProperties = booleanOption(a2);  // expand property references in subsequent arguments
                     break;
                 case "--verify-specifier-count": case "--verify-specifier-count=":
                         assert a2 != null;
                         verifySpecifierCount = Integer.parseInt(a2);
                     break;
                 case "--overwrite": case "--overwrite=":
-                    overwrite = booleanOption(a2);
+                    overwrite = booleanOption(a2);  // overwrite output files
                     break;
                 case "--all": case "--all=":
-                    all = booleanOption(a2);
+                    all = booleanOption(a2);  // copy all classes, even if no patterns
                     break;
                 case "-q": case "--quiet": case "--quiet=":
-                    quiet = booleanOption(a2);
+                    quiet = booleanOption(a2);   // less output
                     break;
                 case "-v": case "--verbose": case "--verbose=":
-                    verbose = booleanOption(a2);
+                    verbose = booleanOption(a2); // more output
                     break;
                 default:
                     throw new IllegalArgumentException("unrecognized flag: "+a);

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -633,8 +633,8 @@ public class Indify {
                     if(poolMarks[memberRefEntry.owner().index()] != 0){
                         mark = poolMarks[memberRefEntry.owner().index()];
                     }
-                    else{
-                        if(memberRefEntry.owner().equals(classModel.thisClass())){
+                    else {
+                        if (memberRefEntry.owner().equals(classModel.thisClass())) {
                             mark = nameMark(memberRefEntry.name().stringValue());
                         }
                     }

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -920,7 +920,7 @@ public class Indify {
                                 args.add(intrinsic);
                                 continue;
                         }
-                        if(!hasReceiver && ownMethod != null) {
+                        if (!hasReceiver && ownMethod != null) {
                             con = constants.get(ownMethod.methodName().stringValue());
                             if (con == null)  break decode;
                             args.clear(); args.add(con);

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -610,11 +610,11 @@ public class Indify {
             if (!quiet)  System.err.flush();
         }
 
-        boolean initializeMarks(){
+        boolean initializeMarks() {
             boolean anyMarkChanged = false;
-            for(PoolEntry entry : classModel.constantPool()){
+            for (PoolEntry entry : classModel.constantPool()) {
                 char mark = 0;
-                if(poolMarks[entry.index()] != 0) continue;
+                if (poolMarks[entry.index()] != 0) continue;
 
                 if(entry instanceof Utf8Entry utf8Entry){
                     mark = nameMark(utf8Entry.stringValue());

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -650,7 +650,7 @@ public class Indify {
             if (mark == 0) return 0;
             String descriptor = type.stringValue();
             String requiredType;
-            switch (mark){
+            switch (mark) {
                 case 'H', 'I': requiredType = "()Ljava/lang/invoke/MethodHandle;";  break;
                 case 'T': requiredType = "()Ljava/lang/invoke/MethodType;";    break;
                 default:  return 0;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -267,7 +267,7 @@ public class Indify {
                     a = a.substring(0, eq+1);
                 }
                 switch (a) {
-                case "--java":
+                case "--java":  // keep this argument
                     return;
                 case "-d": case "--dest": case "-d=": case "--dest=":
                     dest = new File(a2 != null ? a2 : maybeExpandProperties(av.remove(1)));

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -637,7 +637,7 @@ public class Indify {
             return anyMarkChanged;
         }
 
-        char nameAndTypeMark(Utf8Entry name, Utf8Entry type){
+        char nameAndTypeMark(Utf8Entry name, Utf8Entry type) {
             char mark = poolMarks[name.index()] = nameMark(name.stringValue());
             if (mark == 0) return 0;
             String descriptor = type.stringValue();

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -946,9 +946,9 @@ public class Indify {
                             break decode;
                         }
                         arg = jvm.pop();
-                        if(branchCount == 2 && UNKNOWN_CON.equals(arg))
+                        if (branchCount == 2 && UNKNOWN_CON.equals(arg))
                             break;
-                        if((arg instanceof PoolEntry) && ((PoolEntry) arg).tag() == wantedTag)
+                        if ((arg instanceof PoolEntry) && ((PoolEntry) arg).tag() == wantedTag)
                             return (PoolEntry) arg;
                         break decode;
                     }

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -732,7 +732,7 @@ public class Indify {
 
                 int bc = instruction.opcode().bytecode();
                 String UNKNOWN_CON = "<unknown>";
-                switch (bc){
+                switch (bc) {
                     case LDC,LDC_W:           jvm.push(((ConstantInstruction.LoadConstantInstruction) instruction).constantEntry()); break;
                     case LDC2_W:              jvm.push2(((ConstantInstruction.LoadConstantInstruction) instruction).constantEntry()); break;
                     case ACONST_NULL:         jvm.push(null); break;

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -376,7 +376,7 @@ public class Indify {
                 ensureDirectory(dest);
                 outfile = classPathFile(dest, model.thisClass().name().stringValue());
             } else {
-                outfile = f;
+                outfile = f;  // overwrite input file, no matter where it is
             }
             Files.write(outfile.toPath(), transformToBytes(logic.classModel));
             if (!quiet) System.err.println("wrote "+outfile);

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -953,7 +953,7 @@ public class Indify {
                         break decode;
                     }
                     default:
-                        if(jvm.stackMotion(instruction.opcode().bytecode())) break;
+                        if (jvm.stackMotion(instruction.opcode().bytecode())) break;
                         if (bc >= ICONST_M1 && bc <= DCONST_1) {
                             jvm.push(instruction.opcode().constantValue()); break;
                         }

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -885,7 +885,7 @@ public class Indify {
                                 args.clear(); args.add(intrinsic);
                                 continue;
                             case "lookupClass":
-                                if(args.equals(List.of("lookup"))) {
+                                if (args.equals(List.of("lookup"))) {
                                     args.clear(); args.add(classModel.thisClass());
                                     continue;
                                 }

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -292,10 +292,10 @@ public class Indify {
                     all = booleanOption(a2);  // copy all classes, even if no patterns
                     break;
                 case "-q": case "--quiet": case "--quiet=":
-                    quiet = booleanOption(a2);   // less output
+                    quiet = booleanOption(a2);  // less output
                     break;
                 case "-v": case "--verbose": case "--verbose=":
-                    verbose = booleanOption(a2); // more output
+                    verbose = booleanOption(a2);  // more output
                     break;
                 default:
                     throw new IllegalArgumentException("unrecognized flag: "+a);
@@ -548,8 +548,8 @@ public class Indify {
                                     invokeInstruction.method().name().stringValue().equals("invokeExact"))
                             {
                                 System.err.println(">> Removing instruction invokevirtual for Method: " + invokeInstruction.method());
-                                System.err.println(">> Adding invokedynamic instruction and nop instead of invoke virtual: " + ((InvokeDynamicEntry) newConstant).name());
-                                b.invokeDynamicInstruction((InvokeDynamicEntry) newConstant).nop();
+                                System.err.println(">> Adding invokedynamic instruction of invoke virtual: " + ((InvokeDynamicEntry) newConstant).name());
+                                b.invokeDynamicInstruction((InvokeDynamicEntry) newConstant);
 
                                 shouldProceedAfterIndyAdded.pop();
                                 shouldProceedAfterIndyAdded.push(false);
@@ -772,7 +772,7 @@ public class Indify {
             int branchCount = 0;
             Object arg;
             List<Object> args;
-            List<Object> bsmArgs = null;  // args for invokeGeneric
+            List<Object> bsmArgs = null;  // args to invokeGeneric
         decode:
             for(Instruction instruction : instructions){
 

--- a/test/jdk/java/lang/invoke/indify/Indify.java
+++ b/test/jdk/java/lang/invoke/indify/Indify.java
@@ -509,7 +509,6 @@ public class Indify {
                 final Stack<Boolean> shouldProceedAfterIndyAdded = new Stack<>();
 
                 for (Instruction i : getInstructions(m)){
-                    shouldProceedAfterIndyAdded.clear();
                     shouldProceedAfterIndyAdded.push(true);
 
                     if(i.opcode().bytecode() != INVOKESTATIC) continue;  //this is not an invokestatic instruction
@@ -1074,7 +1073,7 @@ public class Indify {
 
             MemberRefEntry ref;
             if(refKind <= (byte) STATIC_SETTER.refKind){
-                 ref = poolBuilder.fieldRefEntry(ownerClass, nameAndTypeEntry);
+                ref = poolBuilder.fieldRefEntry(ownerClass, nameAndTypeEntry);
                 return poolBuilder.methodHandleEntry(refKind, ref);
             }
             else if(refKind == (byte) INTERFACE_VIRTUAL.refKind){


### PR DESCRIPTION
An indify tool in j.l.i tests (also in vmTestBase) convert some source-code private static methods with MT_ MH_, and INDY_ prefixes into MethodHandle, MethodType, and CallSite constants.
### Purpose of Indify

-  **Transformation Tool**: `Indify` transforms existing class files to leverage `invokedynamic` and other JSR 292 features. This transformation allows for dynamic method calls.

### Key Functions

- **Method Handle and Method Type Constants**:
    - **MH_x and MT_x Methods**: These methods are used to generate `MethodHandle` and `MethodType` constants. The tool transforms calls to these methods into `CONSTANT_MethodHandle` and `CONSTANT_MethodType` "ldc" (load constant) instructions.
-  **Invokedynamic Call Sites**:
    - **INDY_x Methods**: These methods generate `invokedynamic` call sites. Each `INDY_x` method starts with a call to an `MH_x` method, which acts as the bootstrap method. This is followed by an `invokeExact` call.
    - **Transformation**: The tool transforms pairs of calls (to `INDY_x` followed by `invokeExact`) into `invokedynamic` instructions. This mimics the JVM's handling of `invokedynamic` instructions, creating dynamic call sites that are linked at runtime.

It currently uses ad-hoc code to process class files and intends to migrate to ASM; but since we have the Classfile API, we can migrate to Classfile API instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307818](https://bugs.openjdk.org/browse/JDK-8307818): Convert Indify tool to Classfile API (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18841/head:pull/18841` \
`$ git checkout pull/18841`

Update a local copy of the PR: \
`$ git checkout pull/18841` \
`$ git pull https://git.openjdk.org/jdk.git pull/18841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18841`

View PR using the GUI difftool: \
`$ git pr show -t 18841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18841.diff">https://git.openjdk.org/jdk/pull/18841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18841#issuecomment-2119464615)