### PR TITLE
8331886: Allow markdown src file overrides

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -681,28 +681,25 @@ ifeq ($(ENABLE_PANDOC), true)
       $(TOPDIR)/make/jdk/src/classes/build/tools/pandocfilter)
 
   $(foreach m, $(ALL_MODULES), \
-    $(eval MAN_$m := $(call FindModuleManDirs, $m)) \
-    $(foreach d, $(MAN_$m), \
-      $(foreach f, $(call ApplySpecFilter, $(filter %.md, $(call FindFiles, $d))), \
-        $(eval $m_$f_NAME := MAN_TO_HTML_$m_$(strip $(call RelativePath, $f, $(TOPDIR)))) \
-        $(eval $(call SetupProcessMarkdown, $($m_$f_NAME), \
-            SRC := $d, \
-            FILES := $f, \
-            DEST := $(DOCS_OUTPUTDIR)/specs/man, \
-            FILTER := $(PANDOC_HTML_MANPAGE_FILTER), \
-            CSS := $(GLOBAL_SPECS_DEFAULT_CSS_FILE), \
-            REPLACEMENTS := \
-		@@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
-		@@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
-		@@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
-            OPTIONS := --toc -V include-before='$(SPECS_TOP)' -V include-after='$(SPECS_BOTTOM_1)', \
-            POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info '$(HEADER_RIGHT_SIDE_INFO)' \
-                --nav-subdirs 1 --nav-link-guides, \
-            EXTRA_DEPS := $(PANDOC_HTML_MANPAGE_FILTER) \
-                $(PANDOC_HTML_MANPAGE_FILTER_SOURCE), \
-        )) \
-        $(eval JDK_SPECS_TARGETS += $($($m_$f_NAME))) \
-      ) \
+    $(eval MAN_$m := $(call ApplySpecFilter, $(filter %.md, $(call FindFiles, \
+          $(call FindModuleManDirs, $m))))) \
+    $(if $(MAN_$m), \
+      $(eval $(call SetupProcessMarkdown, MAN_TO_HTML_$m, \
+        FILES := $(MAN_$m), \
+        DEST := $(DOCS_OUTPUTDIR)/specs/man, \
+        FILTER := $(PANDOC_HTML_MANPAGE_FILTER), \
+        CSS := $(GLOBAL_SPECS_DEFAULT_CSS_FILE), \
+        REPLACEMENTS := \
+            @@COPYRIGHT_YEAR@@ => $(COPYRIGHT_YEAR) ; \
+            @@VERSION_SHORT@@ => $(VERSION_SHORT) ; \
+            @@VERSION_SPECIFICATION@@ => $(VERSION_SPECIFICATION), \
+        OPTIONS := --toc -V include-before='$(SPECS_TOP)' -V include-after='$(SPECS_BOTTOM_1)', \
+        POST_PROCESS := $(TOOL_FIXUPPANDOC) --insert-nav --nav-right-info '$(HEADER_RIGHT_SIDE_INFO)' \
+            --nav-subdirs 1 --nav-link-guides, \
+        EXTRA_DEPS := $(PANDOC_HTML_MANPAGE_FILTER) \
+            $(PANDOC_HTML_MANPAGE_FILTER_SOURCE), \
+      )) \
+      $(eval JDK_SPECS_TARGETS += $(MAN_TO_HTML_$m)) \
     ) \
   )
 

--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -40,8 +40,6 @@ define ProcessMarkdown
 
   # Only continue if this target file hasn't been processed already. This lets
   # the first found source file override any other with the same name.
-  $$(call PrintVar, $1_$2_INPUT_FILE)
-  $$(call PrintVar, $1_$2_OUTPUT_FILE_PROCESSED)
   ifeq ($$($1_$2_OUTPUT_FILE_PROCESSED), )
     $1_$2_OUTPUT_FILE_PROCESSED := true
 

--- a/make/common/ProcessMarkdown.gmk
+++ b/make/common/ProcessMarkdown.gmk
@@ -38,48 +38,55 @@ define ProcessMarkdown
   $1_$2_INPUT_FILE := $3/$2
   $1_$2_MARKER := $$(subst /,_,$1_$2)
 
-  ifneq ($$($1_REPLACEMENTS), )
-    $1_$2_PANDOC_INPUT := $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_pre.tmp
+  # Only continue if this target file hasn't been processed already. This lets
+  # the first found source file override any other with the same name.
+  $$(call PrintVar, $1_$2_INPUT_FILE)
+  $$(call PrintVar, $1_$2_OUTPUT_FILE_PROCESSED)
+  ifeq ($$($1_$2_OUTPUT_FILE_PROCESSED), )
+    $1_$2_OUTPUT_FILE_PROCESSED := true
 
-    $$(eval $$(call SetupTextFileProcessing, $1_$2_PREPROCESSED, \
-        SOURCE_FILES := $$($1_$2_INPUT_FILE), \
-        OUTPUT_FILE := $$($1_$2_PANDOC_INPUT), \
-        REPLACEMENTS := $$($1_REPLACEMENTS), \
-    ))
-  else
-    $1_$2_PANDOC_INPUT := $$($1_$2_INPUT_FILE)
-  endif
+    ifneq ($$($1_REPLACEMENTS), )
+      $1_$2_PANDOC_INPUT := $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_pre.tmp
 
-  ifneq ($$($1_POST_PROCESS), )
-    $1_$2_PANDOC_OUTPUT := $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_post.tmp
-  else
-    $1_$2_PANDOC_OUTPUT := $$($1_$2_OUTPUT_FILE)
-  endif
-
-  ifneq ($$($1_CSS), )
-    ifneq ($$(findstring https:/, $$($1_CSS)), )
-      $1_$2_CSS_OPTION := --css '$$($1_CSS)'
+      $$(eval $$(call SetupTextFileProcessing, $1_$2_PREPROCESSED, \
+          SOURCE_FILES := $$($1_$2_INPUT_FILE), \
+          OUTPUT_FILE := $$($1_$2_PANDOC_INPUT), \
+          REPLACEMENTS := $$($1_REPLACEMENTS), \
+      ))
     else
-      $1_$2_CSS := $$(strip $$(call RelativePath, $$($1_CSS), $$($1_$2_TARGET_DIR)))
-      $1_$2_CSS_OPTION := --css '$$($1_$2_CSS)'
+      $1_$2_PANDOC_INPUT := $$($1_$2_INPUT_FILE)
     endif
-  endif
 
-  # This does not need to be included in VARDEPS since it's from the actual
-  # source file. Only run the shell if the recipe gets executed below.
-  $1_$2_OPTIONS_FROM_SRC = \
-      $$(shell $$(GREP) _pandoc-options_: $3/$2 | $$(CUT) -d : -f 2-)
+    ifneq ($$($1_POST_PROCESS), )
+      $1_$2_PANDOC_OUTPUT := $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_post.tmp
+    else
+      $1_$2_PANDOC_OUTPUT := $$($1_$2_OUTPUT_FILE)
+    endif
 
-  ifneq ($$($1_FILTER), )
-    $1_$2_OPTIONS := --filter $$($1_FILTER)
-  endif
+    ifneq ($$($1_CSS), )
+      ifneq ($$(findstring https:/, $$($1_CSS)), )
+        $1_$2_CSS_OPTION := --css '$$($1_CSS)'
+      else
+        $1_$2_CSS := $$(strip $$(call RelativePath, $$($1_CSS), $$($1_$2_TARGET_DIR)))
+        $1_$2_CSS_OPTION := --css '$$($1_$2_CSS)'
+      endif
+    endif
 
-  $1_$2_VARDEPS := $$($1_OPTIONS) $$($1_$2_OPTIONS) $$($1_CSS) \
-      $$($1_REPLACEMENTS) $$($1_POST_PROCESS)
-  $1_$2_VARDEPS_FILE := $$(call DependOnVariable, $1_$2_VARDEPS, \
-      $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER).vardeps)
+    # This does not need to be included in VARDEPS since it's from the actual
+    # source file. Only run the shell if the recipe gets executed below.
+    $1_$2_OPTIONS_FROM_SRC = \
+        $$(shell $$(GREP) _pandoc-options_: $3/$2 | $$(CUT) -d : -f 2-)
 
