### PR TITLE
8331577: RISC-V: C2 CountLeadingZerosV

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1891,6 +1891,9 @@ enum Nf {
   INSN(vbrev8_v, 0b1010111, 0b010, 0b01000, 0b010010); // reverse bits in every byte of element
   INSN(vrev8_v,  0b1010111, 0b010, 0b01001, 0b010010); // reverse bytes in every elememt
 
+  INSN(vclz_v,  0b1010111, 0b010, 0b01100, 0b010010); // count leading zeros
+  INSN(vctz_v,  0b1010111, 0b010, 0b01101, 0b010010); // ount trailing zeros
+
 #undef INSN
 
 #define INSN(NAME, op, funct3, vm, funct6)                                   \

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1892,7 +1892,7 @@ enum Nf {
   INSN(vrev8_v,  0b1010111, 0b010, 0b01001, 0b010010); // reverse bytes in every elememt
 
   INSN(vclz_v,  0b1010111, 0b010, 0b01100, 0b010010); // count leading zeros
-  INSN(vctz_v,  0b1010111, 0b010, 0b01101, 0b010010); // ount trailing zeros
+  INSN(vctz_v,  0b1010111, 0b010, 0b01101, 0b010010); // count trailing zeros
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -73,6 +73,8 @@ source %{
           return false;
         }
         break;
+      case Op_CountTrailingZerosV:
+      case Op_CountLeadingZerosV:
       case Op_ReverseBytesV:
       case Op_PopCountVL:
       case Op_PopCountVI:
@@ -3841,6 +3843,62 @@ instruct vpopcount(vReg dst, vReg src) %{
     uint vlen = Matcher::vector_length(this);
     __ vsetvli_helper(bt, vlen);
     __ vcpop_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// ------------------------------ CountLeadingZerosV --------------------------
+
+instruct vcountLeadingZeros_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
+  match(Set dst (CountLeadingZerosV src v0));
+  ins_cost(VEC_COST);
+  format %{ "vcount_leading_zeros_masked $dst, $src, v0" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    uint vlen = Matcher::vector_length(this);
+    __ vsetvli_helper(bt, vlen);
+    __ vclz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vcountLeadingZeros(vReg dst, vReg src) %{
+  match(Set dst (CountLeadingZerosV src));
+  ins_cost(VEC_COST);
+  format %{ "vcount_leading_zeros $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    uint vlen = Matcher::vector_length(this);
+    __ vsetvli_helper(bt, vlen);
+    __ vclz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// ------------------------------ CountTrailingZerosV --------------------------
+
+instruct vcountTrailingZeros_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
+  match(Set dst (CountTrailingZerosV src v0));
+  ins_cost(VEC_COST);
+  format %{ "vcount_trailing_zeros_masked $dst, $src, v0" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    uint vlen = Matcher::vector_length(this);
+    __ vsetvli_helper(bt, vlen);
+    __ vctz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vcountTrailingZeros(vReg dst, vReg src) %{
+  match(Set dst (CountTrailingZerosV src));
+  ins_cost(VEC_COST);
+  format %{ "vcount_trailing_zeros $dst, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    uint vlen = Matcher::vector_length(this);
+    __ vsetvli_helper(bt, vlen);
+    __ vctz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3849,15 +3849,15 @@ instruct vpopcount(vReg dst, vReg src) %{
 
 // ------------------------------ CountLeadingZerosV --------------------------
 
-instruct vcountLeadingZeros_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
-  match(Set dst (CountLeadingZerosV src v0));
+instruct vcountLeadingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
+  match(Set dst_src (CountLeadingZerosV dst_src v0));
   ins_cost(VEC_COST);
-  format %{ "vcount_leading_zeros_masked $dst, $src, v0" %}
+  format %{ "vcount_leading_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
     __ vsetvli_helper(bt, vlen);
-    __ vclz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+    __ vclz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3877,15 +3877,15 @@ instruct vcountLeadingZeros(vReg dst, vReg src) %{
 
 // ------------------------------ CountTrailingZerosV --------------------------
 
-instruct vcountTrailingZeros_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
-  match(Set dst (CountTrailingZerosV src v0));
+instruct vcountTrailingZeros_masked(vReg dst_src, vRegMask_V0 v0) %{
+  match(Set dst_src (CountTrailingZerosV dst_src v0));
   ins_cost(VEC_COST);
-  format %{ "vcount_trailing_zeros_masked $dst, $src, v0" %}
+  format %{ "vcount_trailing_zeros_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
     __ vsetvli_helper(bt, vlen);
-    __ vctz_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+    __ vctz_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3761,14 +3761,14 @@ instruct vsignum_reg(vReg dst, vReg zero, vReg one, vRegMask_V0 v0) %{
 
 // -------------------------------- Reverse Bytes Vector Operations ------------------------
 
-instruct vreverse_bytes_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
-  match(Set dst (ReverseBytesV src v0));
-  format %{ "vreverse_bytes_masked $dst, $src, v0" %}
+instruct vreverse_bytes_masked(vReg dst_src, vRegMask_V0 v0) %{
+  match(Set dst_src (ReverseBytesV dst_src v0));
+  format %{ "vreverse_bytes_masked $dst_src, $dst_src, v0" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
     __ vsetvli_helper(bt, vlen);
-    __ vrev8_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+    __ vrev8_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -3819,16 +3819,16 @@ instruct vconvF2HF(vReg dst, vReg src, vReg vtmp, vRegMask_V0 v0, iRegINoSp tmp)
 
 // ------------------------------ Popcount vector ------------------------------
 
-instruct vpopcount_masked(vReg dst, vReg src, vRegMask_V0 v0) %{
-  match(Set dst (PopCountVI src v0));
-  match(Set dst (PopCountVL src v0));
+instruct vpopcount_masked(vReg dst_src, vRegMask_V0 v0) %{
+  match(Set dst_src (PopCountVI dst_src v0));
+  match(Set dst_src (PopCountVL dst_src v0));
   ins_cost(VEC_COST);
-  format %{ "vcpop_v $dst, $src, $v0\t# vcpop_v with mask" %}
+  format %{ "vcpop_v $dst_src, $dst_src, $v0\t# vcpop_v with mask" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     uint vlen = Matcher::vector_length(this);
     __ vsetvli_helper(bt, vlen);
-    __ vcpop_v(as_VectorRegister($dst$$reg), as_VectorRegister($src$$reg), Assembler::v0_t);
+    __ vcpop_v(as_VectorRegister($dst_src$$reg), as_VectorRegister($dst_src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -27,7 +27,8 @@
 * @summary Test vectorization of numberOfTrailingZeros/numberOfLeadingZeros for Long
 * @requires vm.compiler2.enabled
 * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx2.*") |
-*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*")
+*           (os.simpleArch == "aarch64" & vm.cpu.features ~= ".*sve.*") |
+*           (os.simpleArch == "riscv64" & vm.cpu.features ~= ".*zvbb.*")
 * @library /test/lib /
 * @run driver compiler.vectorization.TestNumberOfContinuousZeros
 */


### PR DESCRIPTION
Hi,
Can you help to review this patch adding CountLeadingZerosV and CountTrailingZerosV instrinsics?
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8331577](https://bugs.openjdk.org/browse/JDK-8331577): RISC-V: C2 CountLeadingZerosV (**Sub-task** - P4)
 * [JDK-8331578](https://bugs.openjdk.org/browse/JDK-8331578): RISC-V: C2 CountTrailingZerosV (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19153/head:pull/19153` \
`$ git checkout pull/19153`

Update a local copy of the PR: \
`$ git checkout pull/19153` \
`$ git pull https://git.openjdk.org/jdk.git pull/19153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19153`

View PR using the GUI difftool: \
`$ git pr show -t 19153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19153.diff">https://git.openjdk.org/jdk/pull/19153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19153#issuecomment-2102228401)