### PR TITLE
8331094: ZGC: GTest fails due to incompatible Windows version

### DIFF
--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -84,8 +84,7 @@ public:
 
     // Reserve address space for the test
     if (!reserve_for_test()) {
-      // Failed to reserve address space
-      GTEST_SKIP() << "Failed to reserved address space";
+      GTEST_SKIP() << "Failed to reserve address space";
       return;
     }
 

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -69,7 +69,7 @@ public:
   virtual void SetUp() {
     // Only run test on supported Windows versions
     if (!ZSyscall::is_supported()) {
-      GTEST_SKIP();
+      GTEST_SKIP() << "Requires Windows version 1803 or later";
       return;
     }
 
@@ -85,7 +85,7 @@ public:
     // Reserve address space for the test
     if (!reserve_for_test()) {
       // Failed to reserve address space
-      GTEST_SKIP();
+      GTEST_SKIP() << "Failed to reserved address space";
       return;
     }
 

--- a/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
+++ b/test/hotspot/gtest/gc/z/test_zMapper_windows.cpp
@@ -67,6 +67,12 @@ public:
   }
 
   virtual void SetUp() {
+    // Only run test on supported Windows versions
+    if (!ZSyscall::is_supported()) {
+      GTEST_SKIP();
+      return;
+    }
+
     ZSyscall::initialize();
     ZGlobalsPointers::initialize();
 
@@ -87,6 +93,11 @@ public:
   }
 
   virtual void TearDown() {
+    if (!ZSyscall::is_supported()) {
+      // Test skipped, nothing to cleanup
+      return;
+    }
+
     if (_initialized) {
       _vmm->pd_unreserve(ZOffset::address_unsafe(zoffset(0)), 0);
     }


### PR DESCRIPTION
Please review this test fix for an intermittent tier1 failure.

**Summary**
A newly added Windows specific ZGC tests requires some system calls not available on all Windows systems. This fix adds code to the test setup to ensure the required system calls are supported and otherwise skip the test.

**Testing**
Verified that the test is now skipped if running on a system that is not supported. We get the following output: 
```
[----------] 3 tests from ZMapperTest
[ RUN      ] ZMapperTest.test_alloc_low_address_vm
...\\open\\test\\hotspot\\gtest\\gc\\z\\test_zMapper_windows.cpp(72): Skipped
Requires Windows version 1803 or later

[  SKIPPED ] ZMapperTest.test_alloc_low_address_vm (0 ms)
[ RUN      ] ZMapperTest.test_alloc_high_address_vm
...\\open\\test\\hotspot\\gtest\\gc\\z\\test_zMapper_windows.cpp(72): Skipped
Requires Windows version 1803 or later

[  SKIPPED ] ZMapperTest.test_alloc_high_address_vm (0 ms)
[ RUN      ] ZMapperTest.test_alloc_whole_area_vm
...\\open\\test\\hotspot\\gtest\\gc\\z\\test_zMapper_windows.cpp(72): Skipped
Requires Windows version 1803 or later 
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331094](https://bugs.openjdk.org/browse/JDK-8331094): ZGC: GTest fails due to incompatible Windows version (**Bug** - P3)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18944/head:pull/18944` \
`$ git checkout pull/18944`

Update a local copy of the PR: \
`$ git checkout pull/18944` \
`$ git pull https://git.openjdk.org/jdk.git pull/18944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18944`

View PR using the GUI difftool: \
`$ git pr show -t 18944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18944.diff">https://git.openjdk.org/jdk/pull/18944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18944#issuecomment-2076711506)