### PR TITLE
8331435: Malformed text in jpackage.md file

### DIFF
--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -189,7 +189,7 @@ All files in the input directory will be packaged into the application
 image.
 .RE
 .TP
-\[ga]--app-content \f[I]additional-content\f[R][,\f[I]additional-content\f[R]...]
+\f[V]--app-content\f[R] \f[I]additional-content\f[R] [\f[V],\f[R]\f[I]additional-content\f[R]...]
 A comma separated list of paths to files and/or directories to add to
 the application payload.
 .RS
@@ -443,7 +443,7 @@ Group value of the RPM /.spec file or Section value of DEB control file
 Creates a shortcut for the application.
 .SS macOS platform options (available only when running on macOS):
 .TP
-\[aq]--mac-dmg-content \f[I]additional-content\f[R][,\f[I]additional-content\f[R]...]
+\f[V]--mac-dmg-content\f[R] \f[I]additional-content\f[R] [\f[V],\f[R]\f[I]additional-content\f[R]...]
 Include all the referenced content in the dmg.
 .RS
 .PP


### PR DESCRIPTION
Rerun pandoc on updated source man page file

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8331435`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8331435`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19027/head:pull/19027` \
`$ git checkout pull/19027`

Update a local copy of the PR: \
`$ git checkout pull/19027` \
`$ git pull https://git.openjdk.org/jdk.git pull/19027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19027`

View PR using the GUI difftool: \
`$ git pr show -t 19027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19027.diff">https://git.openjdk.org/jdk/pull/19027.diff</a>

</details>
