### PR TITLE
8329653: JLILaunchTest fails on AIX after JDK-8329131

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -516,14 +516,16 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         }
     }
 
+#if defined(AIX)
     /* at least on AIX try also the LD_LIBRARY_PATH / LIBPATH */
-    if (GetApplicationHomeFromLD_LIBRARY_PATH(path, pathsize)) {
+    if (GetApplicationHomeFromLibpath(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (stat(libjava, &s) == 0) {
             JLI_TraceLauncher("JRE path is %s\n", path);
             return JNI_TRUE;
         }
     }
+#endif
 
     if (!speculative)
       JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -516,6 +516,15 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         }
     }
 
+    /* at least on AIX try also the LD_LIBRARY_PATH / LIBPATH */
+    if (GetApplicationHomeFromLD_LIBRARY_PATH(path, pathsize)) {
+        JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
+        if (stat(libjava, &s) == 0) {
+            JLI_TraceLauncher("JRE path is %s\n", path);
+            return JNI_TRUE;
+        }
+    }
+
     if (!speculative)
       JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
     return JNI_FALSE;

--- a/src/java.base/unix/native/libjli/java_md.h
+++ b/src/java.base/unix/native/libjli/java_md.h
@@ -59,6 +59,8 @@ static jboolean GetJVMPath(const char *jrepath, const char *jvmtype,
                            char *jvmpath, jint jvmpathsize);
 static jboolean GetJREPath(char *path, jint pathsize, jboolean speculative);
 
+jboolean GetApplicationHomeFromLD_LIBRARY_PATH(char *buf, jint bufsize);
+
 #if defined(_AIX)
 #include "java_md_aix.h"
 #endif

--- a/src/java.base/unix/native/libjli/java_md.h
+++ b/src/java.base/unix/native/libjli/java_md.h
@@ -59,9 +59,8 @@ static jboolean GetJVMPath(const char *jrepath, const char *jvmtype,
                            char *jvmpath, jint jvmpathsize);
 static jboolean GetJREPath(char *path, jint pathsize, jboolean speculative);
 
-jboolean GetApplicationHomeFromLD_LIBRARY_PATH(char *buf, jint bufsize);
-
 #if defined(_AIX)
+jboolean GetApplicationHomeFromLibpath(char *buf, jint bufsize);
 #include "java_md_aix.h"
 #endif
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -117,7 +117,8 @@ GetApplicationHomeFromDll(char *buf, jint bufsize)
 
 #if defined(AIX)
 static jboolean
