### PR TITLE
8331646: Add specific regression leap year tests

### DIFF
--- a/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
+++ b/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
@@ -28,8 +28,10 @@
  * @run junit CalendarLeapYearAddTest
  */
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Calendar;
 import java.util.Locale;
@@ -40,14 +42,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CalendarLeapYearAddTest {
 
+    private TestInfo testInfo;
+
+    @BeforeEach
+    void init(TestInfo testInfo) {
+        this.testInfo = testInfo;
+    }
+
     /**
      * 8331646 Calendar month add for leap year
      */
-    @Test
-    public void testMonthAddLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testMonthAddLeapYear")
+    @ValueSource(ints = {1})
+    public void testMonthAddLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, 1);
+        calendar.add(Calendar.MONTH, value);
         /* when added a month date jumps to 29th of March 2024 */
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of March 2024 but got " + calendar.getTime());
@@ -58,11 +68,12 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar 1 month subtract for leap year
      */
-    @Test
-    public void testOneMonthSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testOneMonthSubtractLeapYear")
+    @ValueSource(ints = {-1})
+    public void testOneMonthSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 2, 31, 15, 0, 0);
-        calendar.add(Calendar.MONTH, -1);
+        calendar.add(Calendar.MONTH, value);
         /* when added a month date jumps to 29th of March 2024 */
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
@@ -73,11 +84,12 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar 2 month subtract for leap year
      */
-    @Test
-    public void testTwoMonthSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testTwoMonthSubtractLeapYear")
+    @ValueSource(ints = {-2})
+    public void testTwoMonthSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 3, 30, 15, 0, 0);
-        calendar.add(Calendar.MONTH, -2);
+        calendar.add(Calendar.MONTH, value);
         /* when added a month date jumps to 29th of March 2024 */
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
@@ -88,14 +100,15 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar month add/subtract for leap year
      */
-    @Test
-    public void testMonthAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testMonthAddSubtractLeapYear")
+    @ValueSource(ints = {1})
+    public void testMonthAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, 1);
+        calendar.add(Calendar.MONTH, value);
         /* when added a month date jumps to 29th of March 2024,
            subtracting month in a leap year returns 29th of February 2024  */
-        calendar.add(Calendar.MONTH, -1);
+        calendar.add(Calendar.MONTH, -value);
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
         assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
@@ -105,13 +118,14 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar month and year add/subtract for leap/non-leap year
      */
-    @Test
-    public void testMonthYearAddSubtractNonLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testMonthYearAddSubtractNonLeapYear")
+    @ValueSource(ints = {1})
+    public void testMonthYearAddSubtractNonLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, 1);
-        calendar.add(YEAR, -1);
-        calendar.add(Calendar.MONTH, -1);
+        calendar.add(Calendar.MONTH, value);
+        calendar.add(YEAR, -value);
+        calendar.add(Calendar.MONTH, -value);
         /* When month added date jumps to 29th of March 2024, after year subtracted date jumps to 29th of March 2023
            after month subtracted date jumps to 28th of Feb 2023 as non leap year
          */
@@ -124,12 +138,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar month add/subtract for leap year jumping from March 31st to February 29th and back to March 29th
      */
