### PR TITLE
8331061: Serial: Missed BOT update in TenuredGeneration::expand_and_allocate

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -480,7 +480,7 @@ HeapWord*
 TenuredGeneration::expand_and_allocate(size_t word_size, bool is_tlab) {
   assert(!is_tlab, "TenuredGeneration does not support TLAB allocation");
   expand(word_size*HeapWordSize, _min_heap_delta_bytes);
-  return _the_space->allocate(word_size);
+  return allocate(word_size, is_tlab);
 }
 
 size_t TenuredGeneration::contiguous_available() const {


### PR DESCRIPTION
Add the missed BOT update for allocations in old-gen.

Test succeeds with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331061](https://bugs.openjdk.org/browse/JDK-8331061): Serial: Missed BOT update in TenuredGeneration::expand_and_allocate (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18936/head:pull/18936` \
`$ git checkout pull/18936`

Update a local copy of the PR: \
`$ git checkout pull/18936` \
`$ git pull https://git.openjdk.org/jdk.git pull/18936/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18936`

View PR using the GUI difftool: \
`$ git pr show -t 18936`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18936.diff">https://git.openjdk.org/jdk/pull/18936.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18936#issuecomment-2075245312)