### PR TITLE
8330969: scalability issue with loaded JVMTI agent

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1635,17 +1635,14 @@ private:
   // This function is called only if _enable == true.
   // Iterates over all JavaThread's, counts VTMS transitions and restores
   // jt->jvmti_thread_state() and jt->jvmti_vthread() for VTMS transition protocol.
-  int count_transitions_and_correct_jvmti_thread_states() {
-    int count = 0;
-
+  void count_transitions_and_correct_jvmti_thread_states() {
     for (JavaThread* jt : ThreadsListHandle()) {
       if (jt->is_in_VTMS_transition()) {
-        count++;
+        jt->set_VTMS_transition_mark(true);
         continue; // no need in JvmtiThreadState correction below if in transition
       }
       correct_jvmti_thread_state(jt);
     }
-    return count;
   }
 
 public:
@@ -1655,9 +1652,9 @@ public:
   }
 
   void doit() {
-    int count = _enable ? count_transitions_and_correct_jvmti_thread_states() : 0;
-
-    JvmtiVTMSTransitionDisabler::set_VTMS_transition_count(count);
+    if (_enable) {
+      count_transitions_and_correct_jvmti_thread_states();
+    }
     JvmtiVTMSTransitionDisabler::set_VTMS_notify_jvmti_events(_enable);
   }
 };

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1633,9 +1633,9 @@ private:
   }
 
   // This function is called only if _enable == true.
