### PR TITLE
8331352: error: template-id not allowed for constructor/destructor in C++20

### DIFF
--- a/src/hotspot/share/gc/z/zArray.inline.hpp
+++ b/src/hotspot/share/gc/z/zArray.inline.hpp
@@ -96,7 +96,7 @@ ZActivatedArray<T>::ZActivatedArray(bool locked)
     _array() {}
 
 template <typename T>
-ZActivatedArray<T>::~ZActivatedArray<T>() {
+ZActivatedArray<T>::~ZActivatedArray() {
   FreeHeap(_lock);
 }
 

--- a/src/hotspot/share/utilities/chunkedList.hpp
+++ b/src/hotspot/share/utilities/chunkedList.hpp
@@ -44,7 +44,7 @@ template <class T, MEMFLAGS F> class ChunkedList : public CHeapObj<F> {
   }
 
  public:
-  ChunkedList<T, F>() : _top(_values), _next_used(nullptr), _next_free(nullptr) {}
+  ChunkedList() : _top(_values), _next_used(nullptr), _next_free(nullptr) {}
 
   bool is_full() const {
     return _top == end();

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -99,7 +99,7 @@ template <class T> class EventLogBase : public EventLog {
   EventRecord<T>* _records;
 
  public:
-  EventLogBase<T>(const char* name, const char* handle, int length = LogEventsBufferEntries):
+  EventLogBase(const char* name, const char* handle, int length = LogEventsBufferEntries):
     _mutex(Mutex::event, name),
     _name(name),
     _handle(handle),

--- a/src/hotspot/share/utilities/linkedlist.hpp
+++ b/src/hotspot/share/utilities/linkedlist.hpp
@@ -82,7 +82,7 @@ template <class E> class LinkedListNode : public AnyObj {
 template <class E> class LinkedList : public AnyObj {
  protected:
   LinkedListNode<E>*    _head;
-  NONCOPYABLE(LinkedList<E>);
+  NONCOPYABLE(LinkedList);
 
  public:
   LinkedList() : _head(nullptr) { }


### PR DESCRIPTION
When compiling trunk (819f3d6fc70ff6fe54ac5f9033c17c3dd4326aa5 2024-04-29) by gcc-14.0.1-0.15.fc40.x86_64 there are many errors: 
```
In file included from src/hotspot/share/memory/allocation.hpp:30,
                 from src/hotspot/share/ci/ciBaseObject.hpp:29,
                 from src/hotspot/share/ci/ciMetadata.hpp:28,
                 from src/hotspot/share/ci/ciType.hpp:28,
                 from src/hotspot/share/ci/ciKlass.hpp:28,
                 from src/hotspot/share/ci/ciArrayKlass.hpp:28,
                 from src/hotspot/share/ci/ciArray.hpp:28,
                 from src/hotspot/share/ci/compilerInterface.hpp:28,
                 from src/hotspot/share/compiler/abstractCompiler.hpp:28,
                 from src/hotspot/share/compiler/abstractCompiler.cpp:25:
src/hotspot/share/utilities/linkedlist.hpp:85:15: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
   85 |   NONCOPYABLE(LinkedList<E>);
      |               ^~~~~~~~~~~~~
src/hotspot/share/utilities/globalDefinitions.hpp:87:26: note: in definition of macro ‘NONCOPYABLE’
   87 | #define NONCOPYABLE(C) C(C const&) = delete; C& operator=(C const&) = delete /* next token must be ; */
      |                          ^
src/hotspot/share/utilities/linkedlist.hpp:85:15: note: remove the ‘< >’
   85 |   NONCOPYABLE(LinkedList<E>);
      |               ^~~~~~~~~~~~~
src/hotspot/share/utilities/globalDefinitions.hpp:87:26: note: in definition of macro ‘NONCOPYABLE’
   87 | #define NONCOPYABLE(C) C(C const&) = delete; C& operator=(C const&) = delete /* next token must be ; */
      |                          ^

In file included from src/hotspot/share/gc/z/zGranuleMap.inline.hpp:30,
                 from src/hotspot/share/gc/z/zForwardingTable.inline.hpp:32,
                 from src/hotspot/share/gc/z/zHeap.inline.hpp:30,
                 from src/hotspot/share/gc/z/zGeneration.inline.hpp:30,
                 from src/hotspot/share/gc/z/zBarrier.inline.hpp:30,
                 from src/hotspot/share/gc/z/zBarrierSet.inline.hpp:31,
                 from src/hotspot/share/gc/shared/barrierSetConfig.inline.hpp:44,
                 from src/hotspot/share/oops/access.inline.hpp:31,
                 from src/hotspot/share/memory/iterator.inline.hpp:32,
                 from src/hotspot/share/oops/oop.inline.hpp:31,
                 from src/hotspot/share/compiler/abstractDisassembler.cpp:32:
src/hotspot/share/gc/z/zArray.inline.hpp:99:21: error: template-id not allowed for destructor in C++20 [-Werror=template-id-cdtor]
   99 | ZActivatedArray<T>::~ZActivatedArray<T>() {
      |                     ^
src/hotspot/share/gc/z/zArray.inline.hpp:99:21: note: remove the ‘< >’

In file included from src/hotspot/share/opto/bytecodeInfo.cpp:38:
src/hotspot/share/utilities/events.hpp:102:18: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
  102 |   EventLogBase<T>(const char* name, const char* handle, int length = LogEventsBufferEntries):
      |                  ^
src/hotspot/share/utilities/events.hpp:102:18: note: remove the ‘< >’

In file included from src/hotspot/share/classfile/metadataOnStackMark.hpp:29,
                 from src/hotspot/share/classfile/classLoaderDataGraph.cpp:30:
src/hotspot/share/utilities/chunkedList.hpp:47:20: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
   47 |   ChunkedList<T, F>() : _top(_values), _next_used(nullptr), _next_free(nullptr) {}
      |                    ^
src/hotspot/share/utilities/chunkedList.hpp:47:20: note: remove the ‘< >’
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8331352: error: template-id not allowed for constructor/destructor in C++20`

### Issue
 * [JDK-8331352](https://bugs.openjdk.org/browse/JDK-8331352): error: template-id not allowed for constructor/destructor in C++20 (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19009/head:pull/19009` \
`$ git checkout pull/19009`

Update a local copy of the PR: \
`$ git checkout pull/19009` \
`$ git pull https://git.openjdk.org/jdk.git pull/19009/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19009`

View PR using the GUI difftool: \
`$ git pr show -t 19009`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19009.diff">https://git.openjdk.org/jdk/pull/19009.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19009#issuecomment-2084169415)