### PR TITLE
8278255: Add more warning text in ReentrantLock and ReentrantReadWriteLock

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/Lock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/Lock.java
@@ -80,11 +80,11 @@ import java.util.concurrent.TimeUnit;
  *
  * <pre> {@code
  * Lock l = ...;
- * l.lock();
+ * l.lock(); // lock() as the last statement before the try block
  * try {
  *   // access the resource protected by this lock
  * } finally {
- *   l.unlock();
+ *   l.unlock(); // unlock() as the first statement in the finally block
  * }}</pre>
  *
  * When locking and unlocking occur in different scopes, care must be

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantLock.java
@@ -71,8 +71,9 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  * is available even if other threads are waiting.
  *
  * <p>It is recommended practice to <em>always</em> immediately
- * follow a call to {@code lock} with a {@code try} block, most
- * typically in a before/after construction such as:
+ * follow a call to {@code lock} with a {@code try} block, and
+ * to <em>always</em> immediately call {@code unlock} as the
+ * first statement in the finally block, as follows:
  *
  * <pre> {@code
  * class X {
@@ -80,11 +81,11 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *   // ...
  *
  *   public void m() {
- *     lock.lock();  // block until condition holds
+ *     lock.lock();  // lock() as the last statement before the try block
  *     try {
  *       // ... method body
  *     } finally {
- *       lock.unlock();
+ *       lock.unlock(); // unlock() as the first statement in the finally block
  *     }
  *   }
  * }}</pre>

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -159,7 +159,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *         rwl.writeLock().unlock(); // Unlock write, still hold read
  *       }
  *     }
- *     // Make sure that code which could throw is executed inside the try block
+ *     // Make sure that code that could throw is executed inside the try block
  *     try {
  *       use(data);
  *     } finally {

--- a/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/ReentrantReadWriteLock.java
@@ -141,6 +141,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *
  *   void processCachedData() {
  *     rwl.readLock().lock();
+ *     // Code between the lock() above, and the unlock() below must not throw
  *     if (!cacheValid) {
  *       // Must release read lock before acquiring write lock
  *       rwl.readLock().unlock();
@@ -158,7 +159,7 @@ import jdk.internal.vm.annotation.ReservedStackAccess;
  *         rwl.writeLock().unlock(); // Unlock write, still hold read
  *       }
  *     }
- *
+ *     // Make sure that code which could throw is executed inside the try block
  *     try {
  *       use(data);
  *     } finally {


### PR DESCRIPTION
This is an attempt to be more clear about recommendations on Lock usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8278255](https://bugs.openjdk.org/browse/JDK-8278255): Add more warning text in ReentrantLock and ReentrantReadWriteLock (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18974/head:pull/18974` \
`$ git checkout pull/18974`

Update a local copy of the PR: \
`$ git checkout pull/18974` \
`$ git pull https://git.openjdk.org/jdk.git pull/18974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18974`

View PR using the GUI difftool: \
`$ git pr show -t 18974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18974.diff">https://git.openjdk.org/jdk/pull/18974.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18974#issuecomment-2079232270)