### PR TITLE
8331908: Simplify log code in vectorintrinsics.cpp

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -59,6 +59,17 @@ static bool check_vbox(const TypeInstPtr* vbox_type) {
 }
 #endif
 
+#define log_if_needed(...)        \
+  if (C->print_intrinsics()) {    \
+    tty->print_cr(__VA_ARGS__);   \
+  }
+
+#ifndef PRODUCT
+#define non_product_log_if_needed(...) log_if_needed(__VA_ARGS__)
+#else
+#define non_product_log_if_needed(...)
+#endif
+
 static bool is_vector_mask(ciKlass* klass) {
   return klass->is_subclass_of(ciEnv::current()->vector_VectorMask_klass());
 }
@@ -85,12 +96,8 @@ bool LibraryCallKit::arch_supports_vector_rotate(int opc, int num_elem, BasicTyp
     if ((mask_use_type & VecMaskUseLoad) != 0) {
       if (!Matcher::match_rule_supported_vector(Op_VectorLoadMask, num_elem, elem_bt) ||
           !Matcher::match_rule_supported_vector(Op_LoadVector, num_elem, T_BOOLEAN)) {
-      #ifndef PRODUCT
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** Rejected vector mask loading (%s,%s,%d) because architecture does not support it",
-                        NodeClassNames[Op_VectorLoadMask], type2name(elem_bt), num_elem);
-        }
-      #endif
+        non_product_log_if_needed("  ** Rejected vector mask loading (%s,%s,%d) because architecture does not support it",
+                                  NodeClassNames[Op_VectorLoadMask], type2name(elem_bt), num_elem);
         return false;
       }
     }
@@ -98,12 +105,8 @@ bool LibraryCallKit::arch_supports_vector_rotate(int opc, int num_elem, BasicTyp
     if ((mask_use_type & VecMaskUsePred) != 0) {
       if (!Matcher::has_predicated_vectors() ||
           !Matcher::match_rule_supported_vector_masked(opc, num_elem, elem_bt)) {
-      #ifndef PRODUCT
-        if (C->print_intrinsics()) {
-          tty->print_cr("Rejected vector mask predicate using (%s,%s,%d) because architecture does not support it",
-                        NodeClassNames[opc], type2name(elem_bt), num_elem);
-        }
-      #endif
+        non_product_log_if_needed("Rejected vector mask predicate using (%s,%s,%d) because architecture does not support it",
+                                  NodeClassNames[opc], type2name(elem_bt), num_elem);
         return false;
       }
     }
@@ -185,43 +188,27 @@ Node* GraphKit::vector_shift_count(Node* cnt, int shift_op, BasicType bt, int nu
 bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type, VectorMaskUseType mask_use_type, bool has_scalar_args) {
   // Check that the operation is valid.
   if (sopc <= 0) {
-#ifndef PRODUCT
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** Rejected intrinsification because no valid vector op could be extracted");
-    }
-#endif
+    non_product_log_if_needed("  ** Rejected intrinsification because no valid vector op could be extracted");
     return false;
   }
 
   if (VectorNode::is_vector_rotate(sopc)) {
     if(!arch_supports_vector_rotate(sopc, num_elem, type, mask_use_type, has_scalar_args)) {
-#ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected vector op (%s,%s,%d) because architecture does not support variable vector shifts",
-                      NodeClassNames[sopc], type2name(type), num_elem);
-      }
-#endif
+      non_product_log_if_needed("  ** Rejected vector op (%s,%s,%d) because architecture does not support variable vector shifts",
+                                NodeClassNames[sopc], type2name(type), num_elem);
       return false;
     }
   } else if (VectorNode::is_vector_integral_negate(sopc)) {
     if (!VectorNode::is_vector_integral_negate_supported(sopc, num_elem, type, false)) {
-#ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected vector op (%s,%s,%d) because architecture does not support integral vector negate",
-                      NodeClassNames[sopc], type2name(type), num_elem);
-      }
-#endif
+      non_product_log_if_needed("  ** Rejected vector op (%s,%s,%d) because architecture does not support integral vector negate",
+                                NodeClassNames[sopc], type2name(type), num_elem);
       return false;
     }
   } else {
     // Check that architecture supports this op-size-type combination.
     if (!Matcher::match_rule_supported_vector(sopc, num_elem, type)) {
-#ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected vector op (%s,%s,%d) because architecture does not support it",
-                      NodeClassNames[sopc], type2name(type), num_elem);
-      }
-#endif
+      non_product_log_if_needed("  ** Rejected vector op (%s,%s,%d) because architecture does not support it",
+                                NodeClassNames[sopc], type2name(type), num_elem);
       return false;
     } else {
       assert(Matcher::match_rule_supported(sopc), "must be supported");
@@ -230,23 +217,15 @@ bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type
 
   if (num_elem == 1) {
     if (mask_use_type != VecMaskNotUsed) {
-#ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected vector mask op (%s,%s,%d) because architecture does not support it",
-                      NodeClassNames[sopc], type2name(type), num_elem);
-      }
-#endif
+      non_product_log_if_needed("  ** Rejected vector mask op (%s,%s,%d) because architecture does not support it",
+                                NodeClassNames[sopc], type2name(type), num_elem);
       return false;
     }
 
     if (sopc != 0) {
       if (sopc != Op_LoadVector && sopc != Op_StoreVector) {
-#ifndef PRODUCT
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** Not a svml call or load/store vector op (%s,%s,%d)",
-                        NodeClassNames[sopc], type2name(type), num_elem);
-        }
-#endif
+        non_product_log_if_needed("  ** Not a svml call or load/store vector op (%s,%s,%d)",
+                                  NodeClassNames[sopc], type2name(type), num_elem);
         return false;
       }
     }
@@ -254,10 +233,8 @@ bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type
 
   if (!has_scalar_args && VectorNode::is_vector_shift(sopc) &&
       Matcher::supports_vector_variable_shifts() == false) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** Rejected vector op (%s,%s,%d) because architecture does not support variable vector shifts",
-                    NodeClassNames[sopc], type2name(type), num_elem);
-    }
+    log_if_needed("  ** Rejected vector op (%s,%s,%d) because architecture does not support variable vector shifts",
+                  NodeClassNames[sopc], type2name(type), num_elem);
     return false;
   }
 
