### PR TITLE
8330988: Implementation of 8288293: Windows/gcc Port for hsdis

### DIFF
--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -74,63 +74,65 @@ endif
 
 ifeq ($(HSDIS_BACKEND), binutils)
   ifeq ($(call isTargetOs, windows), true)
-    # On windows, we need to "fake" a completely different toolchain using gcc
-    # instead of the normal microsoft toolchain. This is quite hacky...
+    ifeq ($(TOOLCHAIN_TYPE), microsoft)
+      # On windows, we need to "fake" a completely different toolchain using gcc
+      # instead of the normal microsoft toolchain. This is quite hacky...
 
-    MINGW_BASE := x86_64-w64-mingw32
+      MINGW_BASE := x86_64-w64-mingw32
 
-    MINGW_SYSROOT = $(shell $(MINGW_BASE)-gcc -print-sysroot)
-    ifeq ($(wildcard $(MINGW_SYSROOT)), )
-      # Use fallback path
-      MINGW_SYSROOT := /usr/$(MINGW_BASE)
+      MINGW_SYSROOT = $(shell $(MINGW_BASE)-gcc -print-sysroot)
       ifeq ($(wildcard $(MINGW_SYSROOT)), )
-        $(error mingw sysroot not found)
+        # Use fallback path
+        MINGW_SYSROOT := /usr/$(MINGW_BASE)
+        ifeq ($(wildcard $(MINGW_SYSROOT)), )
+          $(error mingw sysroot not found)
+        endif
       endif
-    endif
 
-    BUILD_HSDIS_CC := $(MINGW_BASE)-gcc
-    BUILD_HSDIS_LD := $(MINGW_BASE)-ld
-    BUILD_HSDIS_OBJCOPY := $(MINGW_BASE)-objcopy
-    BUILD_HSDIS_SYSROOT_CFLAGS := --sysroot=$(MINGW_SYSROOT)
-    BUILD_HSDIS_SYSROOT_LDFLAGS := --sysroot=$(MINGW_SYSROOT)
+      BUILD_HSDIS_CC := $(MINGW_BASE)-gcc
+      BUILD_HSDIS_LD := $(MINGW_BASE)-ld
+      BUILD_HSDIS_OBJCOPY := $(MINGW_BASE)-objcopy
+      BUILD_HSDIS_SYSROOT_CFLAGS := --sysroot=$(MINGW_SYSROOT)
+      BUILD_HSDIS_SYSROOT_LDFLAGS := --sysroot=$(MINGW_SYSROOT)
 
-    MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/mingw/lib
-    ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
-      # Try without mingw
-      MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/lib
+      MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/mingw/lib
       ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
-        $(error mingw sysroot lib path not found)
+        # Try without mingw
+        MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/lib
+        ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
+          $(error mingw sysroot lib path not found)
+        endif
       endif
-    endif
 
-    MINGW_VERSION = $(shell $(MINGW_BASE)-gcc -v 2>&1 | $(GREP) "gcc version" | $(CUT) -d " " -f 3)
-    MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION)
-    ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
-      # Try using only major version number
-      MINGW_VERSION_MAJOR := $(firstword $(subst ., , $(MINGW_VERSION)))
-      MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION_MAJOR)
+      MINGW_VERSION = $(shell $(MINGW_BASE)-gcc -v 2>&1 | $(GREP) "gcc version" | $(CUT) -d " " -f 3)
+      MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION)
       ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
-        $(error mingw gcc lib path not found)
+        # Try using only major version number
+        MINGW_VERSION_MAJOR := $(firstword $(subst ., , $(MINGW_VERSION)))
+        MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION_MAJOR)
+        ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
+          $(error mingw gcc lib path not found)
+        endif
       endif
+
+      TOOLCHAIN_TYPE := gcc
+      OPENJDK_TARGET_OS := linux
+      OPENJDK_TARGET_OS_TYPE := unix
+      CC_OUT_OPTION := -o$(SPACE)
+      GENDEPS_FLAGS := -MMD -MF
+      CFLAGS_DEBUG_SYMBOLS := -g
+      DISABLED_WARNINGS :=
+      DISABLE_WARNING_PREFIX := -Wno-
+      CFLAGS_WARNINGS_ARE_ERRORS := -Werror
+      SHARED_LIBRARY_FLAGS := -shared
+
+      HSDIS_TOOLCHAIN_DEFAULT_CFLAGS := false
+      HSDIS_TOOLCHAIN_DEFAULT_LDFLAGS := false
+      HSDIS_LDFLAGS += -L$(MINGW_GCC_LIB_PATH) -L$(MINGW_SYSROOT_LIB_PATH)
+      MINGW_DLLCRT := $(MINGW_SYSROOT_LIB_PATH)/dllcrt2.o
+      HSDIS_TOOLCHAIN_LIBS := $(MINGW_DLLCRT) -lmingw32 -lgcc -lgcc_eh -lmoldname \
+          -lmingwex -lmsvcrt -lpthread -ladvapi32 -lshell32 -luser32 -lkernel32
     endif
