### PR TITLE
8331418: ZGC: generalize barrier liveness logic

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
@@ -476,7 +476,7 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
   GrowableArray<RegisterData> registers;
   VMReg prev_vm_reg = VMRegImpl::Bad();
 
-  RegMaskIterator rmi(stub->live());
+  RegMaskIterator rmi(stub->preserve_set());
   while (rmi.has_next()) {
     OptoReg::Name opto_reg = rmi.next();
     VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
@@ -491,7 +491,7 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
         index = registers.append(reg_data);
       }
     } else if (vm_reg->is_FloatRegister()) {
-      // We have size encoding in OptoReg of stub->live()
+      // We have size encoding in OptoReg of stub->preserve_set()
       // After encoding, float/neon/sve register has only one slot in regmask
       // Decode it to get the actual size
       VMReg vm_reg_base = vm_reg->as_FloatRegister()->as_VMReg();
@@ -532,12 +532,8 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
     }
   }
 
-  // Remove C-ABI SOE registers, scratch regs and _ref register that will be updated
-  if (stub->result() != noreg) {
-    _gp_regs -= RegSet::range(r19, r30) + RegSet::of(r8, r9, stub->result());
-  } else {
-    _gp_regs -= RegSet::range(r19, r30) + RegSet::of(r8, r9);
-  }
+  // Remove C-ABI SOE registers and scratch regs
+  _gp_regs -= RegSet::range(r19, r30) + RegSet::of(r8, r9);
 
   // Remove C-ABI SOE fp registers
   _fp_regs -= FloatRegSet::range(v8, v15);

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.cpp
@@ -282,7 +282,7 @@ OptoReg::Name BarrierSetAssembler::refine_register(const Node* node, OptoReg::Na
 #define __ _masm->
 
 SaveLiveRegisters::SaveLiveRegisters(MacroAssembler *masm, BarrierStubC2 *stub)
-  : _masm(masm), _reg_mask(stub->live()), _result_reg(stub->result()) {
+  : _masm(masm), _reg_mask(stub->preserve_set()) {
 
   const int register_save_size = iterate_over_register_mask(ACTION_COUNT_ONLY) * BytesPerWord;
   _frame_size = align_up(register_save_size, frame::alignment_in_bytes)
@@ -316,11 +316,6 @@ int SaveLiveRegisters::iterate_over_register_mask(IterationAction action, int of
     const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);
     if (vm_reg->is_Register()) {
       Register std_reg = vm_reg->as_Register();
-
-      // '_result_reg' will hold the end result of the operation. Its content must thus not be preserved.
-      if (std_reg == _result_reg) {
-        continue;
-      }
 
       if (std_reg->encoding() >= R2->encoding() && std_reg->encoding() <= R12->encoding()) {
         reg_save_index++;

--- a/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/gc/shared/barrierSetAssembler_ppc.hpp
@@ -98,7 +98,6 @@ public:
 class SaveLiveRegisters {
   MacroAssembler* _masm;
   RegMask _reg_mask;
-  Register _result_reg;
   int _frame_size;
 
  public:

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -396,7 +396,7 @@ OptoReg::Name BarrierSetAssembler::refine_register(const Node* node, OptoReg::Na
 
 void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
   // Record registers that needs to be saved/restored
-  RegMaskIterator rmi(stub->live());
+  RegMaskIterator rmi(stub->preserve_set());
   while (rmi.has_next()) {
     const OptoReg::Name opto_reg = rmi.next();
     if (OptoReg::is_reg(opto_reg)) {
@@ -414,12 +414,8 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
     }
   }
 
-  // Remove C-ABI SOE registers, tmp regs and _ref register that will be updated
-  if (stub->result() != noreg) {
-    _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2) + RegSet::of(x8, x9) + RegSet::of(x5, stub->result());
-  } else {
-    _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2, x5) + RegSet::of(x8, x9);
-  }
+  // Remove C-ABI SOE registers and tmp regs
+  _gp_regs -= RegSet::range(x18, x27) + RegSet::of(x2, x5) + RegSet::of(x8, x9);
 }
 
 SaveLiveRegisters::SaveLiveRegisters(MacroAssembler* masm, BarrierStubC2* stub)

--- a/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/shared/barrierSetAssembler_x86.cpp
@@ -613,19 +613,12 @@ void SaveLiveRegisters::initialize(BarrierStubC2* stub) {
   caller_saved.Insert(OptoReg::as_OptoReg(r10->as_VMReg()));
   caller_saved.Insert(OptoReg::as_OptoReg(r11->as_VMReg()));
 
-  if (stub->result() != noreg) {
-    caller_saved.Remove(OptoReg::as_OptoReg(stub->result()->as_VMReg()));
-  }
-
-  // Create mask of live registers
-  RegMask live = stub->live();
-
   int gp_spill_size = 0;
   int opmask_spill_size = 0;
   int xmm_spill_size = 0;
 
   // Record registers that needs to be saved/restored
-  RegMaskIterator rmi(live);
+  RegMaskIterator rmi(stub->preserve_set());
   while (rmi.has_next()) {
     const OptoReg::Name opto_reg = rmi.next();
     const VMReg vm_reg = OptoReg::as_VMReg(opto_reg);

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -95,7 +95,7 @@ BarrierStubC2::BarrierStubC2(const MachNode* node)
   : _node(node),
     _entry(),
     _continuation(),
-    _preserve(live()){}
+    _preserve(live()) {}
 
 Label* BarrierStubC2::entry() {
   // The _entry will never be bound when in_scratch_emit_size() is true.
@@ -876,7 +876,7 @@ void BarrierSetC2::compute_liveness_at_stubs() const {
       // If this node tracks out-liveness, update it
       if (!bs_state->needs_livein_data()) {
         RegMask* const regs = bs_state->live(node);
-        if (regs != NULL) {
+        if (regs != nullptr) {
           regs->OR(new_live);
         }
       }
@@ -907,7 +907,7 @@ void BarrierSetC2::compute_liveness_at_stubs() const {
       // If this node tracks in-liveness, update it
       if (bs_state->needs_livein_data()) {
         RegMask* const regs = bs_state->live(node);
-        if (regs != NULL) {
+        if (regs != nullptr) {
           regs->OR(new_live);
         }
       }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -87,14 +87,15 @@ static BarrierSetC2State* barrier_set_state() {
   return reinterpret_cast<BarrierSetC2State*>(Compile::current()->barrier_set_state());
 }
 
-BarrierStubC2::BarrierStubC2(const MachNode* node)
-  : _node(node),
-    _entry(),
-    _continuation() {}
-
 RegMask& BarrierStubC2::live() const {
   return *barrier_set_state()->live(_node);
 }
+
+BarrierStubC2::BarrierStubC2(const MachNode* node)
+  : _node(node),
+    _entry(),
+    _continuation(),
+    _preserve(live()){}
 
 Label* BarrierStubC2::entry() {
   // The _entry will never be bound when in_scratch_emit_size() is true.
@@ -106,6 +107,33 @@ Label* BarrierStubC2::entry() {
 
 Label* BarrierStubC2::continuation() {
   return &_continuation;
+}
+
+void BarrierStubC2::preserve(Register r) {
+  const VMReg vm_reg = r->as_VMReg();
+  assert(vm_reg->is_Register(), "r must be a general-purpose register");
+  _preserve.Insert(OptoReg::as_OptoReg(vm_reg));
+}
+
+void BarrierStubC2::dont_preserve(Register r) {
+  const VMReg vm_reg = r->as_VMReg();
+  assert(vm_reg->is_Register(), "r must be a general-purpose register");
+  OptoReg::Name reg = OptoReg::as_OptoReg(vm_reg);
+  // Subtract not only reg, but also all related OptoRegs that are sub-registers
+  // of the same general-purpose, processor register (e.g. {R11, R11_H} for r11
+  // in aarch64). We assume that all related OptoRegs have contiguous indices.
+  while (OptoReg::is_reg(reg)) {
+    const VMReg vm_reg = OptoReg::as_VMReg(reg);
+    if (!(vm_reg->is_Register()) || vm_reg->as_Register() != r) {
+      break;
+    }
+    _preserve.Remove(reg);
+    reg = OptoReg::add(reg, 1);
+  }
+}
+
+const RegMask& BarrierStubC2::preserve_set() const {
+  return _preserve;
 }
 
 Node* BarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val) const {
@@ -828,6 +856,7 @@ void BarrierSetC2::compute_liveness_at_stubs() const {
   PhaseRegAlloc* const regalloc = C->regalloc();
   RegMask* const live = NEW_ARENA_ARRAY(A, RegMask, cfg->number_of_blocks() * sizeof(RegMask));
   BarrierSetAssembler* const bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  BarrierSetC2State* bs_state = barrier_set_state();
   Block_List worklist;
 
   for (uint i = 0; i < cfg->number_of_blocks(); ++i) {
@@ -849,6 +878,14 @@ void BarrierSetC2::compute_liveness_at_stubs() const {
     // Walk block backwards, computing liveness
     for (int i = block->number_of_nodes() - 1; i >= 0; --i) {
       const Node* const node = block->get_node(i);
+
+      // If this node tracks out-liveness, update it
+      if (!bs_state->needs_livein_data()) {
+        RegMask* const regs = bs_state->live(node);
+        if (regs != NULL) {
+          regs->OR(new_live);
+        }
+      }
 
       // Remove def bits
       const OptoReg::Name first = bs->refine_register(node, regalloc->get_reg_first(node));
@@ -873,10 +910,12 @@ void BarrierSetC2::compute_liveness_at_stubs() const {
         }
       }
 
-       // If this node tracks liveness, update it
-      RegMask* const regs = barrier_set_state()->live(node);
-      if (regs != NULL) {
-        regs->OR(new_live);
+      // If this node tracks in-liveness, update it
+      if (bs_state->needs_livein_data()) {
+        RegMask* const regs = bs_state->live(node);
+        if (regs != NULL) {
+          regs->OR(new_live);
+        }
       }
     }
 

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -142,6 +142,10 @@ public:
     return mach->barrier_data() != ZBarrierElided;
   }
 
+  bool needs_livein_data() const {
+    return true;
+  }
+
   void inc_trampoline_stubs_count() {
     assert(_trampoline_stubs_count != INT_MAX, "Overflow");
     ++_trampoline_stubs_count;
@@ -200,6 +204,9 @@ ZLoadBarrierStubC2::ZLoadBarrierStubC2(const MachNode* node, Address ref_addr, R
     _ref(ref) {
   assert_different_registers(ref, ref_addr.base());
   assert_different_registers(ref, ref_addr.index());
+  // The runtime call updates the value of ref, so we should not spill and
+  // reload its outdated value.
+  dont_preserve(ref);
 }
 
 Address ZLoadBarrierStubC2::ref_addr() const {
@@ -208,10 +215,6 @@ Address ZLoadBarrierStubC2::ref_addr() const {
 
 Register ZLoadBarrierStubC2::ref() const {
   return _ref;
-}
-
-Register ZLoadBarrierStubC2::result() const {
-  return ref();
 }
 
 address ZLoadBarrierStubC2::slow_path() const {
@@ -270,10 +273,6 @@ bool ZStoreBarrierStubC2::is_native() const {
 
 bool ZStoreBarrierStubC2::is_atomic() const {
   return _is_atomic;
-}
-
-Register ZStoreBarrierStubC2::result() const {
-  return noreg;
 }
 
 void ZStoreBarrierStubC2::emit_code(MacroAssembler& masm) {

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.hpp
@@ -51,7 +51,6 @@ static int stubs_start_offset();
   ZBarrierStubC2(const MachNode* node);
 
 public:
-  virtual Register result() const = 0;
   virtual void emit_code(MacroAssembler& masm) = 0;
 };
 
@@ -70,7 +69,6 @@ public:
   Register ref() const;
   address slow_path() const;
 
-  virtual Register result() const;
   virtual void emit_code(MacroAssembler& masm);
 };
 
@@ -94,7 +92,6 @@ public:
   bool is_native() const;
   bool is_atomic() const;
 
-  virtual Register result() const;
   virtual void emit_code(MacroAssembler& masm);
 };
 


### PR DESCRIPTION
This changeset generalizes the logic to analyze, declare, and communicate which registers are live at a C2 barrier stub so that it can be used by other collectors than ZGC adopting the late barrier expansion model (including G1 in the near future, see [JEP 475](https://openjdk.org/jeps/475)).

The main changes are:

- Make it possible to compute register liveness information before (live-in) or after (live-out) each barrier, and let the collector choose by implementing `BarrierSetC2State::needs_livein_data()`.

- Generalize the interface with which collectors declare which registers must be additionally preserved across barrier runtime calls, adding the methods `BarrierStubC2::preserve(Register r)` and `BarrierStubC2::dont_preserve(Register r)`.

- Simplify the interface with which platform-specific logic computes which registers to preserve across barrier runtime calls, replacing the calls to `BarrierStubC2::result()` and `BarrierStubC2::live()` with a single call to `BarrierStubC2::preserve_set()`.

#### Testing

- tier1-5 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode).
- tier1-7 (linux-x64, linux-aarch64; release and debug mode; ZGC tests only) with [an additional patch](https://github.com/openjdk/jdk/commit/4d4e743d8f4cddd5288cee1d69c70fe2b9bea066) that exercises the spilling and restoring logic by forcing ZGC read barriers to always take the slow path and clearing all general-purpose save-on-call registers upon the slow path's runtime call.
- Build with `make hotspot` (linux-riscv64-debug, linux-ppc64le-debug). @RealFYang, @TheRealMDoerr: could you please test and review the riscv and ppc changes? Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331418](https://bugs.openjdk.org/browse/JDK-8331418): ZGC: generalize barrier liveness logic (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [c0fc66de](https://git.openjdk.org/jdk/pull/19026/files/c0fc66deb654a9b930a7b7cf1a7e7fa093739027)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**) ⚠️ Review applies to [c0fc66de](https://git.openjdk.org/jdk/pull/19026/files/c0fc66deb654a9b930a7b7cf1a7e7fa093739027)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19026/head:pull/19026` \
`$ git checkout pull/19026`

Update a local copy of the PR: \
`$ git checkout pull/19026` \
`$ git pull https://git.openjdk.org/jdk.git pull/19026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19026`

View PR using the GUI difftool: \
`$ git pr show -t 19026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19026.diff">https://git.openjdk.org/jdk/pull/19026.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19026#issuecomment-2086593657)