### PR TITLE
8330820: Remove remnants of operator_new.cpp in build system

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -89,8 +89,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
     EXCLUDES := $(JVM_EXCLUDES), \
     EXCLUDE_FILES := gtestLauncher.cpp, \
     EXCLUDE_PATTERNS := $(JVM_EXCLUDE_PATTERNS), \
-    EXTRA_OBJECT_FILES := $(filter-out %/operator_new$(OBJ_SUFFIX), \
-        $(BUILD_LIBJVM_ALL_OBJS)), \
+    EXTRA_OBJECT_FILES := $(BUILD_LIBJVM_ALL_OBJS), \
     DEFAULT_CFLAGS := false, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest/include \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -137,13 +137,6 @@ JVM_STRIPFLAGS ?= $(STRIPFLAGS)
 # This source set is reused so save in cache.
 $(call FillFindCache, $(JVM_SRC_DIRS))
 
-# The global operator new functions defined in operator_new.cpp are intended
-# to detect and prevent the VM code from calling them. See more details in
-# operator_new.cpp. Exclude operator_new.o when statically linking the VM
-# code with JDK natives, as the JDK natives might need to call the global
-# operator new.
-LIBJVM_STATIC_EXCLUDE_OBJS := operator_new.o
-
 ifeq ($(call isTargetOs, windows), true)
   ifeq ($(STATIC_LIBS), true)
     WIN_EXPORT_FILE := $(JVM_OUTPUTDIR)/static-win-exports.def
@@ -217,7 +210,6 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     RC_FILEDESC := $(HOTSPOT_VM_DISTRO) $(OPENJDK_TARGET_CPU_BITS)-Bit $(JVM_VARIANT) VM, \
     PRECOMPILED_HEADER := $(JVM_PRECOMPILED_HEADER), \
     PRECOMPILED_HEADER_EXCLUDE := $(JVM_PRECOMPILED_HEADER_EXCLUDE), \
-    STATIC_LIB_EXCLUDE_OBJS := $(LIBJVM_STATIC_EXCLUDE_OBJS), \
 ))
 
 ifeq ($(call isTargetOs, windows), true)


### PR DESCRIPTION
In [JDK-8282469](https://bugs.openjdk.org/browse/JDK-8282469), the file operator_new.cpp was removed from Hotspot. Unfortunately, some ugly hacks related to this file remained in the build system. They should be removed.