### PR TITLE
JDK-8331298: avoid alignment checks in UBSAN enabled build

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -491,7 +491,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.
-  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base"
+  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment"
   UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,


### PR DESCRIPTION
Currently we run into some alignment related issues when building with '--enable-ubsan' . Those errors already occur in the build. Fixing them might take some time and maybe also some discussion if it is worth the effort ,
So for now the alignment related checks should be disabled to get the UBSAN build working.
Example :

/jdk/src/hotspot/cpu/x86/macroAssembler_x86.hpp:128:13: runtime error: store to misaligned address 0x15099c3cf4ce for type 'int', which requires 4 byte alignment
0x15099c3cf4ce: note: pointer points here
 00 80 0f 86 00 00 00 00 3d 06 00 00 80 76 60 3d 07 00 00 80 76 40 3d 08 00 00 80 76 20 3d 1e 00
             ^
    #0 0x1509b3b04f10 in MacroAssembler::pd_patch_instruction(unsigned char*, unsigned char*, char const*, int) /jdk/src/hotspot/cpu/x86/macroAssembler_x86.hpp:128
    #1 0x1509b3b04f10 in Label::patch_instructions(MacroAssembler*) /jdk/src/hotspot/share/asm/assembler.cpp:201
    #2 0x1509b940b6d8 in VM_Version_StubGenerator::generate_get_cpu_info() /jdk/src/hotspot/cpu/x86/vm_version_x86.cpp:381
    #3 0x1509b94059bd in VM_Version::initialize() /jdk/src/hotspot/cpu/x86/vm_version_x86.cpp:2138
    #4 0x1509b93fb56e in VM_Version_init() /jdk/src/hotspot/share/runtime/vm_version.cpp:32
    #5 0x1509b61ef947 in init_globals() /jdk/src/hotspot/share/runtime/init.cpp:126
    #6 0x1509b8fb0e29 in Threads::create_vm(JavaVMInitArgs*, bool*) /jdk/src/hotspot/share/runtime/threads.cpp:553
    #7 0x1509b67da3d7 in JNI_CreateJavaVM_inner /jdk/src/hotspot/share/prims/jni.cpp:3581
    #8 0x1509b67da3d7 in JNI_CreateJavaVM /jdk/src/hotspot/share/prims/jni.cpp:3672
    #9 0x1509c0eed957 in InitializeJVM /jdk/src/java.base/share/native/libjli/java.c:1550
    #10 0x1509c0eed957 in JavaMain /jdk/src/java.base/share/native/libjli/java.c:491
   ... (rest of output omitted)