### PR TITLE
8327289: Remove unused PrintMethodFlushingStatistics option

### DIFF
--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -981,9 +981,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceMethodReplacement, false,                              \
           "Print when methods are replaced do to recompilation")            \
                                                                             \
-  product(bool, PrintMethodFlushingStatistics, false, DIAGNOSTIC,           \
-          "print statistics about method flushing")                         \
-                                                                            \
   product(intx, MinPassesBeforeFlush, 10, DIAGNOSTIC,                       \
           "Minimum number of sweeper passes before an nmethod "             \
           "can be flushed")                                                 \


### PR DESCRIPTION
Hi all, 

This PR removes the option ```PrintMethodFlushingStatistics```. Last usage was removed in [8290025](https://bugs.openjdk.org/browse/JDK-8290025). 

Testing: 
- [x] Verified unrecognized VM option gets reported after patch. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327289](https://bugs.openjdk.org/browse/JDK-8327289): Remove unused PrintMethodFlushingStatistics option (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18903/head:pull/18903` \
`$ git checkout pull/18903`

Update a local copy of the PR: \
`$ git checkout pull/18903` \
`$ git pull https://git.openjdk.org/jdk.git pull/18903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18903`

View PR using the GUI difftool: \
`$ git pr show -t 18903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18903.diff">https://git.openjdk.org/jdk/pull/18903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18903#issuecomment-2072525877)