### PR TITLE
8330278: Have SSLSocketTemplate.doClientSide use loopback address

### DIFF
--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -273,7 +273,7 @@ public class SSLSocketTemplate extends SSLContextTemplate {
                 configureClientSocket(sslSocket);
                 InetAddress serverAddress = this.serverAddress;
                 InetSocketAddress connectAddress = serverAddress == null
-                        ? new InetSocketAddress("localhost", serverPort)
+                        ? new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort)
                         : new InetSocketAddress(serverAddress, serverPort);
                 sslSocket.connect(connectAddress, 15000);
             } catch (IOException ioe) {

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -23,6 +23,7 @@
 
 import javax.net.ssl.*;
 import java.io.*;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.cert.PKIXBuilderParameters;
@@ -334,7 +335,7 @@ abstract public class TLSBase {
                 sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(TLSBase.getKeyManager(km), TLSBase.getTrustManager(tm), null);
                 sock = (SSLSocket)sslContext.getSocketFactory().createSocket();
-                sock.connect(new InetSocketAddress("localhost", serverPort));
+                sock.connect(new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort));
                 System.err.println("Client connected using port " +
                         sock.getLocalPort());
                 name = "client(" + sock.toString() + ")";


### PR DESCRIPTION
Using the loopback address by default may prove more reliable for some test configurations

ran all jdk_security tests. no issues seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330278](https://bugs.openjdk.org/browse/JDK-8330278): Have SSLSocketTemplate.doClientSide use loopback address (**Bug** - P4)


### Reviewers
 * [Sibabrata Sahoo](https://openjdk.org/census#ssahoo) (@sisahoo - Committer)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19083/head:pull/19083` \
`$ git checkout pull/19083`

Update a local copy of the PR: \
`$ git checkout pull/19083` \
`$ git pull https://git.openjdk.org/jdk.git pull/19083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19083`

View PR using the GUI difftool: \
`$ git pr show -t 19083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19083.diff">https://git.openjdk.org/jdk/pull/19083.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19083#issuecomment-2092814550)