### PR TITLE
Reduce calls to `MethodHandles.lookup()` in `FallbackLinker`

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -63,10 +63,11 @@ public final class FallbackLinker extends AbstractLinker {
     private static final MethodHandle MH_DO_UPCALL;
 
     static {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
         try {
-            MH_DO_DOWNCALL = MethodHandles.lookup().findStatic(FallbackLinker.class, "doDowncall",
+            MH_DO_DOWNCALL = lookup.findStatic(FallbackLinker.class, "doDowncall",
                     MethodType.methodType(Object.class, SegmentAllocator.class, Object[].class, FallbackLinker.DowncallData.class));
-            MH_DO_UPCALL = MethodHandles.lookup().findStatic(FallbackLinker.class, "doUpcall",
+            MH_DO_UPCALL = lookup.findStatic(FallbackLinker.class, "doUpcall",
                     MethodType.methodType(void.class, MethodHandle.class, MemorySegment.class, MemorySegment.class, UpcallData.class));
         } catch (ReflectiveOperationException e) {
             throw new ExceptionInInitializerError(e);


### PR DESCRIPTION
It can be stored in a local variable instead, reducing calls to the method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18990/head:pull/18990` \
`$ git checkout pull/18990`

Update a local copy of the PR: \
`$ git checkout pull/18990` \
`$ git pull https://git.openjdk.org/jdk.git pull/18990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18990`

View PR using the GUI difftool: \
`$ git pr show -t 18990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18990.diff">https://git.openjdk.org/jdk/pull/18990.diff</a>

</details>
