### PR TITLE
8330625: Compilation memory statistic: prevent tearing of the final report

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -428,7 +428,6 @@ void CompilationMemoryStatistic::on_end_compilation() {
                     arena_stat->live_nodes_at_peak(),
                     result);
   }
-  
   if (print) {
     char buf[1024];
     fmn.as_C_string(buf, sizeof(buf));

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -404,14 +404,6 @@ void CompilationMemoryStatistic::on_end_compilation() {
   assert(directive->should_collect_memstat(), "Only call if memstat is enabled");
   const bool print = directive->should_print_memstat();
 
-  if (print) {
-    char buf[1024];
-    fmn.as_C_string(buf, sizeof(buf));
-    tty->print("%s Arena usage %s: ", compilertype2name(ct), buf);
-    arena_stat->print_on(tty);
-    tty->cr();
-  }
-
   // Store result
   // For this to work, we must call on_end_compilation() at a point where
   // Compile|Compilation already handed over the failure string to ciEnv,
@@ -435,6 +427,18 @@ void CompilationMemoryStatistic::on_end_compilation() {
                     arena_stat->ra_at_peak(),
                     arena_stat->live_nodes_at_peak(),
                     result);
+  }
+
+  // We also print a log line for every finished compilation. Note: by doing this after
+  // storing the result data in the compilation cost history, we prevent tearing of
+  // the final report at the end of a VM run (since we wait on the NMTCompilationCostHistory_lock
+  // above that guards the final printout).
+  if (print) {
+    char buf[1024];
+    fmn.as_C_string(buf, sizeof(buf));
+    tty->print("%s Arena usage %s: ", compilertype2name(ct), buf);
+    arena_stat->print_on(tty);
+    tty->cr();
   }
 
   arena_stat->end(); // reset things
@@ -539,6 +543,9 @@ static inline ssize_t diff_entries_by_size(const MemStatEntry* e1, const MemStat
 }
 
 void CompilationMemoryStatistic::print_all_by_size(outputStream* st, bool human_readable, size_t min_size) {
+
+  MutexLocker ml(NMTCompilationCostHistory_lock, Mutex::_no_safepoint_check_flag);
+
   st->print_cr("Compilation memory statistics");
 
   if (!enabled()) {
@@ -559,29 +566,26 @@ void CompilationMemoryStatistic::print_all_by_size(outputStream* st, bool human_
   MemStatEntry::print_header(st);
 
   MemStatEntry** filtered = nullptr;
-  {
-    MutexLocker ml(NMTCompilationCostHistory_lock, Mutex::_no_safepoint_check_flag);
 
-    if (_the_table != nullptr) {
-      // We sort with quicksort
-      int num = 0;
-      filtered = _the_table->calc_flat_array(num, min_size);
-      if (min_size > 0) {
-        st->print_cr("(%d/%d)", num, _the_table->number_of_entries());
-      }
-      if (num > 0) {
-        QuickSort::sort(filtered, num, diff_entries_by_size, false);
-        // Now print. Has to happen under lock protection too, since entries may be changed.
-        for (int i = 0; i < num; i ++) {
-          filtered[i]->print_on(st, human_readable);
-        }
-      } else {
-        st->print_cr("No entries.");
+  if (_the_table != nullptr) {
+    // We sort with quicksort
+    int num = 0;
+    filtered = _the_table->calc_flat_array(num, min_size);
+    if (min_size > 0) {
+      st->print_cr("(%d/%d)", num, _the_table->number_of_entries());
+    }
+    if (num > 0) {
+      QuickSort::sort(filtered, num, diff_entries_by_size, false);
+      // Now print. Has to happen under lock protection too, since entries may be changed.
+      for (int i = 0; i < num; i ++) {
+        filtered[i]->print_on(st, human_readable);
       }
     } else {
-      st->print_cr("Not initialized.");
+      st->print_cr("No entries.");
     }
-  } // locked
+  } else {
+    st->print_cr("Not initialized.");
+  }
 
   FREE_C_HEAP_ARRAY(Entry, filtered);
 }

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -428,11 +428,7 @@ void CompilationMemoryStatistic::on_end_compilation() {
                     arena_stat->live_nodes_at_peak(),
                     result);
   }
-
-  // We also print a log line for every finished compilation. Note: by doing this after
-  // storing the result data in the compilation cost history, we prevent tearing of
-  // the final report at the end of a VM run (since we wait on the NMTCompilationCostHistory_lock
-  // above that guards the final printout).
+  
   if (print) {
     char buf[1024];
     fmn.as_C_string(buf, sizeof(buf));

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -541,6 +541,7 @@ void CompilationMemoryStatistic::print_all_by_size(outputStream* st, bool human_
 
   MutexLocker ml(NMTCompilationCostHistory_lock, Mutex::_no_safepoint_check_flag);
 
+  st->cr();
   st->print_cr("Compilation memory statistics");
 
   if (!enabled()) {
@@ -581,6 +582,7 @@ void CompilationMemoryStatistic::print_all_by_size(outputStream* st, bool human_
   } else {
     st->print_cr("Not initialized.");
   }
+  st->cr();
 
   FREE_C_HEAP_ARRAY(Entry, filtered);
 }


### PR DESCRIPTION
Somewhat trivial change to reduce the chance of tearing the final compilation cost history report. See JBS for details.

---

The patch:
- upon end of a compilation, we print the the offending log line and account the cost in the compilation cost history table. For the latter we lock over NMTCompilationCostHistory_lock. The patch swaps these two actions such that we print after pulling the lock. That greatly reduces, albeit not completely removes, the chance of printing log lines into the final report. (I did not want to widen the scope of that lock to include the printout)
- also moves the locking of NMTCompilationCostHistory_lock  up to the start of the reporting function to include printing the report header into the locking

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330625](https://bugs.openjdk.org/browse/JDK-8330625): Compilation memory statistic: prevent tearing of the final report (**Bug** - P5)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [92049dda](https://git.openjdk.org/jdk/pull/18866/files/92049dda729807021de785675f31cdc05dc08867)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18866/head:pull/18866` \
`$ git checkout pull/18866`

Update a local copy of the PR: \
`$ git checkout pull/18866` \
`$ git pull https://git.openjdk.org/jdk.git pull/18866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18866`

View PR using the GUI difftool: \
`$ git pr show -t 18866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18866.diff">https://git.openjdk.org/jdk/pull/18866.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18866#issuecomment-2069092137)