### PR TITLE
8332029: Provide access to initial value of stderr via JavaLangAccess

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -26,6 +26,7 @@
 package jdk.internal.access;
 
 import java.io.InputStream;
+import java.io.PrintStream;
 import java.lang.annotation.Annotation;
 import java.lang.foreign.MemorySegment;
 import java.lang.invoke.MethodHandle;
@@ -400,6 +401,11 @@ public interface JavaLangAccess {
      * with `System.setIn(newIn)` method
      */
     InputStream initialSystemIn();
+
+    /**
+     * Returns the initial value of System.err.
+     */
+    PrintStream initialSystemErr();
 
     /**
      * Encodes ASCII codepoints as possible from the source array into

--- a/src/java.base/share/classes/jdk/internal/misc/VM.java
+++ b/src/java.base/share/classes/jdk/internal/misc/VM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package jdk.internal.misc;
 
 import static java.lang.Thread.State.*;
 
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -495,5 +496,12 @@ public class VM {
      */
     public static List<BufferPool> getBufferPools() {
         return BufferPoolsHolder.BUFFER_POOLS;
+    }
+
+    /**
+     * Return the initial value of System.err that was set during VM initialization.
+     */
+    public static PrintStream initialErr() {
+        return SharedSecrets.getJavaLangAccess().initialSystemErr();
     }
 }


### PR DESCRIPTION
In preparation for JEP 471 and JEP 472, provide access to the initial value of System.err from JavaLangAccess. The initial value of System.in is already exposed to code in java.base with this shared secret.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332029](https://bugs.openjdk.org/browse/JDK-8332029): Provide access to initial value of stderr via JavaLangAccess (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19171/head:pull/19171` \
`$ git checkout pull/19171`

Update a local copy of the PR: \
`$ git checkout pull/19171` \
`$ git pull https://git.openjdk.org/jdk.git pull/19171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19171`

View PR using the GUI difftool: \
`$ git pr show -t 19171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19171.diff">https://git.openjdk.org/jdk/pull/19171.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19171#issuecomment-2104600412)