### PR TITLE
8331993: Add counting leading/trailing zero tests for Integer

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestDisableAutoVectOpcodes.java
@@ -117,7 +117,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.COUNTTRAILINGZEROS_VL})
+    @IR(failOn = {IRNode.COUNT_TRAILING_ZEROS_VL})
     public void testNumberOfTrailingZeros() {
         for (int i = 0; i < SIZE; ++i) {
             inta[i] = Long.numberOfTrailingZeros(longa[i]);
@@ -125,7 +125,7 @@ public class TestDisableAutoVectOpcodes {
     }
 
     @Test
-    @IR(failOn = {IRNode.COUNTLEADINGZEROS_VL})
+    @IR(failOn = {IRNode.COUNT_LEADING_ZEROS_VL})
     public void testNumberOfLeadingZeros() {
         for (int i = 0; i < SIZE; ++i) {
             inta[i] = Long.numberOfLeadingZeros(longa[i]);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1164,9 +1164,19 @@ public class IRNode {
         vectorNode(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
     }
 
+    public static final String COUNTTRAILINGZEROS_VI = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VI" + POSTFIX;
+    static {
+        vectorNode(COUNTTRAILINGZEROS_VI, "CountTrailingZerosV", TYPE_INT);
+    }
+
     public static final String COUNTLEADINGZEROS_VL = VECTOR_PREFIX + "COUNTLEADINGZEROS_VL" + POSTFIX;
     static {
         vectorNode(COUNTLEADINGZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
+    }
+
+    public static final String COUNTLEADINGZEROS_VI = VECTOR_PREFIX + "COUNTLEADINGZEROS_VI" + POSTFIX;
+    static {
+        vectorNode(COUNTLEADINGZEROS_VI, "CountLeadingZerosV", TYPE_INT);
     }
 
     public static final String POPULATE_INDEX = PREFIX + "POPULATE_INDEX" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1159,24 +1159,24 @@ public class IRNode {
         vectorNode(POPCOUNT_VL, "PopCountVL", TYPE_LONG);
     }
 
-    public static final String COUNTTRAILINGZEROS_VL = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VL" + POSTFIX;
+    public static final String COUNT_TRAILING_ZEROS_VL = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VL" + POSTFIX;
     static {
-        vectorNode(COUNTTRAILINGZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
+        vectorNode(COUNT_TRAILING_ZEROS_VL, "CountTrailingZerosV", TYPE_LONG);
     }
 
-    public static final String COUNTTRAILINGZEROS_VI = VECTOR_PREFIX + "COUNTTRAILINGZEROS_VI" + POSTFIX;
+    public static final String COUNT_TRAILING_ZEROS_VI = VECTOR_PREFIX + "COUNT_TRAILING_ZEROS_VI" + POSTFIX;
     static {
-        vectorNode(COUNTTRAILINGZEROS_VI, "CountTrailingZerosV", TYPE_INT);
+        vectorNode(COUNT_TRAILING_ZEROS_VI, "CountTrailingZerosV", TYPE_INT);
     }
 
-    public static final String COUNTLEADINGZEROS_VL = VECTOR_PREFIX + "COUNTLEADINGZEROS_VL" + POSTFIX;
+    public static final String COUNT_LEADING_ZEROS_VL = VECTOR_PREFIX + "COUNT_LEADING_ZEROS_VL" + POSTFIX;
     static {
-        vectorNode(COUNTLEADINGZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
+        vectorNode(COUNT_LEADING_ZEROS_VL, "CountLeadingZerosV", TYPE_LONG);
     }
 
-    public static final String COUNTLEADINGZEROS_VI = VECTOR_PREFIX + "COUNTLEADINGZEROS_VI" + POSTFIX;
+    public static final String COUNT_LEADING_ZEROS_VI = VECTOR_PREFIX + "COUNT_LEADING_ZEROS_VI" + POSTFIX;
     static {
-        vectorNode(COUNTLEADINGZEROS_VI, "CountLeadingZerosV", TYPE_INT);
+        vectorNode(COUNT_LEADING_ZEROS_VI, "CountLeadingZerosV", TYPE_INT);
     }
 
     public static final String POPULATE_INDEX = PREFIX + "POPULATE_INDEX" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -39,8 +39,10 @@ import java.util.Random;
 import jdk.test.lib.Asserts;
 
 public class TestNumberOfContinuousZeros {
-    private long[] input;
-    private int[] output;
+    private long[] inputLong;
+    private int[] outputLong;
+    private int[] inputInt;
+    private int[] outputInt;
     private static final int LEN = 1024;
     private Random rng;
 
@@ -49,39 +51,71 @@ public class TestNumberOfContinuousZeros {
     }
 
     public TestNumberOfContinuousZeros() {
-        input = new long[LEN];
-        output = new int[LEN];
+        inputLong = new long[LEN];
+        outputLong = new int[LEN];
+        inputInt = new int[LEN];
+        outputInt = new int[LEN];
         rng = new Random(42);
         for (int i = 0; i < LEN; ++i) {
-            input[i] = rng.nextLong();
+            inputLong[i] = rng.nextLong();
+            inputInt[i] = rng.nextInt();
         }
     }
 
     @Test
     @IR(counts = {IRNode.COUNTTRAILINGZEROS_VL, "> 0"})
-    public void vectorizeNumberOfTrailingZeros() {
+    public void vectorizeNumberOfTrailingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
-            output[i] = Long.numberOfTrailingZeros(input[i]);
+            outputLong[i] = Long.numberOfTrailingZeros(inputLong[i]);
         }
     }
 
     @Test
     @IR(counts = {IRNode.COUNTLEADINGZEROS_VL, "> 0"})
-    public void vectorizeNumberOfLeadingZeros() {
+    public void vectorizeNumberOfLeadingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
-            output[i] = Long.numberOfLeadingZeros(input[i]);
+            outputLong[i] = Long.numberOfLeadingZeros(inputLong[i]);
         }
     }
 
-    @Run(test = {"vectorizeNumberOfTrailingZeros", "vectorizeNumberOfLeadingZeros"})
-    public void checkResult() {
-        vectorizeNumberOfTrailingZeros();
+    @Run(test = {"vectorizeNumberOfTrailingZerosLong", "vectorizeNumberOfLeadingZerosLong"})
+    public void checkResultLong() {
+        vectorizeNumberOfTrailingZerosLong();
         for (int i = 0; i < LEN; ++i) {
-            Asserts.assertEquals(output[i], Long.numberOfTrailingZeros(input[i]));
+            Asserts.assertEquals(outputLong[i], Long.numberOfTrailingZeros(inputLong[i]));
         }
-        vectorizeNumberOfLeadingZeros();
+        vectorizeNumberOfLeadingZerosLong();
         for (int i = 0; i < LEN; ++i) {
-            Asserts.assertEquals(output[i], Long.numberOfLeadingZeros(input[i]));
+            Asserts.assertEquals(outputLong[i], Long.numberOfLeadingZeros(inputLong[i]));
+        }
+    }
+
+
+    @Test
+    @IR(counts = {IRNode.COUNTTRAILINGZEROS_VI, "> 0"})
+    public void vectorizeNumberOfTrailingZerosInt() {
+        for (int i = 0; i < LEN; ++i) {
+            outputInt[i] = Integer.numberOfTrailingZeros(inputInt[i]);
+        }
+    }
+
+    @Test
+    @IR(counts = {IRNode.COUNTLEADINGZEROS_VI, "> 0"})
+    public void vectorizeNumberOfLeadingZerosInt() {
+        for (int i = 0; i < LEN; ++i) {
+            outputInt[i] = Integer.numberOfLeadingZeros(inputInt[i]);
+        }
+    }
+
+    @Run(test = {"vectorizeNumberOfTrailingZerosInt", "vectorizeNumberOfLeadingZerosInt"})
+    public void checkResultInt() {
+        vectorizeNumberOfTrailingZerosInt();
+        for (int i = 0; i < LEN; ++i) {
+            Asserts.assertEquals(outputInt[i], Integer.numberOfTrailingZeros(inputInt[i]));
+        }
+        vectorizeNumberOfLeadingZerosInt();
+        for (int i = 0; i < LEN; ++i) {
+            Asserts.assertEquals(outputInt[i], Integer.numberOfLeadingZeros(inputInt[i]));
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java
@@ -63,7 +63,7 @@ public class TestNumberOfContinuousZeros {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTTRAILINGZEROS_VL, "> 0"})
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_VL, "> 0"})
     public void vectorizeNumberOfTrailingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
             outputLong[i] = Long.numberOfTrailingZeros(inputLong[i]);
@@ -71,7 +71,7 @@ public class TestNumberOfContinuousZeros {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTLEADINGZEROS_VL, "> 0"})
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_VL, "> 0"})
     public void vectorizeNumberOfLeadingZerosLong() {
         for (int i = 0; i < LEN; ++i) {
             outputLong[i] = Long.numberOfLeadingZeros(inputLong[i]);
@@ -92,7 +92,7 @@ public class TestNumberOfContinuousZeros {
 
 
     @Test
-    @IR(counts = {IRNode.COUNTTRAILINGZEROS_VI, "> 0"})
+    @IR(counts = {IRNode.COUNT_TRAILING_ZEROS_VI, "> 0"})
     public void vectorizeNumberOfTrailingZerosInt() {
         for (int i = 0; i < LEN; ++i) {
             outputInt[i] = Integer.numberOfTrailingZeros(inputInt[i]);
@@ -100,7 +100,7 @@ public class TestNumberOfContinuousZeros {
     }
 
     @Test
-    @IR(counts = {IRNode.COUNTLEADINGZEROS_VI, "> 0"})
+    @IR(counts = {IRNode.COUNT_LEADING_ZEROS_VI, "> 0"})
     public void vectorizeNumberOfLeadingZerosInt() {
         for (int i = 0; i < LEN; ++i) {
             outputInt[i] = Integer.numberOfLeadingZeros(inputInt[i]);


### PR DESCRIPTION
Hi,
Can you help to review the patch adding some test?
Currently, in hotspot/jtreg/compiler/vectorization/TestNumberOfContinuousZeros.java, there is only tests for Long, not for Integer.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331993](https://bugs.openjdk.org/browse/JDK-8331993): Add counting leading/trailing zero tests for Integer (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [c0aaa35d](https://git.openjdk.org/jdk/pull/19154/files/c0aaa35de789e855dc6d28f95e615a6b4cef2eb5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19154/head:pull/19154` \
`$ git checkout pull/19154`

Update a local copy of the PR: \
`$ git checkout pull/19154` \
`$ git pull https://git.openjdk.org/jdk.git pull/19154/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19154`

View PR using the GUI difftool: \
`$ git pr show -t 19154`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19154.diff">https://git.openjdk.org/jdk/pull/19154.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19154#issuecomment-2102465161)