### PR TITLE
8313674: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -52,8 +52,8 @@ public class BlockDeviceSize {
                     throw new RuntimeException("size differs when retrieved" +
                             " in different ways: " + size1 + " != " + size2);
                 }
-                if (size1 == 0) {
-                    throw new RuntimeException("size() for a block device size returns zero");
+                if (size1 <= 0) {
+                    throw new RuntimeException("size() for a block device size returns zero or a negative value");
                 }
                 System.out.println("OK");
 

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -30,7 +30,6 @@
 
 import java.io.RandomAccessFile;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.channels.FileChannel;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.NoSuchFileException;
@@ -44,7 +43,7 @@ public class BlockDeviceSize {
 
     public static void main(String[] args) throws Throwable {
         for (String blkFname: BLK_FNAMES) {
-            Path blkPath = Paths.get(blkFname);
+            Path blkPath = Path.of(blkFname);
             try (FileChannel ch = FileChannel.open(blkPath, READ);
                  RandomAccessFile file = new RandomAccessFile(blkFname, "r")) {
 

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
- * @run main/manual BlockDeviceSize
  */
 
 import java.io.RandomAccessFile;

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -40,7 +40,7 @@ import static java.nio.file.StandardOpenOption.*;
 
 
 public class BlockDeviceSize {
-    private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1") ;
+    private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
 
     public static void main(String[] args) throws Throwable {
         for (String blkFname: BLK_FNAMES) {

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -24,7 +24,7 @@
 /* @test
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
- * @summary Block devices should not report size=0 on Linux
+ * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
  * @run main/manual BlockDeviceSize
  */
 
@@ -53,6 +53,9 @@ public class BlockDeviceSize {
                 if (size1 != size2) {
                     throw new RuntimeException("size differs when retrieved" +
                             " in different ways: " + size1 + " != " + size2);
+                }
+                if (size1 == 0) {
+                    throw new RuntimeException("size() for a block device size returns zero");
                 }
                 System.out.println("OK");
 

--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -42,13 +42,9 @@ import static java.nio.file.StandardOpenOption.*;
 public class BlockDeviceSize {
     private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1") ;
 
-    public static Path getBlkPath(String blkFileName) {
-        return Paths.get(blkFileName);
-    }
-
     public static void main(String[] args) throws Throwable {
         for (String blkFname: BLK_FNAMES) {
-            Path blkPath = getBlkPath(blkFname);
+            Path blkPath = Paths.get(blkFname);
             try (FileChannel ch = FileChannel.open(blkPath, READ);
                  RandomAccessFile file = new RandomAccessFile(blkFname, "r")) {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313674](https://bugs.openjdk.org/browse/JDK-8313674): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java should test for more block devices (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [39e348b3](https://git.openjdk.org/jdk/pull/19021/files/39e348b334c17365c95b14419f56aa605defd20d)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19021/head:pull/19021` \
`$ git checkout pull/19021`

Update a local copy of the PR: \
`$ git checkout pull/19021` \
`$ git pull https://git.openjdk.org/jdk.git pull/19021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19021`

View PR using the GUI difftool: \
`$ git pr show -t 19021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19021.diff">https://git.openjdk.org/jdk/pull/19021.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19021#issuecomment-2085338045)