### PR TITLE
8331253: 16 bits is not enough for nmethod::_skipped_instructions_size field

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zBarrierSetAssembler_aarch64.cpp
@@ -1141,7 +1141,6 @@ public:
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZLoadBarrierStubC2");
 
   // Stub entry
@@ -1160,7 +1159,6 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
 }
 
 void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZStoreBarrierStubC2");
 
   // Stub entry

--- a/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/gc/z/zBarrierSetAssembler_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -887,7 +887,6 @@ class ZSetupArguments {
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   __ block_comment("generate_c2_load_barrier_stub (zgc) {");
 
   __ bind(*stub->entry());
@@ -911,7 +910,6 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
 }
 
 void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   __ block_comment("ZStoreBarrierStubC2");
 
   // Stub entry

--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1213,7 +1213,6 @@ public:
 #define __ masm->
 
 void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, ZLoadBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZLoadBarrierStubC2");
 
   // Stub entry
@@ -1233,7 +1232,6 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
 }
 
 void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, ZStoreBarrierStubC2* stub) const {
-  Assembler::InlineSkippedInstructionsCounter skipped_counter(masm);
   BLOCK_COMMENT("ZStoreBarrierStubC2");
 
   // Stub entry

--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -1012,6 +1012,8 @@ void CodeBuffer::log_section_sizes(const char* name) {
 }
 
 bool CodeBuffer::finalize_stubs() {
+  // Record size of code before we generate stubs in instructions section
+  _main_code_size = _insts.size();
   if (_finalize_stubs && !pd_finalize_stubs()) {
     // stub allocation failure
     return false;

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -427,6 +427,9 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   address      _total_start;    // first address of combined memory buffer
   csize_t      _total_size;     // size in bytes of combined memory buffer
 
+  // Size of code without stubs generated at the end of instructions section
+  csize_t      _main_code_size;
+
   OopRecorder* _oop_recorder;
 
   OopRecorder  _default_oop_recorder;  // override with initialize_oop_recorder
@@ -457,6 +460,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
     _oop_recorder    = nullptr;
     _overflow_arena  = nullptr;
     _last_insn       = nullptr;
+    _main_code_size  = 0;
     _finalize_stubs  = false;
     _shared_stub_to_interp_requests = nullptr;
     _shared_trampoline_requests = nullptr;
@@ -629,6 +633,9 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
 
   // number of bytes remaining in the insts section
   csize_t insts_remaining() const        { return _insts.remaining(); }
+
+  // size of code without stubs in instruction section
+  csize_t main_code_size() const         { return _main_code_size; }
 
   // is a given address in the insts section?  (2nd version is end-inclusive)
   bool insts_contains(address pc) const  { return _insts.contains(pc); }

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -1126,13 +1126,14 @@ int ciMethod::code_size_for_inlining() {
 // not highly relevant to an inlined method.  So we use the more
 // specific accessor nmethod::insts_size.
 // Also some instructions inside the code are excluded from inline
-// heuristic (e.g. post call nop instructions; see InlineSkippedInstructionsCounter)
+// heuristic (e.g. post call nop instructions and GC barriers;
+// see InlineSkippedInstructionsCounter).
 int ciMethod::inline_instructions_size() {
   if (_inline_instructions_size == -1) {
     GUARDED_VM_ENTRY(
       nmethod* code = get_Method()->code();
       if (code != nullptr && (code->comp_level() == CompLevel_full_optimization)) {
-        int isize = code->insts_end() - code->verified_entry_point() - code->skipped_instructions_size();
+        int isize = code->inline_insts_size();
         _inline_instructions_size = isize > 0 ? isize : 0;
       } else {
         _inline_instructions_size = 0;

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -218,6 +218,8 @@ class nmethod : public CodeBlob {
 
   // _consts_offset == _content_offset because SECT_CONSTS is first in code buffer
 
+  int _inline_insts_size;
+
   int _stub_offset;
 
   // Offsets for different stubs section parts
@@ -232,7 +234,6 @@ class nmethod : public CodeBlob {
   int16_t  _unwind_handler_offset;
   // Number of arguments passed on the stack
   uint16_t _num_stack_arg_slots;
-  uint16_t _skipped_instructions_size;
 
   // Offsets in mutable data section
   // _oops_offset == _data_offset,  offset where embedded oop table begins (inside data)
@@ -589,7 +590,7 @@ public:
   int     oops_count() const { assert(oops_size() % oopSize == 0, "");  return (oops_size() / oopSize) + 1; }
   int metadata_count() const { assert(metadata_size() % wordSize == 0, ""); return (metadata_size() / wordSize) + 1; }
 
-  int skipped_instructions_size () const { return _skipped_instructions_size; }
+  int inline_insts_size() const { return _inline_insts_size; }
   int total_size() const;
 
   // Containment

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1324,8 +1324,9 @@ CodeBuffer* PhaseOutput::init_buffer() {
 
   int pad_req   = NativeCall::instruction_size;
 
+  // GC barrier stubs are generated in code section
   BarrierSetC2* bs = BarrierSet::barrier_set()->barrier_set_c2();
-  stub_req += bs->estimate_stub_size();
+  code_req += bs->estimate_stub_size();
 
   // nmethod and CodeBuffer count stubs & constants as part of method's code.
   // class HandlerImpl is platform-specific and defined in the *.ad files.
@@ -1334,9 +1335,9 @@ CodeBuffer* PhaseOutput::init_buffer() {
   stub_req += MAX_stubs_size;   // ensure per-stub margin
   code_req += MAX_inst_size;    // ensure per-instruction margin
 
-  if (StressCodeBuffers)
+  if (StressCodeBuffers) {
     code_req = const_req = stub_req = exception_handler_req = deopt_handler_req = 0x10;  // force expansion
-
+  }
   int total_req =
           const_req +
           code_req +
@@ -1345,9 +1346,10 @@ CodeBuffer* PhaseOutput::init_buffer() {
           exception_handler_req +
           deopt_handler_req;               // deopt handler
 
-  if (C->has_method_handle_invokes())
-    total_req += deopt_handler_req;  // deopt MH handler
-
+  if (C->has_method_handle_invokes()) {
+    total_req += deopt_handler_req;        // deopt MH handler
+    stub_req  += deopt_handler_req;
+  }
   CodeBuffer* cb = code_buffer();
   cb->initialize(total_req, _buf_sizes._reloc);
 


### PR DESCRIPTION
In [JDK-8329433](https://bugs.openjdk.org/browse/JDK-8329433) I changed `nmethod::_skipped_instructions_size` field type to `uint16_t` assuming that it only count NOP instructions and GC barriers. I did not take into account that Generational ZGC also incudes barrier stubs into this size (original ZGC missed that). It is correct to include them because these stubs are generated in instructions section and not in stubs section:

```
Statistics for 1330 bytecoded nmethods for C2:
...
ZGC:
   main code = 3237080 (75.567032%)
     stubs code = 810577 (25.040375%)
     skipped insts = 44432 (1.372595%)

GenZGC:
   main code = 4034704 (78.238518%)
     stubs code = 1356703 (33.625839%)
     skipped insts = 1074611 (26.634197%)
```

Note, GenZGC has bigger code because it has store barriers. It generates a separate stub for each barrier, no sharing.

After looking on how `_skipped_instructions_size` is used (only in one place when calculated inlinining size of compiled code) I decided replace it with `int _inline_insts_size;`. It is calculated the same way as before.

And instead of including instructions stubs into `_skipped_instructions_size` I recorded size of instructions in code section before stubs are generated. This allow to get more accurate size of main instructions and no need for `InlineSkippedInstructionsCounter` in GC barriers stubs.

I also fixed code in C2 which estimates size of code and stubs sections.

Tested tier1-4,tier8,stress,xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331253](https://bugs.openjdk.org/browse/JDK-8331253): 16 bits is not enough for nmethod::_skipped_instructions_size field (**Bug** - P2)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19029/head:pull/19029` \
`$ git checkout pull/19029`

Update a local copy of the PR: \
`$ git checkout pull/19029` \
`$ git pull https://git.openjdk.org/jdk.git pull/19029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19029`

View PR using the GUI difftool: \
`$ git pr show -t 19029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19029.diff">https://git.openjdk.org/jdk/pull/19029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19029#issuecomment-2087929266)