### PR TITLE
8328306: Allow VM to run with X memory execute by default

### DIFF
--- a/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/downcallLinker_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -33,6 +33,7 @@
 #include "prims/downcallLinker.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/stubCodeGenerator.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 #define __ _masm->
 
@@ -48,6 +49,9 @@ RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 bool needs_return_buffer,
                                                 int captured_state_mask,
                                                 bool needs_transition) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   int code_size = native_invoker_code_base_size + (num_args * native_invoker_size_per_arg);
   int locs_size = 1; // must be non-zero
   CodeBuffer code("nep_invoker_blob", code_size, locs_size);

--- a/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/shared/barrierSetNMethod_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -119,6 +119,7 @@ public:
   }
 
   void set_value(int value) {
+    REQUIRE_THREAD_WX_MODE_WRITE
     Atomic::release_store(guard_addr(), value);
   }
 

--- a/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
@@ -59,7 +59,7 @@ static const Register result        = r7;
 // (8262896).  So each FastGetXXXField is wrapped into a C++ statically
 // compiled template function that optionally switches to WXExec if necessary.
 
-#ifdef __APPLE__
+#if INCLUDE_WX_OLD
 
 static address generated_fast_get_field[T_LONG + 1 - T_BOOLEAN];
 
@@ -87,14 +87,14 @@ address JNI_FastGetField::generate_fast_get_int_field1() {
   return (address)static_fast_get_field_wrapper<BType>;
 }
 
-#else // __APPLE__
+#else // INCLUDE_WX_OLD
 
 template<int BType>
 address JNI_FastGetField::generate_fast_get_int_field1() {
   return generate_fast_get_int_field0((BasicType)BType);
 }
 
-#endif // __APPLE__
+#endif // INCLUDE_WX_OLD
 
 address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   const char *name;

--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -122,6 +122,9 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
                                        BasicType ret_type,
                                        jobject jabi, jobject jconv,
                                        bool needs_return_buffer, int ret_buf_size) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   ResourceMark rm;
   const ABIDescriptor abi = ForeignGlobals::parse_abi_descriptor(jabi);
   const CallRegs call_regs = ForeignGlobals::parse_call_regs(jconv);

--- a/src/hotspot/os/bsd/globals_bsd.hpp
+++ b/src/hotspot/os/bsd/globals_bsd.hpp
@@ -37,7 +37,13 @@
                                                                         \
   AARCH64_ONLY(develop(bool, AssertWXAtThreadSync, true,                \
           "Conservatively check W^X thread state at possible safepoint" \
-          "or handshake"))
+          "or handshake"))                                              \
+  AARCH64_ONLY(develop(bool, AssertWX, false,                           \
+          "Enable extra W^X state checking."))                          \
+  AARCH64_ONLY(develop(bool, UseOldWX, false WX_OLD_ONLY(|| true),      \
+          "Choose old W^X implementation."))                            \
+  AARCH64_ONLY(develop(bool, UseNewWX, false WX_NEW_ONLY(|| true),      \
+          "Choose new W^X implementation."))                            \
 
 // end of RUNTIME_OS_FLAGS
 

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -38,6 +38,9 @@
 #include "os_posix.hpp"
 #include "prims/jniFastGetField.hpp"
 #include "prims/jvm_misc.hpp"
+#if 1
+#include "runtime/atomic.hpp"
+#endif
 #include "runtime/arguments.hpp"
 #include "runtime/frame.inline.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
