### PR TITLE
8323965: modify fix for 8317771 to remove reflection instantiation of the inner class

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CAccessibility.java
@@ -760,18 +760,7 @@ class CAccessibility implements PropertyChangeListener {
     }
 
     private static Accessible createAccessibleTreeNode(JTree t, TreePath p) {
-        Accessible a = null;
-
-        try {
-            Class<?> accessibleJTreeNodeClass = Class.forName("javax.swing.JTree$AccessibleJTree$AccessibleJTreeNode");
-            Constructor<?> constructor = accessibleJTreeNodeClass.getConstructor(t.getAccessibleContext().getClass(), JTree.class, TreePath.class, Accessible.class);
-            constructor.setAccessible(true);
-            a = ((Accessible) constructor.newInstance(t.getAccessibleContext(), t, p, null));
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        return a;
+        return SwingAccessor.getAccessibleJTreeNodeCreateAccessor().createAccessibleJTreeNode(t, p, null);
     }
 
     // This method is called from the native

--- a/src/java.desktop/share/classes/javax/swing/JTree.java
+++ b/src/java.desktop/share/classes/javax/swing/JTree.java
@@ -4272,6 +4272,10 @@ public class JTree extends JComponent implements Scrollable, Accessible
         TreePath   leadSelectionPath;
         Accessible leadSelectionAccessible;
 
+        static {
+            SwingAccessor.setAccessibleJTreeNodeCreateAccessor(new AccessibleTreNodeACreateccessor());
+        }
+
         /**
          * Constructs {@code AccessibleJTree}
          */
@@ -4729,6 +4733,31 @@ public class JTree extends JComponent implements Scrollable, Accessible
 
                 TreePath path = new TreePath(objPath);
                 JTree.this.addSelectionPath(path);
+            }
+        }
+
+        /**
+         * This method creates an accessible tree node
+         *
+         * @param tree Tree? for whose nodes an accessible
+         * @param path path to node
+         * @param ap accessible parent
+         * @return AccessibleJTreeNode
+         */
+        protected Accessible createAccessibleTreeNode(JTree tree, TreePath path, Accessible ap) {
+            return new AccessibleJTreeNode(tree, path, ap);
+        }
+
+        private static class AccessibleTreNodeACreateccessor implements SwingAccessor.AccessibleJTreeNodeCreateAccessor {
+            private AccessibleTreNodeACreateccessor() {}
+
+            @Override
+            public Accessible createAccessibleJTreeNode(JTree tree, TreePath path, Accessible ap) {
+                AccessibleContext ac = tree.getAccessibleContext();
+                if (ac instanceof AccessibleJTree) {
+                    return ((AccessibleJTree) ac).createAccessibleTreeNode(tree, path, ap);
+                }
+                return null;
             }
         }
 

--- a/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingAccessor.java
@@ -33,6 +33,7 @@ import javax.accessibility.AccessibleContext;
 
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
+import javax.swing.tree.TreePath;
 
 /**
  * The SwingAccessor utility class.
@@ -56,6 +57,13 @@ public final class SwingAccessor {
      */
     public interface AccessibleComponentAccessor {
         Accessible getCurrentAccessible(AccessibleContext ac);
+    }
+
+    /**
+     * This interface allows to create an accessible tree node
+     */
+    public interface AccessibleJTreeNodeCreateAccessor {
+        Accessible createAccessibleJTreeNode(JTree tree, TreePath path, Accessible ap);
     }
 
     /**
@@ -302,6 +310,7 @@ public final class SwingAccessor {
     }
 
     private static AccessibleComponentAccessor accessibleComponentAccessor = null;
+    private static AccessibleJTreeNodeCreateAccessor accessibleJTreeNodeCreateAccessor = null;
 
     public static AccessibleComponentAccessor getAccessibleComponentAccessor() {
         var access = accessibleComponentAccessor;
@@ -314,6 +323,19 @@ public final class SwingAccessor {
 
     public static void setAccessibleComponentAccessor(final AccessibleComponentAccessor accessibleAccessor) {
         accessibleComponentAccessor = accessibleAccessor;
+    }
+
+    public static AccessibleJTreeNodeCreateAccessor getAccessibleJTreeNodeCreateAccessor() {
+        var access = accessibleJTreeNodeCreateAccessor;
+        if (access == null) {
+            ensureClassInitialized(JTree.class);
+            access = accessibleJTreeNodeCreateAccessor;
+        }
+        return access;
+    }
+
+    public static void setAccessibleJTreeNodeCreateAccessor(final AccessibleJTreeNodeCreateAccessor accessibleAccessor) {
+        accessibleJTreeNodeCreateAccessor = accessibleAccessor;
     }
 
     private static void ensureClassInitialized(Class<?> c) {


### PR DESCRIPTION
I replaced reflection with using an accessor
@azuev-java please review

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8323965: modify fix for 8317771 to remove reflection instantiation of the inner class`

### Issues
 * [JDK-8323965](https://bugs.openjdk.org/browse/JDK-8323965): modify fix for 8317771 to remove reflection instantiation of the inner class (**Bug** - P4)
 * [JDK-8329667](https://bugs.openjdk.org/browse/JDK-8329667): [macos] Issue with JTree related fix for JDK-8317771 (**Bug** - P3) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18867/head:pull/18867` \
`$ git checkout pull/18867`

Update a local copy of the PR: \
`$ git checkout pull/18867` \
`$ git pull https://git.openjdk.org/jdk.git pull/18867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18867`

View PR using the GUI difftool: \
`$ git pr show -t 18867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18867.diff">https://git.openjdk.org/jdk/pull/18867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18867#issuecomment-2066810032)