### PR TITLE
JDK-8329692 : Add more details to FrameStateTest.java test instructions

### DIFF
--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -112,7 +112,7 @@ public class FrameStateTest implements ActionListener {
     CheckboxGroup cbgResize = new CheckboxGroup();
     Checkbox cbIconState = new Checkbox("Frame State ICONIFIED", cbgState, true);
     Checkbox cbNormState = new Checkbox("Frame State NORMAL", cbgState, false);
-    Checkbox cbNonResize = new Checkbox("Frame Non-resizable", cbgResize, false);
+    Checkbox cbNonResize = new Checkbox("Frame Non-Resizable", cbgResize, false);
     Checkbox cbResize = new Checkbox("Frame Resizable", cbgResize, true);
 
     CreateFrame icontst;
@@ -120,7 +120,7 @@ public class FrameStateTest implements ActionListener {
     public static void main(String[] args) throws Exception {
         PassFailJFrame
                 .builder()
-                .title("FrameState Instructions")
+                .title("Frame Stateand Size Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
                 .rows(26)
@@ -195,7 +195,7 @@ public class FrameStateTest implements ActionListener {
             b7.addActionListener(this);
             addWindowListener(this);
 
-            setBounds(100, 2, 250, 200);
+            setBounds(100, 2, 300, 200);
             setState(iconified ? Frame.ICONIFIED : Frame.NORMAL);
             setResizable(isResizable);
             setVisible(true);

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -114,7 +114,7 @@ public class FrameStateTest implements ActionListener {
                 .title("Frame State and Size Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
-                .rows(26)
+                .rows(27)
                 .columns(70)
                 .logArea(6)
                 .splitUIBottom(() -> new FrameStateTest().createPanel())

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -74,23 +74,26 @@ public class FrameStateTest implements ActionListener {
         </p><p>
         Select the different options for the Frame:
             <ul>
-                <li><i>{Normal, Non-resizalbe}</i></li>
+                <li><i>{Normal, Non-resizable}</i></li>
                 <li><i>{Normal, Resizable}</i></li>
                 <li><i>{Iconified, Resizable}</i></li>
-                <li><i>{Iconified, Non-resizalbe}</i></li>
+                <li><i>{Iconified, Non-resizable}</i></li>
             </ul>
         After choosing the Frame's state click the
         Create Frame button.<br>
         After the Frame (Frame State Test (Window2)) comes
-        up make sure the proper behavior occurred<br>
-        (Frame shown in proper state).<br>
+        up make sure the proper behavior occurred (Frame shown in proper state).<br>
         Click the Dispose button to close the Frame.<br>
 
         </p><hr/><p>
 
         Do the above steps for all the different Frame state combinations available.<br>
-        If you observe the proper behavior the test has passed, Press the Pass button.<br>
-        Otherwise the test has failed, Press the Fail button.
+        For "hide,iconify and show" case, the frame is hidden then iconified hence Window2
+        is not seen on-screen when shown as the frame is still in the ICONIFIED state.
+        Window2 is visible on-screen when it is restored to NORMAL state as observed with
+        "hide,iconify, show and restore" case.<br><br>
+
+        If you observe the proper behavior for all the combinations, press PASS else FAIL.<br>
         </p><p>
         Note: In Frame State Test (Window2) you can also chose the different
         buttons to see different Frame behavior.<br>An example of a problem that
@@ -108,7 +111,7 @@ public class FrameStateTest implements ActionListener {
     CheckboxGroup cbgResize = new CheckboxGroup();
     Checkbox cbIconState = new Checkbox("Frame state ICONIFIED", cbgState, true);
     Checkbox cbNormState = new Checkbox("Frame state NORMAL", cbgState, false);
-    Checkbox cbNonResize = new Checkbox("Frame non-resizable", cbgResize, false);
+    Checkbox cbNonResize = new Checkbox("Frame Non-resizable", cbgResize, false);
     Checkbox cbResize = new Checkbox("Frame Resizable", cbgResize, true);
 
     CreateFrame icontst;
@@ -119,7 +122,7 @@ public class FrameStateTest implements ActionListener {
                 .title("GetBoundsResizeTest Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
-                .rows(25)
+                .rows(27)
                 .columns(70)
                 .logArea(10)
                 .splitUIBottom(() -> new FrameStateTest().createPanel())
@@ -320,11 +323,11 @@ public class FrameStateTest implements ActionListener {
 
         public void stateLog(String message) {
             PassFailJFrame
-                .log("[State=%d] %s %s".formatted(getState(), name, message));
+                .log("[Current State=%d] %s %s".formatted(getState(), name, message));
         }
 
         public void stateLog() {
-            PassFailJFrame.log("[State=" + getState() + "]");
+            PassFailJFrame.log("[Current State=" + getState() + "]");
         }
     }
 }

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -111,7 +111,7 @@ public class FrameStateTest implements ActionListener {
     public static void main(String[] args) throws Exception {
         PassFailJFrame
                 .builder()
-                .title("Frame Stateand Size Test Instructions")
+                .title("Frame State and Size Test Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
                 .rows(26)

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -21,15 +21,6 @@
  * questions.
  */
 
-/*
- * FrameStateTest.java
- *
- * summary: Checks that when setState(Frame.ICONIFIED) is called before
- *      setVisible(true) the Frame is shown in the proper iconified state.
- *      The problem was that it did not honor the initial iconic state, but
- *      instead was shown in the NORMAL state.
- */
-
 import java.awt.Button;
 import java.awt.Checkbox;
 import java.awt.CheckboxGroup;
@@ -52,9 +43,9 @@ import javax.swing.Timer;
  * @test
  * @bug 4157271
  * @summary Checks that when a Frame is created it honors the state it
- *       was set to. The bug was that if setState(Frame.ICONIFIED) was
- *       called before setVisible(true) the Frame would be shown in NORMAL
- *       state instead of ICONIFIED.
+ *          was set to. The bug was that if setState(Frame.ICONIFIED) was
+ *          called before setVisible(true) the Frame would be shown in NORMAL
+ *          state instead of ICONIFIED.
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual FrameStateTest

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -68,10 +68,9 @@ public class FrameStateTest implements ActionListener {
         setVisible(true) the Frame is shown in the proper iconified state.
         The problem was that it did not honor the initial iconic state, but
         instead was shown in the NORMAL state.
-        </p><hr/><p>
-
+        </p><hr/>
         Steps to try to reproduce this problem:
-        </p><p>
+        <p>
         Select the different options for the Frame:
             <ul>
                 <li><i>{Normal, Non-resizable}</i></li>
@@ -81,19 +80,21 @@ public class FrameStateTest implements ActionListener {
             </ul>
         After choosing the Frame's state click the
         Create Frame button.<br>
-        After the Frame (Frame State Test (Window2)) comes
-        up make sure the proper behavior occurred (Frame shown in proper state).<br>
+        After the Frame (Frame State Test (Window2)) comes up make sure the
+        proper behavior occurred (Frame shown in proper state).<br>
         Click the Dispose button to close the Frame.<br>
-
         </p><hr/><p>
 
-        Do the above steps for all the different Frame state combinations available.<br>
-        For "hide,iconify and show" case, the frame is hidden then iconified hence Window2
-        is not seen on-screen when shown as the frame is still in the ICONIFIED state.
-        Window2 is visible on-screen when it is restored to NORMAL state as observed with
-        "hide,iconify,show and restore" case.<br><br>
+        Do the above steps for all the different Frame state combinations
+        available.<br>
+        For "Hide, Iconify and Show" case, the frame is hidden then iconified
+        hence Window2 is not seen on-screen when shown as the frame is still
+        in the ICONIFIED state. Window2 is visible on-screen when it is restored
+        to NORMAL state as observed with "Hide, Iconify, Show and Restore" case.
+        <br><br>
 
-        If you observe the proper behavior for all the combinations, press PASS else FAIL.<br>
+        If you observe the proper behavior for all the combinations,
+        press PASS else FAIL.<br>
         </p><p>
         Note: In Frame State Test (Window2) you can also chose the different
         buttons to see different Frame behavior.<br>An example of a problem that
@@ -109,8 +110,8 @@ public class FrameStateTest implements ActionListener {
     Button btnDispose = new Button("Dispose Frame");
     CheckboxGroup cbgState = new CheckboxGroup();
     CheckboxGroup cbgResize = new CheckboxGroup();
-    Checkbox cbIconState = new Checkbox("Frame state ICONIFIED", cbgState, true);
-    Checkbox cbNormState = new Checkbox("Frame state NORMAL", cbgState, false);
+    Checkbox cbIconState = new Checkbox("Frame State ICONIFIED", cbgState, true);
+    Checkbox cbNormState = new Checkbox("Frame State NORMAL", cbgState, false);
     Checkbox cbNonResize = new Checkbox("Frame Non-resizable", cbgResize, false);
     Checkbox cbResize = new Checkbox("Frame Resizable", cbgResize, true);
 
@@ -119,12 +120,12 @@ public class FrameStateTest implements ActionListener {
     public static void main(String[] args) throws Exception {
         PassFailJFrame
                 .builder()
-                .title("GetBoundsResizeTest Instructions")
+                .title("FrameState Instructions")
                 .instructions(INSTRUCTIONS)
                 .testTimeOut(10)
-                .rows(27)
+                .rows(26)
                 .columns(70)
-                .logArea(10)
+                .logArea(6)
                 .splitUIBottom(() -> new FrameStateTest().createPanel())
                 .build()
                 .awaitAndCheck();
@@ -152,7 +153,7 @@ public class FrameStateTest implements ActionListener {
         if (evt.getSource() == btnCreate) {
             btnCreate.setEnabled(false);
             btnDispose.setEnabled(true);
-            icontst =new CreateFrame(cbIconState.getState(), cbResize.getState());
+            icontst = new CreateFrame(cbIconState.getState(), cbResize.getState());
             icontst.setVisible(true);
         } else if (evt.getSource() == btnDispose) {
             btnCreate.setEnabled(true);
@@ -169,7 +170,7 @@ public class FrameStateTest implements ActionListener {
         String name = "Frame State Test";
 
         CreateFrame(boolean iconified, boolean resizable) {
-            setTitle("Frame State Test (Window 2)");
+            setTitle("Test Window (Window 2)");
 
             isResizable = resizable;
 
@@ -178,13 +179,13 @@ public class FrameStateTest implements ActionListener {
                     ((isResizable) ? "RESIZABLE" : "NON-RESIZABLE"));
 
             setLayout(new FlowLayout());
-            add(b1 = new Button("resizable"));
-            add(b2 = new Button("resize"));
-            add(b3 = new Button("iconify"));
-            add(b4 = new Button("iconify and restore"));
-            add(b5 = new Button("hide and show"));
-            add(b6 = new Button("hide, iconify and show"));
-            add(b7 = new Button("hide, iconify, show and restore"));
+            add(b1 = new Button("Resizable"));
+            add(b2 = new Button("Resize"));
+            add(b3 = new Button("Iconify"));
+            add(b4 = new Button("Iconify and Restore"));
+            add(b5 = new Button("Hide and show"));
+            add(b6 = new Button("Hide, Iconify and Show"));
+            add(b7 = new Button("Hide, Iconify, Show and Restore"));
             b1.addActionListener(this);
             b2.addActionListener(this);
             b3.addActionListener(this);
@@ -194,10 +195,9 @@ public class FrameStateTest implements ActionListener {
             b7.addActionListener(this);
             addWindowListener(this);
 
-            setBounds(100, 2, 200, 200);
+            setBounds(100, 2, 250, 200);
             setState(iconified ? Frame.ICONIFIED : Frame.NORMAL);
             setResizable(isResizable);
-            pack();
             setVisible(true);
         }
 
@@ -323,11 +323,11 @@ public class FrameStateTest implements ActionListener {
 
         public void stateLog(String message) {
             PassFailJFrame
-                .log("[Current State=%d] %s %s".formatted(getState(), name, message));
+                .log("[Current State = %d] %s %s".formatted(getState(), name, message));
         }
 
         public void stateLog() {
-            PassFailJFrame.log("[Current State=" + getState() + "]");
+            PassFailJFrame.log("[Current State = " + getState() + "]");
         }
     }
 }

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -91,7 +91,7 @@ public class FrameStateTest implements ActionListener {
         For "hide,iconify and show" case, the frame is hidden then iconified hence Window2
         is not seen on-screen when shown as the frame is still in the ICONIFIED state.
         Window2 is visible on-screen when it is restored to NORMAL state as observed with
-        "hide,iconify, show and restore" case.<br><br>
+        "hide,iconify,show and restore" case.<br><br>
 
         If you observe the proper behavior for all the combinations, press PASS else FAIL.<br>
         </p><p>
@@ -184,7 +184,7 @@ public class FrameStateTest implements ActionListener {
             add(b4 = new Button("iconify and restore"));
             add(b5 = new Button("hide and show"));
             add(b6 = new Button("hide, iconify and show"));
-            add(b7 = new Button("hide, iconify, show, and restore"));
+            add(b7 = new Button("hide, iconify, show and restore"));
             b1.addActionListener(this);
             b2.addActionListener(this);
             b3.addActionListener(this);

--- a/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
+++ b/test/jdk/java/awt/Frame/FrameStateTest/FrameStateTest.java
@@ -174,7 +174,7 @@ public class FrameStateTest implements ActionListener {
             add(b2 = new Button("Resize"));
             add(b3 = new Button("Iconify"));
             add(b4 = new Button("Iconify and Restore"));
-            add(b5 = new Button("Hide and show"));
+            add(b5 = new Button("Hide and Show"));
             add(b6 = new Button("Hide, Iconify and Show"));
             add(b7 = new Button("Hide, Iconify, Show and Restore"));
             b1.addActionListener(this);


### PR DESCRIPTION
For the following manual test, more instructions are added as to what to expect for "hide,iconify and show" vs "hide,iconify,show and restore" for clarity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329692](https://bugs.openjdk.org/browse/JDK-8329692): Add more details to FrameStateTest.java test instructions (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - Committer) ⚠️ Review applies to [88f5d048](https://git.openjdk.org/jdk/pull/19008/files/88f5d048e9177812ca36b9ef8fb8f10ed6072170)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [88f5d048](https://git.openjdk.org/jdk/pull/19008/files/88f5d048e9177812ca36b9ef8fb8f10ed6072170)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19008/head:pull/19008` \
`$ git checkout pull/19008`

Update a local copy of the PR: \
`$ git checkout pull/19008` \
`$ git pull https://git.openjdk.org/jdk.git pull/19008/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19008`

View PR using the GUI difftool: \
`$ git pr show -t 19008`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19008.diff">https://git.openjdk.org/jdk/pull/19008.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19008#issuecomment-2083856991)