### PR TITLE
8309881: Qualified name of a type element depends on its origin (source vs class)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -518,7 +518,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         if (tsym == null || tsym.name == null) {
             sb.append("<none>");
         } else {
-            sb.append(tsym.getQualifiedName().toString());
+            sb.append(tsym.name.toString());
         }
         if (moreInfo && hasTag(TYPEVAR)) {
             sb.append(hashCode());
@@ -1120,6 +1120,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
                         s += String.valueOf(sym.hashCode());
                     return s;
                 } else if (longform) {
+                    sym.apiComplete();
                     return sym.getQualifiedName().toString();
                 } else {
                     return sym.name.toString();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -518,7 +518,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         if (tsym == null || tsym.name == null) {
             sb.append("<none>");
         } else {
-            sb.append(tsym.name.toString());
+            sb.append(tsym.getQualifiedName().toString());
         }
         if (moreInfo && hasTag(TYPEVAR)) {
             sb.append(hashCode());

--- a/test/langtools/tools/javac/TypeToString.java
+++ b/test/langtools/tools/javac/TypeToString.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8309881
+ * @library /tools/javac/lib
+ * @modules java.compiler
+ *          jdk.compiler
+ * @build JavacTestingAbstractProcessor TypeToString
+ * @compile -cp . -processor TypeToString -proc:only TypeToString.java
+ * @compile/process -cp . -processor TypeToString -proc:only Test
+ */
+import java.lang.Runtime.Version;
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.*;
+import javax.lang.model.util.*;
+
+@SupportedAnnotationTypes("*")
+public class TypeToString extends JavacTestingAbstractProcessor {
+
+    public boolean process(Set<? extends TypeElement> typeElementSet,RoundEnvironment renv) {
+        if (renv.processingOver()) {
+            TypeElement testClass = processingEnv.getElementUtils().getTypeElement("Test");
+            ExecutableElement method = ElementFilter.methodsIn(testClass.getEnclosedElements())
+                                                    .iterator()
+                                                    .next();
+            String expectedTypeToString = "java.lang.Runtime.Version";
+            String actualToString = method.getReturnType().toString();
+
+            if (!Objects.equals(expectedTypeToString, actualToString)) {
+                throw new AssertionError("Unexpected toString value. " +
+                                         "Expected: " + expectedTypeToString + ", " +
+                                         "but got: " + actualToString);
+            }
+
+            actualToString = method.getParameters().get(0).asType().toString();
+
+            if (!Objects.equals(expectedTypeToString, actualToString)) {
+                throw new AssertionError("Unexpected toString value. " +
+                                         "Expected: " + expectedTypeToString + ", " +
+                                         "but got: " + actualToString);
+            }
+        }
+        return false;
+    }
+}
+
+class Test {
+    public Version get(Version v) {
+        return null;
+    }
+}


### PR DESCRIPTION
`javax.lang.model.type.TypeMirror::toString` says: "Any names embedded in the result are qualified if possible."
However in reality the form of the names depends on the source vs.class origin.

This patch enforces qualified name to be used.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331106](https://bugs.openjdk.org/browse/JDK-8331106) to be approved

### Issues
 * [JDK-8309881](https://bugs.openjdk.org/browse/JDK-8309881): Qualified name of a type element depends on its origin (source vs class) (**Bug** - P3)
 * [JDK-8331106](https://bugs.openjdk.org/browse/JDK-8331106): Qualified name of a type element depends on its origin (source vs class) (**CSR**)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [1023edfe](https://git.openjdk.org/jdk/pull/18917/files/1023edfe582965f5e2488f94b9598035b831d4e0)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18917/head:pull/18917` \
`$ git checkout pull/18917`

Update a local copy of the PR: \
`$ git checkout pull/18917` \
`$ git pull https://git.openjdk.org/jdk.git pull/18917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18917`

View PR using the GUI difftool: \
`$ git pr show -t 18917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18917.diff">https://git.openjdk.org/jdk/pull/18917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18917#issuecomment-2072541696)