### PR TITLE
8331695: Serial: DefNewGeneration:_promotion_failed used without being initialized

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -226,6 +226,7 @@ DefNewGeneration::DefNewGeneration(ReservedSpace rs,
                                    size_t max_size,
                                    const char* policy)
   : Generation(rs, initial_size),
+    _promotion_failed(false),
     _preserved_marks_set(false /* in_c_heap */),
     _promo_failure_drain_in_progress(false),
     _should_allocate_from_space(false),


### PR DESCRIPTION
Seems to happen if a full GC occurs before a young GC is triggered.

At cursory glance the other fields of `DefNewGeneration` seems to be initialised correctly.

Building with UBSAN shows the following in debug.
```
src/hotspot/share/gc/serial/defNewGeneration.cpp:886:7: runtime error: load of value 241, which is not a valid value for type 'bool'
    #0 0x14f4544322bb in DefNewGeneration::contribute_scratch(void*&, unsigned long&) src/hotspot/share/gc/serial/defNewGeneration.cpp:886
    #1 0x14f45bb6d8ae in SerialFullGC::allocate_stacks() src/hotspot/share/gc/serial/serialFullGC.cpp:560
    #2 0x14f45bb7549a in SerialFullGC::invoke_at_safepoint(bool) src/hotspot/share/gc/serial/serialFullGC.cpp:699
    #3 0x14f45cb4b77c in TenuredGeneration::collect(bool, bool, unsigned long, bool) src/hotspot/share/gc/serial/tenuredGeneration.cpp:470
    #4 0x14f45bbc3411 in SerialHeap::collect_generation(Generation*, bool, unsigned long, bool, bool, bool) src/hotspot/share/gc/serial/serialHeap.cpp:461
    #5 0x14f45bbc7f20 in SerialHeap::do_collection(bool, bool, unsigned long, bool, SerialHeap::GenerationType) src/hotspot/share/gc/serial/serialHeap.cpp:589
    #6 0x14f45bbca783 in SerialHeap::do_full_collection(bool, SerialHeap::GenerationType) src/hotspot/share/gc/serial/serialHeap.cpp:846
    #7 0x14f45bc0e5cc in VM_GenCollectFull::doit() src/hotspot/share/gc/serial/serialVMOperations.cpp:47
    #8 0x14f45d12e677 in VM_Operation::evaluate() src/hotspot/share/runtime/vmOperations.cpp:75
    #9 0x14f45d1caef0 in VMThread::evaluate_operation(VM_Operation*) src/hotspot/share/runtime/vmThread.cpp:283
    #10 0x14f45d1cdffa in VMThread::inner_execute(VM_Operation*) src/hotspot/share/runtime/vmThread.cpp:427
    #11 0x14f45d1ceedb in VMThread::loop() src/hotspot/share/runtime/vmThread.cpp:493
    #12 0x14f45d1ceedb in VMThread::loop() src/hotspot/share/runtime/vmThread.cpp:478
    #13 0x14f45d1cf320 in VMThread::run() src/hotspot/share/runtime/vmThread.cpp:177
    #14 0x14f45cb6d30c in Thread::call_run() src/hotspot/share/runtime/thread.cpp:221
    #15 0x14f45b2a7fe5 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:846
    #16 0x14f4778cb1d9 in start_thread (/lib64/libpthread.so.0+0x81d9)
    #17 0x14f476815e72 in __clone (/lib64/libc.so.6+0x39e72)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331695](https://bugs.openjdk.org/browse/JDK-8331695): Serial: DefNewGeneration:_promotion_failed used without being initialized (**Bug** - P3)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19094/head:pull/19094` \
`$ git checkout pull/19094`

Update a local copy of the PR: \
`$ git checkout pull/19094` \
`$ git pull https://git.openjdk.org/jdk.git pull/19094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19094`

View PR using the GUI difftool: \
`$ git pr show -t 19094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19094.diff">https://git.openjdk.org/jdk/pull/19094.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19094#issuecomment-2095254300)