### PR TITLE
8330972: Serial: Inline Generation::max_contiguous_available

### DIFF
--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,14 +80,4 @@ void Generation::print_summary_info_on(outputStream* st) {
                time,
                sr->invocations,
                sr->invocations > 0 ? time / sr->invocations : 0.0);
-}
-
-size_t Generation::max_contiguous_available() const {
-  // The largest number of contiguous free words in this or any higher generation.
-  size_t avail = contiguous_available();
-  size_t old_avail = 0;
-  if (SerialHeap::heap()->is_young_gen(this)) {
-    old_avail = SerialHeap::heap()->old_gen()->contiguous_available();
-  }
-  return MAX2(avail, old_avail);
 }

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -99,8 +99,6 @@ class Generation: public CHeapObj<mtGC> {
   // The largest number of contiguous free bytes in the generation,
   // including expansion  (Assumes called at a safepoint.)
   virtual size_t contiguous_available() const = 0;
-  // The largest number of contiguous free bytes in this or any higher generation.
-  virtual size_t max_contiguous_available() const;
 
   MemRegion reserved() const { return _reserved; }
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -416,7 +416,7 @@ void TenuredGeneration::update_counters() {
 }
 
 bool TenuredGeneration::promotion_attempt_is_safe(size_t max_promotion_in_bytes) const {
-  size_t available = max_contiguous_available();
+  size_t available = contiguous_available();
   size_t av_promo  = (size_t)_avg_promoted->padded_average();
   bool   res = (available >= av_promo) || (available >= max_promotion_in_bytes);
 


### PR DESCRIPTION
Hi all,

This patch removes the method `Generation::max_contiguous_available` and uses `contiguous_available` instead in `TenuredGeneration::promotion_attempt_is_safe` (because it is in old-gen).

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330972](https://bugs.openjdk.org/browse/JDK-8330972): Serial: Inline Generation::max_contiguous_available (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18929/head:pull/18929` \
`$ git checkout pull/18929`

Update a local copy of the PR: \
`$ git checkout pull/18929` \
`$ git pull https://git.openjdk.org/jdk.git pull/18929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18929`

View PR using the GUI difftool: \
`$ git pr show -t 18929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18929.diff">https://git.openjdk.org/jdk/pull/18929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18929#issuecomment-2074126743)