@@ -267,12 +244,8 @@ bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type
   if ((mask_use_type & VecMaskUseLoad) != 0) {
     if (!Matcher::match_rule_supported_vector(Op_VectorLoadMask, num_elem, type) ||
         !Matcher::match_rule_supported_vector(Op_LoadVector, num_elem, T_BOOLEAN)) {
-    #ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected vector mask loading (%s,%s,%d) because architecture does not support it",
-                      NodeClassNames[Op_VectorLoadMask], type2name(type), num_elem);
-      }
-    #endif
+      non_product_log_if_needed("  ** Rejected vector mask loading (%s,%s,%d) because architecture does not support it",
+                                NodeClassNames[Op_VectorLoadMask], type2name(type), num_elem);
       return false;
     }
   }
@@ -283,12 +256,8 @@ bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type
   if ((mask_use_type & VecMaskUseStore) != 0) {
     if (!Matcher::match_rule_supported_vector(Op_VectorStoreMask, num_elem, type) ||
         !Matcher::match_rule_supported_vector(Op_StoreVector, num_elem, T_BOOLEAN)) {
-    #ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("Rejected vector mask storing (%s,%s,%d) because architecture does not support it",
-                      NodeClassNames[Op_VectorStoreMask], type2name(type), num_elem);
-      }
-    #endif
+      non_product_log_if_needed("Rejected vector mask storing (%s,%s,%d) because architecture does not support it",
+                                NodeClassNames[Op_VectorStoreMask], type2name(type), num_elem);
       return false;
     }
   }
@@ -305,12 +274,8 @@ bool LibraryCallKit::arch_supports_vector(int sopc, int num_elem, BasicType type
     is_supported |= Matcher::supports_vector_predicate_op_emulation(sopc, num_elem, type);
 
     if (!is_supported) {
-    #ifndef PRODUCT
-      if (C->print_intrinsics()) {
-        tty->print_cr("Rejected vector mask predicate using (%s,%s,%d) because architecture does not support it",
-                      NodeClassNames[sopc], type2name(type), num_elem);
-      }
-    #endif
+      non_product_log_if_needed("Rejected vector mask predicate using (%s,%s,%d) because architecture does not support it",
+                                NodeClassNames[sopc], type2name(type), num_elem);
       return false;
     }
   }
@@ -360,27 +325,21 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
 
   if (opr == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       !opr->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -390,23 +349,17 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   bool is_masked_op = vmask_type != TypePtr::NULL_PTR;
   if (is_masked_op) {
     if (mask_klass == nullptr || mask_klass->const_oop() == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
-      }
+      log_if_needed("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
       return false; // not enough info for intrinsification
     }
 
     if (!is_klass_initialized(mask_klass)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** mask klass argument not initialized");
-      }
+      log_if_needed("  ** mask klass argument not initialized");
       return false;
     }
 
     if (vmask_type->maybe_null()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** null mask values are not allowed for masked op");
-      }
+      log_if_needed("  ** null mask values are not allowed for masked op");
       return false;
     }
   }
@@ -416,17 +369,13 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   int opc = VectorSupport::vop2ideal(opr->get_con(), elem_bt);
   int sopc = VectorNode::opcode(opc, elem_bt);
   if ((opc != Op_CallLeafVector) && (sopc == 0)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** operation not supported: opc=%s bt=%s", NodeClassNames[opc], type2name(elem_bt));
-    }
+    log_if_needed("  ** operation not supported: opc=%s bt=%s", NodeClassNames[opc], type2name(elem_bt));
     return false; // operation not supported
   }
   if (num_elem == 1) {
     if (opc != Op_CallLeafVector || elem_bt != T_DOUBLE) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not a svml call: arity=%d opc=%d vlen=%d etype=%s",
+      log_if_needed("  ** not a svml call: arity=%d opc=%d vlen=%d etype=%s",
                       n, opc, num_elem, type2name(elem_bt));
-      }
       return false;
     }
   }
@@ -439,22 +388,16 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
 
   if (opc == Op_CallLeafVector) {
     if (!UseVectorStubs) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** vector stubs support is disabled");
-      }
+      log_if_needed("  ** vector stubs support is disabled");
       return false;
     }
     if (!Matcher::supports_vector_calling_convention()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** no vector calling conventions supported");
-      }
+      log_if_needed("  ** no vector calling conventions supported");
       return false;
     }
     if (!Matcher::vector_size_supported(elem_bt, num_elem)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** vector size (vlen=%d, etype=%s) is not supported",
+      log_if_needed("  ** vector size (vlen=%d, etype=%s) is not supported",
                       num_elem, type2name(elem_bt));
-      }
       return false;
     }
   }
@@ -463,21 +406,17 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   VectorMaskUseType mask_use_type = is_vector_mask(vbox_klass) ? VecMaskUseAll
                                       : is_masked_op ? VecMaskUseLoad : VecMaskNotUsed;
   if ((sopc != 0) && !arch_supports_vector(sopc, num_elem, elem_bt, mask_use_type)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d opc=%d vlen=%d etype=%s ismask=%d is_masked_op=%d",
+    log_if_needed("  ** not supported: arity=%d opc=%d vlen=%d etype=%s ismask=%d is_masked_op=%d",
                     n, sopc, num_elem, type2name(elem_bt),
                     is_vector_mask(vbox_klass) ? 1 : 0, is_masked_op ? 1 : 0);
-    }
     return false; // not supported
   }
 
   // Return true if current platform has implemented the masked operation with predicate feature.
   bool use_predicate = is_masked_op && sopc != 0 && arch_supports_vector(sopc, num_elem, elem_bt, VecMaskUsePred);
   if (is_masked_op && !use_predicate && !arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d opc=%d vlen=%d etype=%s ismask=0 is_masked_op=1",
+    log_if_needed("  ** not supported: arity=%d opc=%d vlen=%d etype=%s ismask=0 is_masked_op=1",
                     n, sopc, num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
@@ -486,10 +425,8 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     case 3: {
       opd3 = unbox_vector(argument(7), vbox_type, elem_bt, num_elem);
       if (opd3 == nullptr) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** unbox failed v3=%s",
+        log_if_needed("  ** unbox failed v3=%s",
                         NodeClassNames[argument(7)->Opcode()]);
-        }
         return false;
       }
       // fall-through
@@ -497,10 +434,8 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     case 2: {
       opd2 = unbox_vector(argument(6), vbox_type, elem_bt, num_elem);
       if (opd2 == nullptr) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** unbox failed v2=%s",
+        log_if_needed("  ** unbox failed v2=%s",
                         NodeClassNames[argument(6)->Opcode()]);
-        }
         return false;
       }
       // fall-through
@@ -508,10 +443,8 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     case 1: {
       opd1 = unbox_vector(argument(5), vbox_type, elem_bt, num_elem);
       if (opd1 == nullptr) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** unbox failed v1=%s",
+        log_if_needed("  ** unbox failed v1=%s",
                         NodeClassNames[argument(5)->Opcode()]);
-        }
         return false;
       }
       break;
