### PR TITLE
8331619: TabbedPane's contentOpaque, tabsOpaque and setOpaque doesn't work properly in Aqua LAF

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaLookAndFeel.java
@@ -395,6 +395,8 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
         final Color panelBackgroundColor = windowBackgroundColor;
         final Color tabBackgroundColor = windowBackgroundColor;
         final Color controlBackgroundColor = windowBackgroundColor;
+        final Color contentAreaColor = windowBackgroundColor;
+        final Color selectedTabColor = windowBackgroundColor;
 
         final LazyValue controlFont = t -> AquaFonts.getControlTextFont();
         final LazyValue controlSmallFont = t ->
@@ -860,7 +862,7 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             //"TabbedPane.shadow", table.get("controlShadow"),
             //"TabbedPane.darkShadow", table.get("controlDkShadow"),
             //"TabbedPane.focus", table.get("controlText"),
-            "TabbedPane.opaque", useOpaqueComponents,
+            "TabbedPane.opaque", false,
             "TabbedPane.textIconGap", Integer.valueOf(4),
             "TabbedPane.tabInsets", new InsetsUIResource(0, 10, 3, 10), // Label within tab (top, left, bottom, right)
             //"TabbedPane.rightTabInsets", new InsetsUIResource(0, 10, 3, 10), // Label within tab (top, left, bottom, right)
