### PR TITLE
8330016: Stress seed should be initialized for runtime stub compilation

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5063,7 +5063,7 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
 
 // Auxiliary methods to support randomized stressing/fuzzing.
 
-void Compile::initialize_stress_seed(DirectiveSet* directive) {
+void Compile::initialize_stress_seed(const DirectiveSet* directive) {
   if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
     _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
     FLAG_SET_ERGO(StressSeed, _stress_seed);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -856,8 +856,6 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
   if (failing())  return;
   NOT_PRODUCT( verify_graph_edges(); )
 
-  // If any phase is randomized for stress testing, seed random number
-  // generation and log the seed for repeatability.
   if (StressLCM || StressGCM || StressIGVN || StressCCP ||
       StressIncrementalInlining || StressMacroExpansion) {
     initialize_stress_seed(directive);
@@ -988,8 +986,6 @@ Compile::Compile( ciEnv* ci_env,
   _types = new (comp_arena()) Type_Array(comp_arena());
   _node_hash = new (comp_arena()) NodeHash(comp_arena(), 255);
 
-  // If any phase is randomized for stress testing, seed random number
-  // generation and log the seed for repeatability.
   if (StressLCM || StressGCM) {
     initialize_stress_seed(directive);
   }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -604,18 +604,6 @@ void Compile::print_ideal_ir(const char* phase_name) {
 }
 #endif
 
-void Compile::initialize_stress_seed(DirectiveSet* directive) {
-  if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
-    _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
-    FLAG_SET_ERGO(StressSeed, _stress_seed);
-  } else {
-    _stress_seed = StressSeed;
-  }
-  if (_log != nullptr) {
-    _log->elem("stress_test seed='%u'", _stress_seed);
-  }
-}
-
 // ============================================================================
 //------------------------------Compile standard-------------------------------
 
@@ -5074,6 +5062,18 @@ void Compile::remove_speculative_types(PhaseIterGVN &igvn) {
 }
 
 // Auxiliary methods to support randomized stressing/fuzzing.
+
+void Compile::initialize_stress_seed(DirectiveSet* directive) {
+  if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
+    _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
+    FLAG_SET_ERGO(StressSeed, _stress_seed);
+  } else {
+    _stress_seed = StressSeed;
+  }
+  if (_log != nullptr) {
+    _log->elem("stress_test seed='%u'", _stress_seed);
+  }
+}
 
 int Compile::random() {
   _stress_seed = os::next_random(_stress_seed);

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -983,6 +983,21 @@ Compile::Compile( ciEnv* ci_env,
   _igvn_worklist = new (comp_arena()) Unique_Node_List(comp_arena());
   _types = new (comp_arena()) Type_Array(comp_arena());
   _node_hash = new (comp_arena()) NodeHash(comp_arena(), 255);
+
+  // If any phase is randomized for stress testing, seed random number
+  // generation and log the seed for repeatability.
+  if (StressLCM || StressGCM || StressIGVN || StressCCP || StressIncrementalInlining || StressMacroExpansion) {
+    if (FLAG_IS_DEFAULT(StressSeed) || (FLAG_IS_ERGO(StressSeed) && directive->RepeatCompilationOption)) {
+      _stress_seed = static_cast<uint>(Ticks::now().nanoseconds());
+      FLAG_SET_ERGO(StressSeed, _stress_seed);
+    } else {
+      _stress_seed = StressSeed;
+    }
+    if (_log != nullptr) {
+      _log->elem("stress_test seed='%u'", _stress_seed);
+    }
+  }
+
   {
     PhaseGVN gvn;
     set_initial_gvn(&gvn);    // not significant, but GraphKit guys use it pervasively

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -1279,7 +1279,7 @@ private:
   bool randomized_select(int count);
 
   // seed random number generation and log the seed for repeatability.
-  void initialize_stress_seed(DirectiveSet* directive);
+  void initialize_stress_seed(const DirectiveSet* directive);
 
   // supporting clone_map
   CloneMap&     clone_map();

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -812,6 +812,9 @@ private:
   // Sort expensive nodes to locate similar expensive nodes
   void sort_expensive_nodes();
 
+  // seed random number generation and log the seed for repeatability.
+  void initialize_stress_seed(DirectiveSet* directive);
+
   // Compilation environment.
   Arena*      comp_arena()           { return &_comp_arena; }
   ciEnv*      env() const            { return _env; }

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -812,9 +812,6 @@ private:
   // Sort expensive nodes to locate similar expensive nodes
   void sort_expensive_nodes();
 
-  // seed random number generation and log the seed for repeatability.
-  void initialize_stress_seed(DirectiveSet* directive);
-
   // Compilation environment.
   Arena*      comp_arena()           { return &_comp_arena; }
   ciEnv*      env() const            { return _env; }
@@ -1280,6 +1277,9 @@ private:
   // Auxiliary methods for randomized fuzzing/stressing
   int random();
   bool randomized_select(int count);
+
+  // seed random number generation and log the seed for repeatability.
+  void initialize_stress_seed(DirectiveSet* directive);
 
   // supporting clone_map
   CloneMap&     clone_map();


### PR DESCRIPTION
We can initialize the stress seed for runtime stub compilation as we already do for method compilation. This found the bug described in JDK-8329258. It would apply if StressGCM or StressLCM vm flags are set.

Testing: T1-5 default options. T1-5 with -XX:+StressLCM and -XX:+StressGCM. Manually tested that the stress seed is set and printed to compilation log if either stress option is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330016](https://bugs.openjdk.org/browse/JDK-8330016): Stress seed should be initialized for runtime stub compilation (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [6ccef597](https://git.openjdk.org/jdk/pull/19095/files/6ccef5975b37a89406430c9320517d995320d61f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19095/head:pull/19095` \
`$ git checkout pull/19095`

Update a local copy of the PR: \
`$ git checkout pull/19095` \
`$ git pull https://git.openjdk.org/jdk.git pull/19095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19095`

View PR using the GUI difftool: \
`$ git pr show -t 19095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19095.diff">https://git.openjdk.org/jdk/pull/19095.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19095#issuecomment-2095286341)