### PR TITLE
8330684: ClassFile API runs into StackOverflowError while parsing certain class' bytes

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -339,6 +339,10 @@ public final class ClassReaderImpl
     // Constantpool
     @Override
     public PoolEntry entryByIndex(int index) {
+        return entryByIndex(index, 0, 0xff);
+    }
+
+    private PoolEntry entryByIndex(int index, int lowerBoundTag, int upperBoundTag) {
         if (index <= 0 || index >= constantPoolCount) {
             throw new ConstantPoolException("Bad CP index: " + index);
         }
@@ -349,6 +353,10 @@ public final class ClassReaderImpl
                 throw new ConstantPoolException("Unusable CP index: " + index);
             }
             int tag = readU1(offset);
+            if (tag < lowerBoundTag || tag > upperBoundTag) {
+                throw new ConstantPoolException(
+                        "Bad tag (" + tag + ") at index (" + index + ") position (" + offset + ")");
+            }
             final int q = offset + 1;
             info = switch (tag) {
                 case TAG_UTF8 -> new AbstractPoolEntry.Utf8EntryImpl(this, index, buffer, q + 2, readU2(q));
@@ -356,18 +364,23 @@ public final class ClassReaderImpl
                 case TAG_FLOAT -> new AbstractPoolEntry.FloatEntryImpl(this, index, readFloat(q));
                 case TAG_LONG -> new AbstractPoolEntry.LongEntryImpl(this, index, readLong(q));
                 case TAG_DOUBLE -> new AbstractPoolEntry.DoubleEntryImpl(this, index, readDouble(q));
-                case TAG_CLASS -> new AbstractPoolEntry.ClassEntryImpl(this, index, readUtf8Entry(q));
-                case TAG_STRING -> new AbstractPoolEntry.StringEntryImpl(this, index, readUtf8Entry(q));
-                case TAG_FIELDREF -> new AbstractPoolEntry.FieldRefEntryImpl(this, index, readClassEntry(q), readNameAndTypeEntry(q + 2));
-                case TAG_METHODREF -> new AbstractPoolEntry.MethodRefEntryImpl(this, index, readClassEntry(q), readNameAndTypeEntry(q + 2));
-                case TAG_INTERFACEMETHODREF -> new AbstractPoolEntry.InterfaceMethodRefEntryImpl(this, index, readClassEntry(q), readNameAndTypeEntry(q + 2));
-                case TAG_NAMEANDTYPE -> new AbstractPoolEntry.NameAndTypeEntryImpl(this, index, readUtf8Entry(q), readUtf8Entry(q + 2));
-                case TAG_METHODHANDLE -> new AbstractPoolEntry.MethodHandleEntryImpl(this, index, readU1(q), readAbstractMemberRefEntry(q + 1));
-                case TAG_METHODTYPE -> new AbstractPoolEntry.MethodTypeEntryImpl(this, index, readUtf8Entry(q));
-                case TAG_CONSTANTDYNAMIC -> new AbstractPoolEntry.ConstantDynamicEntryImpl(this, index, readU2(q), readNameAndTypeEntry(q + 2));
-                case TAG_INVOKEDYNAMIC -> new AbstractPoolEntry.InvokeDynamicEntryImpl(this, index, readU2(q), readNameAndTypeEntry(q + 2));
-                case TAG_MODULE -> new AbstractPoolEntry.ModuleEntryImpl(this, index, readUtf8Entry(q));
-                case TAG_PACKAGE -> new AbstractPoolEntry.PackageEntryImpl(this, index, readUtf8Entry(q));
+                case TAG_CLASS -> new AbstractPoolEntry.ClassEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
+                case TAG_STRING -> new AbstractPoolEntry.StringEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
+                case TAG_FIELDREF -> new AbstractPoolEntry.FieldRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
+                                                                             (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
+                case TAG_METHODREF -> new AbstractPoolEntry.MethodRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
+                                                                               (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
+                case TAG_INTERFACEMETHODREF -> new AbstractPoolEntry.InterfaceMethodRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
+                                                                                                 (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
+                case TAG_NAMEANDTYPE -> new AbstractPoolEntry.NameAndTypeEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q),
+                                                                                   (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q + 2));
+                case TAG_METHODHANDLE -> new AbstractPoolEntry.MethodHandleEntryImpl(this, index, readU1(q),
+                                                                                     readEntry(q + 1, AbstractPoolEntry.AbstractMemberRefEntry.class, TAG_FIELDREF, TAG_INTERFACEMETHODREF));
+                case TAG_METHODTYPE -> new AbstractPoolEntry.MethodTypeEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
+                case TAG_CONSTANTDYNAMIC -> new AbstractPoolEntry.ConstantDynamicEntryImpl(this, index, readU2(q), (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
+                case TAG_INVOKEDYNAMIC -> new AbstractPoolEntry.InvokeDynamicEntryImpl(this, index, readU2(q), (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
+                case TAG_MODULE -> new AbstractPoolEntry.ModuleEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
+                case TAG_PACKAGE -> new AbstractPoolEntry.PackageEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
                 default -> throw new ConstantPoolException(
                         "Bad tag (" + tag + ") at index (" + index + ") position (" + offset + ")");
             };
@@ -418,7 +431,11 @@ public final class ClassReaderImpl
 
     @Override
     public <T extends PoolEntry> T readEntry(int pos, Class<T> cls) {
-        var e = readEntry(pos);
+        return readEntry(pos, cls, 0, 0xff);
+    }
+
+    private <T extends PoolEntry> T readEntry(int pos, Class<T> cls, int lowerBoundTag, int upperBoundTag) {
+        var e = entryByIndex(readU2(pos), lowerBoundTag, upperBoundTag);
         if (cls.isInstance(e)) return cls.cast(e);
         throw new ConstantPoolException("Not a " + cls.getSimpleName() + " at index: " + readU2(pos));
     }
@@ -433,7 +450,7 @@ public final class ClassReaderImpl
     }
 
     @Override
-    public AbstractPoolEntry.Utf8EntryImpl readUtf8Entry(int pos) {
+    public Utf8Entry readUtf8Entry(int pos) {
         int index = readU2(pos);
         return utf8EntryByIndex(index);
     }
@@ -449,80 +466,27 @@ public final class ClassReaderImpl
 
     @Override
     public ModuleEntry readModuleEntry(int pos) {
-        return readEntry(pos, ModuleEntry.class);
+        return readEntry(pos, ModuleEntry.class, TAG_MODULE, TAG_MODULE);
     }
 
     @Override
     public PackageEntry readPackageEntry(int pos) {
-        return readEntry(pos, PackageEntry.class);
-    }
-
-    private int readIndex(int pos) {
-        int index = readU2(pos);
-        if (index <= 0 || index >= constantPoolCount) {
-            throw new ConstantPoolException("Bad CP index: " + index);
-        }
-        return index;
-    }
-
-    private int getOffset(int index) {
-        int offset = cpOffset[index];
-        if (offset == 0) {
-            throw new ConstantPoolException("Unusable CP index: " + index);
-        }
-        return offset;
+        return readEntry(pos, PackageEntry.class, TAG_PACKAGE, TAG_PACKAGE);
     }
 
     @Override
-    public AbstractPoolEntry.ClassEntryImpl readClassEntry(int pos) {
-        int index = readIndex(pos);
-        PoolEntry info = cp[index];
-        if (info == null) {
-            int offset = getOffset(index);
-            if (readU1(offset) == TAG_CLASS) {
-                info = new AbstractPoolEntry.ClassEntryImpl(this, index, readUtf8Entry(offset + 1));
-                cp[index] = info;
-            }
-        }
-        if (info instanceof AbstractPoolEntry.ClassEntryImpl ce) return ce;
-        throw new ConstantPoolException("Not a ClassEntry at index: " + index);
+    public ClassEntry readClassEntry(int pos) {
+        return readEntry(pos, ClassEntry.class, TAG_CLASS, TAG_CLASS);
     }
 
     @Override
-    public AbstractPoolEntry.NameAndTypeEntryImpl readNameAndTypeEntry(int pos) {
-        int index = readIndex(pos);
-        PoolEntry info = cp[index];
-        if (info == null) {
-            int offset = getOffset(index);
-            if (readU1(offset) == TAG_NAMEANDTYPE) {
-                info = new AbstractPoolEntry.NameAndTypeEntryImpl(this, index, readUtf8Entry(offset + 1), readUtf8Entry(offset + 3));
-                cp[index] = info;
-            }
-        }
-        if (info instanceof AbstractPoolEntry.NameAndTypeEntryImpl nte) return nte;
-        throw new ConstantPoolException("Not a NameAndTypeEntry at index: " + index);
-    }
-
-    private AbstractPoolEntry.AbstractMemberRefEntry readAbstractMemberRefEntry(int pos) {
-        int index = readIndex(pos);
-        PoolEntry info = cp[index];
-        if (info == null) {
-            int offset = getOffset(index);
-            info = switch (readU1(offset)) {
-                case TAG_FIELDREF -> new AbstractPoolEntry.FieldRefEntryImpl(this, index, readClassEntry(offset + 1), readNameAndTypeEntry(offset + 3));
-                case TAG_METHODREF -> new AbstractPoolEntry.MethodRefEntryImpl(this, index, readClassEntry(offset + 1), readNameAndTypeEntry(offset + 3));
-                case TAG_INTERFACEMETHODREF -> new AbstractPoolEntry.InterfaceMethodRefEntryImpl(this, index, readClassEntry(offset + 1), readNameAndTypeEntry(offset + 3));
-                default -> null;
-            };
-            cp[index] = info;
-        }
-        if (info instanceof AbstractPoolEntry.AbstractMemberRefEntry amre) return amre;
-        throw new ConstantPoolException("Not a MemberRefEntry at index: " + index);
+    public NameAndTypeEntry readNameAndTypeEntry(int pos) {
+        return readEntry(pos, NameAndTypeEntry.class, TAG_NAMEANDTYPE, TAG_NAMEANDTYPE);
     }
 
     @Override
     public MethodHandleEntry readMethodHandleEntry(int pos) {
-        return readEntry(pos, MethodHandleEntry.class);
+        return readEntry(pos, MethodHandleEntry.class, TAG_METHODHANDLE, TAG_METHODHANDLE);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -434,6 +434,10 @@ public final class ClassReaderImpl
         return readEntry(pos, cls, 0, 0xff);
     }
 
+    private <T extends PoolEntry> T readEntry(int pos, Class<T> cls, int expectedTag) {
+        return readEntry(pos, cls, expectedTag, expectedTag);
+    }
+
     private <T extends PoolEntry> T readEntry(int pos, Class<T> cls, int lowerBoundTag, int upperBoundTag) {
         var e = entryByIndex(readU2(pos), lowerBoundTag, upperBoundTag);
         if (cls.isInstance(e)) return cls.cast(e);
@@ -466,27 +470,27 @@ public final class ClassReaderImpl
 
     @Override
     public ModuleEntry readModuleEntry(int pos) {
-        return readEntry(pos, ModuleEntry.class, TAG_MODULE, TAG_MODULE);
+        return readEntry(pos, ModuleEntry.class, TAG_MODULE);
     }
 
     @Override
     public PackageEntry readPackageEntry(int pos) {
-        return readEntry(pos, PackageEntry.class, TAG_PACKAGE, TAG_PACKAGE);
+        return readEntry(pos, PackageEntry.class, TAG_PACKAGE);
     }
 
     @Override
     public ClassEntry readClassEntry(int pos) {
-        return readEntry(pos, ClassEntry.class, TAG_CLASS, TAG_CLASS);
+        return readEntry(pos, ClassEntry.class, TAG_CLASS);
     }
 
     @Override
     public NameAndTypeEntry readNameAndTypeEntry(int pos) {
-        return readEntry(pos, NameAndTypeEntry.class, TAG_NAMEANDTYPE, TAG_NAMEANDTYPE);
+        return readEntry(pos, NameAndTypeEntry.class, TAG_NAMEANDTYPE);
     }
 
     @Override
     public MethodHandleEntry readMethodHandleEntry(int pos) {
-        return readEntry(pos, MethodHandleEntry.class, TAG_METHODHANDLE, TAG_METHODHANDLE);
+        return readEntry(pos, MethodHandleEntry.class, TAG_METHODHANDLE);
     }
 
     @Override

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360
+ * @bug 8320360 8330684
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -31,6 +31,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.classfile.ClassFile;
+import java.lang.classfile.constantpool.ConstantPoolException;
 import jdk.internal.classfile.impl.LabelContext;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -91,5 +92,11 @@ class LimitsTest {
     void testReadingOutOfBounds() {
         assertThrows(IllegalArgumentException.class, () -> ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE}), "reading magic only");
         assertThrows(IllegalArgumentException.class, () -> ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE, 0, 0, 0, 0, 0, 2}), "reading invalid CP size");
+    }
+
+    @Test
+    void testInvalidClassEntry() {
+        assertThrows(ConstantPoolException.class, () -> ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
+            0, 0, 0, 0, 0, 2, ClassFile.TAG_METHODREF, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}).thisClass());
     }
 }


### PR DESCRIPTION
ClassFile API dives into the nested constant pool entries without type restrictions, while parsing a class file. Validation of the entry is performed post-parsing. Specifically corrupted constant pool entry may cause infinite loop during parsing and throws SOE.
This patch resolves the issue by providing specific implementations for the nested CP entries parsing, instead of sharing the common (post-checking) code.
Added test simulates the situation on inner-looped method reference entry.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330684](https://bugs.openjdk.org/browse/JDK-8330684): ClassFile API runs into StackOverflowError while parsing certain class' bytes (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18907/head:pull/18907` \
`$ git checkout pull/18907`

Update a local copy of the PR: \
`$ git checkout pull/18907` \
`$ git pull https://git.openjdk.org/jdk.git pull/18907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18907`

View PR using the GUI difftool: \
`$ git pr show -t 18907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18907.diff">https://git.openjdk.org/jdk/pull/18907.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18907#issuecomment-2071649181)