### PR TITLE
8330595: Invoke ObjectMethods::bootstrap method exactly

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -145,6 +145,10 @@ final class BootstrapMethodInvoker {
                 } else if (isLambdaMetafactoryAltMetafactoryBSM(bsmType)) {
                     maybeReBoxElements(argv);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);
+                } else if (isObjectMethodsBootstrapBSM(bsmType)) {
+                    MethodHandle[] methodHandles = new MethodHandle[argv.length - 2];
+                    System.arraycopy(argv, 2, methodHandles, 0, argv.length - 2);
+                    result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>) argv[0], (String) argv[1], methodHandles);
                 } else {
                     maybeReBoxElements(argv);
                     if (type instanceof Class<?> c) {
@@ -188,7 +192,6 @@ final class BootstrapMethodInvoker {
             throw new BootstrapMethodError("bootstrap method initialization exception", ex);
         }
     }
-
 
     /**
      * If resultType is a reference type, do Class::cast on the result through
@@ -247,6 +250,9 @@ final class BootstrapMethodInvoker {
     private static final MethodType LMF_ALT_MT = MethodType.methodType(CallSite.class,
             Lookup.class, String.class, MethodType.class, Object[].class);
 
+    private static final MethodType OBJECT_METHODS_MT = MethodType.methodType(Object.class,
+            Lookup.class, String.class, TypeDescriptor.class, Class.class, String.class, MethodHandle[].class);
+
     private static final MethodType LMF_CONDY_MT = MethodType.methodType(Object.class,
             Lookup.class, String.class, Class.class, MethodType.class, MethodHandle.class, MethodType.class);
 
@@ -287,6 +293,15 @@ final class BootstrapMethodInvoker {
      */
     private static boolean isLambdaMetafactoryAltMetafactoryBSM(MethodType bsmType) {
         return bsmType == LMF_ALT_MT;
+    }
+
+    /**
+     * @return true iff the BSM method type exactly matches
+     *         {@link java.lang.runtime.ObjectMethods#bootstrap(
+     *          MethodHandles.Lookup,String,TypeDescriptor,Class,String,MethodHandle[])}
+     */
+    private static boolean isObjectMethodsBootstrapBSM(MethodType bsmType) {
+        return bsmType == OBJECT_METHODS_MT;
     }
 
     /** The JVM produces java.lang.Integer values to box

--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -146,8 +146,8 @@ final class BootstrapMethodInvoker {
                     maybeReBoxElements(argv);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);
                 } else if (isObjectMethodsBootstrapBSM(bsmType)) {
-                    MethodHandle[] methodHandles = Arrays.copyOfRange(argv, 2, argv.length, MethodHandle[].class);
-                    result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>) argv[0], (String) argv[1], methodHandles);
+                    MethodHandle[] mhs = Arrays.copyOfRange(argv, 2, argv.length, MethodHandle[].class);
+                    result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>)argv[0], (String)argv[1], mhs);
                 } else {
                     maybeReBoxElements(argv);
                     if (type instanceof Class<?> c) {

--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -146,8 +146,7 @@ final class BootstrapMethodInvoker {
                     maybeReBoxElements(argv);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);
                 } else if (isObjectMethodsBootstrapBSM(bsmType)) {
-                    MethodHandle[] methodHandles = new MethodHandle[argv.length - 2];
-                    System.arraycopy(argv, 2, methodHandles, 0, argv.length - 2);
+                    MethodHandle[] methodHandles = Arrays.copyOfRange(argv, 2, argv.length, MethodHandle[].class);
                     result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>) argv[0], (String) argv[1], methodHandles);
                 } else {
                     maybeReBoxElements(argv);


### PR DESCRIPTION
Investigating a recent regression in mainline I realized we have an opportunity to improve the bootstrap overheads of ObjectMethods::bootstrap by using `invokeExact` in a way similar to what we already do for LMF and SCF BSMs. This avoids generating type checking adapters and equates to a one-off startup win of around 5ms in any app that ever has the need to spin up a toString, equals or hashCode method on a record.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330595](https://bugs.openjdk.org/browse/JDK-8330595): Invoke ObjectMethods::bootstrap method exactly (**Enhancement** - P4)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18845/head:pull/18845` \
`$ git checkout pull/18845`

Update a local copy of the PR: \
`$ git checkout pull/18845` \
`$ git pull https://git.openjdk.org/jdk.git pull/18845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18845`

View PR using the GUI difftool: \
`$ git pr show -t 18845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18845.diff">https://git.openjdk.org/jdk/pull/18845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18845#issuecomment-2065217339)