### PR TITLE
8331196: vector api: Remove unnecessary index check in Byte/ShortVector.fromArray/fromArray0Template

### DIFF
--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -3064,12 +3064,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
         }
 
         // Check indices are within array bounds.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, null, byte.class, vsp.laneCount(),
@@ -3821,12 +3819,10 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
         // Check indices are within array bounds.
         // FIXME: Check index under mask controlling.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, maskClass, byte.class, vsp.laneCount(),

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -3065,12 +3065,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
         }
 
         // Check indices are within array bounds.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, null, short.class, vsp.laneCount(),
@@ -3807,12 +3805,10 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
         // Check indices are within array bounds.
         // FIXME: Check index under mask controlling.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, maskClass, short.class, vsp.laneCount(),

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -3637,12 +3637,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
         }
 
         // Check indices are within array bounds.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, null, $type$.class, vsp.laneCount(),
@@ -4838,12 +4836,10 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
         // Check indices are within array bounds.
         // FIXME: Check index under mask controlling.
-        for (int i = 0; i < vsp.length(); i += lsp.length()) {
-            IntVector vix = IntVector
-                .fromArray(lsp, indexMap, mapOffset + i)
-                .add(offset);
-            VectorIntrinsics.checkIndex(vix, a.length);
-        }
+        IntVector vix = IntVector
+            .fromArray(lsp, indexMap, mapOffset)
+            .add(offset);
+        VectorIntrinsics.checkIndex(vix, a.length);
 
         return VectorSupport.loadWithMap(
             vectorType, maskClass, $type$.class, vsp.laneCount(),


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
Some index check in Byte/ShortVector.fromArray/fromArray0Template seems not necessary, could be removed.
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8331196: vector api: Remove unnecessary index check in Byte/ShortVector.fromArray/fromArray0Template`

### Issue
 * [JDK-8331196](https://bugs.openjdk.org/browse/JDK-8331196): vector api: Remove unnecessary index check in Byte/ShortVector.fromArray/fromArray0Template (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18977/head:pull/18977` \
`$ git checkout pull/18977`

Update a local copy of the PR: \
`$ git checkout pull/18977` \
`$ git pull https://git.openjdk.org/jdk.git pull/18977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18977`

View PR using the GUI difftool: \
`$ git pr show -t 18977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18977.diff">https://git.openjdk.org/jdk/pull/18977.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18977#issuecomment-2079492003)