### PR TITLE
8331507: JFR: Improve example usage in -XX:StartFlightRecording:help

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -321,6 +321,7 @@ final class DCmdStart extends AbstractDCmd {
     public String[] getStartupHelp() {
         Map<String, String> parameters = Map.of(
             "$SYNTAX", "-XX:StartFlightRecording:[options]",
+            "$SOURCE_NO_ARGUMENTS", "-XX:StartFlightRecording",
             "$SOURCE", "-XX:StartFlightRecording:",
             "$DELIMITER", ",",
             "$DELIMITER_NAME", "comma",
@@ -334,6 +335,7 @@ final class DCmdStart extends AbstractDCmd {
     public String[] getHelp() {
         Map<String, String> parameters = Map.of(
            "$SYNTAX", "JFR.start [options]",
+           "$SOURCE_NO_ARGUMENTS", "$ jcmd <pid> JFR.start",
            "$SOURCE", "$ jcmd <pid> JFR.start ",
            "$DELIMITER", " ",
            "$DELIMITER_NAME", "whitespace",
@@ -440,7 +442,7 @@ final class DCmdStart extends AbstractDCmd {
 
                Example usage:
 
-                $SOURCE
+                $SOURCE_NO_ARGUMENTS
                 $SOURCEfilename=dump.jfr
                 $SOURCEfilename=$DIRECTORY
                 $SOURCEdumponexit=true


### PR DESCRIPTION
Could I have review that changes the first example for -XX:StartFlightRecording:help. See bug for more details.

Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331507](https://bugs.openjdk.org/browse/JDK-8331507): JFR: Improve example usage in -XX:StartFlightRecording:help (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19067/head:pull/19067` \
`$ git checkout pull/19067`

Update a local copy of the PR: \
`$ git checkout pull/19067` \
`$ git pull https://git.openjdk.org/jdk.git pull/19067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19067`

View PR using the GUI difftool: \
`$ git pr show -t 19067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19067.diff">https://git.openjdk.org/jdk/pull/19067.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19067#issuecomment-2091097864)