### PR TITLE
8331018: Clean up non-standard use of /** comments in `jdk.jshell`

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/DeclarationSnippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/DeclarationSnippet.java
@@ -65,7 +65,7 @@ public abstract class DeclarationSnippet extends PersistentSnippet {
         this.bodyReferences = bodyReferences;
     }
 
-    /**** internal access ****/
+    //*** internal access ****
 
     /**
      * @return the corralled guts

--- a/src/jdk.jshell/share/classes/jdk/jshell/ExpressionSnippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ExpressionSnippet.java
@@ -65,7 +65,7 @@ public class ExpressionSnippet extends Snippet {
         return key().typeName();
     }
 
-    /**** internal access ****/
+    //**** internal access ****
 
     @Override
     ExpressionKey key() {

--- a/src/jdk.jshell/share/classes/jdk/jshell/ImportSnippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/ImportSnippet.java
@@ -96,7 +96,7 @@ public class ImportSnippet extends PersistentSnippet {
         return isStatic;
     }
 
-    /**** internal access ****/
+    //**** internal access ****
 
     @Override
     ImportKey key() {

--- a/src/jdk.jshell/share/classes/jdk/jshell/MaskCommentsAndModifiers.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/MaskCommentsAndModifiers.java
@@ -107,7 +107,7 @@ class MaskCommentsAndModifiers {
         return openToken;
     }
 
-    /****** private implementation methods ******/
+    //****** private implementation methods ******
 
     /**
      * Read the next character

--- a/src/jdk.jshell/share/classes/jdk/jshell/MethodSnippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/MethodSnippet.java
@@ -85,7 +85,7 @@ public class MethodSnippet extends DeclarationSnippet {
         return sb.toString();
     }
 
-    /**** internal access ****/
+    //**** internal access ****
 
     @Override
     MethodKey key() {

--- a/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
@@ -593,7 +593,7 @@ public abstract class Snippet {
         setSequenceNumber(0);
     }
 
-    /**** public access ****/
+    //**** public access ****
 
     /**
      * The unique identifier for the snippet. No two active snippets will have

--- a/src/jdk.jshell/share/classes/jdk/jshell/TypeDeclSnippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TypeDeclSnippet.java
@@ -50,7 +50,7 @@ public class TypeDeclSnippet extends DeclarationSnippet {
                 declareReferences, bodyReferences, syntheticDiags);
     }
 
-    /**** internal access ****/
+    //**** internal access ****
 
     @Override
     TypeDeclKey key() {


### PR DESCRIPTION
Please review a fix to preempt warnings that would otherwise be introduced by [JDK-8303689](https://bugs.openjdk.org/browse/JDK-8303689), which introduces a new javac lint warning to detect documentation comments in unusual places.

The comments here are all one-line comments of the form `/***** message ****/`.

Following the style of an existing similar comment, the comments are changed to the form `//***** message *****`
That existing comment is in Snippet.java:648
```
    //**** internal access ****
    String name() {
        return unitName;
    }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331018](https://bugs.openjdk.org/browse/JDK-8331018): Clean up non-standard use of /** comments in `jdk.jshell` (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18926/head:pull/18926` \
`$ git checkout pull/18926`

Update a local copy of the PR: \
`$ git checkout pull/18926` \
`$ git pull https://git.openjdk.org/jdk.git pull/18926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18926`

View PR using the GUI difftool: \
`$ git pr show -t 18926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18926.diff">https://git.openjdk.org/jdk/pull/18926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18926#issuecomment-2073648180)