### PR TITLE
8331208: Memory stress test that checks OutOfMemoryError stack trace fails

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1397,7 +1397,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   assert(!HAS_PENDING_EXCEPTION, "No exception should be present");
   // some prerequisites that are compiler specific
   if (comp->is_c2() || comp->is_jvmci()) {
-    SandboxedOOMEMark som(THREAD);
+    InternalOOMEMark iom(THREAD);
     method->constants()->resolve_string_constants(CHECK_AND_CLEAR_NONASYNC_NULL);
     // Resolve all classes seen in the signature of the method
     // we are compiling.

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -38,6 +38,7 @@
 #include "compiler/compilerEvent.hpp"
 #include "compiler/compilerOracle.hpp"
 #include "compiler/directivesParser.hpp"
+#include "gc/shared/memAllocator.hpp"
 #include "interpreter/linkResolver.hpp"
 #include "jvm.h"
 #include "jfr/jfrEvents.hpp"
@@ -1396,6 +1397,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   assert(!HAS_PENDING_EXCEPTION, "No exception should be present");
   // some prerequisites that are compiler specific
   if (comp->is_c2() || comp->is_jvmci()) {
+    SandboxedOOMEMark som(THREAD);
     method->constants()->resolve_string_constants(CHECK_AND_CLEAR_NONASYNC_NULL);
     // Resolve all classes seen in the signature of the method
     // we are compiling.

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -126,7 +126,7 @@ bool MemAllocator::Allocation::check_out_of_memory() {
   // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
   report_java_out_of_memory(message);
 
-  if (!_thread->in_sandboxed_oome_mark()) {
+  if (!_thread->in_internal_oome_mark()) {
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP,

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -123,7 +123,7 @@ bool MemAllocator::Allocation::check_out_of_memory() {
   }
 
   const char* message = _overhead_limit_exceeded ? "GC overhead limit exceeded" : "Java heap space";
-  if (!_thread->in_internal_oome_mark()) {
+  if (!_thread->is_in_internal_oome_mark()) {
     // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
     report_java_out_of_memory(message);
     if (JvmtiExport::should_post_resource_exhausted()) {
@@ -137,7 +137,7 @@ bool MemAllocator::Allocation::check_out_of_memory() {
         Universe::out_of_memory_error_java_heap();
     THROW_OOP_(exception, true);
   } else {
-    THROW_OOP_(Universe::out_of_memory_error_java_heap(/* omit_backtrace*/ true), true);
+    THROW_OOP_(Universe::out_of_memory_error_java_heap_without_backtrace(), true);
   }
 }
 

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -123,11 +123,11 @@ bool MemAllocator::Allocation::check_out_of_memory() {
   }
 
   const char* message = _overhead_limit_exceeded ? "GC overhead limit exceeded" : "Java heap space";
+  // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
+  report_java_out_of_memory(message);
+
   SandboxedOOMEMark* som = _thread->sandboxed_oome_mark();
   if (som == nullptr || !som->disable_events()) {
-    // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
-    report_java_out_of_memory(message);
-
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP,

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -123,10 +123,9 @@ bool MemAllocator::Allocation::check_out_of_memory() {
   }
 
   const char* message = _overhead_limit_exceeded ? "GC overhead limit exceeded" : "Java heap space";
-  // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
-  report_java_out_of_memory(message);
-
   if (!_thread->in_internal_oome_mark()) {
+    // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
+    report_java_out_of_memory(message);
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP,

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -126,15 +126,13 @@ bool MemAllocator::Allocation::check_out_of_memory() {
   // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError support
   report_java_out_of_memory(message);
 
-  SandboxedOOMEMark* som = _thread->sandboxed_oome_mark();
-  if (som == nullptr || !som->disable_events()) {
+  if (!_thread->in_sandboxed_oome_mark()) {
     if (JvmtiExport::should_post_resource_exhausted()) {
       JvmtiExport::post_resource_exhausted(
         JVMTI_RESOURCE_EXHAUSTED_OOM_ERROR | JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP,
         message);
     }
-  }
-  if (som == nullptr) {
+
     oop exception = _overhead_limit_exceeded ?
         Universe::out_of_memory_error_gc_overhead_limit() :
         Universe::out_of_memory_error_java_heap();

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -128,10 +128,10 @@ class InternalOOMEMark: public StackObj {
   JavaThread* _thread;
 
  public:
-  InternalOOMEMark(JavaThread* thread) {
+  explicit InternalOOMEMark(JavaThread* thread) {
     if (thread != nullptr) {
-      _outer = thread->in_internal_oome_mark();
-      thread->set_in_internal_oome_mark(true);
+      _outer = thread->is_in_internal_oome_mark();
+      thread->set_is_in_internal_oome_mark(true);
       _thread = thread;
     } else {
       _outer = false;
@@ -142,13 +142,12 @@ class InternalOOMEMark: public StackObj {
   ~InternalOOMEMark() {
     if (_thread != nullptr) {
       // Check that only InternalOOMEMark sets
-      // JavaThread::_in_internal_oome_mark
-      assert(_thread->in_internal_oome_mark(), "must be");
-      _thread->set_in_internal_oome_mark(_outer);
+      // JavaThread::_is_in_internal_oome_mark
+      assert(_thread->is_in_internal_oome_mark(), "must be");
+      _thread->set_is_in_internal_oome_mark(_outer);
     }
   }
 
-  // Returns nullptr iff `activate` was false in the constructor.
   JavaThread* thread() const  { return _thread; }
 };
 

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -122,16 +122,16 @@ public:
 // suppression of JVMTI "resource exhausted" events and
 // throwing a shared, backtrace-less OOME instance.
 // Used for OOMEs that will not be propagated to user code.
-class SandboxedOOMEMark: public StackObj {
+class InternalOOMEMark: public StackObj {
  private:
   bool _outer;
   JavaThread* _thread;
 
  public:
-  SandboxedOOMEMark(JavaThread* thread) {
+  InternalOOMEMark(JavaThread* thread) {
     if (thread != nullptr) {
-      _outer = thread->in_sandboxed_oome_mark();
-      thread->set_in_sandboxed_oome_mark(true);
+      _outer = thread->in_internal_oome_mark();
+      thread->set_in_internal_oome_mark(true);
       _thread = thread;
     } else {
       _outer = false;
@@ -139,12 +139,12 @@ class SandboxedOOMEMark: public StackObj {
     }
   }
 
-  ~SandboxedOOMEMark() {
+  ~InternalOOMEMark() {
     if (_thread != nullptr) {
-      // Check that only SandboxedOOMEMark sets
-      // JavaThread::_in_sandboxed_oome_mark
-      assert(_thread->in_sandboxed_oome_mark(), "must be");
-      _thread->set_in_sandboxed_oome_mark(_outer);
+      // Check that only InternalOOMEMark sets
+      // JavaThread::_in_internal_oome_mark
+      assert(_thread->in_internal_oome_mark(), "must be");
+      _thread->set_in_internal_oome_mark(_outer);
     }
   }
 

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -150,8 +150,7 @@ class SandboxedOOMEMark: public StackObj {
   // Returns nullptr iff `activate` was false in the constructor.
   JavaThread* thread() const  { return _thread; }
 
-  // Does this scope disable JVMTI resource exhausted events and
-  // -XX:+HeapDumpOnOutOfMemoryError and -XX:OnOutOfMemoryError
+  // Does this scope disable JVMTI resource exhausted events
   // when an OOME is thrown?
   bool disable_events() const { return _disable_events; }
 };

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -100,11 +100,11 @@ static void deopt_caller() {
 //   2. null is written to JavaThread::_vm_result
 class RetryableAllocationMark {
  private:
-   SandboxedOOMEMark _som;
+   InternalOOMEMark _iom;
  public:
-  RetryableAllocationMark(JavaThread* thread, bool activate) : _som(activate ? thread : nullptr) {}
+  RetryableAllocationMark(JavaThread* thread, bool activate) : _iom(activate ? thread : nullptr) {}
   ~RetryableAllocationMark() {
-    JavaThread* THREAD = _som.thread();
+    JavaThread* THREAD = _iom.thread();
     if (THREAD != nullptr) {
       if (HAS_PENDING_EXCEPTION) {
         oop ex = PENDING_EXCEPTION;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -104,7 +104,7 @@ class RetryableAllocationMark {
  public:
   RetryableAllocationMark(JavaThread* thread, bool activate) : _iom(activate ? thread : nullptr) {}
   ~RetryableAllocationMark() {
-    JavaThread* THREAD = _iom.thread();
+    JavaThread* THREAD = _iom.thread(); // For exception macros.
     if (THREAD != nullptr) {
       if (HAS_PENDING_EXCEPTION) {
         oop ex = PENDING_EXCEPTION;

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -102,7 +102,7 @@ class RetryableAllocationMark {
  private:
    SandboxedOOMEMark _som;
  public:
-  RetryableAllocationMark(JavaThread* thread, bool activate) : _som(activate ? thread : nullptr, true) {}
+  RetryableAllocationMark(JavaThread* thread, bool activate) : _som(activate ? thread : nullptr) {}
   ~RetryableAllocationMark() {
     JavaThread* THREAD = _som.thread();
     if (THREAD != nullptr) {

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -28,6 +28,7 @@
 #include "classfile/vmClasses.hpp"
 #include "compiler/compileBroker.hpp"
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/memAllocator.hpp"
 #include "gc/shared/oopStorage.inline.hpp"
 #include "jvmci/jniAccessMark.inline.hpp"
 #include "jvmci/jvmciCompilerToVM.hpp"
@@ -92,39 +93,25 @@ static void deopt_caller() {
 }
 
 // Manages a scope for a JVMCI runtime call that attempts a heap allocation.
-// If there is a pending nonasync exception upon closing the scope and the runtime
+// If there is a pending OutOfMemoryError upon closing the scope and the runtime
 // call is of the variety where allocation failure returns null without an
 // exception, the following action is taken:
-//   1. The pending nonasync exception is cleared
+//   1. The pending OutOfMemoryError is cleared
 //   2. null is written to JavaThread::_vm_result
-//   3. Checks that an OutOfMemoryError is Universe::out_of_memory_error_retry().
-class RetryableAllocationMark: public StackObj {
+class RetryableAllocationMark {
  private:
-  JavaThread* _thread;
+   SandboxedOOMEMark _som;
  public:
-  RetryableAllocationMark(JavaThread* thread, bool activate) {
-    if (activate) {
-      assert(!thread->in_retryable_allocation(), "retryable allocation scope is non-reentrant");
-      _thread = thread;
-      _thread->set_in_retryable_allocation(true);
-    } else {
-      _thread = nullptr;
-    }
-  }
+  RetryableAllocationMark(JavaThread* thread, bool activate) : _som(activate ? thread : nullptr, true) {}
   ~RetryableAllocationMark() {
-    if (_thread != nullptr) {
-      _thread->set_in_retryable_allocation(false);
-      JavaThread* THREAD = _thread; // For exception macros.
+    JavaThread* THREAD = _som.thread();
+    if (THREAD != nullptr) {
       if (HAS_PENDING_EXCEPTION) {
         oop ex = PENDING_EXCEPTION;
-        // Do not clear probable async exceptions.
-        CLEAR_PENDING_NONASYNC_EXCEPTION;
-        oop retry_oome = Universe::out_of_memory_error_retry();
-        if (ex->is_a(retry_oome->klass()) && retry_oome != ex) {
-          ResourceMark rm;
-          fatal("Unexpected exception in scope of retryable allocation: " INTPTR_FORMAT " of type %s", p2i(ex), ex->klass()->external_name());
+        THREAD->set_vm_result(nullptr);
+        if (ex->is_a(vmClasses::OutOfMemoryError_klass())) {
+          CLEAR_PENDING_EXCEPTION;
         }
-        _thread->set_vm_result(nullptr);
       }
     }
   }

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -650,12 +650,12 @@ objArrayOop Universe::preallocated_out_of_memory_errors() {
 
 objArrayOop Universe::out_of_memory_errors() { return (objArrayOop)_out_of_memory_errors.resolve(); }
 
-oop Universe::out_of_memory_error_java_heap(bool omit_backtrace) {
-  oop oome = out_of_memory_errors()->obj_at(_oom_java_heap);
-  if (!omit_backtrace) {
-    oome = gen_out_of_memory_error(oome);
-  }
-  return oome;
+oop Universe::out_of_memory_error_java_heap() {
+  return gen_out_of_memory_error(out_of_memory_errors()->obj_at(_oom_java_heap));
+}
+
+oop Universe::out_of_memory_error_java_heap_without_backtrace() {
+  return out_of_memory_errors()->obj_at(_oom_java_heap);
 }
 
 oop Universe::out_of_memory_error_c_heap() {

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -135,7 +135,6 @@ enum OutOfMemoryInstance { _oom_java_heap,
                            _oom_array_size,
                            _oom_gc_overhead_limit,
                            _oom_realloc_objects,
-                           _oom_retry,
                            _oom_count };
 
 OopHandle Universe::_out_of_memory_errors;
@@ -651,8 +650,12 @@ objArrayOop Universe::preallocated_out_of_memory_errors() {
 
 objArrayOop Universe::out_of_memory_errors() { return (objArrayOop)_out_of_memory_errors.resolve(); }
 
-oop Universe::out_of_memory_error_java_heap() {
-  return gen_out_of_memory_error(out_of_memory_errors()->obj_at(_oom_java_heap));
+oop Universe::out_of_memory_error_java_heap(bool omit_backtrace) {
+  oop oome = out_of_memory_errors()->obj_at(_oom_java_heap);
+  if (!omit_backtrace) {
+    oome = gen_out_of_memory_error(oome);
+  }
+  return oome;
 }
 
 oop Universe::out_of_memory_error_c_heap() {
@@ -678,9 +681,6 @@ oop Universe::out_of_memory_error_gc_overhead_limit() {
 oop Universe::out_of_memory_error_realloc_objects() {
   return gen_out_of_memory_error(out_of_memory_errors()->obj_at(_oom_realloc_objects));
 }
-
-// Throw default _out_of_memory_error_retry object as it will never propagate out of the VM
-oop Universe::out_of_memory_error_retry()              { return out_of_memory_errors()->obj_at(_oom_retry);  }
 
 oop Universe::class_init_out_of_memory_error()         { return out_of_memory_errors()->obj_at(_oom_java_heap); }
 oop Universe::class_init_stack_overflow_error()        { return _class_init_stack_overflow_error.resolve(); }
@@ -784,9 +784,6 @@ void Universe::create_preallocated_out_of_memory_errors(TRAPS) {
 
   msg = java_lang_String::create_from_str("Java heap space: failed reallocation of scalar replaced objects", CHECK);
   java_lang_Throwable::set_message(oom_array->obj_at(_oom_realloc_objects), msg());
-
-  msg = java_lang_String::create_from_str("Java heap space: failed retryable allocation", CHECK);
-  java_lang_Throwable::set_message(oom_array->obj_at(_oom_retry), msg());
 
   // Setup the array of errors that have preallocated backtrace
   int len = (StackTraceInThrowable) ? (int)PreallocatedOutOfMemoryErrorCount : 0;

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -271,7 +271,8 @@ class Universe: AllStatic {
   // OutOfMemoryError support. Returns an error with the required message. The returned error
   // may or may not have a backtrace. If error has a backtrace then the stack trace is already
   // filled in.
-  static oop out_of_memory_error_java_heap(bool omit_backtrace=false);
+  static oop out_of_memory_error_java_heap();
+  static oop out_of_memory_error_java_heap_without_backtrace();
   static oop out_of_memory_error_c_heap();
   static oop out_of_memory_error_metaspace();
   static oop out_of_memory_error_class_metaspace();

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -271,7 +271,7 @@ class Universe: AllStatic {
   // OutOfMemoryError support. Returns an error with the required message. The returned error
   // may or may not have a backtrace. If error has a backtrace then the stack trace is already
   // filled in.
-  static oop out_of_memory_error_java_heap();
+  static oop out_of_memory_error_java_heap(bool omit_backtrace=false);
   static oop out_of_memory_error_c_heap();
   static oop out_of_memory_error_metaspace();
   static oop out_of_memory_error_class_metaspace();
@@ -279,8 +279,6 @@ class Universe: AllStatic {
   static oop out_of_memory_error_gc_overhead_limit();
   static oop out_of_memory_error_realloc_objects();
 
-  // Throw default _out_of_memory_error_retry object as it will never propagate out of the VM
-  static oop out_of_memory_error_retry();
   static oop delayed_stack_overflow_error_message();
 
   // Saved StackOverflowError and OutOfMemoryError for use when

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -873,12 +873,15 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
-    if (!THREAD->in_retryable_allocation()) {
+    SandboxedOOMEMark* sam = THREAD->sandboxed_oome_mark();
+    if (sam == nullptr || !sam->disable_events()) {
       report_java_out_of_memory("Requested array size exceeds VM limit");
       JvmtiExport::post_array_size_exhausted();
+    }
+    if (sam == nullptr) {
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {
-      THROW_OOP(Universe::out_of_memory_error_retry());
+      THROW_OOP(Universe::out_of_memory_error_java_heap(/* omit_backtrace*/ true));
     }
   } else if (length < 0) {
     THROW_MSG(vmSymbols::java_lang_NegativeArraySizeException(), err_msg("%d", length));

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -873,8 +873,8 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
-    report_java_out_of_memory("Requested array size exceeds VM limit");
     if (!THREAD->in_internal_oome_mark()) {
+      report_java_out_of_memory("Requested array size exceeds VM limit");
       JvmtiExport::post_array_size_exhausted();
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -873,12 +873,12 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
-    if (!THREAD->in_internal_oome_mark()) {
+    if (!THREAD->is_in_internal_oome_mark()) {
       report_java_out_of_memory("Requested array size exceeds VM limit");
       JvmtiExport::post_array_size_exhausted();
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {
-      THROW_OOP(Universe::out_of_memory_error_java_heap(/* omit_backtrace*/ true));
+      THROW_OOP(Universe::out_of_memory_error_java_heap_without_backtrace());
     }
   } else if (length < 0) {
     THROW_MSG(vmSymbols::java_lang_NegativeArraySizeException(), err_msg("%d", length));

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -873,12 +873,12 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
-    SandboxedOOMEMark* sam = THREAD->sandboxed_oome_mark();
-    if (sam == nullptr || !sam->disable_events()) {
-      report_java_out_of_memory("Requested array size exceeds VM limit");
+    report_java_out_of_memory("Requested array size exceeds VM limit");
+    SandboxedOOMEMark* som = THREAD->sandboxed_oome_mark();
+    if (som == nullptr || !som->disable_events()) {
       JvmtiExport::post_array_size_exhausted();
     }
-    if (sam == nullptr) {
+    if (som == nullptr) {
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {
       THROW_OOP(Universe::out_of_memory_error_java_heap(/* omit_backtrace*/ true));

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -874,11 +874,8 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
     report_java_out_of_memory("Requested array size exceeds VM limit");
-    SandboxedOOMEMark* som = THREAD->sandboxed_oome_mark();
-    if (som == nullptr || !som->disable_events()) {
+    if (!THREAD->in_sandboxed_oome_mark()) {
       JvmtiExport::post_array_size_exhausted();
-    }
-    if (som == nullptr) {
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {
       THROW_OOP(Universe::out_of_memory_error_java_heap(/* omit_backtrace*/ true));

--- a/src/hotspot/share/oops/klass.cpp
+++ b/src/hotspot/share/oops/klass.cpp
@@ -874,7 +874,7 @@ void Klass::set_archived_java_mirror(int mirror_index) {
 void Klass::check_array_allocation_length(int length, int max_length, TRAPS) {
   if (length > max_length) {
     report_java_out_of_memory("Requested array size exceeds VM limit");
-    if (!THREAD->in_sandboxed_oome_mark()) {
+    if (!THREAD->in_internal_oome_mark()) {
       JvmtiExport::post_array_size_exhausted();
       THROW_OOP(Universe::out_of_memory_error_array_size());
     } else {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1251,7 +1251,7 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
 
       InstanceKlass* ik = InstanceKlass::cast(k);
       if (obj == nullptr && !cache_init_error) {
-        SandboxedOOMEMark som(THREAD);
+        InternalOOMEMark iom(THREAD);
 #if COMPILER2_OR_JVMCI
         if (EnableVectorSupport && VectorSupport::is_vector(ik)) {
           obj = VectorSupport::allocate_vector(ik, fr, reg_map, sv, THREAD);
@@ -1266,11 +1266,11 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
       TypeArrayKlass* ak = TypeArrayKlass::cast(k);
       assert(sv->field_size() % type2size[ak->element_type()] == 0, "non-integral array length");
       int len = sv->field_size() / type2size[ak->element_type()];
-      SandboxedOOMEMark som(THREAD);
+      InternalOOMEMark iom(THREAD);
       obj = ak->allocate(len, THREAD);
     } else if (k->is_objArray_klass()) {
       ObjArrayKlass* ak = ObjArrayKlass::cast(k);
-      SandboxedOOMEMark som(THREAD);
+      InternalOOMEMark iom(THREAD);
       obj = ak->allocate(sv->field_size(), THREAD);
     }
 

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -35,6 +35,7 @@
 #include "compiler/compilationPolicy.hpp"
 #include "compiler/compilerDefinitions.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
+#include "gc/shared/memAllocator.hpp"
 #include "interpreter/bytecode.hpp"
 #include "interpreter/bytecodeStream.hpp"
 #include "interpreter/interpreter.hpp"
@@ -1250,6 +1251,7 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
 
       InstanceKlass* ik = InstanceKlass::cast(k);
       if (obj == nullptr && !cache_init_error) {
+        SandboxedOOMEMark som(THREAD);
 #if COMPILER2_OR_JVMCI
         if (EnableVectorSupport && VectorSupport::is_vector(ik)) {
           obj = VectorSupport::allocate_vector(ik, fr, reg_map, sv, THREAD);
@@ -1264,9 +1266,11 @@ bool Deoptimization::realloc_objects(JavaThread* thread, frame* fr, RegisterMap*
       TypeArrayKlass* ak = TypeArrayKlass::cast(k);
       assert(sv->field_size() % type2size[ak->element_type()] == 0, "non-integral array length");
       int len = sv->field_size() / type2size[ak->element_type()];
+      SandboxedOOMEMark som(THREAD);
       obj = ak->allocate(len, THREAD);
     } else if (k->is_objArray_klass()) {
       ObjArrayKlass* ak = ObjArrayKlass::cast(k);
+      SandboxedOOMEMark som(THREAD);
       obj = ak->allocate(sv->field_size(), THREAD);
     }
 

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -455,7 +455,7 @@ JavaThread::JavaThread() :
 #endif
 #endif
   _jni_attach_state(_not_attaching_via_jni),
-  _in_internal_oome_mark(false),
+  _is_in_internal_oome_mark(false),
 #if INCLUDE_JVMCI
   _pending_deoptimization(-1),
   _pending_monitorenter(false),

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -455,11 +455,11 @@ JavaThread::JavaThread() :
 #endif
 #endif
   _jni_attach_state(_not_attaching_via_jni),
+  _sandboxed_oome_mark(nullptr),
 #if INCLUDE_JVMCI
   _pending_deoptimization(-1),
   _pending_monitorenter(false),
   _pending_transfer_to_interpreter(false),
-  _in_retryable_allocation(false),
   _pending_failed_speculation(0),
   _jvmci{nullptr},
   _libjvmci_runtime(nullptr),

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -455,7 +455,7 @@ JavaThread::JavaThread() :
 #endif
 #endif
   _jni_attach_state(_not_attaching_via_jni),
-  _in_sandboxed_oome_mark(false),
+  _in_internal_oome_mark(false),
 #if INCLUDE_JVMCI
   _pending_deoptimization(-1),
   _pending_monitorenter(false),

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -455,7 +455,7 @@ JavaThread::JavaThread() :
 #endif
 #endif
   _jni_attach_state(_not_attaching_via_jni),
-  _sandboxed_oome_mark(nullptr),
+  _in_sandboxed_oome_mark(false),
 #if INCLUDE_JVMCI
   _pending_deoptimization(-1),
   _pending_monitorenter(false),

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -54,7 +54,7 @@ class ContinuationEntry;
 class DeoptResourceMark;
 class JNIHandleBlock;
 class JVMCIRuntime;
-class SandboxedOOMEMark;
+class InternalOOMEMark;
 
 class JvmtiDeferredUpdates;
 class JvmtiSampledObjectAllocEventCollector;
@@ -335,8 +335,8 @@ class JavaThread: public Thread {
   // of _attaching_via_jni and transitions to _attached_via_jni.
   volatile JNIAttachStates _jni_attach_state;
 
-  // In scope of a SandboxedOOMEMark?
-  bool _in_sandboxed_oome_mark;
+  // In scope of an InternalOOMEMark?
+  bool _in_internal_oome_mark;
 
 #if INCLUDE_JVMCI
   // The _pending_* fields below are used to communicate extra information
@@ -713,8 +713,8 @@ private:
   MemRegion deferred_card_mark() const           { return _deferred_card_mark; }
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }
 
-  bool in_sandboxed_oome_mark() const            { return _in_sandboxed_oome_mark; }
-  void set_in_sandboxed_oome_mark(bool b)        { _in_sandboxed_oome_mark = b;    }
+  bool in_internal_oome_mark() const            { return _in_internal_oome_mark; }
+  void set_in_internal_oome_mark(bool b)        { _in_internal_oome_mark = b;    }
 
 #if INCLUDE_JVMCI
   jlong pending_failed_speculation() const        { return _pending_failed_speculation; }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -335,8 +335,8 @@ class JavaThread: public Thread {
   // of _attaching_via_jni and transitions to _attached_via_jni.
   volatile JNIAttachStates _jni_attach_state;
 
-  // Currently active SandboxedOOMEMark, if any.
-  SandboxedOOMEMark* _sandboxed_oome_mark;
+  // In scope of a SandboxedOOMEMark?
+  bool _in_sandboxed_oome_mark;
 
 #if INCLUDE_JVMCI
   // The _pending_* fields below are used to communicate extra information
@@ -713,8 +713,8 @@ private:
   MemRegion deferred_card_mark() const           { return _deferred_card_mark; }
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }
 
-  SandboxedOOMEMark* sandboxed_oome_mark() const         { return _sandboxed_oome_mark; }
-  void set_sandboxed_oome_mark(SandboxedOOMEMark* som)   { _sandboxed_oome_mark = som;  }
+  bool in_sandboxed_oome_mark() const            { return _in_sandboxed_oome_mark; }
+  void set_in_sandboxed_oome_mark(bool b)        { _in_sandboxed_oome_mark = b;    }
 
 #if INCLUDE_JVMCI
   jlong pending_failed_speculation() const        { return _pending_failed_speculation; }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -54,6 +54,7 @@ class ContinuationEntry;
 class DeoptResourceMark;
 class JNIHandleBlock;
 class JVMCIRuntime;
+class SandboxedOOMEMark;
 
 class JvmtiDeferredUpdates;
 class JvmtiSampledObjectAllocEventCollector;
@@ -334,6 +335,8 @@ class JavaThread: public Thread {
   // of _attaching_via_jni and transitions to _attached_via_jni.
   volatile JNIAttachStates _jni_attach_state;
 
+  // Currently active SandboxedOOMEMark, if any.
+  SandboxedOOMEMark* _sandboxed_oome_mark;
 
 #if INCLUDE_JVMCI
   // The _pending_* fields below are used to communicate extra information
@@ -348,10 +351,6 @@ class JavaThread: public Thread {
 
   // Specifies if the DeoptReason for the last uncommon trap was Reason_transfer_to_interpreter
   bool      _pending_transfer_to_interpreter;
-
-  // True if in a runtime call from compiled code that will deoptimize
-  // and re-execute a failed heap allocation in the interpreter.
-  bool      _in_retryable_allocation;
 
   // An id of a speculation that JVMCI compiled code can use to further describe and
   // uniquely identify the speculative optimization guarded by an uncommon trap.
@@ -714,6 +713,9 @@ private:
   MemRegion deferred_card_mark() const           { return _deferred_card_mark; }
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }
 
+  SandboxedOOMEMark* sandboxed_oome_mark() const         { return _sandboxed_oome_mark; }
+  void set_sandboxed_oome_mark(SandboxedOOMEMark* som)   { _sandboxed_oome_mark = som;  }
+
 #if INCLUDE_JVMCI
   jlong pending_failed_speculation() const        { return _pending_failed_speculation; }
   void set_pending_monitorenter(bool b)           { _pending_monitorenter = b; }
@@ -722,9 +724,6 @@ private:
   void set_pending_transfer_to_interpreter(bool b) { _pending_transfer_to_interpreter = b; }
   void set_jvmci_alternate_call_target(address a) { assert(_jvmci._alternate_call_target == nullptr, "must be"); _jvmci._alternate_call_target = a; }
   void set_jvmci_implicit_exception_pc(address a) { assert(_jvmci._implicit_exception_pc == nullptr, "must be"); _jvmci._implicit_exception_pc = a; }
-
-  virtual bool in_retryable_allocation() const    { return _in_retryable_allocation; }
-  void set_in_retryable_allocation(bool b)        { _in_retryable_allocation = b; }
 
   JVMCIRuntime* libjvmci_runtime() const          { return _libjvmci_runtime; }
   void set_libjvmci_runtime(JVMCIRuntime* rt) {

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -52,9 +52,9 @@
 class AsyncExceptionHandshake;
 class ContinuationEntry;
 class DeoptResourceMark;
+class InternalOOMEMark;
 class JNIHandleBlock;
 class JVMCIRuntime;
-class InternalOOMEMark;
 
 class JvmtiDeferredUpdates;
 class JvmtiSampledObjectAllocEventCollector;
@@ -336,7 +336,7 @@ class JavaThread: public Thread {
   volatile JNIAttachStates _jni_attach_state;
 
   // In scope of an InternalOOMEMark?
-  bool _in_internal_oome_mark;
+  bool _is_in_internal_oome_mark;
 
 #if INCLUDE_JVMCI
   // The _pending_* fields below are used to communicate extra information
@@ -713,8 +713,9 @@ private:
   MemRegion deferred_card_mark() const           { return _deferred_card_mark; }
   void set_deferred_card_mark(MemRegion mr)      { _deferred_card_mark = mr;   }
 
-  bool in_internal_oome_mark() const            { return _in_internal_oome_mark; }
-  void set_in_internal_oome_mark(bool b)        { _in_internal_oome_mark = b;    }
+  // Is thread in scope of an InternalOOMEMark?
+  bool is_in_internal_oome_mark() const          { return _is_in_internal_oome_mark; }
+  void set_is_in_internal_oome_mark(bool b)      { _is_in_internal_oome_mark = b;    }
 
 #if INCLUDE_JVMCI
   jlong pending_failed_speculation() const        { return _pending_failed_speculation; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -210,14 +210,6 @@ class Thread: public ThreadShadow {
   DEBUG_ONLY(bool _indirectly_safepoint_thread;)
 
  public:
-  // Determines if a heap allocation failure will be retried
-  // (e.g., by deoptimizing and re-executing in the interpreter).
-  // In this case, the failed allocation must raise
-  // Universe::out_of_memory_error_retry() and omit side effects
-  // such as JVMTI events and handling -XX:+HeapDumpOnOutOfMemoryError
-  // and -XX:OnOutOfMemoryError.
-  virtual bool in_retryable_allocation() const { return false; }
-
 #ifdef ASSERT
   void set_suspendible_thread()   { _suspendible_thread = true; }
   void clear_suspendible_thread() { _suspendible_thread = false; }


### PR DESCRIPTION
This pull request mitigates failures in memory stress tests that check the stack trace of an `OutOfMemoryError` for certain expected entries.

The stack trace of an OOME will [not be allocated once all preallocated OOMEs are used up](https://github.com/openjdk/jdk/blob/3d5eeac3a38ece4a23ea6da2dfe5939d64e81cea/src/hotspot/share/memory/universe.cpp#L722). If the only heap allocations performed in stressful conditions are those of the stress test, then the [4 preallocated OOMEs](https://github.com/openjdk/jdk/blob/f1d0e715b67e2ca47b525069d8153abbb33f75b9/src/hotspot/share/runtime/globals.hpp#L800) would be sufficient. However, it's possible for VM internal allocations to also occur during stressful conditions, especially in `-Xcomp` mode. For example, [CompileBroker::compile_method](https://github.com/openjdk/jdk/blob/3d5eeac3a38ece4a23ea6da2dfe5939d64e81cea/src/hotspot/share/compiler/compileBroker.cpp#L1399) will try to resolve the string constants in the constant pool of the method about to be compiled. This can fail as shown here:
```
V  [jvm.dll+0x62c23a]  Exceptions::_throw+0x11a  (exceptions.cpp:168)
V  [jvm.dll+0x62d85b]  Exceptions::_throw_oop+0xab  (exceptions.cpp:140)
V  [jvm.dll+0xbbce78]  MemAllocator::Allocation::check_out_of_memory+0x208  (memAllocator.cpp:138)
V  [jvm.dll+0xbbcac8]  MemAllocator::allocate+0x158  (memAllocator.cpp:377)
V  [jvm.dll+0x79bd05]  InstanceKlass::allocate_instance+0x95  (instanceKlass.cpp:1509)
V  [jvm.dll+0x7ddeed]  java_lang_String::basic_create+0x9d  (javaClasses.cpp:273)
V  [jvm.dll+0x7e43c0]  java_lang_String::create_from_unicode+0x60  (javaClasses.cpp:291)
V  [jvm.dll+0xdb91a5]  StringTable::do_intern+0xb5  (stringTable.cpp:379)
V  [jvm.dll+0xdba9f2]  StringTable::intern+0x1b2  (stringTable.cpp:368)
V  [jvm.dll+0xdbaaa6]  StringTable::intern+0x86  (stringTable.cpp:328)
V  [jvm.dll+0x51c8b1]  ConstantPool::string_at_impl+0x1d1  (constantPool.cpp:1251)
V  [jvm.dll+0x51b95b]  ConstantPool::resolve_string_constants_impl+0xeb  (constantPool.cpp:800)
V  [jvm.dll+0x4f2f8d]  CompileBroker::compile_method+0x31d  (compileBroker.cpp:1395)
V  [jvm.dll+0x4f3474]  CompileBroker::compile_method+0xc4  (compileBroker.cpp:1348)
```
These internal allocations can occur before the allocations of the test and thus use up the pre-allocated OOMEs. As a result, the OOMEs triggered by the stress test may end up throwing the [default, shared OOME instance](https://github.com/openjdk/jdk/blob/3d5eeac3a38ece4a23ea6da2dfe5939d64e81cea/src/hotspot/share/memory/universe.cpp#L722) that have no stack trace.

This PR mitigates this by introducing a scope (see `InternalOOMEMark` in `memAllocator.hpp`) in which a failed heap allocation results in the shared, stacktrace-less OOME instance being thrown. This scope is used for guarding VM internal allocations where an OOME will not be propagated to user code. In addition, JVMTI "resource exhausted" events are disabled in the scope of an `InternalOOMEMark`.

Note that this change also improves diagnosability because internal OOMEs will no longer use up the limited number of pre-allocated OOMEs.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331208](https://bugs.openjdk.org/browse/JDK-8331208): Memory stress test that checks OutOfMemoryError stack trace fails (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18925/head:pull/18925` \
`$ git checkout pull/18925`

Update a local copy of the PR: \
`$ git checkout pull/18925` \
`$ git pull https://git.openjdk.org/jdk.git pull/18925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18925`

View PR using the GUI difftool: \
`$ git pr show -t 18925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18925.diff">https://git.openjdk.org/jdk/pull/18925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18925#issuecomment-2079748522)