-
-    TOOLCHAIN_TYPE := gcc
-    OPENJDK_TARGET_OS := linux
-    OPENJDK_TARGET_OS_TYPE := unix
-    CC_OUT_OPTION := -o$(SPACE)
-    GENDEPS_FLAGS := -MMD -MF
-    CFLAGS_DEBUG_SYMBOLS := -g
-    DISABLED_WARNINGS :=
-    DISABLE_WARNING_PREFIX := -Wno-
-    CFLAGS_WARNINGS_ARE_ERRORS := -Werror
-    SHARED_LIBRARY_FLAGS := -shared
-
-    HSDIS_TOOLCHAIN_DEFAULT_CFLAGS := false
-    HSDIS_TOOLCHAIN_DEFAULT_LDFLAGS := false
-    HSDIS_LDFLAGS += -L$(MINGW_GCC_LIB_PATH) -L$(MINGW_SYSROOT_LIB_PATH)
-    MINGW_DLLCRT := $(MINGW_SYSROOT_LIB_PATH)/dllcrt2.o
-    HSDIS_TOOLCHAIN_LIBS := $(MINGW_DLLCRT) -lmingw32 -lgcc -lgcc_eh -lmoldname \
-        -lmingwex -lmsvcrt -lpthread -ladvapi32 -lshell32 -luser32 -lkernel32
   else
     HSDIS_TOOLCHAIN_LIBS := -ldl
   endif

--- a/make/Hsdis.gmk
+++ b/make/Hsdis.gmk
@@ -74,64 +74,70 @@ endif
 
 ifeq ($(HSDIS_BACKEND), binutils)
   ifeq ($(call isTargetOs, windows), true)
-    ifeq ($(TOOLCHAIN_TYPE), microsoft)
-      # On windows, we need to "fake" a completely different toolchain using gcc
-      # instead of the normal microsoft toolchain. This is quite hacky...
+    ifeq ($(OPENJDK_TARGET_OS_ENV), windows.cygwin)
+      ifeq ($(TOOLCHAIN_TYPE), microsoft)
+        # On windows, we need to "fake" a completely different toolchain using gcc
+        # instead of the normal microsoft toolchain. This is quite hacky...
 
-      MINGW_BASE := x86_64-w64-mingw32
+        MINGW_BASE := x86_64-w64-mingw32
 
-      MINGW_SYSROOT = $(shell $(MINGW_BASE)-gcc -print-sysroot)
-      ifeq ($(wildcard $(MINGW_SYSROOT)), )
-        # Use fallback path
-        MINGW_SYSROOT := /usr/$(MINGW_BASE)
+        MINGW_SYSROOT = $(shell $(MINGW_BASE)-gcc -print-sysroot)
         ifeq ($(wildcard $(MINGW_SYSROOT)), )
-          $(error mingw sysroot not found)
+          # Use fallback path
+          MINGW_SYSROOT := /usr/$(MINGW_BASE)
+          ifeq ($(wildcard $(MINGW_SYSROOT)), )
+            $(error mingw sysroot not found)
+          endif
         endif
-      endif
 
-      BUILD_HSDIS_CC := $(MINGW_BASE)-gcc
-      BUILD_HSDIS_LD := $(MINGW_BASE)-ld
-      BUILD_HSDIS_OBJCOPY := $(MINGW_BASE)-objcopy
-      BUILD_HSDIS_SYSROOT_CFLAGS := --sysroot=$(MINGW_SYSROOT)
-      BUILD_HSDIS_SYSROOT_LDFLAGS := --sysroot=$(MINGW_SYSROOT)
+        BUILD_HSDIS_CC := $(MINGW_BASE)-gcc
+        BUILD_HSDIS_LD := $(MINGW_BASE)-ld
+        BUILD_HSDIS_OBJCOPY := $(MINGW_BASE)-objcopy
+        BUILD_HSDIS_SYSROOT_CFLAGS := --sysroot=$(MINGW_SYSROOT)
+        BUILD_HSDIS_SYSROOT_LDFLAGS := --sysroot=$(MINGW_SYSROOT)
 
-      MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/mingw/lib
-      ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
-        # Try without mingw
-        MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/lib
+        MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/mingw/lib
         ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
