### PR TITLE
8331405: Shenandoah: Optimize ShenandoahLock with TTAS

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -54,7 +54,8 @@ template<typename BlockOp>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   int ctr = 0;
   int yields = 0;
-  while (Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
+  while (Atomic::load(&_state) == locked ||
+         Atomic::cmpxchg(&_state, unlocked, locked) != unlocked) {
     if ((++ctr & 0xFFF) == 0) {
       BlockOp block(java_thread);
       if (yields > 5) {


### PR DESCRIPTION
JDK-8325587 made the contended lock acquisition as the CAS loop with backoffs. Unfortunately, for `SpinPause` path, we always do the CAS and then spin. This is not efficient, as CAS likely requests memory for ownership, which exacerbates the contention and makes the spin loop run longer before blocking.

We should really use TTAS pattern there, like `Thread::SpinAcquire` does it.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `hotspot_gc_shenandoah`
 - [ ] Linux AArch64 server fastdebug, `all` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331405](https://bugs.openjdk.org/browse/JDK-8331405): Shenandoah: Optimize ShenandoahLock with TTAS (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19018/head:pull/19018` \
`$ git checkout pull/19018`

Update a local copy of the PR: \
`$ git checkout pull/19018` \
`$ git pull https://git.openjdk.org/jdk.git pull/19018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19018`

View PR using the GUI difftool: \
`$ git pr show -t 19018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19018.diff">https://git.openjdk.org/jdk/pull/19018.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19018#issuecomment-2085063158)