### PR TITLE
8331608: Consolidate EncodeGCModeConcurrentFrameClosure and TransformStackChunkClosure

### DIFF
--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -204,17 +204,16 @@ public:
 
 class TransformStackChunkClosure {
   stackChunkOop _chunk;
-  DerivedPointersSupport::RelativizeClosure* _cl;
 
 public:
   TransformStackChunkClosure(stackChunkOop chunk, DerivedPointersSupport::RelativizeClosure* cl)
-    : _chunk(chunk),
-      _cl(cl) {
+    : _chunk(chunk) {
   }
 
   template <ChunkFrames frame_kind, typename RegisterMapT>
   bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
-    f.iterate_derived_pointers(_cl, map);
+    DerivedPointersSupport::RelativizeClosure derived_cl;
+    f.iterate_derived_pointers(&derived_cl, map);
 
     BarrierSetStackChunk* bs_chunk = BarrierSet::barrier_set()->barrier_set_stack_chunk();
     frame fr = f.to_frame();

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -202,13 +202,12 @@ public:
   };
 };
 
-template <typename DerivedPointerClosureType>
-class EncodeGCModeConcurrentFrameClosure {
+class TransformStackChunkClosure {
   stackChunkOop _chunk;
-  DerivedPointerClosureType* _cl;
+  DerivedPointersSupport::RelativizeClosure* _cl;
 
 public:
-  EncodeGCModeConcurrentFrameClosure(stackChunkOop chunk, DerivedPointerClosureType* cl)
+  TransformStackChunkClosure(stackChunkOop chunk, DerivedPointersSupport::RelativizeClosure* cl)
     : _chunk(chunk),
       _cl(cl) {
   }
@@ -296,31 +295,11 @@ void stackChunkOopDesc::relativize_derived_pointers_concurrently() {
   }
 
   DerivedPointersSupport::RelativizeClosure derived_cl;
-  EncodeGCModeConcurrentFrameClosure<decltype(derived_cl)> frame_cl(this, &derived_cl);
+  TransformStackChunkClosure frame_cl(this, &derived_cl);
   iterate_stack(&frame_cl);
 
   release_relativization();
 }
-
-class TransformStackChunkClosure {
-  stackChunkOop _chunk;
-
-public:
-  TransformStackChunkClosure(stackChunkOop chunk) : _chunk(chunk) { }
-
-  template <ChunkFrames frame_kind, typename RegisterMapT>
-  bool do_frame(const StackChunkFrameStream<frame_kind>& f, const RegisterMapT* map) {
-    DerivedPointersSupport::RelativizeClosure derived_cl;
-    f.iterate_derived_pointers(&derived_cl, map);
-
-    BarrierSetStackChunk* bs_chunk = BarrierSet::barrier_set()->barrier_set_stack_chunk();
-    frame fr = f.to_frame();
-    FrameOopIterator<RegisterMapT> iterator(fr, map);
-    bs_chunk->encode_gc_mode(_chunk, &iterator);
-
-    return true;
-  }
-};
 
 void stackChunkOopDesc::transform() {
   assert(!is_gc_mode(), "Should only be called once per chunk");
@@ -330,7 +309,8 @@ void stackChunkOopDesc::transform() {
   set_has_bitmap(true);
   bitmap().clear();
 
-  TransformStackChunkClosure closure(this);
+  DerivedPointersSupport::RelativizeClosure derived_cl;
+  TransformStackChunkClosure closure(this, &derived_cl);
   iterate_stack(&closure);
 }
 

--- a/src/hotspot/share/oops/stackChunkOop.cpp
+++ b/src/hotspot/share/oops/stackChunkOop.cpp
@@ -206,7 +206,7 @@ class TransformStackChunkClosure {
   stackChunkOop _chunk;
 
 public:
-  TransformStackChunkClosure(stackChunkOop chunk, DerivedPointersSupport::RelativizeClosure* cl)
+  TransformStackChunkClosure(stackChunkOop chunk)
     : _chunk(chunk) {
   }
 
@@ -293,8 +293,7 @@ void stackChunkOopDesc::relativize_derived_pointers_concurrently() {
     return;
   }
 
-  DerivedPointersSupport::RelativizeClosure derived_cl;
-  TransformStackChunkClosure frame_cl(this, &derived_cl);
+  TransformStackChunkClosure frame_cl(this);
   iterate_stack(&frame_cl);
 
   release_relativization();
@@ -308,8 +307,7 @@ void stackChunkOopDesc::transform() {
   set_has_bitmap(true);
   bitmap().clear();
 
-  DerivedPointersSupport::RelativizeClosure derived_cl;
-  TransformStackChunkClosure closure(this, &derived_cl);
+  TransformStackChunkClosure closure(this);
   iterate_stack(&closure);
 }
 


### PR DESCRIPTION
Hi all,

After [JDK-8296875](https://bugs.openjdk.org/browse/JDK-8296875), the classes `EncodeGCModeConcurrentFrameClosure` and `TransformStackChunkClosure` almost have the same code. This patch consolidates them into one.

The tests `make test-hotspot_loom` and `make test-hotspot_gc` passed locally (linux & x64). Thanks for taking the time to review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331608](https://bugs.openjdk.org/browse/JDK-8331608): Consolidate EncodeGCModeConcurrentFrameClosure and TransformStackChunkClosure (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19084/head:pull/19084` \
`$ git checkout pull/19084`

Update a local copy of the PR: \
`$ git checkout pull/19084` \
`$ git pull https://git.openjdk.org/jdk.git pull/19084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19084`

View PR using the GUI difftool: \
`$ git pr show -t 19084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19084.diff">https://git.openjdk.org/jdk/pull/19084.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19084#issuecomment-2092878720)