### PR TITLE
JDK-8330565 : C2: Multiple crashes with CTW after JDK-8316991

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -730,9 +730,22 @@ Node* ConnectionGraph::specialize_castpp(Node* castpp, Node* base, Node* current
 
 Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr_load, Node* region, GrowableArray<Node*>* bases_for_loads, GrowableArray<Node *>  &alloc_worklist) {
   const Type* load_type = _igvn->type(curr_load);
-  Node* nsr_value       = _igvn->zerocon(load_type->basic_type());
-  Node* data_phi        = _igvn->transform(PhiNode::make(region, nsr_value, load_type));
-  Node* memory          = curr_load->in(MemNode::Memory);
+  Node* nsr_value = _igvn->zerocon(load_type->basic_type());
+  Node* memory = curr_load->in(MemNode::Memory);
+
+  // The data_phi merging the loads needs to be nullable if
+  // we are loading pointers.
+  if (load_type->make_ptr() != nullptr) {
+    if (load_type->isa_narrowoop()) {
+      load_type = load_type->meet(TypeNarrowOop::NULL_PTR);
+    } else if (load_type->isa_ptr()) {
+      load_type = load_type->meet(TypePtr::NULL_PTR);
+    } else {
+      assert(false, "Unexpected load ptr type.");
+    }
+  }
+
+  Node* data_phi = PhiNode::make(region, nsr_value, load_type);
 
   for (int i = 1; i < bases_for_loads->length(); i++) {
     Node* base = bases_for_loads->at(i);
@@ -746,43 +759,28 @@ Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr
 
       Node* addr = _igvn->transform(new AddPNode(base, base, curr_addp->in(AddPNode::Offset)));
       Node* mem = (memory->is_Phi() && (memory->in(0) == region)) ? memory->in(i) : memory;
-      Node* load = _igvn->transform(curr_load->clone());
+      Node* load = curr_load->clone();
       load->set_req(0, nullptr);
       load->set_req(1, mem);
       load->set_req(2, addr);
 
       if (cmp_region != nullptr) { // see comment on previous if
-        Node* intermediate_phi = _igvn->transform(PhiNode::make(cmp_region, nsr_value, load_type));
-        intermediate_phi->set_req(1, load);
+        Node* intermediate_phi = PhiNode::make(cmp_region, nsr_value, load_type);
+        intermediate_phi->set_req(1, _igvn->transform(load));
         load = intermediate_phi;
       }
 
-      data_phi->set_req(i, load);
+      data_phi->set_req(i, _igvn->transform(load));
     } else {
       // Just use the default, which is already in phi
     }
   }
 
-  // The data_phi merging the loads needs to be nullable if we are loading
-  // pointers
-  if (load_type->make_ptr() != nullptr) {
-    const Type* new_t = _igvn->type(data_phi);
-    if (load_type->isa_narrowoop()) {
-      new_t = load_type->meet(TypeNarrowOop::NULL_PTR);
-    } else if (load_type->isa_narrowklass()) {
-      new_t = load_type->meet(TypeNarrowKlass::NULL_PTR);
-    } else if (load_type->isa_ptr()) {
-      new_t = load_type->meet(TypePtr::NULL_PTR);
-    }
-    _igvn->set_type(data_phi,  new_t);
-    data_phi->raise_bottom_type(new_t);
-  }
-
-  // Takes care of updating CG and split_unique_types worklists due to cloned
-  // AddP->Load.
+  // Takes care of updating CG and split_unique_types worklists due
+  // to cloned AddP->Load.
   updates_after_load_split(data_phi, curr_load, alloc_worklist);
 
-  return data_phi;
+  return _igvn->transform(data_phi);
 }
 
 // This method only reduces CastPP fields loads; SafePoints are handled

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8330565
+ * @summary Check that Reduce Allocation Merges does not crash when legacy
+ *          string concatenation optimization is applied.
+ * @requires vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @compile -XDstringConcat=inline TestReduceAllocationAndNullableLoads.java
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndNullableLoads*::*
+ *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndNullableLoads*::*
+ *                   -XX:-TieredCompilation -Xbatch -Xcomp -server
+ *                   compiler.c2.TestReduceAllocationAndNullableLoads
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndNullableLoads {
+    public static void main(String[] args) {
+        try {
+            // Load / initialize these classes
+            IllegalArgumentException e = new IllegalArgumentException("Reason is: ");
+            StringBuilder xixi = new StringBuilder("abc");
+
+            // The actual test
+            test(new char[] { 'a', 'b', 'c' });
+        } catch (IllegalArgumentException e) { }
+    }
+
+    public static void test(char[] chars) throws IllegalArgumentException {
+        String reason = null;
+
+        for (int i = 0; i < chars.length; i++) {
+            char c = chars[i];
+
+            if (c == 'a') {
+                reason = "first entry" + i;
+                break;
+            }
+        }
+
+        if (reason != null) {
+            throw new IllegalArgumentException("Reason is: " + reason);
+        }
+    }
+}
+

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndNullableLoads.java
@@ -30,7 +30,7 @@
  * @compile -XDstringConcat=inline TestReduceAllocationAndNullableLoads.java
  * @run main/othervm -XX:CompileCommand=compileonly,*TestReduceAllocationAndNullableLoads*::*
  *                   -XX:CompileCommand=dontinline,*TestReduceAllocationAndNullableLoads*::*
- *                   -XX:-TieredCompilation -Xbatch -Xcomp -server
+ *                   -XX:-TieredCompilation -Xcomp -server
  *                   compiler.c2.TestReduceAllocationAndNullableLoads
  */
 


### PR DESCRIPTION
The `# assert(false) failed: Bad graph detected in build_loop_late` failure was caused because a string concatenation optimization using [this method](https://github.com/openjdk/jdk/blob/819f3d6fc70ff6fe54ac5f9033c17c3dd4326aa5/src/hotspot/share/opto/graphKit.cpp#L4115) adds AddP and LoadN nodes to IR graph as NotNull _and_ because RAM was not "nullyfing" phis merging nullable pointers. I was only able to reproduce this problem using a classfile/jar compiled using an "old" version of JDK.. because newer version use InvokeDynamic to do string concatenation.

Tested with JTREG tier1-4 on Linux x86_64 & ARM64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330565](https://bugs.openjdk.org/browse/JDK-8330565): C2: Multiple crashes with CTW after JDK-8316991 (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [94eb0e12](https://git.openjdk.org/jdk/pull/19147/files/94eb0e122e19014783b5a2bf8805842eb3c95e97)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19147/head:pull/19147` \
`$ git checkout pull/19147`

Update a local copy of the PR: \
`$ git checkout pull/19147` \
`$ git pull https://git.openjdk.org/jdk.git pull/19147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19147`

View PR using the GUI difftool: \
`$ git pr show -t 19147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19147.diff">https://git.openjdk.org/jdk/pull/19147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19147#issuecomment-2101675298)