### PR TITLE
s390x: fix assertion issue

### DIFF
--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3194,7 +3194,8 @@ void MacroAssembler::compiler_fast_lock_object(Register oop, Register box, Regis
   Register displacedHeader = temp1;
   Register currentHeader = temp1;
   Register temp = temp2;
-  NearLabel done, object_has_monitor;
+  NearLabel done, object_has_monitor, success;
+  Label failure;
 
   const int hdr_offset = oopDesc::mark_offset_in_bytes();
 


### PR DESCRIPTION
while working on https://github.com/openjdk/jdk/pull/18878 I found out that in case of `DiagnoseSyncOnValueBasedClasses != 0` we are not setting the condition code correctly. And the assert fails with `"CC is not set to NE, it should be` in that PR. 

issue could be reproduced by adding this assert: 
```diff
diff --git a/src/hotspot/cpu/s390/macroAssembler_s390.cpp b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
index 224153f0e84..0fd6b62ee62 100644
--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3292,6 +3292,13 @@ void MacroAssembler::compiler_fast_lock_object(Register oop, Register box, Regis
   // If locking was successful, CR should indicate 'EQ'.
   // The compiler or the native wrapper generates a branch to the runtime call
   // _complete_monitor_locking_Java.
+#ifdef ASSERT
+  NearLabel ok;
+  z_brne(ok);
+  z_bre(ok);
+  stop("CC needs to be EQ or NE");
+  bind(ok);
+#endif // ASSERT
 }
 
 void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Register temp1, Register temp2) {
```

And running `./test/hotspot/jtreg/runtime/Monitor/SyncOnValueBasedClassTest.java` test;

So there could be two solution either we add the correct the cc in the `DiagnoseSyncOnValueBasedClasses != 0` like below or  a better solution seems to be to add CC check like we are doing in https://github.com/openjdk/jdk/pull/18878 after adding success & failure jump-labels. 
```diff
   if (DiagnoseSyncOnValueBasedClasses != 0) {
+    NearLabel set_cc, ok;
     load_klass(temp, oop);
     testbit(Address(temp, Klass::access_flags_offset()), exact_log2(JVM_ACC_IS_VALUE_BASED_CLASS));
-    z_btrue(done);
+    z_btrue(set_cc);
+    z_bru(ok);
+
+    bind(set_cc);
+    z_ltgr(oop, oop);
+    z_brne(done);
+
+    bind(ok);
   }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18987/head:pull/18987` \
`$ git checkout pull/18987`

Update a local copy of the PR: \
`$ git checkout pull/18987` \
`$ git pull https://git.openjdk.org/jdk.git pull/18987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18987`

View PR using the GUI difftool: \
`$ git pr show -t 18987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18987.diff">https://git.openjdk.org/jdk/pull/18987.diff</a>

</details>
