### PR TITLE
8326085: Remove unnecessary UpcallContext constructor

### DIFF
--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -48,7 +48,6 @@ extern struct JavaVM_ main_vm;
 struct UpcallContext {
   Thread* attachedThread;
 
-  UpcallContext() {} // Explicit constructor to address XL C compiler bug.
   ~UpcallContext() {
     if (attachedThread != nullptr) {
       JavaVM_ *vm = (JavaVM *)(&main_vm);


### PR DESCRIPTION
Hi all, 

This PR removes the explicit constructor to UpcallContext (hotspot/share/prims/upcallLinker.cpp) that was added as workaround for [8286891](https://bugs.openjdk.org/browse/JDK-8286891). 

The minimum required version of XLC has since been bumped in [8325880](https://bugs.openjdk.org/browse/JDK-8325880), so we can remove this. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326085](https://bugs.openjdk.org/browse/JDK-8326085): Remove unnecessary UpcallContext constructor (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18982/head:pull/18982` \
`$ git checkout pull/18982`

Update a local copy of the PR: \
`$ git checkout pull/18982` \
`$ git pull https://git.openjdk.org/jdk.git pull/18982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18982`

View PR using the GUI difftool: \
`$ git pr show -t 18982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18982.diff">https://git.openjdk.org/jdk/pull/18982.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18982#issuecomment-2083356810)