### PR TITLE
8332014: Fix `@since` tags in `jdk.jshell`

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/Snippet.java
@@ -249,8 +249,8 @@ public abstract class Snippet {
          * A record declaration.
          * A {@code SubKind} of {@link Kind#TYPE_DECL}.
          * @jls 8.10 Record Types
-         * @since 14
          *
+         * @since 17
          */
         RECORD_SUBKIND(Kind.TYPE_DECL),
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/SourceCodeAnalysis.java
@@ -158,6 +158,8 @@ public abstract class SourceCodeAnalysis {
      * @param input The input String to convert
      * @return usually a singleton list of Snippet, but may be empty or multiple
      * @throws IllegalStateException if the {@code JShell} instance is closed.
+     *
+     * @since 10
      */
     public abstract List<Snippet> sourceToSnippets(String input);
 

--- a/src/jdk.jshell/share/classes/jdk/jshell/tool/JavaShellToolBuilder.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/tool/JavaShellToolBuilder.java
@@ -232,6 +232,8 @@ public interface JavaShellToolBuilder {
      * @throws Exception an unexpected fatal exception
      * @return the exit status with which the tool explicitly exited (if any),
      * otherwise 0 for success or 1 for failure
+     *
+     * @since 10
      */
     default int start(String... arguments) throws Exception {
         run(arguments);


### PR DESCRIPTION
Please review this small change that aims to make the `@since` in this module more accurate, these bugs were reported by the checker tool at #18934 

-field: jdk.jshell.Snippet.SubKind:RECORD_SUBKIND
This should have `@since` 17 as it was a Preview element in JDK 14-16

-method: java.util.List jdk.jshell.SourceCodeAnalysis.sourceToSnippets(java.lang.String)
-method: int jdk.jshell.tool.JavaShellToolBuilder.start(java.lang.String[])

both should have `@since` 10 instead of 9

Thanks