### PR TITLE
8331175: Parallel: Remove VerifyRememberedSets

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -787,6 +787,9 @@ void ParallelScavengeHeap::verify(VerifyOption option /* ignored */) {
 
     log_debug(gc, verify)("Eden");
     young_gen()->verify();
+
+    log_debug(gc, verify)("CardTable");
+    card_table()->verify_all_young_refs_imprecise();
   }
 }
 

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -419,11 +419,6 @@ bool PSScavenge::invoke_no_policy() {
     // Let the size policy know we're starting
     size_policy->minor_collection_begin();
 
-    // Verify no unmarked old->young roots
-    if (VerifyRememberedSets) {
-      heap->card_table()->verify_all_young_refs_imprecise();
-    }
-
     assert(young_gen->to_space()->is_empty(),
            "Attempt to scavenge with live objects in to_space");
     young_gen->to_space()->clear(SpaceDecorator::Mangle);
@@ -627,10 +622,6 @@ bool PSScavenge::invoke_no_policy() {
 #if COMPILER2_OR_JVMCI
     DerivedPointerTable::update_pointers();
 #endif
-
-    if (VerifyRememberedSets) {
-      heap->card_table()->verify_all_young_refs_imprecise();
-    }
 
     if (log_is_enabled(Debug, gc, heap, exit)) {
       accumulated_time()->stop();

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -494,9 +494,6 @@
   product(bool, UseCondCardMark, false,                                     \
           "Check for already marked card before updating card table")       \
                                                                             \
-  product(bool, VerifyRememberedSets, false, DIAGNOSTIC,                    \
-          "Verify GC remembered sets")                                      \
-                                                                            \
   product(bool, DisableExplicitGC, false,                                   \
           "Ignore calls to System.gc()")                                    \
                                                                             \

--- a/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
+++ b/test/hotspot/jtreg/gc/g1/TestVerificationInConcurrentCycle.java
@@ -36,7 +36,6 @@ package gc.g1;
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
  *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
- *   -XX:+VerifyRememberedSets
  *   -XX:+G1VerifyBitmaps
  *   gc.g1.TestVerificationInConcurrentCycle
  */
@@ -55,7 +54,6 @@ package gc.g1;
  *   -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
  *   -XX:+VerifyBeforeGC -XX:+VerifyDuringGC -XX:+VerifyAfterGC
  *   -XX:+UseG1GC -XX:+G1VerifyHeapRegionCodeRoots
- *   -XX:+VerifyRememberedSets
  *   gc.g1.TestVerificationInConcurrentCycle
  */
 


### PR DESCRIPTION
Simple removing a gc verification flag. The resulting structure is consistent with the one in Serial.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331175](https://bugs.openjdk.org/browse/JDK-8331175): Parallel: Remove VerifyRememberedSets (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18968/head:pull/18968` \
`$ git checkout pull/18968`

Update a local copy of the PR: \
`$ git checkout pull/18968` \
`$ git pull https://git.openjdk.org/jdk.git pull/18968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18968`

View PR using the GUI difftool: \
`$ git pr show -t 18968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18968.diff">https://git.openjdk.org/jdk/pull/18968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18968#issuecomment-2079014292)