### PR TITLE
8330621: Make 5 compiler tests use ProcessTools.executeProcess

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/Test7068051.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7068051.java
@@ -134,9 +134,8 @@ public class Test7068051 {
         for (String p : params) {
             jar.addToolArg(p);
         }
-        ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            OutputAnalyzer output = ProcessTools.executeProcess(jar.getCommand());
             output.shouldHaveExitValue(0);
         } catch (Exception ex) {
             throw new AssertionError("TESTBUG: jar failed.", ex);

--- a/test/hotspot/jtreg/compiler/c2/Test7068051.java
+++ b/test/hotspot/jtreg/compiler/c2/Test7068051.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ package compiler.c2;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -135,9 +136,9 @@ public class Test7068051 {
         }
         ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new AssertionError("TESTBUG: jar failed.", ex);
         }
     }

--- a/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
+++ b/test/hotspot/jtreg/compiler/c2/unloaded/TestInlineUnloaded.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,7 @@ package compiler.c2.unloaded;
 
 import jdk.test.lib.JDKToolFinder;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.IOException;
 import java.net.URL;
@@ -179,7 +180,7 @@ public class TestInlineUnloaded {
         }
     }
 
-    static void run(String testCaseName, Consumer<OutputAnalyzer> processor) throws IOException {
+    static void run(String testCaseName, Consumer<OutputAnalyzer> processor) throws Exception {
         ProcessBuilder pb = new ProcessBuilder();
 
         pb.command(JDKToolFinder.getJDKTool("java"),
@@ -192,7 +193,7 @@ public class TestInlineUnloaded {
 
         System.out.println("Command line: [" + pb.command() + "]");
 
-        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        OutputAnalyzer analyzer = ProcessTools.executeProcess(pb);
 
         analyzer.shouldHaveExitValue(0);
 

--- a/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/Agent.java
+++ b/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ package compiler.jsr292.NonInlinedCall;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 import java.io.PrintStream;
@@ -52,7 +53,7 @@ public class Agent {
         System.out.println("Running jar " + Arrays.toString(jar.getCommand()));
 
         ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        OutputAnalyzer output = ProcessTools.executeProcess(pb);
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/Agent.java
+++ b/test/hotspot/jtreg/compiler/jsr292/NonInlinedCall/Agent.java
@@ -52,8 +52,7 @@ public class Agent {
 
         System.out.println("Running jar " + Arrays.toString(jar.getCommand()));
 
-        ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
-        OutputAnalyzer output = ProcessTools.executeProcess(pb);
+        OutputAnalyzer output = ProcessTools.executeProcess(jar.getCommand());
         output.shouldHaveExitValue(0);
     }
 }

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -61,11 +61,10 @@ public class Launcher {
                 .addToolArg(Agent.AGENT_JAR)
                 .addToolArg(Agent.class.getName().replace('.', File.separatorChar) + ".class");
 
-        ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            OutputAnalyzer output = ProcessTools.executeProcess(jar.getCommand());
             output.shouldHaveExitValue(0);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new Error("TESTBUG: jar failed.", ex);
         }
     }

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ package compiler.profiling.spectrapredefineclass;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 import java.io.IOException;
@@ -62,7 +63,7 @@ public class Launcher {
 
         ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);
         } catch (IOException ex) {
             throw new Error("TESTBUG: jar failed.", ex);

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -64,11 +64,10 @@ public class Launcher {
                 .addToolArg(Agent.AGENT_JAR)
                 .addToolArg(Agent.class.getName().replace('.', File.separatorChar) + ".class");
 
-        ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = ProcessTools.executeProcess(pb);
+            OutputAnalyzer output = ProcessTools.executeProcess(jar.getCommand());
             output.shouldHaveExitValue(0);
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             throw new Error("TESTBUG: jar failed.", ex);
         }
     }

--- a/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
+++ b/test/hotspot/jtreg/compiler/profiling/spectrapredefineclass_classloaders/Launcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ package compiler.profiling.spectrapredefineclass_classloaders;
 
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 import java.io.File;
 import java.io.IOException;
@@ -65,7 +66,7 @@ public class Launcher {
 
         ProcessBuilder pb = new ProcessBuilder(jar.getCommand());
         try {
-            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            OutputAnalyzer output = ProcessTools.executeProcess(pb);
             output.shouldHaveExitValue(0);
         } catch (IOException ex) {
             throw new Error("TESTBUG: jar failed.", ex);


### PR DESCRIPTION
Said tests use simple `new ProcessBuilder` and its `start` method to start secondary processes.

As stated in [JDK-8174768](https://bugs.openjdk.org/browse/JDK-8174768), we try to have more information about started secondary processes and make the execution more controllable. This PR makes those tests use ProcessTools.executeProcess instead of using the `.start` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330621](https://bugs.openjdk.org/browse/JDK-8330621): Make 5 compiler tests use ProcessTools.executeProcess (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [c4641d05](https://git.openjdk.org/jdk/pull/18856/files/c4641d054a9e88008306647326860eb929f10eac)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18856/head:pull/18856` \
`$ git checkout pull/18856`

Update a local copy of the PR: \
`$ git checkout pull/18856` \
`$ git pull https://git.openjdk.org/jdk.git pull/18856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18856`

View PR using the GUI difftool: \
`$ git pr show -t 18856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18856.diff">https://git.openjdk.org/jdk/pull/18856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18856#issuecomment-2066266107)