### PR TITLE
8331150: RISC-V: Fix "bad AD file" bug

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -73,6 +73,7 @@ source %{
           return false;
         }
         break;
+      case Op_LoadVectorGather:
       case Op_LoadVectorGatherMasked:
         if (is_subword_type(bt)) {
           return false;


### PR DESCRIPTION
Hi,
Can you help to review this bug fix patch?
The issue was introduced by [JDK-8318650](https://bugs.openjdk.org/browse/JDK-8318650)
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331150](https://bugs.openjdk.org/browse/JDK-8331150): RISC-V: Fix "bad AD file" bug (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18960/head:pull/18960` \
`$ git checkout pull/18960`

Update a local copy of the PR: \
`$ git checkout pull/18960` \
`$ git pull https://git.openjdk.org/jdk.git pull/18960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18960`

View PR using the GUI difftool: \
`$ git pr show -t 18960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18960.diff">https://git.openjdk.org/jdk/pull/18960.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18960#issuecomment-2077855783)