### PR TITLE
8330862: GCBarrierIRExample fails when a different GC is selected via the command line

### DIFF
--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/examples/GCBarrierIRExample.java
@@ -33,6 +33,7 @@ import java.lang.invoke.MethodHandles;
  * @summary Example test that illustrates the use of the IR test framework for
  *          verification of late-expanded GC barriers.
  * @library /test/lib /
+ * @requires vm.gc.ZGenerational
  * @run driver ir_framework.examples.GCBarrierIRExample
  */
 


### PR DESCRIPTION
The example IR framework test introduced by [JDK-8330153](https://bugs.openjdk.org/browse/JDK-8330153) runs on (generational) ZGC only (`TestFramework.runWithFlags("-XX:+UseZGC", "-XX:+ZGenerational")`), but allows the jtreg user to select a conflicting GC externally, which causes the VM to fail. This changeset restricts the test so that it only runs if either ZGC or no GC is selected externally.

**Testing:** tier1-3 (windows-x64, linux-x64, linux-aarch64, and macosx-x64)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330862](https://bugs.openjdk.org/browse/JDK-8330862): GCBarrierIRExample fails when a different GC is selected via the command line (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18906/head:pull/18906` \
`$ git checkout pull/18906`

Update a local copy of the PR: \
`$ git checkout pull/18906` \
`$ git pull https://git.openjdk.org/jdk.git pull/18906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18906`

View PR using the GUI difftool: \
`$ git pr show -t 18906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18906.diff">https://git.openjdk.org/jdk/pull/18906.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18906#issuecomment-2071515026)