### PR TITLE
8327696: [TESTBUG] "javax/swing/JTable/KeyBoardNavigation/KeyBoardNavigation.java" test instruction needs to be corrected

### DIFF
--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -30,7 +30,6 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.SwingUtilities;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -49,52 +48,7 @@ import javax.swing.table.TableModel;
  */
 
 public class KeyBoardNavigation {
-    static JFrame frame;
-    public static PassFailJFrame passFailJFrame;
-
-    static void initTest() throws Exception {
-        final String INSTRUCTIONS = """
-                Instructions to Test:
-                1. Refer the below keyboard navigation specs
-                 (referenced from bug report 4112270).
-                2. Check all combinations of navigational keys in all four modes
-                  shift and control verifying each change to the selection against
-                  the spec. If it does, press "pass", otherwise press "fail".
-
-                  Navigate In - Tab, shift-tab, control-tab, shift-control-tab
-                  Return/shift-return - move focus one cell down/up.
-                  Tab/shift-tab - move focus one cell right/left.
-                  Up/down arrow - deselect current selection; move focus one cell up/down
-                  Left/right arrow - deselect current selection; move focus one cell
-                                             left/right
-                  PageUp/PageDown - deselect current selection; scroll up/down one
-                                    JViewport view; first visible cell in current
-                                    column gets focus
-                  Control-PageUp/PageDown - deselect current selection; scroll
-                                            left/right one JViewport view; first
-                                            visible cell in current row gets
-                                            focus
-                  Home/end - deselect current selection; move focus and view to
-                                     first/last cell in current row
-                  Control-home/end - deselect current selection; move focus and view to
-                                             upper-left/lower-right cell in table
-                  F2 - Allows editing in a cell containing information without
-                               overwriting the information
-                  Esc - Resets the cell content back to the state it was in before
-                                editing started
-                  Ctrl+A, Ctrl+/ = Select all
-                  Ctrl+\\ = De-select all
-                  Shift-up/down arrow - extend selection up/down one row
-                  Shift-left/right arrow - extend selection left/right one column
-                  Control-shift up/down arrow - extend selection to top/bottom of column
-                  Shift-home/end - extend selection to left/right end of row
-                  Control-shift-home/end - extend selection to beginning/end of data
-                  Shift-PageUp/PageDown - extend selection up/down one view and scroll
-                                          table
-                  Control-shift-PageUp/PageDown - extend selection left/right one view
-                                                          and scroll table
-                """;
-
+    static JFrame initTest() {
         final String[] names = {"First Name", "Last Name", "Favorite Color",
                 "Favorite Number", "Vegetarian"};
         final Object[][] data = {
@@ -121,12 +75,7 @@ public class KeyBoardNavigation {
                 {"Arnaud", "Weber", "Green", 44, Boolean.FALSE}
         };
 
-        frame = new JFrame("JTable Keyboard Navigation Test");
-        passFailJFrame = new PassFailJFrame("Test Instructions",
-                INSTRUCTIONS, 5L, 15, 50);
-
-        PassFailJFrame.addTestWindow(frame);
-        PassFailJFrame.positionTestWindow(frame, PassFailJFrame.Position.VERTICAL);
+        JFrame frame = new JFrame("JTable Keyboard Navigation Test");
 
         JTable tableView = getTableDetails(names, data);
 
@@ -150,7 +99,7 @@ public class KeyBoardNavigation {
         colorColumnRenderer.setToolTipText("Click for combo box");
         colorColumn.setCellRenderer(colorColumnRenderer);
 
-        // Set a tooltip for the header of the colors column.
+        // Set a tooltip for the header of the color's column.
         TableCellRenderer headerRenderer = colorColumn.getHeaderRenderer();
         if (headerRenderer instanceof DefaultTableCellRenderer)
             ((DefaultTableCellRenderer) headerRenderer).setToolTipText("Hi Mom!");
@@ -179,6 +128,7 @@ public class KeyBoardNavigation {
         frame.add(scrollPane);
         frame.pack();
         frame.setVisible(true);
+        return frame;
     }
 
     private static JTable getTableDetails(String[] names, Object[][] data) {
@@ -224,13 +174,127 @@ public class KeyBoardNavigation {
     }
 
     public static void main(String[] args) throws Exception {
-        SwingUtilities.invokeAndWait(() -> {
-            try {
-                initTest();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        passFailJFrame.awaitAndCheck();
+        String INSTRUCTIONS = """
+                Instructions to Test:
+                1. Refer the below keyboard navigation specs
+                 (referenced from bug report 4112270).
+                2. Check all combinations of navigational keys in all four modes
+                  shift and control verifying each change to the selection against
+                  the spec. If it does, press "pass", otherwise press "fail".
+
+                """;
+
+        INSTRUCTIONS += getOSSpecificInstructions();
+        PassFailJFrame.builder()
+                .instructions(INSTRUCTIONS)
+                .rows(11)
+                .columns(50)
+                .testUI(KeyBoardNavigation::initTest)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static String getOSSpecificInstructions() {
+        final String WINDOWS_SPECIFIC = """
+                Navigate In - Tab, shift-tab
+                Return/shift-return - move focus one cell down/up.
+                Tab/shift-tab -  move focus one cell right/left.
+                Up/down arrow - deselect current selection; move focus one
+                                cell up/down
+                Left/right arrow - deselect current selection; move focus
+                                   one cell left/right
+                PageUp/PageDown - deselect current selection; scroll up/down
+                                  one JViewport view; first visible cell in
+                                  current column gets focus
+                Control-PageUp/PageDown - deselect current selection;
+                                          move focus and view to
+                                          first/last cell in current row
+                Home/end - deselect current selection; move focus and view to
+                           first/last cell in current row
+                Control-home/end - deselect current selection;
+                                   scroll up/down one  JViewport view;
+                                   first/last visible row of the table
+                F2 - Allows editing in a cell containing information without
+                     overwriting the information
+                Esc -  Resets the cell content back to the state it was in
+                       before editing started
+                Ctrl+A, Ctrl+/ - Select All
+                Ctrl+\\ - De-select all
+                Shift-up/down arrow -  extend selection up/down one row
+                Shift-left/right arrow - extend selection left/right one
+                                         column
+                Control-shift up/down arrow -  extend selection to top/bottom
+                                                of column
+                Shift-home/end -  extend selection to left/right end of row
+                Control-shift-home/end  - extend selection to beginning/end
+                                          of data
+                Shift-PageUp/PageDown - extend selection up/down one view
+                                        and scroll table
+                Control-shift-PageUp/PageDown - extend selection left/right
+                                                end of row
+                """;
+
+        final String LINUX_SPECIFIC = """
+                Navigate In - Tab, shift-tab
+                Return/shift-return - move focus one cell down/up.
+                Tab/shift-tab -  move focus one cell right/left.
+                Up/down arrow - deselect current selection;
+                                move focus one cell up/down
+                Left/right arrow - deselect current selection;
+                                   move focus one cell left/right
+                PageUp/PageDown - deselect current selection;
+                                  scroll up/down one  JViewport view;
+                                  first visible cell in current column gets focus
+                Home/end - deselect current selection; move focus and view to
+                                     first/last cell in current row
+                F2 - Allows editing in a cell containing information without
+                     overwriting the information
+                Esc -  Resets the cell content back to the state it was in
+                       before editing started
+                Ctrl+A, Ctrl+/ - Select All
+                Ctrl+\\ - De-select all
+                Shift-up/down arrow -  extend selection up/down one row
+                Shift-left/right arrow - extend selection left/right one column
+                Control-shift up/down arrow -  extend selection to top/bottom of
+                                               column
+                Shift-home/end -  extend selection to left/right end of row
+                Shift-PageUp/PageDown - extend selection up/down one view and
+                                        scroll  table
+                """;
+
+        final String MAC_SPECIFIC = """
+                Navigate In - Tab, shift-tab
+                Return/shift-return - move focus one cell down/up.
+                Tab/shift-tab -  move focus one cell right/left.
+                Up/down arrow - deselect current selection; move focus one cell
+                                up/down
+                Left/right arrow - deselect current selection;
+                                   move focus one cell left/right
+                fn + Up arrow/fn + Down Arrow - deselect current selection;
+                                   scroll up/down one JViewport view;
+                                   first visible cell in current column gets focus
+                Control-fn+Up Arrow/fn+Down arrow - deselect current selection;
+                                                    move focus and view to
+                                                    first/last cell in current row
+                F2 - Allows editing in a cell containing information without
+                     overwriting the information
+                Esc -  Resets the cell content back to the state it was in
+                       before editing started
+                Ctrl+A, Ctrl+/ - Select All
+                Ctrl+\\ - De-select all
+                Shift-up/down arrow -  extend selection up/down one row
+                Shift-left/right arrow - extend selection left/right one column
+                fn-shift up/down arrow -  extend selection to top/bottom of column
+                Shift-PageUp/PageDown - extend selection up/down one view and scroll
+                                        table
+                                """;
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.startsWith("mac")) {
+            return MAC_SPECIFIC;
+        } else if (osName.startsWith("win")) {
+            return WINDOWS_SPECIFIC;
+        } else {
+            return LINUX_SPECIFIC;
+        }
     }
 }

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -33,7 +33,6 @@ import javax.swing.JTable;
 import javax.swing.border.BevelBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
-import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableModel;
 
@@ -99,10 +98,10 @@ public class KeyBoardNavigation {
         colorColumnRenderer.setToolTipText("Click for combo box");
         colorColumn.setCellRenderer(colorColumnRenderer);
 
-        // Set a tooltip for the header of the color's column.
-        TableCellRenderer headerRenderer = colorColumn.getHeaderRenderer();
-        if (headerRenderer instanceof DefaultTableCellRenderer)
-            ((DefaultTableCellRenderer) headerRenderer).setToolTipText("Hi Mom!");
+        // Set a tooltip for the header of the colors column.
+        if (colorColumn.getHeaderRenderer() instanceof DefaultTableCellRenderer headerRenderer) {
+            headerRenderer.setToolTipText("Hi Mom!");
+        }
 
         // Set the width of the "Vegetarian" column.
         TableColumn vegetarianColumn = tableView.getColumn("Vegetarian");
@@ -112,7 +111,7 @@ public class KeyBoardNavigation {
         TableColumn numbersColumn = tableView.getColumn("Favorite Number");
         DefaultTableCellRenderer numberColumnRenderer = new DefaultTableCellRenderer() {
             public void setValue(Object value) {
-                int cellValue = (value instanceof Number) ? ((Number) value).intValue() : 0;
+                int cellValue = (value instanceof Number number) ? number.intValue() : 0;
                 setForeground((cellValue > 30) ? Color.black : Color.red);
                 setText((value == null) ? "" : value.toString());
             }
@@ -127,7 +126,6 @@ public class KeyBoardNavigation {
 
         frame.add(scrollPane);
         frame.pack();
-        frame.setVisible(true);
         return frame;
     }
 
@@ -196,12 +194,12 @@ public class KeyBoardNavigation {
 
     public static String getOSSpecificInstructions() {
         final String WINDOWS_SPECIFIC = """
-                Navigate In - Tab, shift-tab
-                Return/shift-return - move focus one cell down/up.
-                Tab/shift-tab -  move focus one cell right/left.
-                Up/down arrow - deselect current selection; move focus one
+                Tab, Shift-Tab - Navigate In.
+                Return/Shift-Return - move focus one cell down/up.
+                Tab/Shift-Tab -  move focus one cell right/left.
+                Up/Down Arrow - deselect current selection; move focus one
                                 cell up/down
-                Left/right arrow - deselect current selection; move focus
+                Left/Right Arrow - deselect current selection; move focus
                                    one cell left/right
                 PageUp/PageDown - deselect current selection; scroll up/down
                                   one JViewport view; first visible cell in
@@ -209,9 +207,9 @@ public class KeyBoardNavigation {
                 Control-PageUp/PageDown - deselect current selection;
                                           move focus and view to
                                           first/last cell in current row
-                Home/end - deselect current selection; move focus and view to
+                Home/End - deselect current selection; move focus and view to
                            first/last cell in current row
-                Control-home/end - deselect current selection;
+                Control-Home/End - deselect current selection;
                                    scroll up/down one  JViewport view;
                                    first/last visible row of the table
                 F2 - Allows editing in a cell containing information without
@@ -220,32 +218,32 @@ public class KeyBoardNavigation {
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
                 Ctrl+\\ - De-select all
-                Shift-up/down arrow -  extend selection up/down one row
-                Shift-left/right arrow - extend selection left/right one
+                Shift-Up/Down Arrow -  extend selection up/down one row
+                Shift-Left/Right Arrow - extend selection left/right one
                                          column
-                Control-shift up/down arrow -  extend selection to top/bottom
+                Control-shift Up/Down Arrow -  extend selection to top/bottom
                                                 of column
-                Shift-home/end -  extend selection to left/right end of row
-                Control-shift-home/end  - extend selection to beginning/end
+                Shift-Home/End -  extend selection to left/right end of row
+                Control-Shift-Home/End  - extend selection to beginning/end
                                           of data
                 Shift-PageUp/PageDown - extend selection up/down one view
                                         and scroll table
-                Control-shift-PageUp/PageDown - extend selection left/right
+                Control-Shift-PageUp/PageDown - extend selection left/right
                                                 end of row
                 """;
 
         final String LINUX_SPECIFIC = """
-                Navigate In - Tab, shift-tab
-                Return/shift-return - move focus one cell down/up.
-                Tab/shift-tab -  move focus one cell right/left.
-                Up/down arrow - deselect current selection;
+                Tab, Shift-Tab - Navigate In.
+                Return/Shift-Return - move focus one cell down/up.
+                Tab/Shift-Tab -  move focus one cell right/left.
+                Up/Down Arrow - deselect current selection;
                                 move focus one cell up/down
-                Left/right arrow - deselect current selection;
+                Left/Right Arrow - deselect current selection;
                                    move focus one cell left/right
                 PageUp/PageDown - deselect current selection;
                                   scroll up/down one  JViewport view;
                                   first visible cell in current column gets focus
-                Home/end - deselect current selection; move focus and view to
+                Home/End - deselect current selection; move focus and view to
                                      first/last cell in current row
                 F2 - Allows editing in a cell containing information without
                      overwriting the information
@@ -253,27 +251,27 @@ public class KeyBoardNavigation {
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
                 Ctrl+\\ - De-select all
-                Shift-up/down arrow -  extend selection up/down one row
-                Shift-left/right arrow - extend selection left/right one column
-                Control-shift up/down arrow -  extend selection to top/bottom of
+                Shift-Up/Down Arrow -  extend selection up/down one row
+                Shift-Left/Right Arrow - extend selection left/right one column
+                Control-Shift Up/Down Arrow -  extend selection to top/bottom of
                                                column
-                Shift-home/end -  extend selection to left/right end of row
+                Shift-Home/End -  extend selection to left/right end of row
                 Shift-PageUp/PageDown - extend selection up/down one view and
                                         scroll  table
                 """;
 
         final String MAC_SPECIFIC = """
-                Navigate In - Tab, shift-tab
-                Return/shift-return - move focus one cell down/up.
-                Tab/shift-tab -  move focus one cell right/left.
-                Up/down arrow - deselect current selection; move focus one cell
+                Tab, Shift-Tab - Navigate In.
+                Return/Shift-Return - move focus one cell down/up.
+                Tab/Shift-Tab -  move focus one cell right/left.
+                Up/Down Arrow - deselect current selection; move focus one cell
                                 up/down
-                Left/right arrow - deselect current selection;
+                Left/Right Arrow - deselect current selection;
                                    move focus one cell left/right
-                fn + Up arrow/fn + Down Arrow - deselect current selection;
+                FN + Up Arrow/FN + Down Arrow - deselect current selection;
                                    scroll up/down one JViewport view;
                                    first visible cell in current column gets focus
-                Control-fn+Up Arrow/fn+Down arrow - deselect current selection;
+                Control-FN+Up Arrow/FN+Down Arrow - deselect current selection;
                                                     move focus and view to
                                                     first/last cell in current row
                 F2 - Allows editing in a cell containing information without
@@ -282,9 +280,9 @@ public class KeyBoardNavigation {
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
                 Ctrl+\\ - De-select all
-                Shift-up/down arrow -  extend selection up/down one row
-                Shift-left/right arrow - extend selection left/right one column
-                fn-shift up/down arrow -  extend selection to top/bottom of column
+                Shift-Up/Down Arrow -  extend selection up/down one row
+                Shift-Left/Right Arrow - extend selection left/right one column
+                FN-Shift Up/Down Arrow -  extend selection to top/bottom of column
                 Shift-PageUp/PageDown - extend selection up/down one view and scroll
                                         table
                                 """;

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -189,7 +189,7 @@ public class KeyBoardNavigation {
                 .rows(30)
                 .columns(50)
                 .testUI(KeyBoardNavigation::initTest)
-                .testTimeOut(10000)
+                .testTimeOut(10)
                 .build()
                 .awaitAndCheck();
     }
@@ -270,7 +270,7 @@ public class KeyBoardNavigation {
                                 up/down
                 Left/Right Arrow - Deselect current selection;
                                    move focus one cell left/right
-                FN + Up Arrow/FN + Down Arrow - Deselect current selection;
+                FN+Up Arrow/FN+Down Arrow - Deselect current selection;
                                    scroll up/down one JViewport view;
                                    first visible cell in current column gets focus
                 Control-FN+Up Arrow/FN+Down Arrow - Deselect current selection;

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -120,6 +120,7 @@ public class KeyBoardNavigation {
         numbersColumn.setCellRenderer(numberColumnRenderer);
         numbersColumn.setPreferredWidth(110);
 
+        tableView.setColumnSelectionAllowed(true);
         JScrollPane scrollPane = new JScrollPane(tableView);
         scrollPane.setBorder(new BevelBorder(BevelBorder.LOWERED));
         scrollPane.setPreferredSize(new Dimension(430, 200));
@@ -195,21 +196,21 @@ public class KeyBoardNavigation {
     public static String getOSSpecificInstructions() {
         final String WINDOWS_SPECIFIC = """
                 Tab, Shift-Tab - Navigate In.
-                Return/Shift-Return - move focus one cell down/up.
-                Tab/Shift-Tab -  move focus one cell right/left.
-                Up/Down Arrow - deselect current selection; move focus one
+                Return/Shift-Return - Move focus one cell down/up.
+                Tab/Shift-Tab -  Move focus one cell right/left.
+                Up/Down Arrow - Deselect current selection; move focus one
                                 cell up/down
-                Left/Right Arrow - deselect current selection; move focus
+                Left/Right Arrow - Deselect current selection; move focus
                                    one cell left/right
-                PageUp/PageDown - deselect current selection; scroll up/down
+                PageUp/PageDown - Deselect current selection; scroll up/down
                                   one JViewport view; first visible cell in
                                   current column gets focus
-                Control-PageUp/PageDown - deselect current selection;
+                Control-PageUp/PageDown - Deselect current selection;
                                           move focus and view to
                                           first/last cell in current row
-                Home/End - deselect current selection; move focus and view to
+                Home/End - Deselect current selection; move focus and view to
                            first/last cell in current row
-                Control-Home/End - deselect current selection;
+                Control-Home/End - Deselect current selection;
                                    scroll up/down one  JViewport view;
                                    first/last visible row of the table
                 F2 - Allows editing in a cell containing information without
@@ -217,61 +218,61 @@ public class KeyBoardNavigation {
                 Esc -  Resets the cell content back to the state it was in
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
-                Ctrl+\\ - De-select all
-                Shift-Up/Down Arrow -  extend selection up/down one row
-                Shift-Left/Right Arrow - extend selection left/right one
+                Ctrl+\\ - Deselect all
+                Shift-Up/Down Arrow -  Extend selection up/down one row
+                Shift-Left/Right Arrow - Extend selection left/right one
                                          column
-                Control-shift Up/Down Arrow -  extend selection to top/bottom
+                Control-shift Up/Down Arrow -  Extend selection to top/bottom
                                                 of column
-                Shift-Home/End -  extend selection to left/right end of row
-                Control-Shift-Home/End  - extend selection to beginning/end
+                Shift-Home/End -  Extend selection to left/right end of row
+                Control-Shift-Home/End  - Extend selection to beginning/end
                                           of data
-                Shift-PageUp/PageDown - extend selection up/down one view
+                Shift-PageUp/PageDown - Extend selection up/down one view
                                         and scroll table
-                Control-Shift-PageUp/PageDown - extend selection left/right
+                Control-Shift-PageUp/PageDown - Extend selection left/right
                                                 end of row
                 """;
 
         final String LINUX_SPECIFIC = """
                 Tab, Shift-Tab - Navigate In.
-                Return/Shift-Return - move focus one cell down/up.
-                Tab/Shift-Tab -  move focus one cell right/left.
-                Up/Down Arrow - deselect current selection;
+                Return/Shift-Return - Move focus one cell down/up.
+                Tab/Shift-Tab -  Move focus one cell right/left.
+                Up/Down Arrow - Deselect current selection;
                                 move focus one cell up/down
-                Left/Right Arrow - deselect current selection;
+                Left/Right Arrow - Deselect current selection;
                                    move focus one cell left/right
-                PageUp/PageDown - deselect current selection;
+                PageUp/PageDown - Deselect current selection;
                                   scroll up/down one  JViewport view;
                                   first visible cell in current column gets focus
-                Home/End - deselect current selection; move focus and view to
+                Home/End - Deselect current selection; move focus and view to
                                      first/last cell in current row
                 F2 - Allows editing in a cell containing information without
                      overwriting the information
                 Esc -  Resets the cell content back to the state it was in
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
-                Ctrl+\\ - De-select all
-                Shift-Up/Down Arrow -  extend selection up/down one row
-                Shift-Left/Right Arrow - extend selection left/right one column
-                Control-Shift Up/Down Arrow -  extend selection to top/bottom of
+                Ctrl+\\ - Deselect all
+                Shift-Up/Down Arrow -  Extend selection up/down one row
+                Shift-Left/Right Arrow - Extend selection left/right one column
+                Control-Shift Up/Down Arrow -  Extend selection to top/bottom of
                                                column
-                Shift-Home/End -  extend selection to left/right end of row
-                Shift-PageUp/PageDown - extend selection up/down one view and
+                Shift-Home/End -  Extend selection to left/right end of row
+                Shift-PageUp/PageDown - Extend selection up/down one view and
                                         scroll  table
                 """;
 
         final String MAC_SPECIFIC = """
                 Tab, Shift-Tab - Navigate In.
-                Return/Shift-Return - move focus one cell down/up.
-                Tab/Shift-Tab -  move focus one cell right/left.
-                Up/Down Arrow - deselect current selection; move focus one cell
+                Return/Shift-Return - Move focus one cell down/up.
+                Tab/Shift-Tab -  Move focus one cell right/left.
+                Up/Down Arrow - Deselect current selection; move focus one cell
                                 up/down
-                Left/Right Arrow - deselect current selection;
+                Left/Right Arrow - Deselect current selection;
                                    move focus one cell left/right
-                FN + Up Arrow/FN + Down Arrow - deselect current selection;
+                FN + Up Arrow/FN + Down Arrow - Deselect current selection;
                                    scroll up/down one JViewport view;
                                    first visible cell in current column gets focus
-                Control-FN+Up Arrow/FN+Down Arrow - deselect current selection;
+                Control-FN+Up Arrow/FN+Down Arrow - Deselect current selection;
                                                     move focus and view to
                                                     first/last cell in current row
                 F2 - Allows editing in a cell containing information without
@@ -279,11 +280,11 @@ public class KeyBoardNavigation {
                 Esc -  Resets the cell content back to the state it was in
                        before editing started
                 Ctrl+A, Ctrl+/ - Select All
-                Ctrl+\\ - De-select all
-                Shift-Up/Down Arrow -  extend selection up/down one row
-                Shift-Left/Right Arrow - extend selection left/right one column
-                FN-Shift Up/Down Arrow -  extend selection to top/bottom of column
-                Shift-PageUp/PageDown - extend selection up/down one view and scroll
+                Ctrl+\\ - Deselect all
+                Shift-Up/Down Arrow -  Extend selection up/down one row
+                Shift-Left/Right Arrow - Extend selection left/right one column
+                FN-Shift Up/Down Arrow -  Extend selection to top/bottom of column
+                Shift-PageUp/PageDown - Extend selection up/down one view and scroll
                                         table
                                 """;
         String osName = System.getProperty("os.name").toLowerCase();

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -177,18 +177,19 @@ public class KeyBoardNavigation {
                 Instructions to Test:
                 1. Refer the below keyboard navigation specs
                  (referenced from bug report 4112270).
-                2. Check all combinations of navigational keys in all four modes
-                  shift and control verifying each change to the selection against
-                  the spec. If it does, press "pass", otherwise press "fail".
+                2. Check all combinations of navigational keys mentioned below
+                 and verifying each key combinations against the spec defined.
+                 If it does, press "pass", otherwise press "fail".
 
                 """;
 
         INSTRUCTIONS += getOSSpecificInstructions();
         PassFailJFrame.builder()
                 .instructions(INSTRUCTIONS)
-                .rows(11)
+                .rows(30)
                 .columns(50)
                 .testUI(KeyBoardNavigation::initTest)
+                .testTimeOut(10000)
                 .build()
                 .awaitAndCheck();
     }


### PR DESCRIPTION
Instructions set has been updated as per OS specific. JTable keyboard navigation is tested in each OS and according it's current implementation the instructions has been updated (Few has been removed and few has been updated). 
PassFailJFrame.builder is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327696](https://bugs.openjdk.org/browse/JDK-8327696): [TESTBUG] "javax/swing/JTable/KeyBoardNavigation/KeyBoardNavigation.java" test instruction needs to be corrected (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**) ⚠️ Review applies to [71f1156f](https://git.openjdk.org/jdk/pull/18855/files/71f1156f90b7f9f5daf990abab8de916205b0a58)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18855/head:pull/18855` \
`$ git checkout pull/18855`

Update a local copy of the PR: \
`$ git checkout pull/18855` \
`$ git pull https://git.openjdk.org/jdk.git pull/18855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18855`

View PR using the GUI difftool: \
`$ git pr show -t 18855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18855.diff">https://git.openjdk.org/jdk/pull/18855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18855#issuecomment-2066266242)