### PR TITLE
8331410: Remove unused MemAllocator::mem_allocate_inside_tlab

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -250,19 +250,6 @@ HeapWord* MemAllocator::mem_allocate_outside_tlab(Allocation& allocation) const 
   return mem;
 }
 
-HeapWord* MemAllocator::mem_allocate_inside_tlab(Allocation& allocation) const {
-  assert(UseTLAB, "should use UseTLAB");
-
-  // Try allocating from an existing TLAB.
-  HeapWord* mem = mem_allocate_inside_tlab_fast();
-  if (mem != nullptr) {
-    return mem;
-  }
-
-  // Try refilling the TLAB and allocating the object in it.
-  return mem_allocate_inside_tlab_slow(allocation);
-}
-
 HeapWord* MemAllocator::mem_allocate_inside_tlab_fast() const {
   return _thread->tlab().allocate(_word_size);
 }
@@ -330,7 +317,6 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   tlab.fill(mem, mem + _word_size, allocation._allocated_tlab_size);
   return mem;
 }
-
 
 HeapWord* MemAllocator::mem_allocate_slow(Allocation& allocation) const {
   // Allocation of an oop can always invoke a safepoint.

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -47,7 +47,6 @@ protected:
 
 private:
   // Allocate in a TLAB. Could allocate a new TLAB, and therefore potentially safepoint.
-  HeapWord* mem_allocate_inside_tlab(Allocation& allocation) const;
   HeapWord* mem_allocate_inside_tlab_slow(Allocation& allocation) const;
 
   // Allocate outside a TLAB. Could safepoint.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331410](https://bugs.openjdk.org/browse/JDK-8331410): Remove unused MemAllocator::mem_allocate_inside_tlab (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19019/head:pull/19019` \
`$ git checkout pull/19019`

Update a local copy of the PR: \
`$ git checkout pull/19019` \
`$ git pull https://git.openjdk.org/jdk.git pull/19019/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19019`

View PR using the GUI difftool: \
`$ git pr show -t 19019`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19019.diff">https://git.openjdk.org/jdk/pull/19019.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19019#issuecomment-2084999753)