### PR TITLE
8330960: Serial: Remove SerialFullGC::_total_invocations

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -74,8 +74,6 @@
 #include "jvmci/jvmci.hpp"
 #endif
 
-uint                    SerialFullGC::_total_invocations = 0;
-
 Stack<oop, mtGC>              SerialFullGC::_marking_stack;
 Stack<ObjArrayTask, mtGC>     SerialFullGC::_objarray_stack;
 
@@ -113,7 +111,7 @@ public:
       // we don't start compacting before there is a significant gain to be made.
       // Occasionally, we want to ensure a full compaction, which is determined
       // by the MarkSweepAlwaysCompactCount parameter.
-      if ((SerialFullGC::total_invocations() % MarkSweepAlwaysCompactCount) != 0) {
+      if ((SerialHeap::heap()->total_full_collections() % MarkSweepAlwaysCompactCount) != 0) {
         _allowed_deadspace_words = (space->capacity() * ratio / 100) / HeapWordSize;
       } else {
         _active = false;
@@ -693,9 +691,6 @@ void SerialFullGC::invoke_at_safepoint(bool clear_all_softrefs) {
 #endif
 
   gch->trace_heap_before_gc(_gc_tracer);
-
-  // Increment the invocation count
-  _total_invocations++;
 
   // Capture used regions for old-gen to reestablish old-to-young invariant
   // after full-gc.

--- a/src/hotspot/share/gc/serial/serialFullGC.hpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.hpp
@@ -81,9 +81,6 @@ class SerialFullGC : AllStatic {
   };
 
  protected:
-  // Total invocations of serial full GC
-  static uint _total_invocations;
-
   // Traversal stacks used during phase1
   static Stack<oop, mtGC>                      _marking_stack;
   static Stack<ObjArrayTask, mtGC>             _objarray_stack;
@@ -118,9 +115,6 @@ class SerialFullGC : AllStatic {
   static CLDToOopClosure      adjust_cld_closure;
 
   static void invoke_at_safepoint(bool clear_all_softrefs);
-
-  // Accessors
-  static uint total_invocations() { return _total_invocations; }
 
   // Reference Processing
   static ReferenceProcessor* ref_processor() { return _ref_processor; }


### PR DESCRIPTION
Hi all,

This patch removes the field `SerialFullGC::_total_invocations` and its related usages, and uses `CollectedHeap::_total_full_collections` instead.

Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330960](https://bugs.openjdk.org/browse/JDK-8330960): Serial: Remove SerialFullGC::_total_invocations (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18930/head:pull/18930` \
`$ git checkout pull/18930`

Update a local copy of the PR: \
`$ git checkout pull/18930` \
`$ git pull https://git.openjdk.org/jdk.git pull/18930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18930`

View PR using the GUI difftool: \
`$ git pr show -t 18930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18930.diff">https://git.openjdk.org/jdk/pull/18930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18930#issuecomment-2074478265)