### PR TITLE
8331655: ClassFile API ClassCastException with verbose output of certain class files

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -391,21 +391,7 @@ public final class ClassReaderImpl
 
     @Override
     public AbstractPoolEntry.Utf8EntryImpl utf8EntryByIndex(int index) {
-        if (index <= 0 || index >= constantPoolCount) {
-            throw new ConstantPoolException("Bad CP UTF8 index: " + index);
-        }
-        PoolEntry info = cp[index];
-        if (info == null) {
-            int offset = cpOffset[index];
-            int tag = readU1(offset);
-            final int q = offset + 1;
-            if (tag == TAG_UTF8) {
-                AbstractPoolEntry.Utf8EntryImpl uinfo
-                        = new AbstractPoolEntry.Utf8EntryImpl(this, index, buffer, q + 2, readU2(q));
-                cp[index] = uinfo;
-                return uinfo;
-            }
-        } else if (info instanceof AbstractPoolEntry.Utf8EntryImpl utf8) {
+        if (entryByIndex(index, TAG_UTF8, TAG_UTF8) instanceof AbstractPoolEntry.Utf8EntryImpl utf8) {
             return utf8;
         }
         throw new ConstantPoolException("Not a UTF8 - index: " + index);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -399,13 +399,16 @@ public final class ClassReaderImpl
             int offset = cpOffset[index];
             int tag = readU1(offset);
             final int q = offset + 1;
-            if (tag != TAG_UTF8) throw new ConstantPoolException("Not a UTF8 - index: " + index);
-            AbstractPoolEntry.Utf8EntryImpl uinfo
-                    = new AbstractPoolEntry.Utf8EntryImpl(this, index, buffer, q + 2, readU2(q));
-            cp[index] = uinfo;
-            return uinfo;
+            if (tag == TAG_UTF8) {
+                AbstractPoolEntry.Utf8EntryImpl uinfo
+                        = new AbstractPoolEntry.Utf8EntryImpl(this, index, buffer, q + 2, readU2(q));
+                cp[index] = uinfo;
+                return uinfo;
+            }
+        } else if (info instanceof AbstractPoolEntry.Utf8EntryImpl utf8) {
+            return utf8;
         }
-        return (AbstractPoolEntry.Utf8EntryImpl) info;
+        throw new ConstantPoolException("Not a UTF8 - index: " + index);
     }
 
     @Override

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360 8330684 8331320
+ * @bug 8320360 8330684 8331320 8331655
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */
@@ -36,6 +36,7 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.attribute.CodeAttribute;
 import java.lang.classfile.constantpool.ConstantPoolException;
+import java.lang.classfile.constantpool.IntegerEntry;
 import jdk.internal.classfile.impl.DirectMethodBuilder;
 import jdk.internal.classfile.impl.LabelContext;
 import jdk.internal.classfile.impl.UnboundAttribute;
@@ -104,6 +105,14 @@ class LimitsTest {
     void testInvalidClassEntry() {
         assertThrows(ConstantPoolException.class, () -> ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
             0, 0, 0, 0, 0, 2, ClassFile.TAG_METHODREF, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}).thisClass());
+    }
+
+    @Test
+    void testInvalidUtf8Entry() {
+        var cp = ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
+            0, 0, 0, 0, 0, 3, ClassFile.TAG_INTEGER, 0, 0, 0, 0, ClassFile.TAG_NAMEANDTYPE, 0, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}).constantPool();
+        assertTrue(cp.entryByIndex(1) instanceof IntegerEntry); //parse valid int entry first
+        assertThrows(ConstantPoolException.class, () -> cp.entryByIndex(2));
     }
 
     @Test


### PR DESCRIPTION
Specifically corrupted constant pool of a class file can cause ClassCastException, when the entries are accessed by Class-File API in exact order.

This fix avoids the ClassCastException and throws ConstantPoolException instead.
Test is attached.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331655](https://bugs.openjdk.org/browse/JDK-8331655): ClassFile API ClassCastException with verbose output of certain class files (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19088/head:pull/19088` \
`$ git checkout pull/19088`

Update a local copy of the PR: \
`$ git checkout pull/19088` \
`$ git pull https://git.openjdk.org/jdk.git pull/19088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19088`

View PR using the GUI difftool: \
`$ git pr show -t 19088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19088.diff">https://git.openjdk.org/jdk/pull/19088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19088#issuecomment-2093250515)