### PR TITLE
8331931: JFR: Avoid loading regex classes during startup

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,10 +287,12 @@ public final class SecuritySupport {
 
     public static List<SafePath> getPredefinedJFCFiles() {
         List<SafePath> list = new ArrayList<>();
-        try (var ds = doPrivilegedIOWithReturn(() -> Files.newDirectoryStream(JFC_DIRECTORY.toPath(), "*.jfc"))) {
+        try (var ds = doPrivilegedIOWithReturn(() -> Files.newDirectoryStream(JFC_DIRECTORY.toPath()))) {
             for (Path path : ds) {
                 SafePath s = new SafePath(path);
-                if (!SecuritySupport.isDirectory(s)) {
+                String text = s.toString();
+                System.out.println(text);
+                if (text.endsWith(".jfc") && !SecuritySupport.isDirectory(s)) {
                     list.add(s);
                 }
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/SecuritySupport.java
@@ -291,7 +291,6 @@ public final class SecuritySupport {
             for (Path path : ds) {
                 SafePath s = new SafePath(path);
                 String text = s.toString();
-                System.out.println(text);
                 if (text.endsWith(".jfc") && !SecuritySupport.isDirectory(s)) {
                     list.add(s);
                 }


### PR DESCRIPTION
Could I have review of a change that avoids loading 45 regex related classes when using -XX:StartFlightRecording.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331931](https://bugs.openjdk.org/browse/JDK-8331931): JFR: Avoid loading regex classes during startup (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19146/head:pull/19146` \
`$ git checkout pull/19146`

Update a local copy of the PR: \
`$ git checkout pull/19146` \
`$ git pull https://git.openjdk.org/jdk.git pull/19146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19146`

View PR using the GUI difftool: \
`$ git pr show -t 19146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19146.diff">https://git.openjdk.org/jdk/pull/19146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19146#issuecomment-2101607673)