### PR TITLE
8331691: Generational ZGC: Use ZLocker uniformly

### DIFF
--- a/src/hotspot/share/gc/z/zDriver.cpp
+++ b/src/hotspot/share/gc/z/zDriver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,14 +65,6 @@ void ZDriver::initialize() {
   _lock = new ZLock();
 }
 
-void ZDriver::lock() {
-  _lock->lock();
-}
-
-void ZDriver::unlock() {
-  _lock->unlock();
-}
-
 void ZDriver::set_minor(ZDriverMinor* minor) {
   _minor = minor;
 }
@@ -87,22 +79,6 @@ ZDriverMinor* ZDriver::minor() {
 
 ZDriverMajor* ZDriver::major() {
   return _major;
-}
-
-ZDriverLocker::ZDriverLocker() {
-  ZDriver::lock();
-}
-
-ZDriverLocker::~ZDriverLocker() {
-  ZDriver::unlock();
-}
-
-ZDriverUnlocker::ZDriverUnlocker() {
-  ZDriver::unlock();
-}
-
-ZDriverUnlocker::~ZDriverUnlocker() {
-  ZDriver::lock();
 }
 
 ZDriver::ZDriver()
@@ -205,7 +181,7 @@ void ZDriverMinor::run_thread() {
     // Wait for GC request
     const ZDriverRequest request = _port.receive();
 
-    ZDriverLocker locker;
+    ZLocker<ZLock> locker(_lock);
 
     abortpoint();
 
@@ -458,7 +434,7 @@ void ZDriverMajor::run_thread() {
     // Wait for GC request
     const ZDriverRequest request = _port.receive();
 
-    ZDriverLocker locker;
+    ZLocker<ZLock> locker(_lock);
 
     ZBreakpoint::at_before_gc();
 

--- a/src/hotspot/share/gc/z/zDriver.hpp
+++ b/src/hotspot/share/gc/z/zDriver.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,18 +46,16 @@ class ZDriverMajor;
 class ZLock;
 
 class ZDriver : public ZThread {
-  friend class ZDriverLocker;
-  friend class ZDriverUnlocker;
+  friend class ZGenerationOld;
 
 private:
-  static ZLock*        _lock;
   static ZDriverMinor* _minor;
   static ZDriverMajor* _major;
 
   GCCause::Cause _gc_cause;
 
-  static void lock();
-  static void unlock();
+protected:
+  static ZLock*        _lock;
 
 public:
   static void initialize();
@@ -129,18 +127,6 @@ public:
 
   void set_used_at_start(size_t used);
   size_t used_at_start() const;
-};
-
-class ZDriverLocker : public StackObj {
-public:
-  ZDriverLocker();
-  ~ZDriverLocker();
-};
-
-class ZDriverUnlocker : public StackObj {
-public:
-  ZDriverUnlocker();
-  ~ZDriverUnlocker();
 };
 
 #endif // SHARE_GC_Z_ZDRIVER_HPP

--- a/src/hotspot/share/gc/z/zLock.hpp
+++ b/src/hotspot/share/gc/z/zLock.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,6 +74,16 @@ private:
 public:
   ZLocker(T* lock);
   ~ZLocker();
+};
+
+template <typename T>
+class ZUnlocker : public StackObj {
+private:
+  T* const _lock;
+
+public:
+  ZUnlocker(T* lock);
+  ~ZUnlocker();
 };
 
 #endif // SHARE_GC_Z_ZLOCK_HPP

--- a/src/hotspot/share/gc/z/zLock.inline.hpp
+++ b/src/hotspot/share/gc/z/zLock.inline.hpp
@@ -121,14 +121,14 @@ template <typename T>
 inline ZUnlocker<T>::ZUnlocker(T* lock)
   : _lock(lock) {
   if (_lock != nullptr) {
-    _lock->lock();
+    _lock->unlock();
   }
 }
 
 template <typename T>
 inline ZUnlocker<T>::~ZUnlocker() {
   if (_lock != nullptr) {
-    _lock->unlock();
+    _lock->lock();
   }
 }
 

--- a/src/hotspot/share/gc/z/zLock.inline.hpp
+++ b/src/hotspot/share/gc/z/zLock.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,6 +112,21 @@ inline ZLocker<T>::ZLocker(T* lock)
 
 template <typename T>
 inline ZLocker<T>::~ZLocker() {
+  if (_lock != nullptr) {
+    _lock->unlock();
+  }
+}
+
+template <typename T>
+inline ZUnlocker<T>::ZUnlocker(T* lock)
+  : _lock(lock) {
+  if (_lock != nullptr) {
+    _lock->lock();
+  }
+}
+
+template <typename T>
+inline ZUnlocker<T>::~ZUnlocker() {
   if (_lock != nullptr) {
     _lock->unlock();
   }


### PR DESCRIPTION
Hi all,

This patch removes the classes `ZDriverLocker` and `ZDriverUnlocker`, and uses `ZLocker` and newly added `ZUnlocker` instead. Thanks for taking the time to review.

Testing:
- [x] linux-x64-slowdebug test-hotspot_gc

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331691](https://bugs.openjdk.org/browse/JDK-8331691): Generational ZGC: Use ZLocker uniformly (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19092/head:pull/19092` \
`$ git checkout pull/19092`

Update a local copy of the PR: \
`$ git checkout pull/19092` \
`$ git pull https://git.openjdk.org/jdk.git pull/19092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19092`

View PR using the GUI difftool: \
`$ git pr show -t 19092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19092.diff">https://git.openjdk.org/jdk/pull/19092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19092#issuecomment-2094848992)