### PR TITLE
8331575: C2: crash when ConvL2I is split thru phi at LongCountedLoop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -49,8 +49,9 @@
 //------------------------------split_thru_phi---------------------------------
 // Split Node 'n' through merge point if there is enough win.
 Node* PhaseIdealLoop::split_thru_phi(Node* n, Node* region, int policy) {
-  if (n->Opcode() == Op_ConvI2L && n->bottom_type() != TypeLong::LONG) {
-    // ConvI2L may have type information on it which is unsafe to push up
+  if ((n->Opcode() == Op_ConvI2L && n->bottom_type() != TypeLong::LONG) ||
+      (n->Opcode() == Op_ConvL2I && n->bottom_type() != TypeInt::INT)) {
+    // ConvI2L/ConvL2I may have type information on it which is unsafe to push up
     // so disable this for now
     return nullptr;
   }

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
@@ -26,9 +26,11 @@
  * @bug 8331575
  * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
  * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
- *                   -XX:+StressGCM -XX:StressSeed=92643864 TestLongCountedLoopConvL2I
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:StressSeed=92643864 TestLongCountedLoopConvL2I
  * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
- *                   -XX:+StressGCM TestLongCountedLoopConvL2I
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM TestLongCountedLoopConvL2I
  */
 
 public class TestLongCountedLoopConvL2I {

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331575
+ * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+StressGCM -XX:StressSeed=92643864 TestLongCountedLoopConvL2I
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-TieredCompilation -XX:-UseOnStackReplacement
+ *                   -XX:+StressGCM TestLongCountedLoopConvL2I
+ */
+
+public class TestLongCountedLoopConvL2I {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            testHelper1(42);
+            test1(0);
+        }
+    }
+
+    private static int test1(int res) {
+        int k = 1;
+        for (; k < 2; k *= 2) {
+        }
+        long i = testHelper1(k);
+        for (; i > 0; i--) {
+            res += 42 / ((int) i);
+            for (int j = 1; j < 10; j *= 2) {
+
+            }
+        }
+        return res;
+    }
+
+    private static long testHelper1(int k) {
+        if (k == 2) {
+            return 100;
+        } else {
+            return 99;
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I2.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestLongCountedLoopConvL2I2.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331575
+ * @summary C2: crash when ConvL2I is split thru phi at LongCountedLoop
+ * @run main/othervm -Xcomp -XX:CompileOnly=TestLongCountedLoopConvL2I2.* TestLongCountedLoopConvL2I2
+ */
+
+public class TestLongCountedLoopConvL2I2 {
+    static int x = 34;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 2; i++) {
+            test();
+        }
+    }
+
+    static int test() {
+        int a = 5, b = 6;
+        long lArr[] = new long[2];
+
+        for (long i = 159; i > 1; i -= 3) {
+            a += 3;
+            for (int j = 1; j < 4; j++) {
+                if (a == 9) {
+                    if (x == 73) {
+                        try {
+                            b = 10 / (int) i;
+                        } catch (ArithmeticException a_e) {
+                        }
+                    }
+                }
+            }
+        }
+        return b;
+    }
+}


### PR DESCRIPTION
In the test case:

```
long i;
for (; i > 0; i--) {
    res += 42 / ((int) i);
```

The long counted loop phi has type `[1..100]`. As a consequence, the
`ConvL2I` also has type `[1..100]`. The `DivI` node that follows can't
fault: it is not guarded by a zero check and has no control set.

The `ConvL2I` is split through phi and so is the `DiVI` node:
`PhaseIdealLoop::cannot_split_division()` returns true because the
value coming from the backedge into the `DivI` (when it is about to be
split thru phi) is the result of the `ConvL2I` which has type
`[1..100`] so is not zero as far as the compiler can tell.

On the last iteration of the loop, i is 1. Because the DivI was split
thru Phi, it computes the value for the following iteration, so for i
= 0. This causes a crash when the compiled code runs.

The same problem can't happen with an int counted loop because logic
in `PhaseIdealLoop::split_thru_phi()` prevents a `ConvI2L` from being
split thru phi. I propose to fix this the same way: in the test case,
it's not true that once the `ConvL2I` is split thru phi it keeps type
`[1..100]`. The fix is fairly conservative because it's base on the
existing logic for `ConvI2L`: we would want to not split a `ConvL2I`
only a counted loopd but. I suppose the same is true for the `ConvI2L`
and I thought it would be best to revisit both together.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331575](https://bugs.openjdk.org/browse/JDK-8331575): C2: crash when ConvL2I is split thru phi at LongCountedLoop (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) ⚠️ Review applies to [d48443c3](https://git.openjdk.org/jdk/pull/19086/files/d48443c337f2726d4c2a6d53accf249a709e5379)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19086/head:pull/19086` \
`$ git checkout pull/19086`

Update a local copy of the PR: \
`$ git checkout pull/19086` \
`$ git pull https://git.openjdk.org/jdk.git pull/19086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19086`

View PR using the GUI difftool: \
`$ git pr show -t 19086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19086.diff">https://git.openjdk.org/jdk/pull/19086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19086#issuecomment-2092955349)