### PR TITLE
8331513: Tests should not use the "Classpath" exception form of the legal header

### DIFF
--- a/test/jdk/java/net/httpclient/RedirectTimeoutTest.java
+++ b/test/jdk/java/net/httpclient/RedirectTimeoutTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/java/net/httpclient/http2/ExpectContinueResetTest.java
+++ b/test/jdk/java/net/httpclient/http2/ExpectContinueResetTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Can I please get a review of this copyright text only change that removes the "Classpath" exception from these test files and thus addresses https://bugs.openjdk.org/browse/JDK-8331513?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331513](https://bugs.openjdk.org/browse/JDK-8331513): Tests should not use the "Classpath" exception form of the legal header (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19045/head:pull/19045` \
`$ git checkout pull/19045`

Update a local copy of the PR: \
`$ git checkout pull/19045` \
`$ git pull https://git.openjdk.org/jdk.git pull/19045/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19045`

View PR using the GUI difftool: \
`$ git pr show -t 19045`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19045.diff">https://git.openjdk.org/jdk/pull/19045.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19045#issuecomment-2089548484)