### PR TITLE
8330626: ZGC: Windows address space placeholders not managed correctly

### DIFF
--- a/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
+++ b/src/hotspot/os/windows/gc/z/zVirtualMemory_windows.cpp
@@ -40,21 +40,36 @@ public:
 };
 
 // Implements small pages (paged) support using placeholder reservation.
+// When a memory area is free (kept by the virtual memory manager) a
+// single placeholder is covering that memory area. When memory is
+// allocated from the manager the placeholder is split into granule
+// sized placeholders to allow mapping operations on that granulairty.
 class ZVirtualMemoryManagerSmallPages : public ZVirtualMemoryManagerImpl {
 private:
   class PlaceholderCallbacks : public AllStatic {
   public:
+    // Split an existing placeholder to create a new placeholder
+    // for the requested memory area.
     static void split_placeholder(zoffset start, size_t size) {
       ZMapper::split_placeholder(ZOffset::address_unsafe(start), size);
     }
 
+    // Coalesce all placeholders covering the given memory area.
     static void coalesce_placeholders(zoffset start, size_t size) {
       ZMapper::coalesce_placeholders(ZOffset::address_unsafe(start), size);
     }
 
-    static void split_into_placeholder_granules(zoffset start, size_t size) {
-      for (uintptr_t addr = untype(start); addr < untype(start) + size; addr += ZGranuleSize) {
-        split_placeholder(to_zoffset(addr), ZGranuleSize);
+    // Turn the single placeholder covering a memroy area into granule
+    // sized placeholders. This is done by splitting granule sized placeholders
+    // from the covering placeholder until the whole area is handled.
+    static void create_granule_sized_placeholders(zoffset start, size_t size) {
+      size_t current_placeholder_size = size;
+      zoffset current_placeholder_offset = start;
+      // Split the current placeholder as long as it is larger than a granule
+      while (current_placeholder_size > ZGranuleSize) {
+        split_placeholder(current_placeholder_offset, ZGranuleSize);
+        current_placeholder_offset += ZGranuleSize;
+        current_placeholder_size -= ZGranuleSize;
       }
     }
 
@@ -66,36 +81,66 @@ private:
       }
     }
 
+    // Called when a memory area is returned to the memory manager but can't
+    // be merged with an already existing area. Make sure this area is covered
+    // by a single placeholder.
     static void create_callback(const ZMemory* area) {
       assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
       coalesce_into_one_placeholder(area->start(), area->size());
     }
 
+    // Called when a complete memory area in the memory manager is allocated.
+    // Create granule sized placeholder for the entier area.
     static void destroy_callback(const ZMemory* area) {
       assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
-      // Don't try split the last granule - VirtualFree will fail
-      split_into_placeholder_granules(area->start(), area->size() - ZGranuleSize);
+      create_granule_sized_placeholders(area->start(), area->size());
     }
 
+    // Called when a memory area is allocated at the front of an exising memory area.
+    // Turn the first part of the memory area into granule sized placeholders.
     static void shrink_from_front_callback(const ZMemory* area, size_t size) {
+      assert(area->size() > size, "Must be larger than what we try to split out");
       assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
-      split_into_placeholder_granules(area->start(), size);
+
+      // Before creating the granule sized placeholders we need to make sure
+      // there is a placeholder covering that exact area. Otherwise splitting
+      // of a single granule sized won't work.
+      split_placeholder(area->start(), size);
+      create_granule_sized_placeholders(area->start(), size);
     }
 
+    // Called when a memory area is allocated at the end of an existing memory area.
+    // Turn the second part of the memory area into granule sized placeholders.
     static void shrink_from_back_callback(const ZMemory* area, size_t size) {
+      assert(area->size() > size, "Must be larger than what we try to split out");
       assert(is_aligned(size, ZGranuleSize), "Must be granule aligned");
-      // Don't try split the last granule - VirtualFree will fail
-      split_into_placeholder_granules(to_zoffset(untype(area->end()) - size), size - ZGranuleSize);
+
+      // Before creating the granule sized placeholders we need to make sure
+      // there is a placeholder covering that exact area. Otherwise splitting
+      // of a single granule sized won't work.
+      zoffset placeholder_start = to_zoffset(untype(area->end()) - size);
+
+      split_placeholder(placeholder_start, size);
+      create_granule_sized_placeholders(placeholder_start, size);
     }
 
+    // Called when freeing a memory area and it can be merged at the start of an
+    // existing area. Coalesce the underlying placeholders into one.
     static void grow_from_front_callback(const ZMemory* area, size_t size) {
       assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
-      coalesce_into_one_placeholder(to_zoffset(untype(area->start()) - size), area->size() + size);
+
+      size_t placeholder_size = area->size() + size;
+      zoffset placeholder_start = to_zoffset(untype(area->start()) - size);
+      coalesce_into_one_placeholder(placeholder_start, placeholder_size);
     }
 
+    // Called when freeing a memory area and it can be merged at the end of an
+    // existing area. Coalesce the underlying placeholders into one.
     static void grow_from_back_callback(const ZMemory* area, size_t size) {
       assert(is_aligned(area->size(), ZGranuleSize), "Must be granule aligned");
-      coalesce_into_one_placeholder(area->start(), area->size() + size);
+
+      size_t placeholder_size = area->size() + size;
+      coalesce_into_one_placeholder(area->start(), placeholder_size);
     }
 
     static void register_with(ZMemoryManager* manager) {

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -32,6 +32,11 @@
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 
+ZVirtualMemoryManager::ZVirtualMemoryManager()
+  : _manager(),
+    _reserved(0),
+    _initialized(false) { }
+
 ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity)
   : _manager(),
     _reserved(0),

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -32,11 +32,6 @@
 #include "utilities/align.hpp"
 #include "utilities/debug.hpp"
 
-ZVirtualMemoryManager::ZVirtualMemoryManager()
-  : _manager(),
-    _reserved(0),
-    _initialized(false) { }
-
 ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity)
   : _manager(),
     _reserved(0),

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -47,7 +47,8 @@ public:
 };
 
 class ZVirtualMemoryManager {
-protected:
+friend class ZMapperTest;
+private:
   static size_t calculate_min_range(size_t size);
 
   ZMemoryManager _manager;
@@ -60,10 +61,6 @@ protected:
   bool pd_reserve(zaddress_unsafe addr, size_t size);
   void pd_unreserve(zaddress_unsafe addr, size_t size);
 
-  // To allow testing
-  ZVirtualMemoryManager();
-
-private:
   bool reserve_contiguous(zoffset start, size_t size);
   bool reserve_contiguous(size_t size);
   size_t reserve_discontiguous(zoffset start, size_t size, size_t min_range);

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -47,7 +47,7 @@ public:
 };
 
 class ZVirtualMemoryManager {
-private:
+protected:
   static size_t calculate_min_range(size_t size);
 
   ZMemoryManager _manager;
@@ -60,6 +60,10 @@ private:
   bool pd_reserve(zaddress_unsafe addr, size_t size);
   void pd_unreserve(zaddress_unsafe addr, size_t size);
 
+  // To allow testing
+  ZVirtualMemoryManager();
+
+private:
   bool reserve_contiguous(zoffset start, size_t size);
   bool reserve_contiguous(size_t size);
   size_t reserve_discontiguous(zoffset start, size_t size, size_t min_range);

--- a/src/hotspot/share/gc/z/zVirtualMemory.hpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.hpp
@@ -47,7 +47,8 @@ public:
 };
 
 class ZVirtualMemoryManager {
-friend class ZMapperTest;
+  friend class ZMapperTest;
+
 private:
   static size_t calculate_min_range(size_t size);
 

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -41,8 +41,10 @@ using namespace testing;
 class ZMapperTest : public Test {
 private:
   static constexpr size_t ZMapperTestReservationSize = 32 * M;
+
   static bool            _initialized;
   static ZMemoryManager* _va;
+
   ZVirtualMemoryManager* _vmm;
 
 public:

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -77,7 +77,13 @@ public:
     _va = new (&_vmm->_manager) ZMemoryManager();
 
     // Reserve address space for the test
-    _initialized = reserve_for_test();
+    if (!reserve_for_test()) {
+      // Failed to reserve address space
+      GTEST_SKIP();
+      return;
+    }
+
+    _initialized = true;
   }
 
   virtual void TearDown() {
@@ -88,10 +94,6 @@ public:
   }
 
   static void test_alloc_low_address() {
-    if (!_initialized) {
-      GTEST_SKIP();
-    }
-
     // Verify that we get placeholder for first granule
     zoffset bottom = _va->alloc_low_address(ZGranuleSize);
     EXPECT_ALLOC_OK(bottom);
@@ -116,10 +118,6 @@ public:
   }
 
   static void test_alloc_high_address() {
-    if (!_initialized) {
-      GTEST_SKIP();
-    }
-
     // Verify that we get placeholder for last granule
     zoffset high = _va->alloc_high_address(ZGranuleSize);
     EXPECT_ALLOC_OK(high);
@@ -138,10 +136,6 @@ public:
   }
 
   static void test_alloc_whole_area() {
-    if (!_initialized) {
-      GTEST_SKIP();
-    }
-
     // Alloc the whole reservation
     zoffset bottom = _va->alloc_low_address(ZMapperTestReservationSize);
     EXPECT_ALLOC_OK(bottom);

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+
+#ifdef _WIN64
+
+#include "gc/z/zGlobals.hpp"
+#include "gc/z/zSyscall_windows.hpp"
+#include "gc/z/zVirtualMemory.hpp"
+#include "unittest.hpp"
+
+class TestZVirtualMemoryManager : public ZVirtualMemoryManager {
+private:
+  bool reserve_for_test(size_t size) {
+    const zaddress_unsafe addr = ZOffset::address_unsafe(zoffset(0));
+
+    // Reserve address space
+    if (!pd_reserve(addr, size)) {
+      return false;
+    }
+
+    // Make the address range free
+    _manager.free(zoffset(0), size);
+
+    return true;
+  }
+
+public:
+  TestZVirtualMemoryManager(size_t size) : ZVirtualMemoryManager() {
+    // Initialize platform specific parts before reserving address space
+    pd_initialize_before_reserve();
+
+    // Reserve address space
+    if (!reserve_for_test(size)) {
+      return;
+    }
+
+    // Initialize platform specific parts after reserving address space
+    pd_initialize_after_reserve();
+  }
+
+  ~TestZVirtualMemoryManager() {
+    // Empty the manager to avoid ZList assesrtion
+    for (zoffset offset = _manager.alloc_low_address(2*M);
+         offset != zoffset(UINTPTR_MAX);
+         offset = _manager.alloc_low_address(2*M)) {
+
+    }
+  }
+
+  void test_alloc_patterns() {
+    // Verify that we get placeholder for last granule
+    zoffset highest2m = _manager.alloc_high_address(2*M);
+    zoffset high2m = _manager.alloc_high_address(2*M);
+    _manager.free(highest2m, 2 * M);
+    _manager.free(high2m, 2 * M);
+
+    // Verify that we get placeholder for first granule
+    zoffset lowest2m = _manager.alloc_low_address(2*M);
+    zoffset low2m = _manager.alloc_low_address(2*M);
+    _manager.free(lowest2m, 2 * M);
+    _manager.free(low2m, 2 * M);
+
+    // Destroy a 2M granule
+    highest2m = _manager.alloc_high_address(2*M);
+    high2m = _manager.alloc_high_address(2*M);
+    _manager.free(highest2m, 2 * M);
+    highest2m = _manager.alloc_high_address(2*M);
+    _manager.free(highest2m, 2 * M);
+    _manager.free(high2m, 2 * M);
+  }
+};
+
+TEST(ZMapper, alloc_from_back) {
+  ZSyscall::initialize();
+  ZGlobalsPointers::initialize();
+  TestZVirtualMemoryManager manager(32 * M);
+  manager.test_alloc_patterns();
+}
+#endif


### PR DESCRIPTION
Please review this fix to correctly manage address space placeholders on Windows.

**Summary**
On Windows, when using small pages, we use address space placeholders to ensure consistency of the address space.

When a portion of the address space is mapped these placeholders are replaced by the actual backing and when doing this the size of the placeholder(s) needs to exactly match the size to be backed. For this reason, whenever address space is in use, we split the covering placeholder into multiple `ZGranuleSize` sized placeholders. 

During recent investigations into fragmentation of the ZGC address space, I found that there was a code code path (**currently not in use**) that did not properly manage these placeholders and we could end up in situations where no placeholder was split off when a new chunk of `ZGranuleSize` size was request. The problem is basically an off by one problem in the splitting code and the fix is to avoid this by changing it to first split the covering placeholder into two parts before splitting the part to be used into granules. 

**Testing**
* Manual testing using the included GTest as well as sample applications previously triggering the error case.
* Tier 1-5 Generational ZGC testing (ongoing)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330626](https://bugs.openjdk.org/browse/JDK-8330626): ZGC: Windows address space placeholders not managed correctly (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18912/head:pull/18912` \
`$ git checkout pull/18912`

Update a local copy of the PR: \
`$ git checkout pull/18912` \
`$ git pull https://git.openjdk.org/jdk.git pull/18912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18912`

View PR using the GUI difftool: \
`$ git pr show -t 18912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18912.diff">https://git.openjdk.org/jdk/pull/18912.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18912#issuecomment-2072077013)