-  // Iterates over all JavaThread's, counts VTMS transitions and restores
-  // jt->jvmti_thread_state() and jt->jvmti_vthread() for VTMS transition protocol.
-  void count_transitions_and_correct_jvmti_thread_states() {
+  // Iterates over all JavaThread's, restores jt->jvmti_thread_state() and
+  // jt->jvmti_vthread() for VTMS transition protocol.
+  void correct_jvmti_thread_states() {
     for (JavaThread* jt : ThreadsListHandle()) {
       if (jt->is_in_VTMS_transition()) {
         jt->set_VTMS_transition_mark(true);
@@ -1653,7 +1653,7 @@ public:
 
   void doit() {
     if (_enable) {
-      count_transitions_and_correct_jvmti_thread_states();
+      correct_jvmti_thread_states();
     }
     JvmtiVTMSTransitionDisabler::set_VTMS_notify_jvmti_events(_enable);
   }

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -498,7 +498,7 @@ JvmtiVTMSTransitionDisabler::finish_VTMS_transition(jthread vthread, bool is_mou
   thread->set_is_in_VTMS_transition(false);
   oop vt = JNIHandles::resolve_external_guard(vthread);
   java_lang_Thread::set_is_in_VTMS_transition(vt, false);
-  assert(thread->VTMS_transition_mark(), "sanity ed_heck");
+  assert(thread->VTMS_transition_mark(), "sanity check");
   thread->set_VTMS_transition_mark(false);
 
   if (!sync_protocol_enabled()) {

--- a/src/hotspot/share/prims/jvmtiThreadState.cpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.cpp
@@ -429,7 +429,7 @@ JvmtiVTMSTransitionDisabler::start_VTMS_transition(jthread vthread, bool is_moun
   assert(!thread->is_in_VTMS_transition(), "VTMS_transition sanity check");
 
   // Avoid using MonitorLocker on performance critical path, use
-  // two-level synchronization with lock-free operations on counters.
+  // two-level synchronization with lock-free operations on state bits.
   assert(!thread->VTMS_transition_mark(), "sanity check");
   thread->set_VTMS_transition_mark(true); // Try to enter VTMS transition section optmistically.
   java_lang_Thread::set_is_in_VTMS_transition(vt, true);
@@ -451,7 +451,7 @@ JvmtiVTMSTransitionDisabler::start_VTMS_transition(jthread vthread, bool is_moun
       thread->is_suspended() ||
       JvmtiVTSuspender::is_vthread_suspended(thread_id)
   ) {
-    // Slow path: undo unsuccessful optimistic counter incrementation.
+    // Slow path: undo unsuccessful optimistic set of the VTMS_transition_mark.
     // It can cause an extra waiting cycle for VTMS transition disablers.
     thread->set_VTMS_transition_mark(false);
     java_lang_Thread::set_is_in_VTMS_transition(vth(), false);

--- a/src/hotspot/share/prims/jvmtiThreadState.hpp
+++ b/src/hotspot/share/prims/jvmtiThreadState.hpp
@@ -82,9 +82,8 @@ class JvmtiVTMSTransitionDisabler {
   static volatile int _VTMS_transition_disable_for_one_count; // transitions for one virtual thread are disabled while it is positive
   static volatile int _VTMS_transition_disable_for_all_count; // transitions for all virtual threads are disabled while it is positive
   static volatile bool _SR_mode;                         // there is an active suspender or resumer
-  static volatile int _VTMS_transition_count;            // current number of VTMS transitions
   static volatile int _sync_protocol_enabled_count;      // current number of JvmtiVTMSTransitionDisablers enabled sync protocol
-  static volatile bool _sync_protocol_enabled_permanently; // seen a suspender: JvmtiVTMSTraansitionDisabler protocol is enabled permanently
+  static volatile bool _sync_protocol_enabled_permanently; // seen a suspender: JvmtiVTMSTransitionDisabler protocol is enabled permanently
 
   bool _is_SR;                                           // is suspender or resumer
   jthread _thread;                                       // virtual thread to disable transitions for, no-op if it is a platform thread
@@ -99,8 +98,6 @@ class JvmtiVTMSTransitionDisabler {
   static bool _VTMS_notify_jvmti_events;                 // enable notifications from VirtualThread about VTMS events
   static bool VTMS_notify_jvmti_events()             { return _VTMS_notify_jvmti_events; }
   static void set_VTMS_notify_jvmti_events(bool val) { _VTMS_notify_jvmti_events = val; }
-
-  static void set_VTMS_transition_count(bool val)    { _VTMS_transition_count = val; }
 
   static void inc_sync_protocol_enabled_count()      { Atomic::inc(&_sync_protocol_enabled_count); }
   static void dec_sync_protocol_enabled_count()      { Atomic::dec(&_sync_protocol_enabled_count); }

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -450,6 +450,7 @@ JavaThread::JavaThread() :
   _is_in_VTMS_transition(false),
   _is_in_tmp_VTMS_transition(false),
   _is_disable_suspend(false),
+  _VTMS_transition_mark(false),
 #ifdef ASSERT
   _is_VTMS_transition_disabler(false),
 #endif

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -317,6 +317,7 @@ class JavaThread: public Thread {
   bool                  _is_in_VTMS_transition;          // thread is in virtual thread mount state transition
   bool                  _is_in_tmp_VTMS_transition;      // thread is in temporary virtual thread mount state transition
   bool                  _is_disable_suspend;             // JVMTI suspend is temporarily disabled; used on current thread only
+  bool                  _VTMS_transition_mark;           // used for sync between VTMS transitions and disablers
 #ifdef ASSERT
   bool                  _is_VTMS_transition_disabler;    // thread currently disabled VTMS transitions
 #endif
@@ -663,6 +664,9 @@ private:
 
   bool is_disable_suspend() const                { return _is_disable_suspend; }
   void toggle_is_disable_suspend()               { _is_disable_suspend = !_is_disable_suspend; };
+
+  bool VTMS_transition_mark()                    { return Atomic::load(&_VTMS_transition_mark); }
+  void set_VTMS_transition_mark(bool val)        { Atomic::store(&_VTMS_transition_mark, val); }
 
 #ifdef ASSERT
   bool is_VTMS_transition_disabler() const       { return _is_VTMS_transition_disabler; }

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -665,7 +665,7 @@ private:
   bool is_disable_suspend() const                { return _is_disable_suspend; }
   void toggle_is_disable_suspend()               { _is_disable_suspend = !_is_disable_suspend; };
 
-  bool VTMS_transition_mark()                    { return Atomic::load(&_VTMS_transition_mark); }
+  bool VTMS_transition_mark() const              { return Atomic::load(&_VTMS_transition_mark); }
   void set_VTMS_transition_mark(bool val)        { Atomic::store(&_VTMS_transition_mark, val); }
 
 #ifdef ASSERT


### PR DESCRIPTION
This is a fix of the following JVMTI scalability issue. A closed benchmark with millions of virtual threads shows 3X-4X overhead when a JVMTI agent has been loaded. For instance, this is observable when an app is executed under control of the Oracle Studio `collect` utility.
For performance analysis, experiments and numbers, please, see the comment below this description.

The fix is to replace the global counter `_VTMS_transition_count` with the mark bit `_VTMS_transition_mark` in each `JavaThread`'.

Testing:
 - Tested with mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330969](https://bugs.openjdk.org/browse/JDK-8330969): scalability issue with loaded JVMTI agent (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18937/head:pull/18937` \
`$ git checkout pull/18937`

Update a local copy of the PR: \
`$ git checkout pull/18937` \
`$ git pull https://git.openjdk.org/jdk.git pull/18937/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18937`

View PR using the GUI difftool: \
`$ git pr show -t 18937`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18937.diff">https://git.openjdk.org/jdk/pull/18937.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18937#issuecomment-2075318745)