### PR TITLE
8048691: Spliterator.SORTED characteristics gets cleared for BaseStream.spliterator

### DIFF
--- a/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
+++ b/src/java.base/share/classes/java/util/stream/StreamSpliterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -246,6 +246,11 @@ class StreamSpliterators {
             if ((c & Spliterator.SIZED) != 0) {
                 c &= ~(Spliterator.SIZED | Spliterator.SUBSIZED);
                 c |= (spliterator.characteristics() & (Spliterator.SIZED | Spliterator.SUBSIZED));
+            }
+
+            // It's not allowed for a Spliterator to report SORTED if not also ORDERED
+            if ((c & Spliterator.SORTED) != 0 && (c & Spliterator.ORDERED) == 0) {
+                c &= ~(Spliterator.SORTED);
             }
 
             return c;

--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/StreamSpliteratorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -603,6 +603,27 @@ public class StreamSpliteratorTest extends OpTestCase {
         for (Function<DoubleStream, DoubleStream> f : doubleStreamFunctions()) {
             SpliteratorTestHelper.testDoubleSpliterator(() -> f.apply(data.parallelStream()).spliterator());
         }
+    }
+
+    @Test
+    public void testCharacteristicsForSortedUnorderedStreamSpliterators() {
+        assertValidCombinationOfSortedAndOrdered(
+            DoubleStream.of(3d,2d,4d,1d,5d).sorted().unordered().spliterator()
+        );
+        assertValidCombinationOfSortedAndOrdered(
+            IntStream.of(3,2,4,1,5).sorted().unordered().spliterator()
+        );
+        assertValidCombinationOfSortedAndOrdered(
+            LongStream.of(3L,2L,4L,1L,5L).sorted().unordered().spliterator()
+        );
+        assertValidCombinationOfSortedAndOrdered(
+            Stream.of(3,2,4,1,5).sorted().unordered().spliterator()
+        );
+    }
+
+    void assertValidCombinationOfSortedAndOrdered(Spliterator<?> s) {
+        if (s.hasCharacteristics(Spliterator.SORTED))
+            Assert.assertTrue(s.hasCharacteristics(Spliterator.ORDERED));
     }
 
     private List<Function<DoubleStream, DoubleStream>> doubleStreamFunctions;


### PR DESCRIPTION
Removes SORTED if not also ORDERED for escape-hatch `Stream::spliterator()`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8048691](https://bugs.openjdk.org/browse/JDK-8048691): Spliterator.SORTED characteristics gets cleared for BaseStream.spliterator (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19123/head:pull/19123` \
`$ git checkout pull/19123`

Update a local copy of the PR: \
`$ git checkout pull/19123` \
`$ git pull https://git.openjdk.org/jdk.git pull/19123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19123`

View PR using the GUI difftool: \
`$ git pr show -t 19123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19123.diff">https://git.openjdk.org/jdk/pull/19123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19123#issuecomment-2098632975)