### PR TITLE
8330704: Clean up non-standard use of /** comments in some langtools tests

### DIFF
--- a/test/langtools/jdk/javadoc/tool/EnablePreviewOption.java
+++ b/test/langtools/jdk/javadoc/tool/EnablePreviewOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8199196
  * @summary Test --enable-preview option in javadoc

--- a/test/langtools/jdk/javadoc/tool/ReleaseOption.java
+++ b/test/langtools/jdk/javadoc/tool/ReleaseOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import jdk.javadoc.internal.tool.Main.Result;
 
 import static jdk.javadoc.internal.tool.Main.Result.*;
 
-/**
+/*
  * @test
  * @bug 8086737
  * @summary Test --release option in javadoc

--- a/test/langtools/jdk/javadoc/tool/T4696488.java
+++ b/test/langtools/jdk/javadoc/tool/T4696488.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug     4696488
  * @summary javadoc doesn't handle UNC paths for destination directory

--- a/test/langtools/jdk/javadoc/tool/T4994049/T4994049.java
+++ b/test/langtools/jdk/javadoc/tool/T4994049/T4994049.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug     4994049
  * @summary Unit test for SourcePosition.column with respect to tab expansion

--- a/test/langtools/jdk/javadoc/tool/T6551367.java
+++ b/test/langtools/jdk/javadoc/tool/T6551367.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug     6551367
  * @summary javadoc throws ClassCastException when an link tag tries to reference constructor.

--- a/test/langtools/jdk/javadoc/tool/TestScriptInComment.java
+++ b/test/langtools/jdk/javadoc/tool/TestScriptInComment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8138725 8226765
  * @summary test --allow-script-in-comments

--- a/test/langtools/jdk/javadoc/tool/modules/CommandLineFiles.java
+++ b/test/langtools/jdk/javadoc/tool/modules/CommandLineFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8176539
  * @summary Test use case when all java files are listed

--- a/test/langtools/jdk/javadoc/tool/modules/FilterOptions.java
+++ b/test/langtools/jdk/javadoc/tool/modules/FilterOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8159305 8167383
  * @summary Tests elements filtering options

--- a/test/langtools/jdk/javadoc/tool/modules/PackageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/modules/PackageOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8159305
  * @summary Test modules with packages and subpackages filtering

--- a/test/langtools/jdk/javadoc/tool/modules/PatchModules.java
+++ b/test/langtools/jdk/javadoc/tool/modules/PatchModules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8175346
  * @summary Test patch module options

--- a/test/langtools/jdk/javadoc/tool/modules/ReleaseOptions.java
+++ b/test/langtools/jdk/javadoc/tool/modules/ReleaseOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8175346 8175277
  * @summary Test release option interactions

--- a/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
+++ b/test/langtools/jdk/javadoc/tool/nonConstExprs/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug     8010310
  * @summary Error processing sources with -private

--- a/test/langtools/jdk/javadoc/tool/parser/7091528/T7091528.java
+++ b/test/langtools/jdk/javadoc/tool/parser/7091528/T7091528.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug     7091528 8029145 8037484
  * @summary ensures javadoc parses unique source files and ignores all class files

--- a/test/langtools/jdk/jshell/HighlightUITest.java
+++ b/test/langtools/jdk/jshell/HighlightUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8274148
  * @summary Check the UI behavior of snippet highligting

--- a/test/langtools/jdk/jshell/HistoryUITest.java
+++ b/test/langtools/jdk/jshell/HistoryUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8178077 8232856
  * @summary Check the UI behavior of editing history.

--- a/test/langtools/jdk/jshell/IndentUITest.java
+++ b/test/langtools/jdk/jshell/IndentUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8241950 8247932
  * @summary Check the UI behavior of indentation

--- a/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
+++ b/test/langtools/jdk/jshell/PasteAndMeasurementsUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8182297 8242919 8267459
  * @summary Verify that pasting multi-line snippets works properly.

--- a/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
+++ b/test/langtools/jdk/jshell/ToolMultilineSnippetHistoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8182489
  * @summary test history with multiline snippets

--- a/test/langtools/jdk/jshell/ToolShiftTabTest.java
+++ b/test/langtools/jdk/jshell/ToolShiftTabTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8166334 8188894
  * @summary test shift-tab shortcuts "fixes"

--- a/test/langtools/jdk/jshell/ToolTabCommandTest.java
+++ b/test/langtools/jdk/jshell/ToolTabCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8177076 8185840 8178109 8192863
  * @modules

--- a/test/langtools/jdk/jshell/ToolTabSnippetTest.java
+++ b/test/langtools/jdk/jshell/ToolTabSnippetTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8177076 8185426 8189595 8188072 8221759 8255273
  * @modules

--- a/test/langtools/jdk/jshell/UndefinedClassTest.java
+++ b/test/langtools/jdk/jshell/UndefinedClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,7 +21,7 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8292755
  * @summary InternalError seen while throwing undefined exception


### PR DESCRIPTION
Please review a simple change to clean up inappropriate use of `/**` comments in test code -- most notably to enclose the `jtreg` test description.

There is no change to the functionality of any test, and (obviously) all tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330704](https://bugs.openjdk.org/browse/JDK-8330704): Clean up non-standard use of /** comments in some langtools tests (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18896/head:pull/18896` \
`$ git checkout pull/18896`

Update a local copy of the PR: \
`$ git checkout pull/18896` \
`$ git pull https://git.openjdk.org/jdk.git pull/18896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18896`

View PR using the GUI difftool: \
`$ git pr show -t 18896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18896.diff">https://git.openjdk.org/jdk/pull/18896.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18896#issuecomment-2070483517)