### PR TITLE
8308033: The jcmd thread dump related tests should test virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,6 @@
 serviceability/AsyncGetCallTrace/MyPackage/ASGCTBaseTest.java 8308026 generic-all
 serviceability/jvmti/GetThreadListStackTraces/OneGetThreadListStackTraces.java 8308027 generic-all
 serviceability/jvmti/Heap/IterateHeapWithEscapeAnalysisEnabled.java 8264699 generic-all
-serviceability/dcmd/thread/PrintConcurrentLocksTest.java 8308033 generic-all
-serviceability/dcmd/thread/PrintTest.java 8308033 generic-all
-serviceability/dcmd/thread/ThreadDumpToFileTest.java 8308033 generic-all
-serviceability/tmtools/jstack/DaemonThreadTest.java 8308033 generic-all
 
 ####
 ## Classes not unloaded as expected (TODO, need to check if FJ keeps a reference)

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.testng.Assert;
 
@@ -171,6 +172,9 @@ public class PrintTest {
 
     @Test
     public void jmx() {
+        if (Thread.currentThread().isVirtual()) {
+            throw new SkipException("skipping test since current thread is virtual thread");
+        }
         run(new JMXExecutor());
     }
 }

--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,15 @@ public class DaemonThreadTest {
     }
 
     private static void testNoDaemon() throws Exception {
-        testThread(new NormalThread(), "");
+        Thread t = new NormalThread();
+        if (Thread.currentThread().isVirtual()) {
+            // If the NormalThread was created by a current virtual thread
+            // then the NormalThread too will be marked daemon (since virtual threads
+            // are always daemon). In that case, we explicitly reset daemon to false
+            // for the newly created thread.
+            t.setDaemon(false);
+        }
+        testThread(t, "");
     }
 
     private static void testDaemon() throws Exception {

--- a/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
+++ b/test/hotspot/jtreg/serviceability/tmtools/jstack/DaemonThreadTest.java
@@ -38,6 +38,7 @@ public class DaemonThreadTest {
     static class NormalThread extends Thread {
 
         NormalThread() {
+            setDaemon(false);
         }
 
         @Override
@@ -66,15 +67,7 @@ public class DaemonThreadTest {
     }
 
     private static void testNoDaemon() throws Exception {
-        Thread t = new NormalThread();
-        if (Thread.currentThread().isVirtual()) {
-            // If the NormalThread was created by a current virtual thread
-            // then the NormalThread too will be marked daemon (since virtual threads
-            // are always daemon). In that case, we explicitly reset daemon to false
-            // for the newly created thread.
-            t.setDaemon(false);
-        }
-        testThread(t, "");
+        testThread(new NormalThread(), "");
     }
 
     private static void testDaemon() throws Exception {

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -33,9 +33,6 @@ com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
 com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all
 
-sun/tools/jcmd/JcmdOutputEncodingTest.java 8308033 generic-all
-sun/tools/jstack/BasicJStackTest.java 8308033 generic-all
-
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
 
 javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-x64

--- a/test/jdk/sun/tools/jstack/BasicJStackTest.java
+++ b/test/jdk/sun/tools/jstack/BasicJStackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,11 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.JDKToolLauncher;
 
+import jtreg.SkippedException;
+
 /*
  * @test
- * @bug 8273187
+ * @bug 8273187 8308033
  * @summary Unit test for jstack utility
  * @library /test/lib
  * @run main BasicJStackTest
@@ -42,6 +44,13 @@ public class BasicJStackTest {
     private static ProcessBuilder processBuilder = new ProcessBuilder();
 
     public static void main(String[] args) throws Exception {
+        if (Thread.currentThread().isVirtual()) {
+            // This test runs jstack against the current process and then asserts the
+            // presence of current thread in the stacktraces. We skip this test
+            // when the current thread is a virtual thread since "jstack" command doesn't
+            // print the stacktraces of virtual threads.
+            throw new SkippedException("skipping test since current thread is a virtual thread");
+        }
         testJstackNoArgs();
         testJstack_l();
         testJstackUTF8Encoding();


### PR DESCRIPTION
Can I please get a review of these test-only changes which proposes to remove the `test/jdk/sun/tools/jcmd/JcmdOutputEncodingTest.java` and `test/jdk/sun/tools/jstack/BasicJStackTest.java` tests from `ProblemList-Virtual.txt`?

When jtreg was enhanced to allow running the tests from within a virtual (main) thread, some tests were problem listed since they either were failing at that time or the test code would require additional work to make it work when the current thread is a virtual thread. The `test/jdk/sun/tools/jcmd/JcmdOutputEncodingTest.java` and `test/jdk/sun/tools/jstack/BasicJStackTest.java` are 2 such threads which require special handling when the current thread is a virtual thread.

`test/jdk/sun/tools/jcmd/JcmdOutputEncodingTest.java` has been updated to use a different command to dump stacktraces when the test runs in a virtual thread. I went back and looked at the original issue for which this test was introduced and based on that, using a different command to dump the stacktraces shouldn't impact what the test was originally intended to test.

`test/jdk/sun/tools/jstack/BasicJStackTest.java` has been updated to be skipped when the current thread is the virtual thread. This is because the test exercises the `jstack` tool which doesn't print stacktraces of virtual threads and thus the test isn't applicable for virtual threads.

I've run these tests with this change, both with platform threads and virtual threads in our CI and the tests complete without failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308033](https://bugs.openjdk.org/browse/JDK-8308033): The jcmd thread dump related tests should test virtual threads (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19016/head:pull/19016` \
`$ git checkout pull/19016`

Update a local copy of the PR: \
`$ git checkout pull/19016` \
`$ git pull https://git.openjdk.org/jdk.git pull/19016/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19016`

View PR using the GUI difftool: \
`$ git pr show -t 19016`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19016.diff">https://git.openjdk.org/jdk/pull/19016.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19016#issuecomment-2084878691)