### PR TITLE
8331252: C2: MergeStores: handle negative shift values

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -3108,8 +3108,8 @@ bool MergePrimitiveArrayStores::is_con_RShift(const Node* n, Node const*& base_o
       n->in(2)->is_ConI()) {
     base_out = n->in(1);
     shift_out = n->in(2)->get_int();
-    assert(shift_out >= 0, "must be positive");
-    return true;
+    // The shift must be positive:
+    return shift_out >= 0;
   }
   return false;
 }

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -187,6 +187,10 @@ public class TestMergeStores {
         testGroups.put("test600", new HashMap<String,TestFunction>());
         testGroups.get("test600").put("test600R", (_,i) -> { return test600R(aB.clone(), aI.clone(), i); });
         testGroups.get("test600").put("test600a", (_,i) -> { return test600a(aB.clone(), aI.clone(), i); });
+
+        testGroups.put("test700", new HashMap<String,TestFunction>());
+        testGroups.get("test700").put("test700R", (_,i) -> { return test700R(aI.clone(), i); });
+        testGroups.get("test700").put("test700a", (_,i) -> { return test700a(aI.clone(), i); });
     }
 
     @Warmup(100)
@@ -220,7 +224,8 @@ public class TestMergeStores {
                  "test500a",
                  "test501a",
                  "test502a",
-                 "test600a"})
+                 "test600a",
+                 "test700a"})
     public void runTests(RunInfo info) {
         // Repeat many times, so that we also have multiple iterations for post-warmup to potentially recompile
         int iters = info.isWarmUp() ? 1_000 : 50_000;
@@ -1296,4 +1301,22 @@ public class TestMergeStores {
         return new Object[]{ aB, aI };
     }
 
+    @DontCompile
+    static Object[] test700R(int[] a, long v1) {
+        a[0] = (int)(v1 >> -1);
+        a[1] = (int)(v1 >> -2);
+        return new Object[]{ a };
+    }
+
+    @Test
+    @IR(counts = {IRNode.STORE_B_OF_CLASS, "int\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "0",
+                  IRNode.STORE_C_OF_CLASS, "int\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "0",
+                  IRNode.STORE_I_OF_CLASS, "int\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "2",
+                  IRNode.STORE_L_OF_CLASS, "int\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "0"})
+    static Object[] test700a(int[] a, long v1) {
+        // Negative shift: cannot optimize
+        a[0] = (int)(v1 >> -1);
+        a[1] = (int)(v1 >> -2);
+        return new Object[]{ a };
+    }
 }


### PR DESCRIPTION
Somehow, I have not thought of negative shift constants, and there was no regression test for it.
The fuzzer now found a case.

**I convert the assert into a condition.**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331252](https://bugs.openjdk.org/browse/JDK-8331252): C2: MergeStores: handle negative shift values (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19001/head:pull/19001` \
`$ git checkout pull/19001`

Update a local copy of the PR: \
`$ git checkout pull/19001` \
`$ git pull https://git.openjdk.org/jdk.git pull/19001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19001`

View PR using the GUI difftool: \
`$ git pr show -t 19001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19001.diff">https://git.openjdk.org/jdk/pull/19001.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19001#issuecomment-2083133011)