### PR TITLE
8295153: java/util/Base64/TestEncodingDecodingLength.java ran out of memory 

### DIFF
--- a/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
+++ b/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
@@ -72,7 +72,8 @@ public class TestEncodingDecodingLength {
             m.invoke(ENCODER, LARGE_MEM_SIZE, true);
         } catch (InvocationTargetException ex) {
             Throwable rootEx = ex.getCause();
-            assertEquals(OutOfMemoryError.class, rootEx.getClass(), "00ME should be thrown");
+            assertEquals(OutOfMemoryError.class, rootEx.getClass(),
+                    "OOME should be thrown with Integer.MAX_VALUE input");
             assertEquals("Encoded size is too large", rootEx.getMessage());
         }
     }
@@ -97,7 +98,10 @@ public class TestEncodingDecodingLength {
             */
             m.invoke(DECODER, src, -LARGE_MEM_SIZE + 1, 1);
         } catch (InvocationTargetException ex) {
-            fail("Decode should neither throw NASE or OOME: " + ex.getCause());
+            // 8210583 - decode no longer throws NASE
+            // 8217969 - decode no longer throws OOME
+            fail("Decode threw an unexpected exception with " +
+                    "Integer.MAX_VALUE sized input: " + ex.getCause());
         }
     }
 

--- a/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
+++ b/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,55 +21,78 @@
  * questions.
  */
 
-import java.nio.ByteBuffer;
-import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Base64;
 
-/**
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
  * @test
- * @bug 8210583 8217969 8218265
- * @summary Tests Base64.Encoder.encode and Base64.Decoder.decode
- *          with the large size of input array/buffer
- * @requires (sun.arch.data.model == "64" & os.maxMemory >= 10g)
- * @run main/othervm -Xms6g -Xmx8g TestEncodingDecodingLength
- *
+ * @bug 8210583 8217969 8218265 8295153
+ * @summary White-box test that effectively checks Base64.Encoder.encode and
+ *          Base64.Decoder.decode behavior with large, (Integer.MAX_VALUE) sized
+ *          input array/buffer. Tests the private methods "encodedOutLength" and
+ *          "decodedOutLength".
+ * @run junit/othervm --add-opens java.base/java.util=ALL-UNNAMED TestEncodingDecodingLength
  */
 
+// We perform a white-box test due to the heavy memory usage that testing
+// the public API would require which has shown to cause intermittent issues
 public class TestEncodingDecodingLength {
 
-    public static void main(String[] args) {
-        int size = Integer.MAX_VALUE - 8;
-        byte[] inputBytes = new byte[size];
-        byte[] outputBytes = new byte[size];
+    private static final int size = Integer.MAX_VALUE - 8;
 
-        // Check encoder with large array length
+    // Effectively tests the overloaded Base64.Encoder.encode() methods and
+    // encodeToString() throw OOME instead of NASE with large array values.
+    // All the encode methods call encodedOutLength() which is where the OOME
+    // is expected to be thrown from
+    @Test
+    public void largeEncodeTest() throws NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
         Base64.Encoder encoder = Base64.getEncoder();
-        checkOOM("encode(byte[])", () -> encoder.encode(inputBytes));
-        checkIAE("encode(byte[] byte[])", () -> encoder.encode(inputBytes, outputBytes));
-        checkOOM("encodeToString(byte[])", () -> encoder.encodeToString(inputBytes));
-        checkOOM("encode(ByteBuffer)", () -> encoder.encode(ByteBuffer.wrap(inputBytes)));
+        Method m = encoder.getClass().getDeclaredMethod(
+                "encodedOutLength", int.class, boolean.class);
+        m.setAccessible(true);
 
-        // Check decoder with large array length,
-        // should not throw any exception
-        Arrays.fill(inputBytes, (byte) 86);
+        // IAE case
+        // When throwOOME param is false, encodedOutLength should return -1 in
+        // this situation, which encode() uses to throw IAE
+        assertEquals(-1, m.invoke(encoder, size, false));
+
+        // OOME case
+        try {
+            m.invoke(encoder, size, true);
+        } catch (InvocationTargetException ex) {
+            Throwable rootEx = ex.getCause();
+            assertEquals(OutOfMemoryError.class, rootEx.getClass(), "00ME should be thrown");
+            assertEquals("Encoded size is too large", rootEx.getMessage());
+        }
+    }
+
+    // Effectively tests the overloaded Base64.Decoder.decode() methods do not
+    // throw OOME nor NASE with large array values. All the decode methods call
+    // decodedOutLength(), which is where the potential overflow situation occurs.
+    @Test
+    public void largeDecodeTest() throws NoSuchMethodException, IllegalAccessException {
         Base64.Decoder decoder = Base64.getDecoder();
-        decoder.decode(inputBytes);
-        decoder.decode(inputBytes, outputBytes);
-        decoder.decode(ByteBuffer.wrap(inputBytes));
-    }
-
-    private static final void checkOOM(String methodName, Runnable r) {
+        Method m = decoder.getClass().getDeclaredMethod(
+                "decodedOutLength", byte[].class, int.class, int.class);
+        m.setAccessible(true);
+        byte[] src = {1};
         try {
-            r.run();
-            throw new RuntimeException("OutOfMemoryError should have been thrown by: " + methodName);
-        } catch (OutOfMemoryError er) {}
-    }
-
-    private static final void checkIAE(String methodName, Runnable r) {
-        try {
-            r.run();
-            throw new RuntimeException("IllegalArgumentException should have been thrown by: " + methodName);
-        } catch (IllegalArgumentException iae) {}
+            // decodedOutLength() takes the src array, position, and limit as params.
+            // The src array will be indexed at limit-1 to search for padding.
+            // To avoid passing an array with Integer.MAX_VALUE memory allocated, we
+            // set position param to be -size. Since the initial length
+            // is calculated as limit - position. This mocks the potential overflow
+            // calculation and still allows the array to be indexed without an AIOBE.
+            m.invoke(decoder, src, -size + 1, 1);
+        } catch (InvocationTargetException ex) {
+            fail("Decode should neither throw NASE or OOME: " + ex.getCause());
+        }
     }
 }
-


### PR DESCRIPTION
Please review this PR which converts _TestEncodingDecodingLength.java_ into a whitebox test which allows for testing to be done without memory usage issues.

Currently, the test requires about ~2.75 `Integer.MAX_VALUE` sized byte arrays worth of memory. (2 for the initial array allocation, .75 for the target array in `decode()`). While the `-Xms6g -Xmx8g` options should address this, there have been intermittent memory issues, as the underlying machine machine may be running other tests simultaneously.

By converting this test to a white-box test not only does it get rid of memory issues, but it also gets rid of the need to decode 2GB of data 3 times. The change is done using reflection to test the private visibility methods `encodedOutLength` and `decodedOutLength`, which the public `encode` and `decode` overloaded methods call respectively.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295153](https://bugs.openjdk.org/browse/JDK-8295153): java/util/Base64/TestEncodingDecodingLength.java ran out of memory (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19036/head:pull/19036` \
`$ git checkout pull/19036`

Update a local copy of the PR: \
`$ git checkout pull/19036` \
`$ git pull https://git.openjdk.org/jdk.git pull/19036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19036`

View PR using the GUI difftool: \
`$ git pr show -t 19036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19036.diff">https://git.openjdk.org/jdk/pull/19036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19036#issuecomment-2088701177)