### PR TITLE
8331050: Serial: Remove unused _saved_mark_word in DefNewGeneration and TenuredGeneration

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -139,9 +139,6 @@ class DefNewGeneration: public Generation {
   ContiguousSpace* _from_space;
   ContiguousSpace* _to_space;
 
-  // Saved mark word, for to-space
-  HeapWord* _saved_mark_word;
-
   STWGCTimer* _gc_timer;
 
   DefNewTracer* _gc_tracer;

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -66,7 +66,6 @@ class TenuredGeneration: public Generation {
   void assert_correct_size_change_locking();
 
   ContiguousSpace*    _the_space;       // Actual space holding objects
-  HeapWord*           _saved_mark_word;
 
   GenerationCounters* _gen_counters;
   CSpaceCounters*     _space_counters;
@@ -89,7 +88,6 @@ public:
   void compute_new_size();
 
   ContiguousSpace* space() const { return _the_space; }
-  HeapWord* saved_mark_word() const { return _saved_mark_word; }
 
   // Grow generation with specified size (returns false if unable to grow)
   bool grow_by(size_t bytes);


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331050](https://bugs.openjdk.org/browse/JDK-8331050): Serial: Remove unused _saved_mark_word in DefNewGeneration and TenuredGeneration (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18931/head:pull/18931` \
`$ git checkout pull/18931`

Update a local copy of the PR: \
`$ git checkout pull/18931` \
`$ git pull https://git.openjdk.org/jdk.git pull/18931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18931`

View PR using the GUI difftool: \
`$ git pr show -t 18931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18931.diff">https://git.openjdk.org/jdk/pull/18931.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18931#issuecomment-2075008517)