### PR TITLE
8331231: containers/docker/TestContainerInfo.java fails

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -26,6 +26,7 @@
 /*
  * @test
  * @summary Test container info for cgroup v2
+ * @key cgroups
  * @requires docker.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Please review this simple change adding a cgroups keyword to container test that uses cgroups functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331231](https://bugs.openjdk.org/browse/JDK-8331231): containers/docker/TestContainerInfo.java fails (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19162/head:pull/19162` \
`$ git checkout pull/19162`

Update a local copy of the PR: \
`$ git checkout pull/19162` \
`$ git pull https://git.openjdk.org/jdk.git pull/19162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19162`

View PR using the GUI difftool: \
`$ git pr show -t 19162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19162.diff">https://git.openjdk.org/jdk/pull/19162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19162#issuecomment-2103459808)