### PR TITLE
8319957: PhaseOutput::code_size is unused and should be removed

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1280,7 +1280,6 @@ void PhaseOutput::estimate_buffer_size(int& const_req) {
   }
 
   // Compute prolog code size
-  _method_size = 0;
   _frame_slots = OptoReg::reg2stack(C->matcher()->_old_SP) + C->regalloc()->_framesize;
   assert(_frame_slots >= 0 && _frame_slots < 1000000, "sanity check");
 

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -77,7 +77,6 @@ public:
 class PhaseOutput : public Phase {
 private:
   // Instruction bits passed off to the VM
-  int                    _method_size;           // Size of nmethod code segment in bytes
   CodeBuffer             _code_buffer;           // Where the code is assembled
   int                    _first_block_size;      // Size of unvalidated entry point code / OSR poison code
   ExceptionHandlerTable  _handler_table;         // Table of native-code exception handlers
@@ -166,7 +165,6 @@ public:
   void install();
 
   // Instruction bits passed off to the VM
-  int               code_size()                 { return _method_size; }
   CodeBuffer*       code_buffer()               { return &_code_buffer; }
   int               first_block_size()          { return _first_block_size; }
   void              set_frame_complete(int off) { if (!in_scratch_emit_size()) { _code_offsets.set_value(CodeOffsets::Frame_Complete, off); } }


### PR DESCRIPTION
Hi all, 

This PR removes the unused ```PhaseOutput::code_size / method_size```.

These were moved over from ```src/hotspot/share/opto/compile.hpp``` in the refactor from [8240363](https://bugs.openjdk.org/browse/JDK-8240363). Here's the git link for reference https://github.com/openjdk/jdk/commit/21cd75cb98f658639df14632680e9c5e58f11faa.

I also checked whether there were any usages prior to the refactor and couldn’t find anything so I think it’s safe to remove it. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319957](https://bugs.openjdk.org/browse/JDK-8319957): PhaseOutput::code_size is unused and should be removed (**Enhancement** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18981/head:pull/18981` \
`$ git checkout pull/18981`

Update a local copy of the PR: \
`$ git checkout pull/18981` \
`$ git pull https://git.openjdk.org/jdk.git pull/18981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18981`

View PR using the GUI difftool: \
`$ git pr show -t 18981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18981.diff">https://git.openjdk.org/jdk/pull/18981.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18981#issuecomment-2079819268)