-          $(error mingw sysroot lib path not found)
+          # Try without mingw
+          MINGW_SYSROOT_LIB_PATH := $(MINGW_SYSROOT)/lib
+          ifeq ($(wildcard $(MINGW_SYSROOT_LIB_PATH)), )
+            $(error mingw sysroot lib path not found)
+          endif
         endif
-      endif
 
-      MINGW_VERSION = $(shell $(MINGW_BASE)-gcc -v 2>&1 | $(GREP) "gcc version" | $(CUT) -d " " -f 3)
-      MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION)
-      ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
-        # Try using only major version number
-        MINGW_VERSION_MAJOR := $(firstword $(subst ., , $(MINGW_VERSION)))
-        MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION_MAJOR)
+        MINGW_VERSION = $(shell $(MINGW_BASE)-gcc -v 2>&1 | $(GREP) "gcc version" | $(CUT) -d " " -f 3)
+        MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION)
         ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
-          $(error mingw gcc lib path not found)
+          # Try using only major version number
+          MINGW_VERSION_MAJOR := $(firstword $(subst ., , $(MINGW_VERSION)))
+          MINGW_GCC_LIB_PATH := /usr/lib/gcc/$(MINGW_BASE)/$(MINGW_VERSION_MAJOR)
+          ifeq ($(wildcard $(MINGW_GCC_LIB_PATH)), )
+            $(error mingw gcc lib path not found)
+          endif
         endif
+
+        TOOLCHAIN_TYPE := gcc
+        OPENJDK_TARGET_OS := linux
+        OPENJDK_TARGET_OS_TYPE := unix
+        CC_OUT_OPTION := -o$(SPACE)
+        GENDEPS_FLAGS := -MMD -MF
+        CFLAGS_DEBUG_SYMBOLS := -g
+        DISABLED_WARNINGS :=
+        DISABLE_WARNING_PREFIX := -Wno-
+        CFLAGS_WARNINGS_ARE_ERRORS := -Werror
+        SHARED_LIBRARY_FLAGS := -shared
+
+        HSDIS_TOOLCHAIN_DEFAULT_CFLAGS := false
+        HSDIS_TOOLCHAIN_DEFAULT_LDFLAGS := false
+        HSDIS_LDFLAGS += -L$(MINGW_GCC_LIB_PATH) -L$(MINGW_SYSROOT_LIB_PATH)
+        MINGW_DLLCRT := $(MINGW_SYSROOT_LIB_PATH)/dllcrt2.o
+        HSDIS_TOOLCHAIN_LIBS := $(MINGW_DLLCRT) -lmingw32 -lgcc -lgcc_eh -lmoldname \
+            -lmingwex -lmsvcrt -lpthread -ladvapi32 -lshell32 -luser32 -lkernel32
+      else ifeq ($(TOOLCHAIN_TYPE), gcc)
+        $(error gcc is not yet supported as a hsdis compiler on Cygwin)
       endif
-
-      TOOLCHAIN_TYPE := gcc
-      OPENJDK_TARGET_OS := linux
-      OPENJDK_TARGET_OS_TYPE := unix
-      CC_OUT_OPTION := -o$(SPACE)
-      GENDEPS_FLAGS := -MMD -MF
-      CFLAGS_DEBUG_SYMBOLS := -g
-      DISABLED_WARNINGS :=
-      DISABLE_WARNING_PREFIX := -Wno-
-      CFLAGS_WARNINGS_ARE_ERRORS := -Werror
-      SHARED_LIBRARY_FLAGS := -shared
-
-      HSDIS_TOOLCHAIN_DEFAULT_CFLAGS := false
-      HSDIS_TOOLCHAIN_DEFAULT_LDFLAGS := false
-      HSDIS_LDFLAGS += -L$(MINGW_GCC_LIB_PATH) -L$(MINGW_SYSROOT_LIB_PATH)
-      MINGW_DLLCRT := $(MINGW_SYSROOT_LIB_PATH)/dllcrt2.o
-      HSDIS_TOOLCHAIN_LIBS := $(MINGW_DLLCRT) -lmingw32 -lgcc -lgcc_eh -lmoldname \
-          -lmingwex -lmsvcrt -lpthread -ladvapi32 -lshell32 -luser32 -lkernel32
+    else ifneq ($(OPENJDK_TARGET_OS_ENV), windows.msys2)
+      $(error The only supported Windows POSIX environments for hsdis backend binutils are MSYS2 and Cygwin)
     endif
   else
     HSDIS_TOOLCHAIN_LIBS := -ldl

