### PR TITLE
8326742: Change compiler tests without additional VM flags from @run driver to @run main

### DIFF
--- a/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
@@ -38,7 +38,7 @@
  * @bug 8313672
  * @summary Test CCP notification for value update of AndL through LShiftI and
  *          ConvI2L (no flags).
- * @run driver compiler.ccp.TestShiftConvertAndNotification
+ * @run main/othervm compiler.ccp.TestShiftConvertAndNotification
  *
  */
 

--- a/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestShiftConvertAndNotification.java
@@ -38,7 +38,7 @@
  * @bug 8313672
  * @summary Test CCP notification for value update of AndL through LShiftI and
  *          ConvI2L (no flags).
- * @run main/othervm compiler.ccp.TestShiftConvertAndNotification
+ * @run main compiler.ccp.TestShiftConvertAndNotification
  *
  */
 


### PR DESCRIPTION
The idea of the bug was to lower down the number of tests that use driver mode incorrectly. My investigation shows up that the vast majority of such tests start other processes and in fact are more of the wrappers around that processes. Most of the secondary processes are started using ProcessTools and therefore getting additional VM flags provided by user.

I found only one test that seem to use driver mode incorrectly, this PR fixes it.
Testing: tiers1-5, linux-x64/aarch64, macosx-x64/aarch64, windows-x64, all in debug flavours.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326742](https://bugs.openjdk.org/browse/JDK-8326742): Change compiler tests without additional VM flags from @<!---->run driver to @<!---->run main (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [9a5d6d90](https://git.openjdk.org/jdk/pull/18854/files/9a5d6d90d48dbe0d59be1f4170de8059c544dc6a)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [9a5d6d90](https://git.openjdk.org/jdk/pull/18854/files/9a5d6d90d48dbe0d59be1f4170de8059c544dc6a)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18854/head:pull/18854` \
`$ git checkout pull/18854`

Update a local copy of the PR: \
`$ git checkout pull/18854` \
`$ git pull https://git.openjdk.org/jdk.git pull/18854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18854`

View PR using the GUI difftool: \
`$ git pr show -t 18854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18854.diff">https://git.openjdk.org/jdk/pull/18854.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18854#issuecomment-2066264145)