### PR TITLE
8331541: [i386] linking with libjvm.so fails after JDK-8283326

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -118,7 +118,6 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
 
   # Setup LDFLAGS for linking executables
   if test "x$TOOLCHAIN_TYPE" = xgcc; then
-    EXECUTABLE_LDFLAGS="$EXECUTABLE_LDFLAGS -Wl,--allow-shlib-undefined"
     # Enabling pie on 32 bit builds prevents the JVM from allocating a continuous
     # java heap.
     if test "x$OPENJDK_TARGET_CPU_BITS" != "x32"; then

--- a/src/hotspot/os_cpu/linux_x86/safefetch_linux_x86_32.S
+++ b/src/hotspot/os_cpu/linux_x86/safefetch_linux_x86_32.S
@@ -36,7 +36,7 @@
     #  8(%esp) : default value
     #  4(%esp) : crash address
     #  0(%esp) : return pc
-    .type _SafeFetch32_impl,@function
+    .type SafeFetch32_impl,@function
 SafeFetch32_impl:
     movl 4(%esp),%ecx         # load address from stack
 _SafeFetch32_fault:


### PR DESCRIPTION
Hi, 

The     `.type _SafeFetch32_impl,@function` symbol declaration contains a spurious underscore causing an undefined symbol in libjvm.so.

I am not sure about change in default flags. I have removed the flag that allows linking with undefined symbols
because having the flag on might cause bugs like this one or https://bugs.openjdk.org/browse/JDK-8329983 as the build succeeds even if some symbols are not defined.
Openjdk builds successfully without it on amd64, i386, armhf, arm64, s390, ppc64el and riscv64 with this change[1]. riscv64 build was done locally inside vm:
```
Finished building target 'images' in configuration 'linux-riscv64-server-release'
ubuntu@ubuntu:~/jdk$ 
```
Unfortunately I do not know why it was introduced, so I might be missing something.
I am happy to drop it from this one or move it to a separate issue/pr.
 
[1] https://launchpad.net/~vpa1977/+archive/ubuntu/october-21/+sourcepub/16076564/+listing-archive-extra

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331541](https://bugs.openjdk.org/browse/JDK-8331541): [i386] linking with libjvm.so fails after JDK-8283326 (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19048/head:pull/19048` \
`$ git checkout pull/19048`

Update a local copy of the PR: \
`$ git checkout pull/19048` \
`$ git pull https://git.openjdk.org/jdk.git pull/19048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19048`

View PR using the GUI difftool: \
`$ git pr show -t 19048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19048.diff">https://git.openjdk.org/jdk/pull/19048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19048#issuecomment-2095356149)