### PR TITLE
8330802: Desugar switch in Locale::createLocale

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -997,11 +997,9 @@ public final class Locale implements Cloneable, Serializable {
     private static Locale createLocale(Object key) {
         if (key instanceof BaseLocale base) {
             return new Locale(base, null);
-        } else if (key instanceof LocaleKey lk) {
-            return new Locale(lk.base, lk.exts);
-        } else {
-            throw new InternalError("should not happen");
         }
+        LocaleKey lk = (LocaleKey)key;
+        return new Locale(lk.base, lk.exts);
     }
 
     private static final class LocaleKey {

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -995,11 +995,13 @@ public final class Locale implements Cloneable, Serializable {
 
     private static final ReferencedKeyMap<Object, Locale> LOCALE_CACHE = ReferencedKeyMap.create(true, ConcurrentHashMap::new);
     private static Locale createLocale(Object key) {
-        return switch (key) {
-            case BaseLocale base -> new Locale(base, null);
-            case LocaleKey lk -> new Locale(lk.base, lk.exts);
-            default -> throw new InternalError("should not happen");
-        };
+        if (key instanceof BaseLocale base) {
+            return new Locale(base, null);
+        } else if (key instanceof LocaleKey lk) {
+            return new Locale(lk.base, lk.exts);
+        } else {
+            throw new InternalError("should not happen");
+        }
     }
 
     private static final class LocaleKey {


### PR DESCRIPTION
This switch expression in `Locale::createLocale` is causing a somewhat large startup regression on my local system. Desugaring to if statements seem like the right thing to do while we investigate ways to further reduce overheads in `SwitchBootstraps`.

These numbers are against a baseline which include #18865 and #18845, which already improved the situation:

```
Name             Cnt          Base         Error           Test         Error         Unit  Change
Perfstartup-Noop  20        40,500 ±       1,942         31,000 ±       2,673        ms/op   1,31x (p = 0,000*)
  :.cycles           143254849,000 ± 3398321,355  102205427,650 ± 2192784,853       cycles   0,71x (p = 0,000*)
  :.instructions     307138448,850 ± 2095834,550  219415574,800 ±  376992,067 instructions   0,71x (p = 0,000*)
  :.taskclock               39,500 ±       1,942         22,500 ±       3,858           ms   0,57x (p = 0,000*)
  * = significant
```

Comparing to a baseline without those recent improvements the overhead was almost the double: 
```
Name             Cnt          Base         Error           Test         Error         Unit  Change
Perfstartup-Noop  20        50,000 ±       0,000         31,000 ±       2,673        ms/op   1,61x (p = 0,000*)
  :.cycles           187047932,000 ± 3330400,381  102205427,650 ± 2192784,853       cycles   0,55x (p = 0,000*)
  :.instructions     408219060,350 ± 4031173,140  219415574,800 ±  376992,067 instructions   0,54x (p = 0,000*)
  :.taskclock               53,500 ±       4,249         22,500 ±       3,858           ms   0,42x (p = 0,000*)
  * = significant
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330802](https://bugs.openjdk.org/browse/JDK-8330802): Desugar switch in Locale::createLocale (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [c4f5ee7c](https://git.openjdk.org/jdk/pull/18882/files/c4f5ee7c33b383d402c8ab483cf55f924703b397)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18882/head:pull/18882` \
`$ git checkout pull/18882`

Update a local copy of the PR: \
`$ git checkout pull/18882` \
`$ git pull https://git.openjdk.org/jdk.git pull/18882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18882`

View PR using the GUI difftool: \
`$ git pr show -t 18882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18882.diff">https://git.openjdk.org/jdk/pull/18882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18882#issuecomment-2069060056)