### PR TITLE
8312436: CompletableFuture never completes when 'Throwable.toString()' method throws Exception

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -306,13 +306,57 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         return RESULT.compareAndSet(this, null, (t == null) ? NIL : t);
     }
 
+    static CompletionException wrapInCompletionException(Throwable t) {
+        if (t == null)
+            return new CompletionException();
+
+        String message;
+        Throwable suppressed;
+        try {
+            message = t.toString();
+            suppressed = null;
+        } catch (Throwable unknown) {
+            message = "";
+            suppressed = unknown;
+        }
+
+        final CompletionException wrapping = new CompletionException(message, t);
+
+        if (suppressed != null)
+            wrapping.addSuppressed(suppressed);
+
+        return wrapping;
+    }
+
+    static ExecutionException wrapInExecutionException(Throwable t) {
+        if (t == null)
+            return new ExecutionException();
+
+        String message;
+        Throwable suppressed;
+        try {
+            message = t.toString();
+            suppressed = null;
+        } catch (Throwable unknown) {
+            message = "";
+            suppressed = unknown;
+        }
+
+        final ExecutionException wrapping = new ExecutionException(message, t);
+
+        if (suppressed != null)
+            wrapping.addSuppressed(suppressed);
+
+        return wrapping;
+    }
+
     /**
      * Returns the encoding of the given (non-null) exception as a
      * wrapped CompletionException unless it is one already.
      */
     static AltResult encodeThrowable(Throwable x) {
         return new AltResult((x instanceof CompletionException) ? x :
-                             new CompletionException(x));
+                wrapInCompletionException(x));
     }
 
     /** Completes with an exceptional result, unless already completed. */
@@ -329,7 +373,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
      */
     static Object encodeThrowable(Throwable x, Object r) {
         if (!(x instanceof CompletionException))
-            x = new CompletionException(x);
+            x = wrapInCompletionException(x);
         else if (r instanceof AltResult && x == ((AltResult)r).ex)
             return r;
         return new AltResult(x);
@@ -365,7 +409,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         if (r instanceof AltResult
             && (x = ((AltResult)r).ex) != null
             && !(x instanceof CompletionException))
-            r = new AltResult(new CompletionException(x));
+            r = new AltResult(wrapInCompletionException(x));
         return r;
     }
 
@@ -393,7 +437,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x instanceof CompletionException) &&
                 (cause = x.getCause()) != null)
                 x = cause;
-            throw new ExecutionException(x);
+            throw wrapInExecutionException(x);
         }
         return r;
     }
@@ -410,7 +454,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
                 throw (CancellationException)x;
             if (x instanceof CompletionException)
                 throw (CompletionException)x;
-            throw new CompletionException(x);
+            throw wrapInCompletionException(x);
         }
         return r;
     }
@@ -2605,8 +2649,8 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     /**
      * Returns a string identifying this CompletableFuture, as well as
      * its completion state.  The state, in brackets, contains the
-     * String {@code "Completed Normally"} or the String {@code
-     * "Completed Exceptionally"}, or the String {@code "Not
+     * String {@code "Completed normally"} or the String {@code
+     * "Completed exceptionally"}, or the String {@code "Not
      * completed"} followed by the number of CompletableFutures
      * dependent upon its completion, if any.
      *
@@ -2623,7 +2667,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
                 ? "[Not completed]"
                 : "[Not completed, " + count + " dependents]")
              : (((r instanceof AltResult) && ((AltResult)r).ex != null)
-                ? "[Completed exceptionally: " + ((AltResult)r).ex + "]"
+                ? "[Completed exceptionally: " + ((AltResult)r).ex.getClass().getName() + "]"
                 : "[Completed normally]"));
     }
 

--- a/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
+++ b/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
@@ -80,7 +80,14 @@ public class CompletableFutureTest extends JSR166TestCase {
         return new TestSuite(CompletableFutureTest.class);
     }
 
-    static class CFException extends RuntimeException {}
+    static class CFException extends RuntimeException {
+        // This makes sure that CompletableFuture still behaves appropriately
+        // even if thrown exceptions end up throwing exceptions from their String
+        // representations.
+        @Override public String getMessage() {
+            throw new IllegalStateException("malformed");
+        }
+    }
 
     void checkIncomplete(CompletableFuture<?> f) {
         assertFalse(f.isDone());
@@ -259,8 +266,8 @@ public class CompletableFutureTest extends JSR166TestCase {
      */
     public void testCompleteExceptionally() {
         CompletableFuture<Item> f = new CompletableFuture<>();
-        CFException ex = new CFException();
         checkIncomplete(f);
+        CFException ex = new CFException();
         f.completeExceptionally(ex);
         checkCompletedExceptionally(f, ex);
     }
@@ -5129,5 +5136,4 @@ public class CompletableFutureTest extends JSR166TestCase {
         checkCompletedWithWrappedException(g.toCompletableFuture(), r.ex);
         r.assertInvoked();
     }}
-
 }


### PR DESCRIPTION
Primarily offering this PR for discussion, as Throwables throwing exceptions on toString(), getLocalizedMessage(), or getMessage() seems like a rather unreasonable thing to do.

Nevertheless, there is some things we can do, as witnessed in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312436](https://bugs.openjdk.org/browse/JDK-8312436): CompletableFuture never completes when 'Throwable.toString()' method throws Exception (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18988/head:pull/18988` \
`$ git checkout pull/18988`

Update a local copy of the PR: \
`$ git checkout pull/18988` \
`$ git pull https://git.openjdk.org/jdk.git pull/18988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18988`

View PR using the GUI difftool: \
`$ git pr show -t 18988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18988.diff">https://git.openjdk.org/jdk/pull/18988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18988#issuecomment-2104734563)