### PR TITLE
C1 release buffer immediately after compilation

### DIFF
--- a/src/hotspot/share/c1/c1_Compiler.hpp
+++ b/src/hotspot/share/c1/c1_Compiler.hpp
@@ -35,6 +35,7 @@ class Compiler: public AbstractCompiler {
  private:
   static void init_c1_runtime();
   BufferBlob* init_buffer_blob();
+  void release_buffer_blob();
 
  public:
   // Creation

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1787,12 +1787,6 @@ bool CompileBroker::init_compiler_runtime() {
     return false;
   }
 
-  // C1 specific check
-  if (comp->is_c1() && (thread->get_buffer_blob() == nullptr)) {
-    warning("Initialization of %s thread failed (no space to run compilers)", thread->name());
-    return false;
-  }
-
   return true;
 }
 


### PR DESCRIPTION
C1 holds the scratch buffer until the end of the life of the compiler thread. C1 buffers are quite large (600KB by default), and on a multi-core machine we have a lot of C1 compiler threads. With this change, we apply the C2 approach to C1: release the scratch buffer after compilation.

Tests on Intel and AARCH machines show no performance degradation. Benchmarks were run without warm-up to ensure that C1 compilation performance is not affected by additional CodeHeap allocation.

(temporary comment) on win32, win64 and G2 the change can affect performance:
JmhDotty -w0 -i1, m6g.metal | trunk (average) | patch (average) | patch/trunk %
-- | -- | -- | --
ms/op | 10385.9 | 10263.2 | -1.18
**perf counters**  |   |   |  
cache-misses:u: | 2324430848 | 2324546191 | 0.00
cpu-cycles:u: | 128942342144 | 128895156224 | -0.04
instructions:u: | 196336418816 | 197021138944 | 0.35
L1-icache-loads:u: | 76822976922 | 76803158835 | -0.03
L1-icache-load-misses:u: | 1597096591 | 1586243830 | -0.68
iTLB-loads:u: | 65292206080 | 65153374618 | -0.21
iTLB-load-misses:u: | 73381446 | 74682519 | 1.77
branch-loads:u: | 44119044915 | 44210900173 | 0.21
branch-load-misses:u: | 1484961874 | 1462794977 | -1.49
br_pred:u: | 44061373235 | 44190872371 | 0.29
br_mis_pred:u: | 1499662909 | 1477569413 | -1.47
group0-code_sparsity:u: | 10383031 | 8756836 | -15.66

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18952/head:pull/18952` \
`$ git checkout pull/18952`

Update a local copy of the PR: \
`$ git checkout pull/18952` \
`$ git pull https://git.openjdk.org/jdk.git pull/18952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18952`

View PR using the GUI difftool: \
`$ git pr show -t 18952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18952.diff">https://git.openjdk.org/jdk/pull/18952.diff</a>

</details>
