### PR TITLE
8331950: Remove MemoryPoolMBean/isCollectionUsageThresholdExceeded from ZGC ProblemLists

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -116,5 +116,4 @@ serviceability/sa/sadebugd/SADebugDTest.java                  8307393   generic-
 
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
-vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -47,5 +47,4 @@ serviceability/sa/TestHeapDumpForInvokeDynamic.java           8315646   generic-
 
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64
 
-vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded002/TestDescription.java 8298302 generic-all
 vmTestbase/nsk/sysdict/vm/stress/chain/chain007/chain007.java 8298991 linux-x64


### PR DESCRIPTION
Remove from zgc problemlists.
Trivial fix.

This was omitted when https://bugs.openjdk.org/browse/JDK-8303136 was integrated.

I see the tests passing, including with ZGC.  Just ran my own batch of tests in addition, and it includes passes with e.g. -XX:+UseZGC -XX:+ZGenerational

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331950](https://bugs.openjdk.org/browse/JDK-8331950): Remove MemoryPoolMBean/isCollectionUsageThresholdExceeded from ZGC ProblemLists (**Sub-task** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19143/head:pull/19143` \
`$ git checkout pull/19143`

Update a local copy of the PR: \
`$ git checkout pull/19143` \
`$ git pull https://git.openjdk.org/jdk.git pull/19143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19143`

View PR using the GUI difftool: \
`$ git pr show -t 19143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19143.diff">https://git.openjdk.org/jdk/pull/19143.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19143#issuecomment-2102204599)