### PR TITLE
8332006: Test com/sun/net/httpserver/TcpNoDelayNotRequired.java run timeout with -Xcomp

### DIFF
--- a/test/jdk/com/sun/net/httpserver/TcpNoDelayNotRequired.java
+++ b/test/jdk/com/sun/net/httpserver/TcpNoDelayNotRequired.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 6968351
  * @summary  tcp no delay not required for small payloads
+ * @requires vm.flagless
  * @library /test/lib
  * @run main/othervm/timeout=5 -Dsun.net.httpserver.nodelay=false  TcpNoDelayNotRequired
  */

--- a/test/jdk/com/sun/net/httpserver/TcpNoDelayNotRequired.java
+++ b/test/jdk/com/sun/net/httpserver/TcpNoDelayNotRequired.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 6968351
  * @summary  tcp no delay not required for small payloads
- * @requires vm.flagless
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @run main/othervm/timeout=5 -Dsun.net.httpserver.nodelay=false  TcpNoDelayNotRequired
  */


### PR DESCRIPTION
Hi,
  The testcase TcpNoDelayNotRequired.java run timeout with -Xcomp jvm options. With -Xcomp jvm options, the jvm consumes a lot of time to compile the java code, but the timeout value is set to 5 second.

  I think it has 3 methods to solve this timeout issue.

1. Change timeout value from 5 to 60 or more.
2. Problemlist this testcase in `test/hotspot/jtreg/ProblemList-Xcomp.txt`
3. Set this testcase `@requires vm.compMode != "Xcomp"`, so this testcase will be skiped when set jvm options -`Xcomp` or `-Xcomp -XX:TieredStopAtLevel=1`

  Maybe the 3rd method seems more reasonable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332006](https://bugs.openjdk.org/browse/JDK-8332006): Test com/sun/net/httpserver/TcpNoDelayNotRequired.java run timeout with -Xcomp (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19159/head:pull/19159` \
`$ git checkout pull/19159`

Update a local copy of the PR: \
`$ git checkout pull/19159` \
`$ git pull https://git.openjdk.org/jdk.git pull/19159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19159`

View PR using the GUI difftool: \
`$ git pr show -t 19159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19159.diff">https://git.openjdk.org/jdk/pull/19159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19159#issuecomment-2103035305)