### PR TITLE
8331626: unsafe.cpp:162:38: runtime error in index_oop_from_field_offset_long - applying non-zero offset 4563897424 to null pointer

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -154,13 +154,9 @@ static inline void assert_field_offset_sane(oop p, jlong field_offset) {
 
 static inline void* index_oop_from_field_offset_long(oop p, jlong field_offset) {
   assert_field_offset_sane(p, field_offset);
-  jlong byte_offset = field_offset_to_byte_offset(field_offset);
-
-  if (sizeof(char*) == sizeof(jint)) {   // (this constant folds!)
-    return cast_from_oop<address>(p) + (jint) byte_offset;
-  } else {
-    return cast_from_oop<address>(p) +        byte_offset;
-  }
+  uintptr_t base_address = cast_from_oop<uintptr_t>(p),
+            byte_offset  = (uintptr_t)field_offset_to_byte_offset(field_offset);
+  return (void*)(base_address + byte_offset);
 }
 
 // Externally callable versions:

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -154,8 +154,8 @@ static inline void assert_field_offset_sane(oop p, jlong field_offset) {
 
 static inline void* index_oop_from_field_offset_long(oop p, jlong field_offset) {
   assert_field_offset_sane(p, field_offset);
-  uintptr_t base_address = cast_from_oop<uintptr_t>(p),
-            byte_offset  = (uintptr_t)field_offset_to_byte_offset(field_offset);
+  uintptr_t base_address = cast_from_oop<uintptr_t>(p);
+  uintptr_t byte_offset  = (uintptr_t)field_offset_to_byte_offset(field_offset);
   return (void*)(base_address + byte_offset);
 }
 


### PR DESCRIPTION
`index_oop_from_field_offset_long` is sometimes used to access an absolute address by using `p == nullptr`. Unfortunately, `nullptr + byte_offset` implies undefined behavior and should better get fixed. UBSan complains about it (see JBS issue).
A possible solution is to replace pointer arithmetic by integer arithmetic. We can use unsigned because `assert_field_offset_sane` checks that `byte_offset >= 0`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331626](https://bugs.openjdk.org/browse/JDK-8331626): unsafe.cpp:162:38: runtime error in index_oop_from_field_offset_long - applying non-zero offset 4563897424 to null pointer (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) ⚠️ Review applies to [24ca3361](https://git.openjdk.org/jdk/pull/19087/files/24ca3361c2b7d3c0916fdff066ca49e7b3c350bf)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19087/head:pull/19087` \
`$ git checkout pull/19087`

Update a local copy of the PR: \
`$ git checkout pull/19087` \
`$ git pull https://git.openjdk.org/jdk.git pull/19087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19087`

View PR using the GUI difftool: \
`$ git pr show -t 19087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19087.diff">https://git.openjdk.org/jdk/pull/19087.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19087#issuecomment-2093094417)