### PR TITLE
8331636: [BACKOUT] Build failure after 8330076

### DIFF
--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -329,7 +329,7 @@ ReservedSpace ReservedSpace::last_part(size_t partition_size, size_t alignment) 
 
 ReservedSpace ReservedSpace::partition(size_t offset, size_t partition_size, size_t alignment) {
   assert(offset + partition_size <= size(), "partition failed");
-  ReservedSpace result(base() + offset, partition_size, alignment, page_size(), special(), executable(), nmt_flag());
+  ReservedSpace result(base() + offset, partition_size, alignment, page_size(), special(), executable());
   return result;
 }
 


### PR DESCRIPTION
reverted the changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331636](https://bugs.openjdk.org/browse/JDK-8331636): [BACKOUT] Build failure after 8330076 (**Bug** - P1)


### Reviewers
 * [Jesper Wilhelmsson](https://openjdk.org/census#jwilhelm) (@JesperIRL - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19079/head:pull/19079` \
`$ git checkout pull/19079`

Update a local copy of the PR: \
`$ git checkout pull/19079` \
`$ git pull https://git.openjdk.org/jdk.git pull/19079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19079`

View PR using the GUI difftool: \
`$ git pr show -t 19079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19079.diff">https://git.openjdk.org/jdk/pull/19079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19079#issuecomment-2092697590)