### PR TITLE
8331711: G1 doesn't need pre write barrier for stores from new allocated objects

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -196,11 +196,16 @@ void G1BarrierSetC2::pre_barrier(GraphKit* kit,
     assert(pre_val == nullptr, "loaded already?");
     assert(val_type != nullptr, "need a type");
 
+    if (use_ReduceInitialCardMarks() && obj == kit->just_allocated_object(kit->control())) {
+      // In SATB pre write barrier is used to gray the object disconnected from the graph
+      // which is not necessary for just allocated object
+      return;
+    }
+
     if (use_ReduceInitialCardMarks()
         && g1_can_remove_pre_barrier(kit, &kit->gvn(), adr, bt, alias_idx)) {
       return;
     }
-
   } else {
     // In this case both val_type and alias_idx are unused.
     assert(pre_val != nullptr, "must be loaded already");


### PR DESCRIPTION
The pre-write barrier of G1 is used to capture the object disconnected from the marking graph which could be unmarked aka *white* and stored into *black* objects then break tri-color invariance. But references in new allocated objects are created in object initialization after marking start and never could be white. So we don't need pre-write barrier for stores from new allocated objects. The same mechanism is also used for barrier eliminantion in GenZGC.

Additional testing:
 - [x] Linux aarch64 server release/fastdebug, test/hotspot/jtreg/gc with +UseG1GC
 - [x] Run several iterations of SPECjbb2015 with aggressively frequent concurrent mark

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331711](https://bugs.openjdk.org/browse/JDK-8331711): G1 doesn't need pre write barrier for stores from new allocated objects (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19098/head:pull/19098` \
`$ git checkout pull/19098`

Update a local copy of the PR: \
`$ git checkout pull/19098` \
`$ git pull https://git.openjdk.org/jdk.git pull/19098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19098`

View PR using the GUI difftool: \
`$ git pr show -t 19098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19098.diff">https://git.openjdk.org/jdk/pull/19098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19098#issuecomment-2095567251)