### PR TITLE
8144100: Incorrect case-sensitive equality in com.sun.net.httpserver.BasicAuthenticator

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -118,7 +118,7 @@ public abstract class BasicAuthenticator extends Authenticator {
             return new Authenticator.Retry (401);
         }
         int sp = auth.indexOf (' ');
-        if (sp == -1 || !auth.substring(0, sp).equals ("Basic")) {
+        if (sp == -1 || !auth.substring(0, sp).equalsIgnoreCase("Basic")) {
             return new Authenticator.Failure (401);
         }
         byte[] b = Base64.getDecoder().decode(auth.substring(sp+1));

--- a/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
+++ b/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
@@ -87,7 +87,7 @@ public class BasicAuthToken {
             String statusLine = reader.readLine();
             System.err.println(statusLine);
 
-            if (statusLine.startsWith("HTTP/1.1 401")) {
+            if (!statusLine.startsWith("HTTP/1.1 200")) {
                 throw new RuntimeException("Basic Authentication failed: case-insensitive token" +
                         " used to identify authentication scheme  sent by client parsed incorrectly");
             }

--- a/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
+++ b/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
@@ -97,7 +97,7 @@ public class BasicAuthToken {
 
 
     static class ServerAuthenticator extends BasicAuthenticator {
-        private static boolean invoked = false;
+        private static volatile boolean invoked = false;
 
         ServerAuthenticator(String realm) {
             super(realm);

--- a/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
+++ b/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
@@ -21,11 +21,11 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 8144100
  * @summary checking token sent by client should be done in case-insensitive manner
- * @run main/othervm BasicAuthToken
+ * @run main BasicAuthToken
  */
 
 import java.io.BufferedReader;
@@ -88,10 +88,11 @@ public class BasicAuthToken {
             System.err.println(statusLine);
 
             if (!statusLine.startsWith("HTTP/1.1 200")) {
-                throw new RuntimeException("Basic Authentication failed: case-insensitive token" +
-                        " used to identify authentication scheme  sent by client parsed incorrectly");
+                throw new RuntimeException("unexpected status line: " + statusLine);
             }
-            assert ServerAuthenticator.wasChecked() : "Authenticator was not correctly invoked";
+            if (!ServerAuthenticator.wasChecked()) {
+                throw new RuntimeException("Authenticator wasn't invoked");
+            }
         }
     }
 

--- a/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
+++ b/test/jdk/com/sun/net/httpserver/BasicAuthToken.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8144100
+ * @run main/othervm BasicAuthToken
+ * @summary checking token sent by client should be done in case-insensitive manner
+ */
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Base64;
+import com.sun.net.httpserver.Authenticator;
+import com.sun.net.httpserver.BasicAuthenticator;
+import com.sun.net.httpserver.HttpServer;
+
+public class BasicAuthToken {
+    static final String CRLF = "\r\n";
+    static final String someContext = "/test";
+
+    public static void main(String[] args) throws Exception {
+        HttpServer server = server();
+        try {
+            client(server.getAddress().getPort());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    static HttpServer server() throws Exception {
+        String realm = "someRealm";
+        ServerAuthenticator authenticator = new ServerAuthenticator(realm);
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext(someContext, exchange -> {
+            if (authenticator.authenticate(exchange) instanceof Authenticator.Failure) {
+                exchange.sendResponseHeaders(401, 0);
+                exchange.close();
+                return;
+            }
+            exchange.sendResponseHeaders(200, 1);
+            exchange.close();
+        }).setAuthenticator(authenticator);
+        server.start();
+        return server;
+    }
+
+    static void client(int port) throws Exception {
+        try (Socket socket = new Socket("localhost", port)) {
+            BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream()));
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            String credentials = "username:password";
+            String encodedCredentials = Base64.getEncoder().encodeToString(credentials.getBytes());
+            writer.write("GET " + someContext + " HTTP/1.1" + CRLF);
+            writer.write("Host: localhost:" + port + CRLF);
+            writer.write("User-Agent: Java/" + System.getProperty("java.version") + CRLF);
+            writer.write("Authorization: BAsIc " + encodedCredentials + CRLF);
+            writer.write(CRLF);
+            writer.flush();
+
+            System.err.println("Server response");
+            String statusLine = reader.readLine();
+            System.err.println(statusLine);
+
+            if (statusLine.startsWith("HTTP/1.1 401")) {
+                throw new RuntimeException("Basic Authentication failed: case-insensitive token" +
+                        " used to identify authentication scheme  sent by client parsed incorrectly");
+            }
+        }
+    }
+
+    static class ServerAuthenticator extends BasicAuthenticator {
+        ServerAuthenticator(String realm) {
+            super(realm);
+        }
+
+        @Override
+        public boolean checkCredentials(String username, String password) {
+            String validUsername = "username", validPassword = "password";
+            return username.equals(validUsername) && password.equals(validPassword);
+        }
+    }
+}


### PR DESCRIPTION
Passes Tier 1-3
Please review this change that aims to fix a bug when parsing the client's request.

RFC 9110 states 

> 11. HTTP Authentication 11.1. Authentication Scheme
HTTP provides a general framework for access control and authentication, via an extensible set of challenge-response authentication schemes, which can be used by a server to challenge a client request and by a client to provide authentication information. It uses a **case-insensitive** token to identify the authentication scheme: 
```auth-scheme = token```

But in `BasicAuthenticator#authenticate` it was done in a case sensitive manner

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8144100](https://bugs.openjdk.org/browse/JDK-8144100): Incorrect case-sensitive equality in com.sun.net.httpserver.BasicAuthenticator (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19133/head:pull/19133` \
`$ git checkout pull/19133`

Update a local copy of the PR: \
`$ git checkout pull/19133` \
`$ git pull https://git.openjdk.org/jdk.git pull/19133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19133`

View PR using the GUI difftool: \
`$ git pr show -t 19133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19133.diff">https://git.openjdk.org/jdk/pull/19133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19133#issuecomment-2102529075)