### PR TITLE
8327290: Remove unused notproduct option TraceInvocationCounterOverflow

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -867,9 +867,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceBytecodes, false,                                      \
           "Trace bytecode execution")                                       \
                                                                             \
-  develop(bool, TraceInvocationCounterOverflow, false,                      \
-          "Trace method invocation counter overflow")                       \
-                                                                            \
   develop(bool, VerifyDependencies, trueInDebug,                            \
           "Exercise and verify the compilation dependency mechanism")       \
                                                                             \


### PR DESCRIPTION
Hi all, 

This PR removes the unused option ```TraceInvocationCounterOverflow```. The only usage was removed in [8251462](https://bugs.openjdk.org/browse/JDK-8251462). 

Testing:
- [x] Verified unrecognized option error is reported after removing option. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327290](https://bugs.openjdk.org/browse/JDK-8327290): Remove unused notproduct option TraceInvocationCounterOverflow (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18902/head:pull/18902` \
`$ git checkout pull/18902`

Update a local copy of the PR: \
`$ git checkout pull/18902` \
`$ git pull https://git.openjdk.org/jdk.git pull/18902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18902`

View PR using the GUI difftool: \
`$ git pr show -t 18902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18902.diff">https://git.openjdk.org/jdk/pull/18902.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18902#issuecomment-2072534069)