### PR TITLE
8331511: Tests should not use the "Classpath" exception form of the legal header

### DIFF
--- a/test/jdk/jdk/classfile/OptionsTest.java
+++ b/test/jdk/jdk/classfile/OptionsTest.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or


### PR DESCRIPTION
This patch removes "Classpath" exception from test/jdk/jdk/classfile/OptionsTest.java header.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331511](https://bugs.openjdk.org/browse/JDK-8331511): Tests should not use the "Classpath" exception form of the legal header (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19050/head:pull/19050` \
`$ git checkout pull/19050`

Update a local copy of the PR: \
`$ git checkout pull/19050` \
`$ git pull https://git.openjdk.org/jdk.git pull/19050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19050`

View PR using the GUI difftool: \
`$ git pr show -t 19050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19050.diff">https://git.openjdk.org/jdk/pull/19050.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19050#issuecomment-2089978085)