### PR TITLE
8331054: C2 MergeStores: assert failed: unexpected basic type after JDK-8318446 and JDK-8329555

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2972,8 +2972,12 @@ StoreNode* MergePrimitiveArrayStores::run() {
 
   // Only merge stores on arrays, and the stores must have the same size as the elements.
   const TypeAryPtr* aryptr_t = _store->adr_type()->isa_aryptr();
-  if (aryptr_t == nullptr ||
-      type2aelembytes(aryptr_t->elem()->array_element_basic_type()) != _store->memory_size()) {
+  if (aryptr_t == nullptr) {
+    return nullptr;
+  }
+  BasicType bt = aryptr_t->elem()->array_element_basic_type();
+  if (!is_java_primitive(bt) ||
+      type2aelembytes(bt) != _store->memory_size()) {
     return nullptr;
   }
 
@@ -3019,8 +3023,13 @@ bool MergePrimitiveArrayStores::is_compatible_store(const StoreNode* other_store
   // Check that the size of the stores, and the array elements are all the same.
   const TypeAryPtr* aryptr_t1 = _store->adr_type()->is_aryptr();
   const TypeAryPtr* aryptr_t2 = other_store->adr_type()->is_aryptr();
-  int size1 = type2aelembytes(aryptr_t1->elem()->array_element_basic_type());
-  int size2 = type2aelembytes(aryptr_t2->elem()->array_element_basic_type());
+  BasicType aryptr_bt1 = aryptr_t1->elem()->array_element_basic_type();
+  BasicType aryptr_bt2 = aryptr_t2->elem()->array_element_basic_type();
+  if (!is_java_primitive(aryptr_bt1) || !is_java_primitive(aryptr_bt2)) {
+    return false;
+  }
+  int size1 = type2aelembytes(aryptr_bt1);
+  int size2 = type2aelembytes(aryptr_bt2);
   if (size1 != size2 ||
       size1 != _store->memory_size() ||
       _store->memory_size() != other_store->memory_size()) {

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -1255,11 +1255,11 @@ public class TestMergeStores {
         Object a = null;
         long base = 0;
         if (i % 2 == 0) {
-          a = aB;
-          base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            a = aB;
+            base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
         } else {
-          a = aI;
-          base = UNSAFE.ARRAY_INT_BASE_OFFSET;
+            a = aI;
+            base = UNSAFE.ARRAY_INT_BASE_OFFSET;
         }
         UNSAFE.putByte(a, base + 0, (byte)0xbe);
         UNSAFE.putByte(a, base + 1, (byte)0xba);
@@ -1278,11 +1278,11 @@ public class TestMergeStores {
         Object a = null;
         long base = 0;
         if (i % 2 == 0) {
-          a = aB;
-          base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+            a = aB;
+            base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
         } else {
-          a = aI;
-          base = UNSAFE.ARRAY_INT_BASE_OFFSET;
+            a = aI;
+            base = UNSAFE.ARRAY_INT_BASE_OFFSET;
         }
         // array a is an aryptr, but its element type is unknown, i.e. bottom.
         UNSAFE.putByte(a, base + 0, (byte)0xbe);

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -33,7 +33,7 @@ import java.util.Random;
 
 /*
  * @test
- * @bug 8318446
+ * @bug 8318446 8331054
  * @summary Test merging of consecutive stores
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
@@ -42,7 +42,7 @@ import java.util.Random;
 
 /*
  * @test
- * @bug 8318446
+ * @bug 8318446 8331054
  * @summary Test merging of consecutive stores
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
@@ -183,6 +183,10 @@ public class TestMergeStores {
         //                                                                                   +-----+   +-------------------+
         // First use something in range, and after warmup randomize going outside the range.
         // Consequence: all RangeChecks stay in the final compilation.
+
+        testGroups.put("test600", new HashMap<String,TestFunction>());
+        testGroups.get("test600").put("test600R", (_,i) -> { return test600R(aB.clone(), aI.clone(), i); });
+        testGroups.get("test600").put("test600a", (_,i) -> { return test600a(aB.clone(), aI.clone(), i); });
     }
 
     @Warmup(100)
@@ -215,7 +219,8 @@ public class TestMergeStores {
                  "test400a",
                  "test500a",
                  "test501a",
-                 "test502a"})
+                 "test502a",
+                 "test600a"})
     public void runTests(RunInfo info) {
         // Repeat many times, so that we also have multiple iterations for post-warmup to potentially recompile
         int iters = info.isWarmUp() ? 1_000 : 50_000;
@@ -1244,4 +1249,51 @@ public class TestMergeStores {
         } catch (ArrayIndexOutOfBoundsException _) {}
         return new Object[]{ a, new int[]{ idx } };
     }
+
+    @DontCompile
+    static Object[] test600R(byte[] aB, int[] aI, int i) {
+        Object a = null;
+        long base = 0;
+        if (i % 2 == 0) {
+          a = aB;
+          base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+        } else {
+          a = aI;
+          base = UNSAFE.ARRAY_INT_BASE_OFFSET;
+        }
+        UNSAFE.putByte(a, base + 0, (byte)0xbe);
+        UNSAFE.putByte(a, base + 1, (byte)0xba);
+        UNSAFE.putByte(a, base + 2, (byte)0xad);
+        UNSAFE.putByte(a, base + 3, (byte)0xba);
+        UNSAFE.putByte(a, base + 4, (byte)0xef);
+        UNSAFE.putByte(a, base + 5, (byte)0xbe);
+        UNSAFE.putByte(a, base + 6, (byte)0xad);
+        UNSAFE.putByte(a, base + 7, (byte)0xde);
+        return new Object[]{ aB, aI };
+    }
+
+    @Test
+    @IR(counts = {IRNode.STORE_B_OF_CLASS, "bottom\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "8"}) // note: bottom type
+    static Object[] test600a(byte[] aB, int[] aI, int i) {
+        Object a = null;
+        long base = 0;
+        if (i % 2 == 0) {
+          a = aB;
+          base = UNSAFE.ARRAY_BYTE_BASE_OFFSET;
+        } else {
+          a = aI;
+          base = UNSAFE.ARRAY_INT_BASE_OFFSET;
+        }
+        // array a is an aryptr, but its element type is unknown, i.e. bottom.
+        UNSAFE.putByte(a, base + 0, (byte)0xbe);
+        UNSAFE.putByte(a, base + 1, (byte)0xba);
+        UNSAFE.putByte(a, base + 2, (byte)0xad);
+        UNSAFE.putByte(a, base + 3, (byte)0xba);
+        UNSAFE.putByte(a, base + 4, (byte)0xef);
+        UNSAFE.putByte(a, base + 5, (byte)0xbe);
+        UNSAFE.putByte(a, base + 6, (byte)0xad);
+        UNSAFE.putByte(a, base + 7, (byte)0xde);
+        return new Object[]{ aB, aI };
+    }
+
 }


### PR DESCRIPTION
I just pushed [JDK-8318446](https://bugs.openjdk.org/browse/JDK-8318446), and @jatin-bhateja just pushed a new test with [JDK-8329555](https://bugs.openjdk.org/browse/JDK-8329555).

Note: this is definitely due to the MergeStores logic from [JDK-8318446](https://bugs.openjdk.org/browse/JDK-8318446).
With [JDK-8329555](https://bugs.openjdk.org/browse/JDK-8329555), Jatin only added a test that triggers the bug.

Jatin created a test case, where we have an `array pointer`, but its element type is `bottom`, because it merges multiple different arrays. I attached such an example in the regression test:

https://github.com/openjdk/jdk/blob/52877b8d5c0c24c256611ceb9cef1d4fb0c40f68/test/hotspot/jtreg/compiler/c2/TestMergeStores.java#L1275-L1297

The issue is that I assume that array ptr always have a native type. But they can be bottom type, and the BasicType is then T_ILLEGAL, and trying to get the size in bytes leads to the assert.

**Solution:** just check if the BasicTypes are `is_java_primitive(bt)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331054](https://bugs.openjdk.org/browse/JDK-8331054): C2 MergeStores: assert failed: unexpected basic type after JDK-8318446 and JDK-8329555 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18935/head:pull/18935` \
`$ git checkout pull/18935`

Update a local copy of the PR: \
`$ git checkout pull/18935` \
`$ git pull https://git.openjdk.org/jdk.git pull/18935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18935`

View PR using the GUI difftool: \
`$ git pr show -t 18935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18935.diff">https://git.openjdk.org/jdk/pull/18935.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18935#issuecomment-2075165860)