### PR TITLE
8331159: VM build without C2 fails after JDK-8180450

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -8468,6 +8468,7 @@ class StubGenerator: public StubCodeGenerator {
 
 #endif // LINUX
 
+#ifdef COMPILER2
     if (UseSecondarySupersTable) {
       StubRoutines::_lookup_secondary_supers_table_slow_path_stub = generate_lookup_secondary_supers_table_slow_path_stub();
       if (! InlineSecondarySupersTest) {
@@ -8477,6 +8478,7 @@ class StubGenerator: public StubCodeGenerator {
         }
       }
     }
+#endif
 
     StubRoutines::_upcall_stub_exception_handler = generate_upcall_stub_exception_handler();
 


### PR DESCRIPTION
x86 bits are fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331159](https://bugs.openjdk.org/browse/JDK-8331159): VM build without C2 fails after JDK-8180450 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18962/head:pull/18962` \
`$ git checkout pull/18962`

Update a local copy of the PR: \
`$ git checkout pull/18962` \
`$ git pull https://git.openjdk.org/jdk.git pull/18962/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18962`

View PR using the GUI difftool: \
`$ git pr show -t 18962`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18962.diff">https://git.openjdk.org/jdk/pull/18962.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18962#issuecomment-2078168943)