### PR TITLE
8331771: ZGC: Remove OopMapCacheAlloc_lock ordering workaround

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -91,7 +91,6 @@ class CollectedHeap : public CHeapObj<mtGC> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
   friend class IsSTWGCActiveMark; // Block structured external access to _is_stw_gc_active
-  friend class DisableIsSTWGCActiveMark; // Disable current IsSTWGCActiveMark
   friend class MemAllocator;
   friend class ParallelObjectIterator;
 

--- a/src/hotspot/share/gc/shared/isGCActiveMark.cpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.cpp
@@ -42,15 +42,3 @@ IsSTWGCActiveMark::~IsSTWGCActiveMark() {
   assert(heap->is_stw_gc_active(), "Sanity");
   heap->_is_stw_gc_active = false;
 }
-
-DisableIsSTWGCActiveMark::DisableIsSTWGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(heap->is_stw_gc_active(), "Not reentrant");
-  heap->_is_stw_gc_active = false;
-}
-
-DisableIsSTWGCActiveMark::~DisableIsSTWGCActiveMark() {
-  CollectedHeap* heap = Universe::heap();
-  assert(!heap->is_stw_gc_active(), "Sanity");
-  heap->_is_stw_gc_active = true;
-}

--- a/src/hotspot/share/gc/shared/isGCActiveMark.hpp
+++ b/src/hotspot/share/gc/shared/isGCActiveMark.hpp
@@ -36,10 +36,4 @@ class IsSTWGCActiveMark : public StackObj {
   ~IsSTWGCActiveMark();
 };
 
-class DisableIsSTWGCActiveMark : public StackObj {
- public:
-  DisableIsSTWGCActiveMark();
-  ~DisableIsSTWGCActiveMark();
-};
-
 #endif // SHARE_GC_SHARED_ISGCACTIVEMARK_HPP

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -483,9 +483,6 @@ void ZVerify::after_mark() {
     roots_strong(true /* verify_after_old_mark */);
   }
   if (ZVerifyObjects) {
-    // Workaround OopMapCacheAlloc_lock reordering with the StackWatermark_lock
-    DisableIsSTWGCActiveMark mark;
-
     objects(false /* verify_weaks */);
     guarantee(zverify_broken_object == zaddress::null, "Verification failed");
   }


### PR DESCRIPTION
After [JDK-8331714](https://bugs.openjdk.org/browse/JDK-8331714), we don't need the Generational Z kludge that works around the lock ranking problem with (now gone) `OopMapCacheAlloc_lock`. I also reverted the `DisableIs*Mark` that was added specifically for that kludge in JDK 21. This simplifies further additions of new marks that do not have to replicate `Disable*` code.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331771](https://bugs.openjdk.org/browse/JDK-8331771): ZGC: Remove OopMapCacheAlloc_lock ordering workaround (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19114/head:pull/19114` \
`$ git checkout pull/19114`

Update a local copy of the PR: \
`$ git checkout pull/19114` \
`$ git pull https://git.openjdk.org/jdk.git pull/19114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19114`

View PR using the GUI difftool: \
`$ git pr show -t 19114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19114.diff">https://git.openjdk.org/jdk/pull/19114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19114#issuecomment-2097812373)