### PR TITLE
8306928: Duplicate variable assignement in jdk.internal.net.http.AuthenticationFilter#getCredentials

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/AuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,6 @@ class AuthenticationFilter implements HeaderFilter {
         InetSocketAddress proxyAddress;
         if (proxy && (proxyAddress = req.proxy()) != null) {
             // request sent to server through proxy
-            proxyAddress = req.proxy();
             host = proxyAddress.getHostString();
             port = proxyAddress.getPort();
             protocol = "http"; // we don't support https connection to proxy


### PR DESCRIPTION
Picking up a dropped issue please review this simple change.
Passes tier 1-2

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306928](https://bugs.openjdk.org/browse/JDK-8306928): Duplicate variable assignement in jdk.internal.net.http.AuthenticationFilter#getCredentials (**Enhancement** - P5)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18880/head:pull/18880` \
`$ git checkout pull/18880`

Update a local copy of the PR: \
`$ git checkout pull/18880` \
`$ git pull https://git.openjdk.org/jdk.git pull/18880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18880`

View PR using the GUI difftool: \
`$ git pr show -t 18880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18880.diff">https://git.openjdk.org/jdk/pull/18880.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18880#issuecomment-2069177784)