### PR TITLE
JDK-8330795 : C2: assert((uint)type <= T_CONFLICT && _zero_type[type] != nullptr) failed: bad type with -XX:-UseCompressedClassPointers

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -548,8 +548,8 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
         if (!use_use->is_Load() || !use_use->as_Load()->can_split_through_phi_base(_igvn)) {
           NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. AddP user isn't a [splittable] Load(): %s", n->_idx, _invocation, use_use->Name());)
           return false;
-        } else if (nesting > 0 && load_type->isa_narrowklass()) {
-          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Nested NarrowKlass Load: %s", n->_idx, _invocation, use_use->Name());)
+        } else if (load_type->isa_narrowklass() || load_type->isa_klassptr()) {
+          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. [Narrow] Klass Load: %s", n->_idx, _invocation, use_use->Name());)
           return false;
         }
       }

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -647,6 +647,7 @@ void Type::Initialize_shared(Compile* current) {
 
   _const_basic_type[T_NARROWOOP]   = TypeNarrowOop::BOTTOM;
   _const_basic_type[T_NARROWKLASS] = Type::BOTTOM;
+  _const_basic_type[T_METADATA]    = Type::BOTTOM;
   _const_basic_type[T_BOOLEAN]     = TypeInt::BOOL;
   _const_basic_type[T_CHAR]        = TypeInt::CHAR;
   _const_basic_type[T_BYTE]        = TypeInt::BYTE;
@@ -671,6 +672,7 @@ void Type::Initialize_shared(Compile* current) {
   _zero_type[T_LONG]        = TypeLong::ZERO;
   _zero_type[T_FLOAT]       = TypeF::ZERO;
   _zero_type[T_DOUBLE]      = TypeD::ZERO;
+  _zero_type[T_METADATA]    = TypePtr::NULL_PTR;
   _zero_type[T_OBJECT]      = TypePtr::NULL_PTR;
   _zero_type[T_ARRAY]       = TypePtr::NULL_PTR; // null array is null oop
   _zero_type[T_ADDRESS]     = TypePtr::NULL_PTR; // raw pointers use the same null

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -647,7 +647,6 @@ void Type::Initialize_shared(Compile* current) {
 
   _const_basic_type[T_NARROWOOP]   = TypeNarrowOop::BOTTOM;
   _const_basic_type[T_NARROWKLASS] = Type::BOTTOM;
-  _const_basic_type[T_METADATA]    = Type::BOTTOM;
   _const_basic_type[T_BOOLEAN]     = TypeInt::BOOL;
   _const_basic_type[T_CHAR]        = TypeInt::CHAR;
   _const_basic_type[T_BYTE]        = TypeInt::BYTE;
@@ -672,7 +671,6 @@ void Type::Initialize_shared(Compile* current) {
   _zero_type[T_LONG]        = TypeLong::ZERO;
   _zero_type[T_FLOAT]       = TypeF::ZERO;
   _zero_type[T_DOUBLE]      = TypeD::ZERO;
-  _zero_type[T_METADATA]    = TypePtr::NULL_PTR;
   _zero_type[T_OBJECT]      = TypePtr::NULL_PTR;
   _zero_type[T_ARRAY]       = TypePtr::NULL_PTR; // null array is null oop
   _zero_type[T_ADDRESS]     = TypePtr::NULL_PTR; // raw pointers use the same null

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
@@ -24,7 +24,8 @@
 /*
  * @test
  * @bug 8330795
- * @summary Check that Reduce Allocation Merges can load Klass when CompressedClassPointers is disabled.
+ * @summary Check that Reduce Allocation Merges doesn't crash when CompressedClassPointers
+ *          is disabled and there is an access to Klass "field" through the phi.
  * @requires vm.bits == 64 & vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
  * @run main/othervm -XX:CompileCommand=dontinline,*TestReduceAllocationAndLoadKlass*::test
  *                   -XX:CompileCommand=compileonly,*TestReduceAllocationAndLoadKlass*::test

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8330795
+ * @summary Check that Reduce Allocation Merges can load Klass when CompressedClassPointers is disabled.
+ * @requires vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @run main/othervm -XX:CompileCommand=dontinline,*TestReduceAllocationAndLoadKlass*::test
+ *                   -XX:CompileCommand=compileonly,*TestReduceAllocationAndLoadKlass*::test
+ *                   -XX:CompileCommand=compileonly,*Shape*::*init*
+ *                   -XX:CompileCommand=compileonly,*Point*::*init*
+ *                   -XX:CompileCommand=exclude,*TestReduceAllocationAndLoadKlass*::dummy
+ *                   -XX:-TieredCompilation
+ *                   -XX:-UseCompressedClassPointers
+ *                   -Xbatch
+ *                   -Xcomp
+ *                   -server
+ *                   compiler.c2.TestReduceAllocationAndLoadKlass
+ */
+
+package compiler.c2;
+
+public class TestReduceAllocationAndLoadKlass {
+    public static void main(String[] args) {
+        Point p = new Point();
+        Line q = new Line();
+
+        test(true);
+        test(false);
+    }
+
+    static Class test(boolean cond) {
+        Object p = cond ? dummy() : new Line();
+        return p.getClass();
+    }
+
+    static Point dummy() { return new Point(); }
+
+    static class Shape { }
+    static class Point extends Shape { }
+    static class Line extends Shape { }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
+++ b/test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndLoadKlass.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8330795
  * @summary Check that Reduce Allocation Merges can load Klass when CompressedClassPointers is disabled.
- * @requires vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @requires vm.bits == 64 & vm.flagless & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
  * @run main/othervm -XX:CompileCommand=dontinline,*TestReduceAllocationAndLoadKlass*::test
  *                   -XX:CompileCommand=compileonly,*TestReduceAllocationAndLoadKlass*::test
  *                   -XX:CompileCommand=compileonly,*Shape*::*init*


### PR DESCRIPTION
The `assert((uint)type <= T_CONFLICT && _zero_type[type] != nullptr) failed: bad type` failure was caused by the fact that we didn't have a "zero value" for the type T_METADATA. The RAM patch uses that data when it creates a Phi node merging Klass loads and UseCompressedClassPointers is disabled.

Tested with JTREG tier1-4 on Linux x86_64 & ARM64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330795](https://bugs.openjdk.org/browse/JDK-8330795): C2: assert((uint)type &lt;= T_CONFLICT &amp;&amp; _zero_type[type] != nullptr) failed: bad type with -XX:-UseCompressedClassPointers (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19148/head:pull/19148` \
`$ git checkout pull/19148`

Update a local copy of the PR: \
`$ git checkout pull/19148` \
`$ git pull https://git.openjdk.org/jdk.git pull/19148/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19148`

View PR using the GUI difftool: \
`$ git pr show -t 19148`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19148.diff">https://git.openjdk.org/jdk/pull/19148.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19148#issuecomment-2101674457)