### PR TITLE
8331932: Startup regressions in 23-b13

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -988,32 +988,28 @@ public final class Locale implements Cloneable, Serializable {
             if (locale != null) {
                 return locale;
             }
-            return LOCALE_CACHE.computeIfAbsent(baseloc, LOCALE_LOOKUP);
+            return LOCALE_CACHE.computeIfAbsent(baseloc, LOCALE_CREATOR);
         } else {
             LocaleKey key = new LocaleKey(baseloc, extensions);
-            return LOCALE_CACHE.computeIfAbsent(key, LOCALE_LOOKUP);
+            return LOCALE_CACHE.computeIfAbsent(key, LOCALE_CREATOR);
         }
     }
 
     private static final ReferencedKeyMap<Object, Locale> LOCALE_CACHE
             = ReferencedKeyMap.create(true, ReferencedKeyMap.concurrentHashMapSupplier());
 
-    private static final LocaleKey LOCALE_LOOKUP = new LocaleKey();
-
-    private static final class LocaleKey implements Function<Object, Locale> {
-
+    private static final Function<Object, Locale> LOCALE_CREATOR = new Function<>() {
         @Override
         public Locale apply(Object key) {
-            return createLocale(key);
-        }
-
-        private Locale createLocale(Object key) {
             if (key instanceof BaseLocale base) {
                 return new Locale(base, null);
             }
             LocaleKey lk = (LocaleKey)key;
             return new Locale(lk.base, lk.exts);
         }
+    };
+
+    private static final class LocaleKey {
 
         private final BaseLocale base;
         private final LocaleExtensions exts;

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1015,12 +1015,6 @@ public final class Locale implements Cloneable, Serializable {
         private final LocaleExtensions exts;
         private final int hash;
 
-        private LocaleKey() {
-            base = null;
-            exts = null;
-            hash = 0;
-        }
-
         private LocaleKey(BaseLocale baseLocale, LocaleExtensions extensions) {
             base = baseLocale;
             exts = extensions;

--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeyMap.java
@@ -100,6 +100,21 @@ public final class ReferencedKeyMap<K, V> implements Map<K, V> {
     private final ReferenceQueue<K> stale;
 
     /**
+     * @return a supplier to create a {@code ConcurrentHashMap} appropriate for use in the
+     *         create methods.
+     * @param <K> the type of keys maintained by the new map
+     * @param <V> the type of mapped values
+     */
+    public static <K, V> Supplier<Map<ReferenceKey<K>, V>> concurrentHashMapSupplier() {
+        return new Supplier<>() {
+            @Override
+            public Map<ReferenceKey<K>, V> get() {
+                return new ConcurrentHashMap<>();
+            }
+        };
+    }
+
+    /**
      * Private constructor.
      *
      * @param isSoft          true if {@link SoftReference} keys are to

--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
@@ -81,12 +81,7 @@ public final class ReferencedKeySet<T> extends AbstractSet<T> {
      * @param <E> the type of elements maintained by this set
      */
     public static <E> Supplier<Map<ReferenceKey<E>, ReferenceKey<E>>> concurrentHashMapSupplier() {
-        return new Supplier<>() {
-            @Override
-            public Map<ReferenceKey<E>, ReferenceKey<E>> get() {
-                return new ConcurrentHashMap<>();
-            }
-        };
+        return ReferencedKeyMap.concurrentHashMapSupplier();
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
+++ b/src/java.base/share/classes/jdk/internal/util/ReferencedKeySet.java
@@ -76,6 +76,20 @@ public final class ReferencedKeySet<T> extends AbstractSet<T> {
     final ReferencedKeyMap<T, ReferenceKey<T>> map;
 
     /**
+     * @return a supplier to create a {@code ConcurrentHashMap} appropriate for use in the
+     *         create methods.
+     * @param <E> the type of elements maintained by this set
+     */
+    public static <E> Supplier<Map<ReferenceKey<E>, ReferenceKey<E>>> concurrentHashMapSupplier() {
+        return new Supplier<>() {
+            @Override
+            public Map<ReferenceKey<E>, ReferenceKey<E>> get() {
+                return new ConcurrentHashMap<>();
+            }
+        };
+    }
+
+    /**
      * Private constructor.
      *
      * @param map     backing map

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -165,17 +165,19 @@ public final class BaseLocale {
         // instance which guarantees the locale components are properly cased/interned.
         return CACHE.intern(new BaseLocale(language, script, region, variant),
                 // Avoid lambdas since this may be on the bootstrap path in many locales
-                new UnaryOperator<BaseLocale>() {
-                    @Override
-                    public BaseLocale apply(BaseLocale b) {
-                        return new BaseLocale(
-                                LocaleUtils.toLowerString(b.language).intern(),
-                                LocaleUtils.toTitleString(b.script).intern(),
-                                LocaleUtils.toUpperString(b.region).intern(),
-                                b.variant.intern());
-                    }
-                });
+                INTERNER);
     }
+
+    public static final UnaryOperator<BaseLocale> INTERNER = new UnaryOperator<>() {
+        @Override
+        public BaseLocale apply(BaseLocale b) {
+            return new BaseLocale(
+                    LocaleUtils.toLowerString(b.language).intern(),
+                    LocaleUtils.toTitleString(b.script).intern(),
+                    LocaleUtils.toUpperString(b.region).intern(),
+                    b.variant.intern());
+        }
+    };
 
     public static String convertOldISOCodes(String language) {
         return switch (language) {

--- a/src/java.base/share/classes/sun/util/locale/BaseLocale.java
+++ b/src/java.base/share/classes/sun/util/locale/BaseLocale.java
@@ -38,7 +38,7 @@ import jdk.internal.util.StaticProperty;
 import jdk.internal.vm.annotation.Stable;
 
 import java.util.StringJoiner;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
 
 public final class BaseLocale {
 
@@ -93,7 +93,7 @@ public final class BaseLocale {
 
     // Interned BaseLocale cache
     private static final ReferencedKeySet<BaseLocale> CACHE =
-            ReferencedKeySet.create(true, ConcurrentHashMap::new);
+            ReferencedKeySet.create(true, ReferencedKeySet.concurrentHashMapSupplier());
 
     public static final String SEP = "_";
 
@@ -164,11 +164,17 @@ public final class BaseLocale {
         // "interned" instance can subsequently be used by the Locale
         // instance which guarantees the locale components are properly cased/interned.
         return CACHE.intern(new BaseLocale(language, script, region, variant),
-            (b) -> new BaseLocale(
-                LocaleUtils.toLowerString(b.language).intern(),
-                LocaleUtils.toTitleString(b.script).intern(),
-                LocaleUtils.toUpperString(b.region).intern(),
-                b.variant.intern()));
+                // Avoid lambdas since this may be on the bootstrap path in many locales
+                new UnaryOperator<BaseLocale>() {
+                    @Override
+                    public BaseLocale apply(BaseLocale b) {
+                        return new BaseLocale(
+                                LocaleUtils.toLowerString(b.language).intern(),
+                                LocaleUtils.toTitleString(b.script).intern(),
+                                LocaleUtils.toUpperString(b.region).intern(),
+                                b.variant.intern());
+                    }
+                });
     }
 
     public static String convertOldISOCodes(String language) {


### PR DESCRIPTION
A rather large startup regression was introduced in 23-b13 from [JDK-8309622](https://bugs.openjdk.org/browse/JDK-8309622). Some of that has been dealt with as enhancements such as [JDK-8330802](https://bugs.openjdk.org/browse/JDK-8330802), [JDK-8330595](https://bugs.openjdk.org/browse/JDK-8330595) and [JDK-8330681](https://bugs.openjdk.org/browse/JDK-8330681), which provide both point fixes and reduce initialization overhead of certain constructs more generally. The remaining issues stem from a set of lambdas added in code for `java.util.Locale` and `jdk.internal.util.BaseLocale` causing early bootstrapping of the lambda infrastructure and a bit of class generation.

While the remaining overheads are relatively small and borderline acceptable (< 2-3ms), I think it's still worth acting on them in this particular case since the amount of added bootstrapping overhead is dependent on which locale the system runs under, which complicates testing and comparisons due to relatively large differences in paths taken on different systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331932](https://bugs.openjdk.org/browse/JDK-8331932): Startup regressions in 23-b13 (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [819e3d47](https://git.openjdk.org/jdk/pull/19140/files/819e3d47cc8c4e8f4413bc4c231840ea5202373a)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [819e3d47](https://git.openjdk.org/jdk/pull/19140/files/819e3d47cc8c4e8f4413bc4c231840ea5202373a)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19140/head:pull/19140` \
`$ git checkout pull/19140`

Update a local copy of the PR: \
`$ git checkout pull/19140` \
`$ git pull https://git.openjdk.org/jdk.git pull/19140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19140`

View PR using the GUI difftool: \
`$ git pr show -t 19140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19140.diff">https://git.openjdk.org/jdk/pull/19140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19140#issuecomment-2100786197)