### PR TITLE
8331582: Incorrect default Console provider comment

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -406,7 +406,8 @@ public sealed class Console implements Flushable permits ProxyingConsole {
             /*
              * The JdkConsole provider used for Console instantiation can be specified
              * with the system property "jdk.console", whose value designates the module
-             * name of the implementation, and which defaults to "java.base". If no
+             * name of the implementation, and which defaults to the value
+             * {@code JdkConsoleProvider.DEFAULT_PROVIDER_MODULE_NAME}. If no
              * providers are available, or instantiation failed, java.base built-in
              * Console implementation is used.
              */

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -406,7 +406,7 @@ public sealed class Console implements Flushable permits ProxyingConsole {
             /*
              * The JdkConsole provider used for Console instantiation can be specified
              * with the system property "jdk.console", whose value designates the module
-             * name of the implementation, and which defaults to the value
+             * name of the implementation, and which defaults to the value of
              * {@code JdkConsoleProvider.DEFAULT_PROVIDER_MODULE_NAME}. If no
              * providers are available, or instantiation failed, java.base built-in
              * Console implementation is used.


### PR DESCRIPTION
Fixing a comment in `java.io.Console`, which was a leftover from the fix to https://bugs.openjdk.org/browse/JDK-8308591

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331582](https://bugs.openjdk.org/browse/JDK-8331582): Incorrect default Console provider comment (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [2ab4fdf9](https://git.openjdk.org/jdk/pull/19070/files/2ab4fdf952b6ae4224b8c0d95d7de68fb964fa3c)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) ⚠️ Review applies to [2ab4fdf9](https://git.openjdk.org/jdk/pull/19070/files/2ab4fdf952b6ae4224b8c0d95d7de68fb964fa3c)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [2ab4fdf9](https://git.openjdk.org/jdk/pull/19070/files/2ab4fdf952b6ae4224b8c0d95d7de68fb964fa3c)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [2ab4fdf9](https://git.openjdk.org/jdk/pull/19070/files/2ab4fdf952b6ae4224b8c0d95d7de68fb964fa3c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19070/head:pull/19070` \
`$ git checkout pull/19070`

Update a local copy of the PR: \
`$ git checkout pull/19070` \
`$ git pull https://git.openjdk.org/jdk.git pull/19070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19070`

View PR using the GUI difftool: \
`$ git pr show -t 19070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19070.diff">https://git.openjdk.org/jdk/pull/19070.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19070#issuecomment-2091568035)