--- a/make/autoconf/build-performance.m4
+++ b/make/autoconf/build-performance.m4
@@ -165,7 +165,7 @@ AC_DEFUN([BPERF_SETUP_CCACHE],
   if test "x$TOOLCHAIN_PATH" != x; then
     PATH=$TOOLCHAIN_PATH:$PATH
   fi
-  UTIL_LOOKUP_PROGS(CCACHE, ccache)
+  UTIL_LOOKUP_PROGS(CCACHE, ccache, , NOFIXPATH)
   PATH="$OLD_PATH"
 
   AC_MSG_CHECKING([if ccache is available])

--- a/make/autoconf/flags-other.m4
+++ b/make/autoconf/flags-other.m4
@@ -93,6 +93,10 @@ AC_DEFUN([FLAGS_SETUP_RCFLAGS],
     if test "x$DEBUG_LEVEL" = xrelease; then
       RCFLAGS="$RCFLAGS -DNDEBUG"
     fi
+  elif test "x$TOOLCHAIN_TYPE" = xgcc && test "x$OPENJDK_TARGET_OS" = xwindows; then
+    if test "x$DEBUG_LEVEL" = xrelease; then
+      RCFLAGS="$RCFLAGS -DNDEBUG"
+    fi
   fi
   AC_SUBST(RCFLAGS)
 ])

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -170,22 +170,24 @@ AC_DEFUN([LIB_BUILD_BINUTILS],
     # On Windows, we cannot build with the normal Microsoft CL, but must instead use
     # a separate mingw toolchain.
     if test "x$OPENJDK_BUILD_OS" = xwindows; then
-      if test "x$OPENJDK_TARGET_CPU" = "xx86"; then
-        target_base="i686-w64-mingw32"
-      else
-        target_base="$OPENJDK_TARGET_CPU-w64-mingw32"
-      fi
-      binutils_cc="$target_base-gcc"
-      binutils_target="--host=$target_base --target=$target_base"
-      # Somehow the uint typedef is not included when building with mingw
-      binutils_cflags="-Duint=unsigned"
-      compiler_version=`$binutils_cc --version 2>&1`
-      if ! [ [[ "$compiler_version" =~ GCC ]] ]; then
-        AC_MSG_NOTICE([Could not find correct mingw compiler $binutils_cc.])
-        HELP_MSG_MISSING_DEPENDENCY([$binutils_cc])
-        AC_MSG_ERROR([Cannot continue. $HELP_MSG])
-      else
-        AC_MSG_NOTICE([Using compiler $binutils_cc with version $compiler_version])
+      if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+        if test "x$OPENJDK_TARGET_CPU" = "xx86"; then
+          target_base="i686-w64-mingw32"
+        else
+          target_base="$OPENJDK_TARGET_CPU-w64-mingw32"
+        fi
+        binutils_cc="$target_base-gcc"
+        binutils_target="--host=$target_base --target=$target_base"
+        # Somehow the uint typedef is not included when building with mingw
+        binutils_cflags="-Duint=unsigned"
+        compiler_version=`$binutils_cc --version 2>&1`
+        if ! [ [[ "$compiler_version" =~ GCC ]] ]; then
+          AC_MSG_NOTICE([Could not find correct mingw compiler $binutils_cc.])
+          HELP_MSG_MISSING_DEPENDENCY([$binutils_cc])
+          AC_MSG_ERROR([Cannot continue. $HELP_MSG])
+        else
+          AC_MSG_NOTICE([Using compiler $binutils_cc with version $compiler_version])
+        fi
       fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx; then
       if test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then

--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -157,9 +157,14 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
   fi
 
   if test "x$OPENJDK_TARGET_OS" = xwindows; then
-    BASIC_JVM_LIBS="$BASIC_JVM_LIBS kernel32.lib user32.lib gdi32.lib winspool.lib \
-        comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib powrprof.lib uuid.lib \
-        ws2_32.lib winmm.lib version.lib psapi.lib"
+    # Only Visual C++ requires static import libraries
+    if test "x$TOOLCHAIN_TYPE" = xmicrosoft; then
+      BASIC_JVM_LIBS="$BASIC_JVM_LIBS kernel32.lib user32.lib gdi32.lib winspool.lib \
+          comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib powrprof.lib uuid.lib \
+          ws2_32.lib winmm.lib version.lib psapi.lib"
+    elif test "x$TOOLCHAIN_TYPE" = xgcc; then
+      BASIC_JVM_LIBS="$BASIC_JVM_LIBS -lpowrprof -lws2_32 -lwinmm -lversion -lpsapi"
+    fi
   fi
   LIB_SETUP_JVM_LIBS(BUILD)
   LIB_SETUP_JVM_LIBS(TARGET)

--- a/make/autoconf/util_paths.m4
+++ b/make/autoconf/util_paths.m4
@@ -442,13 +442,14 @@ AC_DEFUN([UTIL_LOOKUP_PROGS],
 # $1: variable to set
 # $2: executable name (or list of names) to look for
 # $3: [path]
+# $4: set to NOFIXPATH to skip prefixing FIXPATH, even if needed on platform
 AC_DEFUN([UTIL_LOOKUP_TOOLCHAIN_PROGS],
 [
   if test "x$ac_tool_prefix" = x; then
-    UTIL_LOOKUP_PROGS($1, $2, $3)
+    UTIL_LOOKUP_PROGS($1, $2, $3, $4)
   else
     prefixed_names=$(for name in $2; do echo ${ac_tool_prefix}${name} $name; done)
-    UTIL_LOOKUP_PROGS($1, $prefixed_names, $3)
+    UTIL_LOOKUP_PROGS($1, $prefixed_names, $3, $4)
   fi
 ])
 

--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -113,7 +113,7 @@ define ResolveLibPath
   ifneq ($$($1_$2_MODULE), gtest)
     ifneq ($$($1_$2_NAME), jvm)
       # This is the common case
-      ifeq ($$(call isTargetOs, windows), true)
+      ifeq ($(TOOLCHAIN_TYPE), microsoft)
         $1_$2_LIBPATH := $$(SUPPORT_OUTPUTDIR)/native/$$($1_$2_MODULE)/lib$$($1_$2_NAME)
       else
         ifeq ($(STATIC_LIBS), true)
@@ -132,7 +132,7 @@ define ResolveLibPath
       else
         $1_$2_JVM_VARIANT_PATH := $(JVM_VARIANT_MAIN)
       endif
-      ifeq ($$(call isTargetOs, windows), true)
+      ifeq ($(TOOLCHAIN_TYPE), microsoft)
         ifeq ($(STATIC_LIBS), true)
           $1_$2_LIBPATH := $$(HOTSPOT_OUTPUTDIR)/variant-$$($1_$2_JVM_VARIANT_PATH)/libjvm/objs/static
         else
@@ -149,7 +149,7 @@ define ResolveLibPath
   else
     # Special treatment for virtual module "gtest"
     ifeq ($$($1_$2_NAME), jvm)
-      ifeq ($$(call isTargetOs, windows), true)
+      ifeq ($(TOOLCHAIN_TYPE), microsoft)
         ifeq ($(STATIC_LIBS), true)
           $1_$2_LIBPATH := $$(JVM_OUTPUTDIR)/gtest/objs/static
         else
@@ -208,7 +208,7 @@ define AddJdkLibrary
   $1_EXTRA_HEADER_DIRS += $$($1_$2_MODULE):lib$$($1_$2_NAME)
 
   ifneq ($(STATIC_LIBS), true)
-    ifeq ($$(call isTargetOs, windows), true)
+    ifeq ($(TOOLCHAIN_TYPE), microsoft)
       ifeq ($$(filter -libpath:$$($1_$2_LIBPATH), $$($1_LDFLAGS)), )
         $1_LDFLAGS += -libpath:$$($1_$2_LIBPATH)
       endif

--- a/make/common/Utils.gmk
+++ b/make/common/Utils.gmk
@@ -187,9 +187,6 @@ isBuildCpu = \
 isBuildCpuArch = \
   $(strip $(if $(filter $(OPENJDK_BUILD_CPU_ARCH), $1), true, false))
 
-isCompiler = \
-  $(strip $(if $(filter $(TOOLCHAIN_TYPE), $1), true, false))
-
 ################################################################################
 #
 # Common utility functions

--- a/make/common/native/CompileFile.gmk
+++ b/make/common/native/CompileFile.gmk
@@ -323,29 +323,43 @@ define CreateWindowsResourceFile
     $1_RES_VARDEPS_FILE := $$(call DependOnVariable, $1_RES_VARDEPS, \
         $$($1_RES).vardeps)
 
-    $$($1_RES): $$($1_VERSIONINFO_RESOURCE) $$($1_RES_VARDEPS_FILE)
-		$$(call LogInfo, Compiling resource $$(notdir $$($1_VERSIONINFO_RESOURCE)) (for $$($1_BASENAME)))
-		$$(call MakeDir, $$(@D) $$($1_OBJECT_DIR))
-		$$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
-		    $$($1_RC) $$($1_RCFLAGS) $$($1_SYSROOT_CFLAGS) $(CC_OUT_OPTION)$$@ \
-		    $$($1_VERSIONINFO_RESOURCE) 2>&1 ))
-                # Windows RC compiler does not support -showIncludes, so we mis-use CL
-                # for this. Filter out RC specific arguments that are unknown to CL.
-                # For some unknown reason, in this case CL actually outputs the show
-                # includes to stderr so need to redirect it to hide the output from the
-                # main log.
-		$$(call ExecuteWithLog, $$($1_RES_DEPS_FILE)$(OBJ_SUFFIX), \
-		    $$($1_CC) $$(filter-out -l%, $$($1_RCFLAGS)) \
-		        $$($1_SYSROOT_CFLAGS) -showIncludes -nologo -TC \
-		        $(CC_OUT_OPTION)$$($1_RES_DEPS_FILE)$(OBJ_SUFFIX) -P -Fi$$($1_RES_DEPS_FILE).pp \
-		        $$($1_VERSIONINFO_RESOURCE)) 2>&1 \
-		    | $(TR) -d '\r' | $(GREP) -v -e "^Note: including file:" \
-		        -e "^$$(notdir $$($1_VERSIONINFO_RESOURCE))$$$$" || test "$$$$?" = "1" ; \
-		$(ECHO) $$($1_RES): \\ > $$($1_RES_DEPS_FILE) ; \
-		$(SED) $(WINDOWS_SHOWINCLUDE_SED_PATTERN) $$($1_RES_DEPS_FILE)$(OBJ_SUFFIX).log \
-		    >> $$($1_RES_DEPS_FILE) ; \
-		$(ECHO) >> $$($1_RES_DEPS_FILE) ;\
-		$(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_RES_DEPS_FILE) \
-		    > $$($1_RES_DEPS_TARGETS_FILE)
+    ifeq ($(TOOLCHAIN_TYPE), gcc)
+      $$($1_RES): $$($1_VERSIONINFO_RESOURCE) $$($1_RES_VARDEPS_FILE)
+		  $$(call LogInfo, Compiling resource $$(notdir $$($1_VERSIONINFO_RESOURCE)) (for $$($1_BASENAME)))
+		  $$(call MakeDir, $$(@D) $$($1_OBJECT_DIR))
+		  $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
+		      $$($1_RC) $$(addprefix --preprocessor-arg=, $$(GENDEPS_FLAGS) \
+		      $$(addsuffix .tmp, $$($1_RES_DEPS_FILE)) -MT $$@) \
+		      $$($1_RCFLAGS) $$($1_SYSROOT_CFLAGS) $(CC_OUT_OPTION)$$@ \
+		      -O coff $$($1_VERSIONINFO_RESOURCE) 2>&1 ))
+		  $$(call fix-deps-file, $$($1_RES_DEPS_FILE))
+		  $(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_RES_DEPS_FILE) \
+		      > $$($1_RES_DEPS_TARGETS_FILE)
+    else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+      $$($1_RES): $$($1_VERSIONINFO_RESOURCE) $$($1_RES_VARDEPS_FILE)
+		  $$(call LogInfo, Compiling resource $$(notdir $$($1_VERSIONINFO_RESOURCE)) (for $$($1_BASENAME)))
+		  $$(call MakeDir, $$(@D) $$($1_OBJECT_DIR))
+		  $$(call ExecuteWithLog, $$@, $$(call MakeCommandRelative, \
+		      $$($1_RC) $$($1_RCFLAGS) $$($1_SYSROOT_CFLAGS) $(CC_OUT_OPTION)$$@ \
+		      $$($1_VERSIONINFO_RESOURCE) 2>&1 ))
+                  # Windows RC compiler does not support -showIncludes, so we mis-use CL
+                  # for this. Filter out RC specific arguments that are unknown to CL.
+                  # For some unknown reason, in this case CL actually outputs the show
+                  # includes to stderr so need to redirect it to hide the output from the
+                  # main log.
+		  $$(call ExecuteWithLog, $$($1_RES_DEPS_FILE)$(OBJ_SUFFIX), \
+		      $$($1_CC) $$(filter-out -l%, $$($1_RCFLAGS)) \
+		          $$($1_SYSROOT_CFLAGS) -showIncludes -nologo -TC \
+		          $(CC_OUT_OPTION)$$($1_RES_DEPS_FILE)$(OBJ_SUFFIX) -P -Fi$$($1_RES_DEPS_FILE).pp \
+		          $$($1_VERSIONINFO_RESOURCE)) 2>&1 \
+		      | $(TR) -d '\r' | $(GREP) -v -e "^Note: including file:" \
+		          -e "^$$(notdir $$($1_VERSIONINFO_RESOURCE))$$$$" || test "$$$$?" = "1" ; \
+		  $(ECHO) $$($1_RES): \\ > $$($1_RES_DEPS_FILE) ; \
+		  $(SED) $(WINDOWS_SHOWINCLUDE_SED_PATTERN) $$($1_RES_DEPS_FILE)$(OBJ_SUFFIX).log \
+		      >> $$($1_RES_DEPS_FILE) ; \
+		  $(ECHO) >> $$($1_RES_DEPS_FILE) ;\
+		  $(SED) $(DEPENDENCY_TARGET_SED_PATTERN) $$($1_RES_DEPS_FILE) \
+		      > $$($1_RES_DEPS_TARGETS_FILE)
+    endif
   endif
 endef