@@ -194,9 +197,11 @@ NOINLINE frame os::current_frame() {
 
 bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
                                              ucontext_t* uc, JavaThread* thread) {
+#if INCLUDE_WX_OLD
   // Enable WXWrite: this function is called by the signal handler at arbitrary
   // point of execution.
   ThreadWXEnable wx(WXWrite, thread);
+#endif
 
   // decide if this trap can be handled by a stub
   address stub = nullptr;
@@ -205,6 +210,12 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
 
   //%note os_trap_1
   if (info != nullptr && uc != nullptr && thread != nullptr) {
+#if INCLUDE_WX_NEW
+    // Enable WXExec: this function is called by the signal handler at arbitrary
+    // point of execution.
+    auto _wx = WXExecMark(thread);
+#endif
+
     pc = (address) os::Posix::ucontext_get_pc(uc);
 
     // Handle ALL stack overflow variations here
@@ -503,8 +514,26 @@ int os::extra_bang_size_in_bytes() {
   return 0;
 }
 
-void os::current_thread_enable_wx(WXMode mode) {
-  pthread_jit_write_protect_np(mode == WXExec);
+#ifndef PRODUCT
+static uint _wx_changes[2] = {0};
+static uint _wx_changes_total = 0;
+#endif
+
+void os::current_thread_enable_wx(WXMode mode, bool use_new_code) {
+#ifndef PRODUCT
+  Atomic::inc(&_wx_changes[use_new_code ? 1 : 0]);
+  Atomic::inc(&_wx_changes_total);
+  if (is_power_of_2(_wx_changes_total)) {
+    log_develop_info(wx, perf)("WX transitions: old %d new %d total %d %.1f:%.1f",
+      _wx_changes[0], _wx_changes[1], _wx_changes_total,
+      100.0 * _wx_changes[0] / _wx_changes_total,
+      100.0 * _wx_changes[1] / _wx_changes_total);
+  }
+#endif
+
+  if (use_new_code ? UseNewWX : UseOldWX && !UseNewWX) {
+    pthread_jit_write_protect_np(mode == WXExec);
+  }
 }
 
 static inline void atomic_copy64(const volatile void *src, volatile void *dst) {

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -33,6 +33,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/linkedlist.hpp"
 #include "utilities/resizeableResourceHash.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/macros.hpp"
 
 template <typename T>
@@ -154,6 +155,8 @@ class CodeSection {
     _skipped_instructions_size = cs->_skipped_instructions_size;
   }
 
+  address     writable_end() const  { REQUIRE_THREAD_WX_MODE_WRITE return _end; }
+
  public:
   address     start() const         { return _start; }
   address     mark() const          { return _mark; }
@@ -219,24 +222,24 @@ class CodeSection {
 
   // Code emission
   void emit_int8(uint8_t x1) {
-    address curr = end();
+    address curr = writable_end();
     *((uint8_t*)  curr++) = x1;
     set_end(curr);
   }
 
   template <typename T>
-  void emit_native(T x) { put_native(end(), x); set_end(end() + sizeof x); }
+  void emit_native(T x) { put_native(writable_end(), x); set_end(end() + sizeof x); }
 
   void emit_int16(uint16_t x) { emit_native(x); }
   void emit_int16(uint8_t x1, uint8_t x2) {
-    address curr = end();
+    address curr = writable_end();
     *((uint8_t*)  curr++) = x1;
     *((uint8_t*)  curr++) = x2;
     set_end(curr);
   }
 
   void emit_int24(uint8_t x1, uint8_t x2, uint8_t x3)  {
-    address curr = end();
+    address curr = writable_end();
     *((uint8_t*)  curr++) = x1;
     *((uint8_t*)  curr++) = x2;
     *((uint8_t*)  curr++) = x3;
@@ -245,7 +248,7 @@ class CodeSection {
 
   void emit_int32(uint32_t x) { emit_native(x); }
   void emit_int32(uint8_t x1, uint8_t x2, uint8_t x3, uint8_t x4)  {
-    address curr = end();
+    address curr = writable_end();
     *((uint8_t*)  curr++) = x1;
     *((uint8_t*)  curr++) = x2;
     *((uint8_t*)  curr++) = x3;

--- a/src/hotspot/share/c1/c1_Compilation.cpp
+++ b/src/hotspot/share/c1/c1_Compilation.cpp
@@ -390,6 +390,10 @@ int Compilation::compile_java_method() {
     BAILOUT_("mdo allocation failed", no_frame_size);
   }
 
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
+
   {
     PhaseTraceTime timeit(_t_buildIR);
     build_hir();

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -40,6 +40,7 @@
 #include "memory/resourceArea.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/vm_version.hpp"
 #include "utilities/bitMap.inline.hpp"
 #include "utilities/macros.hpp"
@@ -62,6 +63,10 @@ void Compiler::init_c1_runtime() {
 
 
 void Compiler::initialize() {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
+
   // Buffer blob must be allocated per C1 compiler thread at startup
   BufferBlob* buffer_blob = init_buffer_blob();
 

--- a/src/hotspot/share/c1/c1_Runtime1.cpp
+++ b/src/hotspot/share/c1/c1_Runtime1.cpp
@@ -1318,7 +1318,7 @@ void Runtime1::patch_code(JavaThread* current, Runtime1::StubID stub_id) {
 
   // Enable WXWrite: the function is called by c1 stub as a runtime function
   // (see another implementation above).
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   if (TracePatching) {
     tty->print_cr("Deoptimizing because patch is needed");

--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -413,6 +413,11 @@ bool ClassLoaderDataGraph::do_unloading() {
   ClassLoaderData* prev = nullptr;
   uint loaders_processed = 0;
   uint loaders_removed = 0;
+
+  // Anticipate nmethod::is_unloading()
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
 
   for (ClassLoaderData* data = _head; data != nullptr; data = data->next()) {
     if (data->is_alive()) {

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -172,6 +172,9 @@ RuntimeBlob::RuntimeBlob(
 void RuntimeBlob::free(RuntimeBlob* blob) {
   assert(blob != nullptr, "caller must check for nullptr");
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   blob->purge();
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
@@ -229,6 +232,9 @@ BufferBlob::BufferBlob(const char* name, CodeBlobKind kind, int size)
 
 BufferBlob* BufferBlob::create(const char* name, uint buffer_size) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
 
   BufferBlob* blob = nullptr;
   unsigned int size = sizeof(BufferBlob);
@@ -254,6 +260,9 @@ BufferBlob::BufferBlob(const char* name, CodeBlobKind kind, CodeBuffer* cb, int 
 // Used by gtest
 BufferBlob* BufferBlob::create(const char* name, CodeBuffer* cb) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
 
   BufferBlob* blob = nullptr;
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(BufferBlob));
@@ -320,7 +329,9 @@ VtableBlob::VtableBlob(const char* name, int size) :
 }
 
 VtableBlob* VtableBlob::create(const char* name, int buffer_size) {
-  assert(JavaThread::current()->thread_state() == _thread_in_vm, "called with the wrong state");
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
 
   VtableBlob* blob = nullptr;
   unsigned int size = sizeof(VtableBlob);

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -61,6 +61,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.inline.hpp"
 #include "runtime/safepointVerifiers.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "runtime/vmThread.hpp"
 #include "sanitizers/leak.hpp"
 #include "services/memoryService.hpp"
@@ -496,6 +497,9 @@ CodeBlob* CodeCache::next_blob(CodeHeap* heap, CodeBlob* cb) {
  */
 CodeBlob* CodeCache::allocate(uint size, CodeBlobType code_blob_type, bool handle_alloc_failure, CodeBlobType orig_code_blob_type) {
   assert_locked_or_safepoint(CodeCache_lock);
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   assert(size > 0, "Code cache allocation request must be > 0");
   if (size == 0) {
     return nullptr;
@@ -568,6 +572,9 @@ CodeBlob* CodeCache::allocate(uint size, CodeBlobType code_blob_type, bool handl
 }
 
 void CodeCache::free(CodeBlob* cb) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   assert_locked_or_safepoint(CodeCache_lock);
   CodeHeap* heap = get_code_heap(cb);
   print_trace("free", cb);
@@ -782,6 +789,9 @@ void CodeCache::gc_on_allocation() {
     // In case the GC is concurrent, we make sure only one thread requests the GC.
     if (Atomic::cmpxchg(&_unloading_threshold_gc_requested, false, true) == false) {
       log_info(codecache)("Triggering aggressive GC due to having only %.3f%% free memory", free_ratio * 100.0);
+#if INCLUDE_WX_NEW
+      auto _wx = WXExecMark(Thread::current());
+#endif
       Universe::heap()->collect(GCCause::_codecache_GC_aggressive);
     }
     return;
@@ -809,6 +819,9 @@ void CodeCache::gc_on_allocation() {
     if (Atomic::cmpxchg(&_unloading_threshold_gc_requested, false, true) == false) {
       log_info(codecache)("Triggering threshold (%.3f%%) GC due to allocating %.3f%% since last unloading (%.3f%% used -> %.3f%% used)",
                           threshold * 100.0, allocated_since_last_ratio * 100.0, last_used_ratio * 100.0, used_ratio * 100.0);
+#if INCLUDE_WX_NEW
+      auto _wx = WXExecMark(Thread::current());
+#endif
       Universe::heap()->collect(GCCause::_codecache_GC_threshold);
     }
   }
@@ -1142,6 +1155,9 @@ void CodeCache::initialize() {
 }
 
 void codeCache_init() {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   CodeCache::initialize();
 }
 
@@ -1221,6 +1237,9 @@ static void check_live_nmethods_dependencies(DepChange& changes) {
 
 void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, KlassDepChange& changes) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
 
   // search the hierarchy looking for nmethods which are affected by the loading of this class
 
@@ -1299,6 +1318,9 @@ void CodeCache::mark_dependents_for_evol_deoptimization(DeoptimizationScope* deo
   reset_old_method_table();
 
   NMethodIterator iter(NMethodIterator::all);
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   while(iter.next()) {
     nmethod* nm = iter.method();
     // Walk all alive nmethods to check for old Methods.
@@ -1314,6 +1336,9 @@ void CodeCache::mark_dependents_for_evol_deoptimization(DeoptimizationScope* deo
 void CodeCache::mark_all_nmethods_for_evol_deoptimization(DeoptimizationScope* deopt_scope) {
   assert(SafepointSynchronize::is_at_safepoint(), "Can only do this at a safepoint!");
   NMethodIterator iter(NMethodIterator::all);
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (!nm->method()->is_method_handle_intrinsic()) {
@@ -1333,6 +1358,9 @@ void CodeCache::mark_all_nmethods_for_evol_deoptimization(DeoptimizationScope* d
 void CodeCache::mark_all_nmethods_for_deoptimization(DeoptimizationScope* deopt_scope) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
   NMethodIterator iter(NMethodIterator::not_unloading);
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (!nm->is_native_method()) {
@@ -1343,6 +1371,9 @@ void CodeCache::mark_all_nmethods_for_deoptimization(DeoptimizationScope* deopt_
 
 void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method* dependee) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
 
   NMethodIterator iter(NMethodIterator::not_unloading);
   while(iter.next()) {
@@ -1355,6 +1386,9 @@ void CodeCache::mark_for_deoptimization(DeoptimizationScope* deopt_scope, Method
 
 void CodeCache::make_marked_nmethods_deoptimized() {
   RelaxedNMethodIterator iter(RelaxedNMethodIterator::not_unloading);
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   while(iter.next()) {
     nmethod* nm = iter.method();
     if (nm->is_marked_for_deoptimization() && !nm->has_been_deoptimized() && nm->can_be_deoptimized()) {

--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -198,10 +198,12 @@ void CompiledIC::ensure_initialized(CallInfo* call_info, Klass* receiver_klass) 
 
 void CompiledIC::set_to_clean() {
   log_debug(inlinecache)("IC@" INTPTR_FORMAT ": set to clean", p2i(_call->instruction_address()));
+  REQUIRE_THREAD_WX_MODE_WRITE
   _call->set_destination_mt_safe(SharedRuntime::get_resolve_virtual_call_stub());
 }
 
 void CompiledIC::set_to_monomorphic() {
+  REQUIRE_THREAD_WX_MODE_WRITE
   assert(data()->is_initialized(), "must be initialized");
   Method* method = data()->speculated_method();
   nmethod* code = method->code();
@@ -257,6 +259,7 @@ void CompiledIC::set_to_megamorphic(CallInfo* call_info) {
   log_trace(inlinecache)("IC@" INTPTR_FORMAT ": to megamorphic %s entry: " INTPTR_FORMAT,
                          p2i(_call->instruction_address()), call_info->selected_method()->print_value_string(), p2i(entry));
 
+  REQUIRE_THREAD_WX_MODE_WRITE
   _call->set_destination_mt_safe(entry);
   assert(is_megamorphic(), "sanity check");
 }
@@ -321,6 +324,7 @@ void CompiledIC::verify() {
 // ----------------------------------------------------------------------------
 
 void CompiledDirectCall::set_to_clean() {
+  REQUIRE_THREAD_WX_MODE_WRITE
   // in_use is unused but needed to match template function in nmethod
   assert(CompiledICLocker::is_safe(instruction_address()), "mt unsafe call");
   // Reset call site

--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -34,6 +34,7 @@
 #include "runtime/mutexLocker.hpp"
 #include "runtime/orderAccess.hpp"
 #include "runtime/perfData.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/exceptions.hpp"
 
 PerfCounter* DependencyContext::_perf_total_buckets_allocated_count   = nullptr;
@@ -68,6 +69,9 @@ void DependencyContext::init() {
 // deoptimization.
 //
 void DependencyContext::mark_dependent_nmethods(DeoptimizationScope* deopt_scope, DepChange& changes) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {
     nmethod* nm = b->get_nmethod();
     if (nm->is_marked_for_deoptimization()) {
@@ -215,6 +219,10 @@ void DependencyContext::remove_all_dependents() {
 }
 
 void DependencyContext::remove_and_mark_for_deoptimization_all_dependents(DeoptimizationScope* deopt_scope) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
+
   nmethodBucket* b = dependencies_not_unloading();
   set_dependencies(nullptr);
   while (b != nullptr) {

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -882,7 +882,7 @@ public:
 
   // used by jvmti to track if the load events has been reported
   bool  load_reported() const                     { return _load_reported; }
-  void  set_load_reported()                       { _load_reported = true; }
+  void  set_load_reported()                       { REQUIRE_THREAD_WX_MODE_WRITE _load_reported = true; }
 
  public:
   // ScopeDesc retrieval operation

--- a/src/hotspot/share/code/nmethod.inline.hpp
+++ b/src/hotspot/share/code/nmethod.inline.hpp
@@ -30,6 +30,7 @@
 #include "code/nativeInst.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/frame.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 inline bool nmethod::is_deopt_pc(address pc) { return is_deopt_entry(pc) || is_deopt_mh_entry(pc); }
 
@@ -66,6 +67,5 @@ address ExceptionCache::handler_at(int index) {
 
 // increment_count is only called under lock, but there may be concurrent readers.
 inline void ExceptionCache::increment_count() { Atomic::release_store(&_count, _count + 1); }
-
 
 #endif // SHARE_CODE_NMETHOD_INLINE_HPP

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1909,6 +1909,12 @@ void CompileBroker::compiler_thread_loop() {
     log->end_elem();
   }
 
+  // If we switch to WXWrite (C1/C2), stay there, otherwise
+  // remain in WXExec (JVMCI).
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(thread);
+#endif
+
   // If compiler thread/runtime initialization fails, exit the compiler thread
   if (!init_compiler_runtime()) {
     return;

--- a/src/hotspot/share/gc/shared/concurrentGCThread.cpp
+++ b/src/hotspot/share/gc/shared/concurrentGCThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@
 #include "runtime/jniHandles.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/os.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 ConcurrentGCThread::ConcurrentGCThread() :
     _should_terminate(false),
@@ -45,7 +46,12 @@ void ConcurrentGCThread::run() {
   // Wait for initialization to complete
   wait_init_completed();
 
-  run_service();
+  {
+#if INCLUDE_WX_NEW
+    auto _wx = WXWriteMark(this);
+#endif
+    run_service();
+  }
 
   // Signal thread has terminated
   MonitorLocker ml(Terminator_lock);

--- a/src/hotspot/share/gc/shared/workerThread.cpp
+++ b/src/hotspot/share/gc/shared/workerThread.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
 #include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "runtime/safepoint.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 WorkerTaskDispatcher::WorkerTaskDispatcher() :
     _task(nullptr),
@@ -196,6 +197,10 @@ WorkerThread::WorkerThread(const char* name_prefix, uint name_suffix, WorkerTask
 
 void WorkerThread::run() {
   os::set_priority(this, NearMaxPriority);
+
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(this);
+#endif
 
   while (true) {
     _dispatcher->worker_run_task();

--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -46,7 +46,7 @@ bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     return true;
   }
 
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
 
   if (nm->is_unloading()) {
     // We don't need to take the lock when unlinking nmethods from

--- a/src/hotspot/share/gc/x/xBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/x/xBarrierSetNMethod.cpp
@@ -41,7 +41,7 @@ bool XBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     return true;
   }
 
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   if (nm->is_unloading()) {
     // We don't need to take the lock when unlinking nmethods from

--- a/src/hotspot/share/gc/x/xNMethod.cpp
+++ b/src/hotspot/share/gc/x/xNMethod.cpp
@@ -207,7 +207,7 @@ void XNMethod::nmethod_oops_do(nmethod* nm, OopClosure* cl) {
   XNMethod::nmethod_oops_do_inner(nm, cl);
 }
 
-void XNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
+void XNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl, bool fix_relocations) {
   // Process oops table
   {
     oop* const begin = nm->oops_begin();
@@ -233,7 +233,7 @@ void XNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
   }
 
   // Process non-immediate oops
-  if (oops->has_non_immediates()) {
+  if (fix_relocations && oops->has_non_immediates()) {
     nm->fix_oop_relocations();
   }
 }

--- a/src/hotspot/share/gc/x/xNMethod.hpp
+++ b/src/hotspot/share/gc/x/xNMethod.hpp
@@ -49,7 +49,7 @@ public:
   static void set_guard_value(nmethod* nm, int value);
 
   static void nmethod_oops_do(nmethod* nm, OopClosure* cl);
-  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl);
+  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl, bool fix_relocations = true);
 
   static void nmethod_oops_barrier(nmethod* nm);
 

--- a/src/hotspot/share/gc/x/xUnload.cpp
+++ b/src/hotspot/share/gc/x/xUnload.cpp
@@ -79,7 +79,7 @@ public:
     XReentrantLock* const lock = XNMethod::lock_for_nmethod(nm);
     XLocker<XReentrantLock> locker(lock);
     XIsUnloadingOopClosure cl;
-    XNMethod::nmethod_oops_do_inner(nm, &cl);
+    XNMethod::nmethod_oops_do_inner(nm, &cl, false /* fix_relocations */);
     return cl.is_unloading();
   }
 };

--- a/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/z/zBarrierSetNMethod.cpp
@@ -49,7 +49,7 @@ bool ZBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
     return true;
   }
 
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, Thread::current()));
 
   if (nm->is_unloading()) {
     log_develop_trace(gc, nmethod)("nmethod: " PTR_FORMAT " visited by entry (unloading)", p2i(nm));

--- a/src/hotspot/share/gc/z/zNMethod.cpp
+++ b/src/hotspot/share/gc/z/zNMethod.cpp
@@ -254,7 +254,7 @@ void ZNMethod::nmethod_oops_do(nmethod* nm, OopClosure* cl) {
   ZNMethod::nmethod_oops_do_inner(nm, cl);
 }
 
-void ZNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
+void ZNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl, bool fix_relocations) {
   // Process oops table
   {
     oop* const begin = nm->oops_begin();
@@ -279,7 +279,7 @@ void ZNMethod::nmethod_oops_do_inner(nmethod* nm, OopClosure* cl) {
   }
 
   // Process non-immediate oops
-  if (data->has_non_immediate_oops()) {
+  if (fix_relocations && data->has_non_immediate_oops()) {
     nm->fix_oop_relocations();
   }
 }

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -56,7 +56,7 @@ public:
   static void nmethod_patch_barriers(nmethod* nm);
 
   static void nmethod_oops_do(nmethod* nm, OopClosure* cl);
-  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl);
+  static void nmethod_oops_do_inner(nmethod* nm, OopClosure* cl, bool fix_relocations = true);
 
   static void nmethods_do_begin(bool secondary);
   static void nmethods_do_end(bool secondary);

--- a/src/hotspot/share/gc/z/zUnload.cpp
+++ b/src/hotspot/share/gc/z/zUnload.cpp
@@ -82,7 +82,7 @@ public:
       return false;
     }
     ZIsUnloadingOopClosure cl(nm);
-    ZNMethod::nmethod_oops_do_inner(nm, &cl);
+    ZNMethod::nmethod_oops_do_inner(nm, &cl, false /* fix_relocations */);
     return cl.is_unloading();
   }
 };

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -73,6 +73,7 @@
 #include "runtime/stubRoutines.hpp"
 #include "runtime/synchronizer.hpp"
 #include "runtime/threadCritical.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/checkedCast.hpp"
 #include "utilities/copy.hpp"
@@ -984,7 +985,7 @@ JRT_END
 
 nmethod* InterpreterRuntime::frequency_counter_overflow(JavaThread* current, address branch_bcp) {
   // Enable WXWrite: the function is called directly by interpreter.
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   // frequency_counter_overflow_inner can throw async exception.
   nmethod* nm = frequency_counter_overflow_inner(current, branch_bcp);
@@ -1306,7 +1307,11 @@ void SignatureHandlerLibrary::add(const methodHandle& method) {
     if (UseFastSignatureHandlers && method->size_of_parameters() <= Fingerprinter::fp_max_size_of_parameters) {
       // use customized signature handler
       MutexLocker mu(SignatureHandlerLibrary_lock);
+#if INCLUDE_WX_NEW
+      auto _wx = WXLazyMark(Thread::current());
+#endif
       // make sure data structure is initialized
+      // may require WXWrite
       initialize();
       // lookup method signature's fingerprint
       uint64_t fingerprint = Fingerprinter(method).fingerprint();
@@ -1317,6 +1322,9 @@ void SignatureHandlerLibrary::add(const methodHandle& method) {
       if (handler_index < 0) {
         ResourceMark rm;
         ptrdiff_t align_offset = align_up(_buffer, CodeEntryAlignment) - (address)_buffer;
+#if INCLUDE_WX_NEW
+        auto _wx = WXWriteMark(Thread::current());
+#endif
         CodeBuffer buffer((address)(_buffer + align_offset),
                           checked_cast<int>(SignatureHandlerLibrary::buffer_size - align_offset));
         InterpreterRuntime::SignatureHandlerGenerator(method, &buffer).generate(fingerprint);

--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -157,7 +157,7 @@ void JfrJvmtiAgent::retransform_classes(JNIEnv* env, jobjectArray classes_array,
   }
   ResourceMark rm(THREAD);
   // WXWrite is needed before entering the vm below and in callee methods.
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, THREAD));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, THREAD));
   jclass* const classes = create_classes_array(classes_count, CHECK);
   assert(classes != nullptr, "invariant");
   for (jint i = 0; i < classes_count; i++) {

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -105,7 +105,7 @@ NO_TRANSITION(void, jfr_set_enabled(JNIEnv* env, jclass jvm, jlong event_type_id
   JfrEventSetting::set_enabled(event_type_id, JNI_TRUE == enabled);
   if (EventOldObjectSample::eventId == event_type_id) {
     JavaThread* thread = JavaThread::thread_from_jni_environment(env);
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     ThreadInVMfromNative transition(thread);
     if (JNI_TRUE == enabled) {
       LeakProfiler::start(JfrOptionSet::old_object_queue_size());

--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.cpp
@@ -700,7 +700,7 @@ void JfrRecorderService::emit_leakprofiler_events(int64_t cutoff_ticks, bool emi
   JfrRotationLock lock;
   // Take the rotation lock before the transition.
   JavaThread* current_thread = JavaThread::current();
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
   ThreadInVMfromNative transition(current_thread);
   LeakProfiler::emit_events(cutoff_ticks, emit_all, skip_bfs);
 }

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -291,7 +291,7 @@ void JfrStorage::register_full(BufferPtr buffer, Thread* thread) {
       JavaThread* jt = JavaThread::cast(thread);
       if (jt->thread_state() == _thread_in_native) {
         // Transition java thread to vm so it can issue a notify.
-        MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+        WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, jt));
         ThreadInVMfromNative transition(jt);
         _post_box.post(MSG_FULLBUFFER);
         return;

--- a/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
+++ b/src/hotspot/share/jfr/support/jfrIntrinsics.cpp
@@ -56,7 +56,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
   assert(JfrThreadLocal::is_vthread(jt), "invariant");
   const u2 vthread_thread_local_epoch = JfrThreadLocal::vthread_epoch(jt);
   const u2 current_epoch = ThreadIdAccess::current_epoch();
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   if (vthread_thread_local_epoch == current_epoch) {
     // After the epoch test in the intrinsic, the thread sampler interleaved
     // and suspended the thread. As part of taking a sample, it updated
@@ -74,7 +74,7 @@ void* JfrIntrinsicSupport::write_checkpoint(JavaThread* jt) {
 
 void* JfrIntrinsicSupport::return_lease(JavaThread* jt) {
   DEBUG_ONLY(assert_precondition(jt);)
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   ThreadStateTransition::transition_from_java(jt, _thread_in_native);
   assert(jt->jfr_thread_local()->has_java_event_writer(), "invariant");
   assert(jt->jfr_thread_local()->shelved_buffer() != nullptr, "invariant");

--- a/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
+++ b/src/hotspot/share/jfr/writers/jfrJavaEventWriter.cpp
@@ -123,7 +123,7 @@ void JfrJavaEventWriter::flush(jobject writer, jint used, jint requested, JavaTh
   u1* const new_current_position = is_valid ? buffer->pos() + used : buffer->pos();
   assert(start_pos_offset != invalid_offset, "invariant");
   // can safepoint here
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, jt));
   ThreadInVMfromNative transition(jt);
   oop const w = JNIHandles::resolve_non_null(writer);
   assert(w != nullptr, "invariant");

--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -41,6 +41,7 @@
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/os.hpp"
 #include "runtime/sharedRuntime.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/align.hpp"
 
 // frequently used constants
@@ -710,6 +711,10 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     char* speculations,
     int speculations_len,
     JVMCI_TRAPS) {
+
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(JavaThread::current());
+#endif
 
   JavaThread* thread = JavaThread::current();
   HotSpotCompiledCodeStream* stream = new HotSpotCompiledCodeStream(thread, (const u1*) compiled_code_buffer, with_type_info, object_pool);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -164,7 +164,7 @@ Handle JavaArgumentUnboxer::next_arg(BasicType expectedType) {
 
 // Bring the JVMCI compiler thread into the VM state.
 #define JVMCI_VM_ENTRY_MARK                                       \
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));       \
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));              \
   ThreadInVMfromNative __tiv(thread);                             \
   HandleMarkCleaner __hm(thread);                                 \
   JavaThread* THREAD = thread;                                    \

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -1971,6 +1971,12 @@ static bool after_compiler_upcall(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, c
 }
 
 void JVMCIRuntime::compile_method(JVMCIEnv* JVMCIENV, JVMCICompiler* compiler, const methodHandle& method, int entry_bci) {
+  // Compiler thread loop runs as WXLazyWrite.  If we need to switch to WXExec here,
+  // then it means we are mixing C1/C2 tasks with JVMCI tasks in the same thread.
+#if INCLUDE_WX_NEW
+  auto _wx = WXExecMark(JavaThread::current());
+#endif
+
   JVMCI_EXCEPTION_CONTEXT
 
   JVMCICompileState* compile_state = JVMCIENV->compile_state();

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -215,7 +215,8 @@ class outputStream;
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \
   LOG_TAG(vtables) \
-  LOG_TAG(vtablestubs)
+  LOG_TAG(vtablestubs) \
+  NOT_PRODUCT(WX_ONLY(LOG_TAG(wx))) \
 
 #define PREFIX_LOG_TAG(T) (LogTag::_##T)
 

--- a/src/hotspot/share/memory/heap.cpp
+++ b/src/hotspot/share/memory/heap.cpp
@@ -163,6 +163,7 @@ void CodeHeap::mark_segmap_as_used(size_t beg, size_t end, bool is_FreeBlock_joi
 }
 
 void CodeHeap::invalidate(size_t beg, size_t end, size_t hdr_size) {
+  REQUIRE_THREAD_WX_MODE_WRITE
 #ifndef PRODUCT
   // Fill the given range with some bad value.
   // length is expected to be in segment_size units.
@@ -276,6 +277,7 @@ bool CodeHeap::expand_by(size_t size) {
 
 
 void* CodeHeap::allocate(size_t instance_size) {
+  REQUIRE_THREAD_WX_MODE_WRITE
   size_t number_of_segments = size_to_segments(instance_size + header_size());
   assert(segments_to_size(number_of_segments) >= sizeof(FreeBlock), "not enough room for FreeList");
   assert_locked_or_safepoint(CodeCache_lock);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -978,6 +978,9 @@ void InstanceKlass::rewrite_class(TRAPS) {
 // This is outside is_rewritten flag. In case of an exception, it can be
 // executed more than once.
 void InstanceKlass::link_methods(TRAPS) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current()); // link_method --> make_adapters
+#endif
   int len = methods()->length();
   for (int i = len-1; i >= 0; i--) {
     methodHandle m(THREAD, methods()->at(i));
@@ -3358,6 +3361,9 @@ void InstanceKlass::adjust_default_methods(bool* trace_name_printed) {
 // On-stack replacement stuff
 void InstanceKlass::add_osr_nmethod(nmethod* n) {
   assert_lock_strong(NMethodState_lock);
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
 #ifndef PRODUCT
   nmethod* prev = lookup_osr_nmethod(n->method(), n->osr_entry_bci(), n->comp_level(), true);
   assert(prev == nullptr || !prev->is_in_use() COMPILER2_PRESENT(|| StressRecompilation),
@@ -3383,6 +3389,9 @@ void InstanceKlass::add_osr_nmethod(nmethod* n) {
 bool InstanceKlass::remove_osr_nmethod(nmethod* n) {
   // This is a short non-blocking critical region, so the no safepoint check is ok.
   ConditionalMutexLocker ml(NMethodState_lock, !NMethodState_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   assert(n->is_osr_method(), "wrong kind of nmethod");
   nmethod* last = nullptr;
   nmethod* cur  = osr_nmethods_head();
@@ -3426,6 +3435,9 @@ int InstanceKlass::mark_osr_nmethods(DeoptimizationScope* deopt_scope, const Met
   ConditionalMutexLocker ml(NMethodState_lock, !NMethodState_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
   nmethod* osr = osr_nmethods_head();
   int found = 0;
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(JavaThread::current());
+#endif
   while (osr != nullptr) {
     assert(osr->is_osr_method(), "wrong kind of nmethod found in chain");
     if (osr->method() == m) {

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -35,6 +35,7 @@
 #include "opto/runtime.hpp"
 #include "runtime/stubRoutines.hpp"
 #include "runtime/globals_extension.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/macros.hpp"
 
 
@@ -64,6 +65,9 @@ const char* C2Compiler::retry_no_superword() {
 void compiler_stubs_init(bool in_compiler_thread);
 
 bool C2Compiler::init_c2_runtime() {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(JavaThread::current());
+#endif
 
 #ifdef ASSERT
   if (!AlignVector && VerifyAlignVector) {
@@ -127,6 +131,10 @@ void C2Compiler::compile_method(ciEnv* env, ciMethod* target, int entry_bci, boo
   bool eliminate_boxing = EliminateAutoBox;
   bool do_locks_coarsening = EliminateLocks;
   bool do_superword = UseSuperWord;
+
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(JavaThread::current());
+#endif
 
   while (!env->failing()) {
     ResourceMark rm;

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3419,6 +3419,9 @@ void copy_jni_function_table(const struct JNINativeInterface_ *new_jni_NativeInt
 void quicken_jni_functions() {
   // Replace Get<Primitive>Field with fast versions
   if (UseFastJNIAccessors && !VerifyJNIFields && !CheckJNICalls) {
+#if INCLUDE_WX_NEW
+    auto _wx = WXWriteMark(Thread::current());
+#endif
     address func;
     func = JNI_FastGetField::generate_fast_get_boolean_field();
     if (func != (address)-1) {
@@ -3624,7 +3627,7 @@ static jint JNI_CreateJavaVM_inner(JavaVM **vm, void **penv, void *args) {
 
     // Since this is not a JVM_ENTRY we have to set the thread state manually before leaving.
     ThreadStateTransition::transition_from_vm(thread, _thread_in_native);
-    MACOS_AARCH64_ONLY(thread->enable_wx(WXExec));
+    WX_OLD_ONLY(thread->enable_wx(WXExec));
   } else {
     // If create_vm exits because of a pending exception, exit with that
     // exception.  In the future when we figure out how to reclaim memory,
@@ -3727,7 +3730,7 @@ static jint JNICALL jni_DestroyJavaVM_inner(JavaVM *vm) {
   // Since this is not a JVM_ENTRY we have to set the thread state manually before entering.
 
   // We are going to VM, change W^X state to the expected one.
-  MACOS_AARCH64_ONLY(WXMode oldmode = thread->enable_wx(WXWrite));
+  WX_OLD_ONLY(WXMode oldmode = thread->enable_wx(WXWrite));
 
   ThreadStateTransition::transition_from_native(thread, _thread_in_vm);
   Threads::destroy_vm();
@@ -3780,11 +3783,11 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   // Set correct safepoint info. The thread is going to call into Java when
   // initializing the Java level thread object. Hence, the correct state must
   // be set in order for the Safepoint code to deal with it correctly.
+  thread->initialize_thread_current();
+  WX_ONLY(thread->init_wx());
   thread->set_thread_state(_thread_in_vm);
   thread->record_stack_base_and_size();
   thread->register_thread_stack_with_NMT();
-  thread->initialize_thread_current();
-  MACOS_AARCH64_ONLY(thread->init_wx());
 
   if (!os::create_attached_thread(thread)) {
     thread->smr_delete();
@@ -3855,7 +3858,7 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   // Now leaving the VM, so change thread_state. This is normally automatically taken care
   // of in the JVM_ENTRY. But in this situation we have to do it manually.
   ThreadStateTransition::transition_from_vm(thread, _thread_in_native);
-  MACOS_AARCH64_ONLY(thread->enable_wx(WXExec));
+  WX_OLD_ONLY(thread->enable_wx(WXExec));
 
   // Perform any platform dependent FPU setup
   os::setup_fpu();
@@ -3910,7 +3913,7 @@ jint JNICALL jni_DetachCurrentThread(JavaVM *vm)  {
   }
 
   // We are going to VM, change W^X state to the expected one.
-  MACOS_AARCH64_ONLY(thread->enable_wx(WXWrite));
+  WX_OLD_ONLY(thread->enable_wx(WXWrite));
 
   // Safepoint support. Have to do call-back to safepoint code, if in the
   // middle of a safepoint operation
@@ -3930,7 +3933,7 @@ jint JNICALL jni_DetachCurrentThread(JavaVM *vm)  {
 
   // Go to the execute mode, the initial state of the thread on creation.
   // Use os interface as the thread is not a JavaThread anymore.
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXExec));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXExec));
 
   HOTSPOT_JNI_DETACHCURRENTTHREAD_RETURN(JNI_OK);
   return JNI_OK;

--- a/src/hotspot/share/prims/jniCheck.cpp
+++ b/src/hotspot/share/prims/jniCheck.cpp
@@ -101,7 +101,7 @@ extern "C" {                                                             \
     if (env != xenv) {                                                   \
       NativeReportJNIFatalError(thr, warn_wrong_jnienv);                 \
     }                                                                    \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thr));               \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thr));                      \
     VM_ENTRY_BASE(result_type, header, thr)
 
 

--- a/src/hotspot/share/prims/jvmtiEnter.xsl
+++ b/src/hotspot/share/prims/jvmtiEnter.xsl
@@ -437,7 +437,7 @@ struct jvmtiInterface_1_ jvmti</xsl:text>
   <xsl:if test="count(@impl)=0 or not(contains(@impl,'innative'))">
     <xsl:text>JavaThread* current_thread = JavaThread::cast(this_thread);</xsl:text>
     <xsl:value-of select="$space"/>
-    <xsl:text>MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));</xsl:text>
+    <xsl:text>WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));</xsl:text>
     <xsl:value-of select="$space"/>
     <xsl:text>ThreadInVMfromNative __tiv(current_thread);</xsl:text>
     <xsl:value-of select="$space"/>

--- a/src/hotspot/share/prims/jvmtiEnv.cpp
+++ b/src/hotspot/share/prims/jvmtiEnv.cpp
@@ -197,7 +197,7 @@ JvmtiEnv::GetThreadLocalStorage(jthread thread, void** data_ptr) {
     // other than the current thread is required we need to transition
     // from native so as to resolve the jthread.
 
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current_thread);
     VM_ENTRY_BASE(jvmtiError, JvmtiEnv::GetThreadLocalStorage , current_thread)
     debug_only(VMNativeEntryWrapper __vew;)
@@ -3516,7 +3516,7 @@ JvmtiEnv::RawMonitorEnter(JvmtiRawMonitor * rmonitor) {
   } else {
     Thread* thread = Thread::current();
     // 8266889: raw_enter changes Java thread state, needs WXWrite
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));
     rmonitor->raw_enter(thread);
   }
   return JVMTI_ERROR_NONE;
@@ -3550,7 +3550,7 @@ jvmtiError
 JvmtiEnv::RawMonitorWait(JvmtiRawMonitor * rmonitor, jlong millis) {
   Thread* thread = Thread::current();
   // 8266889: raw_wait changes Java thread state, needs WXWrite
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   int r = rmonitor->raw_wait(millis, thread);
 
   switch (r) {

--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -382,7 +382,7 @@ JvmtiExport::get_jvmti_interface(JavaVM *jvm, void **penv, jint version) {
   if (JvmtiEnv::get_phase() == JVMTI_PHASE_LIVE) {
     JavaThread* current_thread = JavaThread::current();
     // transition code: native to VM
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
     ThreadInVMfromNative __tiv(current_thread);
     VM_ENTRY_BASE(jvmtiEnv*, JvmtiExport::get_jvmti_interface, current_thread)
     debug_only(VMNativeEntryWrapper __vew;)

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -134,7 +134,7 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
     return JVMTI_ERROR_NULL_POINTER;
   }
 
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
   ThreadInVMfromNative tiv(current_thread);
   JvmtiVTMSTransitionDisabler disabler;
 

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -1086,6 +1086,9 @@ void JvmtiDeferredEventQueue::post(JvmtiEnv* env) {
 }
 
 void JvmtiDeferredEventQueue::run_nmethod_entry_barriers() {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   for(QueueNode* node = _queue_head; node != nullptr; node = node->next()) {
      node->event().run_nmethod_entry_barriers();
   }

--- a/src/hotspot/share/prims/jvmtiRawMonitor.cpp
+++ b/src/hotspot/share/prims/jvmtiRawMonitor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,10 @@ void JvmtiPendingMonitors::transition_raw_monitors() {
          "Java thread has not been created yet or more than one java thread "
          "is running. Raw monitor transition will not work");
   JavaThread* current_java_thread = JavaThread::current();
-  {
+  if (count() > 0) {
+#if INCLUDE_WX_NEW
+    auto _wx = WXExecMark(Thread::current());
+#endif
     ThreadToNativeFromVM ttnfvm(current_java_thread);
     for (int i = 0; i < count(); i++) {
       JvmtiRawMonitor* rmonitor = monitors()->at(i);

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -390,7 +390,7 @@ UNSAFE_ENTRY_SCOPED(void, Unsafe_SetMemory0(JNIEnv *env, jobject unsafe, jobject
   {
     GuardUnsafeAccess guard(thread);
     if (StubRoutines::unsafe_setmemory() != nullptr) {
-      MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
+      WX_OLD_ONLY(ThreadWXEnable wx(WXExec, thread));
       StubRoutines::UnsafeSetMemory_stub()(p, sz, value);
     } else {
       Copy::fill_to_memory_atomic(p, sz, value);
@@ -409,7 +409,7 @@ UNSAFE_ENTRY_SCOPED(void, Unsafe_CopyMemory0(JNIEnv *env, jobject unsafe, jobjec
   {
     GuardUnsafeAccess guard(thread);
     if (StubRoutines::unsafe_arraycopy() != nullptr) {
-      MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, thread));
+      WX_OLD_ONLY(ThreadWXEnable wx(WXExec, thread));
       StubRoutines::UnsafeArrayCopy_stub()(src, dst, sz);
     } else {
       Copy::conjoint_memory_atomic(src, dst, sz);
@@ -441,14 +441,14 @@ UNSAFE_LEAF (void, Unsafe_WriteBack0(JNIEnv *env, jobject unsafe, jlong line)) {
   }
 #endif
 
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
   assert(StubRoutines::data_cache_writeback() != nullptr, "sanity");
   (StubRoutines::DataCacheWriteback_stub())(addr_from_java(line));
 } UNSAFE_END
 
 static void doWriteBackSync0(bool is_pre)
 {
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXExec, Thread::current()));
   assert(StubRoutines::data_cache_writeback_sync() != nullptr, "sanity");
   (StubRoutines::DataCacheWritebackSync_stub())(is_pre);
 }

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -90,7 +90,7 @@ JavaThread* UpcallLinker::on_entry(UpcallStub::FrameData* context, jobject recei
 
   // The call to transition_from_native below contains a safepoint check
   // which needs the code cache to be writable.
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   // After this, we are officially in Java Code. This needs to be done before we change any of the thread local
   // info, since we cannot find oops before the new information is set up completely.

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -818,6 +818,9 @@ WB_ENTRY(jint, WB_DeoptimizeMethod(JNIEnv* env, jobject o, jobject method, jbool
   {
     MutexLocker mu(Compile_lock);
     methodHandle mh(THREAD, Method::checked_resolve_jmethod_id(jmid));
+#if INCLUDE_WX_NEW
+    auto _wx = WXLazyMark(thread);
+#endif
     if (is_osr) {
       result += mh->method_holder()->mark_osr_nmethods(&deopt_scope, mh());
     } else {
@@ -1607,6 +1610,9 @@ CodeBlob* WhiteBox::allocate_code_blob(int size, CodeBlobType blob_type) {
   }
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
+#if INCLUDE_WX_NEW
+    auto _wx = WXWriteMark(Thread::current());
+#endif
     blob = (BufferBlob*) CodeCache::allocate(full_size, blob_type);
     if (blob != nullptr) {
       ::new (blob) BufferBlob("WB::DummyBlob", CodeBlobKind::Buffer, full_size);

--- a/src/hotspot/share/prims/whitebox.inline.hpp
+++ b/src/hotspot/share/prims/whitebox.inline.hpp
@@ -33,7 +33,7 @@
 
 #define WB_ENTRY(result_type, header) JNI_ENTRY(result_type, header) \
   ClearPendingJniExcCheck _clearCheck(env); \
-  MACOS_AARCH64_ONLY(ThreadWXEnable _wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable _wx(WXWrite, thread));
 
 #define WB_END JNI_END
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -249,7 +249,7 @@ static JRT_LEAF(intptr_t*, thaw(JavaThread* thread, int kind))
   ResetNoHandleMark rnhm;
 
   // we might modify the code cache via BarrierSetNMethod::nmethod_entry_barrier
-  MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));
   return ConfigT::thaw(thread, (Continuation::thaw_kind)kind);
 JRT_END
 
@@ -1995,6 +1995,9 @@ inline bool ThawBase::seen_by_gc() {
 }
 
 NOINLINE intptr_t* ThawBase::thaw_slow(stackChunkOop chunk, bool return_barrier) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(Thread::current());
+#endif
   LogTarget(Trace, continuations) lt;
   if (lt.develop_is_enabled()) {
     LogStream ls(lt);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -127,8 +127,13 @@ void DeoptimizationScope::mark(nmethod* nm, bool inc_recompile_counts) {
     return;
   }
 
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
+
   nmethod::DeoptimizationStatus status =
     inc_recompile_counts ? nmethod::deoptimize : nmethod::deoptimize_noupdate;
+  REQUIRE_THREAD_WX_MODE_WRITE
   Atomic::store(&nm->_deoptimization_status, status);
 
   // Make sure active is not committed
@@ -2604,7 +2609,7 @@ Deoptimization::update_method_data_from_interpreter(MethodData* trap_mdo, int tr
 
 Deoptimization::UnrollBlock* Deoptimization::uncommon_trap(JavaThread* current, jint trap_request, jint exec_mode) {
   // Enable WXWrite: current function is called from methods compiled by C2 directly
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   // Still in Java no safepoints
   {

--- a/src/hotspot/share/runtime/interfaceSupport.inline.hpp
+++ b/src/hotspot/share/runtime/interfaceSupport.inline.hpp
@@ -283,7 +283,7 @@ class VMNativeEntryWrapper {
 #define JRT_ENTRY(result_type, header)                               \
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current));       \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current));              \
     ThreadInVMfromJava __tiv(current);                               \
     VM_ENTRY_BASE(result_type, header, current)                      \
     debug_only(VMEntryWrapper __vew;)
@@ -311,7 +311,7 @@ class VMNativeEntryWrapper {
 #define JRT_ENTRY_NO_ASYNC(result_type, header)                      \
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current));       \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current));              \
     ThreadInVMfromJava __tiv(current, false /* check asyncs */);     \
     VM_ENTRY_BASE(result_type, header, current)                      \
     debug_only(VMEntryWrapper __vew;)
@@ -321,7 +321,7 @@ class VMNativeEntryWrapper {
 #define JRT_BLOCK_ENTRY(result_type, header)                         \
   result_type header {                                               \
     assert(current == JavaThread::current(), "Must be");             \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current));       \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, current));              \
     HandleMarkCleaner __hm(current);
 
 #define JRT_BLOCK                                                    \
@@ -358,7 +358,7 @@ extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
     assert(thread == Thread::current(), "JNIEnv is only valid in same thread"); \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));               \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE(result_type, header, thread)
@@ -383,7 +383,7 @@ extern "C" {                                                         \
 extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread=JavaThread::thread_from_jni_environment(env); \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));               \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE(result_type, header, thread)
@@ -393,7 +393,7 @@ extern "C" {                                                         \
 extern "C" {                                                         \
   result_type JNICALL header {                                       \
     JavaThread* thread = JavaThread::current();                      \
-    MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, thread));        \
+    WX_OLD_ONLY(ThreadWXEnable __wx(WXWrite, thread));               \
     ThreadInVMfromNative __tiv(thread);                              \
     debug_only(VMNativeEntryWrapper __vew;)                          \
     VM_ENTRY_BASE(result_type, header, thread)

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -95,14 +95,14 @@ JavaCallWrapper::JavaCallWrapper(const methodHandle& callee_method, Handle recei
   debug_only(_thread->inc_java_call_counter());
   _thread->set_active_handles(new_handles);     // install new handle block and reset Java frame linkage
 
-  MACOS_AARCH64_ONLY(_thread->enable_wx(WXExec));
+  WX_OLD_ONLY(_thread->enable_wx(WXExec));
 }
 
 
 JavaCallWrapper::~JavaCallWrapper() {
   assert(_thread == JavaThread::current(), "must still be the same thread");
 
-  MACOS_AARCH64_ONLY(_thread->enable_wx(WXWrite));
+  WX_OLD_ONLY(_thread->enable_wx(WXWrite));
 
   // restore previous handle block & Java frame linkage
   JNIHandleBlock *_old_handles = _thread->active_handles();
@@ -322,6 +322,9 @@ Handle JavaCalls::construct_new_instance(InstanceKlass* klass, Symbol* construct
 
 
 void JavaCalls::call(JavaValue* result, const methodHandle& method, JavaCallArguments* args, TRAPS) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXExecMark(THREAD);
+#endif
   // Check if we need to wrap a potential OS exception handler around thread.
   // This is used for e.g. Win32 structured exception handlers.
   // Need to wrap each and every time, since there might be native code down the
@@ -412,6 +415,9 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
         }
       }
 #endif
+
+      REQUIRE_THREAD_WX_MODE_EXEC
+
       StubRoutines::call_stub()(
         (address)&link,
         // (intptr_t*)&(result->_value), // see NOTE above (compiler problem)

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -377,10 +377,10 @@ void JavaThread::check_possible_safepoint() {
   clear_unhandled_oops();
 #endif // CHECK_UNHANDLED_OOPS
 
+#if INCLUDE_WX_OLD
   // Macos/aarch64 should be in the right state for safepoint (e.g.
   // deoptimization needs WXWrite).  Crashes caused by the wrong state rarely
   // happens in practice, making such issues hard to find and reproduce.
-#if defined(__APPLE__) && defined(AARCH64)
   if (AssertWXAtThreadSync) {
     assert_wx_state(WXWrite);
   }
@@ -1254,7 +1254,7 @@ void JavaThread::check_special_condition_for_native_trans(JavaThread *thread) {
   thread->set_thread_state(_thread_in_vm);
 
   // Enable WXWrite: called directly from interpreter native wrapper.
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   SafepointMechanism::process_if_requested_with_exit_check(thread, true /* check asyncs */);
 
@@ -1447,7 +1447,8 @@ void JavaThread::verify_states_for_handshake() {
 
 void JavaThread::nmethods_do(NMethodClosure* cf) {
   DEBUG_ONLY(verify_frame_info();)
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, Thread::current());)
+  REQUIRE_THREAD_WX_MODE_WRITE
 
   if (has_last_Java_frame()) {
     // Traverse the execution stack

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -565,6 +565,9 @@ private:
   inline ThreadSafepointState* safepoint_state() const;
   inline void set_safepoint_state(ThreadSafepointState* state);
   inline bool is_at_poll_safepoint();
+#if INCLUDE_WX_NEW
+  inline void check_wx(JavaThreadState s) const;
+#endif
 
   // JavaThread termination and lifecycle support:
   void smr_delete();

--- a/src/hotspot/share/runtime/javaThread.inline.hpp
+++ b/src/hotspot/share/runtime/javaThread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -147,9 +147,37 @@ inline JavaThreadState JavaThread::thread_state() const    {
 #endif
 }
 
+#if INCLUDE_WX_NEW
+inline void JavaThread::check_wx(JavaThreadState s) const {
+#ifdef ASSERT
+  if (!AssertWXAtThreadSync) {
+    return;
+  }
+  if (s == _thread_blocked && _thread_state == _thread_in_vm) {
+    return;
+  }
+  if (s == _thread_in_vm && _thread_state == _thread_blocked) {
+    return;
+  }
+  if (is_Compiler_thread()) {
+    if (s == _thread_in_native || s == _thread_in_vm) {
+      return;
+    }
+  }
+  assert(!wx_state().is_lazy(), "thread state transition while in lazy mode");
+  REQUIRE_THREAD_WX_MODE_EXEC
+#endif
+}
+#endif
+
 inline void JavaThread::set_thread_state(JavaThreadState s) {
   assert(current_or_null() == nullptr || current_or_null() == this,
          "state change should only be called by the current thread");
+#if INCLUDE_WX_NEW
+  if (AssertWXAtThreadSync) {
+    check_wx(s);
+  }
+#endif
 #if defined(PPC64) || defined (AARCH64) || defined(RISCV64)
   // Use membars when accessing volatile _thread_state. See
   // Threads::create_vm() for size checks.

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1062,7 +1062,7 @@ class os: AllStatic {
 
 #if defined(__APPLE__) && defined(AARCH64)
   // Enables write or execute access to writeable and executable pages.
-  static void current_thread_enable_wx(WXMode mode);
+  static void current_thread_enable_wx(WXMode mode, bool use_new_code = false);
 #endif // __APPLE__ && AARCH64
 
  protected:

--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -609,7 +609,7 @@ void SafepointSynchronize::handle_polling_page_exception(JavaThread *thread) {
   thread->set_thread_state(_thread_in_vm);
 
   // Enable WXWrite: the function is called implicitly from java code.
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, thread));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, thread));
 
   if (log_is_enabled(Info, safepoint, stats)) {
     Atomic::inc(&_nof_threads_hit_polling_page);

--- a/src/hotspot/share/runtime/stackWatermarkSet.cpp
+++ b/src/hotspot/share/runtime/stackWatermarkSet.cpp
@@ -82,6 +82,9 @@ static void verify_processing_context() {
 }
 
 void StackWatermarkSet::before_unwind(JavaThread* jt) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(jt);
+#endif
   verify_processing_context();
   assert(jt->has_last_Java_frame(), "must have a Java frame");
   for (StackWatermark* current = head(jt); current != nullptr; current = current->next()) {
@@ -91,6 +94,9 @@ void StackWatermarkSet::before_unwind(JavaThread* jt) {
 }
 
 void StackWatermarkSet::after_unwind(JavaThread* jt) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(jt);
+#endif
   verify_processing_context();
   assert(jt->has_last_Java_frame(), "must have a Java frame");
   for (StackWatermark* current = head(jt); current != nullptr; current = current->next()) {
@@ -104,6 +110,9 @@ void StackWatermarkSet::on_iteration(JavaThread* jt, const frame& fr) {
     // Don't perform barrier when error reporting walks the stack.
     return;
   }
+#if INCLUDE_WX_NEW
+  auto _wx = WXLazyMark(jt);
+#endif
   verify_processing_context();
   for (StackWatermark* current = head(jt); current != nullptr; current = current->next()) {
     current->on_iteration(fr);
@@ -115,6 +124,9 @@ void StackWatermarkSet::on_iteration(JavaThread* jt, const frame& fr) {
 void StackWatermarkSet::on_safepoint(JavaThread* jt) {
   StackWatermark* watermark = get(jt, StackWatermarkKind::gc);
   if (watermark != nullptr) {
+#if INCLUDE_WX_NEW
+    auto _wx = WXLazyMark(jt);
+#endif
     watermark->on_safepoint();
   }
 }

--- a/src/hotspot/share/runtime/stubRoutines.cpp
+++ b/src/hotspot/share/runtime/stubRoutines.cpp
@@ -35,6 +35,7 @@
 #include "runtime/timerTrace.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/stubRoutines.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "utilities/align.hpp"
 #include "utilities/copy.hpp"
 #ifdef COMPILER2
@@ -239,6 +240,9 @@ static BufferBlob* initialize_stubs(StubCodeGenerator::StubsKind kind,
                                     const char* timer_msg,
                                     const char* buffer_name,
                                     const char* assert_msg) {
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
   ResourceMark rm;
   TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
   // Add extra space for large CodeEntryAlignment

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -468,13 +468,20 @@ class StubRoutines: AllStatic {
 
   static jshort f2hf(jfloat x) {
     assert(_f2hf != nullptr, "stub is not implemented on this platform");
-    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+    WX_OLD_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+#if INCLUDE_WX_NEW
+    auto _wx = WXExecMark(JavaThread::current()); // About to call into code cache
+#endif
+
     typedef jshort (*f2hf_stub_t)(jfloat x);
     return ((f2hf_stub_t)_f2hf)(x);
   }
   static jfloat hf2f(jshort x) {
     assert(_hf2f != nullptr, "stub is not implemented on this platform");
-    MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+    WX_OLD_ONLY(ThreadWXEnable wx(WXExec, Thread::current());) // About to call into code cache
+#if INCLUDE_WX_NEW
+    auto _wx = WXExecMark(JavaThread::current()); // About to call into code cache
+#endif
     typedef jfloat (*hf2f_stub_t)(jshort x);
     return ((hf2f_stub_t)_hf2f)(x);
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -39,6 +39,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/atomic.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/init.hpp"
 #include "runtime/javaThread.inline.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/orderAccess.hpp"
@@ -141,8 +142,7 @@ Thread::Thread() {
     // If the main thread creates other threads before the barrier set that is an error.
     assert(Thread::current_or_null() == nullptr, "creating thread before barrier set");
   }
-
-  MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
+  WX_OLD_ONLY(DEBUG_ONLY(_wx_init = false));
 }
 
 void Thread::initialize_tlab() {
@@ -205,7 +205,9 @@ void Thread::call_run() {
 
   // Perform common initialization actions
 
-  MACOS_AARCH64_ONLY(this->init_wx());
+#if INCLUDE_WX
+  this->init_wx();
+#endif
 
   register_thread_stack_with_NMT();
 
@@ -595,3 +597,43 @@ void Thread::SpinRelease(volatile int * adr) {
   // more than covers this on all platforms.
   *adr = 0;
 }
+
+#if INCLUDE_WX
+void Thread::assert_can_change_wx_state(WXState wx_state) const {
+#if 0
+  // FIXME
+  guarantee((wx_mode(wx_state) == os::WXWrite) == ((wx_depth() % 2) == 1), "Strange W^X pattern");
+#endif
+  if (is_Worker_thread() || is_ConcurrentGC_thread()) {
+    // GC threads set WXWrite at startup
+    guarantee(wx_depth() <= 1, "Unexpected GC thread W^X depth");
+    return;
+  }
+  if (is_VM_thread()) {
+    // X --> W, should never request W --> X
+    guarantee(wx_depth() <= 1, "Unexpected CompilerThread W^X depth");
+    return;
+  }
+  guarantee(is_Java_thread(), "Not allowed to change W^X state");
+  JavaThreadState state = JavaThread::cast(this)->thread_state();
+  if (is_Compiler_thread()) {
+    // X --> W --> X (register_method --> gc_on_allocation)
+    guarantee(wx_depth() <= 2, "Unexpected CompilerThread W^X depth");
+    guarantee(state == _thread_in_vm || state == _thread_in_native ||
+              (can_call_java() && state == _thread_in_Java),
+              "CompilerThread W^X change from unexpected thread state %d", state);
+    return;
+  }
+  int max_in_init_depth = 3;   // X --> W --> X --> W (universe_post_init)
+  int max_post_init_depth = 2; // X --> W --> X       (AdapterBlob::create --> gc_on_allocation)
+  int max_depth = is_init_completed() ? max_post_init_depth : max_in_init_depth;
+  guarantee(wx_depth() <= max_depth, "Unexpected JavaThread W^X depth");
+  guarantee(state == _thread_in_vm || (can_call_java() && state == _thread_in_Java),
+            "JavaThread W^X change from unexpected thread state %d", state);
+}
+
+#if 0
+const Thread::WXEnable Thread::_wx_root_scope;
+#endif
+
+#endif

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -38,6 +38,9 @@
 #include "runtime/threadStatisticalInfo.hpp"
 #include "runtime/unhandledOops.hpp"
 #include "utilities/globalDefinitions.hpp"
+#if 1
+#include "utilities/vmError.hpp"
+#endif
 #include "utilities/macros.hpp"
 #if INCLUDE_JFR
 #include "jfr/support/jfrThreadExtension.hpp"
@@ -59,7 +62,6 @@ class ThreadClosure;
 class ThreadsList;
 class ThreadsSMRSupport;
 class VMErrorCallback;
-
 
 DEBUG_ONLY(class ResourceMark;)
 
@@ -614,18 +616,127 @@ protected:
   static void SpinAcquire(volatile int * Lock, const char * Name);
   static void SpinRelease(volatile int * Lock);
 
-#if defined(__APPLE__) && defined(AARCH64)
+  // Lazy mode allows lazy transitions between Write and Exec.
+  class WXState {
+    WXMode _mode;
+    bool   _lazy;
+   public:
+    WXState(WXMode mode, bool lazy = false) : _mode(mode), _lazy(lazy) {}
+    WXMode wx_mode() const { return _mode; }
+    void set_wx_mode(WXMode mode) { _mode = mode; }
+    bool is_lazy() const { return _lazy; }
+    const char* name() const {
+      return _lazy ?
+        _mode == WXWrite ? "WXWrite (lazy)" : "WXExec (lazy)"
+      :
+        _mode == WXWrite ? "WXWrite" : "WXExec";
+    }
+    bool operator== (const WXState s) const { return _mode == s._mode && _lazy == s._lazy; }
+    bool operator!= (const WXState s) const { return !(*this == s); }
+  };
+
+#if INCLUDE_WX
+#if INCLUDE_WX_OLD
  private:
   DEBUG_ONLY(bool _wx_init);
   WXMode _wx_state;
+  inline void set_os_wx_mode_old(WXMode mode);
  public:
-  void init_wx();
   WXMode enable_wx(WXMode new_state);
 
   void assert_wx_state(WXMode expected) {
     assert(_wx_state == expected, "wrong state");
   }
-#endif // __APPLE__ && AARCH64
+#endif
+#if INCLUDE_WX_NEW
+
+  static WXState wx_lazy_state(WXState s) {
+    return WXState(s.wx_mode(), true /* lazy */);
+  }
+
+  class WXEnable;
+
+ private:
+  friend class WXEnable;
+
+  static const WXEnable _wx_root_scope;
+
+  struct wx {
+    WXState         _state;
+#ifdef ASSERT
+    bool            _init;
+    uint            _writes_required;
+    uint            _writes_required_at_last_x2w;
+    uint            _depth;
+#if 0
+    const WXEnable* _scope;
+#endif
+#if INCLUDE_WX_OLD
+    uint            _changes_old;
+#endif
+#if INCLUDE_WX_NEW
+    uint            _changes_new;
+#endif
+    const char*     _last_change_file;
+    int             _last_change_line;
+    void set_last_change_loc(const char* FILE, int LINE) {
+      _last_change_file = FILE; _last_change_line = LINE;
+    }
+    const char* last_change_file() const { return _last_change_file; }
+    int last_change_line() const { return _last_change_line; }
+#else
+    void set_last_change_loc(const char* FILE, int LINE) {}
+    const char* last_change_file() const { return "<unknown>"; }
+    int last_change_line() const { return -1; }
+#endif
+    wx() : _state(WXExec) {
+#ifdef ASSERT
+#if 0
+      _scope = &_wx_root_scope;
+#endif
+      _depth = 0;
+      _init = false;
+      _writes_required = 0;
+      _writes_required_at_last_x2w = 0;
+      _last_change_file = __FILE__;
+      _last_change_line = __LINE__;
+#if INCLUDE_WX_OLD
+      _changes_old = 0;
+#endif
+      _changes_new = 0;
+#endif
+    }
+  } _wx;
+
+  inline void set_os_wx_mode_new(WXMode mode);
+
+  WXState set_wx_state(WXState new_state, const char* FILE, int LINE);
+
+ public:
+  void init_wx();
+  WXState wx_state() const { return _wx._state; }
+  WXState wx_lazy_state() const { return wx_lazy_state(_wx._state); }
+#if 0
+  const WXEnable* wx_scope() const { return _wx._scope; }
+  void set_wx_scope(const WXEnable* s) { _wx._scope = s; }
+#endif
+#ifdef ASSERT
+  void set_last_wx_change_loc(const char* FILE, int LINE) { _wx.set_last_change_loc(FILE, LINE); }
+  const char* last_wx_change_file() const { return _wx.last_change_file(); }
+  int last_wx_change_line() const { return _wx.last_change_line(); }
+  int inc_wx_depth(int i) { return _wx._depth += i; }
+  int wx_depth() const    { return _wx._depth; }
+  void inc_wx_writes_required() { _wx._writes_required += 1; }
+  uint wx_writes_required() const { return _wx._writes_required; }
+  uint wx_writes_required_at_last_x2w() const { return _wx._writes_required_at_last_x2w; }
+  void set_wx_writes_required_at_last_x2w() { _wx._writes_required_at_last_x2w = _wx._writes_required; }
+  void assert_can_change_wx_state(WXState new_state) const;
+
+  inline void require_wx_mode(WXMode expected, const char* FILE, int LINE);
+#endif
+
+#endif // INCLUDE_WX_NEW
+#endif // INCLUDE_WX
 
  private:
   bool _in_asgct = false;

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -30,6 +30,7 @@
 
 #include "gc/shared/tlab_globals.hpp"
 #include "runtime/atomic.hpp"
+#include "utilities/events.hpp"
 
 #if defined(__APPLE__) && defined(AARCH64)
 #include "runtime/os.hpp"
@@ -70,13 +71,30 @@ inline void Thread::set_threads_hazard_ptr(ThreadsList* new_list) {
   Atomic::release_store_fence(&_threads_hazard_ptr, new_list);
 }
 
-#if defined(__APPLE__) && defined(AARCH64)
+#if INCLUDE_WX
 inline void Thread::init_wx() {
   assert(this == Thread::current(), "should only be called for current thread");
+#if INCLUDE_WX_OLD
   assert(!_wx_init, "second init");
   _wx_state = WXWrite;
-  os::current_thread_enable_wx(_wx_state);
+  set_os_wx_mode_old(_wx_state);
   DEBUG_ONLY(_wx_init = true);
+#endif
+#if INCLUDE_WX_NEW
+  assert(!_wx._init, "second init");
+  set_os_wx_mode_new(wx_state().wx_mode());
+  DEBUG_ONLY(_wx._init = true;)
+#endif
+}
+
+#if INCLUDE_WX_OLD
+inline void Thread::set_os_wx_mode_old(WXMode mode) {
+#ifdef ASSERT
+  ++_wx._changes_old;
+#endif
+#if defined(__APPLE__) && defined(AARCH64)
+  os::current_thread_enable_wx(mode, false);
+#endif
 }
 
 inline WXMode Thread::enable_wx(WXMode new_state) {
@@ -85,10 +103,48 @@ inline WXMode Thread::enable_wx(WXMode new_state) {
   WXMode old = _wx_state;
   if (_wx_state != new_state) {
     _wx_state = new_state;
-    os::current_thread_enable_wx(new_state);
+    set_os_wx_mode_old(new_state);
   }
   return old;
 }
-#endif // __APPLE__ && AARCH64
+#endif // INCLUDE_WX_OLD
+
+#if INCLUDE_WX_NEW
+inline void Thread::set_os_wx_mode_new(WXMode mode) {
+#ifdef ASSERT
+  ++_wx._changes_new;
+#endif
+#if INCLUDE_WX_OLD
+  assert(_wx._changes_new <= _wx._changes_old + 2, "new code not better?");
+#endif
+#if defined(__APPLE__) && defined(AARCH64)
+  os::current_thread_enable_wx(mode, true);
+#endif
+}
+
+inline Thread::WXState Thread::set_wx_state(WXState new_state, const char* FILE, int LINE) {
+  assert(_wx._init, "should be inited");
+  WXState old_state = _wx._state;
+  if (AssertWX) {
+    guarantee(this == Thread::current(), "should only be called for current thread");
+    guarantee(old_state != new_state || _wx._depth == 0, "set_wx_state() call outside of WXEnable?");
+    if (new_state != old_state) {
+      assert_can_change_wx_state(new_state);
+    }
+  }
+
+  if (new_state.wx_mode() != old_state.wx_mode()) {
+    set_os_wx_mode_new(new_state.wx_mode());
+  }
+  if (new_state != old_state) {
+    set_last_wx_change_loc(FILE, LINE);
+  }
+  _wx._state = new_state;
+
+  return old_state;
+}
+
+#endif // INCLUDE_WX_NEW
+#endif // INCLUDE_WX
 
 #endif // SHARE_RUNTIME_THREAD_INLINE_HPP

--- a/src/hotspot/share/runtime/threadWXSetters.inline.hpp
+++ b/src/hotspot/share/runtime/threadWXSetters.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,9 +28,12 @@
 
 // No threadWXSetters.hpp
 
-#if defined(__APPLE__) && defined(AARCH64)
+#if INCLUDE_WX
 
 #include "runtime/thread.inline.hpp"
+#include "utilities/events.hpp"
+
+#if INCLUDE_WX_OLD
 
 class ThreadWXEnable  {
   Thread* _thread;
@@ -46,7 +49,180 @@ public:
     }
   }
 };
-#endif // __APPLE__ && AARCH64
+#endif
+
+#if INCLUDE_WX_NEW
+class Thread::WXEnable : public StackObj {
+  Thread* _thread;
+  WXState _old_state;
+  WXState _new_state;
+  uint   _wx_writes_required;
+  const WXEnable* _parent;
+  const char* _old_file;
+  int         _old_line;
+
+  friend class Thread;
+
+  WXEnable() : _old_state(WXExec), _new_state(WXExec) {
+    _thread = nullptr;
+    _wx_writes_required = 0;
+#if 0
+    _parent = nullptr;
+#endif
+    _old_file = __FILE__;
+    _old_line = __LINE__;
+  }
+
+public:
+  WXEnable(Thread* thread, WXState new_state, const char* FILE, int LINE) :
+    _thread(thread), _old_state(thread->wx_state()), _new_state(new_state)
+  {
+#if 0
+// FIXME: use array instead, to avoid dangling pointer error.
+   WXScope* scope = new (&thread->_wx_scopes[_wx_scope_depth]) WXScope(_wx_scope_depth);
+#endif
+#if 0
+    _parent = thread->wx_scope();
+    thread->set_wx_scope(this);
+#endif
+    WXState old_state = _old_state;
+#if 1
+    if (old_state == new_state) {
+      os::breakpoint();
+    } else if (old_state.wx_mode() == new_state.wx_mode()) {
+      os::breakpoint();
+    }
+#endif
+
+#if 0
+    assert(old_state.is_lazy() == _parent->_new_state.is_lazy(),
+           "lazy state (%s) does not match parent (%s)",
+           wx_state_name(old_state),
+           wx_state_name(_parent->_new_state));
+#endif
+
+    _old_file = thread->last_wx_change_file();
+    _old_line = thread->last_wx_change_line();
+
+    // FIXME TODO use state transition table + asserts to verify?
+    assert(!new_state.is_lazy() || new_state.wx_mode() == old_state.wx_mode(), "lazy request changed mode");
+
+    // Outermost scope?
+    if (AssertWX) {
+      _wx_writes_required = _thread->wx_writes_required();
+      if (old_state == WXWrite && new_state == WXExec) {
+        guarantee(_thread->wx_writes_required() > _thread->wx_writes_required_at_last_x2w(),
+                  "Unused outer write scope");
+      } else if (new_state == WXWrite && old_state != WXWrite) {
+        _thread->set_wx_writes_required_at_last_x2w();
+      }
+    } else {
+      _wx_writes_required = 0;
+    }
+#if 0
+    // FIXME
+    if (old_state.wx_mode() != new_state.wx_mode() && !new_state.is_lazy() && !old_state.is_lazy()) {
+      thread->inc_wx_depth(1);
+    }
+#endif
+    if (old_state != new_state) {
+      _thread->set_wx_state(new_state, FILE, LINE);
+    }
+  }
+
+  ~WXEnable() {
+    Thread* thread = _thread;
+    if (thread == nullptr) {
+      // root scope
+      return;
+    }
+    WXState cur_state = thread->wx_state();
+    WXState new_state = _new_state;
+
+    assert(new_state == cur_state || (new_state.is_lazy() && cur_state.is_lazy()),
+           "state not restored by inner scope?");
+
+    if (AssertWX) {
+      if (new_state == WXWrite) {
+        guarantee(thread->wx_writes_required() > _wx_writes_required, "no writes required, use lazy mode?");
+      }
+    }
+
+    WXState old_state = _old_state;
+    if (old_state.is_lazy()) {
+      old_state.set_wx_mode(cur_state.wx_mode());
+    }
+
+#if 0
+    // FIXME
+    if (old_state.wx_mode() != cur_state.wx_mode() && !old_state.is_lazy() && !cur_state.is_lazy()) {
+      thread->inc_wx_depth(-1);
+    }
+#endif
+
+    if (old_state != cur_state) {
+      thread->set_wx_state(old_state, __FILE__, __LINE__);
+    }
+    thread->set_last_wx_change_loc(_old_file, _old_line);
+#if 0
+// FIXME: use array instead, to avoid dangling pointer error.
+#endif
+#if 0
+    thread->set_wx_scope(_parent);
+#endif
+
+#if 0
+    assert(old_state.is_lazy() == _parent->_new_state.is_lazy(),
+           "lazy state (%s) does not match parent (%s)",
+           old_state.name(),
+           _parent->_new_state.name());
+#endif
+  }
+};
+
+typedef Thread::WXEnable WXMark;
+
+inline WXMark WXLazyMark(Thread* t, const char* FILE, int LINE) {
+  return WXMark(t, t->wx_lazy_state(), FILE, LINE);
+}
+
+#define WXExecMark(t)  WXMark(t, WXExec, __FILE__, __LINE__)
+#define WXWriteMark(t) WXMark(t, WXWrite, __FILE__, __LINE__)
+#define WXLazyMark(t)  WXLazyMark(t, __FILE__, __LINE__)
+
+inline void Thread::require_wx_mode(WXMode expected, const char* FILE, int LINE) {
+  assert(this == Thread::current(), "should only be called for current thread");
+  if (AssertWX) {
+    if (expected == WXWrite) {
+      inc_wx_writes_required();
+    }
+    guarantee(wx_state().wx_mode() == expected,
+             "unexpected state %s (expected %s) at %s:%d, last set at %s:%d",
+              wx_state().name(),
+              expected == WXExec ? "WXExec" : "WXWrite",
+              FILE, LINE,
+              last_wx_change_file(), last_wx_change_line());
+  }
+}
+
+#define require_wx_mode(mode) require_wx_mode((mode), __FILE__, __LINE__)
+
+#define REQUIRE_THREAD_WX_MODE_EXEC  Thread::current()->require_wx_mode(WXExec);
+#define REQUIRE_THREAD_WX_MODE_WRITE Thread::current()->require_wx_mode(WXWrite);
+
+#endif // INCLUDE_WX_NEW
+
+#else
+
+#define WXMark(t, m)   StackObj()
+#define WXExecMark(t)  StackObj()
+#define WXWriteMark(t) StackObj()
+#define WXLazyMark(t)  StackObj()
+
+#define REQUIRE_THREAD_WX_MODE_EXEC
+#define REQUIRE_THREAD_WX_MODE_WRITE
+
+#endif // INCLUDE_WX
 
 #endif // SHARE_RUNTIME_THREADWXSETTERS_INLINE_HPP
 

--- a/src/hotspot/share/runtime/vmThread.cpp
+++ b/src/hotspot/share/runtime/vmThread.cpp
@@ -485,6 +485,11 @@ void VMThread::loop() {
   no_op.set_calling_thread(_vm_thread);
   safepointALot_op.set_calling_thread(_vm_thread);
 
+  // Performance optimization: enter write mode early and stay there
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(Thread::current());
+#endif
+
   while (true) {
     if (should_terminate()) break;
     wait_for_operation();

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -641,4 +641,30 @@
 #define INCLUDE_ASAN 0
 #endif
 
+#if defined(__APPLE__) && defined(AARCH64)
+#define INCLUDE_WX 1
+#define INCLUDE_WX_OLD 1
+#define INCLUDE_WX_NEW 1
+#else
+#define INCLUDE_WX 0
+#define INCLUDE_WX_OLD 0
+#define INCLUDE_WX_NEW 0
+#endif
+
+#if INCLUDE_WX
+#define WX_ONLY(x) x
+#if INCLUDE_WX_OLD
+#define WX_OLD_ONLY(x) x
+#else
+#define WX_OLD_ONLY(x)
+#endif
+#if INCLUDE_WX_NEW
+#define WX_NEW_ONLY(x) x
+#else
+#define WX_NEW_ONLY(x)
+#endif
+#else
+#define WX_ONLY(x)
+#endif
+
 #endif // SHARE_UTILITIES_MACROS_HPP

--- a/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
+++ b/test/hotspot/gtest/aarch64/test_assembler_aarch64.cpp
@@ -30,6 +30,8 @@
 #include "asm/assembler.inline.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "unittest.hpp"
 
 #define __ _masm.
@@ -51,6 +53,12 @@ static void asm_check(const unsigned int *insns, const unsigned int *insns1, siz
 }
 
 TEST_VM(AssemblerAArch64, validate) {
+  JavaThread* THREAD = JavaThread::current();
+  ThreadInVMfromNative invm(THREAD);
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(THREAD);
+#endif
+
   // Smoke test for assembler
   BufferBlob* b = BufferBlob::create("aarch64Test", 500000);
   CodeBuffer code(b);

--- a/test/hotspot/gtest/code/test_codestrings.cpp
+++ b/test/hotspot/gtest/code/test_codestrings.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@
 #include "asm/macroAssembler.inline.hpp"
 #include "compiler/disassembler.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 
 #include "utilities/vmassert_uninstall.hpp"
 #include <regex>
@@ -269,6 +271,12 @@ TEST_VM(codestrings, DISABLED_validate)
 TEST_VM(codestrings, validate)
 #endif
 {
+    JavaThread* THREAD = JavaThread::current();
+    ThreadInVMfromNative invm(THREAD);
+#if INCLUDE_WX_NEW
+    auto _wx = WXWriteMark(THREAD);
+#endif
+
     code_buffer_test();
     buffer_blob_test();
 }

--- a/test/hotspot/gtest/code/test_vtableStub.cpp
+++ b/test/hotspot/gtest/code/test_vtableStub.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 #include "precompiled.hpp"
 #include "code/vtableStubs.hpp"
 #include "runtime/interfaceSupport.inline.hpp"
+#include "runtime/threadWXSetters.inline.hpp"
 #include "unittest.hpp"
 
 #ifndef ZERO
@@ -32,6 +33,9 @@
 TEST_VM(code, vtableStubs) {
   // Should be in VM to use locks
   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(JavaThread::current());
+#endif
 
   VtableStubs::find_vtable_stub(0); // min vtable index
   for (int i = 0; i < 15; i++) {
@@ -44,6 +48,10 @@ TEST_VM(code, vtableStubs) {
 TEST_VM(code, itableStubs) {
   // Should be in VM to use locks
   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
+#if INCLUDE_WX_NEW
+  auto _wx = WXWriteMark(JavaThread::current());
+#endif
+
 
   VtableStubs::find_itable_stub(0); // min itable index
   for (int i = 0; i < 15; i++) {

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -97,7 +97,7 @@ static int init_jvm(int argc, char **argv, bool disable_error_handling, JavaVM**
     // CreateJavaVM leaves WXExec context, while gtests
     // calls internal functions assuming running in WXWwrite.
     // Switch to WXWrite once for all test cases.
-    MACOS_AARCH64_ONLY(Thread::current()->enable_wx(WXWrite));
+    WX_OLD_ONLY(Thread::current()->enable_wx(WXWrite));
   }
   return ret;
 }

--- a/test/hotspot/gtest/runtime/test_stubRoutines.cpp
+++ b/test/hotspot/gtest/runtime/test_stubRoutines.cpp
@@ -62,7 +62,7 @@ static void test_arraycopy_func(address func, int alignment) {
 }
 
 TEST_VM(StubRoutines, array_copy_routine) {
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXExec));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXExec));
 
 #define TEST_ARRAYCOPY(type)                                                                  \
   test_arraycopy_func(          StubRoutines::type##_arraycopy(),          sizeof(type));     \
@@ -78,11 +78,11 @@ TEST_VM(StubRoutines, array_copy_routine) {
 
 #undef TEST_ARRAYCOPY
 
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXWrite));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXWrite));
 }
 
 TEST_VM(StubRoutines, copy_routine) {
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXExec));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXExec));
 
 #define TEST_COPYRTN(type) \
   test_arraycopy_func(CAST_FROM_FN_PTR(address, Copy::conjoint_##type##s_atomic),  sizeof(type)); \
@@ -103,11 +103,11 @@ TEST_VM(StubRoutines, copy_routine) {
   test_arraycopy_func(CAST_FROM_FN_PTR(address, Copy::aligned_conjoint_words), sizeof(jlong));
   test_arraycopy_func(CAST_FROM_FN_PTR(address, Copy::aligned_disjoint_words), sizeof(jlong));
 
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXWrite));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXWrite));
 }
 
 TEST_VM(StubRoutines, array_fill_routine) {
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXExec));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXExec));
 
 #define TEST_FILL(type)                                                                      \
   if (StubRoutines::_##type##_fill != nullptr) {                                             \
@@ -149,5 +149,5 @@ TEST_VM(StubRoutines, array_fill_routine) {
 
 #undef TEST_FILL
 
-  MACOS_AARCH64_ONLY(os::current_thread_enable_wx(WXWrite));
+  WX_OLD_ONLY(os::current_thread_enable_wx(WXWrite));
 }

--- a/test/hotspot/gtest/runtime/test_threads.cpp
+++ b/test/hotspot/gtest/runtime/test_threads.cpp
@@ -180,7 +180,7 @@ TEST_VM(ThreadsTest, claim_overflow) {
 TEST_VM(ThreadsTest, fast_jni_in_vm) {
   JavaThread* current = JavaThread::current();
   JNIEnv* env = current->jni_environment();
-  MACOS_AARCH64_ONLY(ThreadWXEnable wx(WXWrite, current));
+  WX_OLD_ONLY(ThreadWXEnable wx(WXWrite, current));
 
   // DirectByteBuffer is an easy way to trigger GetIntField,
   // see JDK-8262896


### PR DESCRIPTION
Old "write by default" and new "exec by default" transitions, side by side for comparisons.  Logging with
`-Xlog:wx+perf=debug` shows 2 orders of magnitude improvement during startup:

```
[0.005s][info][wx,perf] WX transitions: old 2 new 0 total 2 100.0:0.0
[0.007s][info][wx,perf] WX transitions: old 2 new 2 total 4 50.0:50.0
[0.012s][info][wx,perf] WX transitions: old 4 new 4 total 8 50.0:50.0
[0.015s][info][wx,perf] WX transitions: old 7 new 9 total 16 43.8:56.2
[0.146s][info][wx,perf] WX transitions: old 19 new 13 total 32 59.4:40.6
[0.147s][info][wx,perf] WX transitions: old 45 new 19 total 64 70.3:29.7
[0.148s][info][wx,perf] WX transitions: old 105 new 23 total 128 82.0:18.0
[0.150s][info][wx,perf] WX transitions: old 229 new 27 total 256 89.5:10.5
[0.156s][info][wx,perf] WX transitions: old 465 new 47 total 512 90.8:9.2
[0.165s][info][wx,perf] WX transitions: old 957 new 67 total 1024 93.5:6.5
[0.178s][info][wx,perf] WX transitions: old 1965 new 83 total 2048 95.9:4.1
[0.200s][info][wx,perf] WX transitions: old 3977 new 119 total 4096 97.1:2.9
[0.260s][info][wx,perf] WX transitions: old 7995 new 197 total 8192 97.6:2.4
[0.327s][info][wx,perf] WX transitions: old 16124 new 260 total 16384 98.4:1.6
[0.412s][info][wx,perf] WX transitions: old 32370 new 398 total 32768 98.8:1.2
[0.476s][info][wx,perf] WX transitions: old 64942 new 594 total 65536 99.1:0.9
[0.585s][info][wx,perf] WX transitions: old 130260 new 812 total 131072 99.4:0.6

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328306](https://bugs.openjdk.org/browse/JDK-8328306): Allow VM to run with X memory execute by default (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19155/head:pull/19155` \
`$ git checkout pull/19155`

Update a local copy of the PR: \
`$ git checkout pull/19155` \
`$ git pull https://git.openjdk.org/jdk.git pull/19155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19155`

View PR using the GUI difftool: \
`$ git pr show -t 19155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19155.diff">https://git.openjdk.org/jdk/pull/19155.diff</a>

</details>
