### PR TITLE
8331942: On Linux aarch64, CDS archives should be using 64K alignment by default

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -190,6 +190,17 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_JDK_OPTIONS],
   fi
   AC_SUBST(INCLUDE_SA)
 
+  # Setup default CDS alignment. On platforms where one build may run on machines with different
+  # page sizes, the JVM choses a compatible alignment to fit all possible page sizes. This slightly
+  # increases archive size.
+  # The only platform having this problem at the moment is Linux on aarch64, which may encounter
+  # three different page sizes: 4K, 64K, and if run on Mac m1 hardware, 16K.
+  COMPATIBLE_CDS_ALIGNMENT_DEFAULT=false
+  if test "x$OPENJDK_TARGET_OS" = "xlinux" && test "x$OPENJDK_TARGET_CPU" = "xaarch64"; then
+    COMPATIBLE_CDS_ALIGNMENT_DEFAULT=true
+  fi
+  AC_SUBST(COMPATIBLE_CDS_ALIGNMENT_DEFAULT)
+
   # Compress jars
   COMPRESS_JARS=false
 
@@ -673,7 +684,7 @@ AC_DEFUN([JDKOPT_ENABLE_DISABLE_CDS_ARCHIVE],
 #
 AC_DEFUN([JDKOPT_ENABLE_DISABLE_COMPATIBLE_CDS_ALIGNMENT],
 [
-  UTIL_ARG_ENABLE(NAME: compatible-cds-alignment, DEFAULT: false,
+  UTIL_ARG_ENABLE(NAME: compatible-cds-alignment, DEFAULT: $COMPATIBLE_CDS_ALIGNMENT_DEFAULT,
       RESULT: ENABLE_COMPATIBLE_CDS_ALIGNMENT,
       DESC: [enable use alternative compatible cds core region alignment],
       DEFAULT_DESC: [disabled],


### PR DESCRIPTION
On Linux aarch64, a JVM may encounter three different page sizes: 4K, 64K, and (when run on Mac M1 hardware) 16K.

Since forgetting to specify `--enable-compatible-cds-alignment` is a common error that is only noticed when running the produced JVM on hardware with different page size, we propose to enable that option by default on Linux aarch64. The cost is a moderate increase in CDS archive size (about 300K).

I tested this patch on:
- x64 Linux
- x64 Linux, crossbuilding to aarch64
- building natively on aarch64 Linux

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331942](https://bugs.openjdk.org/browse/JDK-8331942): On Linux aarch64, CDS archives should be using 64K alignment by default (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19142/head:pull/19142` \
`$ git checkout pull/19142`

Update a local copy of the PR: \
`$ git checkout pull/19142` \
`$ git pull https://git.openjdk.org/jdk.git pull/19142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19142`

View PR using the GUI difftool: \
`$ git pr show -t 19142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19142.diff">https://git.openjdk.org/jdk/pull/19142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19142#issuecomment-2100925092)