### PR TITLE
8331495: Limit BasicDirectoryModel/LoaderThreadCount.java to Windows only

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
@@ -40,6 +40,7 @@ import javax.swing.JFileChooser;
 /*
  * @test
  * @bug 8325179
+ * @requires os.family == "windows"
  * @summary Verifies there's only one BasicDirectoryModel.FilesLoader thread
  *          at any given moment
  * @run main/othervm -Djava.awt.headless=true LoaderThreadCount


### PR DESCRIPTION
As soon as I integrated `test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java` #18957, the test started failing in CI on Linux and macOS. There are six failures found so far.

Before starting code review and later, I ran the test many times on CI and I never saw so many failures.

To reduce the noise, I'm limiting the test to **Windows only** where it's stable.

I submitted [JDK-8331494](https://bugs.openjdk.org/browse/JDK-8331494) to make the test more stable on Linux and macOS if possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331495](https://bugs.openjdk.org/browse/JDK-8331495): Limit BasicDirectoryModel/LoaderThreadCount.java to Windows only (**Sub-task** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19038/head:pull/19038` \
`$ git checkout pull/19038`

Update a local copy of the PR: \
`$ git checkout pull/19038` \
`$ git pull https://git.openjdk.org/jdk.git pull/19038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19038`

View PR using the GUI difftool: \
`$ git pr show -t 19038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19038.diff">https://git.openjdk.org/jdk/pull/19038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19038#issuecomment-2088734535)