-    @Test
-    public void testMonthAddSubtractLeapYearReversed(TestInfo testInfo) {
+    @ParameterizedTest(name = "testMonthAddSubtractLeapYearReversed")
+    @ValueSource(ints = {1})
+    public void testMonthAddSubtractLeapYearReversed(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 2, 31, 15, 0, 0);
-        calendar.add(MONTH, -1);
-        calendar.add(MONTH, 1);
+        calendar.add(MONTH, -value);
+        calendar.add(MONTH, value);
         /* when month removed date jumps to 29th of February,
            adding a month results in 29th of March 2024 as it's leap year
         */
@@ -142,12 +157,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar year add/subtract for leap year
      */
-    @Test
-    public void testYearAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testYearAddSubtractLeapYear")
+    @ValueSource(ints = {1})
+    public void testYearAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(YEAR, 1);
-        calendar.add(YEAR, -1);
+        calendar.add(YEAR, value);
+        calendar.add(YEAR, -value);
         /* when evaluated to no leap year date jumps to 28 of Feb 2023, removing year results in 28th of Feb 2024 */
         assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 28th of February 2024 but got " + calendar.getTime());
@@ -158,15 +174,16 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar year add/subtract for leap year
      */
-    @Test
-    public void testYearDayAddSubtractLeapYearReversed(TestInfo testInfo) {
+    @ParameterizedTest(name = "testYearDayAddSubtractLeapYearReversed")
+    @ValueSource(ints = {1})
+    public void testYearDayAddSubtractLeapYearReversed(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2023, 1, 28, 15, 0, 0);
-        calendar.add(YEAR, 1);
-        calendar.add(DATE, 1);
+        calendar.add(YEAR, value);
+        calendar.add(DATE, value);
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
-        calendar.add(YEAR, -1);
+        calendar.add(YEAR, -value);
         /* when evaluated to leap year + 1 day the date jumps to 29th of Feb 2024,
          removing year results in 28th of Feb 2023 */
         assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
@@ -178,12 +195,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar day of year add/subtract for leap year
      */
-    @Test
-    public void testDayOfYearAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testDayOfYearAddSubtractLeapYear")
+    @ValueSource(ints = {365})
+    public void testDayOfYearAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_YEAR, 365);
-        calendar.add(DAY_OF_YEAR, -365);
+        calendar.add(DAY_OF_YEAR, value);
+        calendar.add(DAY_OF_YEAR, -value);
         /* adding/subtracting same amount of days should land on the same day in leap year*/
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
@@ -194,12 +212,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar date add/subtract for leap year
      */
-    @Test
-    public void testDateAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testDateAddSubtractLeapYear")
+    @ValueSource(ints = {365})
+    public void testDateAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DATE, 365);
-        calendar.add(DATE, -365);
+        calendar.add(DATE, value);
+        calendar.add(DATE, -value);
         /* DATE behaves as date DAY_OF_YEAR */
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
@@ -210,12 +229,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar week of the year add/subtract for leap year
      */
-    @Test
-    public void testWeekOfYearAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testWeekOfYearAddSubtractLeapYear")
+    @ValueSource(ints = {52})
+    public void testWeekOfYearAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(WEEK_OF_YEAR, 52);
-        calendar.add(WEEK_OF_YEAR, -52);
+        calendar.add(WEEK_OF_YEAR, value);
+        calendar.add(WEEK_OF_YEAR, -value);
         /* adding year in weeks should not mess the date*/
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
@@ -226,12 +246,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar day of month add/subtract for leap year
      */
-    @Test
-    public void testDateOfMonthAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testDateOfMonthAddSubtractLeapYear")
+    @ValueSource(ints = {31})
+    public void testDateOfMonthAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_MONTH, 31);
-        calendar.add(DAY_OF_MONTH, -31);
+        calendar.add(DAY_OF_MONTH, value);
+        calendar.add(DAY_OF_MONTH, -value);
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
         assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
@@ -241,12 +262,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar day of week add/subtract for leap year
      */
-    @Test
-    public void testDayOfWeekAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testDayOfWeekAddSubtractLeapYear")
+    @ValueSource(ints = {6})
+    public void testDayOfWeekAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_WEEK, 6);
-        calendar.add(DAY_OF_WEEK, -6);
+        calendar.add(DAY_OF_WEEK, value);
+        calendar.add(DAY_OF_WEEK, -value);
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
         assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
