### PR TITLE
8332015: Add `@since` tags to jdk.httpserver

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/BasicAuthenticator.java
@@ -85,6 +85,8 @@ public abstract class BasicAuthenticator extends Authenticator {
      *         correctly quoted, as specified in <a href="https://tools.ietf.org/html/rfc7230#section-3.2">
      *         RFC 7230 section-3.2</a>. Note, any {@code \} character used for
      *         quoting must itself be quoted in source code.
+     *
+     * @since 14
      */
     public BasicAuthenticator(String realm, Charset charset) {
         Objects.requireNonNull(charset);

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/package-info.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/spi/package-info.java
@@ -26,5 +26,6 @@
 /**
  * Provides a pluggable service provider interface, which allows the HTTP server
  * implementation to be replaced with other implementations.
+ * @since 1.6
  */
 package com.sun.net.httpserver.spi;


### PR DESCRIPTION
Please review this simple change, aiming to fix current uses of `@since` in the source code
-The constructor BasicAuthenticator(java.lang.String,java.nio.charset.Charset) needs an `@since 14` instead of 9.
-com.sun.net.httpserver.spi: package-info.java does not contain an `@since`.
Thanks in advance.