### PR TITLE
8331573: Rename CollectedHeap::is_gc_active to be explicitly about STW GCs

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2404,7 +2404,7 @@ void G1CollectedHeap::expand_heap_after_young_collection(){
 
 bool G1CollectedHeap::do_collection_pause_at_safepoint() {
   assert_at_safepoint_on_vm_thread();
-  guarantee(!is_gc_active(), "collection is not reentrant");
+  guarantee(!is_stw_gc_active(), "collection is not reentrant");
 
   do_collection_pause_at_safepoint_helper();
   return true;
@@ -2474,7 +2474,7 @@ void G1CollectedHeap::flush_region_pin_cache() {
 void G1CollectedHeap::do_collection_pause_at_safepoint_helper() {
   ResourceMark rm;
 
-  IsGCActiveMark active_gc_mark;
+  IsSTWGCActiveMark active_gc_mark;
   GCIdMark gc_id_mark;
   SvcGCMarker sgcm(SvcGCMarker::MINOR);
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -754,7 +754,7 @@ private:
   // false if unable to do the collection due to the GC locker being
   // active, true otherwise.
   // precondition: at safepoint on VM thread
-  // precondition: !is_gc_active()
+  // precondition: !is_stw_gc_active()
   bool do_collection_pause_at_safepoint();
 
   // Helper for do_collection_pause_at_safepoint, containing the guts

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -265,7 +265,7 @@ inline bool G1CollectedHeap::is_obj_dead(const oop obj, const HeapRegion* hr) co
 
 inline void G1CollectedHeap::pin_object(JavaThread* thread, oop obj) {
   assert(obj != nullptr, "obj must not be null");
-  assert(!is_gc_active(), "must not pin objects during a GC");
+  assert(!is_stw_gc_active(), "must not pin objects during a GC pause");
   assert(obj->is_typeArray(), "must be typeArray");
 
   uint obj_region_idx = heap_region_containing(obj)->hrm_index();
@@ -274,7 +274,7 @@ inline void G1CollectedHeap::pin_object(JavaThread* thread, oop obj) {
 
 inline void G1CollectedHeap::unpin_object(JavaThread* thread, oop obj) {
   assert(obj != nullptr, "obj must not be null");
-  assert(!is_gc_active(), "must not unpin objects during a GC");
+  assert(!is_stw_gc_active(), "must not unpin objects during a GC pause");
 
   uint obj_region_idx = heap_region_containing(obj)->hrm_index();
   G1ThreadLocalData::pin_count_cache(thread).dec_count(obj_region_idx);

--- a/src/hotspot/share/gc/g1/g1FullGCScope.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCScope.hpp
@@ -52,7 +52,7 @@ class G1FullGCScope : public StackObj {
   SvcGCMarker             _svc_marker;
   STWGCTimer              _timer;
   G1FullGCTracer*         _tracer;
-  IsGCActiveMark          _active;
+  IsSTWGCActiveMark       _active;
   G1FullGCJFRTracerMark   _tracer_mark;
   ClearedAllSoftRefs      _soft_refs;
   G1FullGCMonitoringScope _monitoring_scope;

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1564,7 +1564,7 @@ bool G1RemSet::clean_card_before_refine(CardValue** const card_ptr_addr) {
 
 void G1RemSet::refine_card_concurrently(CardValue* const card_ptr,
                                         const uint worker_id) {
-  assert(!_g1h->is_gc_active(), "Only call concurrently");
+  assert(!_g1h->is_stw_gc_active(), "Only call concurrently");
   check_card_ptr(card_ptr, _ct);
 
   // Construct the MemRegion representing the card.

--- a/src/hotspot/share/gc/g1/g1VMOperations.cpp
+++ b/src/hotspot/share/gc/g1/g1VMOperations.cpp
@@ -146,7 +146,7 @@ void VM_G1PauseConcurrent::doit() {
 
   G1ConcGCMonitoringScope monitoring_scope(g1h->monitoring_support());
   SvcGCMarker sgcm(SvcGCMarker::CONCURRENT);
-  IsGCActiveMark x;
+  IsSTWGCActiveMark x;
 
   work();
 }

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -459,7 +459,7 @@ void ParallelScavengeHeap::do_full_collection(bool clear_all_soft_refs) {
 HeapWord* ParallelScavengeHeap::failed_mem_allocate(size_t size) {
   assert(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
   assert(Thread::current() == (Thread*)VMThread::vm_thread(), "should be in vm thread");
-  assert(!is_gc_active(), "not reentrant");
+  assert(!is_stw_gc_active(), "not reentrant");
   assert(!Heap_lock->owned_by_self(), "this thread should not own the Heap_lock");
 
   // We assume that allocation in eden will fail unless we collect.

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1267,9 +1267,9 @@ bool PSParallelCompact::invoke(bool maximum_heap_compaction) {
          "should be in vm thread");
 
   ParallelScavengeHeap* heap = ParallelScavengeHeap::heap();
-  assert(!heap->is_gc_active(), "not reentrant");
+  assert(!heap->is_stw_gc_active(), "not reentrant");
 
-  IsGCActiveMark mark;
+  IsSTWGCActiveMark mark;
 
   const bool clear_all_soft_refs =
     heap->soft_ref_policy()->should_clear_all_soft_refs();
@@ -1490,7 +1490,7 @@ private:
 public:
   PCAddThreadRootsMarkingTaskClosure(uint worker_id) : _worker_id(worker_id) { }
   void do_thread(Thread* thread) {
-    assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+    assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
     ResourceMark rm;
 
@@ -1507,7 +1507,7 @@ public:
 };
 
 void steal_marking_work(TaskTerminator& terminator, uint worker_id) {
-  assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+  assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
   ParCompactionManager* cm =
     ParCompactionManager::gc_thread_compaction_manager(worker_id);
@@ -1984,7 +1984,7 @@ void PSParallelCompact::write_block_fill_histogram()
 #endif // #ifdef ASSERT
 
 static void compaction_with_stealing_work(TaskTerminator* terminator, uint worker_id) {
-  assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+  assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
   ParCompactionManager* cm =
     ParCompactionManager::gc_thread_compaction_manager(worker_id);

--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -84,7 +84,7 @@ ParallelScavengeTracer        PSScavenge::_gc_tracer;
 CollectorCounters*            PSScavenge::_counters = nullptr;
 
 static void scavenge_roots_work(ParallelRootType::Value root_type, uint worker_id) {
-  assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+  assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
   PSPromotionManager* pm = PSPromotionManager::gc_thread_promotion_manager(worker_id);
   PSPromoteRootsClosure  roots_to_old_closure(pm);
@@ -115,7 +115,7 @@ static void scavenge_roots_work(ParallelRootType::Value root_type, uint worker_i
 }
 
 static void steal_work(TaskTerminator& terminator, uint worker_id) {
-  assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+  assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
   PSPromotionManager* pm =
     PSPromotionManager::gc_thread_promotion_manager(worker_id);
@@ -232,11 +232,11 @@ public:
 bool PSScavenge::invoke() {
   assert(SafepointSynchronize::is_at_safepoint(), "should be at safepoint");
   assert(Thread::current() == (Thread*)VMThread::vm_thread(), "should be in vm thread");
-  assert(!ParallelScavengeHeap::heap()->is_gc_active(), "not reentrant");
+  assert(!ParallelScavengeHeap::heap()->is_stw_gc_active(), "not reentrant");
 
   ParallelScavengeHeap* const heap = ParallelScavengeHeap::heap();
   PSAdaptiveSizePolicy* policy = heap->size_policy();
-  IsGCActiveMark mark;
+  IsSTWGCActiveMark mark;
 
   const bool scavenge_done = PSScavenge::invoke_no_policy();
   const bool need_full_gc = !scavenge_done;
@@ -264,7 +264,7 @@ class PSThreadRootsTaskClosure : public ThreadClosure {
 public:
   PSThreadRootsTaskClosure(uint worker_id) : _worker_id(worker_id) { }
   virtual void do_thread(Thread* thread) {
-    assert(ParallelScavengeHeap::heap()->is_gc_active(), "called outside gc");
+    assert(ParallelScavengeHeap::heap()->is_stw_gc_active(), "called outside gc");
 
     PSPromotionManager* pm = PSPromotionManager::gc_thread_promotion_manager(_worker_id);
     PSScavengeRootsClosure roots_closure(pm);

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -484,7 +484,7 @@ void SerialHeap::do_collection(bool full,
   assert(my_thread->is_VM_thread(), "only VM thread");
   assert(Heap_lock->is_locked(),
          "the requesting thread should have the Heap_lock");
-  guarantee(!is_gc_active(), "collection is not reentrant");
+  guarantee(!is_stw_gc_active(), "collection is not reentrant");
 
   if (GCLocker::check_active_before_gc()) {
     return; // GC is disabled (e.g. JNI GetXXXCritical operation)
@@ -495,7 +495,7 @@ void SerialHeap::do_collection(bool full,
 
   ClearedAllSoftRefs casr(do_clear_all_soft_refs, soft_ref_policy());
 
-  IsGCActiveMark active_gc_mark;
+  IsSTWGCActiveMark active_gc_mark;
 
   bool complete = full && (max_generation == OldGen);
   bool old_collects_young = complete;

--- a/src/hotspot/share/gc/shared/collectedHeap.cpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.cpp
@@ -243,7 +243,7 @@ CollectedHeap::CollectedHeap() :
   _capacity_at_last_gc(0),
   _used_at_last_gc(0),
   _soft_ref_policy(),
-  _is_gc_active(false),
+  _is_stw_gc_active(false),
   _last_whole_heap_examined_time_ns(os::javaTimeNanos()),
   _total_collections(0),
   _total_full_collections(0),

--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -90,8 +90,8 @@ public:
 class CollectedHeap : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
-  friend class IsGCActiveMark; // Block structured external access to _is_gc_active
-  friend class DisableIsGCActiveMark; // Disable current IsGCActiveMark
+  friend class IsSTWGCActiveMark; // Block structured external access to _is_stw_gc_active
+  friend class DisableIsSTWGCActiveMark; // Disable current IsSTWGCActiveMark
   friend class MemAllocator;
   friend class ParallelObjectIterator;
 
@@ -112,7 +112,7 @@ class CollectedHeap : public CHeapObj<mtGC> {
   // Not used by all GCs
   MemRegion _reserved;
 
-  bool _is_gc_active;
+  bool _is_stw_gc_active;
 
   // (Minimum) Alignment reserve for TLABs and PLABs.
   static size_t _lab_alignment_reserve;
@@ -374,10 +374,8 @@ protected:
   // allocated object.
   virtual bool requires_barriers(stackChunkOop obj) const = 0;
 
-  // Returns "true" iff there is a stop-world GC in progress.  (I assume
-  // that it should answer "false" for the concurrent part of a concurrent
-  // collector -- dld).
-  bool is_gc_active() const { return _is_gc_active; }
+  // Returns "true" iff there is a stop-world GC in progress.
+  bool is_stw_gc_active() const { return _is_stw_gc_active; }
 
   // Total number of GC collections (started)
   unsigned int total_collections() const { return _total_collections; }

--- a/src/hotspot/share/gc/shared/isGCActiveMark.cpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.cpp
@@ -29,28 +29,28 @@
 #include "utilities/debug.hpp"
 
 // This class provides a method for block structured setting of the
-// _is_gc_active state without requiring accessors in CollectedHeap
+// _is_stw_gc_active state without requiring accessors in CollectedHeap
 
-IsGCActiveMark::IsGCActiveMark() {
+IsSTWGCActiveMark::IsSTWGCActiveMark() {
   CollectedHeap* heap = Universe::heap();
-  assert(!heap->is_gc_active(), "Not reentrant");
-  heap->_is_gc_active = true;
+  assert(!heap->is_stw_gc_active(), "Not reentrant");
+  heap->_is_stw_gc_active = true;
 }
 
-IsGCActiveMark::~IsGCActiveMark() {
+IsSTWGCActiveMark::~IsSTWGCActiveMark() {
   CollectedHeap* heap = Universe::heap();
-  assert(heap->is_gc_active(), "Sanity");
-  heap->_is_gc_active = false;
+  assert(heap->is_stw_gc_active(), "Sanity");
+  heap->_is_stw_gc_active = false;
 }
 
-DisableIsGCActiveMark::DisableIsGCActiveMark() {
+DisableIsSTWGCActiveMark::DisableIsSTWGCActiveMark() {
   CollectedHeap* heap = Universe::heap();
-  assert(heap->is_gc_active(), "Not reentrant");
-  heap->_is_gc_active = false;
+  assert(heap->is_stw_gc_active(), "Not reentrant");
+  heap->_is_stw_gc_active = false;
 }
 
-DisableIsGCActiveMark::~DisableIsGCActiveMark() {
+DisableIsSTWGCActiveMark::~DisableIsSTWGCActiveMark() {
   CollectedHeap* heap = Universe::heap();
-  assert(!heap->is_gc_active(), "Sanity");
-  heap->_is_gc_active = true;
+  assert(!heap->is_stw_gc_active(), "Sanity");
+  heap->_is_stw_gc_active = true;
 }

--- a/src/hotspot/share/gc/shared/isGCActiveMark.hpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.hpp
@@ -28,18 +28,18 @@
 #include "memory/allocation.hpp"
 
 // This class provides a method for block structured setting of the
-// _is_gc_active state without requiring accessors in CollectedHeap
+// _is_stw_gc_active state without requiring accessors in CollectedHeap
 
-class IsGCActiveMark : public StackObj {
+class IsSTWGCActiveMark : public StackObj {
  public:
-  IsGCActiveMark();
-  ~IsGCActiveMark();
+  IsSTWGCActiveMark();
+  ~IsSTWGCActiveMark();
 };
 
-class DisableIsGCActiveMark : public StackObj {
+class DisableIsSTWGCActiveMark : public StackObj {
  public:
-  DisableIsGCActiveMark();
-  ~DisableIsGCActiveMark();
+  DisableIsSTWGCActiveMark();
+  ~DisableIsSTWGCActiveMark();
 };
 
 #endif // SHARE_GC_SHARED_ISGCACTIVEMARK_HPP

--- a/src/hotspot/share/gc/shared/memAllocator.cpp
+++ b/src/hotspot/share/gc/shared/memAllocator.cpp
@@ -147,7 +147,7 @@ void MemAllocator::Allocation::verify_before() {
   JavaThread* THREAD = _thread; // For exception macros.
   assert(!HAS_PENDING_EXCEPTION, "Should not allocate with exception pending");
   debug_only(check_for_valid_allocation_state());
-  assert(!Universe::heap()->is_gc_active(), "Allocation during gc not allowed");
+  assert(!Universe::heap()->is_stw_gc_active(), "Allocation during GC pause not allowed");
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -92,7 +92,7 @@
   nonstatic_field(CardTableBarrierSet,         _card_table,                                   CardTable*)                            \
                                                                                                                                      \
   nonstatic_field(CollectedHeap,               _reserved,                                     MemRegion)                             \
-  nonstatic_field(CollectedHeap,               _is_gc_active,                                 bool)                                  \
+  nonstatic_field(CollectedHeap,               _is_stw_gc_active,                             bool)                                  \
   nonstatic_field(CollectedHeap,               _total_collections,                            unsigned int)                          \
                                                                                                                                      \
   nonstatic_field(ContiguousSpace,             _bottom,                                       HeapWord*)                             \

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -132,7 +132,7 @@ private:
   ShenandoahHeap* const _heap;
   const GCIdMark                _gc_id_mark;
   const SvcGCMarker             _svc_gc_mark;
-  const IsGCActiveMark          _is_gc_active_mark;
+  const IsSTWGCActiveMark       _is_gc_active_mark;
   TraceMemoryManagerStats       _trace_pause;
 
 public:

--- a/src/hotspot/share/gc/x/xDriver.cpp
+++ b/src/hotspot/share/gc/x/xDriver.cpp
@@ -116,7 +116,7 @@ public:
 
     // Setup GC id and active marker
     GCIdMark gc_id_mark(_gc_id);
-    IsGCActiveMark gc_active_mark;
+    IsSTWGCActiveMark gc_active_mark;
 
     // Verify before operation
     XVerify::before_zoperation();

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -438,7 +438,7 @@ public:
   virtual void doit() {
     // Setup GC id and active marker
     GCIdMark gc_id_mark(_gc_id);
-    IsGCActiveMark gc_active_mark;
+    IsSTWGCActiveMark gc_active_mark;
 
     // Verify before operation
     ZVerify::before_zoperation();

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -484,7 +484,7 @@ void ZVerify::after_mark() {
   }
   if (ZVerifyObjects) {
     // Workaround OopMapCacheAlloc_lock reordering with the StackWatermark_lock
-    DisableIsGCActiveMark mark;
+    DisableIsSTWGCActiveMark mark;
 
     objects(false /* verify_weaks */);
     guarantee(zverify_broken_object == zaddress::null, "Verification failed");

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -878,7 +878,7 @@ static OopStorage* object_handles() {
 }
 
 jlong JVMCIRuntime::make_oop_handle(const Handle& obj) {
-  assert(!Universe::heap()->is_gc_active(), "can't extend the root set during GC");
+  assert(!Universe::heap()->is_stw_gc_active(), "can't extend the root set during GC pause");
   assert(oopDesc::is_oop(obj()), "not an oop");
 
   oop* ptr = OopHandle(object_handles(), obj()).ptr_raw();

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -1342,8 +1342,8 @@ bool Universe::release_fullgc_alot_dummy() {
   return true;
 }
 
-bool Universe::is_gc_active() {
-  return heap()->is_gc_active();
+bool Universe::is_stw_gc_active() {
+  return heap()->is_stw_gc_active();
 }
 
 bool Universe::is_in_heap(const void* p) {

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -295,7 +295,7 @@ class Universe: AllStatic {
   // The particular choice of collected heap.
   static CollectedHeap* heap() { return _collectedHeap; }
 
-  DEBUG_ONLY(static bool is_gc_active();)
+  DEBUG_ONLY(static bool is_stw_gc_active();)
   DEBUG_ONLY(static bool is_in_heap(const void* p);)
   DEBUG_ONLY(static bool is_in_heap_or_null(const void* p) { return p == nullptr || is_in_heap(p); })
 

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -312,7 +312,7 @@ void Method::mask_for(int bci, InterpreterOopMap* mask) {
   methodHandle h_this(Thread::current(), this);
   // Only GC uses the OopMapCache during thread stack root scanning
   // any other uses generate an oopmap but do not save it in the cache.
-  if (Universe::heap()->is_gc_active()) {
+  if (Universe::heap()->is_stw_gc_active()) {
     method_holder()->mask_for(h_this, bci, mask);
   } else {
     OopMapCache::compute_one_oop_map(h_this, bci, mask);

--- a/src/hotspot/share/oops/oop.cpp
+++ b/src/hotspot/share/oops/oop.cpp
@@ -226,6 +226,6 @@ bool oopDesc::size_might_change() {
   // the grey portion of an already copied array. This will cause the first
   // disjunct below to fail if the two comparands are computed across such
   // a concurrent change.
-  return Universe::heap()->is_gc_active() && is_objArray() && is_forwarded() && (UseParallelGC || UseG1GC);
+  return Universe::heap()->is_stw_gc_active() && is_objArray() && is_forwarded() && (UseParallelGC || UseG1GC);
 }
 #endif

--- a/src/hotspot/share/prims/forte.cpp
+++ b/src/hotspot/share/prims/forte.cpp
@@ -602,7 +602,7 @@ void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void* ucontext) {
     return;
   }
 
-  if (Universe::heap()->is_gc_active()) {
+  if (Universe::heap()->is_stw_gc_active()) {
     trace->num_frames = ticks_GC_active; // -2
     return;
   }

--- a/src/hotspot/share/runtime/jniHandles.cpp
+++ b/src/hotspot/share/runtime/jniHandles.cpp
@@ -83,7 +83,7 @@ static void report_handle_allocation_failure(AllocFailType alloc_failmode,
 }
 
 jobject JNIHandles::make_global(Handle obj, AllocFailType alloc_failmode) {
-  assert(!Universe::heap()->is_gc_active(), "can't extend the root set during GC");
+  assert(!Universe::heap()->is_stw_gc_active(), "can't extend the root set during GC pause");
   assert(!current_thread_in_native(), "must not be in native");
   jobject res = nullptr;
   if (!obj.is_null()) {
@@ -105,7 +105,7 @@ jobject JNIHandles::make_global(Handle obj, AllocFailType alloc_failmode) {
 }
 
 jweak JNIHandles::make_weak_global(Handle obj, AllocFailType alloc_failmode) {
-  assert(!Universe::heap()->is_gc_active(), "can't extend the root set during GC");
+  assert(!Universe::heap()->is_stw_gc_active(), "can't extend the root set during GC pause");
   assert(!current_thread_in_native(), "must not be in native");
   jweak res = nullptr;
   if (!obj.is_null()) {


### PR DESCRIPTION
`CollectedHeap::is_gc_active()` is confusing, since its name implies _any_ GC phase is running, while it actually only covers the STW GCs. It would be good to rename it for clarity. The freed-up name, `is_gc_active` could then be repurposed to track any (concurrent or STW) GC phase running. That would be useful to resolve [JDK-8331572](https://bugs.openjdk.org/browse/JDK-8331572).

Doing this rename separately guarantees we have caught and renamed all current uses.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331573](https://bugs.openjdk.org/browse/JDK-8331573): Rename CollectedHeap::is_gc_active to be explicitly about STW GCs (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19064/head:pull/19064` \
`$ git checkout pull/19064`

Update a local copy of the PR: \
`$ git checkout pull/19064` \
`$ git pull https://git.openjdk.org/jdk.git pull/19064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19064`

View PR using the GUI difftool: \
`$ git pr show -t 19064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19064.diff">https://git.openjdk.org/jdk/pull/19064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19064#issuecomment-2090699201)