### PR TITLE
8332020: jwebserver tool prints invalid URL in case of IPv6 address binding

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -170,19 +170,17 @@ final class SimpleFileServerImpl {
             if (!addrSpecified) {
                 writer.println(ResourceBundleHelper.getMessage("loopback.info"));
             }
-            String url;
             if (inetAddr instanceof Inet6Address && addr.contains(":") && !addr.startsWith("[")) {
-                // RFC-2732, section 2:
+                // we use the "addr" when printing the URL, so make sure it
+                // conforms to RFC-2732, section 2:
                 // To use a literal IPv6 address in a URL, the literal
                 // address should be enclosed in "[" and "]" characters.
-                url = "http://[" + addr + "]:" + port + "/";
-            } else {
-                url = "http://" + addr + ":" + port + "/";
+                addr = "[" + addr + "]";
             }
             if (isAnyLocal) {
-                writer.println(ResourceBundleHelper.getMessage("msg.start.anylocal", root, port, url));
+                writer.println(ResourceBundleHelper.getMessage("msg.start.anylocal", root, addr, port));
             } else {
-                writer.println(ResourceBundleHelper.getMessage("msg.start.other", root, addr, port, url));
+                writer.println(ResourceBundleHelper.getMessage("msg.start.other", root, addr, port));
             }
         }
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/SimpleFileServerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import com.sun.net.httpserver.SimpleFileServer;
 import com.sun.net.httpserver.SimpleFileServer.OutputLevel;
 
 import java.io.PrintWriter;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -169,10 +170,19 @@ final class SimpleFileServerImpl {
             if (!addrSpecified) {
                 writer.println(ResourceBundleHelper.getMessage("loopback.info"));
             }
-            if (isAnyLocal) {
-                writer.println(ResourceBundleHelper.getMessage("msg.start.anylocal", root, addr, port));
+            String url;
+            if (inetAddr instanceof Inet6Address && addr.contains(":") && !addr.startsWith("[")) {
+                // RFC-2732, section 2:
+                // To use a literal IPv6 address in a URL, the literal
+                // address should be enclosed in "[" and "]" characters.
+                url = "http://[" + addr + "]:" + port + "/";
             } else {
-                writer.println(ResourceBundleHelper.getMessage("msg.start.other", root, addr, port));
+                url = "http://" + addr + ":" + port + "/";
+            }
+            if (isAnyLocal) {
+                writer.println(ResourceBundleHelper.getMessage("msg.start.anylocal", root, port, url));
+            } else {
+                writer.println(ResourceBundleHelper.getMessage("msg.start.other", root, addr, port, url));
             }
         }
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/resources/simpleserver.properties
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/resources/simpleserver.properties
@@ -61,12 +61,12 @@ loopback.info=\
 Binding to loopback by default. For all interfaces use "-b 0.0.0.0" or "-b ::".
 
 msg.start.anylocal=\
-Serving {0} and subdirectories on 0.0.0.0 (all interfaces) port {1}\n\
-URL {2}
+Serving {0} and subdirectories on 0.0.0.0 (all interfaces) port {2}\n\
+URL http://{1}:{2}/
 
 msg.start.other=\
 Serving {0} and subdirectories on {1} port {2}\n\
-URL {3}
+URL http://{1}:{2}/
 
 error.prefix=Error:
 

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/resources/simpleserver.properties
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/simpleserver/resources/simpleserver.properties
@@ -61,12 +61,12 @@ loopback.info=\
 Binding to loopback by default. For all interfaces use "-b 0.0.0.0" or "-b ::".
 
 msg.start.anylocal=\
-Serving {0} and subdirectories on 0.0.0.0 (all interfaces) port {2}\n\
-URL http://{1}:{2}/
+Serving {0} and subdirectories on 0.0.0.0 (all interfaces) port {1}\n\
+URL {2}
 
 msg.start.other=\
 Serving {0} and subdirectories on {1} port {2}\n\
-URL http://{1}:{2}/
+URL {3}
 
 error.prefix=Error:
 

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import jdk.internal.util.OperatingSystem;
+import jdk.test.lib.net.IPSupport;
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 8332020
+ * @summary verifies that when jwebserver is launched with a IPv6 bind address
+ *          then the URL printed contains the correct host literal
+ * @modules jdk.httpserver java.base/jdk.internal.util
+ * @library /test/lib
+ * @build jdk.test.lib.net.IPSupport
+ * @run driver IPv6BoundHost
+ */
+public class IPv6BoundHost {
+
+    private static final Path JDK_BIN_DIR = Path.of(System.getProperty("java.home")).resolve("bin");
+    private static final Path JWEBSERVER_BINARY = OperatingSystem.isWindows()
+            ? JDK_BIN_DIR.resolve("jwebserver.exe") : JDK_BIN_DIR.resolve("jwebserver");
+
+    public static void main(final String[] args) throws Exception {
+        IPSupport.printPlatformSupport(System.err); // for debug purposes
+        if (!IPSupport.hasIPv6()) {
+            throw new SkippedException("Skipping test - IPv6 is not supported");
+        }
+        final String output = launchJwebserverAndExit(List.of("-b", "::1"));
+        if (output.contains("URL http://[::1]:")
+                || output.contains("URL http://[0:0:0:0:0:0:0:1]:")) {
+            // found expected content
+            System.out.println("found expected URL in jwebserver output");
+        } else {
+            throw new AssertionError("missing IPv6 address in jwebserver process output");
+        }
+    }
+
+    private static String launchJwebserverAndExit(final List<String> args) throws Exception {
+        final Predicate<String> waitForLine = (s) -> s.startsWith("URL http://");
+        final StringBuilder sb = new StringBuilder();  // stdout & stderr
+        final List<String> cmd = new ArrayList<>();
+        cmd.add(JWEBSERVER_BINARY.toString());
+        cmd.addAll(args);
+        // start the process and await the waitForLine before returning
+        final Process p = ProcessTools.startProcess("8332020-test", new ProcessBuilder(cmd),
+                line -> sb.append(line).append("\n"),
+                waitForLine,
+                30,  // suitably high default timeout, not expected to timeout
+                TimeUnit.SECONDS);
+        System.out.println(sb.toString()); // print the process' stdout/stderr
+        // the process has started and it is confirmed that the process output has the line
+        // we were waiting for. now kill the process.
+        p.destroy();
+        final int exitCode = p.waitFor();
+        if (!isNormalExitCode(exitCode)) {
+            throw new AssertionError("jwebserver exited with unexpected exit code: " + exitCode);
+        }
+        return sb.toString();
+    }
+
+    private static boolean isNormalExitCode(final int exitCode) {
+        final int SIGTERM = 15;
+        if (OperatingSystem.isWindows()) {
+            return exitCode == 1; // we expect exit code == 1 on Windows for Process.destroy()
+        } else {
+            // signal terminated exit code on Unix is 128 + signal value
+            return exitCode == (128 + SIGTERM);
+        }
+    }
+}

--- a/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
+++ b/test/jdk/com/sun/net/httpserver/simpleserver/jwebserver/IPv6BoundHost.java
@@ -53,7 +53,7 @@ public class IPv6BoundHost {
         if (!IPSupport.hasIPv6()) {
             throw new SkippedException("Skipping test - IPv6 is not supported");
         }
-        final String output = launchJwebserverAndExit(List.of("-b", "::1"));
+        final String output = launchJwebserverAndExit(List.of("-b", "::1", "-p", "0"));
         if (output.contains("URL http://[::1]:")
                 || output.contains("URL http://[0:0:0:0:0:0:0:1]:")) {
             // found expected content


### PR DESCRIPTION
Can I please get a review of this change which proposes to address https://bugs.openjdk.org/browse/JDK-8332020?

`jwebserver` when it is launched prints a URL where the server is accessible. When launched using an IPv6 bind address, the printed URL doesn't enclose the IPv6 literal in `[` `]` thus rendering it in the form:
```
URL http://0:0:0:0:0:0:0:1:8000/
```
This is an incorrect representation. As noted in RFC-2732 https://www.rfc-editor.org/rfc/rfc2732#section-2, the host literal is expected to be enclosed between `[` and `]`. 

The commit in this PR addresses that issues. A new jtreg test has been introduced to reproduce this issue and verify the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332020: jwebserver tool prints invalid URL in case of IPv6 address binding`

### Issue
 * [JDK-8332020](https://bugs.openjdk.org/browse/JDK-8332020): jwebserver tool prints invalid URL in case of IPv6 address binding (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer) ⚠️ Review applies to [b8268744](https://git.openjdk.org/jdk/pull/19173/files/b82687446c76e44af81274d106845b41df319612)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19173/head:pull/19173` \
`$ git checkout pull/19173`

Update a local copy of the PR: \
`$ git checkout pull/19173` \
`$ git pull https://git.openjdk.org/jdk.git pull/19173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19173`

View PR using the GUI difftool: \
`$ git pr show -t 19173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19173.diff">https://git.openjdk.org/jdk/pull/19173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19173#issuecomment-2104270935)