--- a/make/common/native/DebugSymbols.gmk
+++ b/make/common/native/DebugSymbols.gmk
@@ -46,8 +46,12 @@ define CreateDebugSymbols
 
         # Setup where the platform specific debuginfo files end up
         ifeq ($(call isTargetOs, windows), true)
-          $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb \
-              $$($1_SYMBOLS_DIR)/$$($1_BASENAME).map
+          ifeq ($(TOOLCHAIN_TYPE), gcc)
+            $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb
+          else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+            $1_DEBUGINFO_FILES := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb \
+                $$($1_SYMBOLS_DIR)/$$($1_BASENAME).map
+          endif
           $1_DEBUGINFO_ZIP := $$($1_SYMBOLS_DIR)/$$($1_BASENAME).diz
         else ifeq ($(call isTargetOs, macosx), true)
           $1_DEBUGINFO_FILES := \
@@ -60,10 +64,14 @@ define CreateDebugSymbols
         endif
 
         ifeq ($(call isTargetOs, windows), true)
-          $1_EXTRA_LDFLAGS += -debug "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb" \
-              "-map:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).map"
-          ifeq ($(SHIP_DEBUG_SYMBOLS), public)
-            $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).stripped.pdb"
+          ifeq ($(TOOLCHAIN_TYPE), gcc)
+            $1_EXTRA_LDFLAGS += -Wl$(COMMA)--pdb=$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb
+          else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+            $1_EXTRA_LDFLAGS += -debug "-pdb:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).pdb" \
+                "-map:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).map"
+            ifeq ($(SHIP_DEBUG_SYMBOLS), public)
+              $1_EXTRA_LDFLAGS += "-pdbstripped:$$($1_SYMBOLS_DIR)/$$($1_BASENAME).stripped.pdb"
+            endif
           endif
         endif
 

