### PR TITLE
8331478 JFR: Rename printHelp methods for jdk.jfr.internal.dcmd classes

### DIFF
--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.cpp
@@ -221,7 +221,7 @@ void JfrDCmd::execute(DCmdSource source, TRAPS) {
     return;
   }
   if (source == DCmd_Source_Internal && _args != nullptr && strcmp(_args, "help") == 0) {
-     print_java_help("printStartupHelp");
+     print_java_help("getStartupHelp");
      vm_exit(0);
   }
 
@@ -246,17 +246,17 @@ void JfrDCmd::execute(DCmdSource source, TRAPS) {
   handle_dcmd_result(output(), result.get_oop(), source, THREAD);
 }
 
-void JfrDCmd::print_java_help(const char* help_method) const {
+void JfrDCmd::print_java_help(const char* get_help_method) const {
   static const char signature[] = "()[Ljava/lang/String;";
   JavaThread* thread = JavaThread::current();
   JavaValue result(T_OBJECT);
-  JfrJavaArguments printHelp(&result, javaClass(), help_method, signature, thread);
-  invoke(printHelp, thread);
+  JfrJavaArguments java_method(&result, javaClass(), get_help_method, signature, thread);
+  invoke(java_method, thread);
   handle_dcmd_result(output(), result.get_oop(), DCmd_Source_MBean, thread);
 }
 
 void JfrDCmd::print_help(const char* name) const {
-  print_java_help("printHelp");
+  print_java_help("getHelp");
 }
 
 static void initialize_dummy_descriptors(GrowableArray<DCmdArgumentInfo*>* array) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ abstract class AbstractDCmd {
     private String source;
 
     // Called by native
-    public abstract String[] printHelp();
+    public abstract String[] getHelp();
 
     // Called by native. The number of arguments for each command is
     // reported to the DCmdFramework as a hardcoded number in native.
@@ -233,7 +233,7 @@ abstract class AbstractDCmd {
     }
 
     protected final void printHelpText() {
-        for (String line : printHelp()) {
+        for (String line : getHelp()) {
             println(line);
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdCheck.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ final class DCmdCheck extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
             // 0123456789001234567890012345678900123456789001234567890012345678900123456789001234567890
         return """
                Syntax : JFR.check [options]

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdConfigure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,7 @@ final class DCmdConfigure extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
         throw new InternalError("Should not reach here!");
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,7 +194,7 @@ final class DCmdDump extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
             // 0123456789001234567890012345678900123456789001234567890012345678900123456789001234567890
         return """
                Syntax : JFR.dump [options]

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdQuery.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdQuery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public final class DCmdQuery extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
         List<String> lines = new ArrayList<>();
         lines.addAll(getOptions().lines().toList());
         lines.add("");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -318,7 +318,7 @@ final class DCmdStart extends AbstractDCmd {
         return false;
     }
 
-    public String[] printStartupHelp() {
+    public String[] getStartupHelp() {
         Map<String, String> parameters = Map.of(
             "$SYNTAX", "-XX:StartFlightRecording:[options]",
             "$SOURCE", "-XX:StartFlightRecording:",
@@ -331,7 +331,7 @@ final class DCmdStart extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
         Map<String, String> parameters = Map.of(
            "$SYNTAX", "JFR.start [options]",
            "$SOURCE", "$ jcmd <pid> JFR.start ",

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,7 @@ final class DCmdStop extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
             // 0123456789001234567890012345678900123456789001234567890012345678900123456789001234567890
         return """
                Syntax : JFR.stop [options]

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class DCmdView extends AbstractDCmd {
     }
 
     @Override
-    public String[] printHelp() {
+    public String[] getHelp() {
         List<String> lines = new ArrayList<>();
         lines.addAll(getOptions().lines().toList());
         lines.add("");


### PR DESCRIPTION
Could I have a review of a PR that changes the name of the print method used by the JFR diagnostic commands. The names are legacy from when they printed the help, but that has not been the case for many years.

Testing: tier1,tier2 + test/jdk/jdk/jfr

Thanks
Erik