### PR TITLE
8331077 : nroff man page update for jar tool

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,7 @@ public class ArraysSupport {
     public static int vectorizedHashCode(Object array, int fromIndex, int length, int initialValue,
                                          int basicType) {
         return switch (basicType) {
-            case T_BOOLEAN -> unsignedHashCode(initialValue, (byte[]) array, fromIndex, length);
+            case T_BOOLEAN -> signedHashCode(initialValue, (byte[]) array, fromIndex, length);
             case T_CHAR -> array instanceof byte[]
                     ? utf16hashCode(initialValue, (byte[]) array, fromIndex, length)
                     : hashCode(initialValue, (char[]) array, fromIndex, length);
@@ -211,7 +211,7 @@ public class ArraysSupport {
         };
     }
 
-    private static int unsignedHashCode(int result, byte[] a, int fromIndex, int length) {
+    private static int signedHashCode(int result, byte[] a, int fromIndex, int length) {
         int end = fromIndex + length;
         for (int i = fromIndex; i < end; i++) {
             result = 31 * result + (a[i] & 0xff);

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -186,7 +186,8 @@ created or a non-modular JAR file being updated.
 Specifies the location of module dependence for generating the hash.
 .TP
 \f[V]\[at]\f[R]\f[I]file\f[R]
-Reads \f[V]jar\f[R] options and file names from a text file.
+Reads \f[V]jar\f[R] options and file names from a text file as if they were supplied
+on the command line.
 .SH OPERATION MODIFIERS VALID ONLY IN CREATE, UPDATE, AND GENERATE-INDEX MODES
 .PP
 You can use the following options to customize the actions of the create
@@ -330,11 +331,13 @@ class files from the file \f[V]classes.list\f[R].
 .PP
 \f[B]Note:\f[R]
 .PP
-To shorten or simplify the \f[V]jar\f[R] command, you can specify
-arguments in a separate text file and pass it to the \f[V]jar\f[R]
+To shorten or simplify the \f[V]jar\f[R] command, you can provide an arg file that lists
+the files to include in the JAR file and pass it to the \f[V]jar\f[R]
 command with the at sign (\f[V]\[at]\f[R]) as a prefix.
 .RS
 .PP
 \f[V]jar --create --file my.jar \[at]classes.list\f[R]
 .RE
+.PP
+If one or more entries in the arg file cannot be found then the jar command fails without creating the JAR file.
 .RE

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
nroff man page update for jar tool. <br>

This update is caused by the change of https://bugs.openjdk.org/browse/JDK-8318971. While the .md man pages got updated in other repos, the corresponding nroff man page was never updated in OpenJDK repos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331077](https://bugs.openjdk.org/browse/JDK-8331077): nroff man page update for jar tool (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19034/head:pull/19034` \
`$ git checkout pull/19034`

Update a local copy of the PR: \
`$ git checkout pull/19034` \
`$ git pull https://git.openjdk.org/jdk.git pull/19034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19034`

View PR using the GUI difftool: \
`$ git pr show -t 19034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19034.diff">https://git.openjdk.org/jdk/pull/19034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19034#issuecomment-2088589570)