@@ -256,12 +278,13 @@ public class CalendarLeapYearAddTest {
     /**
      * 8331646 Calendar day of week in month add/subtract for leap year
      */
-    @Test
-    public void testDayOfWeekInMonthAddSubtractLeapYear(TestInfo testInfo) {
+    @ParameterizedTest(name = "testDayOfWeekInMonthAddSubtractLeapYear")
+    @ValueSource(ints = {6})
+    public void testDayOfWeekInMonthAddSubtractLeapYear(int value) {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_WEEK_IN_MONTH, 6);
-        calendar.add(DAY_OF_WEEK_IN_MONTH, -6);
+        calendar.add(DAY_OF_WEEK_IN_MONTH, value);
+        calendar.add(DAY_OF_WEEK_IN_MONTH, -value);
         assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
                 + " Expected 29th of February 2024 but got " + calendar.getTime());
         assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()

--- a/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
+++ b/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
@@ -34,11 +34,22 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import static java.util.Calendar.*;
+import static java.util.Calendar.APRIL;
+import static java.util.Calendar.DATE;
+import static java.util.Calendar.DAY_OF_MONTH;
+import static java.util.Calendar.DAY_OF_WEEK;
+import static java.util.Calendar.DAY_OF_WEEK_IN_MONTH;
+import static java.util.Calendar.DAY_OF_YEAR;
+import static java.util.Calendar.FEBRUARY;
+import static java.util.Calendar.LONG;
+import static java.util.Calendar.MARCH;
 import static java.util.Calendar.MONTH;
+import static java.util.Calendar.WEEK_OF_YEAR;
+import static java.util.Calendar.YEAR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CalendarLeapYearAddTest {
@@ -51,8 +62,7 @@ public class CalendarLeapYearAddTest {
     public void testAddLeapYear(String testName, int calendarDate, int calendarMonth, int calendarYear,
                                 int value, int calendarField, int expectedDate, int expectedMonth,
                                 int expectedYear) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(calendarYear, calendarMonth, calendarDate);
+        Calendar calendar = new GregorianCalendar(calendarYear, calendarMonth, calendarDate);
         calendar.add(calendarField, value);
         assertEquals(expectedDate, calendar.get(DATE), testName
                 + " Expected " + expectedDate + " of " + expectedMonth + expectedYear + " but got " + calendar.getTime());
@@ -65,11 +75,10 @@ public class CalendarLeapYearAddTest {
      */
     @Test
     public void testMonthYearAddSubtractNonLeapYear() {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, 1);
+        Calendar calendar = new GregorianCalendar(2024, FEBRUARY, 29);
+        calendar.add(MONTH, 1);
         calendar.add(YEAR, -1);
-        calendar.add(Calendar.MONTH, -1);
+        calendar.add(MONTH, -1);
         /* When month added date jumps to 29th of March 2024, after year subtracted date jumps to 29th of March 2023
            after month subtracted date jumps to 28th of Feb 2023 as non leap year
          */
@@ -87,8 +96,7 @@ public class CalendarLeapYearAddTest {
     public void testAddSubtractLeapYear(String testName, int calendarDate, int calendarMonth, int calendarYear,
                                         int firstValue, int secondValue, int calendarField, int expectedDate,
                                         int expectedMonth, int expectedYear) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(calendarYear, calendarMonth, calendarDate);
+        Calendar calendar = new GregorianCalendar(calendarYear, calendarMonth, calendarDate);
         calendar.add(calendarField, firstValue);
         calendar.add(calendarField, secondValue);
         assertEquals(expectedDate, calendar.get(DATE), testName
@@ -99,23 +107,23 @@ public class CalendarLeapYearAddTest {
 
     private static Stream<Arguments> calendarAddSubtractSource() {
         return Stream.of(
-                Arguments.of("testMonthAddSubtractLeapYearReversed", 31, 2, 2024, -1, 1, MONTH, 29, MARCH, 2024),
-                Arguments.of("testMonthAddSubtractLeapYear", 29, 1, 2024, 1, -1, MONTH, 29, FEBRUARY, 2024),
-                Arguments.of("testYearAddSubtractLeapYear", 29, 1, 2024, 1, -1, YEAR, 28, FEBRUARY, 2024),
-                Arguments.of("testDayOfYearAddSubtractLeapYear", 29, 1, 2024, 365, -365, DAY_OF_YEAR, 29, FEBRUARY, 2024),
-                Arguments.of("testDateAddSubtractLeapYear", 29, 1, 2024, 365, -365, DATE, 29, FEBRUARY, 2024),
-                Arguments.of("testWeekOfYearAddSubtractLeapYear", 29, 1, 2024, 52, -52, WEEK_OF_YEAR, 29, FEBRUARY, 2024),
-                Arguments.of("testDateOfMonthAddSubtractLeapYear", 29, 1, 2024, 31, -31, DAY_OF_MONTH, 29, FEBRUARY, 2024),
-                Arguments.of("testDayOfWeekInMonthAddSubtractLeapYear", 29, 1, 2024, 6, -6, DAY_OF_WEEK_IN_MONTH, 29, FEBRUARY, 2024),
-                Arguments.of("testDayOfWeekAddSubtractLeapYear", 29, 1, 2024, 6, -6, DAY_OF_WEEK, 29, FEBRUARY, 2024)
+                Arguments.of("testMonthAddSubtractLeapYearReversed", 31, MARCH, 2024, -1, 1, MONTH, 29, MARCH, 2024),
+                Arguments.of("testMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 1, -1, MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testYearAddSubtractLeapYear", 29, FEBRUARY, 2024, 1, -1, YEAR, 28, FEBRUARY, 2024),
+                Arguments.of("testDayOfYearAddSubtractLeapYear", 29, FEBRUARY, 2024, 365, -365, DAY_OF_YEAR, 29, FEBRUARY, 2024),
+                Arguments.of("testDateAddSubtractLeapYear", 29, FEBRUARY, 2024, 365, -365, DATE, 29, FEBRUARY, 2024),
+                Arguments.of("testWeekOfYearAddSubtractLeapYear", 29, FEBRUARY, 2024, 52, -52, WEEK_OF_YEAR, 29, FEBRUARY, 2024),
+                Arguments.of("testDateOfMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 31, -31, DAY_OF_MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testDayOfWeekInMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 6, -6, DAY_OF_WEEK_IN_MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testDayOfWeekAddSubtractLeapYear", 29, FEBRUARY, 2024, 6, -6, DAY_OF_WEEK, 29, FEBRUARY, 2024)
         );
     }
 
     private static Stream<Arguments> calendarAddSource() {
         return Stream.of(
-                Arguments.of("testMonthAddLeapYear", 29, 1, 2024, 1, MONTH, 29, MARCH, 2024),
-                Arguments.of("testOneMonthSubtractLeapYear", 31, 2, 2024, -1, MONTH, 29, FEBRUARY, 2024),
-                Arguments.of("testTwoMonthSubtractLeapYear", 30, 3, 2024, -2, MONTH, 29, FEBRUARY, 2024)
+                Arguments.of("testMonthAddLeapYear", 29, FEBRUARY, 2024, 1, MONTH, 29, MARCH, 2024),
+                Arguments.of("testOneMonthSubtractLeapYear", 31, MARCH, 2024, -1, MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testTwoMonthSubtractLeapYear", 30, APRIL, 2024, -2, MONTH, 29, FEBRUARY, 2024)
         );
     }
 }

--- a/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
+++ b/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331646
+ * @summary confirm that Calendar.add() works correctly with leap year calculations
+ * @run junit CalendarLeapYearAddTest
+ */
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+import static java.util.Calendar.*;
+import static java.util.Calendar.MONTH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CalendarLeapYearAddTest {
+
+    /**
+     * 8331646 Calendar month add for leap year
+     */
+    @Test
+    public void testMonthAddLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(Calendar.MONTH, 1);
+        /* when added a month date jumps to 29th of March 2024 */
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of March 2024 but got " + calendar.getTime());
+        assertEquals(MARCH, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected March but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar 1 month subtract for leap year
+     */
+    @Test
+    public void testOneMonthSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 2, 31, 15, 0, 0);
+        calendar.add(Calendar.MONTH, -1);
+        /* when added a month date jumps to 29th of March 2024 */
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar 2 month subtract for leap year
+     */
+    @Test
+    public void testTwoMonthSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 3, 30, 15, 0, 0);
+        calendar.add(Calendar.MONTH, -2);
+        /* when added a month date jumps to 29th of March 2024 */
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar month add/subtract for leap year
+     */
+    @Test
+    public void testMonthAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(Calendar.MONTH, 1);
+        /* when added a month date jumps to 29th of March 2024,
+           subtracting month in a leap year returns 29th of February 2024  */
+        calendar.add(Calendar.MONTH, -1);
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar month and year add/subtract for leap/non-leap year
+     */
+    @Test
+    public void testMonthYearAddSubtractNonLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(Calendar.MONTH, 1);
+        calendar.add(YEAR, -1);
+        calendar.add(Calendar.MONTH, -1);
+        /* When month added date jumps to 29th of March 2024, after year subtracted date jumps to 29th of March 2023
+           after month subtracted date jumps to 28th of Feb 2023 as non leap year
+         */
+        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 28th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar month add/subtract for leap year jumping from March 31st to February 29th and back to March 29th
+     */
+    @Test
+    public void testMonthAddSubtractLeapYearReversed(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 2, 31, 15, 0, 0);
+        calendar.add(MONTH, -1);
+        calendar.add(MONTH, 1);
+        /* when month removed date jumps to 29th of February,
+           adding a month results in 29th of March 2024 as it's leap year
+        */
+        assertEquals(29,calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of March 2024 but got " + calendar.getTime());
+        assertEquals(MARCH, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected March but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar year add/subtract for leap year
+     */
+    @Test
+    public void testYearAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(YEAR, 1);
+        calendar.add(YEAR, -1);
+        /* when evaluated to no leap year date jumps to 28 of Feb 2023, removing year results in 28th of Feb 2024 */
+        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 28th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar year add/subtract for leap year
+     */
+    @Test
+    public void testYearDayAddSubtractLeapYearReversed(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2023, 1, 28, 15, 0, 0);
+        calendar.add(YEAR, 1);
+        calendar.add(DATE, 1);
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        calendar.add(YEAR, -1);
+        /* when evaluated to leap year + 1 day the date jumps to 29th of Feb 2024,
+         removing year results in 28th of Feb 2023 */
+        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 28th of February 2023 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar day of year add/subtract for leap year
+     */
+    @Test
+    public void testDayOfYearAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(DAY_OF_YEAR, 365);
+        calendar.add(DAY_OF_YEAR, -365);
+        /* adding/subtracting same amount of days should land on the same day in leap year*/
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar date add/subtract for leap year
+     */
+    @Test
+    public void testDateAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(DATE, 365);
+        calendar.add(DATE, -365);
+        /* DATE behaves as date DAY_OF_YEAR */
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar week of the year add/subtract for leap year
+     */
+    @Test
+    public void testWeekOfYearAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(WEEK_OF_YEAR, 52);
+        calendar.add(WEEK_OF_YEAR, -52);
+        /* adding year in weeks should not mess the date*/
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar day of month add/subtract for leap year
+     */
+    @Test
+    public void testDateOfMonthAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(DAY_OF_MONTH, 31);
+        calendar.add(DAY_OF_MONTH, -31);
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar day of week add/subtract for leap year
+     */
+    @Test
+    public void testDayOfWeekAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(DAY_OF_WEEK, 6);
+        calendar.add(DAY_OF_WEEK, -6);
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+
+    /**
+     * 8331646 Calendar day of week in month add/subtract for leap year
+     */
+    @Test
+    public void testDayOfWeekInMonthAddSubtractLeapYear(TestInfo testInfo) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, 1, 29, 15, 0, 0);
+        calendar.add(DAY_OF_WEEK_IN_MONTH, 6);
+        calendar.add(DAY_OF_WEEK_IN_MONTH, -6);
+        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
+                + " Expected 29th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
+                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    }
+}

--- a/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
+++ b/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
@@ -113,7 +113,7 @@ public class CalendarLeapYearAddTest {
                 Arguments.of("testDayOfYearAddSubtractLeapYear", 29, FEBRUARY, 2024, 365, -365, DAY_OF_YEAR, 29, FEBRUARY, 2024),
                 Arguments.of("testDateAddSubtractLeapYear", 29, FEBRUARY, 2024, 365, -365, DATE, 29, FEBRUARY, 2024),
                 Arguments.of("testWeekOfYearAddSubtractLeapYear", 29, FEBRUARY, 2024, 52, -52, WEEK_OF_YEAR, 29, FEBRUARY, 2024),
-                Arguments.of("testDateOfMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 31, -31, DAY_OF_MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testDayOfMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 31, -31, DAY_OF_MONTH, 29, FEBRUARY, 2024),
                 Arguments.of("testDayOfWeekInMonthAddSubtractLeapYear", 29, FEBRUARY, 2024, 6, -6, DAY_OF_WEEK_IN_MONTH, 29, FEBRUARY, 2024),
                 Arguments.of("testDayOfWeekAddSubtractLeapYear", 29, FEBRUARY, 2024, 6, -6, DAY_OF_WEEK, 29, FEBRUARY, 2024)
         );

--- a/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
+++ b/test/jdk/java/util/Calendar/CalendarLeapYearAddTest.java
@@ -28,13 +28,14 @@
  * @run junit CalendarLeapYearAddTest
  */
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Calendar;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import static java.util.Calendar.*;
 import static java.util.Calendar.MONTH;
@@ -42,252 +43,79 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CalendarLeapYearAddTest {
 
-    private TestInfo testInfo;
-
-    @BeforeEach
-    void init(TestInfo testInfo) {
-        this.testInfo = testInfo;
-    }
-
     /**
-     * 8331646 Calendar month add for leap year
+     * 8331646 Calendar add for leap year
      */
-    @ParameterizedTest(name = "testMonthAddLeapYear")
-    @ValueSource(ints = {1})
-    public void testMonthAddLeapYear(int value) {
+    @ParameterizedTest
+    @MethodSource("calendarAddSource")
+    public void testAddLeapYear(String testName, int calendarDate, int calendarMonth, int calendarYear,
+                                int value, int calendarField, int expectedDate, int expectedMonth,
+                                int expectedYear) {
         Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, value);
-        /* when added a month date jumps to 29th of March 2024 */
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of March 2024 but got " + calendar.getTime());
-        assertEquals(MARCH, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected March but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar 1 month subtract for leap year
-     */
-    @ParameterizedTest(name = "testOneMonthSubtractLeapYear")
-    @ValueSource(ints = {-1})
-    public void testOneMonthSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 2, 31, 15, 0, 0);
-        calendar.add(Calendar.MONTH, value);
-        /* when added a month date jumps to 29th of March 2024 */
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar 2 month subtract for leap year
-     */
-    @ParameterizedTest(name = "testTwoMonthSubtractLeapYear")
-    @ValueSource(ints = {-2})
-    public void testTwoMonthSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 3, 30, 15, 0, 0);
-        calendar.add(Calendar.MONTH, value);
-        /* when added a month date jumps to 29th of March 2024 */
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar month add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testMonthAddSubtractLeapYear")
-    @ValueSource(ints = {1})
-    public void testMonthAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, value);
-        /* when added a month date jumps to 29th of March 2024,
-           subtracting month in a leap year returns 29th of February 2024  */
-        calendar.add(Calendar.MONTH, -value);
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+        calendar.set(calendarYear, calendarMonth, calendarDate);
+        calendar.add(calendarField, value);
+        assertEquals(expectedDate, calendar.get(DATE), testName
+                + " Expected " + expectedDate + " of " + expectedMonth + expectedYear + " but got " + calendar.getTime());
+        assertEquals(expectedMonth, calendar.get(MONTH), testName
+                + " Expected " + expectedMonth + " but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
     }
 
     /**
      * 8331646 Calendar month and year add/subtract for leap/non-leap year
      */
-    @ParameterizedTest(name = "testMonthYearAddSubtractNonLeapYear")
-    @ValueSource(ints = {1})
-    public void testMonthYearAddSubtractNonLeapYear(int value) {
+    @Test
+    public void testMonthYearAddSubtractNonLeapYear() {
         Calendar calendar = Calendar.getInstance();
         calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(Calendar.MONTH, value);
-        calendar.add(YEAR, -value);
-        calendar.add(Calendar.MONTH, -value);
+        calendar.add(Calendar.MONTH, 1);
+        calendar.add(YEAR, -1);
+        calendar.add(Calendar.MONTH, -1);
         /* When month added date jumps to 29th of March 2024, after year subtracted date jumps to 29th of March 2023
            after month subtracted date jumps to 28th of Feb 2023 as non leap year
          */
-        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 28th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+        assertEquals(28, calendar.get(DATE),
+                "testMonthYearAddSubtractNonLeapYear Expected 28th of February 2024 but got " + calendar.getTime());
+        assertEquals(FEBRUARY, calendar.get(MONTH),
+                " testMonthYearAddSubtractNonLeapYear Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
     }
 
     /**
-     * 8331646 Calendar month add/subtract for leap year jumping from March 31st to February 29th and back to March 29th
+     * 8331646 Calendar add/subtract for leap year
      */
-    @ParameterizedTest(name = "testMonthAddSubtractLeapYearReversed")
-    @ValueSource(ints = {1})
-    public void testMonthAddSubtractLeapYearReversed(int value) {
+    @ParameterizedTest
+    @MethodSource("calendarAddSubtractSource")
+    public void testAddSubtractLeapYear(String testName, int calendarDate, int calendarMonth, int calendarYear,
+                                        int firstValue, int secondValue, int calendarField, int expectedDate,
+                                        int expectedMonth, int expectedYear) {
         Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 2, 31, 15, 0, 0);
-        calendar.add(MONTH, -value);
-        calendar.add(MONTH, value);
-        /* when month removed date jumps to 29th of February,
-           adding a month results in 29th of March 2024 as it's leap year
-        */
-        assertEquals(29,calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of March 2024 but got " + calendar.getTime());
-        assertEquals(MARCH, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected March but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+        calendar.set(calendarYear, calendarMonth, calendarDate);
+        calendar.add(calendarField, firstValue);
+        calendar.add(calendarField, secondValue);
+        assertEquals(expectedDate, calendar.get(DATE), testName
+                + " Expected " + expectedDate + " of " + expectedMonth + expectedYear + " but got " + calendar.getTime());
+        assertEquals(expectedMonth, calendar.get(MONTH), testName
+                + " Expected " + expectedMonth + " but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
     }
 
-    /**
-     * 8331646 Calendar year add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testYearAddSubtractLeapYear")
-    @ValueSource(ints = {1})
-    public void testYearAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(YEAR, value);
-        calendar.add(YEAR, -value);
-        /* when evaluated to no leap year date jumps to 28 of Feb 2023, removing year results in 28th of Feb 2024 */
-        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 28th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    private static Stream<Arguments> calendarAddSubtractSource() {
+        return Stream.of(
+                Arguments.of("testMonthAddSubtractLeapYearReversed", 31, 2, 2024, -1, 1, MONTH, 29, MARCH, 2024),
+                Arguments.of("testMonthAddSubtractLeapYear", 29, 1, 2024, 1, -1, MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testYearAddSubtractLeapYear", 29, 1, 2024, 1, -1, YEAR, 28, FEBRUARY, 2024),
+                Arguments.of("testDayOfYearAddSubtractLeapYear", 29, 1, 2024, 365, -365, DAY_OF_YEAR, 29, FEBRUARY, 2024),
+                Arguments.of("testDateAddSubtractLeapYear", 29, 1, 2024, 365, -365, DATE, 29, FEBRUARY, 2024),
+                Arguments.of("testWeekOfYearAddSubtractLeapYear", 29, 1, 2024, 52, -52, WEEK_OF_YEAR, 29, FEBRUARY, 2024),
+                Arguments.of("testDateOfMonthAddSubtractLeapYear", 29, 1, 2024, 31, -31, DAY_OF_MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testDayOfWeekInMonthAddSubtractLeapYear", 29, 1, 2024, 6, -6, DAY_OF_WEEK_IN_MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testDayOfWeekAddSubtractLeapYear", 29, 1, 2024, 6, -6, DAY_OF_WEEK, 29, FEBRUARY, 2024)
+        );
     }
 
-    /**
-     * 8331646 Calendar year add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testYearDayAddSubtractLeapYearReversed")
-    @ValueSource(ints = {1})
-    public void testYearDayAddSubtractLeapYearReversed(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2023, 1, 28, 15, 0, 0);
-        calendar.add(YEAR, value);
-        calendar.add(DATE, value);
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        calendar.add(YEAR, -value);
-        /* when evaluated to leap year + 1 day the date jumps to 29th of Feb 2024,
-         removing year results in 28th of Feb 2023 */
-        assertEquals(28, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 28th of February 2023 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar day of year add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testDayOfYearAddSubtractLeapYear")
-    @ValueSource(ints = {365})
-    public void testDayOfYearAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_YEAR, value);
-        calendar.add(DAY_OF_YEAR, -value);
-        /* adding/subtracting same amount of days should land on the same day in leap year*/
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar date add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testDateAddSubtractLeapYear")
-    @ValueSource(ints = {365})
-    public void testDateAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DATE, value);
-        calendar.add(DATE, -value);
-        /* DATE behaves as date DAY_OF_YEAR */
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar week of the year add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testWeekOfYearAddSubtractLeapYear")
-    @ValueSource(ints = {52})
-    public void testWeekOfYearAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(WEEK_OF_YEAR, value);
-        calendar.add(WEEK_OF_YEAR, -value);
-        /* adding year in weeks should not mess the date*/
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar day of month add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testDateOfMonthAddSubtractLeapYear")
-    @ValueSource(ints = {31})
-    public void testDateOfMonthAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_MONTH, value);
-        calendar.add(DAY_OF_MONTH, -value);
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar day of week add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testDayOfWeekAddSubtractLeapYear")
-    @ValueSource(ints = {6})
-    public void testDayOfWeekAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_WEEK, value);
-        calendar.add(DAY_OF_WEEK, -value);
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
-    }
-
-    /**
-     * 8331646 Calendar day of week in month add/subtract for leap year
-     */
-    @ParameterizedTest(name = "testDayOfWeekInMonthAddSubtractLeapYear")
-    @ValueSource(ints = {6})
-    public void testDayOfWeekInMonthAddSubtractLeapYear(int value) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.set(2024, 1, 29, 15, 0, 0);
-        calendar.add(DAY_OF_WEEK_IN_MONTH, value);
-        calendar.add(DAY_OF_WEEK_IN_MONTH, -value);
-        assertEquals(29, calendar.get(DATE), testInfo.getDisplayName()
-                + " Expected 29th of February 2024 but got " + calendar.getTime());
-        assertEquals(FEBRUARY, calendar.get(MONTH), testInfo.getDisplayName()
-                + " Expected February but got " + calendar.getDisplayName(MONTH, LONG, Locale.getDefault()));
+    private static Stream<Arguments> calendarAddSource() {
+        return Stream.of(
+                Arguments.of("testMonthAddLeapYear", 29, 1, 2024, 1, MONTH, 29, MARCH, 2024),
+                Arguments.of("testOneMonthSubtractLeapYear", 31, 2, 2024, -1, MONTH, 29, FEBRUARY, 2024),
+                Arguments.of("testTwoMonthSubtractLeapYear", 30, 3, 2024, -2, MONTH, 29, FEBRUARY, 2024)
+        );
     }
 }


### PR DESCRIPTION
Calendar.add() tests that describe its behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331646](https://bugs.openjdk.org/browse/JDK-8331646): Add specific regression leap year tests (**Task** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [f6ba2e31](https://git.openjdk.org/jdk/pull/19082/files/f6ba2e31fbf64da00ad96c82f92a6600d572b9b6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19082/head:pull/19082` \
`$ git checkout pull/19082`

Update a local copy of the PR: \
`$ git checkout pull/19082` \
`$ git pull https://git.openjdk.org/jdk.git pull/19082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19082`

View PR using the GUI difftool: \
`$ git pr show -t 19082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19082.diff">https://git.openjdk.org/jdk/pull/19082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19082#issuecomment-2096332718)