-  $$($1_$2_PANDOC_OUTPUT): $$($1_$2_PANDOC_INPUT) $$($1_$2_VARDEPS_FILE) $$($1_EXTRA_DEPS)
+    ifneq ($$($1_FILTER), )
+      $1_$2_OPTIONS := --filter $$($1_FILTER)
+    endif
+
+    $1_$2_VARDEPS := $$($1_OPTIONS) $$($1_$2_OPTIONS) $$($1_CSS) \
+        $$($1_REPLACEMENTS) $$($1_POST_PROCESS)
+    $1_$2_VARDEPS_FILE := $$(call DependOnVariable, $1_$2_VARDEPS, \
+        $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER).vardeps)
+
+    $$($1_$2_PANDOC_OUTPUT): $$($1_$2_PANDOC_INPUT) $$($1_$2_VARDEPS_FILE) $$($1_EXTRA_DEPS)
 	$$(call LogInfo, Converting $2 to $$($1_FORMAT))
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$(dir $$($1_$2_PANDOC_OUTPUT)))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER), \
@@ -96,17 +103,18 @@ define ProcessMarkdown
 	  fi
         endif
 
-  # If we have no post processing, PANDOC_OUTPUT is set to OUTPUT_FILE. Otherwise
-  # PANDOC_OUTPUT is a temporary file, and we must now create the real OUTPUT_FILE.
-  ifneq ($$($1_POST_PROCESS), )
-    $$($1_$2_OUTPUT_FILE): $$($1_$2_PANDOC_OUTPUT)
+    # If we have no post processing, PANDOC_OUTPUT is set to OUTPUT_FILE. Otherwise
+    # PANDOC_OUTPUT is a temporary file, and we must now create the real OUTPUT_FILE.
+    ifneq ($$($1_POST_PROCESS), )
+      $$($1_$2_OUTPUT_FILE): $$($1_$2_PANDOC_OUTPUT)
 	$$(call LogInfo, Post-processing markdown file $2)
 	$$(call MakeDir, $$(SUPPORT_OUTPUTDIR)/markdown $$($1_$2_TARGET_DIR))
 	$$(call ExecuteWithLog, $$(SUPPORT_OUTPUTDIR)/markdown/$$($1_$2_MARKER)_post, \
 	    ( $$($1_POST_PROCESS) $$($1_$2_PANDOC_OUTPUT) > $$($1_$2_OUTPUT_FILE) ) )
