### PR TITLE
8331392: G1: Make HRPrinter distinguish between different types of reclamation

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1317,7 +1317,7 @@ public:
     if (!_cleanup_list.is_empty()) {
       log_debug(gc)("Reclaimed %u empty regions", _cleanup_list.length());
       // Now print the empty regions list.
-      _g1h->hr_printer()->cleanup(&_cleanup_list);
+      _g1h->hr_printer()->mark_reclaim(&_cleanup_list);
       // And actually make them available.
       _g1h->prepend_to_freelist(&_cleanup_list);
     }

--- a/src/hotspot/share/gc/g1/g1HRPrinter.cpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.cpp
@@ -27,12 +27,12 @@
 #include "gc/g1/g1HeapRegionSet.hpp"
 #include "gc/g1/g1HRPrinter.hpp"
 
-void G1HRPrinter::cleanup(FreeRegionList* cleanup_list) {
+void G1HRPrinter::mark_reclaim(FreeRegionList* cleanup_list) {
   if (is_active()) {
     FreeRegionListIterator iter(cleanup_list);
     while (iter.more_available()) {
       HeapRegion* hr = iter.get_next();
-      cleanup(hr);
+      mark_reclaim(hr);
     }
   }
 }

--- a/src/hotspot/share/gc/g1/g1HRPrinter.hpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.hpp
@@ -42,6 +42,10 @@ private:
                           action, hr->get_type_str(), p2i(hr->bottom()), p2i(hr->top()), p2i(hr->end()));
   }
 
+  void mark_reclaim(HeapRegion* hr) {
+    print("MARK-RECLAIM", hr);
+  }
+
 public:
   // In some places we iterate over a list in order to generate output
   // for the list's elements. By exposing this we can avoid this
@@ -82,13 +86,19 @@ public:
     }
   }
 
-  void cleanup(HeapRegion* hr) {
+  void mark_reclaim(FreeRegionList* free_list);
+
+  void eager_reclaim(HeapRegion* hr) {
     if (is_active()) {
-      print("CLEANUP", hr);
+      print("EAGER-RECLAIM", hr);
     }
   }
 
-  void cleanup(FreeRegionList* free_list);
+  void evac_reclaim(HeapRegion* hr) {
+    if (is_active()) {
+      print("EVAC-RECLAIM", hr);
+    }
+  }
 
   void post_compaction(HeapRegion* hr) {
     if (is_active()) {

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -412,7 +412,7 @@ public:
       r->set_containing_set(nullptr);
       _humongous_regions_reclaimed++;
       _g1h->free_humongous_region(r, nullptr);
-      _g1h->hr_printer()->cleanup(r);
+      _g1h->hr_printer()->eager_reclaim(r);
     };
 
     _g1h->humongous_obj_regions_iterate(r, free_humongous_region);
@@ -760,7 +760,7 @@ class FreeCSetClosure : public HeapRegionClosure {
 
     // Free the region and its remembered set.
     _g1h->free_region(r, nullptr);
-    _g1h->hr_printer()->cleanup(r);
+    _g1h->hr_printer()->evac_reclaim(r);
   }
 
   void handle_failed_region(HeapRegion* r) {


### PR DESCRIPTION
Hi all,

  while debugging some unrelated issues using the HRPrinter logging, I found it useful to discriminate between different sources of reclamation in the output. At least "cleanup" seems a bit non-descriptive to me, and only ever fit the case where we "cleaned up" completely empty regions during the Cleanup pause (pre jdk11).

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331392](https://bugs.openjdk.org/browse/JDK-8331392): G1: Make HRPrinter distinguish between different types of reclamation (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19013/head:pull/19013` \
`$ git checkout pull/19013`

Update a local copy of the PR: \
`$ git checkout pull/19013` \
`$ git pull https://git.openjdk.org/jdk.git pull/19013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19013`

View PR using the GUI difftool: \
`$ git pr show -t 19013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19013.diff">https://git.openjdk.org/jdk/pull/19013.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19013#issuecomment-2084783740)