### PR TITLE
8332008: Enable issuestitle check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,6 +5,7 @@ version=23
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
+warning=issuestitle
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)


### PR DESCRIPTION
As requested in [SKARA-2170](https://bugs.openjdk.org/browse/SKARA-2170) and [SKARA-2248](https://bugs.openjdk.org/browse/SKARA-2248), now Skara bot is able to warn on trailing periods or leading lowercase letter in issue titles.
I am going to update the jcheck configuration to configure issuestitle check as a warning. Given that it's just a warning, it wouldn't block integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332008](https://bugs.openjdk.org/browse/JDK-8332008): Enable issuestitle check (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19161/head:pull/19161` \
`$ git checkout pull/19161`

Update a local copy of the PR: \
`$ git checkout pull/19161` \
`$ git pull https://git.openjdk.org/jdk.git pull/19161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19161`

View PR using the GUI difftool: \
`$ git pr show -t 19161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19161.diff">https://git.openjdk.org/jdk/pull/19161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19161#issuecomment-2103502212)