### PR TITLE
8331167: UBSan enabled build fails in adlc on macOS

### DIFF
--- a/src/hotspot/share/adlc/adlparse.cpp
+++ b/src/hotspot/share/adlc/adlparse.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -5225,7 +5225,7 @@ void ADLParser::skipws_common(bool do_preproc) {
     if (*_ptr == '\n') {                   // keep proper track of new lines
       if (!do_preproc)  break;             // let caller handle the newline
       next_line();
-      _ptr = _curline; next = _ptr + 1;
+      _ptr = _curline; if (_ptr != nullptr) next = _ptr + 1;
     }
     else if ((*_ptr == '/') && (*next == '/'))      // C++ comment
       do { _ptr++; next++; } while(*_ptr != '\n');  // So go to end of line


### PR DESCRIPTION
When configuring with '--enable-ubsan' (https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) and doing a macOS x86_64 fastdebug build, I run into this build error after very short time :
jdk/src/hotspot/share/adlc/adlparse.cpp:5228:36: runtime error: applying non-zero offset 1 to null pointer
    #0 0x103fa4b4b in ADLParser::skipws_common(bool) adlparse.cpp:5228
    #1 0x103f76aed in ADLParser::skipws() adlparse.hpp:271
    #2 0x103f763c6 in ADLParser::parse() adlparse.cpp:95
    #3 0x10407054d in main main.cpp:178
    #4 0x7fff2044ef3c in start+0x0 (libdyld.dylib:x86_64+0x15f3c)

So it seems that UBSan support is currently not working well on macOS because the build fails early.  Seems we add 1 to a nullptr in the adlc code in some cases and UBSAN complains about it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331167](https://bugs.openjdk.org/browse/JDK-8331167): UBSan enabled build fails in adlc on macOS (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18976/head:pull/18976` \
`$ git checkout pull/18976`

Update a local copy of the PR: \
`$ git checkout pull/18976` \
`$ git pull https://git.openjdk.org/jdk.git pull/18976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18976`

View PR using the GUI difftool: \
`$ git pr show -t 18976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18976.diff">https://git.openjdk.org/jdk/pull/18976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18976#issuecomment-2079267931)