### PR TITLE
8331401: G1: Make G1HRPrinter AllStatic

### DIFF
--- a/src/hotspot/share/gc/g1/g1Allocator.cpp
+++ b/src/hotspot/share/gc/g1/g1Allocator.cpp
@@ -31,6 +31,7 @@
 #include "gc/g1/g1HeapRegion.inline.hpp"
 #include "gc/g1/g1HeapRegionSet.inline.hpp"
 #include "gc/g1/g1HeapRegionType.hpp"
+#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1NUMA.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "gc/shared/tlab_globals.hpp"
@@ -118,7 +119,7 @@ void G1Allocator::reuse_retained_old_region(G1EvacInfo* evacuation_info,
     // it's retired again.
     _g1h->old_set_remove(retained_region);
     old->set(retained_region);
-    _g1h->hr_printer()->reuse(retained_region);
+    G1HRPrinter::reuse(retained_region);
     evacuation_info->set_alloc_regions_used_before(retained_region->used());
   }
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -40,7 +40,6 @@
 #include "gc/g1/g1HeapRegionSet.hpp"
 #include "gc/g1/g1HeapTransition.hpp"
 #include "gc/g1/g1HeapVerifier.hpp"
-#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1MonitoringSupport.hpp"
 #include "gc/g1/g1MonotonicArenaFreeMemoryTask.hpp"
 #include "gc/g1/g1MonotonicArenaFreePool.hpp"
@@ -264,8 +263,6 @@ public:
 
   void update_parallel_gc_threads_cpu_time();
 private:
-
-  G1HRPrinter _hr_printer;
 
   // Return true if an explicit GC should start a concurrent cycle instead
   // of doing a STW full GC. A concurrent cycle should be started if:
@@ -668,8 +665,6 @@ public:
   uint old_marking_cycles_completed() const {
     return _old_marking_cycles_completed;
   }
-
-  G1HRPrinter* hr_printer() { return &_hr_printer; }
 
   // Allocates a new heap region instance.
   HeapRegion* new_heap_region(uint hrs_index, MemRegion mr);

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -40,6 +40,7 @@
 #include "gc/g1/g1HeapRegionRemSet.inline.hpp"
 #include "gc/g1/g1HeapRegionSet.inline.hpp"
 #include "gc/g1/g1HeapVerifier.hpp"
+#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/g1Policy.hpp"
 #include "gc/g1/g1RegionMarkStatsCache.inline.hpp"
@@ -1317,7 +1318,7 @@ public:
     if (!_cleanup_list.is_empty()) {
       log_debug(gc)("Reclaimed %u empty regions", _cleanup_list.length());
       // Now print the empty regions list.
-      _g1h->hr_printer()->mark_reclaim(&_cleanup_list);
+      G1HRPrinter::mark_reclaim(&_cleanup_list);
       // And actually make them available.
       _g1h->prepend_to_freelist(&_cleanup_list);
     }

--- a/src/hotspot/share/gc/g1/g1HRPrinter.hpp
+++ b/src/hotspot/share/gc/g1/g1HRPrinter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,11 @@
 
 #include "gc/g1/g1HeapRegion.hpp"
 #include "logging/log.hpp"
+#include "memory/allStatic.hpp"
 
 class FreeRegionList;
 
-class G1HRPrinter {
+class G1HRPrinter : public AllStatic {
 
 private:
 
@@ -40,7 +41,7 @@ private:
                           action, hr->get_type_str(), p2i(hr->bottom()), p2i(hr->top()), p2i(hr->end()));
   }
 
