### PR TITLE
8331085: Crash in MergePrimitiveArrayStores::is_compatible_store()

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2971,7 +2971,11 @@ StoreNode* MergePrimitiveArrayStores::run() {
   }
 
   // Only merge stores on arrays, and the stores must have the same size as the elements.
-  const TypeAryPtr* aryptr_t = _store->adr_type()->isa_aryptr();
+  const TypePtr* ptr_t = _store->adr_type();
+  if (ptr_t == nullptr) {
+    return nullptr;
+  }
+  const TypeAryPtr* aryptr_t = ptr_t->isa_aryptr();
   if (aryptr_t == nullptr) {
     return nullptr;
   }
@@ -3016,6 +3020,7 @@ bool MergePrimitiveArrayStores::is_compatible_store(const StoreNode* other_store
 
   if (other_store == nullptr ||
       _store->Opcode() != other_store->Opcode() ||
+      other_store->adr_type() == nullptr ||
       other_store->adr_type()->isa_aryptr() == nullptr) {
     return false;
   }

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresNullAdrType.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresNullAdrType.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+/*
+ * @test
+ * @bug 8318446 8331085
+ * @summary Test merge stores, when "adr_type() == nullptr" because of TOP somewhere in the address.
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresNullAdrType::test
+ *                   -XX:-TieredCompilation -Xcomp
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:+StressCCP
+ *                   -XX:RepeatCompilation=1000
+ *                   compiler.c2.TestMergeStoresNullAdrType
+ * @run main compiler.c2.TestMergeStoresNullAdrType
+ */
+
+public class TestMergeStoresNullAdrType {
+    static int arr[] = new int[100];
+
+    static void test() {
+        boolean b = false;
+        for (int k = 269; k > 10; --k) {
+            b = b;
+            int j = 6;
+            while ((j -= 3) > 0) {
+                if (b) {
+                } else {
+                    arr[j] >>= 2;
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        test();
+    }
+}


### PR DESCRIPTION
In the `MergeStore` logic, I check the `adr_type()`. But in some rare cases this can be a `nullptr`, I did not expect that.

Exampe: during IGVN, the address is dying, with TOP somewhere in the inputs.
```
   1 Con === 0 [[ ]] #top
1022 AddP === _ 1 1 41 [[ 1019 1021 ]] !orig=539,[572] !jvms: Test::dMeth @ bci:223 (line 35)
1019 StoreI === 1128 827 1022 1020 [[ 1075 541 1073 574 ]] @int[int:>=0] (java/lang/Cloneable,java/io/Serializable):exact+any *, idx=6; Memory: @null !orig=574,1068 !jvms: Test::dMeth @ bci:227 (line 35)
```
I now check for `nullptr`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331085](https://bugs.openjdk.org/browse/JDK-8331085): Crash in MergePrimitiveArrayStores::is_compatible_store() (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19103/head:pull/19103` \
`$ git checkout pull/19103`

Update a local copy of the PR: \
`$ git checkout pull/19103` \
`$ git pull https://git.openjdk.org/jdk.git pull/19103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19103`

View PR using the GUI difftool: \
`$ git pr show -t 19103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19103.diff">https://git.openjdk.org/jdk/pull/19103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19103#issuecomment-2097492104)