### PR TITLE
8309259: Reduce calls to MethodHandles.lookup() in jdk.internal.net.http.Stream

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package jdk.internal.net.http;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.net.URI;

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -28,6 +28,7 @@ package jdk.internal.net.http;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.net.URI;
@@ -1724,9 +1725,10 @@ class Stream<T> extends ExchangeImpl<T> {
     private static final VarHandle DEREGISTERED;
     static {
         try {
-            STREAM_STATE = MethodHandles.lookup()
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            STREAM_STATE = lookup
                     .findVarHandle(Stream.class, "streamState", int.class);
-            DEREGISTERED = MethodHandles.lookup()
+            DEREGISTERED = lookup
                     .findVarHandle(Stream.class, "deRegistered", boolean.class);
         } catch (Exception x) {
             throw new ExceptionInInitializerError(x);


### PR DESCRIPTION
Please review this simple enhancement that is just reducing the number of times we call the `MethodHandles.lookup()` method, as it can be a bit slow.
Passes tier 1-3

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8309259](https://bugs.openjdk.org/browse/JDK-8309259): Reduce calls to MethodHandles.lookup() in jdk.internal.net.http.Stream (**Enhancement** - P5)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18862/head:pull/18862` \
`$ git checkout pull/18862`

Update a local copy of the PR: \
`$ git checkout pull/18862` \
`$ git pull https://git.openjdk.org/jdk.git pull/18862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18862`

View PR using the GUI difftool: \
`$ git pr show -t 18862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18862.diff">https://git.openjdk.org/jdk/pull/18862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18862#issuecomment-2068905780)