### PR TITLE
8330852: All callers of JvmtiEnvBase::get_threadOop_and_JavaThread should pass current thread explicitly

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -158,7 +158,7 @@ JvmtiEnv::SetThreadLocalStorage(jthread thread, const void* data) {
     java_thread = current;
     state = java_thread->jvmti_thread_state();
   } else {
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -207,7 +207,7 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
 
     JavaThread* java_thread = nullptr;
     oop thread_obj = nullptr;
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -586,11 +586,12 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
     JvmtiEventController::set_user_enabled(this, nullptr, (oop) nullptr, event_type, enabled);
   } else {
     // We have a specified event_thread.
-    ThreadsListHandle tlh;
+    JavaThread* current_thread = JavaThread::current();
+    ThreadsListHandle tlh(current_thread);
 
     JavaThread* java_thread = nullptr;
     oop thread_obj = nullptr;
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, current_thread, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -861,7 +862,7 @@ JvmtiEnv::GetThreadState(jthread thread, jint* thread_state_ptr) {
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_THREAD_NOT_ALIVE) {
     // We got an error code so we don't have a JavaThread*, but only
     // return an error from here if the error is not because the thread
@@ -933,7 +934,7 @@ JvmtiEnv::SuspendThread(jthread thread) {
     JavaThread* java_thread = nullptr;
     oop thread_oop = nullptr;
 
-    err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+    err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -1075,11 +1076,12 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
 jvmtiError
 JvmtiEnv::ResumeThread(jthread thread) {
   JvmtiVTMSTransitionDisabler disabler(true);
-  ThreadsListHandle tlh;
+  JavaThread* current_thread = JavaThread::current();
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -1183,7 +1185,7 @@ JvmtiEnv::StopThread(jthread thread, jobject exception) {
 
   NULL_CHECK(thread, JVMTI_ERROR_INVALID_THREAD);
 
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
 
   bool is_virtual = thread_oop != nullptr && thread_oop->is_a(vmClasses::BaseVirtualThread_klass());
 
@@ -1219,7 +1221,7 @@ JvmtiEnv::InterruptThread(jthread thread) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -1357,7 +1359,7 @@ JvmtiEnv::GetOwnedMonitorInfo(jthread thread, jint* owned_monitor_count_ptr, job
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, calling_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     delete owned_monitors_list;
     return err;
@@ -1415,7 +1417,7 @@ JvmtiEnv::GetOwnedMonitorStackDepthInfo(jthread thread, jint* monitor_info_count
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, calling_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     delete owned_monitors_list;
     return err;
@@ -1730,7 +1732,7 @@ JvmtiEnv::PopFrame(jthread thread) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   Handle thread_handle(current_thread, thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
@@ -1781,11 +1783,12 @@ jvmtiError
 JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   ResourceMark rm;
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh;
+  JavaThread* current_thread = JavaThread::current();
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2047,7 +2050,7 @@ JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_p
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2088,7 +2091,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2130,7 +2133,7 @@ JvmtiEnv::GetLocalInt(jthread thread, jint depth, jint slot, jint* value_ptr) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2172,7 +2175,7 @@ JvmtiEnv::GetLocalLong(jthread thread, jint depth, jint slot, jlong* value_ptr) 
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2214,7 +2217,7 @@ JvmtiEnv::GetLocalFloat(jthread thread, jint depth, jint slot, jfloat* value_ptr
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2256,7 +2259,7 @@ JvmtiEnv::GetLocalDouble(jthread thread, jint depth, jint slot, jdouble* value_p
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2297,7 +2300,7 @@ JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2334,7 +2337,7 @@ JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2371,7 +2374,7 @@ JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2408,7 +2411,7 @@ JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2445,7 +2448,7 @@ JvmtiEnv::SetLocalDouble(jthread thread, jint depth, jint slot, jdouble value) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -3714,7 +3717,7 @@ JvmtiEnv::GetThreadCpuTime(jthread thread, jlong* nanos_ptr) {
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
 
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
 
   if (thread_oop != nullptr && thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -197,7 +197,7 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
     // other than the current thread is required we need to transition
     // from native so as to resolve the jthread.
 
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current);
     VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current)
     debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -197,7 +197,7 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
     // other than the current thread is required we need to transition
     // from native so as to resolve the jthread.
 
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current));
     ThreadInVMfromNative __tiv(current);
     VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current)
     debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -586,12 +586,12 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
     JvmtiEventController::set_user_enabled(this, nullptr, (oop) nullptr, event_type, enabled);
   } else {
     // We have a specified event_thread.
-    JavaThread* current_thread = JavaThread::current();
-    ThreadsListHandle tlh(current_thread);
+    JavaThread* current = JavaThread::current();
+    ThreadsListHandle tlh(current);
 
     JavaThread* java_thread = nullptr;
     oop thread_obj = nullptr;
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, current_thread, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, current, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -1076,12 +1076,12 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
 jvmtiError
 JvmtiEnv::ResumeThread(jthread thread) {
   JvmtiVTMSTransitionDisabler disabler(true);
-  JavaThread* current_thread = JavaThread::current();
-  ThreadsListHandle tlh(current_thread);
+  JavaThread* current = JavaThread::current();
+  ThreadsListHandle tlh(current);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -1783,17 +1783,16 @@ jvmtiError
 JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   ResourceMark rm;
   JvmtiVTMSTransitionDisabler disabler(thread);
-  JavaThread* current_thread = JavaThread::current();
-  ThreadsListHandle tlh(current_thread);
+  JavaThread* current = JavaThread::current();
+  ThreadsListHandle tlh(current);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
 
-  JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle thread_handle(current, thread_obj);
   JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_handle);

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -186,9 +186,9 @@ JvmtiEnv::SetThreadLocalStorage(jthread thread, const void* data) {
 // data_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   if (thread == nullptr) {
-    JvmtiThreadState* state = current->jvmti_thread_state();
+    JvmtiThreadState* state = current_thread->jvmti_thread_state();
     *data_ptr = (state == nullptr) ? nullptr :
       state->env_thread_state(this)->get_agent_thread_local_storage_data();
   } else {
@@ -198,22 +198,22 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
     // from native so as to resolve the jthread.
 
     MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
-    ThreadInVMfromNative __tiv(current);
-    VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current)
+    ThreadInVMfromNative __tiv(current_thread);
+    VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current_thread)
     debug_only(VMNativeEntryWrapper __vew;)
 
     JvmtiVTMSTransitionDisabler disabler(thread);
-    ThreadsListHandle tlh(current);
+    ThreadsListHandle tlh(current_thread);
 
     JavaThread* java_thread = nullptr;
     oop thread_obj = nullptr;
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
 
-    HandleMark hm(current);
-    Handle thread_handle(current, thread_obj);
+    HandleMark hm(current_thread);
+    Handle thread_handle(current_thread, thread_obj);
     JvmtiThreadState* state = JvmtiThreadState::state_for(java_thread, thread_handle);
     *data_ptr = (state == nullptr) ? nullptr :
       state->env_thread_state(this)->get_agent_thread_local_storage_data();
@@ -586,12 +586,12 @@ JvmtiEnv::SetEventNotificationMode(jvmtiEventMode mode, jvmtiEvent event_type, j
     JvmtiEventController::set_user_enabled(this, nullptr, (oop) nullptr, event_type, enabled);
   } else {
     // We have a specified event_thread.
-    JavaThread* current = JavaThread::current();
-    ThreadsListHandle tlh(current);
+    JavaThread* current_thread = JavaThread::current();
+    ThreadsListHandle tlh(current_thread);
 
     JavaThread* java_thread = nullptr;
     oop thread_obj = nullptr;
-    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, current, &java_thread, &thread_obj);
+    jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), event_thread, current_thread, &java_thread, &thread_obj);
     if (err != JVMTI_ERROR_NONE) {
       return err;
     }
@@ -856,13 +856,13 @@ JvmtiEnv::GetJLocationFormat(jvmtiJlocationFormat* format_ptr) {
 // thread_state_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetThreadState(jthread thread, jint* thread_state_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE && err != JVMTI_ERROR_THREAD_NOT_ALIVE) {
     // We got an error code so we don't have a JavaThread*, but only
     // return an error from here if the error is not because the thread
@@ -1076,12 +1076,12 @@ JvmtiEnv::SuspendAllVirtualThreads(jint except_count, const jthread* except_list
 jvmtiError
 JvmtiEnv::ResumeThread(jthread thread) {
   JvmtiVTMSTransitionDisabler disabler(true);
-  JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
+  JavaThread* current_thread = JavaThread::current();
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -1176,16 +1176,16 @@ JvmtiEnv::ResumeAllVirtualThreads(jint except_count, const jthread* except_list)
 
 jvmtiError
 JvmtiEnv::StopThread(jthread thread, jobject exception) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
 
   NULL_CHECK(thread, JVMTI_ERROR_INVALID_THREAD);
 
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
 
   bool is_virtual = thread_oop != nullptr && thread_oop->is_a(vmClasses::BaseVirtualThread_klass());
 
@@ -1213,29 +1213,29 @@ JvmtiEnv::StopThread(jthread thread, jobject exception) {
 // thread - NOT protected by ThreadsListHandle and NOT pre-checked
 jvmtiError
 JvmtiEnv::InterruptThread(jthread thread) {
-  JavaThread* current = JavaThread::current();
-  HandleMark hm(current);
+  JavaThread* current_thread  = JavaThread::current();
+  HandleMark hm(current_thread);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
     // For virtual threads we have to call into Java to interrupt:
-    Handle obj(current, thread_obj);
+    Handle obj(current_thread, thread_obj);
     JavaValue result(T_VOID);
     JavaCalls::call_virtual(&result,
                             obj,
                             vmClasses::Thread_klass(),
                             vmSymbols::interrupt_method_name(),
                             vmSymbols::void_method_signature(),
-                            current);
+                            current_thread);
 
     return JVMTI_ERROR_NONE;
   }
@@ -1347,33 +1347,33 @@ JvmtiEnv::GetThreadInfo(jthread thread, jvmtiThreadInfo* info_ptr) {
 // owned_monitors_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetOwnedMonitorInfo(jthread thread, jint* owned_monitor_count_ptr, jobject** owned_monitors_ptr) {
-  JavaThread* current = JavaThread::current();
-  HandleMark hm(current);
+  JavaThread* calling_thread = JavaThread::current();
+  HandleMark hm(calling_thread);
 
   // growable array of jvmti monitors info on the C-heap
   GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
       new (mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(calling_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, calling_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     delete owned_monitors_list;
     return err;
   }
 
   if (java_thread != nullptr) {
-    Handle thread_handle(current, thread_oop);
-    EscapeBarrier eb(true, current, java_thread);
+    Handle thread_handle(calling_thread, thread_oop);
+    EscapeBarrier eb(true, calling_thread, java_thread);
     if (!eb.deoptimize_objects(MaxJavaStackTraceDepth)) {
       delete owned_monitors_list;
       return JVMTI_ERROR_OUT_OF_MEMORY;
     }
     // get owned monitors info with handshake
-    GetOwnedMonitorInfoClosure op(this, current, owned_monitors_list);
+    GetOwnedMonitorInfoClosure op(this, calling_thread, owned_monitors_list);
     JvmtiHandshake::execute(&op, &tlh, java_thread, thread_handle);
     err = op.result();
   }
@@ -1405,33 +1405,33 @@ JvmtiEnv::GetOwnedMonitorInfo(jthread thread, jint* owned_monitor_count_ptr, job
 // monitor_info_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetOwnedMonitorStackDepthInfo(jthread thread, jint* monitor_info_count_ptr, jvmtiMonitorStackDepthInfo** monitor_info_ptr) {
-  JavaThread* current = JavaThread::current();
-  HandleMark hm(current);
+  JavaThread* calling_thread = JavaThread::current();
+  HandleMark hm(calling_thread);
 
   // growable array of jvmti monitors info on the C-heap
   GrowableArray<jvmtiMonitorStackDepthInfo*> *owned_monitors_list =
          new (mtServiceability) GrowableArray<jvmtiMonitorStackDepthInfo*>(1, mtServiceability);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(calling_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, calling_thread, &java_thread, &thread_oop);
   if (err != JVMTI_ERROR_NONE) {
     delete owned_monitors_list;
     return err;
   }
 
   if (java_thread != nullptr) {
-    Handle thread_handle(current, thread_oop);
-    EscapeBarrier eb(true, current, java_thread);
+    Handle thread_handle(calling_thread, thread_oop);
+    EscapeBarrier eb(true, calling_thread, java_thread);
     if (!eb.deoptimize_objects(MaxJavaStackTraceDepth)) {
       delete owned_monitors_list;
       return JVMTI_ERROR_OUT_OF_MEMORY;
     }
     // get owned monitors info with handshake
-    GetOwnedMonitorInfoClosure op(this, current, owned_monitors_list);
+    GetOwnedMonitorInfoClosure op(this, calling_thread, owned_monitors_list);
     JvmtiHandshake::execute(&op, &tlh, java_thread, thread_handle);
     err = op.result();
   }
@@ -1721,24 +1721,24 @@ JvmtiEnv::GetFrameCount(jthread thread, jint* count_ptr) {
 // thread - NOT protected by ThreadsListHandle and NOT pre-checked
 jvmtiError
 JvmtiEnv::PopFrame(jthread thread) {
-  JavaThread* current = JavaThread::current();
-  HandleMark hm(current);
+  JavaThread* current_thread = JavaThread::current();
+  HandleMark hm(current_thread);
 
   if (thread == nullptr) {
     return JVMTI_ERROR_INVALID_THREAD;
   }
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
-  Handle thread_handle(current, thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
+  Handle thread_handle(current_thread, thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
-  bool self = java_thread == current;
+  bool self = java_thread == current_thread;
 
   err = check_non_suspended_or_opaque_frame(java_thread, thread_obj, self);
   if (err != JVMTI_ERROR_NONE) {
@@ -1752,7 +1752,7 @@ JvmtiEnv::PopFrame(jthread thread) {
   }
 
   // Eagerly reallocate scalar replaced objects.
-  EscapeBarrier eb(true, current, java_thread);
+  EscapeBarrier eb(true, current_thread, java_thread);
   if (!eb.deoptimize_objects(1)) {
     // Reallocation of scalar replaced objects failed -> return with error
     return JVMTI_ERROR_OUT_OF_MEMORY;
@@ -1783,16 +1783,17 @@ jvmtiError
 JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
   ResourceMark rm;
   JvmtiVTMSTransitionDisabler disabler(thread);
-  JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
+  JavaThread* current_thread = JavaThread::current();
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
 
+  JavaThread* current = JavaThread::current();
   HandleMark hm(current);
   Handle thread_handle(current, thread_obj);
   JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_handle);
@@ -2039,25 +2040,25 @@ JvmtiEnv::IterateOverInstancesOfClass(oop k_mirror, jvmtiHeapObjectFilter object
 // value_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
-                                     current, depth, slot, self);
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
+                                     current_thread, depth, slot, self);
     VMThread::execute(&op);
     err = op.result();
     if (err == JVMTI_ERROR_NONE) {
@@ -2065,7 +2066,7 @@ JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_p
     }
   } else {
     // Support for ordinary threads
-    VM_GetOrSetLocal op(java_thread, current, depth, slot, self);
+    VM_GetOrSetLocal op(java_thread, current_thread, depth, slot, self);
     VMThread::execute(&op);
     err = op.result();
     if (err == JVMTI_ERROR_NONE) {
@@ -2080,25 +2081,25 @@ JvmtiEnv::GetLocalObject(jthread thread, jint depth, jint slot, jobject* value_p
 // value - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetReceiver op(this, Handle(current, thread_obj),
-                                   current, depth, self);
+    VM_VirtualThreadGetReceiver op(this, Handle(current_thread, thread_obj),
+                                   current_thread, depth, self);
     VMThread::execute(&op);
     err = op.result();
     if (err == JVMTI_ERROR_NONE) {
@@ -2106,7 +2107,7 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
     }
   } else {
     // Support for ordinary threads
-    VM_GetReceiver op(java_thread, current, depth, self);
+    VM_GetReceiver op(java_thread, current_thread, depth, self);
     VMThread::execute(&op);
     err = op.result();
     if (err == JVMTI_ERROR_NONE) {
@@ -2122,24 +2123,24 @@ JvmtiEnv::GetLocalInstance(jthread thread, jint depth, jobject* value_ptr){
 // value_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalInt(jthread thread, jint depth, jint slot, jint* value_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2164,24 +2165,24 @@ JvmtiEnv::GetLocalInt(jthread thread, jint depth, jint slot, jint* value_ptr) {
 // value_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalLong(jthread thread, jint depth, jint slot, jlong* value_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2206,24 +2207,24 @@ JvmtiEnv::GetLocalLong(jthread thread, jint depth, jint slot, jlong* value_ptr) 
 // value_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalFloat(jthread thread, jint depth, jint slot, jfloat* value_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2248,24 +2249,24 @@ JvmtiEnv::GetLocalFloat(jthread thread, jint depth, jint slot, jfloat* value_ptr
 // value_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetLocalDouble(jthread thread, jint depth, jint slot, jdouble* value_ptr) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
   bool self = is_JavaThread_current(java_thread, thread_obj);
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2289,17 +2290,17 @@ JvmtiEnv::GetLocalDouble(jthread thread, jint depth, jint slot, jdouble* value_p
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2308,7 +2309,7 @@ JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
   val.l = value;
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_OBJECT, val, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2326,17 +2327,17 @@ JvmtiEnv::SetLocalObject(jthread thread, jint depth, jint slot, jobject value) {
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2345,7 +2346,7 @@ JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
   val.i = value;
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_INT, val, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2363,17 +2364,17 @@ JvmtiEnv::SetLocalInt(jthread thread, jint depth, jint slot, jint value) {
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2382,7 +2383,7 @@ JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
   val.j = value;
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_LONG, val, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2400,17 +2401,17 @@ JvmtiEnv::SetLocalLong(jthread thread, jint depth, jint slot, jlong value) {
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2419,7 +2420,7 @@ JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
   val.f = value;
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_FLOAT, val, self);
     VMThread::execute(&op);
     err = op.result();
@@ -2437,17 +2438,17 @@ JvmtiEnv::SetLocalFloat(jthread thread, jint depth, jint slot, jfloat value) {
 // depth - pre-checked as non-negative
 jvmtiError
 JvmtiEnv::SetLocalDouble(jthread thread, jint depth, jint slot, jdouble value) {
-  JavaThread* current = JavaThread::current();
+  JavaThread* current_thread = JavaThread::current();
   // rm object is created to clean up the javaVFrame created in
   // doit_prologue(), but after doit() is finished with it.
-  ResourceMark rm(current);
-  HandleMark hm(current);
+  ResourceMark rm(current_thread);
+  HandleMark hm(current_thread);
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
@@ -2456,7 +2457,7 @@ JvmtiEnv::SetLocalDouble(jthread thread, jint depth, jint slot, jdouble value) {
   val.d = value;
 
   if (java_lang_VirtualThread::is_instance(thread_obj)) {
-    VM_VirtualThreadGetOrSetLocal op(this, Handle(current, thread_obj),
+    VM_VirtualThreadGetOrSetLocal op(this, Handle(current_thread, thread_obj),
                                      depth, slot, T_DOUBLE, val, self);
     VMThread::execute(&op);
     err = op.result();
@@ -3711,12 +3712,12 @@ JvmtiEnv::GetThreadCpuTimerInfo(jvmtiTimerInfo* info_ptr) {
 // nanos_ptr - pre-checked for null
 jvmtiError
 JvmtiEnv::GetThreadCpuTime(jthread thread, jlong* nanos_ptr) {
-  JavaThread* current = JavaThread::current();
-  ThreadsListHandle tlh(current);
+  JavaThread* current_thread = JavaThread::current();
+  ThreadsListHandle tlh(current_thread);
   JavaThread* java_thread = nullptr;
   oop thread_oop = nullptr;
 
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_oop);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_oop);
 
   if (thread_oop != nullptr && thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
     // No support for virtual threads (yet).

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2161,21 +2161,21 @@ JvmtiEnvBase::check_top_frame(Thread* current_thread, JavaThread* java_thread,
 
 jvmtiError
 JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
-  JavaThread* current = JavaThread::current();
-  HandleMark hm(current);
+  JavaThread* current_thread = JavaThread::current();
+  HandleMark hm(current_thread);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current);
+  ThreadsListHandle tlh(current_thread);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
-  Handle thread_handle(current, thread_obj);
-  bool self = java_thread == current;
+  Handle thread_handle(current_thread, thread_obj);
+  bool self = java_thread == current_thread;
 
   err = check_non_suspended_or_opaque_frame(java_thread, thread_obj, self);
   if (err != JVMTI_ERROR_NONE) {
@@ -2189,7 +2189,7 @@ JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
   }
 
   // Eagerly reallocate scalar replaced objects.
-  EscapeBarrier eb(true, current, java_thread);
+  EscapeBarrier eb(true, current_thread, java_thread);
   if (!eb.deoptimize_objects(0)) {
     // Reallocation of scalar replaced objects failed -> return with error
     return JVMTI_ERROR_OUT_OF_MEMORY;

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2161,21 +2161,21 @@ JvmtiEnvBase::check_top_frame(Thread* current_thread, JavaThread* java_thread,
 
 jvmtiError
 JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
-  JavaThread* current_thread = JavaThread::current();
-  HandleMark hm(current_thread);
+  JavaThread* current = JavaThread::current();
+  HandleMark hm(current);
 
   JvmtiVTMSTransitionDisabler disabler(thread);
-  ThreadsListHandle tlh(current_thread);
+  ThreadsListHandle tlh(current);
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
     return err;
   }
-  Handle thread_handle(current_thread, thread_obj);
-  bool self = java_thread == current_thread;
+  Handle thread_handle(current, thread_obj);
+  bool self = java_thread == current;
 
   err = check_non_suspended_or_opaque_frame(java_thread, thread_obj, self);
   if (err != JVMTI_ERROR_NONE) {
@@ -2189,7 +2189,7 @@ JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
   }
 
   // Eagerly reallocate scalar replaced objects.
-  EscapeBarrier eb(true, current_thread, java_thread);
+  EscapeBarrier eb(true, current, java_thread);
   if (!eb.deoptimize_objects(0)) {
     // Reallocation of scalar replaced objects failed -> return with error
     return JVMTI_ERROR_OUT_OF_MEMORY;

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1421,14 +1421,6 @@ JvmtiEnvBase::get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread, 
   return JVMTI_ERROR_NONE;
 }
 
-jvmtiError
-JvmtiEnvBase::get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread,
-                                           JavaThread** jt_pp, oop* thread_oop_p) {
-  JavaThread* cur_thread = JavaThread::current();
-  jvmtiError err = get_threadOop_and_JavaThread(t_list, thread, cur_thread, jt_pp, thread_oop_p);
-  return err;
-}
-
 // Check for JVMTI_ERROR_NOT_SUSPENDED and JVMTI_ERROR_OPAQUE_FRAME errors.
 // Used in PopFrame and ForceEarlyReturn implementations.
 jvmtiError
@@ -1981,7 +1973,7 @@ JvmtiHandshake::execute(JvmtiUnitedHandshakeClosure* hs_cl, jthread target) {
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
 
-  jvmtiError err = JvmtiEnvBase::get_threadOop_and_JavaThread(tlh.list(), target, &java_thread, &thread_obj);
+  jvmtiError err = JvmtiEnvBase::get_threadOop_and_JavaThread(tlh.list(), target, current, &java_thread, &thread_obj);
   if (err != JVMTI_ERROR_NONE) {
     hs_cl->set_result(err);
     return;
@@ -2177,7 +2169,7 @@ JvmtiEnvBase::force_early_return(jthread thread, jvalue value, TosState tos) {
 
   JavaThread* java_thread = nullptr;
   oop thread_obj = nullptr;
-  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, &java_thread, &thread_obj);
+  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current_thread, &java_thread, &thread_obj);
 
   if (err != JVMTI_ERROR_NONE) {
     return err;

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -216,8 +216,6 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
 
   static jvmtiError get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread, JavaThread* cur_thread,
                                                  JavaThread** jt_pp, oop* thread_oop_p);
-  static jvmtiError get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread,
-                                                 JavaThread** jt_pp, oop* thread_oop_p);
 
   // Return true if java thread is a carrier thread with a mounted virtual thread.
   static bool is_cthread_with_mounted_vthread(JavaThread* jt);


### PR DESCRIPTION
Some cleanup related to JvmtiEnvBase::get_threadOop_and_JavaThread method

Testing: tier1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330852](https://bugs.openjdk.org/browse/JDK-8330852): All callers of JvmtiEnvBase::get_threadOop_and_JavaThread should pass current thread explicitly (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18986/head:pull/18986` \
`$ git checkout pull/18986`

Update a local copy of the PR: \
`$ git checkout pull/18986` \
`$ git pull https://git.openjdk.org/jdk.git pull/18986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18986`

View PR using the GUI difftool: \
`$ git pr show -t 18986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18986.diff">https://git.openjdk.org/jdk/pull/18986.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18986#issuecomment-2080218439)