### PR TITLE
8331108: Unused Math.abs call in java.lang.FdLibm.Expm1#compute

### DIFF
--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/FdLibm.java
+++ b/src/java.base/share/classes/java/lang/FdLibm.java
@@ -3005,7 +3005,6 @@ final class FdLibm {
 
             hx  = __HI(x);  // high word of x
             xsb = hx & SIGN_BIT;                 // sign bit of x
-            y = Math.abs(x);
             hx &= EXP_SIGNIF_BITS;               // high word of |x|
 
             // filter out huge and non-finite argument


### PR DESCRIPTION
Remove unnecessary setting of variable y, found by an IDE inspection noted in the bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331108](https://bugs.openjdk.org/browse/JDK-8331108): Unused Math.abs call in java.lang.FdLibm.Expm1#compute (**Enhancement** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [e8f5c334](https://git.openjdk.org/jdk/pull/18963/files/e8f5c3343c06a885665ca713ef15d94c6ecfc372)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**) ⚠️ Review applies to [e8f5c334](https://git.openjdk.org/jdk/pull/18963/files/e8f5c3343c06a885665ca713ef15d94c6ecfc372)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18963/head:pull/18963` \
`$ git checkout pull/18963`

Update a local copy of the PR: \
`$ git checkout pull/18963` \
`$ git pull https://git.openjdk.org/jdk.git pull/18963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18963`

View PR using the GUI difftool: \
`$ git pr show -t 18963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18963.diff">https://git.openjdk.org/jdk/pull/18963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18963#issuecomment-2078217277)