### PR TITLE
8331153: JFR: Improve logging of jdk/jfr/api/consumer/filestream/TestOrdered.java

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -91,6 +91,7 @@ public class TestOrdered {
             System.out.println();
             System.out.println("Testing: testSetOrderedTrue reuse = " + reuse);
             AtomicReference<Instant> timestamp = new AtomicReference<>(Instant.MIN);
+            AtomicBoolean unordered = new AtomicBoolean(false);
             try (EventStream es = EventStream.openFile(p)) {
                 es.setReuse(reuse);
                 es.setOrdered(true);
@@ -98,11 +99,14 @@ public class TestOrdered {
                     Instant endTime = e.getEndTime();
                     printTimestamp(endTime);
                     if (endTime.isBefore(timestamp.get())) {
-                        throw new Error("Events are not ordered! Reuse = " + reuse);
+                        unordered.set(true);
                     }
                     timestamp.set(endTime);
                 });
                 es.start();
+            }
+            if (unordered.get()) {
+                throw new Exception("Events are not ordered! Reuse = " + reuse);
             }
         }
     }
@@ -112,7 +116,7 @@ public class TestOrdered {
             System.out.println();
             System.out.println("Testing: testSetOrderedFalse reuse = " + reuse);
             AtomicReference<Instant> timestamp = new AtomicReference<>(Instant.MIN);
-            AtomicBoolean unoreded = new AtomicBoolean(false);
+            AtomicBoolean unordered = new AtomicBoolean(false);
             try (EventStream es = EventStream.openFile(p)) {
                 es.setReuse(reuse);
                 es.setOrdered(false);
@@ -120,12 +124,12 @@ public class TestOrdered {
                     Instant endTime = e.getEndTime();
                     printTimestamp(endTime);
                     if (endTime.isBefore(timestamp.get())) {
-                        unoreded.set(true);
+                        unordered.set(true);
                     }
                     timestamp.set(endTime);
                 });
                 es.start();
-                if (!unoreded.get()) {
+                if (!unordered.get()) {
                     throw new Exception("Expected at least some events to be out of order! Reuse = " + reuse);
                 }
             }

--- a/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
+++ b/test/jdk/jdk/jfr/api/consumer/filestream/TestOrdered.java
@@ -88,12 +88,15 @@ public class TestOrdered {
 
     private static void testSetOrderedTrue(Path p) throws Exception {
         for (boolean reuse : BOOLEAN_STATES) {
+            System.out.println();
+            System.out.println("Testing: testSetOrderedTrue reuse = " + reuse);
             AtomicReference<Instant> timestamp = new AtomicReference<>(Instant.MIN);
             try (EventStream es = EventStream.openFile(p)) {
                 es.setReuse(reuse);
                 es.setOrdered(true);
                 es.onEvent(e -> {
                     Instant endTime = e.getEndTime();
+                    printTimestamp(endTime);
                     if (endTime.isBefore(timestamp.get())) {
                         throw new Error("Events are not ordered! Reuse = " + reuse);
                     }
@@ -106,6 +109,8 @@ public class TestOrdered {
 
     private static void testSetOrderedFalse(Path p) throws Exception {
         for (boolean reuse : BOOLEAN_STATES) {
+            System.out.println();
+            System.out.println("Testing: testSetOrderedFalse reuse = " + reuse);
             AtomicReference<Instant> timestamp = new AtomicReference<>(Instant.MIN);
             AtomicBoolean unoreded = new AtomicBoolean(false);
             try (EventStream es = EventStream.openFile(p)) {
@@ -113,10 +118,9 @@ public class TestOrdered {
                 es.setOrdered(false);
                 es.onEvent(e -> {
                     Instant endTime = e.getEndTime();
-                    System.out.println("testSetOrderedFalse: endTime: " + endTime);
+                    printTimestamp(endTime);
                     if (endTime.isBefore(timestamp.get())) {
                         unoreded.set(true);
-                        es.close();
                     }
                     timestamp.set(endTime);
                 });
@@ -126,6 +130,12 @@ public class TestOrdered {
                 }
             }
         }
+    }
+
+    private static void printTimestamp(Instant timestamp) {
+        long seconds = timestamp.getEpochSecond();
+        long nanos = timestamp.getNano();
+        System.out.println(timestamp + " seconds = " + seconds + " nanos = " + nanos);
     }
 
     private static Path makeUnorderedRecording() throws Exception {


### PR DESCRIPTION
Could I have a review of a PR that improves logging of a test to be able to debug failures more easily.

Fixes:
Timestamps for all events are written with nanosecond precision
Tests no longer abort before all events have been processed.
Fixed typo of the word ordered

Testing: jdk/jfr/api/consumer/filestream/TestOrdered.java

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331153](https://bugs.openjdk.org/browse/JDK-8331153): JFR: Improve logging of jdk/jfr/api/consumer/filestream/TestOrdered.java (**Sub-task** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18961/head:pull/18961` \
`$ git checkout pull/18961`

Update a local copy of the PR: \
`$ git checkout pull/18961` \
`$ git pull https://git.openjdk.org/jdk.git pull/18961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18961`

View PR using the GUI difftool: \
`$ git pr show -t 18961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18961.diff">https://git.openjdk.org/jdk/pull/18961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18961#issuecomment-2078038761)