### PR TITLE
8280988: [XWayland] Click on title to request focus test failures

### DIFF
--- a/test/jdk/java/awt/Focus/6981400/Test1.java
+++ b/test/jdk/java/awt/Focus/6981400/Test1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,12 +41,26 @@
 // The FOCUS_LOST/FOCUS_GAINED events order in the original frame is tracked and should be:
 // b0 -> b1 -> b2 -> b3.
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.AWTException;
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.KeyEvent;
+import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+
 import test.java.awt.regtesthelpers.Util;
 
 public class Test1 {
@@ -81,6 +95,7 @@ public class Test1 {
 
         try {
             robot = new Robot();
+            robot.setAutoDelay(50);
         } catch (AWTException ex) {
             throw new RuntimeException("Error: can't create Robot");
         }
@@ -90,13 +105,13 @@ public class Test1 {
         f0.add(f0b2);
         f0.add(f0b3);
         f0.setLayout(new FlowLayout());
-        f0.setBounds(0, 100, 400, 200);
+        f0.setBounds(100, 100, 400, 200);
 
         f1.add(f1b0);
-        f1.setBounds(0, 400, 400, 200);
+        f1.setBounds(100, 400, 400, 200);
 
         f2.add(f2b0);
-        f2.setBounds(0, 400, 400, 200);
+        f2.setBounds(100, 400, 400, 200);
 
         f0b0.addFocusListener(new FocusAdapter() {
             @Override
@@ -115,6 +130,7 @@ public class Test1 {
         f0.setVisible(true);
 
         Util.waitForIdle(robot);
+        robot.delay(500);
 
         if (!f0b0.isFocusOwner()) {
             Util.clickOnComp(f0b0, robot);
@@ -156,24 +172,21 @@ public class Test1 {
         tracking = true;
 
         robot.keyPress(KeyEvent.VK_TAB);
-        robot.delay(50);
         robot.keyRelease(KeyEvent.VK_TAB);
-        robot.delay(50);
 
         robot.keyPress(KeyEvent.VK_TAB);
-        robot.delay(50);
         robot.keyRelease(KeyEvent.VK_TAB);
-        robot.delay(50);
 
         robot.keyPress(KeyEvent.VK_TAB);
-        robot.delay(50);
         robot.keyRelease(KeyEvent.VK_TAB);
 
-        robot.delay(50);
         Util.clickOnComp(compToClick, robot);
 
-        robot.delay(50);
-        Util.clickOnTitle(f0, robot);
+        if (Util.isOnWayland()) {
+            Util.clickOnComp(f0, robot);
+        } else {
+            Util.clickOnTitle(f0, robot);
+        }
 
         Util.waitForIdle(robot);
 

--- a/test/jdk/java/awt/Focus/6981400/Test1.java
+++ b/test/jdk/java/awt/Focus/6981400/Test1.java
@@ -27,8 +27,8 @@
  * @bug     6981400
  * @summary Tabbing between textfiled do not work properly when ALT+TAB
  * @author  anton.tarasov
- * @library ../../regtesthelpers
- * @build   Util
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build   Util jdk.test.lib.Platform
  * @run     main Test1
  */
 
@@ -61,6 +61,7 @@ import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 
+import jdk.test.lib.Platform;
 import test.java.awt.regtesthelpers.Util;
 
 public class Test1 {
@@ -182,7 +183,7 @@ public class Test1 {
 
         Util.clickOnComp(compToClick, robot);
 
-        if (Util.isOnWayland()) {
+        if (Platform.isOnWayland()) {
             Util.clickOnComp(f0, robot);
         } else {
             Util.clickOnTitle(f0, robot);

--- a/test/jdk/java/awt/Focus/6981400/Test1.java
+++ b/test/jdk/java/awt/Focus/6981400/Test1.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 
 import jdk.test.lib.Platform;
 import test.java.awt.regtesthelpers.Util;
@@ -87,7 +88,7 @@ public class Test1 {
 
     static boolean tracking;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         Toolkit.getDefaultToolkit().addAWTEventListener(new AWTEventListener() {
             public void eventDispatched(AWTEvent e) {
                 System.out.println(e);
@@ -169,23 +170,27 @@ public class Test1 {
         System.out.println("\nTest passed.");
     }
 
-    public static void test(Component compToClick) {
+    public static void test(Component compToClick) throws Exception {
         tracking = true;
 
         robot.keyPress(KeyEvent.VK_TAB);
         robot.keyRelease(KeyEvent.VK_TAB);
+        robot.waitForIdle();
 
         robot.keyPress(KeyEvent.VK_TAB);
         robot.keyRelease(KeyEvent.VK_TAB);
+        robot.waitForIdle();
 
         robot.keyPress(KeyEvent.VK_TAB);
         robot.keyRelease(KeyEvent.VK_TAB);
+        robot.waitForIdle();
 
         Util.clickOnComp(compToClick, robot);
 
-        if (Platform.isOnWayland()) {
-            Util.clickOnComp(f0, robot);
-        } else {
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(f0::toFront);
+
+        if (!Platform.isOnWayland()) {
             Util.clickOnTitle(f0, robot);
         }
 

--- a/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
+++ b/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
@@ -35,6 +35,7 @@ import java.awt.AWTEvent;
 import java.awt.Button;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.EventQueue;
 import java.awt.FlowLayout;
 import java.awt.Frame;
 import java.awt.KeyboardFocusManager;
@@ -57,7 +58,7 @@ public class ActualFocusedWindowBlockingTest {
     Button wButton = new Button("window button") {public String toString() {return "Window_Button";}};
     Button aButton = new Button("auxiliary button") {public String toString() {return "Auxiliary_Button";}};
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         ActualFocusedWindowBlockingTest app = new ActualFocusedWindowBlockingTest();
         app.init();
         app.start();
@@ -81,7 +82,7 @@ public class ActualFocusedWindowBlockingTest {
         tuneAndShowWindows(new Window[] {owner, win, frame});
     }
 
-    public void start() {
+    public void start() throws Exception {
         System.out.println("\nTest started:\n");
 
         // Test 1.
@@ -112,9 +113,9 @@ public class ActualFocusedWindowBlockingTest {
         clickOnCheckFocus(fButton);
         clickOnCheckFocus(aButton);
 
-        if (Platform.isOnWayland()) {
-            Util.clickOnComp(owner, robot);
-        } else {
+        EventQueue.invokeAndWait(owner::toFront);
+
+        if (!Platform.isOnWayland()) {
             Util.clickOnTitle(owner, robot);
         }
 
@@ -138,9 +139,12 @@ public class ActualFocusedWindowBlockingTest {
         robot.delay(500);
     }
 
-    void clickOnCheckFocus(Component c) {
-        if (c instanceof Frame && !Platform.isOnWayland()) {
-            Util.clickOnTitle((Frame)c, robot);
+    void clickOnCheckFocus(Component c) throws Exception {
+        if (c instanceof Frame) {
+            EventQueue.invokeAndWait(() -> ((Frame) c).toFront());
+            if (!Platform.isOnWayland()) {
+                Util.clickOnTitle((Frame) c, robot);
+            }
         } else {
             Util.clickOnComp(c, robot);
         }

--- a/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
+++ b/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,20 @@
   @run       main ActualFocusedWindowBlockingTest
 */
 
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.AWTEvent;
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.KeyboardFocusManager;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.AWTEventListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.WindowEvent;
+
 import test.java.awt.regtesthelpers.Util;
 
 public class ActualFocusedWindowBlockingTest {
@@ -99,7 +111,12 @@ public class ActualFocusedWindowBlockingTest {
         clickOnCheckFocus(fButton);
         clickOnCheckFocus(aButton);
 
-        Util.clickOnTitle(owner, robot);
+        if (Util.isOnWayland()) {
+            Util.clickOnComp(owner, robot);
+        } else {
+            Util.clickOnTitle(owner, robot);
+        }
+
         if (!testFocused(fButton)) {
             throw new TestFailedException("The owner's component [" + fButton + "] couldn't be focused as the most recent focus owner");
         }
@@ -117,10 +134,11 @@ public class ActualFocusedWindowBlockingTest {
             y += 200;
             Util.waitForIdle(robot);
         }
+        robot.delay(500);
     }
 
     void clickOnCheckFocus(Component c) {
-        if (c instanceof Frame) {
+        if (c instanceof Frame && !Util.isOnWayland()) {
             Util.clickOnTitle((Frame)c, robot);
         } else {
             Util.clickOnComp(c, robot);

--- a/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
+++ b/test/jdk/java/awt/Focus/ActualFocusedWindowTest/ActualFocusedWindowBlockingTest.java
@@ -26,8 +26,8 @@
   @key headful
   @bug       6314575
   @summary   Tests that previosly focused owned window doesn't steal focus when an owner's component requests focus.
-  @library   ../../regtesthelpers
-  @build     Util
+  @library /java/awt/regtesthelpers /test/lib
+  @build   Util jdk.test.lib.Platform
   @run       main ActualFocusedWindowBlockingTest
 */
 
@@ -45,6 +45,7 @@ import java.awt.event.AWTEventListener;
 import java.awt.event.FocusEvent;
 import java.awt.event.WindowEvent;
 
+import jdk.test.lib.Platform;
 import test.java.awt.regtesthelpers.Util;
 
 public class ActualFocusedWindowBlockingTest {
@@ -111,7 +112,7 @@ public class ActualFocusedWindowBlockingTest {
         clickOnCheckFocus(fButton);
         clickOnCheckFocus(aButton);
 
-        if (Util.isOnWayland()) {
+        if (Platform.isOnWayland()) {
             Util.clickOnComp(owner, robot);
         } else {
             Util.clickOnTitle(owner, robot);
@@ -138,7 +139,7 @@ public class ActualFocusedWindowBlockingTest {
     }
 
     void clickOnCheckFocus(Component c) {
-        if (c instanceof Frame && !Util.isOnWayland()) {
+        if (c instanceof Frame && !Platform.isOnWayland()) {
             Util.clickOnTitle((Frame)c, robot);
         } else {
             Util.clickOnComp(c, robot);

--- a/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
+++ b/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
@@ -211,9 +211,8 @@ public class ModalDialogInFocusEventTest
 
     void clickOnFrameTitle(Frame frame) throws InterruptedException,
             InvocationTargetException {
-        if (isOnWayland) {
-            EventQueue.invokeAndWait(frame::toFront);
-        } else {
+        EventQueue.invokeAndWait(frame::toFront);
+        if (!isOnWayland) {
             System.out.println("click on title of " + frame.getName());
             int[] point = new int[2];
             EventQueue.invokeAndWait(() -> {

--- a/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
+++ b/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,11 +22,11 @@
  */
 
 /*
-  test
+  @test
   @bug 4531693 4636269 4681908 4688142 4691646 4721470
   @summary Showing modal dialog during dispatching SequencedEvent
   @key headful
-  @run main AutomaticAppletTest
+  @run main ModalDialogInFocusEventTest
 */
 
 import java.awt.AWTEvent;
@@ -67,6 +67,8 @@ public class ModalDialogInFocusEventTest
     };
     static final int MAX_STAGE_NUM = stages.length;
     static final Object stageMonitor = new Object();
+
+    static boolean isOnWayland;
 
     Robot robot = null;
     Frame frame;
@@ -209,18 +211,22 @@ public class ModalDialogInFocusEventTest
 
     void clickOnFrameTitle(Frame frame) throws InterruptedException,
             InvocationTargetException {
-        System.out.println("click on title of " + frame.getName());
-        int[] point = new int[2];
-        EventQueue.invokeAndWait(() -> {
-            Point location = frame.getLocationOnScreen();
-            Insets insets = frame.getInsets();
-            int width = frame.getWidth();
-            point[0] = location.x + width / 2;
-            point[1] = location.y + insets.top / 2;
-        });
-        robot.mouseMove(point[0], point[1]);
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        if (isOnWayland) {
+            EventQueue.invokeAndWait(frame::toFront);
+        } else {
+            System.out.println("click on title of " + frame.getName());
+            int[] point = new int[2];
+            EventQueue.invokeAndWait(() -> {
+                Point location = frame.getLocationOnScreen();
+                Insets insets = frame.getInsets();
+                int width = frame.getWidth();
+                point[0] = location.x + width / 2;
+                point[1] = location.y + insets.top / 2;
+            });
+            robot.mouseMove(point[0], point[1]);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        }
         EventQueue.invokeAndWait(frame::requestFocusInWindow);
     }
 
@@ -344,6 +350,7 @@ public class ModalDialogInFocusEventTest
 
     public static void main(String[] args) throws InterruptedException,
             InvocationTargetException {
+        isOnWayland = System.getenv("WAYLAND_DISPLAY") != null;
         ModalDialogInFocusEventTest test = new ModalDialogInFocusEventTest();
         test.start();
     }

--- a/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
+++ b/test/jdk/java/awt/Focus/ModalDialogInFocusEventTest.java
@@ -23,9 +23,9 @@
 
 /*
   @test
+  @key headful
   @bug 4531693 4636269 4681908 4688142 4691646 4721470
   @summary Showing modal dialog during dispatching SequencedEvent
-  @key headful
   @run main ModalDialogInFocusEventTest
 */
 

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,12 +21,31 @@
  * questions.
  */
 
-
-import java.awt.*;
-import java.awt.event.*;
+import java.awt.Button;
+import java.awt.Checkbox;
+import java.awt.Choice;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.List;
+import java.awt.Panel;
+import java.awt.Robot;
+import java.awt.Scrollbar;
+import java.awt.TextArea;
+import java.awt.TextField;
+import java.awt.event.HierarchyBoundsListener;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.SwingUtilities;
-import java.io.*;
 
 /**
  * AWT Mixing test for HierarchyBoundsListener ancestors.
@@ -137,9 +156,9 @@ public class HierarchyBoundsListenerMixingTest {
         robot.mouseMove((int) components[0].getLocationOnScreen().x + components[0].getSize().width / 2,
                         (int) components[0].getLocationOnScreen().y + components[0].getSize().height / 2);
         robot.delay(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         robot.delay(delay);
 
         resetValues();
@@ -177,45 +196,54 @@ public class HierarchyBoundsListenerMixingTest {
         robot.delay(delay * 5);
 
         resetValues();
-        int x = (int) frame.getLocationOnScreen().x;
-        int y = (int) frame.getLocationOnScreen().y;
-        int w = frame.getSize().width;
-        int h = frame.getSize().height;
 
-        robot.mouseMove(x + w + BORDER_SHIFT, y + h / 2);
-        robot.delay(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.delay(delay);
-        for (int i = 0; i < 20; i++) {
-            robot.mouseMove(x + w + i + BORDER_SHIFT, y + h / 2);
-            robot.delay(50);
-        }
-        robot.delay(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+        int x;
+        int y;
+        int w;
+        int h;
 
-        if (! resizeTriggered) {
-            synchronized (resizeLock) {
-                try {
-                    resizeLock.wait(delay * 10);
-                } catch (Exception e) {
+        if (!isOnWayland) {
+            x = frame.getLocationOnScreen().x;
+            y = frame.getLocationOnScreen().y;
+            w = frame.getSize().width;
+            h = frame.getSize().height;
+
+            robot.mouseMove(x + w + BORDER_SHIFT, y + h / 2);
+            robot.delay(delay);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(delay);
+            for (int i = 0; i < 20; i++) {
+                robot.mouseMove(x + w + i + BORDER_SHIFT, y + h / 2);
+                robot.delay(50);
+            }
+            robot.delay(delay);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (!resizeTriggered) {
+                synchronized (resizeLock) {
+                    try {
+                        resizeLock.wait(delay * 10);
+                    } catch (Exception e) {
+                    }
                 }
             }
-        }
 
-        for (int i = 0; i < components.length; i++) {
-            if (! ancestorResized[i]) {
-                System.err.println("FAIL: Frame resized using mouse action. " +
-                                   "Ancestor resized event did not occur for " +
-                                   components[i].getClass());
+            for (int i = 0; i < components.length; i++) {
+                if (!ancestorResized[i]) {
+                    System.err.println("FAIL: Frame resized using mouse action. " +
+                            "Ancestor resized event did not occur for " +
+                            components[i].getClass());
+                    passed = false;
+                }
+            }
+            if (moveCount > 0) {
+                System.err.println("FAIL: Ancestor moved event occurred when Frame resized using mouse");
                 passed = false;
             }
-        }
-        if (moveCount > 0) {
-            System.err.println("FAIL: Ancestor moved event occured when Frame resized using mouse");
-            passed = false;
+
+            resetValues();
         }
 
-        resetValues();
         try {
             EventQueue.invokeAndWait(new Runnable() {
                 public void run() {
@@ -250,51 +278,54 @@ public class HierarchyBoundsListenerMixingTest {
         robot.delay(delay * 10);
 
         resetValues();
-        x = (int) frame.getLocationOnScreen().x;
-        y = (int) frame.getLocationOnScreen().y;
-        w = frame.getSize().width;
-        h = frame.getSize().height;
 
-        //Click on the dummy frame so that the test frame loses focus. This is to workaround
-        //a bug in Linux AS.
-        robot.mouseMove((int) dummy.getLocationOnScreen().x + dummy.getSize().width / 2,
-                        (int) dummy.getLocationOnScreen().y + dummy.getSize().height / 2);
-        robot.delay(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.delay(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
-        robot.delay(delay);
+        if (!isOnWayland) {
+            x = frame.getLocationOnScreen().x;
+            y = frame.getLocationOnScreen().y;
+            w = frame.getSize().width;
+            h = frame.getSize().height;
 
-        robot.mouseMove(x + w / 2, y + 10);
-        robot.delay(delay);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
-        robot.delay(delay);
-        for (int i = 1; i <= 20; i++) {
-            robot.mouseMove(x + w / 2 + i, y + 10);
-            robot.delay(50);
-        }
-        robot.delay(delay);
-        robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            //Click on the dummy frame so that the test frame loses focus. This is to workaround
+            //a bug in Linux AS.
+            robot.mouseMove((int) dummy.getLocationOnScreen().x + dummy.getSize().width / 2,
+                            (int) dummy.getLocationOnScreen().y + dummy.getSize().height / 2);
+            robot.delay(delay);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(delay);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(delay);
 
-        if (! moveTriggered) {
-            synchronized (moveLock) {
-                try {
-                    moveLock.wait(delay * 10);
-                } catch (Exception e) {
+            robot.mouseMove(x + w / 2, y + 10);
+            robot.delay(delay);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(delay);
+            for (int i = 1; i <= 20; i++) {
+                robot.mouseMove(x + w / 2 + i, y + 10);
+                robot.delay(50);
+            }
+            robot.delay(delay);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            if (! moveTriggered) {
+                synchronized (moveLock) {
+                    try {
+                        moveLock.wait(delay * 10);
+                    } catch (Exception e) {
+                    }
                 }
             }
-        }
 
-        for (int i = 0; i < components.length; i++) {
-            if (! ancestorMoved[i]) {
-                System.err.println("FAIL: Frame moved using mouse action. " +
-                                   "Ancestor moved event did not occur for " + components[i].getClass());
+            for (int i = 0; i < components.length; i++) {
+                if (! ancestorMoved[i]) {
+                    System.err.println("FAIL: Frame moved using mouse action. " +
+                                       "Ancestor moved event did not occur for " + components[i].getClass());
+                    passed = false;
+                }
+            }
+            if (resizeCount > 0) {
+                System.err.println("FAIL: Ancestor resized event occured when Frame moved using mouse");
                 passed = false;
             }
-        }
-        if (resizeCount > 0) {
-            System.err.println("FAIL: Ancestor resized event occured when Frame moved using mouse");
-            passed = false;
         }
 
         return passed;
@@ -445,12 +476,14 @@ public class HierarchyBoundsListenerMixingTest {
     private static String failureMessage = "";
     private static Thread mainThread = null;
     private static int sleepTime = 300000;
+    private static boolean isOnWayland;
 
     // Not sure about what happens if multiple of this test are
     //  instantiated in the same VM.  Being static (and using
     //  static vars), it aint gonna work.  Not worrying about
     //  it for now.
-    public static void main(String args[]) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException {
+        isOnWayland = System.getenv("WAYLAND_DISPLAY") != null;
         mainThread = Thread.currentThread();
         try {
             init();

--- a/test/jdk/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
+++ b/test/jdk/java/awt/Mixing/AWT_Mixing/HierarchyBoundsListenerMixingTest.java
@@ -47,6 +47,8 @@ import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.SwingUtilities;
 
+import jdk.test.lib.Platform;
+
 /**
  * AWT Mixing test for HierarchyBoundsListener ancestors.
  * <p>See <a href="https://bugs.openjdk.org/browse/JDK-6768230">CR6768230</a> for details.
@@ -56,7 +58,8 @@ import javax.swing.SwingUtilities;
  * @key headful
  * @bug 6768230 8221823
  * @summary Mixing test for HierarchyBoundsListener ancestors
- * @build FrameBorderCounter
+ * @library /test/lib
+ * @build FrameBorderCounter jdk.test.lib.Platform
  * @run main HierarchyBoundsListenerMixingTest
  */
 public class HierarchyBoundsListenerMixingTest {
@@ -202,7 +205,7 @@ public class HierarchyBoundsListenerMixingTest {
         int w;
         int h;
 
-        if (!isOnWayland) {
+        if (!Platform.isOnWayland()) {
             x = frame.getLocationOnScreen().x;
             y = frame.getLocationOnScreen().y;
             w = frame.getSize().width;
@@ -279,7 +282,7 @@ public class HierarchyBoundsListenerMixingTest {
 
         resetValues();
 
-        if (!isOnWayland) {
+        if (!Platform.isOnWayland()) {
             x = frame.getLocationOnScreen().x;
             y = frame.getLocationOnScreen().y;
             w = frame.getSize().width;
@@ -476,14 +479,12 @@ public class HierarchyBoundsListenerMixingTest {
     private static String failureMessage = "";
     private static Thread mainThread = null;
     private static int sleepTime = 300000;
-    private static boolean isOnWayland;
 
     // Not sure about what happens if multiple of this test are
     //  instantiated in the same VM.  Being static (and using
     //  static vars), it aint gonna work.  Not worrying about
     //  it for now.
     public static void main(String[] args) throws InterruptedException {
-        isOnWayland = System.getenv("WAYLAND_DISPLAY") != null;
         mainThread = Thread.currentThread();
         try {
             init();

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -661,6 +661,15 @@ public final class Util {
         }
 
         return result.get(0);
+    }
+
+    /**
+     * Checks if the current system is running on Wayland display server on Linux.
+     *
+     * @return {@code true} if the system is running on Wayland display server
+     */
+    public static boolean isOnWayland() {
+        return System.getenv("WAYLAND_DISPLAY") != null;
     }
 
 }

--- a/test/jdk/java/awt/regtesthelpers/Util.java
+++ b/test/jdk/java/awt/regtesthelpers/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -661,15 +661,6 @@ public final class Util {
         }
 
         return result.get(0);
-    }
-
-    /**
-     * Checks if the current system is running on Wayland display server on Linux.
-     *
-     * @return {@code true} if the system is running on Wayland display server
-     */
-    public static boolean isOnWayland() {
-        return System.getenv("WAYLAND_DISPLAY") != null;
     }
 
 }

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -472,5 +472,14 @@ public class Platform {
      */
     public static boolean areCustomLoadersSupportedForCDS() {
         return (is64bit() && (isLinux() || isOSX() || isWindows()));
+    }
+
+    /**
+     * Checks if the current system is running on Wayland display server on Linux.
+     *
+     * @return {@code true} if the system is running on Wayland display server
+     */
+    public static boolean isOnWayland() {
+        return System.getenv("WAYLAND_DISPLAY") != null;
     }
 }


### PR DESCRIPTION
Some tests try to get the focus of a window by clicking on its title bar.

On XWayland, however, emulating mouse clicks with XTEST currently only affects the XWayland server, not the window decorations, so trying to click on the window title will have no effect.

So the solution is to click inside the window or call `toFront()` to get the window focused.

Some tests have issues with AWT/Swing calls not being on EDT, it is not the goal of this change to fix them as they require way too many code changes, and make this PR hard to review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280988](https://bugs.openjdk.org/browse/JDK-8280988): [XWayland] Click on title to request focus test failures (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**) ⚠️ Review applies to [ef4d7716](https://git.openjdk.org/jdk/pull/18995/files/ef4d771603c7ffda750f327cf37e2ad9d756cf79)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/18995/head:pull/18995` \
`$ git checkout pull/18995`

Update a local copy of the PR: \
`$ git checkout pull/18995` \
`$ git pull https://git.openjdk.org/jdk.git pull/18995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18995`

View PR using the GUI difftool: \
`$ git pr show -t 18995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/18995.diff">https://git.openjdk.org/jdk/pull/18995.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/18995#issuecomment-2082410891)