### PR TITLE
8331428: ubsan: JVM flag checking complains about  MaxTenuringThresholdConstraintFunc, InitialTenuringThresholdConstraintFunc and AllocatePrefetchStepSizeConstraintFunc

### DIFF
--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -174,7 +174,7 @@ JVMFlag::Error MaxMetaspaceFreeRatioConstraintFunc(uint value, bool verbose) {
   }
 }
 
-JVMFlag::Error InitialTenuringThresholdConstraintFunc(uintx value, bool verbose) {
+JVMFlag::Error InitialTenuringThresholdConstraintFunc(uint value, bool verbose) {
 #if INCLUDE_PARALLELGC
   JVMFlag::Error status = InitialTenuringThresholdConstraintFuncParallel(value, verbose);
   if (status != JVMFlag::SUCCESS) {
@@ -185,7 +185,7 @@ JVMFlag::Error InitialTenuringThresholdConstraintFunc(uintx value, bool verbose)
   return JVMFlag::SUCCESS;
 }
 
-JVMFlag::Error MaxTenuringThresholdConstraintFunc(uintx value, bool verbose) {
+JVMFlag::Error MaxTenuringThresholdConstraintFunc(uint value, bool verbose) {
 #if INCLUDE_PARALLELGC
   JVMFlag::Error status = MaxTenuringThresholdConstraintFuncParallel(value, verbose);
   if (status != JVMFlag::SUCCESS) {

--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
+++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,8 @@
  f(size_t, MarkStackSizeConstraintFunc)                        \
  f(uint,   MinMetaspaceFreeRatioConstraintFunc)                \
  f(uint,   MaxMetaspaceFreeRatioConstraintFunc)                \
- f(uintx,  InitialTenuringThresholdConstraintFunc)             \
- f(uintx,  MaxTenuringThresholdConstraintFunc)                 \
+ f(uint,   InitialTenuringThresholdConstraintFunc)             \
+ f(uint,   MaxTenuringThresholdConstraintFunc)                 \
                                                                \
  f(uintx,  MaxGCPauseMillisConstraintFunc)                     \
  f(uintx,  GCPauseIntervalMillisConstraintFunc)                \

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,11 +67,11 @@ JVMFlag::Error CICompilerCountConstraintFunc(intx value, bool verbose) {
   }
 }
 
-JVMFlag::Error AllocatePrefetchStepSizeConstraintFunc(intx value, bool verbose) {
+JVMFlag::Error AllocatePrefetchStepSizeConstraintFunc(int value, bool verbose) {
   if (AllocatePrefetchStyle == 3) {
     if (value % wordSize != 0) {
       JVMFlag::printError(verbose,
-                          "AllocatePrefetchStepSize (" INTX_FORMAT ") must be multiple of %d\n",
+                          "AllocatePrefetchStepSize (%d) must be multiple of %d\n",
                           value, wordSize);
       return JVMFlag::VIOLATES_CONSTRAINT;
     }

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
 #define COMPILER_CONSTRAINTS(f)                         \
   f(intx,  CICompilerCountConstraintFunc)               \
   f(intx,  AllocatePrefetchInstrConstraintFunc)         \
-  f(intx,  AllocatePrefetchStepSizeConstraintFunc)      \
+  f(int,   AllocatePrefetchStepSizeConstraintFunc)      \
   f(intx,  CompileThresholdConstraintFunc)              \
   f(intx,  OnStackReplacePercentageConstraintFunc)      \
   f(uintx, CodeCacheSegmentSizeConstraintFunc)          \


### PR DESCRIPTION
Seems MaxTenuringThresholdConstraintFunc, InitialTenuringThresholdConstraintFunc and AllocatePrefetchStepSizeConstraintFunc check uint values (see gc_globals.hpp). However those functions have uintx in the check functions.
This causes Ubsan to complain :

/jdk/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp:176:12: runtime error: call to function MaxTenuringThresholdConstraintFunc(unsigned long, bool) through pointer to incorrect function type 'JVMFlag::Error (*)(unsigned int, bool)'
jvmFlagConstraintsGC.cpp:188: note: MaxTenuringThresholdConstraintFunc(unsigned long, bool) defined here
    #0 0x10541cfbe in FlagAccessImpl_uint::typed_check_constraint(void*, unsigned int, bool) const jvmFlagAccess.cpp:176
    #1 0x1054253d7 in JVMFlagLimit::check_all_constraints(JVMFlagConstraintPhase) jvmFlagLimit.cpp:179
    #2 0x105f20b98 in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:471
    #3 0x10538c3fb in JNI_CreateJavaVM_inner(JavaVM_**, void**, void*) jni.cpp:3581
    #4 0x10342e71c in JavaMain java.c:491
    #5 0x103435248 in ThreadJavaMain java_md_macosx.m:720
    #6 0x7fff204338fb in _pthread_start+0xdf (libsystem_pthread.dylib:x86_64+0x68fb)
    #7 0x7fff2042f442 in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x2442)

/jdk/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp:176:12: runtime error: call to function InitialTenuringThresholdConstraintFunc(unsigned long, bool) through pointer to incorrect function type 'JVMFlag::Error (*)(unsigned int, bool)'
jvmFlagConstraintsGC.cpp:177: note: InitialTenuringThresholdConstraintFunc(unsigned long, bool) defined here
    #0 0x117b1cfbe in FlagAccessImpl_uint::typed_check_constraint(void*, unsigned int, bool) const jvmFlagAccess.cpp:176
    #1 0x117b253d7 in JVMFlagLimit::check_all_constraints(JVMFlagConstraintPhase) jvmFlagLimit.cpp:179
    #2 0x118620b98 in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:471
    #3 0x117a8c3fb in JNI_CreateJavaVM_inner(JavaVM_**, void**, void*) jni.cpp:3581
    #4 0x10077e71c in JavaMain java.c:491
    #5 0x100785248 in ThreadJavaMain java_md_macosx.m:720
    #6 0x7fff204338fb in _pthread_start+0xdf (libsystem_pthread.dylib:x86_64+0x68fb)
    #7 0x7fff2042f442 in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x2442)

and

/jdk/src/hotspot/share/runtime/flags/jvmFlagAccess.cpp:157:12: runtime error: call to function AllocatePrefetchStepSizeConstraintFunc(long, bool) through pointer to incorrect function type 'JVMFlag::Error (*)(int, bool)'
jvmFlagConstraintsCompiler.cpp:70: note: AllocatePrefetchStepSizeConstraintFunc(long, bool) defined here
    #0 0x10239bcee in FlagAccessImpl_int::typed_check_constraint(void*, int, bool) const jvmFlagAccess.cpp:157
    #1 0x1023a53d7 in JVMFlagLimit::check_all_constraints(JVMFlagConstraintPhase) jvmFlagLimit.cpp:179
    #2 0x102ee640b in universe_init() universe.cpp:875
    #3 0x10213ee27 in init_globals() init.cpp:128
    #4 0x102ea0d69 in Threads::create_vm(JavaVMInitArgs*, bool*) threads.cpp:553
    #5 0x10230c3fb in JNI_CreateJavaVM_inner(JavaVM_**, void**, void*) jni.cpp:3581
    #6 0x10041271c in JavaMain java.c:491
    #7 0x100419248 in ThreadJavaMain java_md_macosx.m:720
    #8 0x7fff204338fb in _pthread_start+0xdf (libsystem_pthread.dylib:x86_64+0x68fb)
    #9 0x7fff2042f442 in thread_start+0xe (libsystem_pthread.dylib:x86_64+0x2442)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331428](https://bugs.openjdk.org/browse/JDK-8331428): ubsan: JVM flag checking complains about  MaxTenuringThresholdConstraintFunc, InitialTenuringThresholdConstraintFunc and AllocatePrefetchStepSizeConstraintFunc (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19074/head:pull/19074` \
`$ git checkout pull/19074`

Update a local copy of the PR: \
`$ git checkout pull/19074` \
`$ git pull https://git.openjdk.org/jdk.git pull/19074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19074`

View PR using the GUI difftool: \
`$ git pr show -t 19074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19074.diff">https://git.openjdk.org/jdk/pull/19074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19074#issuecomment-2092471648)