### PR TITLE
8331331: :tier1 target explanation in doc/testing.md is incorrect

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -180,7 +180,7 @@ more tab-completion friendly. For more complex test runs, the
 fully qualified test descriptors, which clearly and unambigously show
 which tests will be run. As an example, <code>:tier1</code> will expand
 to
-<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1</code>.
+<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1 jtreg:$(TOPDIR)/test/lib-test:tier1</code>.
 You can always submit a list of fully qualified test descriptors in the
 <code>TEST</code> variable if you want to shortcut the parser.</p>
 <h3 id="common-test-groups">Common Test Groups</h3>

--- a/doc/testing.html
+++ b/doc/testing.html
@@ -179,8 +179,9 @@ more tab-completion friendly. For more complex test runs, the
 <p>The test specifications given in <code>TEST</code> is parsed into
 fully qualified test descriptors, which clearly and unambigously show
 which tests will be run. As an example, <code>:tier1</code> will expand
-to
-<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1 jtreg:$(TOPDIR)/test/lib-test:tier1</code>.
+to include all subcomponent test directories that define `tier1`,
+for example:
+<code>jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 ...</code>.
 You can always submit a list of fully qualified test descriptors in the
 <code>TEST</code> variable if you want to shortcut the parser.</p>
 <h3 id="common-test-groups">Common Test Groups</h3>

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -105,7 +105,7 @@ The test specifications given in `TEST` is parsed into fully qualified test
 descriptors, which clearly and unambigously show which tests will be run. As an
 example, `:tier1` will expand to `jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1
 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1
-jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1`. You can
+jtreg:$(TOPDIR)/test/jaxp:tier1 jtreg:$(TOPDIR)/test/lib-test:tier1`. You can
 always submit a list of fully qualified test descriptors in the `TEST` variable
 if you want to shortcut the parser.
 

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -103,11 +103,11 @@ test runs, the `test TEST="x"` solution needs to be used.
 
 The test specifications given in `TEST` is parsed into fully qualified test
 descriptors, which clearly and unambigously show which tests will be run. As an
-example, `:tier1` will expand to `jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1
-jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1
-jtreg:$(TOPDIR)/test/jaxp:tier1 jtreg:$(TOPDIR)/test/lib-test:tier1`. You can
-always submit a list of fully qualified test descriptors in the `TEST` variable
-if you want to shortcut the parser.
+example, `:tier1` will expand to include all subcomponent test directories
+that define `tier1`, for example: `jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1
+jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 ...`. You
+can always submit a list of fully qualified test descriptors in the `TEST`
+variable if you want to shortcut the parser.
 
 ### Common Test Groups
 


### PR DESCRIPTION
Hi,

In doc/testing.md file, it says:

As an example, :tier1 will expand to jtreg:$(TOPDIR)/test/hotspot/jtreg:tier1 jtreg:$(TOPDIR)/test/jdk:tier1 jtreg:$(TOPDIR)/test/langtools:tier1 jtreg:$(TOPDIR)/test/nashorn:tier1 jtreg:$(TOPDIR)/test/jaxp:tier1.

The actual situation is :tier1 doesn't contains test/nashorn:tier1, and the document missed test/lib-test:tier1

$ make -n test-tier1 &> test-tier1.log
$ grep "Running test " test-tier1.log
Running test 'jtreg:test/hotspot/jtreg:tier1'
Running test 'jtreg:test/jdk:tier1'
Running test 'jtreg:test/langtools:tier1'
Running test 'jtreg:test/jaxp:tier1'
Running test 'jtreg:test/lib-test:tier1'

Only change the document, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331331](https://bugs.openjdk.org/browse/JDK-8331331): :tier1 target explanation in doc/testing.md is incorrect (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19002/head:pull/19002` \
`$ git checkout pull/19002`

Update a local copy of the PR: \
`$ git checkout pull/19002` \
`$ git pull https://git.openjdk.org/jdk.git pull/19002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19002`

View PR using the GUI difftool: \
`$ git pr show -t 19002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19002.diff">https://git.openjdk.org/jdk/pull/19002.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19002#issuecomment-2083153703)