### PR TITLE
8330577: G1 sometimes sends jdk.G1HeapRegionTypeChange for non-changes

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -150,7 +150,9 @@ double HeapRegion::calc_gc_efficiency() {
 }
 
 void HeapRegion::set_free() {
-  report_region_type_change(G1HeapRegionTraceType::Free);
+  if (!is_free()) {
+    report_region_type_change(G1HeapRegionTraceType::Free);
+  }
   _type.set_free();
 }
 


### PR DESCRIPTION
Avoid to report jdk.G1HeapRegionTypeChange event if G1 region type is set to free even it is of type free already.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330577](https://bugs.openjdk.org/browse/JDK-8330577): G1 sometimes sends jdk.G1HeapRegionTypeChange for non-changes (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [36d9877b](https://git.openjdk.org/jdk/pull/18949/files/36d9877bde9234f8ab1ffa8c54a393439ac62a83)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [36d9877b](https://git.openjdk.org/jdk/pull/18949/files/36d9877bde9234f8ab1ffa8c54a393439ac62a83)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18949/head:pull/18949` \
`$ git checkout pull/18949`

Update a local copy of the PR: \
`$ git checkout pull/18949` \
`$ git pull https://git.openjdk.org/jdk.git pull/18949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18949`

View PR using the GUI difftool: \
`$ git pr show -t 18949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18949.diff">https://git.openjdk.org/jdk/pull/18949.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18949#issuecomment-2076902863)