### PR TITLE
8312104: Update java man pages to include new security category in -XshowSettings

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1095,7 +1095,6 @@ Do not attempt to use shared class data.
 .TP
 \f[V]-XshowSettings\f[R]
 Shows all settings and then continues.
-This is the default value.
 .TP
 \f[V]-XshowSettings:\f[R]\f[I]category\f[R]
 Shows settings and continues.
@@ -1113,7 +1112,7 @@ Shows settings related to locale.
 Shows settings related to system properties.
 .TP
 \f[V]security\f[R]
-Shows all security settings.
+Shows all settings related to security.
 .RS
 .PP
 sub-category arguments for \f[V]security\f[R] include the following:

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1095,6 +1095,7 @@ Do not attempt to use shared class data.
 .TP
 \f[V]-XshowSettings\f[R]
 Shows all settings and then continues.
+This is the default value.
 .TP
 \f[V]-XshowSettings:\f[R]\f[I]category\f[R]
 Shows settings and continues.
@@ -1103,14 +1104,22 @@ following:
 .RS
 .TP
 \f[V]all\f[R]
-Shows all categories of settings.
-This is the default value.
+Shows all categories of settings in verbose detail and then continues.
 .TP
 \f[V]locale\f[R]
 Shows settings related to locale.
 .TP
 \f[V]properties\f[R]
 Shows settings related to system properties.
+.TP
+\f[V]security\f[R]
+Shows all security settings.
+sub-category arguments for \f[V]security\f[R] include the following: *
+\f[V]security:all\f[R] : show all security settings and continue *
+\f[V]security:properties\f[R] : show security properties and continue *
+\f[V]security:providers\f[R] : show static security provider settings
+and continue * \f[V]security:tls\f[R] : show TLS related security
+settings and continue
 .TP
 \f[V]vm\f[R]
 Shows the settings of the JVM.

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1104,7 +1104,7 @@ following:
 .RS
 .TP
 \f[V]all\f[R]
-Shows all categories of settings in verbose detail and then continues.
+Shows all categories of settings in \f[B]verbose\f[R] detail.
 .TP
 \f[V]locale\f[R]
 Shows settings related to locale.
@@ -1114,12 +1114,18 @@ Shows settings related to system properties.
 .TP
 \f[V]security\f[R]
 Shows all security settings.
-sub-category arguments for \f[V]security\f[R] include the following: *
-\f[V]security:all\f[R] : show all security settings and continue *
-\f[V]security:properties\f[R] : show security properties and continue *
-\f[V]security:providers\f[R] : show static security provider settings
-and continue * \f[V]security:tls\f[R] : show TLS related security
-settings and continue
+.RS
+.PP
+sub-category arguments for \f[V]security\f[R] include the following:
+.IP \[bu] 2
+\f[V]security:all\f[R] : shows all security settings
+.IP \[bu] 2
+\f[V]security:properties\f[R] : shows security properties
+.IP \[bu] 2
+\f[V]security:providers\f[R] : shows static security provider settings
+.IP \[bu] 2
+\f[V]security:tls\f[R] : shows TLS related security settings
+.RE
 .TP
 \f[V]vm\f[R]
 Shows the settings of the JVM.


### PR DESCRIPTION
Incorporate man page changes related to JDK-8281658 and related issues (including JDK-8311653)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312104](https://bugs.openjdk.org/browse/JDK-8312104): Update java man pages to include new security category in -XshowSettings (**Sub-task** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19078/head:pull/19078` \
`$ git checkout pull/19078`

Update a local copy of the PR: \
`$ git checkout pull/19078` \
`$ git pull https://git.openjdk.org/jdk.git pull/19078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19078`

View PR using the GUI difftool: \
`$ git pr show -t 19078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19078.diff">https://git.openjdk.org/jdk/pull/19078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19078#issuecomment-2093097880)