### PR TITLE
8330611: AES-CTR vector intrinsic may read out of bounds (x86_64, AVX-512)

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -6588,6 +6588,14 @@ void Assembler::xorw(Register dst, Register src) {
   emit_arith(0x33, 0xC0, dst, src);
 }
 
+void Assembler::xorw(Register dst, Address src) {
+  InstructionMark im(this);
+  emit_int8(0x66);
+  prefix(src, dst);
+  emit_int8(0x33);
+  emit_operand(dst, src, 0);
+}
+
 // AVX 3-operands scalar float-point arithmetic instructions
 
 void Assembler::vaddsd(XMMRegister dst, XMMRegister nds, Address src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -2253,6 +2253,7 @@ private:
   void xorb(Address dst, Register src);
   void xorb(Register dst, Address src);
   void xorw(Register dst, Register src);
+  void xorw(Register dst, Address src);
 
   void xorq(Register dst, Address src);
   void xorq(Address dst, int32_t imm32);

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -2181,7 +2181,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
 
   const Register rounds = rax;
   const Register pos = r12;
-  const Register tail = r13;
+  const Register tail = r15;
 
   Label PRELOOP_START, EXIT_PRELOOP, REMAINDER, REMAINDER_16, LOOP, END, EXIT, END_LOOP,
   AES192, AES256, AES192_REMAINDER16, REMAINDER16_END_LOOP, AES256_REMAINDER16,

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_aes.cpp
@@ -2181,6 +2181,7 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
 
   const Register rounds = rax;
   const Register pos = r12;
+  const Register tail = r13;
 
   Label PRELOOP_START, EXIT_PRELOOP, REMAINDER, REMAINDER_16, LOOP, END, EXIT, END_LOOP,
   AES192, AES256, AES192_REMAINDER16, REMAINDER16_END_LOOP, AES256_REMAINDER16,
@@ -2615,29 +2616,36 @@ void StubGenerator::aesctr_encrypt(Register src_addr, Register dest_addr, Regist
   // Save encrypted counter value in xmm0 for next invocation, before XOR operation
   __ movdqu(Address(saved_encCounter_start, 0), xmm0);
   // XOR encryted block cipher in xmm0 with PT to produce CT
-  __ evpxorq(xmm0, xmm0, Address(src_addr, pos, Address::times_1, 0), Assembler::AVX_128bit);
   // extract up to 15 bytes of CT from xmm0 as specified by length register
   __ testptr(len_reg, 8);
   __ jcc(Assembler::zero, EXTRACT_TAIL_4BYTES);
-  __ pextrq(Address(dest_addr, pos), xmm0, 0);
+  __ pextrq(tail, xmm0, 0);
+  __ xorq(tail, Address(src_addr, pos, Address::times_1, 0));
+  __ movq(Address(dest_addr, pos), tail);
   __ psrldq(xmm0, 8);
   __ addl(pos, 8);
   __ bind(EXTRACT_TAIL_4BYTES);
   __ testptr(len_reg, 4);
   __ jcc(Assembler::zero, EXTRACT_TAIL_2BYTES);
-  __ pextrd(Address(dest_addr, pos), xmm0, 0);
+  __ pextrd(tail, xmm0, 0);
+  __ xorl(tail, Address(src_addr, pos, Address::times_1, 0));
+  __ movl(Address(dest_addr, pos), tail);
   __ psrldq(xmm0, 4);
   __ addq(pos, 4);
   __ bind(EXTRACT_TAIL_2BYTES);
   __ testptr(len_reg, 2);
   __ jcc(Assembler::zero, EXTRACT_TAIL_1BYTE);
-  __ pextrw(Address(dest_addr, pos), xmm0, 0);
+  __ pextrw(tail, xmm0, 0);
+  __ xorw(tail, Address(src_addr, pos, Address::times_1, 0));
+  __ movw(Address(dest_addr, pos), tail);
   __ psrldq(xmm0, 2);
   __ addl(pos, 2);
   __ bind(EXTRACT_TAIL_1BYTE);
   __ testptr(len_reg, 1);
   __ jcc(Assembler::zero, END);
-  __ pextrb(Address(dest_addr, pos), xmm0, 0);
+  __ pextrb(tail, xmm0, 0);
+  __ xorb(tail, Address(src_addr, pos, Address::times_1, 0));
+  __ movb(Address(dest_addr, pos), tail);
   __ addl(pos, 1);
 
   __ bind(END);


### PR DESCRIPTION
We would like to propose a fix for 8330611.

To avoid an out of bounds memory read when the input's size is not multiple of the block size, we read the plaintext/ciphertext tail in 8, 4, 2 and 1 byte batches depending on what it is guaranteed to be available by 'len_reg'. This behavior replaces the read of 16 bytes of input upfront and later discard of spurious data.

While we add 3 extra instructions + 3 extra memory reads in the worst case —to the same cache line probably—, the performance impact of this fix should be low because it only occurs at the end of the input and when its length is not multiple of the block size.

A reliable test case for this bug is hard to develop because we would need accurate heap allocation. The fact that spuriously read data is silently discarded most of the time makes this bug harder to observe. No regressions have been observed in the compiler/codegen/aes jtreg category. Additionally, we verified the fix manually with the debugger.

This work is in collaboration with @franferrax .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330611](https://bugs.openjdk.org/browse/JDK-8330611): AES-CTR vector intrinsic may read out of bounds (x86_64, AVX-512) (**Bug** - P3)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [455f7062](https://git.openjdk.org/jdk/pull/18849/files/455f70626f5b9b920ae6b6d97cdc1b7aaff0f622)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Contributors
 * Francisco Ferrari Bihurriet `<fferrari@openjdk.org>`
 * Martin Balao `<mbalao@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18849/head:pull/18849` \
`$ git checkout pull/18849`

Update a local copy of the PR: \
`$ git checkout pull/18849` \
`$ git pull https://git.openjdk.org/jdk.git pull/18849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18849`

View PR using the GUI difftool: \
`$ git pr show -t 18849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18849.diff">https://git.openjdk.org/jdk/pull/18849.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18849#issuecomment-2065515815)