### PR TITLE
8330585: Refactor/rename forwardee handling

### DIFF
--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -227,8 +227,8 @@ void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
   if (state.is_in_cset()) {
     oop forwardee;
     markWord m = obj->mark();
-    if (obj->is_forwarded(m)) {
-      forwardee = obj->forwardee(m);
+    if (m.is_forwarded()) {
+      forwardee = m.forwardee();
     } else {
       forwardee = _par_scan_state->copy_to_survivor_space(state, obj, m);
     }

--- a/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -227,8 +227,8 @@ void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
   if (state.is_in_cset()) {
     oop forwardee;
     markWord m = obj->mark();
-    if (m.is_marked()) {
-      forwardee = cast_to_oop(m.decode_pointer());
+    if (obj->is_forwarded(m)) {
+      forwardee = obj->forwardee(m);
     } else {
       forwardee = _par_scan_state->copy_to_survivor_space(state, obj, m);
     }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -211,8 +211,8 @@ void G1ParScanThreadState::do_oop_evac(T* p) {
   }
 
   markWord m = obj->mark();
-  if (m.is_marked()) {
-    obj = cast_to_oop(m.decode_pointer());
+  if (obj->is_forwarded(m)) {
+    obj = obj->forwardee(m);
   } else {
     obj = do_copy_to_survivor_space(region_attr, obj, m);
   }

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -211,8 +211,8 @@ void G1ParScanThreadState::do_oop_evac(T* p) {
   }
 
   markWord m = obj->mark();
-  if (obj->is_forwarded(m)) {
-    obj = obj->forwardee(m);
+  if (m.is_forwarded()) {
+    obj = m.forwardee();
   } else {
     obj = do_copy_to_survivor_space(region_attr, obj, m);
   }

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -145,7 +145,7 @@ inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
   // in o. There may be multiple threads racing on it, and it may be forwarded
   // at any time.
   markWord m = o->mark();
-  if (!m.is_marked()) {
+  if (!o->is_forwarded(m)) {
     return copy_unmarked_to_survivor_space<promote_immediately>(o, m);
   } else {
     // Ensure any loads from the forwardee follow all changes that precede
@@ -153,7 +153,7 @@ inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
     // other thread.
     OrderAccess::acquire();
     // Return the already installed forwardee.
-    return cast_to_oop(m.decode_pointer());
+    return o->forwardee(m);
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -145,7 +145,7 @@ inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
   // in o. There may be multiple threads racing on it, and it may be forwarded
   // at any time.
   markWord m = o->mark();
-  if (!o->is_forwarded(m)) {
+  if (!m.is_forwarded()) {
     return copy_unmarked_to_survivor_space<promote_immediately>(o, m);
   } else {
     // Ensure any loads from the forwardee follow all changes that precede
@@ -153,7 +153,7 @@ inline oop PSPromotionManager::copy_to_survivor_space(oop o) {
     // other thread.
     OrderAccess::acquire();
     // Return the already installed forwardee.
-    return o->forwardee(m);
+    return m.forwardee();
   }
 }
 

--- a/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.inline.hpp
@@ -43,7 +43,7 @@ inline void PreservedMarks::push_if_necessary(oop obj, markWord m) {
 }
 
 inline void PreservedMarks::push_always(oop obj, markWord m) {
-  assert(!m.is_marked(), "precondition");
+  assert(!m.is_forwarded(), "precondition");
   PreservedMark elem(obj, m);
   _stack.push(elem);
 }

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -228,7 +228,7 @@ class markWord {
   }
 
   // used to encode pointers during GC
-  markWord clear_lock_bits() { return markWord(value() & ~lock_mask_in_place); }
+  markWord clear_lock_bits() const { return markWord(value() & ~lock_mask_in_place); }
 
   // age operations
   markWord set_marked()   { return markWord((value() & ~lock_mask_in_place) | marked_value); }
@@ -262,7 +262,11 @@ class markWord {
   inline static markWord encode_pointer_as_mark(void* p) { return from_pointer(p).set_marked(); }
 
   // Recover address of oop from encoded form used in mark
-  inline void* decode_pointer() { return (void*)clear_lock_bits().value(); }
+  inline void* decode_pointer() const { return (void*)clear_lock_bits().value(); }
+
+  inline oop forwardee() const {
+    return cast_to_oop(decode_pointer());
+  }
 };
 
 // Support atomic operations.

--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -143,6 +143,9 @@ class markWord {
   bool is_marked()   const {
     return (mask_bits(value(), lock_mask_in_place) == marked_value);
   }
+  bool is_forwarded()   const {
+    return (mask_bits(value(), lock_mask_in_place) == marked_value);
+  }
   bool is_neutral()  const {  // Not locked, or marked - a "clean" neutral state
     return (mask_bits(value(), lock_mask_in_place) == unlocked_value);
   }

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -256,7 +256,6 @@ class oopDesc {
 
   // Forward pointer operations for scavenge
   inline bool is_forwarded() const;
-  inline bool is_forwarded(markWord m) const;
 
   inline void forward_to(oop p);
 
@@ -267,7 +266,6 @@ class oopDesc {
   inline oop forward_to_atomic(oop p, markWord compare, atomic_memory_order order = memory_order_conservative);
 
   inline oop forwardee() const;
-  inline oop forwardee(markWord m) const;
 
   // Age of object during scavenge
   inline uint age() const;

--- a/src/hotspot/share/oops/oop.hpp
+++ b/src/hotspot/share/oops/oop.hpp
@@ -256,6 +256,7 @@ class oopDesc {
 
   // Forward pointer operations for scavenge
   inline bool is_forwarded() const;
+  inline bool is_forwarded(markWord m) const;
 
   inline void forward_to(oop p);
 
@@ -266,6 +267,7 @@ class oopDesc {
   inline oop forward_to_atomic(oop p, markWord compare, atomic_memory_order order = memory_order_conservative);
 
   inline oop forwardee() const;
+  inline oop forwardee(markWord m) const;
 
   // Age of object during scavenge
   inline uint age() const;

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -262,12 +262,7 @@ bool oopDesc::is_gc_marked() const {
 
 // Used by scavengers
 bool oopDesc::is_forwarded() const {
-  return is_forwarded(mark());
-}
-
-// Non-racy version.
-bool oopDesc::is_forwarded(markWord m) const {
-  return m.is_forwarded();
+  return mark().is_forwarded();
 }
 
 // Used by scavengers
@@ -292,12 +287,7 @@ oop oopDesc::forward_to_atomic(oop p, markWord compare, atomic_memory_order orde
 // The forwardee is used when copying during scavenge and mark-sweep.
 // It does need to clear the low two locking- and GC-related bits.
 oop oopDesc::forwardee() const {
-  return forwardee(mark());
-}
-
-oop oopDesc::forwardee(markWord m) const {
-  assert(is_forwarded(m), "only decode when actually forwarded");
-  return cast_to_oop(m.decode_pointer());
+  return mark().forwardee();
 }
 
 // The following method needs to be MT safe.

--- a/src/hotspot/share/oops/oop.inline.hpp
+++ b/src/hotspot/share/oops/oop.inline.hpp
@@ -262,9 +262,12 @@ bool oopDesc::is_gc_marked() const {
 
 // Used by scavengers
 bool oopDesc::is_forwarded() const {
-  // The extra heap check is needed since the obj might be locked, in which case the
-  // mark would point to a stack location and have the sentinel bit cleared
-  return mark().is_marked();
+  return is_forwarded(mark());
+}
+
+// Non-racy version.
+bool oopDesc::is_forwarded(markWord m) const {
+  return m.is_forwarded();
 }
 
 // Used by scavengers
@@ -289,8 +292,12 @@ oop oopDesc::forward_to_atomic(oop p, markWord compare, atomic_memory_order orde
 // The forwardee is used when copying during scavenge and mark-sweep.
 // It does need to clear the low two locking- and GC-related bits.
 oop oopDesc::forwardee() const {
-  assert(is_forwarded(), "only decode when actually forwarded");
-  return cast_to_oop(mark().decode_pointer());
+  return forwardee(mark());
+}
+
+oop oopDesc::forwardee(markWord m) const {
+  assert(is_forwarded(m), "only decode when actually forwarded");
+  return cast_to_oop(m.decode_pointer());
 }
 
 // The following method needs to be MT safe.


### PR DESCRIPTION
In several places in GCs we use is_marked() where we really mean is_forwarded(), and do weird things like decode forwardee directly from a markWord instead of using a proper helper, etc.

This change cleans it up. It introduces a bunch of APIs to facilitate that: 
 - oopDesc::forwardee(markWord): This doesn't have to be in oopDesc right now, but I'd like to put it there in preparation of https://bugs.openjdk.org/browse/JDK-8305898, which requires it to be in oopDesc. Also, it's nice as a non-racy companion of oopDesc::forwardee().
 - oopDesc::is_forwarded(markWord): It doesn't have to be in oopDesc, either, but I think it's good to have it at the same level of API abstraction as oopDesc::forwardee(markWord).

Testing:
 - [x] hotspot_gc
 - [x] tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330585](https://bugs.openjdk.org/browse/JDK-8330585): Refactor/rename forwardee handling (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18863/head:pull/18863` \
`$ git checkout pull/18863`

Update a local copy of the PR: \
`$ git checkout pull/18863` \
`$ git pull https://git.openjdk.org/jdk.git pull/18863/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18863`

View PR using the GUI difftool: \
`$ git pr show -t 18863`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18863.diff">https://git.openjdk.org/jdk/pull/18863.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18863#issuecomment-2066471368)