### PR TITLE
8331591: sun.font.CharSequenceCodePointIterator is buggy and unused

### DIFF
--- a/src/java.desktop/share/classes/sun/font/CodePointIterator.java
+++ b/src/java.desktop/share/classes/sun/font/CodePointIterator.java
@@ -56,14 +56,12 @@ public abstract class CodePointIterator {
         return new CharArrayCodePointIterator(text, start, limit);
     }
 
-    public static CodePointIterator create(CharSequence text) {
-        return new CharSequenceCodePointIterator(text);
-    }
-
     public static CodePointIterator create(CharacterIterator iter) {
         return new CharacterIteratorCodePointIterator(iter);
     }
+
 }
+
 
 final class CharArrayCodePointIterator extends CodePointIterator {
     private char[] text;
@@ -114,57 +112,6 @@ final class CharArrayCodePointIterator extends CodePointIterator {
             char cp2 = text[--index];
             if (Character.isLowSurrogate(cp2) && index > start) {
                 char cp1 = text[index - 1];
-                if (Character.isHighSurrogate(cp1)) {
-                    --index;
-                    return Character.toCodePoint(cp1, cp2);
-                }
-            }
-            return cp2;
-        }
-        return DONE;
-    }
-
-    public int charIndex() {
-        return index;
-    }
-}
-
-final class CharSequenceCodePointIterator extends CodePointIterator {
-    private CharSequence text;
-    private int index;
-
-    public CharSequenceCodePointIterator(CharSequence text) {
-        this.text = text;
-    }
-
-    public void setToStart() {
-        index = 0;
-    }
-
-    public void setToLimit() {
-        index = text.length();
-    }
-
-    public int next() {
-        if (index < text.length()) {
-            char cp1 = text.charAt(index++);
-            if (Character.isHighSurrogate(cp1) && index < text.length()) {
-                char cp2 = text.charAt(index+1);
-                if (Character.isLowSurrogate(cp2)) {
-                    ++index;
-                    return Character.toCodePoint(cp1, cp2);
-                }
-            }
-            return cp1;
-        }
-        return DONE;
-    }
-
-    public int prev() {
-        if (index > 0) {
-            char cp2 = text.charAt(--index);
-            if (Character.isLowSurrogate(cp2) && index > 0) {
-                char cp1 = text.charAt(index - 1);
                 if (Character.isHighSurrogate(cp1)) {
                     --index;
                     return Character.toCodePoint(cp1, cp2);

--- a/src/java.desktop/share/classes/sun/font/CodePointIterator.java
+++ b/src/java.desktop/share/classes/sun/font/CodePointIterator.java
@@ -59,9 +59,7 @@ public abstract class CodePointIterator {
     public static CodePointIterator create(CharacterIterator iter) {
         return new CharacterIteratorCodePointIterator(iter);
     }
-
 }
-
 
 final class CharArrayCodePointIterator extends CodePointIterator {
     private char[] text;


### PR DESCRIPTION
Delete an internal class that has been around for 20 years but never been used.
Verified that is true at least as far back as JDK7
All platforms build. Tests pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331591](https://bugs.openjdk.org/browse/JDK-8331591): sun.font.CharSequenceCodePointIterator is buggy and unused (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - no project role)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19072/head:pull/19072` \
`$ git checkout pull/19072`

Update a local copy of the PR: \
`$ git checkout pull/19072` \
`$ git pull https://git.openjdk.org/jdk.git pull/19072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19072`

View PR using the GUI difftool: \
`$ git pr show -t 19072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19072.diff">https://git.openjdk.org/jdk/pull/19072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19072#issuecomment-2091805224)