### PR TITLE
8331404: IGV: Show line numbers for callees in properties

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -609,23 +609,7 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
       }
     }
 
-    if (caller != nullptr) {
-      stringStream bciStream;
-      ciMethod* last = nullptr;
-      int last_bci;
-      while(caller) {
-        if (caller->has_method()) {
-          last = caller->method();
-          last_bci = caller->bci();
-        }
-        bciStream.print("%d ", caller->bci());
-        caller = caller->caller();
-      }
-      print_prop("bci", bciStream.freeze());
-      if (last != nullptr && last->has_linenumber_table() && last_bci >= 0) {
-        print_prop("line", last->line_number_from_bci(last_bci));
-      }
-    }
+    print_bci_and_line_number(caller);
 
 #ifdef ASSERT
     if (node->debug_orig() != nullptr) {
@@ -651,6 +635,35 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
     tail(PROPERTIES_ELEMENT);
     tail(NODE_ELEMENT);
+  }
+}
+
+void IdealGraphPrinter::print_bci_and_line_number(JVMState* caller) {
+  if (caller != nullptr) {
+    ResourceMark rm;
+    stringStream bciStream;
+    stringStream lineStream;
+
+    // Print line and bci numbers for the callee and all entries in the call stack until we reach the root method.
+    while (caller) {
+      const int bci = caller->bci();
+      bool appended_line = false;
+      if (caller->has_method()) {
+        ciMethod* method = caller->method();
+        if (method->has_linenumber_table() && bci >= 0) {
+          lineStream.print("%d ", method->line_number_from_bci(bci));
+          appended_line = true;
+        }
+      }
+      if (!appended_line) {
+        lineStream.print("%s ", "_");
+      }
+      bciStream.print("%d ", bci);
+      caller = caller->caller();
+    }
+
+    print_prop("bci", bciStream.freeze());
+    print_prop("line", lineStream.freeze());
   }
 }
 

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -40,6 +40,7 @@ class Matcher;
 class Node;
 class InlineTree;
 class ciMethod;
+class JVMState;
 
 class IdealGraphPrinter : public CHeapObj<mtCompiler> {
  private:
@@ -96,9 +97,10 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   Compile *C;
   double _max_freq;
 
-  void print_method(ciMethod *method, int bci, InlineTree *tree);
-  void print_inline_tree(InlineTree *tree);
-  void visit_node(Node *n, bool edges, VectorSet* temp_set);
+  void print_method(ciMethod* method, int bci, InlineTree* tree);
+  void print_inline_tree(InlineTree* tree);
+  void visit_node(Node* n, bool edges, VectorSet* temp_set);
+  void print_bci_and_line_number(JVMState* caller);
   void print_field(const Node* node);
   ciField* get_field(const Node* node);
   ciField* find_source_field_of_array_access(const Node* node, uint& depth);


### PR DESCRIPTION
IGV shows the `bci` for a node in the callee, followed by the bci in the caller method and so on until we reach the root method. For the `line` property, we currently only show the line number found in the root method (`first()` is the root method being compiled and `second()` and `third()` are inlined):

Example program:
![image](https://github.com/openjdk/jdk/assets/17833009/579fe9eb-4bd8-42d8-9d03-875f25bd97ae)

Properties of the store to `fFld`:
![image](https://github.com/openjdk/jdk/assets/17833009/3763cccf-c1ba-4d7f-a986-eae8bf0654b0)

One could read the line number from the `jvms` property above. But you would need to expand that property with the button on the right side which opens a window. But then you cannot click anything else anymore in IGV until you close the window again.

A simpler and easier to read solution is to add the line number information to match the bci numbers (they are printed in callee->root method order which I think is okay - especially if there are a lot of inlinees, it could be easier to have the really interesting numbers at the start on the left side). This would look something like that:
![image](https://github.com/openjdk/jdk/assets/17833009/fcab3af6-69ac-43ae-89be-19fc4476d12f)

If there is no line number information for a bci, I simply emit a `_`. 

Testing:
- Manual testing in IGV
- Sanity testing by running `java -Xcomp -XX:+PrintIdealGraph -XX:PrintIdealGraphLevel=4 -XX:PrintIdealGraphFile=graph.xml HelloWorld.java`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331404](https://bugs.openjdk.org/browse/JDK-8331404): IGV: Show line numbers for callees in properties (**Enhancement** - P4)


### Reviewers
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19025/head:pull/19025` \
`$ git checkout pull/19025`

Update a local copy of the PR: \
`$ git checkout pull/19025` \
`$ git pull https://git.openjdk.org/jdk.git pull/19025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19025`

View PR using the GUI difftool: \
`$ git pr show -t 19025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19025.diff">https://git.openjdk.org/jdk/pull/19025.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19025#issuecomment-2085721583)