### PR TITLE
8331346: Update PreviewFeature of STREAM_GATHERERS to JEP-473

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -79,7 +79,7 @@ public @interface PreviewFeature {
         STRUCTURED_CONCURRENCY,
         @JEP(number=466, title="ClassFile API", status="Second Preview")
         CLASSFILE_API,
-        @JEP(number=461, title="Stream Gatherers", status="Preview")
+        @JEP(number=473, title="Stream Gatherers", status="Second Preview")
         STREAM_GATHERERS,
         LANGUAGE_MODEL,
         /**


### PR DESCRIPTION
This PR finalizes JEP 473 by modifying the PreviewFeature JEP number and status for Stream Gatherers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331346](https://bugs.openjdk.org/browse/JDK-8331346): Update PreviewFeature of STREAM_GATHERERS to JEP-473 (**Task** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19003/head:pull/19003` \
`$ git checkout pull/19003`

Update a local copy of the PR: \
`$ git checkout pull/19003` \
`$ git pull https://git.openjdk.org/jdk.git pull/19003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19003`

View PR using the GUI difftool: \
`$ git pr show -t 19003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19003.diff">https://git.openjdk.org/jdk/pull/19003.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19003#issuecomment-2084801538)