@@ -880,6 +882,10 @@ public class AquaLookAndFeel extends BasicLookAndFeel {
             "TabbedPane.selectedTabTitleShadowDisabledColor", selectedTabTitleShadowDisabledColor,
             "TabbedPane.selectedTabTitleShadowNormalColor", selectedTabTitleShadowNormalColor,
             "TabbedPane.nonSelectedTabTitleNormalColor", nonSelectedTabTitleNormalColor,
+            "TabbedPane.contentAreaColor", contentAreaColor,
+            "TabbedPane.contentOpaque", Boolean.TRUE,
+            "TabbedPane.tabsOpaque", Boolean.TRUE,
+            "TabbedPane.selected", selectedTabColor,
 
             // *** Table
             "Table.font", viewFont, // [3577901] Aqua HIG says "default font of text in lists and tables" should be 12 point (vm).

--- a/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestBackgroundScrollPolicy.java
@@ -34,7 +34,7 @@ import javax.swing.UnsupportedLookAndFeelException;
 /*
  * @test
  * @key headful
- * @bug 8172269 8244557
+ * @bug 8172269 8244557 8331619
  * @summary Tests JTabbedPane background for SCROLL_TAB_LAYOUT
  * @run main/othervm -Dsun.java2d.uiScale=1 TestBackgroundScrollPolicy
  */
@@ -48,17 +48,19 @@ public class TestBackgroundScrollPolicy {
         ROBOT.setAutoDelay(100);
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             System.out.println("Testing L&F: " + laf.getClassName());
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
-            try {
-                SwingUtilities.invokeAndWait(() -> createGUI());
-                ROBOT.waitForIdle();
+            if (!laf.getClassName().contains("Aqua")) {
+                SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
+                try {
+                    SwingUtilities.invokeAndWait(() -> createGUI());
+                    ROBOT.waitForIdle();
+                    ROBOT.delay(1000);
+                    SwingUtilities.invokeAndWait(() -> test(laf));
+                    ROBOT.delay(2000);
+                } finally {
+                    if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
+                }
                 ROBOT.delay(1000);
-                SwingUtilities.invokeAndWait(() -> test(laf));
-                ROBOT.delay(2000);
-            } finally {
-                if (frame != null) SwingUtilities.invokeAndWait(() -> frame.dispose());
             }
-            ROBOT.delay(1000);
         }
     }
 

--- a/test/jdk/javax/swing/JTabbedPane/TestTabbedPaneOpacityInAqua.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestTabbedPaneOpacityInAqua.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.event.ActionEvent;
+import javax.swing.AbstractAction;
+import javax.swing.AbstractButton;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTabbedPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 8331619
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "mac")
+ * @summary Test JTabbedPane's contentarea and tab color
+ *          for Aqua LAFs when opacity is enabled or disabled.
+ * @run main/manual TestTabbedPaneOpacityInAqua
+ */
+
+public class TestTabbedPaneOpacityInAqua {
+    private static JFrame frame;
+    private static JTabbedPane tabPane;
+    private static final String INSTRUCTIONS = """
+            The background color of panel which contains the tabbed pane is green.
+            The background color of the tabbed pane is red.
+            The TabbedPane is not opaque initially.
+            For 'Content Opaque' and 'Tabs Opaque' to have effect, tab pane opacity should
+            be set to false i.e. Opaque checkbox should be unchecked.
+
+            Check the default behaviour of the tabbed pane:
+              - selected tab is gray and unselected tabs are red(filled with alpha binding).
+              - the content area is opaque (it must be gray).
+
+            Test Case 1 - Test Content pane opacity:
+            To test Content pane opacity, make sure "Opaque checkbox" is UNCHECKED.
+
+            Verify the following with 'content opaque' option:
+            when checked:
+              - the content area should be opaque (it must be gray).
+            when unchecked:
+              - the content area should be transparent (it must be green).
+
+            Test Case 2 - Test Tabs opacity:
+            To test Tabs opacity, make sure "Opaque checkbox" is UNCHECKED.
+
+            Verify the following with 'tabs opaque' option:
+            when checked:
+              - the tabs are opaque (it must be red, except the selected tab which must be gray).
+            when unchecked:
+              - the tabs are transparent (it must be either gray or green).
+              - if Content Opaque checkbox is checked then tabs are gray.
+              - if Content Opaque checkbox is unchecked then tabs are green.
+              
+            Test Case 3 - Test Tab Pane opacity:
+            To test Content pane opacity, make sure "Content Opaque checkbox" is UNCHECKED.
+
+            Verify the following with 'opaque' option:
+            when checked:
+              - the content area should be opaque (it must be gray).
+            when unchecked:
+              - the content area should be transparent (it must be green).""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("JTabbedPane Tab and Content Area Color Test Instructions")
+                .instructions(INSTRUCTIONS)
+                .testTimeOut(10)
+                .rows(25)
+                .columns(60)
+                .testUI(TestTabbedPaneOpacityInAqua::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createAndShowUI() {
+        int NUM_TABS = 5;
+        frame = new JFrame("Test JTabbedPane Opaque Color");
+        JTabbedPane tabPane = new JTabbedPane();
+        tabPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+        tabPane.setTabPlacement(JTabbedPane.TOP);
+        PassFailJFrame.positionTestWindow(
+                frame, PassFailJFrame.Position.HORIZONTAL);
+        for (int i = 0; i < NUM_TABS; ++i) {
+            tabPane.addTab("Tab " + i , new JLabel("Content Area"));
+        }
+        JPanel panel = new JPanel(new BorderLayout());
+        panel.add(tabPane, BorderLayout.CENTER);
+        panel.setBackground(Color.green);
+        tabPane.setBackground(Color.red);
+
+        JCheckBox contentOpaqueChkBox = new JCheckBox(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                if (((AbstractButton)e.getSource()).isSelected()) {
+                    UIManager.put("TabbedPane.contentOpaque", Boolean.TRUE);
+                } else {
+                    UIManager.put("TabbedPane.contentOpaque", Boolean.FALSE);
+                }
+                tabPane.repaint();
+                SwingUtilities.updateComponentTreeUI(frame);
+            }
+        });
+        contentOpaqueChkBox.setText("Content Opaque");
+        contentOpaqueChkBox.setSelected(true);
+        contentOpaqueChkBox.setEnabled(true);
+
+        JCheckBox tabOpaqueChkBox = new JCheckBox(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                if (((AbstractButton)e.getSource()).isSelected()) {
+                    UIManager.put("TabbedPane.tabsOpaque", Boolean.TRUE);
+                } else {
+                    UIManager.put("TabbedPane.tabsOpaque", Boolean.FALSE);
+                }
+                tabPane.repaint();
+                SwingUtilities.updateComponentTreeUI(frame);
+            }
+        });
+        tabOpaqueChkBox.setText("Tabs Opaque");
+        tabOpaqueChkBox.setSelected(true);
+        tabOpaqueChkBox.setEnabled(true);
+
+        JCheckBox tabPaneOpaqueChkBox = new JCheckBox(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                tabPane.setOpaque(((AbstractButton)e.getSource()).isSelected());
+                contentOpaqueChkBox.setEnabled(!((AbstractButton)e.getSource()).isSelected());
+                tabOpaqueChkBox.setEnabled(!((AbstractButton)e.getSource()).isSelected());
+                tabPane.repaint();
+                SwingUtilities.updateComponentTreeUI(frame);
+            }
+        });
+        tabPaneOpaqueChkBox.setText("Opaque");
+
+        JPanel checkBoxPanel = new JPanel();
+        checkBoxPanel.add(tabPaneOpaqueChkBox);
+        checkBoxPanel.add(contentOpaqueChkBox);
+        checkBoxPanel.add(tabOpaqueChkBox);
+
+        panel.add(checkBoxPanel, BorderLayout.NORTH);
+        frame.add(panel);
+        frame.setSize(500, 500);
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setVisible(true);
+        return frame;
+    }
+}

--- a/test/jdk/javax/swing/JTabbedPane/TestTabbedPaneOpacityInAqua.java
+++ b/test/jdk/javax/swing/JTabbedPane/TestTabbedPaneOpacityInAqua.java
@@ -78,7 +78,7 @@ public class TestTabbedPaneOpacityInAqua {
               - the tabs are transparent (it must be either gray or green).
               - if Content Opaque checkbox is checked then tabs are gray.
               - if Content Opaque checkbox is unchecked then tabs are green.
-              
+
             Test Case 3 - Test Tab Pane opacity:
             To test Content pane opacity, make sure "Content Opaque checkbox" is UNCHECKED.
 


### PR DESCRIPTION
JTabbedPane's contentOpaque and tabsOpaque properties are not honored in Aqua L&F. JTabbedPane's content area and tab background color are not as expected when tabbedpane opacity is set to true or false. Fix is to handle the opacity behavior correctly and inline with other LAF as well. 

Existing test `TestBackgroundScrollPolicy.java` failed with the proposed fix and it is updated to run only for linux and windows platform because the content area for tabbedpane is rendered to the width and height of tabbedpane starting from (0, 0) position (https://github.com/openjdk/jdk/blob/cf7c97732320d70de5f5725c920d5c3861a2c9c8/src/java.desktop/macosx/classes/com/apple/laf/AquaTabbedPaneUI.java#L684C16-L684C16) and that leaves no place for tab area behind tabs.

CI testing is green after this test update and link posted in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331619](https://bugs.openjdk.org/browse/JDK-8331619): TabbedPane's contentOpaque, tabsOpaque and setOpaque doesn't work properly in Aqua LAF (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19170/head:pull/19170` \
`$ git checkout pull/19170`

Update a local copy of the PR: \
`$ git checkout pull/19170` \
`$ git pull https://git.openjdk.org/jdk.git pull/19170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19170`

View PR using the GUI difftool: \
`$ git pr show -t 19170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19170.diff">https://git.openjdk.org/jdk/pull/19170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19170#issuecomment-2104036806)