### PR TITLE
8331764: C2 SuperWord: refactor _align_to_ref/_mem_ref_for_main_loop_alignment

### DIFF
--- a/src/hotspot/share/opto/superword.hpp
+++ b/src/hotspot/share/opto/superword.hpp
@@ -411,10 +411,14 @@ class SuperWord : public ResourceObj {
 
   GrowableArray<SWNodeInfo> _node_info;  // Info needed per node
   CloneMap&            _clone_map;       // map of nodes created in cloning
-  MemNode const* _align_to_ref;          // Memory reference that pre-loop will align to
 
   PairSet _pairset;
   PackSet _packset;
+
+  // Memory reference, and the alignment width (aw) for which we align the main-loop,
+  // by adjusting the pre-loop limit.
+  MemNode const* _mem_ref_for_main_loop_alignment;
+  int _aw_for_main_loop_alignment;
 
  public:
   SuperWord(const VLoopAnalyzer &vloop_analyzer);
@@ -563,8 +567,6 @@ class SuperWord : public ResourceObj {
   Arena* arena()                   { return &_arena; }
 
   int get_vw_bytes_special(MemNode* s);
-  const MemNode* align_to_ref() const { return _align_to_ref; }
-  void set_align_to_ref(const MemNode* m) { _align_to_ref = m; }
 
   // Ensure node_info contains element "i"
   void grow_node_info(int i) { if (i >= _node_info.length()) _node_info.at_put_grow(i, SWNodeInfo::initial); }
@@ -670,6 +672,7 @@ private:
   // Alignment within a vector memory reference
   int memory_alignment(MemNode* s, int iv_adjust);
   // Ensure that the main loop vectors are aligned by adjusting the pre loop limit.
+  void determine_mem_ref_and_aw_for_main_loop_alignment();
   void adjust_pre_loop_limit_to_align_main_loop_vectors();
 };
 


### PR DESCRIPTION
This PR accomplishes these things:
- Rename `_align_to_ref` -> `_mem_ref_for_main_loop_alignment`.
- Move the `mem_ref` finding for alignment out of `SuperWord::find_adjacent_refs`. This is too early, and we don't even know if the relevant `mem_ref` is going to be vectorized. It makes more sense to pick a `mem_ref` directly in `SuperWord::adjust_pre_loop_limit_to_align_main_loop_vectors`, where we already know what packs are going to be vectorized.
- For the alignment width (aw), we can use the `vector_width` of the pack to which the `mem_ref` belongs, rather than the potentially much larger `vector_width_in_bytes`. I track this with `_aw_for_main_loop_alignment` now.

I need this for https://github.com/openjdk/jdk/pull/18822, and decided to split it out into an independent change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331764](https://bugs.openjdk.org/browse/JDK-8331764): C2 SuperWord: refactor _align_to_ref/_mem_ref_for_main_loop_alignment (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19115/head:pull/19115` \
`$ git checkout pull/19115`

Update a local copy of the PR: \
`$ git checkout pull/19115` \
`$ git pull https://git.openjdk.org/jdk.git pull/19115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19115`

View PR using the GUI difftool: \
`$ git pr show -t 19115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19115.diff">https://git.openjdk.org/jdk/pull/19115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19115#issuecomment-2098162626)