### PR TITLE
8331344: No compiler replay file with CompilerCommand MemLimit

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
@@ -50,6 +50,7 @@ class ArenaStatCounter : public CHeapObj<mtCompiler> {
   // MemLimit handling
   size_t _limit;
   bool _hit_limit;
+  bool _limit_in_process;
 
   // Peak composition:
   // Size of node arena when total peaked (c2 only)
@@ -86,6 +87,9 @@ public:
 
   size_t limit() const              { return _limit; }
   bool   hit_limit() const          { return _hit_limit; }
+  bool   limit_in_process() const     { return _limit_in_process; }
+  void   set_limit_in_process(bool v) { _limit_in_process = v; }
+
 };
 
 class CompilationMemoryStatistic : public AllStatic {


### PR DESCRIPTION
When using the compiler memory limit with the crash suboption (e.g. `-XX:CompileCommand=MemLimit,*.*,1g~crash`), the JVM asserts but may fail to produce a replay file. We also may see partly corrupted hs-err files.

This happens if the memory limit hit was caused by growing ResourceAreas, not the C2 node arena. We also use ResourceArea when producing the replay file. 

If those RA usages cause another Arena chunk to be allocated, we re-enter `CompilationMemoryStatistic::on_arena_change` recursively, possibly multiple times. This will at least prevent replay file generation, but also may abort error handling altogether if a stack overflow happens. 

The patch prevents that recursion. It would be better to prevent replay file generation from using RA altogether, but this would be a larger patch and difficult to keep from bitrotting.

Also provided regression test.

Tested:

- manually on Linux x64 and MacOS m1, with and without an artificially inflated resource area usage that reliably triggers the error. With the patch, the error is gone.
- GHAs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331344](https://bugs.openjdk.org/browse/JDK-8331344): No compiler replay file with CompilerCommand MemLimit (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Ashutosh Mehra](https://openjdk.org/census#asmehra) (@ashu-mehra - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19005/head:pull/19005` \
`$ git checkout pull/19005`

Update a local copy of the PR: \
`$ git checkout pull/19005` \
`$ git pull https://git.openjdk.org/jdk.git pull/19005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19005`

View PR using the GUI difftool: \
`$ git pr show -t 19005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19005.diff">https://git.openjdk.org/jdk/pull/19005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19005#issuecomment-2084774394)