### PR TITLE
8331098: [Aarch64] Fix crash in Arrays.equals() intrinsic with -CCP

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5588,7 +5588,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     //      return false;
     bind(A_IS_NOT_NULL);
     ldrw(cnt1, Address(a1, length_offset));
-    // Increase loop counter by size of length field.
+    // Increase loop counter by diff between base- and actual start-offset.
     addw(cnt1, cnt1, extra_length);
     lea(a1, Address(a1, start_offset));
     lea(a2, Address(a2, start_offset));
@@ -5654,7 +5654,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     cbz(a1, DONE);
     ldrw(cnt1, Address(a1, length_offset));
     cbz(a2, DONE);
-    // Increase loop counter by size of length field.
+    // Increase loop counter by diff between base- and actual start-offset.
     addw(cnt1, cnt1, extra_length);
 
     // on most CPUs a2 is still "locked"(surprisingly) in ldrw and it's

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5551,6 +5551,8 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   bool is_8aligned = is_aligned(base_offset, BytesPerWord);
   assert(is_aligned(base_offset, BytesPerWord) || is_aligned(length_offset, BytesPerWord),
          "base_offset or length_offset must be 8-byte aligned");
+  assert(is_aligned(base_offset, BytesPerWord) || base_offset == length_offset + BytesPerInt,
+         "base_offset must be 8-byte aligned or no padding between base and length");
   int start_offset = is_8aligned ? base_offset : length_offset;
   int extra_length = is_8aligned ? 0 : BytesPerInt / elem_size;
   int stubBytesThreshold = 3 * 64 + (UseSIMDForArrayEquals ? 0 : 16);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5671,7 +5671,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     if (extra_length != 0) {
       // Increase loop counter by size of length field.
       addw(cnt1, cnt1, extra_length);
-      // We don't need cnt2 on that path. 
+      // We don't need cnt2 on that path.
     }
     // on most CPUs a2 is still "locked"(surprisingly) in ldrw and it's
     // faster to perform another branch before comparing a1 and a2

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5586,17 +5586,17 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     //      return false;
     bind(A_IS_NOT_NULL);
     ldrw(cnt1, Address(a1, length_offset));
-    ldrw(cnt2, Address(a2, length_offset));
     if (extra_length != 0) {
       // Increase loop counter by size of length field.
       addw(cnt1, cnt1, extra_length);
-      addw(cnt2, cnt2, extra_length);
+      // We don't need cnt2 on that path. 
     }
     if (is_8aligned) {
       // Check if lenghts are equal. When bases are
       // not aligned, we compare the lengths in the
       // main loop and don't need to compare it
       // explicitely ahead of the loop.
+      ldrw(cnt2, Address(a2, length_offset));
       eorw(tmp5, cnt1, cnt2);
       cbnzw(tmp5, DONE);
     }
@@ -5664,11 +5664,14 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     cbz(a1, DONE);
     ldrw(cnt1, Address(a1, length_offset));
     cbz(a2, DONE);
-    ldrw(cnt2, Address(a2, length_offset));
+    if (is_8aligned) {
+      // cnt2 only needed when doing explicit length-compares.
+      ldrw(cnt2, Address(a2, length_offset));
+    }
     if (extra_length != 0) {
       // Increase loop counter by size of length field.
       addw(cnt1, cnt1, extra_length);
-      addw(cnt2, cnt2, extra_length);
+      // We don't need cnt2 on that path. 
     }
     // on most CPUs a2 is still "locked"(surprisingly) in ldrw and it's
     // faster to perform another branch before comparing a1 and a2

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5546,7 +5546,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   int base_offset
     = arrayOopDesc::base_offset_in_bytes(elem_size == 2 ? T_CHAR : T_BYTE);
   // When the length offset is not aligned to 8 bytes,
-  // then we align it down, this is valid as the new
+  // then we align it down. This is valid because the new
   // offset will always be the klass which is the same
   // for type arrays.
   int start_offset = align_down(length_offset, BytesPerWord);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5551,7 +5551,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
   // for type arrays.
   int start_offset = align_down(length_offset, BytesPerWord);
   int extra_length = base_offset - start_offset;
-  assert(start_offset == length_offset || start_offset == klass_offset, 
+  assert(start_offset == length_offset || start_offset == klass_offset,
          "start offset must be 8-byte-aligned or be the klass offset");
   assert(base_offset != start_offset, "must include the length field");
   extra_length = extra_length / elem_size; // We count in elements, not bytes.

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5591,7 +5591,7 @@ address MacroAssembler::arrays_equals(Register a1, Register a2, Register tmp3,
     if (extra_length != 0) {
       // Increase loop counter by size of length field.
       addw(cnt1, cnt1, extra_length);
-      // We don't need cnt2 on that path. 
+      // We don't need cnt2 on that path.
     }
     if (is_8aligned) {
       // Check if lenghts are equal. When bases are


### PR DESCRIPTION
The implementations of Arrays.equals() in macroAssembler_aarch64.cpp, MacroAssembler::arrays_equals() assumes that the start of arrays is 8-byte-aligned. Since [JDK-8139457](https://bugs.openjdk.org/browse/JDK-8139457) this is no longer the case, at least when running with -CompressedClassPointers (or Lilliput). The effect is that the loops may run over the array end, and if the array is at heap boundary, and that memory is unmapped, then it may crash.

The proposed fix aims to always enter the main loop(s) with an aligned address:
 - When the array base is 8-byte-aligned (default, with +CCP), then compare the array lengths separately, then enter the main loop with the array base.
 - When the array base is not 8-byte-aligned (-CCP and Lilliput), then enter the loop with the address of the array-length (which is then 8-byte-aligned), and compare array lengths in the main loop, and elide the explicit array lengths comparison.

Testing:
 - [x] tier1 (+CCP)
 - [x] tier1 (-CCP)
 - [x] tier2 (+CCP)
 - [x] tier2 (-CCP)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331098](https://bugs.openjdk.org/browse/JDK-8331098): [Aarch64] Fix crash in Arrays.equals() intrinsic with -CCP (**Bug** - P3)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) ⚠️ Review applies to [84f9a933](https://git.openjdk.org/jdk/pull/18948/files/84f9a9334ca7a161edcc8783dddbdd439ce058bd)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) ⚠️ Review applies to [88da6b5d](https://git.openjdk.org/jdk/pull/18948/files/88da6b5da93cf7eab3849e123507df0dbb3bb550)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18948/head:pull/18948` \
`$ git checkout pull/18948`

Update a local copy of the PR: \
`$ git checkout pull/18948` \
`$ git pull https://git.openjdk.org/jdk.git pull/18948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18948`

View PR using the GUI difftool: \
`$ git pr show -t 18948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18948.diff">https://git.openjdk.org/jdk/pull/18948.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18948#issuecomment-2076889669)