-  void mark_reclaim(HeapRegion* hr) {
+  static void mark_reclaim(HeapRegion* hr) {
     print("MARK-RECLAIM", hr);
   }
 
@@ -48,79 +49,79 @@ public:
   // In some places we iterate over a list in order to generate output
   // for the list's elements. By exposing this we can avoid this
   // iteration if the printer is not active.
-  bool is_active() { return log_is_enabled(Trace, gc, region); }
+  static bool is_active() { return log_is_enabled(Trace, gc, region); }
 
   // The methods below are convenient wrappers for the print() method.
 
-  void alloc(HeapRegion* hr, bool force = false) {
+  static void alloc(HeapRegion* hr, bool force = false) {
     if (is_active()) {
       print((force) ? "ALLOC-FORCE" : "ALLOC", hr);
     }
   }
 
-  void retire(HeapRegion* hr) {
+  static void retire(HeapRegion* hr) {
     if (is_active()) {
       print("RETIRE", hr);
     }
   }
 
-  void reuse(HeapRegion* hr) {
+  static void reuse(HeapRegion* hr) {
     if (is_active()) {
       print("REUSE", hr);
     }
   }
 
-  void cset(HeapRegion* hr) {
+  static void cset(HeapRegion* hr) {
     if (is_active()) {
       print("CSET", hr);
     }
   }
 
-  void evac_failure(HeapRegion* hr) {
+  static void evac_failure(HeapRegion* hr) {
     if (is_active()) {
       print("EVAC-FAILURE", hr);
     }
   }
 
-  void mark_reclaim(FreeRegionList* free_list);
+  static void mark_reclaim(FreeRegionList* free_list);
 
-  void eager_reclaim(HeapRegion* hr) {
+  static void eager_reclaim(HeapRegion* hr) {
     if (is_active()) {
       print("EAGER-RECLAIM", hr);
     }
   }
 
-  void evac_reclaim(HeapRegion* hr) {
+  static void evac_reclaim(HeapRegion* hr) {
     if (is_active()) {
       print("EVAC-RECLAIM", hr);
     }
   }
 
-  void post_compaction(HeapRegion* hr) {
+  static void post_compaction(HeapRegion* hr) {
     if (is_active()) {
       print("POST-COMPACTION", hr);
     }
   }
 
-  void commit(HeapRegion* hr) {
+  static void commit(HeapRegion* hr) {
     if (is_active()) {
       print("COMMIT", hr);
     }
   }
 
-  void active(HeapRegion* hr) {
+  static void active(HeapRegion* hr) {
     if (is_active()) {
       print("ACTIVE", hr);
     }
   }
 
-  void inactive(HeapRegion* hr) {
+  static void inactive(HeapRegion* hr) {
     if (is_active()) {
       print("INACTIVE", hr);
     }
   }
 
-  void uncommit(HeapRegion* hr) {
+  static void uncommit(HeapRegion* hr) {
     if (is_active()) {
       print("UNCOMMIT", hr);
     }

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -30,6 +30,7 @@
 #include "gc/g1/g1HeapRegion.hpp"
 #include "gc/g1/g1HeapRegionManager.inline.hpp"
 #include "gc/g1/g1HeapRegionSet.inline.hpp"
+#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1NUMAStats.hpp"
 #include "jfr/jfrEvents.hpp"
 #include "logging/logStream.hpp"
@@ -170,7 +171,7 @@ void HeapRegionManager::expand(uint start, uint num_regions, WorkerThreads* pret
       _regions.set_by_index(i, hr);
       _allocated_heapregions_length = MAX2(_allocated_heapregions_length, i + 1);
     }
-    G1CollectedHeap::heap()->hr_printer()->commit(hr);
+    G1HRPrinter::commit(hr);
   }
   activate_regions(start, num_regions);
 }
@@ -193,13 +194,12 @@ void HeapRegionManager::uncommit_regions(uint start, uint num_regions) {
   guarantee(num_regions > 0, "No point in calling this for zero regions");
 
   uint end = start + num_regions;
-  G1HRPrinter* printer = G1CollectedHeap::heap()->hr_printer();
-  if (printer->is_active()) {
+  if (G1HRPrinter::is_active()) {
     for (uint i = start; i < end; i++) {
       // Can't use at() here since region is no longer marked available.
       HeapRegion* hr = _regions.get_by_index(i);
       assert(hr != nullptr, "Region should still be present");
-      printer->uncommit(hr);
+      G1HRPrinter::uncommit(hr);
     }
   }
 
@@ -223,7 +223,7 @@ void HeapRegionManager::initialize_regions(uint start, uint num_regions) {
     hr->initialize();
     hr->set_node_index(G1NUMA::numa()->index_for_region(hr));
     insert_into_free_list(hr);
-    G1CollectedHeap::heap()->hr_printer()->active(hr);
+    G1HRPrinter::active(hr);
   }
 }
 
@@ -250,7 +250,7 @@ void HeapRegionManager::deactivate_regions(uint start, uint num_regions) {
   for (uint i = start; i < end; i++) {
     HeapRegion* hr = at(i);
     hr->set_node_index(G1NUMA::UnknownNodeIndex);
-    G1CollectedHeap::heap()->hr_printer()->inactive(hr);
+    G1HRPrinter::inactive(hr);
   }
 
   _committed_map.deactivate(start, end);

--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -27,6 +27,7 @@
 #include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1CollectionSet.hpp"
 #include "gc/g1/g1EvacFailureRegions.inline.hpp"
+#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/g1ParScanThreadState.inline.hpp"
 #include "gc/g1/g1RootClosures.hpp"
@@ -642,7 +643,7 @@ oop G1ParScanThreadState::handle_evacuation_failure_par(oop old, markWord m, siz
     HeapRegion* r = _g1h->heap_region_containing(old);
 
     if (_evac_failure_regions->record(_worker_id, r->hrm_index(), cause_pinned)) {
-      _g1h->hr_printer()->evac_failure(r);
+      G1HRPrinter::evac_failure(r);
     }
 
     // Mark the failing object in the marking bitmap and later use the bitmap to handle

--- a/src/hotspot/share/gc/g1/g1YoungCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.cpp
@@ -216,10 +216,6 @@ G1GCPhaseTimes* G1YoungCollector::phase_times() const {
   return _g1h->phase_times();
 }
 
-G1HRPrinter* G1YoungCollector::hr_printer() const {
-  return _g1h->hr_printer();
-}
-
 G1MonitoringSupport* G1YoungCollector::monitoring_support() const {
   return _g1h->monitoring_support();
 }
@@ -264,13 +260,9 @@ void G1YoungCollector::wait_for_root_region_scanning() {
 }
 
 class G1PrintCollectionSetClosure : public HeapRegionClosure {
-private:
-  G1HRPrinter* _hr_printer;
 public:
-  G1PrintCollectionSetClosure(G1HRPrinter* hr_printer) : HeapRegionClosure(), _hr_printer(hr_printer) { }
-
   virtual bool do_heap_region(HeapRegion* r) {
-    _hr_printer->cset(r);
+    G1HRPrinter::cset(r);
     return false;
   }
 };
@@ -286,8 +278,8 @@ void G1YoungCollector::calculate_collection_set(G1EvacInfo* evacuation_info, dou
 
   concurrent_mark()->verify_no_collection_set_oops();
 
-  if (hr_printer()->is_active()) {
-    G1PrintCollectionSetClosure cl(hr_printer());
+  if (G1HRPrinter::is_active()) {
+    G1PrintCollectionSetClosure cl;
     collection_set()->iterate(&cl);
     collection_set()->iterate_optional(&cl);
   }

--- a/src/hotspot/share/gc/g1/g1YoungCollector.hpp
+++ b/src/hotspot/share/gc/g1/g1YoungCollector.hpp
@@ -40,7 +40,6 @@ class G1ConcurrentMark;
 class G1EvacFailureRegions;
 class G1EvacInfo;
 class G1GCPhaseTimes;
-class G1HRPrinter;
 class G1MonitoringSupport;
 class G1MonotonicArenaMemoryStats;
 class G1NewTracer;
@@ -69,7 +68,6 @@ class G1YoungCollector {
   STWGCTimer* gc_timer_stw() const;
   G1NewTracer* gc_tracer_stw() const;
 
-  G1HRPrinter* hr_printer() const;
   G1MonitoringSupport* monitoring_support() const;
   G1GCPhaseTimes* phase_times() const;
   G1Policy* policy() const;

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -36,6 +36,7 @@
 #include "gc/g1/g1EvacStats.inline.hpp"
 #include "gc/g1/g1HeapRegion.inline.hpp"
 #include "gc/g1/g1HeapRegionRemSet.inline.hpp"
+#include "gc/g1/g1HRPrinter.hpp"
 #include "gc/g1/g1OopClosures.inline.hpp"
 #include "gc/g1/g1ParScanThreadState.hpp"
 #include "gc/g1/g1RemSet.hpp"
@@ -412,7 +413,7 @@ public:
       r->set_containing_set(nullptr);
       _humongous_regions_reclaimed++;
       _g1h->free_humongous_region(r, nullptr);
-      _g1h->hr_printer()->eager_reclaim(r);
+      G1HRPrinter::eager_reclaim(r);
     };
 
     _g1h->humongous_obj_regions_iterate(r, free_humongous_region);
@@ -760,7 +761,7 @@ class FreeCSetClosure : public HeapRegionClosure {
 
     // Free the region and its remembered set.
     _g1h->free_region(r, nullptr);
-    _g1h->hr_printer()->evac_reclaim(r);
+    G1HRPrinter::evac_reclaim(r);
   }
 
   void handle_failed_region(HeapRegion* r) {


### PR DESCRIPTION
Hi all,

  the HRPrinter does not have any member variables (static or non-static), so it can be made AllStatic.

I.e. there is no reason to have an instance variable around.

Testing: gha

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331401](https://bugs.openjdk.org/browse/JDK-8331401): G1: Make G1HRPrinter AllStatic (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19058/head:pull/19058` \
`$ git checkout pull/19058`

Update a local copy of the PR: \
`$ git checkout pull/19058` \
`$ git pull https://git.openjdk.org/jdk.git pull/19058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19058`

View PR using the GUI difftool: \
`$ git pr show -t 19058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19058.diff">https://git.openjdk.org/jdk/pull/19058.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19058#issuecomment-2090376239)