### PR TITLE
8331734: Atomic MemorySegment VarHandle operations fails for element layouts

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -26,6 +26,8 @@
 package jdk.internal.foreign;
 
 import jdk.internal.vm.annotation.ForceInline;
+import sun.security.action.GetPropertyAction;
+
 import java.lang.foreign.AddressLayout;
 import java.lang.foreign.GroupLayout;
 import java.lang.foreign.MemoryLayout;
@@ -66,6 +68,9 @@ public class LayoutPath {
     private static final MethodHandle MH_CHECK_ALIGN;
     private static final MethodHandle MH_SEGMENT_RESIZE;
     private static final MethodHandle MH_ADD;
+
+    private static final boolean USE_FULL_CHECKS = Boolean.parseBoolean(
+            GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.handle.USE_FULL_CHECKS", "false"));
 
     static {
         try {
@@ -206,7 +211,7 @@ public class LayoutPath {
 
         // If we have an enclosing layout, drop the alignment check for the accessed element,
         // we check the root layout instead
-        ValueLayout accessedLayout = enclosing != null ? valueLayout.withByteAlignment(1) : valueLayout;
+        ValueLayout accessedLayout = (enclosing != null && !USE_FULL_CHECKS) ? valueLayout.withByteAlignment(1) : valueLayout;
         VarHandle handle = accessedLayout.varHandle();
         handle = MethodHandles.collectCoordinates(handle, 1, offsetHandle());
 

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -26,7 +26,6 @@
 package jdk.internal.foreign;
 
 import jdk.internal.vm.annotation.ForceInline;
-import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.AddressLayout;
 import java.lang.foreign.GroupLayout;
@@ -68,9 +67,6 @@ public class LayoutPath {
     private static final MethodHandle MH_CHECK_ALIGN;
     private static final MethodHandle MH_SEGMENT_RESIZE;
     private static final MethodHandle MH_ADD;
-
-    private static final boolean USE_FULL_CHECKS = Boolean.parseBoolean(
-            GetPropertyAction.privilegedGetProperty("jdk.internal.foreign.handle.USE_FULL_CHECKS", "false"));
 
     static {
         try {
@@ -209,10 +205,7 @@ public class LayoutPath {
                     String.format("Path does not select a value layout: %s", breadcrumbs()));
         }
 
-        // If we have an enclosing layout, drop the alignment check for the accessed element,
-        // we check the root layout instead
-        ValueLayout accessedLayout = (enclosing != null && !USE_FULL_CHECKS) ? valueLayout.withByteAlignment(1) : valueLayout;
-        VarHandle handle = accessedLayout.varHandle();
+        VarHandle handle = valueLayout.varHandle();
         handle = MethodHandles.collectCoordinates(handle, 1, offsetHandle());
 
         // we only have to check the alignment of the root layout for the first dereference we do,

--- a/test/jdk/java/foreign/TestAccessModes.java
+++ b/test/jdk/java/foreign/TestAccessModes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,17 +23,13 @@
 
 /*
  * @test
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
- * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
  */
 
-import java.lang.foreign.AddressLayout;
-import java.lang.foreign.Arena;
-import java.lang.foreign.MemoryLayout;
-import java.lang.foreign.MemorySegment;
-import java.lang.foreign.ValueLayout;
+import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -50,10 +46,12 @@ import static org.testng.Assert.*;
 public class TestAccessModes {
 
     @Test(dataProvider = "segmentsAndLayoutsAndModes")
-    public void testAccessModes(MemorySegment segment, ValueLayout layout, AccessMode mode) throws Throwable {
-        VarHandle varHandle = layout.varHandle();
+    public void testAccessModes(MemorySegment segment, MemoryLayout layout, AccessMode mode) throws Throwable {
+        VarHandle varHandle = layout instanceof ValueLayout ?
+                layout.varHandle() :
+                layout.varHandle(MemoryLayout.PathElement.groupElement(0));
         MethodHandle methodHandle = varHandle.toMethodHandle(mode);
-        boolean compatible = AccessModeKind.supportedModes(layout).contains(AccessModeKind.of(mode));
+        boolean compatible = AccessModeKind.supportedModes(accessLayout(layout)).contains(AccessModeKind.of(mode));
         try {
             Object o = methodHandle.invokeWithArguments(makeArgs(segment, varHandle.accessModeType(mode)));
             assertTrue(compatible);
@@ -61,8 +59,17 @@ public class TestAccessModes {
             assertFalse(compatible);
         } catch (IllegalArgumentException ex) {
             // access is unaligned, but access mode is supported
-            assertTrue(compatible);
+            assertTrue(compatible ||
+                    (layout instanceof GroupLayout && segment.maxByteAlignment() < layout.byteAlignment()));
         }
+    }
+
+    static ValueLayout accessLayout(MemoryLayout layout) {
+        return switch (layout) {
+            case ValueLayout vl -> vl;
+            case GroupLayout gl -> accessLayout(gl.memberLayouts().get(0));
+            default -> throw new IllegalStateException();
+        };
     }
 
     Object[] makeArgs(MemorySegment segment, MethodType type) throws Throwable {
@@ -143,8 +150,9 @@ public class TestAccessModes {
         };
         List<MemoryLayout> layouts = new ArrayList<>();
         for (MemoryLayout layout : valueLayouts) {
-            for (int align : new int[] { 1, 2, 4, 8 }) {
+            for (int align : new int[] { 2 }) {
                 layouts.add(layout.withByteAlignment(align));
+                layouts.add(MemoryLayout.structLayout(layout.withByteAlignment(align)));
             }
         }
         return layouts.toArray(new MemoryLayout[0]);

--- a/test/jdk/java/foreign/TestAccessModes.java
+++ b/test/jdk/java/foreign/TestAccessModes.java
@@ -150,7 +150,7 @@ public class TestAccessModes {
         };
         List<MemoryLayout> layouts = new ArrayList<>();
         for (MemoryLayout layout : valueLayouts) {
-            for (int align : new int[] { 2 }) {
+            for (int align : new int[] { 1, 2, 4, 8 }) {
                 layouts.add(layout.withByteAlignment(align));
                 layouts.add(MemoryLayout.structLayout(layout.withByteAlignment(align)));
             }

--- a/test/jdk/java/foreign/TestAccessModes.java
+++ b/test/jdk/java/foreign/TestAccessModes.java
@@ -23,10 +23,10 @@
 
 /*
  * @test
- * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
- * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
- * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
- * @run testng/othervm -Djdk.internal.foreign.handle.USE_FULL_CHECKS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=true -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=false -Xverify:all TestAccessModes
+ * @run testng/othervm -Djava.lang.invoke.VarHandle.VAR_HANDLE_GUARDS=false -Djava.lang.invoke.VarHandle.VAR_HANDLE_IDENTITY_ADAPT=true -Xverify:all TestAccessModes
  */
 
 import java.lang.foreign.*;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -142,6 +142,7 @@ public class LoopOverNonConstant extends JavaLayouts {
         return sum;
     }
 
+    @Benchmark
     public int segment_loop_nested() {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
 package org.openjdk.bench.java.lang.foreign;
 
 import java.lang.foreign.Arena;
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 
 import org.openjdk.jmh.annotations.Benchmark;
@@ -37,6 +38,8 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import sun.misc.Unsafe;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.TimeUnit;
@@ -56,6 +59,13 @@ public class LoopOverNonConstant extends JavaLayouts {
     static final int ELEM_SIZE = 1_000_000;
     static final int CARRIER_SIZE = (int)JAVA_INT.byteSize();
     static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    static final VarHandle VH_SEQ_INT = bindToZeroOffset(MemoryLayout.sequenceLayout(ELEM_SIZE, JAVA_INT).varHandle(PathElement.sequenceElement()));
+    static final VarHandle VH_SEQ_INT_UNALIGNED = bindToZeroOffset(MemoryLayout.sequenceLayout(ELEM_SIZE, JAVA_INT.withByteAlignment(1)).varHandle(PathElement.sequenceElement()));
+
+    static VarHandle bindToZeroOffset(VarHandle varHandle) {
+        return MethodHandles.insertCoordinates(varHandle, 1, 0L);
+    }
 
     Arena arena;
     MemorySegment segment;
@@ -128,6 +138,23 @@ public class LoopOverNonConstant extends JavaLayouts {
         int sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += (int) VH_INT_UNALIGNED.get(segment, (long) i);
+        }
+        return sum;
+    }
+
+    public int segment_loop_nested() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += (int) VH_SEQ_INT.get(segment, (long) i);
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public int segment_loop_nested_unaligned() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += (int) VH_SEQ_INT_UNALIGNED.get(segment, (long) i);
         }
         return sum;
     }


### PR DESCRIPTION
This PR fixes an issue that has crept into the FFM API implementation.

From very early stages, the FFM API used to disable the alignment check on nested layout elements, in favor of an alignment check against the memory segment base address. The rationale was that the JIT had issue with eliminating redundant alignment checks, and accessing nested elements could never result in alignment issues, since the alignment of the container is provably bigger than that of the contained element. This means that, when creating a var handle for a nested layout element, we set the nested layout alignment to 1 (unaligned), derive its var handle, and then decorate the var handle with an alignment check for the container.

At some point in 22, we tweaked the API to throw `UnsupportedOperationException` when using an access mode incompatible with the alignment constraint of the accessed layout. That is, a volatile read on an `int` is only possible if the access occurs at an address that is at least 4-byte aligned. Otherwise an `UOE` is thrown.

Unfortunately this change broke the aforementioned optimization: creating a var handle for an unaligned layout works, but the resulting layout will *not* support any of the atomic access modes.

Since this optimization is not really required anymore (proper C2 support to hoist/eliminate alignment checks has been added since then), it is better to disable this implementation quirk, and leave optimizations to C2.

(If we really really wanted to optimize things a bit, we could remove the container alignment check in the case the accessed value is the first layout element nested in the container, but this PR doesn't go that far).

I've run relevant benchmarks before/after and found no differences. In part this is because `arrayElementVarHandle` is unaffected. But, even after tweaking the `LoopOverNonConstant` benchmark to add explicit tests for the code path affected, no significant difference was found, sign that C2 is indeed able to spot (and remove) the redundant alignment check. Note: if we know that `aligned_to_N(base)` holds, then it's easy to prove that `aligned_to_M(base + offset + index * scale)` holds, when `N >= M` and with `offset` and `scale` known (the latter a power of two).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331734](https://bugs.openjdk.org/browse/JDK-8331734): Atomic MemorySegment VarHandle operations fails for element layouts (**Bug** - P2)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**) ⚠️ Review applies to [aa5ed595](https://git.openjdk.org/jdk/pull/19124/files/aa5ed59518012e292d04ee3f80a73272f1f0ef15)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to [aa5ed595](https://git.openjdk.org/jdk/pull/19124/files/aa5ed59518012e292d04ee3f80a73272f1f0ef15)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19124/head:pull/19124` \
`$ git checkout pull/19124`

Update a local copy of the PR: \
`$ git checkout pull/19124` \
`$ git pull https://git.openjdk.org/jdk.git pull/19124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19124`

View PR using the GUI difftool: \
`$ git pr show -t 19124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19124.diff">https://git.openjdk.org/jdk/pull/19124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19124#issuecomment-2098778844)