### PR TITLE
8314846: Do not store Klass::_secondary_super_cache in CDS archive

### DIFF
--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -726,7 +726,6 @@ void Klass::metaspace_pointers_do(MetaspaceClosure* it) {
   }
 
   it->push(&_name);
-  it->push(&_secondary_super_cache);
   it->push(&_secondary_supers);
   for (int i = 0; i < _primary_super_limit; i++) {
     it->push(&_primary_supers[i]);
@@ -756,6 +755,11 @@ void Klass::remove_unshareable_info() {
     ResourceMark rm;
     log_trace(cds, unshareable)("remove: %s", external_name());
   }
+
+  // _secondary_super_cache may be updated by an is_subtype_of() call
+  // while ArchiveBuilder is copying metaspace objects. Let's reset it to
+  // null and let it be repopulated at runtime.
+  set_secondary_super_cache(nullptr);
 
   set_subklass(nullptr);
   set_next_sibling(nullptr);


### PR DESCRIPTION
This bug was found during Leyden development.

CDS's `ArchiveBuilder` expects the class metadata to stop mutating while we're inside the CDS dumping safepoint. However, `Klass::_secondary_super_cache` can be updated as a side effect of `Klass::is_subtype_of()`.

Currently, we don't call `Klass::is_subtype_of()`inside the CDS safepoint. However, it's likely that future optimizations will make such calls (as being done in the Leyden prototype). When that happens, the CDS dump will fail with a hard-to-debug failure (some class is found inside `_secondary_super_cache` that `ArchiveBuilder` doesn't know about.

There's no benefit in storing `Klass::_secondary_super_cache` in the CDS archive. So the safest thing to do is to stop scanning it during CDS dumping, and clear it to `nullptr` when the `Klass` is stored in the CDS archive.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314846](https://bugs.openjdk.org/browse/JDK-8314846): Do not store Klass::_secondary_super_cache in CDS archive (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18848/head:pull/18848` \
`$ git checkout pull/18848`

Update a local copy of the PR: \
`$ git checkout pull/18848` \
`$ git pull https://git.openjdk.org/jdk.git pull/18848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18848`

View PR using the GUI difftool: \
`$ git pr show -t 18848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18848.diff">https://git.openjdk.org/jdk/pull/18848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18848#issuecomment-2065424848)