### PR TITLE
8330735: RISC-V: No need to move sp to tmp register in set_last_Java_frame

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -228,20 +228,16 @@ void MacroAssembler::check_and_handle_popframe(Register java_thread) {}
 // has to be reset to 0. This is required to allow proper stack traversal.
 void MacroAssembler::set_last_Java_frame(Register last_java_sp,
                                          Register last_java_fp,
-                                         Register last_java_pc,
-                                         Register tmp) {
+                                         Register last_java_pc) {
 
   if (last_java_pc->is_valid()) {
-      sd(last_java_pc, Address(xthread,
-                               JavaThread::frame_anchor_offset() +
-                               JavaFrameAnchor::last_Java_pc_offset()));
+    sd(last_java_pc, Address(xthread,
+                             JavaThread::frame_anchor_offset() +
+                             JavaFrameAnchor::last_Java_pc_offset()));
   }
 
   // determine last_java_sp register
-  if (last_java_sp == sp) {
-    mv(tmp, sp);
-    last_java_sp = tmp;
-  } else if (!last_java_sp->is_valid()) {
+  if (!last_java_sp->is_valid()) {
     last_java_sp = esp;
   }
 
@@ -262,7 +258,7 @@ void MacroAssembler::set_last_Java_frame(Register last_java_sp,
   la(tmp, last_java_pc);
   sd(tmp, Address(xthread, JavaThread::frame_anchor_offset() + JavaFrameAnchor::last_Java_pc_offset()));
 
-  set_last_Java_frame(last_java_sp, last_java_fp, noreg, tmp);
+  set_last_Java_frame(last_java_sp, last_java_fp, noreg);
 }
 
 void MacroAssembler::set_last_Java_frame(Register last_java_sp,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -146,7 +146,7 @@ class MacroAssembler: public Assembler {
   // last Java Frame (fills frame anchor)
   void set_last_Java_frame(Register last_java_sp, Register last_java_fp, address last_java_pc, Register tmp);
   void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Label &last_java_pc, Register tmp);
-  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Register last_java_pc, Register tmp);
+  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Register last_java_pc);
 
   // thread in the default location (xthread)
   void reset_last_Java_frame(bool clear_fp);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2434,7 +2434,7 @@ class StubGenerator: public StubCodeGenerator {
       __ membar(__ LoadLoad);
     }
 
-    __ set_last_Java_frame(sp, fp, ra, t0);
+    __ set_last_Java_frame(sp, fp, ra);
 
     __ enter();
     __ add(t1, sp, wordSize);


### PR DESCRIPTION
Hi, please review this refactoring to remove the unnecessary move from sp to temp register.

There is no restriction for riscv when using `sp` as an operand in instructions. So we do not have to move the sp register to a temp register before we store `last_java_sp`.

Testing:

- [x] Tier1-3 (linux-riscv64, release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330735](https://bugs.openjdk.org/browse/JDK-8330735): RISC-V: No need to move sp to tmp register in set_last_Java_frame (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18875/head:pull/18875` \
`$ git checkout pull/18875`

Update a local copy of the PR: \
`$ git checkout pull/18875` \
`$ git pull https://git.openjdk.org/jdk.git pull/18875/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18875`

View PR using the GUI difftool: \
`$ git pr show -t 18875`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18875.diff">https://git.openjdk.org/jdk/pull/18875.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18875#issuecomment-2068368161)