### PR TITLE
8331164: createJMHBundle.sh download jars fail when url needed to be redirected

### DIFF
--- a/make/devkit/createJMHBundle.sh
+++ b/make/devkit/createJMHBundle.sh
@@ -44,7 +44,7 @@ rm -f *
 fetchJar() {
   url="${MAVEN_MIRROR}/$1/$2/$3/$2-$3.jar"
   if command -v curl > /dev/null; then
-      curl -O --fail $url
+      curl -OL --fail $url
   elif command -v wget > /dev/null; then
       wget $url
   else


### PR DESCRIPTION
Hi,

  The curl command lack of "-L" option, cause download file fail, the size of download file is empty.

  curl download fail without `-L`:
   ```log
> rm -rf jmh-core-1.37.jar ; curl -O --fail https://maven.aliyun.com/repository/public/org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar ; ls -lh jmh-core-1.37.jar ; du -sh jmh-core-1.37.jar 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
-rw-rw-r-- 1 yansendao yansendao 0 Apr 26 17:37 jmh-core-1.37.jar
0       jmh-core-1.37.jar
```

  curl download success with `-L`:
```
> rm -rf jmh-core-1.37.jar ; curl -OL --fail https://maven.aliyun.com/repository/public/org/openjdk/jmh/jmh-core/1.37/jmh-core-1.37.jar ; ls -lh jmh-core-1.37.jar ; du -sh jmh-core-1.37.jar 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  540k  100  540k    0     0  1097k      0 --:--:-- --:--:-- --:--:-- 1097k
-rw-rw-r-- 1 yansendao yansendao 541K Apr 26 17:38 jmh-core-1.37.jar
544K    jmh-core-1.37.jar
```


  Only change devkit shell script, the risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331164](https://bugs.openjdk.org/browse/JDK-8331164): createJMHBundle.sh download jars fail when url needed to be redirected (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18965/head:pull/18965` \
`$ git checkout pull/18965`

Update a local copy of the PR: \
`$ git checkout pull/18965` \
`$ git pull https://git.openjdk.org/jdk.git pull/18965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18965`

View PR using the GUI difftool: \
`$ git pr show -t 18965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18965.diff">https://git.openjdk.org/jdk/pull/18965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18965#issuecomment-2078574848)