### PR TITLE
8330624: Inconsistent use of semicolon in the code snippet of java.io.Serializable javadoc

### DIFF
--- a/src/java.base/share/classes/java/io/Serializable.java
+++ b/src/java.base/share/classes/java/io/Serializable.java
@@ -68,7 +68,7 @@ package java.io;
  *
  * <PRE>
  * private void writeObject(java.io.ObjectOutputStream out)
- *     throws IOException
+ *     throws IOException;
  * private void readObject(java.io.ObjectInputStream in)
  *     throws IOException, ClassNotFoundException;
  * private void readObjectNoData()


### PR DESCRIPTION
Fix the description of java.io.Serializable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330624](https://bugs.openjdk.org/browse/JDK-8330624): Inconsistent use of semicolon in the code snippet of java.io.Serializable javadoc (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18874/head:pull/18874` \
`$ git checkout pull/18874`

Update a local copy of the PR: \
`$ git checkout pull/18874` \
`$ git pull https://git.openjdk.org/jdk.git pull/18874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18874`

View PR using the GUI difftool: \
`$ git pr show -t 18874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18874.diff">https://git.openjdk.org/jdk/pull/18874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18874#issuecomment-2067650584)