### PR TITLE
8330703: Improve link syntax in javax.lang.model.util

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
@@ -40,10 +40,10 @@ import javax.annotation.processing.ProcessingEnvironment;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
-* @see <a href="package-summary.html#expectedEvolution">
-* <strong>Expected visitor evolution</strong></a>
- * @see <a href="AbstractAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractAnnotationValueVisitor6
  * @see AbstractAnnotationValueVisitor7
  * @see AbstractAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
@@ -45,10 +45,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="AbstractElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractElementVisitor6
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
@@ -43,10 +43,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="AbstractTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractTypeVisitor6
  * @see AbstractTypeVisitor7
  * @see AbstractTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
@@ -57,10 +57,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="ElementKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementKindVisitor6
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
@@ -74,9 +74,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="ElementScanner6.html#note_for_subclasses"><strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementScanner6
  * @see ElementScanner7
  * @see ElementScanner8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
@@ -48,10 +48,10 @@ import static javax.lang.model.SourceVersion.*;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="SimpleAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleAnnotationValueVisitor6
  * @see SimpleAnnotationValueVisitor7
  * @see SimpleAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
@@ -53,10 +53,10 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="SimpleElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleElementVisitor6
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
@@ -52,10 +52,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="SimpleTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleTypeVisitor6
  * @see SimpleTypeVisitor7
  * @see SimpleTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
@@ -56,10 +56,10 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="package-summary.html#expectedEvolution">
- * <strong>Expected visitor evolution</strong></a>
- * @see <a href="TypeKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see javax.lang.model.util##expectedEvolution
+ * <strong>Expected visitor evolution</strong>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see TypeKindVisitor6
  * @see TypeKindVisitor7
  * @see TypeKindVisitor8


### PR DESCRIPTION
Use javadoc-based from than HTML-based syntax for `@see` tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330703](https://bugs.openjdk.org/browse/JDK-8330703): Improve link syntax in javax.lang.model.util (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18869/head:pull/18869` \
`$ git checkout pull/18869`

Update a local copy of the PR: \
`$ git checkout pull/18869` \
`$ git pull https://git.openjdk.org/jdk.git pull/18869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18869`

View PR using the GUI difftool: \
`$ git pr show -t 18869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18869.diff">https://git.openjdk.org/jdk/pull/18869.diff</a>

</details>