@@ -526,10 +459,8 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
     mask = unbox_vector(argument(n + 5), mbox_type, elem_bt, num_elem);
     if (mask == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed mask=%s",
+      log_if_needed("  ** unbox failed mask=%s",
                       NodeClassNames[argument(n + 5)->Opcode()]);
-      }
       return false;
     }
   }
@@ -539,12 +470,10 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
     assert(UseVectorStubs, "sanity");
     operation = gen_call_to_svml(opr->get_con(), elem_bt, num_elem, opd1, opd2);
     if (operation == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** svml call failed for %s_%s_%d",
+      log_if_needed("  ** svml call failed for %s_%s_%d",
                          (elem_bt == T_FLOAT)?"float":"double",
                          VectorSupport::svmlname[opr->get_con() - VectorSupport::VECTOR_OP_SVML_START],
                          num_elem * type2aelembytes(elem_bt));
-      }
       return false;
      }
   } else {
@@ -599,9 +528,7 @@ bool LibraryCallKit::inline_vector_shuffle_iota() {
   }
 
   if (!is_klass_initialized(shuffle_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -708,9 +635,7 @@ bool LibraryCallKit::inline_vector_mask_operation() {
   }
 
   if (!is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -720,10 +645,8 @@ bool LibraryCallKit::inline_vector_mask_operation() {
 
   int mopc = VectorSupport::vop2ideal(oper->get_con(), elem_bt);
   if (!arch_supports_vector(mopc, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s",
+    log_if_needed("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s",
                     mopc, num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
 
@@ -732,10 +655,8 @@ bool LibraryCallKit::inline_vector_mask_operation() {
   const TypeInstPtr* mask_box_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
   Node* mask_vec = unbox_vector(mask, mask_box_type, elem_bt, num_elem, true);
   if (mask_vec == nullptr) {
-    if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed mask=%s",
+    log_if_needed("  ** unbox failed mask=%s",
                       NodeClassNames[argument(4)->Opcode()]);
-    }
     return false;
   }
 
@@ -774,9 +695,7 @@ bool LibraryCallKit::inline_vector_shuffle_to_vector() {
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(shuffle_klass) || !is_klass_initialized(vector_klass) ) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -791,10 +710,8 @@ bool LibraryCallKit::inline_vector_shuffle_to_vector() {
   int cast_vopc = VectorCastNode::opcode(-1, T_BYTE); // from shuffle of type T_BYTE
   // Make sure that cast is implemented to particular type/size combination.
   if (!arch_supports_vector(cast_vopc, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s",
+    log_if_needed("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s",
         cast_vopc, num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
@@ -838,27 +755,21 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
   if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || mode == nullptr ||
       bits_type == nullptr || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr ||
       !vlen->is_con() || !mode->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s bitwise=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s bitwise=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(5)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -872,12 +783,10 @@ bool LibraryCallKit::inline_vector_frombits_coerced() {
   int opc = bcast_mode == VectorSupport::MODE_BITS_COERCED_LONG_TO_MASK ? Op_VectorLongToMask : Op_Replicate;
 
   if (!arch_supports_vector(opc, num_elem, elem_bt, checkFlags, true /*has_scalar_args*/)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=0 op=broadcast vlen=%d etype=%s ismask=%d bcast_mode=%d",
+    log_if_needed("  ** not supported: arity=0 op=broadcast vlen=%d etype=%s ismask=%d bcast_mode=%d",
                     num_elem, type2name(elem_bt),
                     is_mask ? 1 : 0,
                     bcast_mode);
-    }
     return false; // not supported
   }
 
@@ -973,27 +882,21 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr || !from_ms->is_con() ||
       vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s from_ms=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(6)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -1001,11 +904,9 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
 
   // TODO When mask usage is supported, VecMaskNotUsed needs to be VecMaskUseLoad.
   if (!arch_supports_vector(is_store ? Op_StoreVector : Op_LoadVector, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s ismask=no",
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s ismask=no",
                     is_store, is_store ? "store" : "load",
                     num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
 
@@ -1046,18 +947,14 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
                       arr_type->elem()->array_element_basic_type() != elem_bt);
   BasicType mem_elem_bt = mismatched_ms ? arr_type->elem()->array_element_basic_type() : elem_bt;
   if (!is_java_primitive(mem_elem_bt)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** non-primitive array element type");
-    }
+    log_if_needed("  ** non-primitive array element type");
     return false;
   }
   int mem_num_elem = mismatched_ms ? (num_elem * type2aelembytes(elem_bt)) / type2aelembytes(mem_elem_bt) : num_elem;
   if (arr_type != nullptr && !is_mask && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
                     is_store, is_store ? "store" : "load",
                     num_elem, type2name(elem_bt), type2name(arr_type->elem()->array_element_basic_type()));
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1068,11 +965,9 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
     if (is_store) {
       if (!arch_supports_vector(Op_StoreVector, num_elem, elem_bt, VecMaskNotUsed)
           || !arch_supports_vector(Op_VectorReinterpret, mem_num_elem, mem_elem_bt, VecMaskNotUsed)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
+        log_if_needed("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
                         is_store, "store",
                         num_elem, type2name(elem_bt));
-        }
         set_map(old_map);
         set_sp(old_sp);
         return false; // not supported
@@ -1080,11 +975,9 @@ bool LibraryCallKit::inline_vector_mem_operation(bool is_store) {
     } else {
       if (!arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed)
           || !arch_supports_vector(Op_VectorReinterpret, num_elem, elem_bt, VecMaskNotUsed)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
+        log_if_needed("  ** not supported: arity=%d op=%s vlen=%d*8 etype=%s/8 ismask=no",
                         is_store, "load",
                         mem_num_elem, type2name(mem_elem_bt));
-        }
         set_map(old_map);
         set_sp(old_sp);
         return false; // not supported
@@ -1198,35 +1091,27 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   if (vector_klass == nullptr || mask_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr || from_ms == nullptr ||
       elem_klass->const_oop() == nullptr || !vlen->is_con() || !from_ms->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s from_ms=%s",
+    log_if_needed("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s from_ms=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(7)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   if (!is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** mask klass argument not initialized");
-    }
+    log_if_needed("  ** mask klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -1248,11 +1133,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   BIG_ENDIAN_ONLY(if (mismatched_ms) return false;)
   // If there is no consistency between array and vector element types, it must be special byte array case
   if (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, mismatched_ms)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s",
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s",
                     is_store, is_store ? "storeMasked" : "loadMasked",
                     num_elem, type2name(elem_bt), type2name(arr_type->elem()->array_element_basic_type()));
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1274,10 +1157,8 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
       // Masked vector load with IOOBE always uses the predicated load.
       const TypeInt* offset_in_range = gvn().type(argument(9))->isa_int();
       if (!offset_in_range->is_con()) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** missing constant: offsetInRange=%s",
+        log_if_needed("  ** missing constant: offsetInRange=%s",
                         NodeClassNames[argument(8)->Opcode()]);
-        }
         set_map(old_map);
         set_sp(old_sp);
         return false;
@@ -1286,11 +1167,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
     }
 
     if (needs_predicate) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: op=%s vlen=%d etype=%s mismatched_ms=%d",
+      log_if_needed("  ** not supported: op=%s vlen=%d etype=%s mismatched_ms=%d",
                       is_store ? "storeMasked" : "loadMasked",
                       num_elem, type2name(elem_bt), mismatched_ms ? 1 : 0);
-      }
       set_map(old_map);
       set_sp(old_sp);
       return false;
@@ -1301,10 +1180,8 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   // the normal vector load and blend operations are supported by backend.
   if (!supports_predicate && (!arch_supports_vector(Op_LoadVector, mem_num_elem, mem_elem_bt, VecMaskNotUsed) ||
       !arch_supports_vector(Op_VectorBlend, mem_num_elem, mem_elem_bt, VecMaskUseLoad))) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: op=loadMasked vlen=%d etype=%s mismatched_ms=%d",
+    log_if_needed("  ** not supported: op=loadMasked vlen=%d etype=%s mismatched_ms=%d",
                     num_elem, type2name(elem_bt), mismatched_ms ? 1 : 0);
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1314,11 +1191,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   // with byte type is supported by backend.
   if (mismatched_ms) {
     if (!arch_supports_vector(Op_VectorReinterpret, mem_num_elem, T_BYTE, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s mismatched_ms=1",
+      log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s mismatched_ms=1",
                       is_store, is_store ? "storeMasked" : "loadMasked",
                       num_elem, type2name(elem_bt));
-      }
       set_map(old_map);
       set_sp(old_sp);
       return false;
@@ -1328,11 +1203,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   // Since it needs to unbox the mask, we need to double check that the related load operations
   // for mask are supported by backend.
   if (!arch_supports_vector(Op_LoadVector, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s",
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s",
                       is_store, is_store ? "storeMasked" : "loadMasked",
                       num_elem, type2name(elem_bt));
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1352,11 +1225,9 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
 
   Node* mask = unbox_vector(is_store ? argument(9) : argument(8), mbox_type, elem_bt, num_elem);
   if (mask == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** unbox failed mask=%s",
+    log_if_needed("  ** unbox failed mask=%s",
                     is_store ? NodeClassNames[argument(9)->Opcode()]
                              : NodeClassNames[argument(8)->Opcode()]);
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1365,10 +1236,8 @@ bool LibraryCallKit::inline_vector_mem_masked_operation(bool is_store) {
   if (is_store) {
     Node* val = unbox_vector(argument(8), vbox_type, elem_bt, num_elem);
     if (val == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed vector=%s",
+      log_if_needed("  ** unbox failed vector=%s",
                       NodeClassNames[argument(8)->Opcode()]);
-      }
       set_map(old_map);
       set_sp(old_sp);
       return false; // operand unboxing failed
@@ -1460,28 +1329,22 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
 
   if (vector_klass == nullptr || elem_klass == nullptr || vector_idx_klass == nullptr || vlen == nullptr ||
       vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || vector_idx_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s viclass=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s viclass=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   if (!is_klass_initialized(vector_klass) || !is_klass_initialized(vector_idx_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -1492,44 +1355,34 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
   bool is_masked_op = vmask_type != TypePtr::NULL_PTR;
   if (is_masked_op) {
     if (mask_klass == nullptr || mask_klass->const_oop() == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** missing constant: maskclass=%s", NodeClassNames[argument(1)->Opcode()]);
-      }
+      log_if_needed("  ** missing constant: maskclass=%s", NodeClassNames[argument(1)->Opcode()]);
       return false; // not enough info for intrinsification
     }
 
     if (!is_klass_initialized(mask_klass)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** mask klass argument not initialized");
-      }
+      log_if_needed("  ** mask klass argument not initialized");
       return false;
     }
 
     if (vmask_type->maybe_null()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** null mask values are not allowed for masked op");
-      }
+      log_if_needed("  ** null mask values are not allowed for masked op");
       return false;
     }
 
     // Check whether the predicated gather/scatter node is supported by architecture.
     VectorMaskUseType mask = (VectorMaskUseType) (VecMaskUseLoad | VecMaskUsePred);
     if (!arch_supports_vector(is_scatter ? Op_StoreVectorScatterMasked : Op_LoadVectorGatherMasked, num_elem, elem_bt, mask)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s is_masked_op=1",
+      log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s is_masked_op=1",
                       is_scatter, is_scatter ? "scatterMasked" : "gatherMasked",
                       num_elem, type2name(elem_bt));
-      }
       return false; // not supported
     }
   } else {
     // Check whether the normal gather/scatter node is supported for non-masked operation.
     if (!arch_supports_vector(is_scatter ? Op_StoreVectorScatter : Op_LoadVectorGather, num_elem, elem_bt, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s is_masked_op=0",
+      log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s is_masked_op=0",
                       is_scatter, is_scatter ? "scatter" : "gather",
                       num_elem, type2name(elem_bt));
-      }
       return false; // not supported
     }
   }
@@ -1537,11 +1390,9 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
   // Check that the vector holding indices is supported by architecture
   // For sub-word gathers expander receive index array.
   if (!is_subword_type(elem_bt) && !arch_supports_vector(Op_LoadVector, num_elem, T_INT, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=%d op=%s/loadindex vlen=%d etype=int is_masked_op=%d",
+      log_if_needed("  ** not supported: arity=%d op=%s/loadindex vlen=%d etype=int is_masked_op=%d",
                       is_scatter, is_scatter ? "scatter" : "gather",
                       num_elem, is_masked_op ? 1 : 0);
-      }
       return false; // not supported
   }
 
@@ -1559,11 +1410,9 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
 
   // The array must be consistent with vector type
   if (arr_type == nullptr || (arr_type != nullptr && !elem_consistent_with_arr(elem_bt, arr_type, false))) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
+    log_if_needed("  ** not supported: arity=%d op=%s vlen=%d etype=%s atype=%s ismask=no",
                     is_scatter, is_scatter ? "scatter" : "gather",
                     num_elem, type2name(elem_bt), type2name(arr_type->elem()->array_element_basic_type()));
-    }
     set_map(old_map);
     set_sp(old_sp);
     return false;
@@ -1595,11 +1444,9 @@ bool LibraryCallKit::inline_vector_gather_scatter(bool is_scatter) {
     const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
     mask = unbox_vector(is_scatter ? argument(10) : argument(9), mbox_type, elem_bt, num_elem);
     if (mask == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed mask=%s",
+      log_if_needed("  ** unbox failed mask=%s",
                     is_scatter ? NodeClassNames[argument(10)->Opcode()]
                                : NodeClassNames[argument(9)->Opcode()]);
-      }
       set_map(old_map);
       set_sp(old_sp);
       return false;
@@ -1669,26 +1516,20 @@ bool LibraryCallKit::inline_vector_reduction() {
 
   if (opr == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       !opr->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -1696,23 +1537,17 @@ bool LibraryCallKit::inline_vector_reduction() {
   bool is_masked_op = vmask_type != TypePtr::NULL_PTR;
   if (is_masked_op) {
     if (mask_klass == nullptr || mask_klass->const_oop() == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
-      }
+      log_if_needed("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
       return false; // not enough info for intrinsification
     }
 
     if (!is_klass_initialized(mask_klass)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** mask klass argument not initialized");
-      }
+      log_if_needed("  ** mask klass argument not initialized");
       return false;
     }
 
     if (vmask_type->maybe_null()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** null mask values are not allowed for masked op");
-      }
+      log_if_needed("  ** null mask values are not allowed for masked op");
       return false;
     }
   }
@@ -1724,20 +1559,16 @@ bool LibraryCallKit::inline_vector_reduction() {
 
   // When using mask, mask use type needs to be VecMaskUseLoad.
   if (!arch_supports_vector(sopc, num_elem, elem_bt, is_masked_op ? VecMaskUseLoad : VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=%d/reduce vlen=%d etype=%s is_masked_op=%d",
+    log_if_needed("  ** not supported: arity=1 op=%d/reduce vlen=%d etype=%s is_masked_op=%d",
                     sopc, num_elem, type2name(elem_bt), is_masked_op ? 1 : 0);
-    }
     return false;
   }
 
   // Return true if current platform has implemented the masked operation with predicate feature.
   bool use_predicate = is_masked_op && arch_supports_vector(sopc, num_elem, elem_bt, VecMaskUsePred);
   if (is_masked_op && !use_predicate && !arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=%d/reduce vlen=%d etype=%s is_masked_op=1",
+    log_if_needed("  ** not supported: arity=1 op=%d/reduce vlen=%d etype=%s is_masked_op=1",
                     sopc, num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
@@ -1756,10 +1587,8 @@ bool LibraryCallKit::inline_vector_reduction() {
     const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
     mask = unbox_vector(argument(6), mbox_type, elem_bt, num_elem);
     if (mask == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed mask=%s",
+      log_if_needed("  ** unbox failed mask=%s",
                       NodeClassNames[argument(6)->Opcode()]);
-      }
       return false;
     }
   }
@@ -1822,26 +1651,20 @@ bool LibraryCallKit::inline_vector_test() {
 
   if (cond == nullptr || vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       !cond->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: cond=%s vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: cond=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -1851,11 +1674,9 @@ bool LibraryCallKit::inline_vector_test() {
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
 
   if (!arch_supports_vector(Op_VectorTest, num_elem, elem_bt, is_vector_mask(vbox_klass) ? VecMaskUseLoad : VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=2 op=test/%d vlen=%d etype=%s ismask=%d",
+    log_if_needed("  ** not supported: arity=2 op=test/%d vlen=%d etype=%s ismask=%d",
                     cond->get_con(), num_elem, type2name(elem_bt),
                     is_vector_mask(vbox_klass));
-    }
     return false;
   }
 
@@ -1900,26 +1721,20 @@ bool LibraryCallKit::inline_vector_blend() {
   }
   if (mask_klass->const_oop() == nullptr || vector_klass->const_oop() == nullptr ||
       elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: vclass=%s mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass) || !is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -1927,10 +1742,8 @@ bool LibraryCallKit::inline_vector_blend() {
   int num_elem = vlen->get_con();
 
   if (!arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=2 op=blend vlen=%d etype=%s ismask=useload",
+    log_if_needed("  ** not supported: arity=2 op=blend vlen=%d etype=%s ismask=useload",
                     num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
   ciKlass* vbox_klass = vector_klass->const_oop()->as_instance()->java_lang_Class_klass();
@@ -1974,27 +1787,21 @@ bool LibraryCallKit::inline_vector_compare() {
   }
   if (!cond->is_con() || vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr ||
       elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: cond=%s vclass=%s mclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: cond=%s vclass=%s mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass) || !is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -2004,19 +1811,15 @@ bool LibraryCallKit::inline_vector_compare() {
 
   if ((cond->get_con() & BoolTest::unsigned_compare) != 0) {
     if (!Matcher::supports_vector_comparison_unsigned(num_elem, elem_bt)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: unsigned comparison op=comp/%d vlen=%d etype=%s ismask=usestore",
+      log_if_needed("  ** not supported: unsigned comparison op=comp/%d vlen=%d etype=%s ismask=usestore",
                       cond->get_con() & (BoolTest::unsigned_compare - 1), num_elem, type2name(elem_bt));
-      }
       return false;
     }
   }
 
   if (!arch_supports_vector(Op_VectorMaskCmp, num_elem, elem_bt, VecMaskUseStore)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore",
+    log_if_needed("  ** not supported: arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore",
                     cond->get_con(), num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
@@ -2032,19 +1835,15 @@ bool LibraryCallKit::inline_vector_compare() {
   bool is_masked_op = argument(7)->bottom_type() != TypePtr::NULL_PTR;
   Node* mask = is_masked_op ? unbox_vector(argument(7), mbox_type, elem_bt, num_elem) : nullptr;
   if (is_masked_op && mask == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: mask = null arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore is_masked_op=1",
+    log_if_needed("  ** not supported: mask = null arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore is_masked_op=1",
                     cond->get_con(), num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
   bool use_predicate = is_masked_op && arch_supports_vector(Op_VectorMaskCmp, num_elem, elem_bt, VecMaskUsePred);
   if (is_masked_op && !use_predicate && !arch_supports_vector(Op_AndV, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore is_masked_op=1",
+    log_if_needed("  ** not supported: arity=2 op=comp/%d vlen=%d etype=%s ismask=usestore is_masked_op=1",
                     cond->get_con(), num_elem, type2name(elem_bt));
-    }
     return false;
   }
 
@@ -2097,27 +1896,21 @@ bool LibraryCallKit::inline_vector_rearrange() {
       vector_klass->const_oop()  == nullptr ||
       elem_klass->const_oop()    == nullptr ||
       !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s sclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: vclass=%s sclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)  ||
       !is_klass_initialized(shuffle_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -2125,10 +1918,8 @@ bool LibraryCallKit::inline_vector_rearrange() {
   int num_elem = vlen->get_con();
 
   if (!arch_supports_vector(Op_VectorLoadShuffle, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=0 op=load/shuffle vlen=%d etype=%s ismask=no",
+    log_if_needed("  ** not supported: arity=0 op=load/shuffle vlen=%d etype=%s ismask=no",
                     num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
 
@@ -2138,9 +1929,7 @@ bool LibraryCallKit::inline_vector_rearrange() {
       (mask_klass == nullptr ||
        mask_klass->const_oop() == nullptr ||
        !is_klass_initialized(mask_klass))) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** mask_klass argument not initialized");
-    }
+    log_if_needed("  ** mask_klass argument not initialized");
   }
   VectorMaskUseType checkFlags = (VectorMaskUseType)(is_masked_op ? (VecMaskUseLoad | VecMaskUsePred) : VecMaskNotUsed);
   if (!arch_supports_vector(Op_VectorRearrange, num_elem, elem_bt, checkFlags)) {
@@ -2149,10 +1938,8 @@ bool LibraryCallKit::inline_vector_rearrange() {
        (!arch_supports_vector(Op_VectorRearrange, num_elem, elem_bt, VecMaskNotUsed) ||
         !arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad)     ||
         !arch_supports_vector(Op_Replicate, num_elem, elem_bt, VecMaskNotUsed))) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=2 op=shuffle/rearrange vlen=%d etype=%s ismask=no",
+      log_if_needed("  ** not supported: arity=2 op=shuffle/rearrange vlen=%d etype=%s ismask=no",
                       num_elem, type2name(elem_bt));
-      }
       return false; // not supported
     }
   }
@@ -2175,10 +1962,8 @@ bool LibraryCallKit::inline_vector_rearrange() {
     const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
     mask = unbox_vector(argument(7), mbox_type, elem_bt, num_elem);
     if (mask == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=3 op=shuffle/rearrange vlen=%d etype=%s ismask=useload is_masked_op=1",
+      log_if_needed("  ** not supported: arity=3 op=shuffle/rearrange vlen=%d etype=%s ismask=useload is_masked_op=1",
                       num_elem, type2name(elem_bt));
-      }
       return false;
     }
   }
@@ -2280,19 +2065,15 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
     return false; // dead code
   }
   if (!opr->is_con() || vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: opr=%s vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -2300,32 +2081,24 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
   bool is_masked_op = vmask_type != TypePtr::NULL_PTR;
   if (is_masked_op) {
     if (mask_klass == nullptr || mask_klass->const_oop() == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
-      }
+      log_if_needed("  ** missing constant: maskclass=%s", NodeClassNames[argument(2)->Opcode()]);
       return false; // not enough info for intrinsification
     }
 
     if (!is_klass_initialized(mask_klass)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** mask klass argument not initialized");
-      }
+      log_if_needed("  ** mask klass argument not initialized");
       return false;
     }
 
     if (vmask_type->maybe_null()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** null mask values are not allowed for masked op");
-      }
+      log_if_needed("  ** null mask values are not allowed for masked op");
       return false;
     }
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -2337,17 +2110,13 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
   bool is_rotate = VectorNode::is_rotate_opcode(opc);
 
   if (opc == 0 || (!is_shift && !is_rotate)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** operation not supported: op=%d bt=%s", opr->get_con(), type2name(elem_bt));
-    }
+    log_if_needed("  ** operation not supported: op=%d bt=%s", opr->get_con(), type2name(elem_bt));
     return false; // operation not supported
   }
 
   int sopc = VectorNode::opcode(opc, elem_bt);
   if (sopc == 0) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** operation not supported: opc=%s bt=%s", NodeClassNames[opc], type2name(elem_bt));
-    }
+    log_if_needed("  ** operation not supported: opc=%s bt=%s", NodeClassNames[opc], type2name(elem_bt));
     return false; // operation not supported
   }
 
@@ -2370,10 +2139,8 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
         (!arch_supports_vector(sopc, num_elem, elem_bt, VecMaskNotUsed, has_scalar_args) ||
          !arch_supports_vector(Op_VectorBlend, num_elem, elem_bt, VecMaskUseLoad))) {
 
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=0 op=int/%d vlen=%d etype=%s is_masked_op=%d",
+      log_if_needed("  ** not supported: arity=0 op=int/%d vlen=%d etype=%s is_masked_op=%d",
                       sopc, num_elem, type2name(elem_bt), is_masked_op ? 1 : 0);
-      }
       return false; // not supported
     }
   }
@@ -2404,9 +2171,7 @@ bool LibraryCallKit::inline_vector_broadcast_int() {
     const TypeInstPtr* mbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, mbox_klass);
     mask = unbox_vector(argument(7), mbox_type, elem_bt, num_elem);
     if (mask == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed mask=%s", NodeClassNames[argument(7)->Opcode()]);
-      }
+      log_if_needed("  ** unbox failed mask=%s", NodeClassNames[argument(7)->Opcode()]);
       return false;
     }
   }
@@ -2456,8 +2221,7 @@ bool LibraryCallKit::inline_vector_convert() {
   if (!opr->is_con() ||
       vector_klass_from->const_oop() == nullptr || elem_klass_from->const_oop() == nullptr || !vlen_from->is_con() ||
       vector_klass_to->const_oop() == nullptr || elem_klass_to->const_oop() == nullptr || !vlen_to->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: opr=%s vclass_from=%s etype_from=%s vlen_from=%s vclass_to=%s etype_to=%s vlen_to=%s",
+    log_if_needed("  ** missing constant: opr=%s vclass_from=%s etype_from=%s vlen_from=%s vclass_to=%s etype_to=%s vlen_to=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
@@ -2465,13 +2229,10 @@ bool LibraryCallKit::inline_vector_convert() {
                     NodeClassNames[argument(4)->Opcode()],
                     NodeClassNames[argument(5)->Opcode()],
                     NodeClassNames[argument(6)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass_from) || !is_klass_initialized(vector_klass_to)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
@@ -2508,11 +2269,9 @@ bool LibraryCallKit::inline_vector_convert() {
                             num_elem_from,
                             elem_bt_from,
                             is_mask ? VecMaskUseAll : VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=%s/1 vlen1=%d etype1=%s ismask=%d",
+    log_if_needed("  ** not supported: arity=1 op=%s/1 vlen1=%d etype1=%s ismask=%d",
                     is_cast ? "cast" : "reinterpret",
                     num_elem_from, type2name(elem_bt_from), is_mask);
-    }
     return false;
   }
 
@@ -2521,11 +2280,9 @@ bool LibraryCallKit::inline_vector_convert() {
                             num_elem_to,
                             elem_bt_to,
                             is_mask ? VecMaskUseAll : VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=%s/2 vlen2=%d etype2=%s ismask=%d",
+    log_if_needed("  ** not supported: arity=1 op=%s/2 vlen2=%d etype2=%s ismask=%d",
                     is_cast ? "cast" : "reinterpret",
                     num_elem_to, type2name(elem_bt_to), is_mask);
-    }
     return false;
   }
 
@@ -2565,10 +2322,8 @@ bool LibraryCallKit::inline_vector_convert() {
     // Make sure that vector cast is implemented to particular type/size combination if it is
     // not a mask casting.
     if (!is_mask && !arch_supports_vector(cast_vopc, num_elem_to, elem_bt_to, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s ismask=%d",
+      log_if_needed("  ** not supported: arity=1 op=cast#%d/3 vlen2=%d etype2=%s ismask=%d",
                       cast_vopc, num_elem_to, type2name(elem_bt_to), is_mask);
-      }
       return false;
     }
 
@@ -2580,11 +2335,9 @@ bool LibraryCallKit::inline_vector_convert() {
       // It is possible that arch does not support this intermediate vector size
       // TODO More complex logic required here to handle this corner case for the sizes.
       if (!arch_supports_vector(cast_vopc, num_elem_for_cast, elem_bt_to, VecMaskNotUsed)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** not supported: arity=1 op=cast#%d/4 vlen1=%d etype2=%s ismask=%d",
+        log_if_needed("  ** not supported: arity=1 op=cast#%d/4 vlen1=%d etype2=%s ismask=%d",
                         cast_vopc,
                         num_elem_for_cast, type2name(elem_bt_to), is_mask);
-        }
         return false;
       }
 
@@ -2602,10 +2355,8 @@ bool LibraryCallKit::inline_vector_convert() {
                                 num_elem_for_resize,
                                 elem_bt_from,
                                 VecMaskNotUsed)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** not supported: arity=1 op=cast/5 vlen2=%d etype1=%s ismask=%d",
+        log_if_needed("  ** not supported: arity=1 op=cast/5 vlen2=%d etype1=%s ismask=%d",
                         num_elem_for_resize, type2name(elem_bt_from), is_mask);
-        }
         return false;
       }
 
@@ -2616,10 +2367,8 @@ bool LibraryCallKit::inline_vector_convert() {
       if (is_mask) {
         // Make sure that cast for vector mask is implemented to particular type/size combination.
         if (!arch_supports_vector(Op_VectorMaskCast, num_elem_to, elem_bt_to, VecMaskNotUsed)) {
-          if (C->print_intrinsics()) {
-            tty->print_cr("  ** not supported: arity=1 op=maskcast vlen2=%d etype2=%s ismask=%d",
+          log_if_needed("  ** not supported: arity=1 op=maskcast vlen2=%d etype2=%s ismask=%d",
                           num_elem_to, type2name(elem_bt_to), is_mask);
-          }
           return false;
         }
         op = gvn().transform(new VectorMaskCastNode(op, dst_type));
@@ -2657,35 +2406,27 @@ bool LibraryCallKit::inline_vector_insert() {
     return false; // dead code
   }
   if (vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con() || !idx->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s idx=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s idx=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
   int num_elem = vlen->get_con();
   if (!arch_supports_vector(Op_VectorInsert, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: arity=1 op=insert vlen=%d etype=%s ismask=no",
+    log_if_needed("  ** not supported: arity=1 op=insert vlen=%d etype=%s ismask=no",
                     num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
 
@@ -2751,25 +2492,19 @@ bool LibraryCallKit::inline_vector_extract() {
     return false; // dead code
   }
   if (vector_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
   BasicType elem_bt = elem_type->basic_type();
@@ -2807,26 +2542,20 @@ bool LibraryCallKit::inline_vector_extract() {
       opd = gvn().transform(new URShiftLNode(opd, pos));
       opd = gvn().transform(new AndLNode(opd, gvn().makecon(TypeLong::ONE)));
     } else {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** Rejected mask extraction because architecture does not support it");
-      }
+      log_if_needed("  ** Rejected mask extraction because architecture does not support it");
       return false; // not supported
     }
   } else {
     // vbox_klass is vector. This is used for Vector.lane(int).
     if (!idx->is_con()) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** missing constant: idx=%s", NodeClassNames[argument(4)->Opcode()]);
-      }
+      log_if_needed("  ** missing constant: idx=%s", NodeClassNames[argument(4)->Opcode()]);
       return false; // not enough info for intrinsification
     }
 
     int vopc = ExtractNode::opcode(elem_bt);
     if (!arch_supports_vector(vopc, num_elem, elem_bt, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: arity=1 op=extract vlen=%d etype=%s ismask=no",
+      log_if_needed("  ** not supported: arity=1 op=extract vlen=%d etype=%s ismask=no",
                       num_elem, type2name(elem_bt));
-      }
       return false; // not supported
     }
 
@@ -2882,29 +2611,23 @@ bool LibraryCallKit::inline_vector_compress_expand() {
   if (vector_klass == nullptr || elem_klass == nullptr || mask_klass == nullptr || vlen == nullptr ||
       vector_klass->const_oop() == nullptr || mask_klass->const_oop() == nullptr ||
       elem_klass->const_oop() == nullptr || !vlen->is_con() || !opr->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: opr=%s vclass=%s mclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: opr=%s vclass=%s mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()],
                     NodeClassNames[argument(3)->Opcode()],
                     NodeClassNames[argument(4)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   if (!is_klass_initialized(vector_klass) || !is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -2913,10 +2636,8 @@ bool LibraryCallKit::inline_vector_compress_expand() {
   int opc = VectorSupport::vop2ideal(opr->get_con(), elem_bt);
 
   if (!arch_supports_vector(opc, num_elem, elem_bt, VecMaskUseLoad)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: opc=%d vlen=%d etype=%s ismask=useload",
+    log_if_needed("  ** not supported: opc=%d vlen=%d etype=%s ismask=useload",
                     opc, num_elem, type2name(elem_bt));
-    }
     return false; // not supported
   }
 
@@ -2927,10 +2648,8 @@ bool LibraryCallKit::inline_vector_compress_expand() {
     vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
     opd1 = unbox_vector(argument(5), vbox_type, elem_bt, num_elem);
     if (opd1 == nullptr) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** unbox failed vector=%s",
+      log_if_needed("  ** unbox failed vector=%s",
                       NodeClassNames[argument(5)->Opcode()]);
-      }
       return false;
     }
   }
@@ -2941,10 +2660,8 @@ bool LibraryCallKit::inline_vector_compress_expand() {
 
   Node* mask = unbox_vector(argument(6), mbox_type, elem_bt, num_elem);
   if (mask == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** unbox failed mask=%s",
+    log_if_needed("  ** unbox failed mask=%s",
                     NodeClassNames[argument(6)->Opcode()]);
-    }
     return false;
   }
 
@@ -2975,27 +2692,21 @@ bool LibraryCallKit::inline_index_vector() {
   if (vector_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       vector_klass->const_oop() == nullptr || !vlen->is_con() ||
       elem_klass->const_oop() == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: vclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: vclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   if (!is_klass_initialized(vector_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -3004,9 +2715,7 @@ bool LibraryCallKit::inline_index_vector() {
 
   // Check whether the iota index generation op is supported by the current hardware
   if (!arch_supports_vector(Op_VectorLoadConst, num_elem, elem_bt, VecMaskNotUsed)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
-    }
+    log_if_needed("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
     return false; // not supported
   }
 
@@ -3021,9 +2730,7 @@ bool LibraryCallKit::inline_index_vector() {
   } else {
     // Check whether the vector multiply op is supported by the current hardware
     if (!arch_supports_vector(vmul_op, num_elem, elem_bt, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
-      }
+      log_if_needed("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
       return false; // not supported
     }
 
@@ -3032,10 +2739,8 @@ bool LibraryCallKit::inline_index_vector() {
       int cast_op = elem_bt == T_LONG ? Op_ConvI2L :
                     elem_bt == T_FLOAT? Op_ConvI2F : Op_ConvI2D;
       if (!Matcher::match_rule_supported(cast_op)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** Rejected op (%s) because architecture does not support it",
+        log_if_needed("  ** Rejected op (%s) because architecture does not support it",
                         NodeClassNames[cast_op]);
-        }
         return false; // not supported
       }
     }
@@ -3045,10 +2750,8 @@ bool LibraryCallKit::inline_index_vector() {
   const TypeInstPtr* vbox_type = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass);
   Node* opd = unbox_vector(argument(3), vbox_type, elem_bt, num_elem);
   if (opd == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** unbox failed vector=%s",
+    log_if_needed("  ** unbox failed vector=%s",
                     NodeClassNames[argument(3)->Opcode()]);
-    }
     return false;
   }
 
@@ -3061,9 +2764,7 @@ bool LibraryCallKit::inline_index_vector() {
   } else {
     // Check whether the vector addition op is supported by the current hardware
     if (!arch_supports_vector(vadd_op, num_elem, elem_bt, VecMaskNotUsed)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
-      }
+      log_if_needed("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
       return false; // not supported
     }
   }
@@ -3124,27 +2825,21 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
 
   if (mask_klass == nullptr || elem_klass == nullptr || vlen == nullptr ||
       mask_klass->const_oop() == nullptr || elem_klass->const_oop() == nullptr || !vlen->is_con()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** missing constant: mclass=%s etype=%s vlen=%s",
+    log_if_needed("  ** missing constant: mclass=%s etype=%s vlen=%s",
                     NodeClassNames[argument(0)->Opcode()],
                     NodeClassNames[argument(1)->Opcode()],
                     NodeClassNames[argument(2)->Opcode()]);
-    }
     return false; // not enough info for intrinsification
   }
 
   if (!is_klass_initialized(mask_klass)) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** klass argument not initialized");
-    }
+    log_if_needed("  ** klass argument not initialized");
     return false;
   }
 
   ciType* elem_type = elem_klass->const_oop()->as_instance()->java_mirror_type();
   if (!elem_type->is_primitive_type()) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** not a primitive bt=%d", elem_type->basic_type());
-    }
+    log_if_needed("  ** not a primitive bt=%d", elem_type->basic_type());
     return false; // should be primitive type
   }
 
@@ -3157,9 +2852,7 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
     if (!arch_supports_vector(Op_VectorLoadConst, num_elem, elem_bt, VecMaskNotUsed) ||
         !arch_supports_vector(Op_Replicate, num_elem, elem_bt, VecMaskNotUsed) ||
         !arch_supports_vector(Op_VectorMaskCmp, num_elem, elem_bt, VecMaskUseStore)) {
-      if (C->print_intrinsics()) {
-        tty->print_cr("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
-      }
+      log_if_needed("  ** not supported: vlen=%d etype=%s", num_elem, type2name(elem_bt));
       return false; // not supported
     }
 
@@ -3168,10 +2861,8 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
       int cast_op = is_integral_type(elem_bt) ? Op_ConvL2I
                                               : (elem_bt == T_FLOAT ? Op_ConvL2F : Op_ConvL2D);
       if (!Matcher::match_rule_supported(cast_op)) {
-        if (C->print_intrinsics()) {
-          tty->print_cr("  ** Rejected op (%s) because architecture does not support it",
+        log_if_needed("  ** Rejected op (%s) because architecture does not support it",
                         NodeClassNames[cast_op]);
-        }
         return false; // not supported
       }
     }
@@ -3180,9 +2871,7 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
   Node* offset = argument(3);
   Node* limit = argument(5);
   if (offset == nullptr || limit == nullptr) {
-    if (C->print_intrinsics()) {
-      tty->print_cr("  ** offset or limit argument is null");
-    }
+    log_if_needed("  ** offset or limit argument is null");
     return false; // not supported
   }
 
@@ -3238,3 +2927,6 @@ bool LibraryCallKit::inline_index_partially_in_upper_range() {
   C->set_max_vector_size(MAX2(C->max_vector_size(), (uint)(num_elem * type2aelembytes(elem_bt))));
   return true;
 }
+
+#undef non_product_log_if_needed
+#undef log_if_needed


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
Curretly, log code in vectorintrinsics.cpp is a bit redundant, could be simplified a bit.
Thanks.

## Test
sanity test, jdk/incubator/vector

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331908](https://bugs.openjdk.org/browse/JDK-8331908): Simplify log code in vectorintrinsics.cpp (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19135/head:pull/19135` \
`$ git checkout pull/19135`

Update a local copy of the PR: \
`$ git checkout pull/19135` \
`$ git pull https://git.openjdk.org/jdk.git pull/19135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19135`

View PR using the GUI difftool: \
`$ git pr show -t 19135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19135.diff">https://git.openjdk.org/jdk/pull/19135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19135#issuecomment-2100072301)