### PR TITLE
8330733: Generational ZGC: Remove ZBarrier::verify_old_object_live_slow_path

### DIFF
--- a/src/hotspot/share/gc/z/zBarrier.cpp
+++ b/src/hotspot/share/gc/z/zBarrier.cpp
@@ -141,18 +141,6 @@ zaddress ZBarrier::blocking_load_barrier_on_phantom_slow_path(volatile zpointer*
   return addr;
 }
 
-//
-// Clean barrier
-//
-
-zaddress ZBarrier::verify_old_object_live_slow_path(zaddress addr) {
-  // Verify that the object was indeed alive
-  assert(ZHeap::heap()->is_young(addr) || ZHeap::heap()->is_object_live(addr), "Should be live");
-
-  return addr;
-}
-
-//
 // Mark barrier
 //
 

--- a/src/hotspot/share/gc/z/zBarrier.hpp
+++ b/src/hotspot/share/gc/z/zBarrier.hpp
@@ -108,8 +108,6 @@ private:
   static zaddress blocking_load_barrier_on_weak_slow_path(volatile zpointer* p, zaddress addr);
   static zaddress blocking_load_barrier_on_phantom_slow_path(volatile zpointer* p, zaddress addr);
 
-  static zaddress verify_old_object_live_slow_path(zaddress addr);
-
   static zaddress mark_slow_path(zaddress addr);
   static zaddress mark_young_slow_path(zaddress addr);
   static zaddress mark_from_young_slow_path(zaddress addr);


### PR DESCRIPTION
Hi all,

This trivial patch removes the unused method `ZBarrier::verify_old_object_live_slow_path`.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330733](https://bugs.openjdk.org/browse/JDK-8330733): Generational ZGC: Remove ZBarrier::verify_old_object_live_slow_path (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18872/head:pull/18872` \
`$ git checkout pull/18872`

Update a local copy of the PR: \
`$ git checkout pull/18872` \
`$ git pull https://git.openjdk.org/jdk.git pull/18872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18872`

View PR using the GUI difftool: \
`$ git pr show -t 18872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18872.diff">https://git.openjdk.org/jdk/pull/18872.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18872#issuecomment-2067564805)