### PR TITLE
8326150: Typo in the documentation for jdk.jshell

### DIFF
--- a/src/jdk.jshell/share/classes/module-info.java
+++ b/src/jdk.jshell/share/classes/module-info.java
@@ -35,7 +35,7 @@ import jdk.internal.javac.ParticipatesInPreview;
  * and programmatically launching the existing Java shell tool.
  * <p>
  *     The {@link jdk.jshell} is the package for creating 'snippet' evaluating tools.
- *     Generally, this is only package that would be needed for creating tools.
+ *     Generally, this is the only package that would be needed for creating tools.
  * </p>
  * <p>
  *     The {@link jdk.jshell.spi} package specifies a Service Provider Interface (SPI)


### PR DESCRIPTION
This patch fixes typo in the jdk.jshell module-info.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326150](https://bugs.openjdk.org/browse/JDK-8326150): Typo in the documentation for jdk.jshell (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18909/head:pull/18909` \
`$ git checkout pull/18909`

Update a local copy of the PR: \
`$ git checkout pull/18909` \
`$ git pull https://git.openjdk.org/jdk.git pull/18909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18909`

View PR using the GUI difftool: \
`$ git pr show -t 18909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18909.diff">https://git.openjdk.org/jdk/pull/18909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18909#issuecomment-2071831218)