### PR TITLE
8331549: Inline MemAllocator::mem_allocate_slow

### DIFF
--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -318,7 +318,15 @@ HeapWord* MemAllocator::mem_allocate_inside_tlab_slow(Allocation& allocation) co
   return mem;
 }
 
-HeapWord* MemAllocator::mem_allocate_slow(Allocation& allocation) const {
+HeapWord* MemAllocator::mem_allocate(Allocation& allocation) const {
+  if (UseTLAB) {
+    // Try allocating from an existing TLAB.
+    HeapWord* mem = mem_allocate_inside_tlab_fast();
+    if (mem != nullptr) {
+      return mem;
+    }
+  }
+
   // Allocation of an oop can always invoke a safepoint.
   debug_only(allocation._thread->check_for_valid_safepoint_state());
 
@@ -331,18 +339,6 @@ HeapWord* MemAllocator::mem_allocate_slow(Allocation& allocation) const {
   }
 
   return mem_allocate_outside_tlab(allocation);
-}
-
-HeapWord* MemAllocator::mem_allocate(Allocation& allocation) const {
-  if (UseTLAB) {
-    // Try allocating from an existing TLAB.
-    HeapWord* mem = mem_allocate_inside_tlab_fast();
-    if (mem != nullptr) {
-      return mem;
-    }
-  }
-
-  return mem_allocate_slow(allocation);
 }
 
 oop MemAllocator::allocate() const {

--- a/src/hotspot/share/gc/shared/memAllocator.hpp
+++ b/src/hotspot/share/gc/shared/memAllocator.hpp
@@ -52,9 +52,6 @@ private:
   // Allocate outside a TLAB. Could safepoint.
   HeapWord* mem_allocate_outside_tlab(Allocation& allocation) const;
 
-  // Fast-path TLAB allocation failed. Takes a slow-path and potentially safepoint.
-  HeapWord* mem_allocate_slow(Allocation& allocation) const;
-
 protected:
   MemAllocator(Klass* klass, size_t word_size, Thread* thread)
     : _thread(thread),


### PR DESCRIPTION
Trivial inlining a method. (The diff looks larger than its real size.) The resulting logic is much cleaner, IMO -- try tlab-fast, then tlab-slow, finally outside of tlab.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331549](https://bugs.openjdk.org/browse/JDK-8331549): Inline MemAllocator::mem_allocate_slow (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19051/head:pull/19051` \
`$ git checkout pull/19051`

Update a local copy of the PR: \
`$ git checkout pull/19051` \
`$ git pull https://git.openjdk.org/jdk.git pull/19051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19051`

View PR using the GUI difftool: \
`$ git pr show -t 19051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19051.diff">https://git.openjdk.org/jdk/pull/19051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19051#issuecomment-2089984117)