### PR TITLE
8331334: com/sun/net/httpserver/HttpsParametersClientAuthTest.java fails in testServerNeedClientAuth(false)

### DIFF
--- a/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
@@ -50,6 +50,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpsConfigurator;
 import com.sun.net.httpserver.HttpsParameters;
 import com.sun.net.httpserver.HttpsServer;
+import jdk.internal.util.OperatingSystem;
 import jdk.test.lib.net.SimpleSSLContext;
 import jdk.test.lib.net.URIBuilder;
 import org.junit.jupiter.api.Test;
@@ -68,12 +69,16 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @bug 8326381
  * @summary verifies that the setNeedClientAuth() and setWantClientAuth()
  *          methods on HttpsParameters class work as expected
+ * @modules java.base/jdk.internal.util
  * @library /test/lib
  * @build jdk.test.lib.net.SimpleSSLContext jdk.test.lib.net.URIBuilder
  * @run junit HttpsParametersClientAuthTest
  */
 public class HttpsParametersClientAuthTest {
 
+    private static final String WSAECONNABORTED_MSG =
+            "An established connection was aborted by the software in your host machine";
+    private static final boolean IS_WINDOWS = OperatingSystem.isWindows();
     private static final AtomicInteger TID = new AtomicInteger();
     private static final ThreadFactory SRV_THREAD_FACTORY = (r) -> {
         final Thread t = new Thread(r);
@@ -222,7 +227,9 @@ public class HttpsParametersClientAuthTest {
                         // verify it failed due to right reason
                         Throwable cause = ioe;
                         while (cause != null) {
-                            // either of SocketException or SSLHandshakeException are OK
+                            // either of SocketException or SSLHandshakeException are OK.
+                            // additionally on Windows we accept even IOException
+                            // caused by WSAECONNABORTED
                             if (cause instanceof SocketException se) {
                                 final String msg = se.getMessage();
                                 assertTrue(msg != null && msg.contains("Connection reset"),
@@ -235,6 +242,14 @@ public class HttpsParametersClientAuthTest {
                                         "unexpected message in SSLHandshakeException: " + msg);
                                 System.out.println("received the expected exception: " + she);
                                 break;
+                            } else if (IS_WINDOWS && cause instanceof IOException winIOE) {
+                                if (WSAECONNABORTED_MSG.equalsIgnoreCase(winIOE.getMessage())) {
+                                    // on Windows we sometimes receive this exception, which is
+                                    // acceptable
+                                    System.out.println("(windows) received the expected exception: "
+                                            + winIOE);
+                                    break;
+                                }
                             }
                             cause = cause.getCause();
                         }

--- a/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
+++ b/test/jdk/com/sun/net/httpserver/HttpsParametersClientAuthTest.java
@@ -76,8 +76,6 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class HttpsParametersClientAuthTest {
 
-    private static final String WSAECONNABORTED_MSG =
-            "An established connection was aborted by the software in your host machine";
     private static final boolean IS_WINDOWS = OperatingSystem.isWindows();
     private static final AtomicInteger TID = new AtomicInteger();
     private static final ThreadFactory SRV_THREAD_FACTORY = (r) -> {
@@ -225,11 +223,11 @@ public class HttpsParametersClientAuthTest {
                             throw ioe;
                         }
                         // verify it failed due to right reason
-                        Throwable cause = ioe;
+                        Throwable cause = ioe.getCause();
                         while (cause != null) {
                             // either of SocketException or SSLHandshakeException are OK.
                             // additionally on Windows we accept even IOException
-                            // caused by WSAECONNABORTED
+                            // (caused by WSAECONNABORTED)
                             if (cause instanceof SocketException se) {
                                 final String msg = se.getMessage();
                                 assertTrue(msg != null && msg.contains("Connection reset"),
@@ -243,13 +241,11 @@ public class HttpsParametersClientAuthTest {
                                 System.out.println("received the expected exception: " + she);
                                 break;
                             } else if (IS_WINDOWS && cause instanceof IOException winIOE) {
-                                if (WSAECONNABORTED_MSG.equalsIgnoreCase(winIOE.getMessage())) {
-                                    // on Windows we sometimes receive this exception, which is
-                                    // acceptable
-                                    System.out.println("(windows) received the expected exception: "
-                                            + winIOE);
-                                    break;
-                                }
+                                // on Windows we sometimes receive this exception, which is
+                                // acceptable
+                                System.out.println("(windows) received the expected exception: "
+                                        + winIOE);
+                                break;
                             }
                             cause = cause.getCause();
                         }


### PR DESCRIPTION
Can I get a review of this test-only fix which addresses the intermittent failrues in `com/sun/net/httpserver/HttpsParametersClientAuthTest.java` on Windows?

As noted in https://bugs.openjdk.org/browse/JDK-8331334, the test relies on the TLS communication (of a HTTP request) to fail and then asserts on the exception types. On Windows, sometimes the exception type differs, although the underlying failure is the expected failure.

The commit in this PR adds an additional condition to allow for `IOException` to be thrown when on Windows. The exception type and message check is additionally only added for Windows and the message check is very specific intentionally, to make sure we don't allow any `IOException` to result in the test passing. The usage of the `WSAECONNABORTED_MSG` has a precedent in `test/jdk/java/net/httpclient/HandshakeFailureTest.java`, so I think that should be OK in this test too.

With these changes the test hasn't failed in a test repeat of 100. Without the changes, the test fails around 15 times in a test repeat of 100. Additionally tier1, tier2 and tier3 tests have been run with this change and those tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331334](https://bugs.openjdk.org/browse/JDK-8331334): com/sun/net/httpserver/HttpsParametersClientAuthTest.java fails in testServerNeedClientAuth(false) (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19091/head:pull/19091` \
`$ git checkout pull/19091`

Update a local copy of the PR: \
`$ git checkout pull/19091` \
`$ git pull https://git.openjdk.org/jdk.git pull/19091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19091`

View PR using the GUI difftool: \
`$ git pr show -t 19091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19091.diff">https://git.openjdk.org/jdk/pull/19091.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19091#issuecomment-2094662639)