### PR TITLE
8331207: Misleading example in DateFormat#parse docs

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -407,7 +407,8 @@ public abstract class DateFormat extends Format {
 
     /**
      * Parse a date/time string according to the given parse position.  For
-     * example, a time text {@code "07/10/96 4:5 PM, PDT"} will be parsed into a {@code Date}
+     * example, if {@code this} has the pattern "M/d/yy, h:mm&#160;a",
+     * then a time text "7/10/96, 4:05&#160;PM" will be parsed into a {@code Date}
      * that is equivalent to {@code Date(837039900000L)}.
      *
      * <p> By default, parsing is lenient: If the input is not in the form used

--- a/src/java.base/share/classes/java/text/DateFormat.java
+++ b/src/java.base/share/classes/java/text/DateFormat.java
@@ -407,8 +407,8 @@ public abstract class DateFormat extends Format {
 
     /**
      * Parse a date/time string according to the given parse position.  For
-     * example, if {@code this} has the pattern "M/d/yy, h:mm&#160;a",
-     * then a time text "7/10/96, 4:05&#160;PM" will be parsed into a {@code Date}
+     * example, if {@code this} has the pattern {@code "M/d/yy h:m a, z"},
+     * then a time text {@code "07/10/96 4:5 PM, PDT"} will be parsed into a {@code Date}
      * that is equivalent to {@code Date(837039900000L)}.
      *
      * <p> By default, parsing is lenient: If the input is not in the form used


### PR DESCRIPTION
Correct a misleading example in the DateFormat parse documentation. 

Common usage is to use a factory instance. The original example provided assumes a pattern provided by a COMPAT factory instance.

The pattern itself should be explicitly provided, since users may be using CLDR factory instances.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331207](https://bugs.openjdk.org/browse/JDK-8331207): Misleading example in DateFormat#parse docs (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18983/head:pull/18983` \
`$ git checkout pull/18983`

Update a local copy of the PR: \
`$ git checkout pull/18983` \
`$ git pull https://git.openjdk.org/jdk.git pull/18983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18983`

View PR using the GUI difftool: \
`$ git pr show -t 18983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18983.diff">https://git.openjdk.org/jdk/pull/18983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18983#issuecomment-2079835190)