### PR TITLE
8330247: C2: CTW fail with assert(adr_t->is_known_instance_field()) failed: instance required

### DIFF
--- a/src/hotspot/share/opto/macro.cpp
+++ b/src/hotspot/share/opto/macro.cpp
@@ -573,6 +573,9 @@ bool PhaseMacroExpand::can_eliminate_allocation(PhaseIterGVN* igvn, AllocateNode
     if (res_type == nullptr) {
       NOT_PRODUCT(fail_eliminate = "Neither instance or array allocation";)
       can_eliminate = false;
+    } else if (!res_type->klass_is_exact()) {
+      NOT_PRODUCT(fail_eliminate = "Not an exact type.";)
+      can_eliminate = false;
     } else if (res_type->isa_aryptr()) {
       int length = alloc->in(AllocateNode::ALength)->find_int_con(-1);
       if (length < 0) {

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8330247
+ * @summary Check that Reduce Allocation Merges doesn't try to reduce non-exact allocations.
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ * @requires vm.debug & vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndNonExactAllocate*::test
+ *                   -XX:CompileCommand=compileonly,*::allocateInstance
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndNonExactAllocate*::*
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+TraceReduceAllocationMerges
+ *                   -XX:-TieredCompilation
+ *                   -Xbatch
+ *                   -Xcomp
+ *                   -server
+ *                   compiler.c2.TestReduceAllocationAndNonExactAllocate
+ */
+
+package compiler.c2;
+
+import jdk.internal.misc.Unsafe;
+
+public class TestReduceAllocationAndNonExactAllocate {
+    private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    public static void main(String[] args) {
+	    try {
+            if (test(20, Integer.class) != 2032) {
+                throw new RuntimeException("Expected the value to be 2032.");
+            }
+	    }
+	    catch (InstantiationException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static int test(int val, Class<?> c) throws InstantiationException {
+        Object p = null;
+
+        if (val == 20) {
+            p = UNSAFE.allocateInstance(c);
+        }
+
+        dummy();
+        return p != null ? 2032 : 3242;
+    }
+
+    static int dummy() { return 42; }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNonExactAllocate.java
@@ -48,12 +48,12 @@ public class TestReduceAllocationAndNonExactAllocate {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 
     public static void main(String[] args) {
-	    try {
+        try {
             if (test(20, Integer.class) != 2032) {
                 throw new RuntimeException("Expected the value to be 2032.");
             }
-	    }
-	    catch (InstantiationException e) {
+        }
+        catch (InstantiationException e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
The logic in reduce allocation merges (RAM) makes use of `PhaseMacroExpand:;can_eliminate_allocation` to check whether an allocation can be scalar replaced. However, we can only SR allocations of exact types - due to rematerialization logic.

The scalar replacement logic not related to RAM has this check in `split_unique_types` so there is no performance regression by adding this check here.

Tested on Linux x64 tiers1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330247](https://bugs.openjdk.org/browse/JDK-8330247): C2: CTW fail with assert(adr_t-&gt;is_known_instance_field()) failed: instance required (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18851/head:pull/18851` \
`$ git checkout pull/18851`

Update a local copy of the PR: \
`$ git checkout pull/18851` \
`$ git pull https://git.openjdk.org/jdk.git pull/18851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18851`

View PR using the GUI difftool: \
`$ git pr show -t 18851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18851.diff">https://git.openjdk.org/jdk/pull/18851.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18851#issuecomment-2065546069)