### PR TITLE
8330681: Explicit hashCode and equals for java.lang.runtime.SwitchBootstraps$TypePairs

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -704,11 +704,6 @@ public class SwitchBootstraps {
 
         public static Map<TypePairs, String> initialize() {
             Map<TypePairs, String> typePairToName = new HashMap<>();
-            typePairToName.put(new TypePairs(byte.class,   char.class),   "isIntToCharExact");      // redirected
-            typePairToName.put(new TypePairs(short.class,  byte.class),   "isIntToByteExact");      // redirected
-            typePairToName.put(new TypePairs(short.class,  char.class),   "isIntToCharExact");      // redirected
-            typePairToName.put(new TypePairs(char.class,   byte.class),   "isIntToByteExact");      // redirected
-            typePairToName.put(new TypePairs(char.class,   short.class),  "isIntToShortExact");     // redirected
             typePairToName.put(new TypePairs(int.class,    byte.class),   "isIntToByteExact");
             typePairToName.put(new TypePairs(int.class,    short.class),  "isIntToShortExact");
             typePairToName.put(new TypePairs(int.class,    char.class),   "isIntToCharExact");
@@ -730,7 +725,7 @@ public class SwitchBootstraps {
             typePairToName.put(new TypePairs(double.class, int.class),    "isDoubleToIntExact");
             typePairToName.put(new TypePairs(double.class, long.class),   "isDoubleToLongExact");
             typePairToName.put(new TypePairs(double.class, float.class),  "isDoubleToFloatExact");
-            return typePairToName;
+            return Map.copyOf(typePairToName);
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -704,6 +704,11 @@ public class SwitchBootstraps {
 
         public static Map<TypePairs, String> initialize() {
             Map<TypePairs, String> typePairToName = new HashMap<>();
+            typePairToName.put(new TypePairs(byte.class,   char.class),   "isIntToCharExact");      // redirected
+            typePairToName.put(new TypePairs(short.class,  byte.class),   "isIntToByteExact");      // redirected
+            typePairToName.put(new TypePairs(short.class,  char.class),   "isIntToCharExact");      // redirected
+            typePairToName.put(new TypePairs(char.class,   byte.class),   "isIntToByteExact");      // redirected
+            typePairToName.put(new TypePairs(char.class,   short.class),  "isIntToShortExact");     // redirected
             typePairToName.put(new TypePairs(int.class,    byte.class),   "isIntToByteExact");
             typePairToName.put(new TypePairs(int.class,    short.class),  "isIntToShortExact");
             typePairToName.put(new TypePairs(int.class,    char.class),   "isIntToCharExact");
@@ -725,7 +730,7 @@ public class SwitchBootstraps {
             typePairToName.put(new TypePairs(double.class, int.class),    "isDoubleToIntExact");
             typePairToName.put(new TypePairs(double.class, long.class),   "isDoubleToLongExact");
             typePairToName.put(new TypePairs(double.class, float.class),  "isDoubleToFloatExact");
-            return Map.copyOf(typePairToName);
+            return typePairToName;
         }
     }
 }

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -82,8 +82,6 @@ public class SwitchBootstraps {
     private static final MethodTypeDesc TYPES_SWITCH_DESCRIPTOR =
             MethodTypeDesc.ofDescriptor("(Ljava/lang/Object;ILjava/util/function/BiPredicate;Ljava/util/List;)I");
 
-    private static final Map<TypePairs, String> typePairToName;
-
     static {
         try {
             NULL_CHECK = LOOKUP.findStatic(Objects.class, "isNull",
@@ -99,7 +97,6 @@ public class SwitchBootstraps {
         catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);
         }
-        typePairToName = TypePairs.initialize();
     }
 
     /**
@@ -507,7 +504,7 @@ public class SwitchBootstraps {
                             }
 
                             TypePairs typePair = TypePairs.of(Wrapper.asPrimitiveType(selectorType), classLabel);
-                            String methodName = typePairToName.get(typePair);
+                            String methodName = TypePairs.typePairToName.get(typePair);
                             cb.invokestatic(ExactConversionsSupport.class.describeConstable().orElseThrow(),
                                     methodName,
                                     MethodTypeDesc.of(ConstantDescs.CD_boolean, typePair.from.describeConstable().orElseThrow()));
@@ -684,6 +681,9 @@ public class SwitchBootstraps {
 
     // TypePairs should be in sync with the corresponding record in Lower
     record TypePairs(Class<?> from, Class<?> to) {
+
+        private static final Map<TypePairs, String> typePairToName = initialize();
+
         public static TypePairs of(Class<?> from,  Class<?> to) {
             if (from == byte.class || from == short.class || from == char.class) {
                 from = int.class;
@@ -692,7 +692,7 @@ public class SwitchBootstraps {
         }
 
         public int hashCode() {
-            return Objects.hash(from, to);
+            return 31 * from.hashCode() + to.hashCode();
         }
 
         public boolean equals(Object other) {

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -691,6 +691,17 @@ public class SwitchBootstraps {
             return new TypePairs(from, to);
         }
 
+        public int hashCode() {
+            return Objects.hash(from, to);
+        }
+
+        public boolean equals(Object other) {
+            if (other instanceof TypePairs otherPair) {
+                return otherPair.from == from && otherPair.to == to;
+            }
+            return false;
+        }
+
         public static Map<TypePairs, String> initialize() {
             Map<TypePairs, String> typePairToName = new HashMap<>();
             typePairToName.put(new TypePairs(byte.class,   char.class),   "isIntToCharExact");      // redirected


### PR DESCRIPTION
We can reduce overhead of first use of a switch bootstrap by moving `typePairToName` into `TypePairs` and by explicitly overriding `hashCode` and `equals`. The first change avoids loading and initializing the `TypePairs` class in actual cases, the second remove some excess code generation from happening on first use.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330681](https://bugs.openjdk.org/browse/JDK-8330681): Explicit hashCode and equals for java.lang.runtime.SwitchBootstraps$TypePairs (**Enhancement** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18865/head:pull/18865` \
`$ git checkout pull/18865`

Update a local copy of the PR: \
`$ git checkout pull/18865` \
`$ git pull https://git.openjdk.org/jdk.git pull/18865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18865`

View PR using the GUI difftool: \
`$ git pr show -t 18865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18865.diff">https://git.openjdk.org/jdk/pull/18865.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18865#issuecomment-2066593028)