--- a/make/common/native/Flags.gmk
+++ b/make/common/native/Flags.gmk
@@ -83,7 +83,7 @@ define SetupCompilerFlags
   # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS, TOOLCHAIN_TYPE and
   # OPENJDK_TARGET_OS plus OPENJDK_TARGET_CPU pair dependent variables for CFLAGS.
   $1_EXTRA_CFLAGS := $$($1_CFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_CFLAGS_$(OPENJDK_TARGET_OS)) \
-      $$($1_CFLAGS_$(TOOLCHAIN_TYPE)) \
+      $$($1_CFLAGS_$(TOOLCHAIN_TYPE)) $$($1_CFLAGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS)) \
       $$($1_CFLAGS_$(OPENJDK_TARGET_OS)_$(OPENJDK_TARGET_CPU))
 
   ifneq ($(DEBUG_LEVEL), release)
@@ -102,10 +102,11 @@ define SetupCompilerFlags
     $1_EXTRA_CFLAGS += $$(STATIC_LIBS_CFLAGS)
   endif
 
-  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS and/or TOOLCHAIN_TYPE
-  # dependent variables for CXXFLAGS.
+  # Pickup extra OPENJDK_TARGET_OS_TYPE, OPENJDK_TARGET_OS and TOOLCHAIN_TYPE dependent
+  # variables for CXXFLAGS, and additionally the pair dependent TOOLCHAIN_TYPE plus
+  # OPENJDK_TARGET_OS.
   $1_EXTRA_CXXFLAGS := $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS_TYPE)) $$($1_CXXFLAGS_$(OPENJDK_TARGET_OS)) \
