### PR TITLE
8330362: G1: Inline offset array element accessor in G1BlockOffsetTable

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.cpp
@@ -43,17 +43,12 @@ G1BlockOffsetTable::G1BlockOffsetTable(MemRegion heap, G1RegionToSpaceMapper* st
                      p2i(bot_reserved.start()), bot_reserved.byte_size(), p2i(bot_reserved.end()));
 }
 
-void G1BlockOffsetTable::set_offset_array_raw(uint8_t* addr, uint8_t offset) {
+void G1BlockOffsetTable::set_offset_array(uint8_t* addr, uint8_t offset) {
+  check_address(addr, "Block offset table address out of range");
   Atomic::store(addr, offset);
 }
 
-void G1BlockOffsetTable::set_offset_array(uint8_t* addr, uint8_t offset) {
-  check_address(addr, "Block offset table address out of range");
-  set_offset_array_raw(addr, offset);
-}
-
 void G1BlockOffsetTable::set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low) {
-  check_address(addr, "Block offset table address out of range");
   assert(high >= low, "addresses out of order");
   size_t offset = pointer_delta(high, low);
   check_offset(offset, "offset too large");

--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.hpp
@@ -56,7 +56,6 @@ private:
   // For performance these have to devolve to array accesses in product builds.
   inline uint8_t offset_array(uint8_t* addr) const;
 
-  inline void set_offset_array_raw(uint8_t* addr, uint8_t offset);
   inline void set_offset_array(uint8_t* addr, uint8_t offset);
 
   inline void set_offset_array(uint8_t* addr, HeapWord* high, HeapWord* low);


### PR DESCRIPTION
Hi all,

This patch inlines the method `G1BlockOffsetTable::set_offset_array_raw`. I think the method `G1BlockOffsetTable::offset_array` is a `getter` corresponding to the `setter` `G1BlockOffsetTable::set_offset_array` and the check in `G1BlockOffsetTable::offset_array` is useful, so it seems good to keep it.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330362](https://bugs.openjdk.org/browse/JDK-8330362): G1: Inline offset array element accessor in G1BlockOffsetTable (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18881/head:pull/18881` \
`$ git checkout pull/18881`

Update a local copy of the PR: \
`$ git checkout pull/18881` \
`$ git pull https://git.openjdk.org/jdk.git pull/18881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18881`

View PR using the GUI difftool: \
`$ git pr show -t 18881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18881.diff">https://git.openjdk.org/jdk/pull/18881.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18881#issuecomment-2068988635)