### PR TITLE
8329330: NoClassDefFoundError: Could not initialize class jdk.jfr.internal.MirrorEvents

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -44,8 +44,6 @@ import jdk.jfr.events.FileForceEvent;
 import jdk.jfr.events.FileReadEvent;
 import jdk.jfr.events.FileWriteEvent;
 import jdk.jfr.events.InitialSecurityPropertyEvent;
-import jdk.jfr.events.SocketReadEvent;
-import jdk.jfr.events.SocketWriteEvent;
 
 import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.LogLevel;
@@ -62,8 +60,6 @@ public final class JDKEvents {
         FileForceEvent.class,
         FileReadEvent.class,
         FileWriteEvent.class,
-        SocketReadEvent.class,
-        SocketWriteEvent.class,
         ActiveSettingEvent.class,
         ActiveRecordingEvent.class,
         // jdk.internal.event.* classes need their mirror


### PR DESCRIPTION
Could I have a review of a PR that removes mirror events from initialisation.

Testing: jdk/jdk/jfr 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329330](https://bugs.openjdk.org/browse/JDK-8329330): NoClassDefFoundError: Could not initialize class jdk.jfr.internal.MirrorEvents (**Bug** - P2)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18843/head:pull/18843` \
`$ git checkout pull/18843`

Update a local copy of the PR: \
`$ git checkout pull/18843` \
`$ git pull https://git.openjdk.org/jdk.git pull/18843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18843`

View PR using the GUI difftool: \
`$ git pr show -t 18843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18843.diff">https://git.openjdk.org/jdk/pull/18843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18843#issuecomment-2064134612)