### PR TITLE
8331485: Odd Results when Parsing Scientific Notation with Large Exponent

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2479,7 +2479,6 @@ public class DecimalFormat extends NumberFormat {
                     symbols.getGroupingSeparator();
             String exponentString = symbols.getExponentSeparator();
             boolean sawDecimal = false;
-            boolean sawExponent = false;
             boolean sawDigit = false;
             int exponent = 0; // Set to the exponent value, if any
 
@@ -2579,18 +2578,18 @@ public class DecimalFormat extends NumberFormat {
                     // require that they be followed by a digit.  Otherwise
                     // we backup and reprocess them.
                     backup = position;
-                } else if (checkExponent && !isExponent && text.regionMatches(position, exponentString, 0, exponentString.length())
-                        && !sawExponent) {
+                } else if (checkExponent && !isExponent
+                        && text.regionMatches(position, exponentString, 0, exponentString.length())) {
                     // Process the exponent by recursively calling this method.
                     ParsePosition pos = new ParsePosition(position + exponentString.length());
                     boolean[] stat = new boolean[STATUS_LENGTH];
                     DigitList exponentDigits = new DigitList();
 
                     if (subparse(text, pos, "", symbols.getMinusSignText(), exponentDigits, true, stat)) {
-                        // We parse the exponent with isExponent true, thus fitsIntoLong
-                        // only returns false here if the value exceeds Long.MAX_VALUE.
-                        // We do not need to worry about false being returned for faulty
-                        // values as they are ignored by DigitList
+                        // We parse the exponent with isExponent == true, thus fitsIntoLong()
+                        // only returns false here if the exponent DigitList value exceeds
+                        // Long.MAX_VALUE. We do not need to worry about false being
+                        // returned for faulty values as they are ignored by DigitList.
                         if (exponentDigits.fitsIntoLong(stat[STATUS_POSITIVE], true)) {
                             position = pos.index; // Advance past the exponent
                             try {

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2591,7 +2591,6 @@ public class DecimalFormat extends NumberFormat {
                         // Long.MAX_VALUE. We do not need to worry about false being
                         // returned for faulty values as they are ignored by DigitList.
                         if (exponentDigits.fitsIntoLong(stat[STATUS_POSITIVE], true)) {
-                            position = pos.index; // Advance past the exponent
                             try {
                                 exponent = Math.toIntExact(exponentDigits.getLong());
                             } catch (ArithmeticException ex) {
@@ -2603,6 +2602,7 @@ public class DecimalFormat extends NumberFormat {
                             // is int, so assign it to the largest possible, Integer.MAX_VALUE
                             exponent = Integer.MAX_VALUE;
                         }
+                        position = pos.index; // Advance past the exponent
                         if (!stat[STATUS_POSITIVE]) {
                             exponent = -exponent;
                         }

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -2593,19 +2593,20 @@ public class DecimalFormat extends NumberFormat {
                         if (exponentDigits.fitsIntoLong(stat[STATUS_POSITIVE], true)) {
                             try {
                                 exponent = Math.toIntExact(exponentDigits.getLong());
+                                if (!stat[STATUS_POSITIVE]) {
+                                    exponent = -exponent;
+                                }
                             } catch (ArithmeticException ex) {
-                                // If overflow, Integer.MAX_VALUE is sufficient
-                                exponent = Integer.MAX_VALUE;
+                                // For all overflow and underflow, determine
+                                // appropriate value based off positive status
+                                exponent = stat[STATUS_POSITIVE] ?
+                                        Integer.MAX_VALUE : Integer.MIN_VALUE;
                             }
                         } else {
-                            // Value is greater than Long.MAX_VALUE, exponent field
-                            // is int, so assign it to the largest possible, Integer.MAX_VALUE
-                            exponent = Integer.MAX_VALUE;
+                            exponent = stat[STATUS_POSITIVE] ?
+                                    Integer.MAX_VALUE : Integer.MIN_VALUE;
                         }
                         position = pos.index; // Advance past the exponent
-                        if (!stat[STATUS_POSITIVE]) {
-                            exponent = -exponent;
-                        }
                     }
                     break; // Whether we fail or succeed, we exit this loop
                 } else {
@@ -2643,8 +2644,9 @@ public class DecimalFormat extends NumberFormat {
             try {
                 digits.decimalAt = Math.addExact(digits.decimalAt, exponent);
             } catch (ArithmeticException ex) {
-                // If overflow, Integer.MAX_VALUE is sufficient
-                digits.decimalAt = Integer.MAX_VALUE;
+                // Depending on overflow/underflow, adjust exponent value
+                digits.decimalAt = digits.decimalAt + exponent > 0
+                        ? Integer.MIN_VALUE : Integer.MAX_VALUE;
             }
 
             // If none of the text string was recognized.  For example, parse

--- a/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
@@ -123,7 +123,7 @@ public class LargeExponentsTest {
                 Arguments.of("1.23E32ABC9920", 1.23E32),
                 // 0 exponent
                 Arguments.of("1.23E0", 1.23),
-                // Trailing zeroes
+                // Leading zeroes
                 Arguments.of("1.23E0000123", 1.23E123),
                 // Trailing zeroes - Past Long.MAX_VALUE length
                 Arguments.of("1.23E00000000000000000000000000000000000000000123", 1.23E123),

--- a/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.text.NumberFormat;
+import java.text.ParseException;
 import java.text.ParsePosition;
 import java.util.ArrayList;
 import java.util.List;
@@ -54,11 +55,24 @@ public class LargeExponentsTest {
     // parses to 0 and that an exponent > Long.MAX_VALUE no longer parses to the mantissa.
     @ParameterizedTest
     @MethodSource({"largeExponentValues", "smallExponentValues", "bugReportValues", "edgeCases"})
-    public void overflowTest(String parseString, Double expectedValue) {
+    public void overflowTest(String parseString, Double expectedValue) throws ParseException {
+        checkParse(parseString, expectedValue);
+        checkParseWithPP(parseString, expectedValue);
+    }
+
+    // Checks the parse(String, ParsePosition) method
+    public void checkParse(String parseString, Double expectedValue) {
         ParsePosition pp = new ParsePosition(0);
         Number actualValue = FMT.parse(parseString, pp);
         assertEquals(expectedValue, (double)actualValue);
         assertEquals(parseString.length(), pp.getIndex());
+    }
+
+    // Checks the parse(String) method
+    public void checkParseWithPP(String parseString, Double expectedValue)
+            throws ParseException {
+        Number actualValue = FMT.parse(parseString);
+        assertEquals(expectedValue, (double)actualValue);
     }
 
     // Generate large enough exponents that should all be parsed as infinity

--- a/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331485
+ * @summary Ensure correctness when parsing large (+/-) exponent values that
+ *          exceed Integer.MAX_VALUE and Long.MAX_VALUE.
+ * @run junit LargeExponentsTest
+ */
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// We prevent odd results when parsing large exponent values by ensuring
+// that we properly handle overflow in the implementation of DigitList
+public class LargeExponentsTest {
+
+    // Exponent symbol is 'E'
+    private static final NumberFormat FMT = NumberFormat.getInstance(Locale.US);
+
+    // Check that the parsed value is equal to the expected.
+    // We are mainly checking that an exponent > Integer.MAX_VALUE no longer parses to 0
+    // and that an exponent > Long.MAX_VALUE no longer parses to the mantissa.
+    @ParameterizedTest
+    @MethodSource({"largeExponentValues", "smallExponentValues", "bugReportValues", "edgeCases"})
+    public void overflowTest(String parseString, Double expectedValue) throws ParseException {
+        Number actualValue = FMT.parse(parseString);
+        assertEquals(expectedValue, (double)actualValue);
+    }
+
+    // Generate large enough exponents that should all be parsed as infinity
+    // when positive. This includes exponents that exceed Long.MAX_VALUE
+    private static List<Arguments> largeExponentValues() {
+        return createExponentValues(false);
+    }
+
+    // Same as previous provider but for negative exponent values, so expecting
+    // a parsed value of 0.
+    private static List<Arguments> smallExponentValues() {
+        return createExponentValues(true);
+    }
+
+    // Programmatically generate some large parse values that are expected
+    // to be parsed as infinity or 0
+    private static List<Arguments> createExponentValues(boolean negative) {
+        List<Arguments> args = new ArrayList<>();
+        // Start with a base value that should be parsed as infinity
+        String baseValue = "12234.123E1100";
+        // Continuously add to the String until we trigger the overflow condition
+        for (int i = 0; i < 100; i++) {
+            StringBuilder bldr = new StringBuilder();
+            // Add to exponent
+            bldr.append(baseValue).append("1".repeat(i));
+            // Add to mantissa
+            bldr.insert(0, "1".repeat(i));
+            args.add(Arguments.of(
+                    // Prepend "-" to exponent if negative
+                    negative ? bldr.insert(bldr.indexOf("E")+1, "-").toString() : bldr.toString(),
+                    // Expect 0 if negative, else infinity
+                    negative ? 0.0 : Double.POSITIVE_INFINITY));
+        }
+        return args;
+    }
+
+    // The provided values are all from the JBS issue
+    // These contain exponents that exceed Integer.MAX_VALUE, but not Long.MAX_VALUE
+    private static Stream<Arguments> bugReportValues() {
+        return Stream.of(
+                Arguments.of("0.123E1", 1.23),
+                Arguments.of("0.123E309", 1.23E308),
+                Arguments.of("0.123E310", Double.POSITIVE_INFINITY),
+                Arguments.of("0.123E2147483647", Double.POSITIVE_INFINITY),
+                Arguments.of("0.123E2147483648", Double.POSITIVE_INFINITY),
+                Arguments.of("0.0123E2147483648", Double.POSITIVE_INFINITY),
+                Arguments.of("0.0123E2147483649", Double.POSITIVE_INFINITY),
+                Arguments.of("1.23E2147483646", Double.POSITIVE_INFINITY),
+                Arguments.of("1.23E2147483647", Double.POSITIVE_INFINITY),
+                Arguments.of("0.123E4294967296", Double.POSITIVE_INFINITY),
+                Arguments.of("0.123E-322", 9.9E-324),
+                Arguments.of("0.123E-323", 0.0),
+                Arguments.of("0.123E-2147483648", 0.0),
+                Arguments.of("0.123E-2147483649", 0.0)
+        );
+    }
+
+    // Some odd edge case values to ensure parse correctness
+    private static Stream<Arguments> edgeCases() {
+        return Stream.of(
+                // Decimal in exponent, everything past decimal is ignored
+                Arguments.of("1.23E33.332", 1.23E33),
+                // Non-numeric value in exponent, ignores subsequent chars
+                Arguments.of("1.23E32ABC9920", 1.23E32),
+                // 0 exponent
+                Arguments.of("1.23E0", 1.23),
+                // Trailing zeroes
+                Arguments.of("1.23E0000123", 1.23E123),
+                // Trailing zeroes - Past Long.MAX_VALUE length
+                Arguments.of("1.23E00000000000000000000000000000000000000000123", 1.23E123),
+                // Trailing zeroes
+                Arguments.of("1.23E100", 1.23E100),
+                // Long.MAX_VALUE length
+                Arguments.of("1.23E1234567891234567800", Double.POSITIVE_INFINITY),
+                // Long.MAX_VALUE with trailing zeroes
+                Arguments.of("1.23E9223372036854775807000", Double.POSITIVE_INFINITY),
+                // Long.MIN_VALUE
+                Arguments.of("1.23E-9223372036854775808", 0.0)
+        );
+    }
+}

--- a/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
@@ -125,7 +125,7 @@ public class LargeExponentsTest {
                 Arguments.of("1.23E0", 1.23),
                 // Leading zeroes
                 Arguments.of("1.23E0000123", 1.23E123),
-                // Trailing zeroes - Past Long.MAX_VALUE length
+                // Leading zeroes - Past Long.MAX_VALUE length
                 Arguments.of("1.23E00000000000000000000000000000000000000000123", 1.23E123),
                 // Trailing zeroes
                 Arguments.of("1.23E100", 1.23E100),

--- a/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
+++ b/test/jdk/java/text/Format/DecimalFormat/LargeExponentsTest.java
@@ -133,6 +133,9 @@ public class LargeExponentsTest {
     // Some odd edge case values to ensure parse correctness
     private static Stream<Arguments> edgeCases() {
         return Stream.of(
+                // Exponent itself does not cause underflow, but decimalAt adjustment
+                // based off mantissa should. decimalAt(-1) + exponent(Integer.MIN_VALUE) = underflow
+                Arguments.of("0.0123E-2147483648", 0.0),
                 // 0 exponent
                 Arguments.of("1.23E0", 1.23),
                 // Leading zeroes

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640
+ * @bug 8327640 8331485
  * @summary Test suite for NumberFormat parsing when lenient.
  * @run junit/othervm -Duser.language=en -Duser.country=US LenientParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP LenientParseTest
@@ -34,6 +34,7 @@
  * @run junit/othervm -Duser.language=ar -Duser.country=AR LenientParseTest
  */
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -125,6 +126,18 @@ public class LenientParseTest {
         dFmt.setParseIntegerOnly(true);
         assertEquals(expectedValue, successParse(dFmt, toParse, expectedIndex));
         dFmt.setParseIntegerOnly(false);
+    }
+
+    @Test // Non-localized, only run once
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void badExponentParseNumberFormatTest() {
+        // Some fmt, with an "E" exponent string
+        DecimalFormat fmt = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
+        // Upon non-numeric in exponent, parse will still successfully complete
+        // but index should end on the last valid char in exponent
+        assertEquals(1.23E45, successParse(fmt, "1.23E45.123", 7));
+        assertEquals(1.23E45, successParse(fmt, "1.23E45.", 7));
+        assertEquals(1.23E45, successParse(fmt, "1.23E45FOO3222", 7));
     }
 
     // ---- CurrencyFormat tests ----

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640
+ * @bug 8327640 8331485
  * @summary Test suite for NumberFormat parsing with strict leniency
  * @run junit/othervm -Duser.language=en -Duser.country=US StrictParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP StrictParseTest
@@ -112,7 +112,19 @@ public class StrictParseTest {
         successParse(nonLocalizedDFmt, "a12345,67890b");
         successParse(nonLocalizedDFmt, "a1234,67890b");
         failParse(nonLocalizedDFmt, "a123456,7890b", 6);
+    }
 
+    @Test // Non-localized, only run once
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void badExponentParseNumberFormatTest() {
+        // Some fmt, with an "E" exponent string
+        DecimalFormat fmt = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
+        fmt.setStrict(true);
+        // Upon non-numeric in exponent, parse will exit early and suffix will not
+        // exactly match, causing failure
+        failParse(fmt, "1.23E45.1", 7);
+        failParse(fmt, "1.23E45.", 7);
+        failParse(fmt, "1.23E45FOO3222", 7);
     }
 
     // All input Strings should fail


### PR DESCRIPTION
Please review this PR which corrects an edge case bug for java.text.DecimalFormat that causes incorrect parsing results for strings with very large exponent values.

When parsing values with large exponents, if the value of the exponent exceeds `Integer.MAX_VALUE`, the parsed value  is equal to 0. If the value of the exponent exceeds `Long.MAX_VALUE`, the parsed value is equal to the mantissa. Both results are confusing and incorrect.

For example,

```
NumberFormat fmt = NumberFormat.getInstance(Locale.US);
fmt.parse(".1E2147483648"); // returns 0.0
fmt.parse(".1E9223372036854775808"); // returns 0.1
// For comparison
Double.parseDouble(".1E2147483648"); // returns Infinity
Double.parseDouble(".1E9223372036854775808"); // returns Infinity
```

After this change, both parse calls return `Double.POSITIVE_INFINITY` now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8331485](https://bugs.openjdk.org/browse/JDK-8331485): Odd Results when Parsing Scientific Notation with Large Exponent (**Bug** - P4)
 * [JDK-8331680](https://bugs.openjdk.org/browse/JDK-8331680): NumberFormat is missing some bad exponent strict parse cases (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [bc391f96](https://git.openjdk.org/jdk/pull/19075/files/bc391f966c04602a7c29c7a612c163a062e053be)
 * @ahauschulte (no known openjdk.org user name / role) ⚠️ Review applies to [2c167493](https://git.openjdk.org/jdk/pull/19075/files/2c1674938a4fda385e9b365654d5e7a96ee5b038)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19075/head:pull/19075` \
`$ git checkout pull/19075`

Update a local copy of the PR: \
`$ git checkout pull/19075` \
`$ git pull https://git.openjdk.org/jdk.git pull/19075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19075`

View PR using the GUI difftool: \
`$ git pr show -t 19075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19075.diff">https://git.openjdk.org/jdk/pull/19075.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19075#issuecomment-2092582058)