### PR TITLE
8331202: Support for Duration until another Instant

### DIFF
--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1166,17 +1166,10 @@ public final class Instant
      * Calculates the {@code Duration} until another {@code Instant}.
      * <p>
      * The start and end points are {@code this} and the specified instant.
-     * The result will be negative if the end is before the start.
-     * <p>
-     * There are two ways to determine the duration between two instants.
-     * The first is to invoke this method.
-     * The second is to use {@link Duration#between(Temporal, Temporal)}:
-     * <pre>
-     *   // two ways to determine the duration
-     *   duration = start.until(end);
-     *   duration = Duration.between(start, end);
-     * </pre>
-     * The choice should be made based on which makes the code more readable.
+     * The result will be negative if the end is before the start. Calling
+     * this method is equivalent to
+     * {@link Duration#between(Temporal, Temporal) Duration.between(this,
+     * endExclusive)}.
      * <p>
      * This instance is immutable and unaffected by this method call.
      *

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1160,6 +1160,36 @@ public final class Instant
             };
         }
         return unit.between(this, end);
+    }
+
+    /**
+     * Calculates the {@code Duration} between another {@code Instant}.
+     * <p>
+     * The start and end points are {@code this} and the specified instant.
+     * The result will be negative if the end is before the start.
+     * <p>
+     * There are two equivalent ways of using this method.
+     * The first is to invoke this method.
+     * The second is to use {@link Duration#between(Temporal, Temporal)}:
+     * <pre>
+     *   // these two lines are equivalent
+     *   duration = start.until(end);
+     *   duration = Duration.between(start, end);
+     * </pre>
+     * The choice should be made based on which makes the code more readable.
+     * <p>
+     * This instance is immutable and unaffected by this method call.
+     *
+     * @param endExclusive  the end {@code Instant}, exclusive, not null
+     * @return the {@code Duration} between this {@code Instant} and the
+     *      end {@code Instant}
+     * @throws ArithmeticException if numeric overflow occurs
+     * @since 23
+     */
+    public Duration until(Instant endExclusive) {
+        long secsDiff = Math.subtractExact(endExclusive.seconds, seconds);
+        int nanosDiff = endExclusive.nanos - nanos;
+        return Duration.ofSeconds(secsDiff, nanosDiff);
     }
 
     private long nanosUntil(Instant end) {

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1181,8 +1181,8 @@ public final class Instant
      * This instance is immutable and unaffected by this method call.
      *
      * @param endExclusive the end {@code Instant}, exclusive, not null
-     * @return the {@code Duration} between this {@code Instant} and the
-     *      end {@code Instant}
+     * @return the {@code Duration} from this {@code Instant} until the
+     *      specified {@code endExclusive} {@code Instant}
      * @see Duration#between(Temporal, Temporal)
      * @since 23
      */

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1187,6 +1187,7 @@ public final class Instant
      * @since 23
      */
     public Duration until(Instant endExclusive) {
+        Objects.requireNonNull(endExclusive, "endExclusive");
         long secsDiff = Math.subtractExact(endExclusive.seconds, seconds);
         int nanosDiff = endExclusive.nanos - nanos;
         return Duration.ofSeconds(secsDiff, nanosDiff);

--- a/src/java.base/share/classes/java/time/Instant.java
+++ b/src/java.base/share/classes/java/time/Instant.java
@@ -1163,16 +1163,16 @@ public final class Instant
     }
 
     /**
-     * Calculates the {@code Duration} between another {@code Instant}.
+     * Calculates the {@code Duration} until another {@code Instant}.
      * <p>
      * The start and end points are {@code this} and the specified instant.
      * The result will be negative if the end is before the start.
      * <p>
-     * There are two equivalent ways of using this method.
+     * There are two ways to determine the duration between two instants.
      * The first is to invoke this method.
      * The second is to use {@link Duration#between(Temporal, Temporal)}:
      * <pre>
-     *   // these two lines are equivalent
+     *   // two ways to determine the duration
      *   duration = start.until(end);
      *   duration = Duration.between(start, end);
      * </pre>
@@ -1180,10 +1180,10 @@ public final class Instant
      * <p>
      * This instance is immutable and unaffected by this method call.
      *
-     * @param endExclusive  the end {@code Instant}, exclusive, not null
+     * @param endExclusive the end {@code Instant}, exclusive, not null
      * @return the {@code Duration} between this {@code Instant} and the
      *      end {@code Instant}
-     * @throws ArithmeticException if numeric overflow occurs
+     * @see Duration#between(Temporal, Temporal)
      * @since 23
      */
     public Duration until(Instant endExclusive) {

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -66,6 +66,7 @@ import java.time.temporal.ChronoUnit;
 import org.testng.annotations.Test;
 import org.testng.annotations.DataProvider;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 /**
  * Test Instant.
@@ -139,5 +140,12 @@ public class TestInstant extends AbstractTest {
         Duration expected = Duration.ofSeconds(end.getEpochSecond() - start.getEpochSecond(),
                 end.getNano() - start.getNano());
         assertEquals(start.until(end), expected);
+    }
+
+    @Test
+    public void test_until_1arg_NPE() {
+        assertThrows(NullPointerException.class, () -> {
+            Instant.now().until(null);
+        });
     }
 }

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,7 @@
  */
 package test.java.time;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
@@ -68,7 +69,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  * Test Instant.
- * @bug 8273369
+ * @bug 8273369 8331202
  */
 @Test
 public class TestInstant extends AbstractTest {
@@ -119,5 +120,24 @@ public class TestInstant extends AbstractTest {
     public void test_millisUntil() {
         assertEquals(Instant.MIN.until(Instant.MIN.plusSeconds(1), ChronoUnit.MILLIS), 1000L);
         assertEquals(Instant.MAX.plusSeconds(-1).until(Instant.MAX, ChronoUnit.MILLIS), 1000L);
+    }
+
+    @DataProvider
+    private Object[][] provider_until_1arg() {
+        Instant t1 = Instant.ofEpochSecond(0, 10);
+        Instant t2 = Instant.ofEpochSecond(10, -20);
+        return new Object[][] {
+            {t1, t2},
+            {t2, t1},
+            {Instant.MIN, Instant.MAX},
+            {Instant.MAX, Instant.MIN},
+        };
+    }
+
+    @Test(dataProvider = "provider_until_1arg")
+    public void test_until_1arg(Instant start, Instant end) {
+        Duration expected = Duration.ofSeconds(end.getEpochSecond() - start.getEpochSecond(),
+                end.getNano() - start.getNano());
+        assertEquals(start.until(end), expected);
     }
 }

--- a/test/jdk/java/time/test/java/time/TestInstant.java
+++ b/test/jdk/java/time/test/java/time/TestInstant.java
@@ -137,9 +137,12 @@ public class TestInstant extends AbstractTest {
 
     @Test(dataProvider = "provider_until_1arg")
     public void test_until_1arg(Instant start, Instant end) {
+        Duration result = start.until(end);
         Duration expected = Duration.ofSeconds(end.getEpochSecond() - start.getEpochSecond(),
                 end.getNano() - start.getNano());
-        assertEquals(start.until(end), expected);
+        assertEquals(result, expected);
+        expected = Duration.between(start, end);
+        assertEquals(result, expected);
     }
 
     @Test


### PR DESCRIPTION
A new method on Instant to return the duration `until` another Instant is suggested per the following discussion thread:

https://mail.openjdk.org/pipermail/core-libs-dev/2024-April/122131.html

A CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331215](https://bugs.openjdk.org/browse/JDK-8331215) to be approved

### Issues
 * [JDK-8331202](https://bugs.openjdk.org/browse/JDK-8331202): Support for Duration until another Instant (**Enhancement** - P4)
 * [JDK-8331215](https://bugs.openjdk.org/browse/JDK-8331215): Support for Duration until another Instant (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [df2c1157](https://git.openjdk.org/jdk/pull/19007/files/df2c115765fc1486484829dee5dd8425e995b35f)
 * [Stephen Colebourne](https://openjdk.org/census#scolebourne) (@jodastephen - Author) ⚠️ Review applies to [df2c1157](https://git.openjdk.org/jdk/pull/19007/files/df2c115765fc1486484829dee5dd8425e995b35f)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19007/head:pull/19007` \
`$ git checkout pull/19007`

Update a local copy of the PR: \
`$ git checkout pull/19007` \
`$ git pull https://git.openjdk.org/jdk.git pull/19007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19007`

View PR using the GUI difftool: \
`$ git pr show -t 19007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19007.diff">https://git.openjdk.org/jdk/pull/19007.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19007#issuecomment-2083531518)