### PR TITLE
8330815: Use pattern matching for instanceof in KeepAliveCache

### DIFF
--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,13 +389,13 @@ class KeepAliveKey {
      */
     @Override
     public boolean equals(Object obj) {
-        if ((obj instanceof KeepAliveKey) == false)
-            return false;
-        KeepAliveKey kae = (KeepAliveKey)obj;
-        return host.equals(kae.host)
-            && (port == kae.port)
-            && protocol.equals(kae.protocol)
-            && this.obj == kae.obj;
+        if (obj instanceof KeepAliveKey kae) {
+            return host.equals(kae.host)
+                && (port == kae.port)
+                && protocol.equals(kae.protocol)
+                && this.obj == kae.obj;
+        }
+        return false;
     }
 
     /**
@@ -405,7 +405,7 @@ class KeepAliveKey {
     @Override
     public int hashCode() {
         String str = protocol+host+port;
-        return this.obj == null? str.hashCode() :
+        return this.obj == null ? str.hashCode() :
             str.hashCode() + this.obj.hashCode();
     }
 }

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -389,13 +389,13 @@ class KeepAliveKey {
      */
     @Override
     public boolean equals(Object obj) {
-        if (obj instanceof KeepAliveKey kae) {
-            return host.equals(kae.host)
-                && (port == kae.port)
-                && protocol.equals(kae.protocol)
-                && this.obj == kae.obj;
-        }
-        return false;
+        if (!(obj instanceof KeepAliveKey kae))
+            return false;
+
+        return host.equals(kae.host)
+            && (port == kae.port)
+            && protocol.equals(kae.protocol)
+            && this.obj == kae.obj;
     }
 
     /**


### PR DESCRIPTION
In su.net.www.http.KeepAliveCache we could use pattern matching for instanceof.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330815](https://bugs.openjdk.org/browse/JDK-8330815): Use pattern matching for instanceof in KeepAliveCache (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [a7129acd](https://git.openjdk.org/jdk/pull/18885/files/a7129acd30aa54585a901e321c9be7b803f6bf58)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18885/head:pull/18885` \
`$ git checkout pull/18885`

Update a local copy of the PR: \
`$ git checkout pull/18885` \
`$ git pull https://git.openjdk.org/jdk.git pull/18885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18885`

View PR using the GUI difftool: \
`$ git pr show -t 18885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18885.diff">https://git.openjdk.org/jdk/pull/18885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18885#issuecomment-2069154586)