### PR TITLE
8331011: [XWayland] TokenStorage fails under Security Manager

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,8 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.nio.file.attribute.PosixFilePermission;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -58,6 +60,7 @@ import static sun.awt.screencast.ScreencastHelper.SCREENCAST_DEBUG;
  * The restore token allows the ScreenCast session to be restored
  * with previously granted screen access permissions.
  */
+@SuppressWarnings("removal")
 final class TokenStorage {
 
     private TokenStorage() {}
@@ -69,8 +72,24 @@ final class TokenStorage {
     private static final Path PROPS_PATH;
     private static final Path PROP_FILENAME;
 
+    private static void doPrivilegedRunnable(Runnable runnable) {
+        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            @Override
+            public Void run() {
+                runnable.run();
+                return null;
+            }
+        });
+    }
+
     static {
-        PROPS_PATH = setupPath();
+        PROPS_PATH = AccessController.doPrivileged(new PrivilegedAction<Path>() {
+            @Override
+            public Path run() {
+                return setupPath();
+            }
+        });
+
         if (PROPS_PATH != null) {
             PROP_FILENAME = PROPS_PATH.getFileName();
             if (SCREENCAST_DEBUG) {
@@ -192,9 +211,9 @@ final class TokenStorage {
                     }
 
                     if (kind == ENTRY_CREATE) {
-                        setFilePermission(PROPS_PATH);
+                        doPrivilegedRunnable(() -> setFilePermission(PROPS_PATH));
                     } else if (kind == ENTRY_MODIFY) {
-                        readTokens(PROPS_PATH);
+                        doPrivilegedRunnable(() -> readTokens(PROPS_PATH));
                     } else if (kind == ENTRY_DELETE) {
                         synchronized (PROPS) {
                             PROPS.clear();
@@ -207,24 +226,31 @@ final class TokenStorage {
         }
     }
 
+    private static WatchService watchService;
+
     private static void setupWatch() {
-        try {
-            WatchService watchService =
-                    FileSystems.getDefault().newWatchService();
+        doPrivilegedRunnable(() -> {
+            try {
+                watchService =
+                        FileSystems.getDefault().newWatchService();
 
-            PROPS_PATH
-                    .getParent()
-                    .register(watchService,
-                            ENTRY_CREATE,
-                            ENTRY_DELETE,
-                            ENTRY_MODIFY);
+                PROPS_PATH
+                        .getParent()
+                        .register(watchService,
+                                ENTRY_CREATE,
+                                ENTRY_DELETE,
+                                ENTRY_MODIFY);
 
-            new WatcherThread(watchService).start();
-        } catch (Exception e) {
-            if (SCREENCAST_DEBUG) {
-                System.err.printf("Token storage: failed to setup " +
-                        "file watch %s\n", e);
+            } catch (Exception e) {
+                if (SCREENCAST_DEBUG) {
+                    System.err.printf("Token storage: failed to setup " +
+                            "file watch %s\n", e);
+                }
             }
+        });
+
+        if (watchService != null) {
+            new WatcherThread(watchService).start();
         }
     }
 
@@ -276,7 +302,7 @@ final class TokenStorage {
             }
 
             if (changed) {
-                store("save tokens");
+                doPrivilegedRunnable(() -> store("save tokens"));
             }
         }
     }
@@ -331,7 +357,7 @@ final class TokenStorage {
                     .toList();
         }
 
-        removeMalformedRecords(malformed);
+        doPrivilegedRunnable(() -> removeMalformedRecords(malformed));
 
         // 1. Try to find exact matches
         for (TokenItem tokenItem : allTokenItems) {


### PR DESCRIPTION
This fix adds missing doPrivileged calls in TokenStorage, which is used to help take screenshots in Wayland.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331011](https://bugs.openjdk.org/browse/JDK-8331011): [XWayland] TokenStorage fails under Security Manager (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18950/head:pull/18950` \
`$ git checkout pull/18950`

Update a local copy of the PR: \
`$ git checkout pull/18950` \
`$ git pull https://git.openjdk.org/jdk.git pull/18950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18950`

View PR using the GUI difftool: \
`$ git pr show -t 18950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18950.diff">https://git.openjdk.org/jdk/pull/18950.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18950#issuecomment-2077010793)