-      $$($1_CXXFLAGS_$(TOOLCHAIN_TYPE))
+      $$($1_CXXFLAGS_$(TOOLCHAIN_TYPE)) $$($1_CXXFLAGS_$(TOOLCHAIN_TYPE)_$(OPENJDK_TARGET_OS))
 
   ifneq ($(DEBUG_LEVEL), release)
     # Pickup extra debug dependent variables for CXXFLAGS

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -40,13 +40,12 @@ ifeq ($(call check-jvm-feature, compiler2), true)
     ifeq ($(TOOLCHAIN_TYPE), clang)
       ADLC_LDFLAGS += -m64
       ADLC_CFLAGS := -fno-rtti -fexceptions -ffunction-sections -m64 -DAIX -mcpu=pwr8
-    else
-      ADLC_LDFLAGS += -q64
-      ADLC_CFLAGS := -qnortti -qeh -q64 -DAIX
     endif
   else ifeq ($(call isBuildOs, windows), true)
-    ADLC_CFLAGS := -nologo -EHsc
-    ADLC_CFLAGS_WARNINGS := -W3 -D_CRT_SECURE_NO_WARNINGS
+    ifeq ($(TOOLCHAIN_TYPE), microsoft)
+      ADLC_CFLAGS := -nologo -EHsc
+      ADLC_CFLAGS_WARNINGS := -W3 -D_CRT_SECURE_NO_WARNINGS
+    endif
   endif
 
   # Set the C++ standard

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -65,7 +65,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         -I$(GTEST_FRAMEWORK_SRC)/googletest/include \
         -I$(GTEST_FRAMEWORK_SRC)/googlemock \
         -I$(GTEST_FRAMEWORK_SRC)/googlemock/include, \
