### PR TITLE
8331394: G1: Remove SKIP_RETIRED_FULL_REGIONS define in G1HRPrinter

### DIFF
--- a/src/hotspot/share/gc/g1/g1HRPrinter.hpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.hpp
@@ -28,8 +28,6 @@
 #include "gc/g1/g1HeapRegion.hpp"
 #include "logging/log.hpp"
 
-#define SKIP_RETIRED_FULL_REGIONS 1
-
 class FreeRegionList;
 
 class G1HRPrinter {
@@ -58,9 +56,7 @@ public:
 
   void retire(HeapRegion* hr) {
     if (is_active()) {
-      if (!SKIP_RETIRED_FULL_REGIONS || hr->top() < hr->end()) {
-        print("RETIRE", hr);
-      }
+      print("RETIRE", hr);
     }
   }
 


### PR DESCRIPTION
Hi all,

  please review this removal of the compile-time define SKIP_RETIRED_FULL_REGIONS. I doubt it has ever been used except for some initial debugging and then just kept. If needed, it can be re-added locally for debugging something, but I do not think it is necessary to have it available publicy.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331394](https://bugs.openjdk.org/browse/JDK-8331394): G1: Remove SKIP_RETIRED_FULL_REGIONS define in G1HRPrinter (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19012/head:pull/19012` \
`$ git checkout pull/19012`

Update a local copy of the PR: \
`$ git checkout pull/19012` \
`$ git pull https://git.openjdk.org/jdk.git pull/19012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19012`

View PR using the GUI difftool: \
`$ git pr show -t 19012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19012.diff">https://git.openjdk.org/jdk/pull/19012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19012#issuecomment-2084779543)