### PR TITLE
8331633: Use MIN2 in bound_minus_alignment

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -58,7 +58,7 @@ static size_t bound_minus_alignment(size_t desired_size,
                                     size_t maximum_size,
                                     size_t alignment) {
   size_t max_minus = maximum_size - alignment;
-  return desired_size < max_minus ? desired_size : max_minus;
+  return MIN2(desired_size, max_minus);
 }
 
 void GenArguments::initialize_alignments() {


### PR DESCRIPTION
Trivial use of `MIN2`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331633](https://bugs.openjdk.org/browse/JDK-8331633): Use MIN2 in bound_minus_alignment (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19076/head:pull/19076` \
`$ git checkout pull/19076`

Update a local copy of the PR: \
`$ git checkout pull/19076` \
`$ git pull https://git.openjdk.org/jdk.git pull/19076/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19076`

View PR using the GUI difftool: \
`$ git pr show -t 19076`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19076.diff">https://git.openjdk.org/jdk/pull/19076.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19076#issuecomment-2092592563)