### PR TITLE
8330822: Remove ModRefBarrierSet::write_ref_array_work

### DIFF
--- a/src/hotspot/share/gc/g1/g1BarrierSet.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.hpp
@@ -74,8 +74,6 @@ class G1BarrierSet: public CardTableBarrierSet {
   inline void write_region(MemRegion mr);
   void write_region(JavaThread* thread, MemRegion mr);
 
-  inline void write_ref_array_work(MemRegion mr);
-
   template <DecoratorSet decorators, typename T>
   void write_ref_field_post(T* field);
   void write_ref_field_post_slow(volatile CardValue* byte);

--- a/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BarrierSet.inline.hpp
@@ -72,10 +72,6 @@ inline void G1BarrierSet::write_region(MemRegion mr) {
   write_region(JavaThread::current(), mr);
 }
 
-inline void G1BarrierSet::write_ref_array_work(MemRegion mr) {
-  write_region(mr);
-}
-
 template <DecoratorSet decorators, typename T>
 inline void G1BarrierSet::write_ref_field_post(T* field) {
   volatile CardValue* byte = _card_table->byte_for(field);

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.cpp
@@ -80,10 +80,6 @@ CardTableBarrierSet::~CardTableBarrierSet() {
   delete _card_table;
 }
 
-void CardTableBarrierSet::write_ref_array_work(MemRegion mr) {
-  _card_table->dirty_MemRegion(mr);
-}
-
 void CardTableBarrierSet::write_region(MemRegion mr) {
   _card_table->dirty_MemRegion(mr);
 }

--- a/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/cardTableBarrierSet.hpp
@@ -70,8 +70,6 @@ public:
     write_region(mr);
   }
 
-  void write_ref_array_work(MemRegion mr);
-
  public:
   // Record a reference update. Note that these versions are precise!
   // The scanning code has to handle the fact that the write barrier may be

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.hpp
@@ -68,9 +68,6 @@ public:
   // at the address "start", which may not necessarily be HeapWord-aligned
   inline void write_ref_array(HeapWord* start, size_t count);
 
- protected:
-  virtual void write_ref_array_work(MemRegion mr) = 0;
-
  public:
   // The ModRef abstraction introduces pre and post barriers
   template <DecoratorSet decorators, typename BarrierSetT>

--- a/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
+++ b/src/hotspot/share/gc/shared/modRefBarrierSet.inline.hpp
@@ -54,7 +54,7 @@ void ModRefBarrierSet::write_ref_array(HeapWord* start, size_t count) {
   // If compressed oops were not being used, these should already be aligned
   assert(UseCompressedOops || (aligned_start == start && aligned_end == end),
          "Expected heap word alignment of start and end");
-  write_ref_array_work(MemRegion(aligned_start, aligned_end));
+  write_region(MemRegion(aligned_start, aligned_end));
 }
 
 template <DecoratorSet decorators, typename BarrierSetT>


### PR DESCRIPTION
Simple merging a protected api into another method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330822](https://bugs.openjdk.org/browse/JDK-8330822): Remove ModRefBarrierSet::write_ref_array_work (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18887/head:pull/18887` \
`$ git checkout pull/18887`

Update a local copy of the PR: \
`$ git checkout pull/18887` \
`$ git pull https://git.openjdk.org/jdk.git pull/18887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18887`

View PR using the GUI difftool: \
`$ git pr show -t 18887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18887.diff">https://git.openjdk.org/jdk/pull/18887.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18887#issuecomment-2069505894)