### PR TITLE
8331789: ubsan: deoptimization.cpp:403:29: runtime error: load of value 208, which is not a valid value for type 'bool'

### DIFF
--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -535,7 +535,7 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
 #if COMPILER2_OR_JVMCI
   if ((jvmci_enabled COMPILER2_PRESENT( || ((DoEscapeAnalysis || EliminateNestedLocks) && EliminateLocks) ))
       && !EscapeBarrier::objs_are_deoptimized(current, deoptee.id())) {
-    bool unused;
+    bool unused = false;
     restore_eliminated_locks(current, chunk, realloc_failures, deoptee, exec_mode, unused);
   }
 #endif // COMPILER2_OR_JVMCI


### PR DESCRIPTION
When using ubsan (configure flag --enable-ubsan) on macOS x86_64 we run into this error :

/jdk/src/hotspot/share/runtime/deoptimization.cpp:403:29: runtime error: load of value 208, which is not a valid value for type 'bool'
    #0 0x10247693e in restore_eliminated_locks(JavaThread*, GrowableArray<compiledVFrame*>*, bool, frame&, int, bool&) deoptimization.cpp:403
    #1 0x102474b6f in Deoptimization::fetch_unroll_info_helper(JavaThread*, int) deoptimization.cpp:552
    #2 0x10247fae9 in Deoptimization::uncommon_trap(JavaThread*, int, int) deoptimization.cpp:2624
    #3 0x12846ab80 (<unknown module>)

Reason might be an uninitialized bool variable on one code path, which is unused in the calling function anyway.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331789](https://bugs.openjdk.org/browse/JDK-8331789): ubsan: deoptimization.cpp:403:29: runtime error: load of value 208, which is not a valid value for type 'bool' (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19121/head:pull/19121` \
`$ git checkout pull/19121`

Update a local copy of the PR: \
`$ git checkout pull/19121` \
`$ git pull https://git.openjdk.org/jdk.git pull/19121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19121`

View PR using the GUI difftool: \
`$ git pr show -t 19121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19121.diff">https://git.openjdk.org/jdk/pull/19121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19121#issuecomment-2098480740)