### PR TITLE
8320215: HeapDumper can use DumpWriter buffer during merge

### DIFF
--- a/src/hotspot/share/services/heapDumperCompression.cpp
+++ b/src/hotspot/share/services/heapDumperCompression.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -49,11 +49,11 @@ FileWriter::~FileWriter() {
   }
 }
 
-char const* FileWriter::write_buf(char* buf, ssize_t size) {
+char const* FileWriter::write_buf(char* buf, size_t size) {
   assert(_fd >= 0, "Must be open");
   assert(size > 0, "Must write at least one byte");
 
-  if (!os::write(_fd, buf, (size_t)size)) {
+  if (!os::write(_fd, buf, size)) {
     return os::strerror(errno);
   }
 

--- a/src/hotspot/share/services/heapDumperCompression.hpp
+++ b/src/hotspot/share/services/heapDumperCompression.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020 SAP SE. All rights reserved.
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public:
   virtual char const* open_writer() = 0;
 
   // Does the write. Returns null on success and a static error message otherwise.
-  virtual char const* write_buf(char* buf, ssize_t size) = 0;
+  virtual char const* write_buf(char* buf, size_t size) = 0;
 };
 
 
@@ -74,7 +74,7 @@ public:
   virtual char const* open_writer();
 
   // Does the write. Returns null on success and a static error message otherwise.
-  virtual char const* write_buf(char* buf, ssize_t size);
+  virtual char const* write_buf(char* buf, size_t size);
 
   const char* get_file_path() { return _path; }
 


### PR DESCRIPTION
The fix updates HeapMerger to use writer buffer (no need to copy memory, also writer buffer is 1MB instead of 4KB).
Additionally fixed small issue in FileWriter (looks like `ssize_t` instead of `size_t` is a typo, the argument should be unsigned)

Testing: all HeapDump-related tests on Oracle supported platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320215](https://bugs.openjdk.org/browse/JDK-8320215): HeapDumper can use DumpWriter buffer during merge (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Yi Yang](https://openjdk.org/census#yyang) (@y1yang0 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18850/head:pull/18850` \
`$ git checkout pull/18850`

Update a local copy of the PR: \
`$ git checkout pull/18850` \
`$ git pull https://git.openjdk.org/jdk.git pull/18850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18850`

View PR using the GUI difftool: \
`$ git pr show -t 18850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18850.diff">https://git.openjdk.org/jdk/pull/18850.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18850#issuecomment-2065519132)