-LibjavaExists(const char *path) {
+LibjavaExists(const char *path)
+{
     char tmp[PATH_MAX + 1];
     struct stat statbuf;
     JLI_Snprintf(tmp, PATH_MAX, "%s/%s", path, JAVA_DLL);
@@ -136,7 +137,7 @@ GetApplicationHomeFromLibpath(char *buf, jint bufsize)
 {
     char *env = getenv(LD_LIBRARY_PATH);
     char *tmp;
-    char* save_ptr = NULL;
+    char *save_ptr = NULL;
     char *envpath = JLI_StringDup(env);
     for (tmp = strtok_r(envpath, ":", &save_ptr); tmp != NULL; tmp = strtok_r(NULL, ":", &save_ptr)) {
         if (LibjavaExists(tmp)) {

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -125,7 +125,7 @@ LibjavaExists(const char *path)
 
 /*
  * Retrieves the path to the JRE home by locating libjava.so in
- * one of the LIBPATH and then truncating the path to it.
+ * LIBPATH and then truncating the path to it.
  */
 jboolean
 GetApplicationHomeFromLibpath(char *buf, jint bufsize)

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -25,6 +25,13 @@
 #include <sys/time.h>
 #include "java.h"
 
+#define JAVA_DLL "libjava.so"
+#ifdef AIX
+#define LD_LIBRARY_PATH "LIBPATH"
+#else
+#define LD_LIBRARY_PATH "LD_LIBRARY_PATH"
+#endif
+
 /*
  * Find the last occurrence of a string
  */
@@ -105,6 +112,44 @@ GetApplicationHomeFromDll(char *buf, jint bufsize)
             return TruncatePath(buf, JNI_TRUE);
         }
     }
+    return JNI_FALSE;
+}
+
+static jboolean
+LibjavaExists(const char *path) {
+    char tmp[PATH_MAX + 1];
+    struct stat statbuf;
+    JLI_Snprintf(tmp, PATH_MAX, "%s/%s", path, JAVA_DLL);
+    if (stat(tmp, &statbuf) == 0) {
+        return JNI_TRUE;
+    }
+    return JNI_FALSE;
+}
+
+/*
+ * Retrieves the path to the JRE home by locating libjava.so in
+ * one of the LD_LIBRARY_PATH and then truncating the path to it.
+ */
+jboolean
+GetApplicationHomeFromLD_LIBRARY_PATH(char *buf, jint bufsize)
+{
+    char *env = getenv(LD_LIBRARY_PATH);
+    char *tmp;
+    char* save_ptr = NULL;
+    char *envpath = JLI_StringDup(env);
+    for (tmp = strtok_r(envpath, ":", &save_ptr); tmp != NULL; tmp = strtok_r(NULL, ":", &save_ptr)) {
+        if (LibjavaExists(tmp)) {
+            char *path = realpath(tmp, buf);
+            if (path == buf) {
+                JLI_StrCat(buf, "/");
+                if (JNI_TRUE == TruncatePath(buf, JNI_TRUE)) {
+                    JLI_MemFree(envpath);
+                    return JNI_TRUE;
+                }
+            }
+        }
+    }
+    JLI_MemFree(envpath);
     return JNI_FALSE;
 }
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -26,11 +26,6 @@
 #include "java.h"
 
 #define JAVA_DLL "libjava.so"
-#ifdef AIX
-#define LD_LIBRARY_PATH "LIBPATH"
-#else
-#define LD_LIBRARY_PATH "LD_LIBRARY_PATH"
-#endif
 
 /*
  * Find the last occurrence of a string
@@ -130,12 +125,12 @@ LibjavaExists(const char *path)
 
 /*
  * Retrieves the path to the JRE home by locating libjava.so in
- * one of the LD_LIBRARY_PATH and then truncating the path to it.
+ * one of the LIBPATH and then truncating the path to it.
  */
 jboolean
 GetApplicationHomeFromLibpath(char *buf, jint bufsize)
 {
-    char *env = getenv(LD_LIBRARY_PATH);
+    char *env = getenv("LIBPATH");
     char *tmp;
     char *save_ptr = NULL;
     char *envpath = JLI_StringDup(env);

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -115,6 +115,7 @@ GetApplicationHomeFromDll(char *buf, jint bufsize)
     return JNI_FALSE;
 }
 
+#if defined(AIX)
 static jboolean
 LibjavaExists(const char *path) {
     char tmp[PATH_MAX + 1];
@@ -131,7 +132,7 @@ LibjavaExists(const char *path) {
  * one of the LD_LIBRARY_PATH and then truncating the path to it.
  */
 jboolean
-GetApplicationHomeFromLD_LIBRARY_PATH(char *buf, jint bufsize)
+GetApplicationHomeFromLibpath(char *buf, jint bufsize)
 {
     char *env = getenv(LD_LIBRARY_PATH);
     char *tmp;
@@ -152,6 +153,7 @@ GetApplicationHomeFromLD_LIBRARY_PATH(char *buf, jint bufsize)
     JLI_MemFree(envpath);
     return JNI_FALSE;
 }
+#endif
 
 /*
  * Return true if the named program exists


### PR DESCRIPTION
Since ~ end of March, after [JDK-8329131](https://bugs.openjdk.org/browse/JDK-8329131), tools/launcher/JliLaunchTest.java fails on AIX. Failure is :

 stdout: [];
 stderr: [Error: could not find libjava.so
Error: Could not find Java SE Runtime Environment.
]
 exitValue = 2

java.lang.RuntimeException: Expected to get exit value of [0], exit value is: [2]
at jdk.test.lib.process.OutputAnalyzer.shouldHaveExitValue(OutputAnalyzer.java:521)
at JliLaunchTest.main(JliLaunchTest.java:58)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1575)

Maybe we need to do further adjustments to BUILD_JDK_JTREG_EXECUTABLES_LIBS_exeJliLaunchTest / BUILD_JDK_JTREG_EXECUTABLES_LDFLAGS_exeJliLaunchTest on AIX ?
Or somehow adjust the coding that attempts to find parts of "JRE" (libjava.so) ? The libjli.so is gone on AIX after [JDK-8329131](https://bugs.openjdk.org/browse/JDK-8329131), and with this also the image discovery based on GetApplicationHomeFromDll which uses libjli.so .

Without libjli.so we have to analyze the LD-LIBRARY_PATH / LIBPATH envvar. There is no other methos available on AIX, because it lacks the $ORIGIN feature of the rpath.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329653](https://bugs.openjdk.org/browse/JDK-8329653): JLILaunchTest fails on AIX after JDK-8329131 (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [5890bca3](https://git.openjdk.org/jdk/pull/19000/files/5890bca38fe30f98b40c553ab17cb0912fcef7e2)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [5890bca3](https://git.openjdk.org/jdk/pull/19000/files/5890bca38fe30f98b40c553ab17cb0912fcef7e2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19000/head:pull/19000` \
`$ git checkout pull/19000`

Update a local copy of the PR: \
`$ git checkout pull/19000` \
`$ git pull https://git.openjdk.org/jdk.git pull/19000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19000`

View PR using the GUI difftool: \
`$ git pr show -t 19000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19000.diff">https://git.openjdk.org/jdk/pull/19000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19000#issuecomment-2082950838)