### PR TITLE
8331708: jdk/internal/jline/RedirectedStdOut.java times-out on macosx-aarch64

### DIFF
--- a/test/jdk/jdk/internal/jline/RedirectedStdOut.java
+++ b/test/jdk/jdk/internal/jline/RedirectedStdOut.java
@@ -29,9 +29,11 @@
  * @modules jdk.internal.le
  * @library /test/lib
  * @run main RedirectedStdOut runRedirectAllTest
- * @run main/othervm RedirectedStdOut runRedirectOutOnly
+ * @run main/othervm --enable-native-access=ALL-UNNAMED RedirectedStdOut runRedirectOutOnly
  */
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.lang.foreign.Arena;
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
@@ -58,7 +60,6 @@ public class RedirectedStdOut {
     //verify the case where neither stdin/out/err is attached to a terminal,
     //this test is weaker, but more reliable:
     void runRedirectAllTest() throws Exception {
-        if (true) return ;
         ProcessBuilder builder =
                 ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName());
         OutputAnalyzer output = ProcessTools.executeProcess(builder);
@@ -146,6 +147,10 @@ public class RedirectedStdOut {
         MethodHandle logintty = linker.downcallHandle(loginttyAddress.get(),
                                                       loginttyDescriptor);
         logintty.invoke(child.get(ValueLayout.JAVA_INT, 0));
+
+        //createTestJavaProcessBuilder logs to (current process') System.out, but
+        //that may not work since the redirect. Setting System.out to a scratch value:
+        System.setOut(new PrintStream(new ByteArrayOutputStream()));
 
         ProcessBuilder builder =
             ProcessTools.createTestJavaProcessBuilder(ConsoleTest.class.getName());


### PR DESCRIPTION
When integrating:
https://github.com/openjdk/jdk/pull/18996

I've forgot to push one last commit which was stabilizing the test of Mac OS/X. I am sorry for that.

The test will create a pseudo terminal, and change the current process stdin/stdout to write into the pty. But, there's nothing reading from the pty on the other side. This mostly works, OK, but the `ProcessTools` will write a debug log into `System.out` (which will write to stdout, which is the pty), and that blocks on Mac OS/X, presumably because there's nothing reading from the pty.

This patch changes the `System.out` for the main process to a scratch value, so no write to stdout/FD 1 is done, and no blocking should happen. (The process' stdout/FD 1 should remain attached to the pty.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331708](https://bugs.openjdk.org/browse/JDK-8331708): jdk/internal/jline/RedirectedStdOut.java times-out on macosx-aarch64 (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19097/head:pull/19097` \
`$ git checkout pull/19097`

Update a local copy of the PR: \
`$ git checkout pull/19097` \
`$ git pull https://git.openjdk.org/jdk.git pull/19097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19097`

View PR using the GUI difftool: \
`$ git pr show -t 19097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19097.diff">https://git.openjdk.org/jdk/pull/19097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19097#issuecomment-2095454485)