### PR TITLE
8331999: BasicDirectoryModel/LoaderThreadCount.java frequently fails on Windows in CI

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java
@@ -164,7 +164,7 @@ public final class LoaderThreadCount extends ThreadGroup {
             System.out.println("  = 1: " + ones);
             System.out.println("  = 2: " + twos);
             System.out.println("  > 2: " + count);
-            if (count > 0) {
+            if (count > loaderCount.size() / 2) {
                 throw new RuntimeException("Detected " + count + " snapshots "
                                            + "with several loading threads");
             }


### PR DESCRIPTION
The `javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java` test frequently fails on Windows in CI, which creates noise.

All of the failures on Windows look the same:
```text
Number of snapshots: 20
Number of snapshots where number of loader threads:
  = 1: 19
  = 2: 0
  > 2: 1
Exception in Test Runner: class java.lang.RuntimeException:
Detected 1 snapshots with several loading threads
java.lang.RuntimeException: Detected 1 snapshots with several loading threads
        at LoaderThreadCount.runTest(LoaderThreadCount.java:168)
        at LoaderThreadCount.wrapper(LoaderThreadCount.java:108)
        at java.base/java.lang.Thread.run(Thread.java:1575)
```

To remove these false failures, I'm introducing a *tolerance factor*: fail the test if the number of snapshots with more than 2 file loader threads is greater than half of the number of valid snapshots. In terms of code:

```java
count > loaderCount.size() / 2
```

The test still fails without the fix for [JDK-8325179](https://bugs.openjdk.org/browse/JDK-8325179).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331999](https://bugs.openjdk.org/browse/JDK-8331999): BasicDirectoryModel/LoaderThreadCount.java frequently fails on Windows in CI (**Bug** - P2)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19156/head:pull/19156` \
`$ git checkout pull/19156`

Update a local copy of the PR: \
`$ git checkout pull/19156` \
`$ git pull https://git.openjdk.org/jdk.git pull/19156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19156`

View PR using the GUI difftool: \
`$ git pr show -t 19156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19156.diff">https://git.openjdk.org/jdk/pull/19156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19156#issuecomment-2102625727)