-  endif
+    endif
 
-  $1 += $$($1_$2_OUTPUT_FILE)
+    $1 += $$($1_$2_OUTPUT_FILE)
+  endif
 endef
 
 ################################################################################


### PR DESCRIPTION
For c, c++  and java source files, we have a built in system for letting more specific files override if there are multiple files with the same name found, by letting the first found file with a given name override any later found files with that name. This is typically used for OS specific variants or when needing to override a source file with a file from a custom source set. We would like to make it possible to do the same for markdown files used to generate man pages.

This will not have an immediate use i OpenJDK, but is needed for a custom override in proprietary code.

The change in Docs.gmk removes unnecessary extra loops so that SetupProcessMarkdown is called only once per module. This is necessary for the override mechanism to kick in for each module src set.

The logic in ProcessMarkdown.gmk is more or less copied from SetupNativeCompilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331886](https://bugs.openjdk.org/browse/JDK-8331886): Allow markdown src file overrides (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19132/head:pull/19132` \
`$ git checkout pull/19132`

Update a local copy of the PR: \
`$ git checkout pull/19132` \
`$ git pull https://git.openjdk.org/jdk.git pull/19132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19132`

View PR using the GUI difftool: \
`$ git pr show -t 19132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19132.diff">https://git.openjdk.org/jdk/pull/19132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19132#issuecomment-2099545590)