### PR TITLE
8330693: Generational ZGC: Simplify ZAddress::finalizable_good and ZAddress::mark_good

### DIFF
--- a/src/hotspot/share/gc/z/zAddress.inline.hpp
+++ b/src/hotspot/share/gc/z/zAddress.inline.hpp
@@ -600,9 +600,7 @@ inline zpointer ZAddress::finalizable_good(zaddress addr, zpointer prev) {
     return color_null();
   }
 
-  const uintptr_t non_mark_bits_mask = ZPointerMarkMetadataMask ^ ZPointerAllMetadataMask;
-  const uintptr_t non_mark_prev_bits = untype(prev) & non_mark_bits_mask;
-  return color(addr, ZPointerLoadGoodMask | ZPointerMarkedYoung | ZPointerFinalizable | non_mark_prev_bits | ZPointerRememberedMask);
+  return color(addr, ZPointerLoadGoodMask | ZPointerMarkedYoung | ZPointerFinalizable | ZPointerRememberedMask);
 }
 
 inline zpointer ZAddress::mark_good(zaddress addr, zpointer prev) {
@@ -610,9 +608,7 @@ inline zpointer ZAddress::mark_good(zaddress addr, zpointer prev) {
     return color_null();
   }
 
-  const uintptr_t non_mark_bits_mask = ZPointerMarkMetadataMask ^ ZPointerAllMetadataMask;
-  const uintptr_t non_mark_prev_bits = untype(prev) & non_mark_bits_mask;
-  return color(addr, ZPointerLoadGoodMask | ZPointerMarkedYoung | ZPointerMarkedOld | non_mark_prev_bits | ZPointerRememberedMask);
+  return color(addr, ZPointerLoadGoodMask | ZPointerMarkedYoung | ZPointerMarkedOld | ZPointerRememberedMask);
 }
 
 inline zpointer ZAddress::mark_old_good(zaddress addr, zpointer prev) {


### PR DESCRIPTION
Hi all,

This patch simplifies the methods `ZAddress::finalizable_good` and `ZAddress::mark_good`, mainly removing the code which computes the `non_mark_prev_bits`.

The tests `make test-tier1_gc` passed locally. Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330693](https://bugs.openjdk.org/browse/JDK-8330693): Generational ZGC: Simplify ZAddress::finalizable_good and ZAddress::mark_good (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18873/head:pull/18873` \
`$ git checkout pull/18873`

Update a local copy of the PR: \
`$ git checkout pull/18873` \
`$ git pull https://git.openjdk.org/jdk.git pull/18873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18873`

View PR using the GUI difftool: \
`$ git pr show -t 18873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18873.diff">https://git.openjdk.org/jdk/pull/18873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18873#issuecomment-2067565787)