### PR TITLE
8330849: Add test to verify memory usage with recursive locking

### DIFF
--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  */
 public class TestRecursiveMonitorChurn {
     static class Monitor {
-        public static int i, j;
+        public static volatile int i, j;
         synchronized void doSomething() {
             i++;
             doSomethingElse();
@@ -46,7 +46,7 @@ public class TestRecursiveMonitorChurn {
         }
     }
 
-    public static Monitor monitor;
+    public static volatile Monitor monitor;
     public static void main(String[] args) throws IOException {
         if (args.length == 1 && args[0].equals("test")) {
             // The actual test, in a forked JVM.
@@ -58,7 +58,7 @@ public class TestRecursiveMonitorChurn {
         } else {
             ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
                     "-XX:+UnlockDiagnosticVMOptions",
-                    "-Xmx100M", "-XX:AsyncDeflationInterval=0",
+                    "-Xmx100M", "-XX:AsyncDeflationInterval=0", "-XX:GuaranteedAsyncDeflationInterval=0",
                     "-XX:NativeMemoryTracking=summary", "-XX:+PrintNMTStatistics",
                     "TestRecursiveMonitorChurn",
                     "test");


### PR DESCRIPTION
Before recursive support has been added to lightweight locking, using recursive locking patterns would inflate lightweight locks to full monitors. In some scenarios (when churning lots of recursively locked objects), this could lead to excessive native memory usage. I'd like to add a test that verifies that this does not happen.

I verified that the new test fails reliably with an earlier commit that did not have LW recursive locking, yet, and passes with latest LW recursive locking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330849](https://bugs.openjdk.org/browse/JDK-8330849): Add test to verify memory usage with recursive locking (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [7a1cdc3f](https://git.openjdk.org/jdk/pull/18899/files/7a1cdc3f6af4c2c60795433e408d7082bb35e2ea)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18899/head:pull/18899` \
`$ git checkout pull/18899`

Update a local copy of the PR: \
`$ git checkout pull/18899` \
`$ git pull https://git.openjdk.org/jdk.git pull/18899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18899`

View PR using the GUI difftool: \
`$ git pr show -t 18899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18899.diff">https://git.openjdk.org/jdk/pull/18899.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18899#issuecomment-2070589777)