### PR TITLE
8331097: Tests build is broken after pr/18914

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
@@ -122,6 +122,7 @@ public class CodeAttributeTools {
     public void benchmarkStackCounter(Blackhole bh) {
         for (var d : data) bh.consume(new StackCounter(
                 d.labelContext(),
+                d.thisClass(),
                 d.methodName(),
                 d.methodDesc(),
                 d.isStatic(),


### PR DESCRIPTION
Pr/18914 broke tests build.
This patch fixes `test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools`

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331097](https://bugs.openjdk.org/browse/JDK-8331097): Tests build is broken after pr/18914 (**Bug** - P1)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18943/head:pull/18943` \
`$ git checkout pull/18943`

Update a local copy of the PR: \
`$ git checkout pull/18943` \
`$ git pull https://git.openjdk.org/jdk.git pull/18943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18943`

View PR using the GUI difftool: \
`$ git pr show -t 18943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18943.diff">https://git.openjdk.org/jdk/pull/18943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18943#issuecomment-2076605932)