-    CFLAGS_windows := -EHsc, \
+    CFLAGS_microsoft := -EHsc, \
     CFLAGS_macosx := -DGTEST_OS_MAC=1, \
     OPTIMIZATION := $(JVM_OPTIMIZATION), \
     COPY_DEBUG_SYMBOLS := $(GTEST_COPY_DEBUG_SYMBOLS), \
@@ -95,7 +95,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
         -I$(GTEST_FRAMEWORK_SRC)/googletest/include \
         -I$(GTEST_FRAMEWORK_SRC)/googlemock/include \
         $(addprefix -I,$(GTEST_TEST_SRC)), \
-    CFLAGS_windows := -EHsc, \
+    CFLAGS_microsoft := -EHsc, \
     CFLAGS_macosx := -DGTEST_OS_MAC=1, \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc) \
         undef stringop-overflow, \

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -165,15 +165,15 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
   # Set JVM_OPTIMIZATION directly so other jvm-feature flags can override it
   # later on if desired
   JVM_OPTIMIZATION := HIGHEST_JVM
-  ifeq ($(call isCompiler, gcc), true)
-    JVM_CFLAGS_FEATURES += -flto=auto -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
-    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto -fuse-linker-plugin -fno-strict-aliasing
-  else ifeq ($(call isCompiler, microsoft), true)
-    JVM_CFLAGS_FEATURES += -GL
+  ifeq ($(TOOLCHAIN_TYPE), gcc)
+    JVM_CFLAGS_FEATURES += -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing -fno-fat-lto-objects
+    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=$(JOBS) -fuse-linker-plugin -fno-strict-aliasing
+  else ifeq ($(TOOLCHAIN_TYPE), microsoft)
+    JVM_CFLAGS_FEATURES += -GL -Gy
     JVM_LDFLAGS_FEATURES += -LTCG:INCREMENTAL
   endif
 else
-  ifeq ($(call isCompiler, gcc), true)
+  ifeq ($(TOOLCHAIN_TYPE), gcc)
     JVM_LDFLAGS_FEATURES += -O1
   endif
 endif

--- a/make/ide/eclipse/CreateWorkspace.gmk
+++ b/make/ide/eclipse/CreateWorkspace.gmk
@@ -101,7 +101,7 @@ define SetupEclipseWorkspaceBody
   $$(call MakeDir, $$($1_IDE_OUTPUTDIR))
 
   ifneq ($$(findstring $$($1_NATURE), HOTSPOT NATIVE MIXED), )
-    ifeq ($$(call isCompiler, microsoft), true)
+    ifeq ($(TOOLCHAIN_TYPE), microsoft)
       $$(error Visual C++ is not yet supported as an indexer for Native Workspaces!)
     endif
   endif


### PR DESCRIPTION
WIP

This changeset contains hsdis for Windows/gcc Port. It supports both the binutils and capstone backends, though the LLVM backend is left out due to compatibility issues encountered during the build. Currently, which gcc distributions are supported is still to be clarified, as several, ranging from Cygwin, to MinGW64, to the gcc subsystems from MSYS2. For this reason, the build system hack in place at the moment to compile the binutils backend on Windows is still left in place, for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330988](https://bugs.openjdk.org/browse/JDK-8330988): Implementation of 8288293: Windows/gcc Port for hsdis (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18915/head:pull/18915` \
`$ git checkout pull/18915`

Update a local copy of the PR: \
`$ git checkout pull/18915` \
`$ git pull https://git.openjdk.org/jdk.git pull/18915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18915`

View PR using the GUI difftool: \
`$ git pr show -t 18915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18915.diff">https://git.openjdk.org/jdk/pull/18915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18915#issuecomment-2072398311)