### PR TITLE
8330853: Add missing checks for ConnectionGraph::can_reduce_cmp() call

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -494,8 +494,7 @@ bool ConnectionGraph::can_reduce_cmp(Node* n, Node* cmp) const {
   Node* left = cmp->in(1);
   Node* right = cmp->in(2);
 
-  return (cmp->Opcode() == Op_CmpP || cmp->Opcode() == Op_CmpN) &&
-         (left == n || right == n) &&
+  return (left == n || right == n) &&
          (left->is_Con() || right->is_Con()) &&
          cmp->outcnt() == 1;
 }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -490,6 +490,7 @@ bool ConnectionGraph::can_reduce_phi_check_inputs(PhiNode* ophi) const {
 // I require the 'other' input to be a constant so that I can move the Cmp
 // around safely.
 bool ConnectionGraph::can_reduce_cmp(Node* n, Node* cmp) const {
+  assert(cmp->Opcode() == Op_CmpP || cmp->Opcode() == Op_CmpN, "not expected node: %s", cmp->Name());
   Node* left = cmp->in(1);
   Node* right = cmp->in(2);
 
@@ -568,11 +569,14 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
         // CmpP/N used by the If controlling the cast.
         if (use->in(0)->is_IfTrue() || use->in(0)->is_IfFalse()) {
           Node* iff = use->in(0)->in(0);
-          Node* iff_cmp = iff->in(1)->in(1); // if->bool->cmp
-          if (!can_reduce_cmp(n, iff_cmp)) {
-            NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);)
-            NOT_PRODUCT(n->dump(5);)
-            return false;
+          if (iff->Opcode() == Op_If && iff->in(1)->is_Bool() && iff->in(1)->in(1)->is_Cmp()) {
+            Node* iff_cmp = iff->in(1)->in(1);
+            int opc = iff_cmp->Opcode();
+            if ((opc == Op_CmpP || opc == Op_CmpN) && !can_reduce_cmp(n, iff_cmp)) {
+              NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);)
+              NOT_PRODUCT(n->dump(5);)
+              return false;
+            }
           }
         }
       }

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -557,8 +557,12 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
     } else if (use->is_CastPP()) {
       const Type* cast_t = _igvn->type(use);
       if (cast_t == nullptr || cast_t->make_ptr()->isa_instptr() == nullptr) {
-        NOT_PRODUCT(use->dump();)
-        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP is not to an instance.", n->_idx, _invocation);)
+#ifndef PRODUCT
+        if (TraceReduceAllocationMerges) {
+          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP is not to an instance.", n->_idx, _invocation);
+          use->dump();
+        }
+#endif
         return false;
       }
 
@@ -572,8 +576,12 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
             Node* iff_cmp = iff->in(1)->in(1);
             int opc = iff_cmp->Opcode();
             if ((opc == Op_CmpP || opc == Op_CmpN) && !can_reduce_cmp(n, iff_cmp)) {
-              NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);)
-              NOT_PRODUCT(n->dump(5);)
+#ifndef PRODUCT
+              if (TraceReduceAllocationMerges) {
+                tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
+                n->dump(5);
+              }
+#endif
               return false;
             }
           }


### PR DESCRIPTION
In Leyden testing CI we start hitting assert:

```
# Internal Error (/workspace/open/src/hotspot/share/opto/node.hpp:407), pid=3216007, tid=3216030
# assert(i < _max) failed: oob: i=2, _max=2

Stack: [0x00007f20b011b000,0x00007f20b021b000], sp=0x00007f20b02157e0, free space=1001k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0xbf5bb4] Node::in(unsigned int) const [clone .part.0]+0x24 (node.hpp:407)
V [libjvm.so+0xbf69ea] ConnectionGraph::can_reduce_cmp(Node*, Node*) const+0x9a (node.hpp:407)
V [libjvm.so+0xbf74a6] ConnectionGraph::can_reduce_check_users(Node*, unsigned int) const+0x996 (escape.cpp:578)
```

[JDK-8316991](https://bugs.openjdk.org/browse/JDK-8316991) added new code which assumes that we always have sequence : IfNode->Bool->Cmp: [escape.cpp#L569](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/escape.cpp#L569)
which is not true in some cases. In failed cases there is additional Opaque4 node between If and Bool nodes.

The fix is to add missing checks for If, Bool and Cmp nodes.

The fix is verified in Leyden CI testing. The failure happens only with special C2 mode compilation in Leyden.
Running our regular tier1-3,stress,xcomp too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330853](https://bugs.openjdk.org/browse/JDK-8330853): Add missing checks for ConnectionGraph::can_reduce_cmp() call (**Bug** - P3)


### Reviewers
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Cesar Soares Lucas](https://openjdk.org/census#cslucas) (@JohnTortugo - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18916/head:pull/18916` \
`$ git checkout pull/18916`

Update a local copy of the PR: \
`$ git checkout pull/18916` \
`$ git pull https://git.openjdk.org/jdk.git pull/18916/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18916`

View PR using the GUI difftool: \
`$ git pr show -t 18916`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18916.diff">https://git.openjdk.org/jdk/pull/18916.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18916#issuecomment-2072518023)