### PR TITLE
8319997: JFR: Reduce use of dynamic proxies

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ import jdk.jfr.internal.util.Utils;
  */
 public final class EventType {
     private static final String UNKNOWN = new String();
-    private static final List<String> UNCATEGORIZED = List.of("Uncategorized");
+    private static final String[] UNCATEGORIZED = { "Uncategorized" };
     private final PlatformEventType platformEventType;
     private Map<String, ValueDescriptor> cache; // create lazy to avoid memory overhead
     private String label = UNKNOWN;
@@ -235,11 +235,8 @@ public final class EventType {
      * @see Category
      */
     public List<String> getCategoryNames() {
-        Category c = platformEventType.getAnnotation(Category.class);
-        if (c == null) {
-            return UNCATEGORIZED;
-        }
-        return List.of(c.value());
+        String[] categories = platformEventType.getAnnotationValue(Category.class, UNCATEGORIZED);
+        return List.of(categories);
     }
 
     // package private

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/AnnotationConstruct.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/AnnotationConstruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,19 +72,11 @@ public final class AnnotationConstruct {
     }
 
     public String getLabel() {
-        Label label = getAnnotation(Label.class);
-        if (label == null) {
-            return null;
-        }
-        return label.value();
+        return getAnnotationValue(Label.class, null);
     }
 
     public String getDescription() {
-        Description description = getAnnotation(Description.class);
-        if (description == null) {
-            return null;
-        }
-        return description.value();
+        return getAnnotationValue(Description.class, null);
     }
 
     @SuppressWarnings("unchecked")
@@ -100,7 +92,20 @@ public final class AnnotationConstruct {
         return annotationElements;
     }
 
-    private AnnotationElement getAnnotationElement(Class<? extends Annotation> clazz) {
+    /**
+     * Convenience method that returns the annotation value, or a default value
+     * if the type lacks the annotation.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getAnnotationValue(Class<? extends java.lang.annotation.Annotation> clazz, T defaultValue) {
+        AnnotationElement ae = getAnnotationElement(clazz);
+        if (ae == null) {
+            return defaultValue;
+        }
+        return (T) ae.getValues().get(0);
+    }
+
+    AnnotationElement getAnnotationElement(Class<? extends Annotation> clazz) {
         // if multiple annotation elements with the same name exists, prioritize
         // the one with the same id. Note, id alone is not a guarantee, since it
         // may differ between JVM instances.
@@ -123,8 +128,8 @@ public final class AnnotationConstruct {
         // Must be initialized lazily since some annotation elements
         // are added after construction
         if (unsignedFlag < 0) {
-            Unsigned unsigned = getAnnotation(Unsigned.class);
-            unsignedFlag = (byte) (unsigned == null ? 0 :1);
+            AnnotationElement ae = getAnnotationElement(Unsigned.class);
+            unsignedFlag = (byte) (ae == null ? 0 :1);
         }
         return unsignedFlag == (byte)1 ? true : false;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -290,72 +290,48 @@ public final class EventControl {
     }
 
     private static Control defineEnabled(PlatformEventType type) {
-        Enabled enabled = type.getAnnotation(Enabled.class);
         // Java events are enabled by default,
         // JVM events are not, maybe they should be? Would lower learning curve
         // there too.
-        String def = type.isJVM() ? "false" : "true";
-        if (enabled != null) {
-            def = Boolean.toString(enabled.value());
-        }
+        Boolean defaultValue = Boolean.valueOf(!type.isJVM());
+        String def = type.getAnnotationValue(Enabled.class, defaultValue).toString();
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_ENABLED, Enabled.NAME, def, Collections.emptyList()));
         return new Control(new EnabledSetting(type, def), def);
     }
 
     private static Control defineThreshold(PlatformEventType type) {
-        Threshold threshold = type.getAnnotation(Threshold.class);
-        String def = "0 ns";
-        if (threshold != null) {
-            def = threshold.value();
-        }
+        String def = type.getAnnotationValue(Threshold.class, "0 ns");
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_THRESHOLD, Threshold.NAME, def, Collections.emptyList()));
         return new Control(new ThresholdSetting(type), def);
     }
 
     private static Control defineStackTrace(PlatformEventType type) {
-        StackTrace stackTrace = type.getAnnotation(StackTrace.class);
-        String def = "true";
-        if (stackTrace != null) {
-            def = Boolean.toString(stackTrace.value());
-        }
+        String def = type.getAnnotationValue(StackTrace.class, Boolean.TRUE).toString();
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_STACK_TRACE, StackTrace.NAME, def, Collections.emptyList()));
         return new Control(new StackTraceSetting(type, def), def);
     }
 
     private static Control defineCutoff(PlatformEventType type) {
-        Cutoff cutoff = type.getAnnotation(Cutoff.class);
-        String def = Cutoff.INFINITY;
-        if (cutoff != null) {
-            def = cutoff.value();
-        }
+        String def = type.getAnnotationValue(Cutoff.class, Cutoff.INFINITY);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_CUTOFF, Cutoff.NAME, def, Collections.emptyList()));
         return new Control(new CutoffSetting(type), def);
     }
 
     private static Control defineThrottle(PlatformEventType type) {
-        Throttle throttle = type.getAnnotation(Throttle.class);
-        String def = Throttle.DEFAULT;
-        if (throttle != null) {
-            def = throttle.value();
-        }
+        String def = type.getAnnotationValue(Throttle.class, Throttle.DEFAULT);
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_THROTTLE, Throttle.NAME, def, Collections.emptyList()));
         return new Control(new ThrottleSetting(type), def);
     }
 
     private static Control defineLevel(PlatformEventType type) {
-        Level level = type.getAnnotation(Level.class);
-        String[] values = level.value();
-        String def = values[0];
+        String[] levels = type.getAnnotationValue(Level.class, new String[0]);
+        String def = levels[0]; // Level value always exists
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_LEVEL, Level.NAME, def, Collections.emptyList()));
-        return new Control(new LevelSetting(type, values), def);
+        return new Control(new LevelSetting(type, levels), def);
     }
 
     private static Control definePeriod(PlatformEventType type) {
-        Period period = type.getAnnotation(Period.class);
-        String def = "everyChunk";
-        if (period != null) {
-            def = period.value();
-        }
+        String def = type.getAnnotationValue(Period.class, "everyChunk");
         type.add(PrivateAccess.getInstance().newSettingDescriptor(TYPE_PERIOD, PeriodSetting.NAME, def, Collections.emptyList()));
         return new Control(new PeriodSetting(type), def);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -73,10 +73,10 @@ public final class MetadataRepository {
         for (Type type : TypeLibrary.getTypes()) {
             if (type instanceof PlatformEventType pEventType) {
                 EventType eventType = PrivateAccess.getInstance().newEventType(pEventType);
-                pEventType.setHasCutoff(eventType.getAnnotation(Cutoff.class) != null);
-                pEventType.setHasThrottle(eventType.getAnnotation(Throttle.class) != null);
-                pEventType.setHasLevel(eventType.getAnnotation(Level.class) != null);
-                pEventType.setHasPeriod(eventType.getAnnotation(Period.class) != null);
+                pEventType.setHasCutoff(type.hasAnnotation(Cutoff.class));
+                pEventType.setHasThrottle(type.hasAnnotation(Throttle.class));
+                pEventType.setHasLevel(type.hasAnnotation(Level.class));
+                pEventType.setHasPeriod(type.hasAnnotation(Period.class));
                 // Must add hook before EventControl is created as it removes
                 // annotations, such as Period and Threshold.
                 if (pEventType.hasPeriod()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Type.java
@@ -264,6 +264,10 @@ public class Type implements Comparable<Type> {
         return annos.getUnmodifiableAnnotationElements();
     }
 
+    public <T> T getAnnotationValue(Class<? extends java.lang.annotation.Annotation> clazz, T defaultValue) {
+       return annos.getAnnotationValue(clazz, defaultValue);
+    }
+
     public <T> T getAnnotation(Class<? extends java.lang.annotation.Annotation> clazz) {
         return annos.getAnnotation(clazz);
     }
@@ -358,5 +362,9 @@ public class Type implements Comparable<Type> {
 
     public boolean isInternal() {
         return internal;
+    }
+
+    public boolean hasAnnotation(Class<? extends java.lang.annotation.Annotation> clazz) {
+        return annos.getAnnotationElement(clazz) != null;
     }
 }


### PR DESCRIPTION
Hi,

Could I have a review of a change that removes the use of dynamic proxies for known event metadata, for example labels and descriptions.

Testing: test/jdk/jdk/jfr

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319997](https://bugs.openjdk.org/browse/JDK-8319997): JFR: Reduce use of dynamic proxies (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19106/head:pull/19106` \
`$ git checkout pull/19106`

Update a local copy of the PR: \
`$ git checkout pull/19106` \
`$ git pull https://git.openjdk.org/jdk.git pull/19106/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19106`

View PR using the GUI difftool: \
`$ git pr show -t 19106`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19106.diff">https://git.openjdk.org/jdk/pull/19106.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19106#issuecomment-2096547261)