### PR TITLE
8331427: Rename confusingly named ArraysSupport.signedHashCode

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -200,7 +200,7 @@ public class ArraysSupport {
     public static int vectorizedHashCode(Object array, int fromIndex, int length, int initialValue,
                                          int basicType) {
         return switch (basicType) {
-            case T_BOOLEAN -> signedHashCode(initialValue, (byte[]) array, fromIndex, length);
+            case T_BOOLEAN -> unsignedHashCode(initialValue, (byte[]) array, fromIndex, length);
             case T_CHAR -> array instanceof byte[]
                     ? utf16hashCode(initialValue, (byte[]) array, fromIndex, length)
                     : hashCode(initialValue, (char[]) array, fromIndex, length);
@@ -211,7 +211,7 @@ public class ArraysSupport {
         };
     }
 
-    private static int signedHashCode(int result, byte[] a, int fromIndex, int length) {
+    private static int unsignedHashCode(int result, byte[] a, int fromIndex, int length) {
         int end = fromIndex + length;
         for (int i = fromIndex; i < end; i++) {
             result = 31 * result + (a[i] & 0xff);


### PR DESCRIPTION
Please review this trivial method rename. While this issue was originally spotted in [another PR], it makes sense to address it separately. Test results are pending; not that I expect failures, but still.

[another PR]: https://github.com/openjdk/jdk/pull/14831#issuecomment-1655477396

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331427](https://bugs.openjdk.org/browse/JDK-8331427): Rename confusingly named ArraysSupport.signedHashCode (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [e83c991f](https://git.openjdk.org/jdk/pull/19023/files/e83c991fb5d972bd6ea2ee04424ebdf3cd36138e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19023/head:pull/19023` \
`$ git checkout pull/19023`

Update a local copy of the PR: \
`$ git checkout pull/19023` \
`$ git pull https://git.openjdk.org/jdk.git pull/19023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19023`

View PR using the GUI difftool: \
`$ git pr show -t 19023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19023.diff">https://git.openjdk.org/jdk/pull/19023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19023#issuecomment-2085538433)