### PR TITLE
8331514: Tests should not use the Classpath exception form of the legal header

### DIFF
--- a/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
+++ b/test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
Can I please get a review of this copyright text only change which removes the "Classpath" exception from the `test/jdk/java/lang/ProcessBuilder/JspawnhelperWarnings.java` test file and thus addresses https://bugs.openjdk.org/browse/JDK-8331514?