### PR TITLE
8331863: DUIterator_Fast used before it is constructed

### DIFF
--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1569,8 +1569,8 @@ Node* Node::last_out(DUIterator_Last& i) const {
 class SimpleDUIterator : public StackObj {
  private:
   Node* node;
-  DUIterator_Fast i;
   DUIterator_Fast imax;
+  DUIterator_Fast i;
  public:
   SimpleDUIterator(Node* n): node(n), i(n->fast_outs(imax)) {}
   bool has_next() { return i < imax; }


### PR DESCRIPTION
`SimpleDUIterator` constructs two `DUIterator_Fast` but passes a reference to the second when constructing the first. In debug values are read from this not yet constructed object.

Found when building a debug build with UBSAN
```
/src/hotspot/share/opto/node.cpp:124:8: runtime error: load of value 200, which is not a valid value for type 'bool'
    #0 0x14619f4e6476 in DUIterator_Common::reset(DUIterator_Common const&) /src/hotspot/share/opto/node.cpp:124
    #1 0x1461a32556a5 in DUIterator_Fast::operator=(DUIterator_Fast const&) /src/hotspot/share/opto/node.hpp:1486
    #2 0x1461a32556a5 in Node::fast_outs(DUIterator_Fast&) const /src/hotspot/share/opto/node.hpp:1491
    #3 0x1461a32556a5 in SimpleDUIterator::SimpleDUIterator(Node*) /src/hotspot/share/opto/node.hpp:1575
    #4 0x1461a32556a5 in G1BarrierSetC2::has_cas_in_use_chain(Node*) const /src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp:855
    #5 0x1461a3256cf1 in G1BarrierSetC2::verify_pre_load(Node*, Unique_Node_List&) const /src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp:881
    #6 0x1461a325eec3 in G1BarrierSetC2::verify_gc_barriers(Compile*, BarrierSetC2::CompilePhase) const /src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp:1019
    #7 0x1461a325eec3 in G1BarrierSetC2::verify_gc_barriers(Compile*, BarrierSetC2::CompilePhase) const /src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp:963
    #8 0x1461a23160ed in Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*) /src/hotspot/share/opto/compile.cpp:875
    #9 0x1461a1845fd0 in C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) /src/hotspot/share/opto/c2compiler.cpp:142
    #10 0x1461a235ac39 in CompileBroker::invoke_compiler_on_method(CompileTask*) /src/hotspot/share/compiler/compileBroker.cpp:2305
    #11 0x1461a235ee4e in CompileBroker::compiler_thread_loop() /src/hotspot/share/compiler/compileBroker.cpp:1963
    #12 0x1461a4076f8d in JavaThread::thread_main_inner() /src/hotspot/share/runtime/javaThread.cpp:760
    #13 0x1461a409da23 in JavaThread::run() /src/hotspot/share/runtime/javaThread.cpp:745
    #14 0x1461a7b6d2bc in Thread::call_run() /src/hotspot/share/runtime/thread.cpp:221
    #15 0x1461a62a8105 in thread_native_entry /src/hotspot/os/linux/os_linux.cpp:846
    #16 0x1461c29801d9 in start_thread (/lib64/libpthread.so.0+0x81d9)
    #17 0x1461c18cae72 in __clone (/lib64/libc.so.6+0x39e72)
```