### PR TITLE
8331021: Deprecate and then obsolete the DontYieldALot flag

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -501,6 +501,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "RegisterFinalizersAtInit",     JDK_Version::jdk(22), JDK_Version::jdk(23), JDK_Version::jdk(24) },
+  { "DontYieldALot",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "PreserveAllAnnotations",       JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseNotificationThread",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseEmptySlotsInSupers",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1313,9 +1313,6 @@ const int ObjectAlignmentInBytes = 8;
   develop(intx, MethodHistogramCutoff, 100,                                 \
           "The cutoff value for method invocation histogram (+CountCalls)") \
                                                                             \
-  develop(intx, DontYieldALotInterval,    10,                               \
-          "Interval between which yields will be dropped (milliseconds)")   \
-                                                                            \
   develop(intx, DeoptimizeALotInterval,     5,                              \
           "Number of exits until DeoptimizeALot kicks in")                  \
                                                                             \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -698,7 +698,7 @@ const int ObjectAlignmentInBytes = 8;
           "registering as parallel capable")                                \
                                                                             \
   product_pd(bool, DontYieldALot,                                           \
-          "Throw away obvious excess yield calls")                          \
+             "(Deprecated) Throw away obvious excess yield calls")          \
                                                                             \
   product(bool, DisablePrimordialThreadGuardPages, false, EXPERIMENTAL,     \
                "Disable the use of stack guard pages if the JVM is loaded " \

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -56,6 +56,7 @@ public class VMDeprecatedOptions {
         ArrayList<String[]> deprecated = new ArrayList(
           Arrays.asList(new String[][] {
             // deprecated non-alias flags:
+            {"DontYieldALot", "false"},
             {"UseNotificationThread", "true"},
             {"PreserveAllAnnotations", "true"},
             {"AllowRedefinitionToAddDeleteMethods", "true"},


### PR DESCRIPTION
The `DontYieldALot` flag is an anachronism from very early Java days - see JBS issue for some details. It should be deprecated for removal in JDK 23.

BTW the description of the flag:
> Throw away obvious excess yield calls

has been incorrect for a long time - it throws away all yield calls.

As I was changing globals.hpp I also took the opportunity to remove the unused  `DontYieldALotInterval` flag.

Testing:
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331022](https://bugs.openjdk.org/browse/JDK-8331022) to be approved

### Issues
 * [JDK-8331021](https://bugs.openjdk.org/browse/JDK-8331021): Deprecate and then obsolete the DontYieldALot flag (**Bug** - P4)
 * [JDK-8331022](https://bugs.openjdk.org/browse/JDK-8331022): Deprecate and then obsolete the DontYieldALot flag (**CSR**)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [4981b6fa](https://git.openjdk.org/jdk/pull/18928/files/4981b6fae8c7f38cb442597f5e68ceffb777d9c9)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18928/head:pull/18928` \
`$ git checkout pull/18928`

Update a local copy of the PR: \
`$ git checkout pull/18928` \
`$ git pull https://git.openjdk.org/jdk.git pull/18928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18928`

View PR using the GUI difftool: \
`$ git pr show -t 18928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18928.diff">https://git.openjdk.org/jdk/pull/18928.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18928#issuecomment-2073881214)