### PR TITLE
8332066: AArch64: Math test failures since JDK-8331558

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -2285,33 +2285,6 @@ Address MacroAssembler::form_address(Register Rd, Register base, int64_t byte_of
   return Address(Rd);
 }
 
-// On Neoverse, MSUB uses the same ALU with other instructions (e.g. SDIV).
-// The combination of MUL/SUB can utilize multiple ALUs,
-// and can be somewhat faster than MSUB.
-void MacroAssembler::msub(Register Rd, Register Rn, Register Rm, Register Ra)
-{
-  if (VM_Version::supports_a53mac() && Ra != zr)
-    nop();
-  if (VM_Version::is_neoverse()) {
-    mul(rscratch1, Rn, Rm);
-    sub(Rd, Ra, rscratch1);
-  } else {
-    Assembler::msub(Rd, Rn, Rm, Ra);
-  }
-}
-
-void MacroAssembler::msubw(Register Rd, Register Rn, Register Rm, Register Ra)
-{
-  if (VM_Version::supports_a53mac() && Ra != zr)
-    nop();
-  if (VM_Version::is_neoverse()) {
-    mulw(rscratch1, Rn, Rm);
-    subw(Rd, Ra, rscratch1);
-  } else {
-    Assembler::msubw(Rd, Rn, Rm, Ra);
-  }
-}
-
 int MacroAssembler::corrected_idivl(Register result, Register ra, Register rb,
                                     bool want_remainder, Register scratch)
 {
@@ -2336,7 +2309,7 @@ int MacroAssembler::corrected_idivl(Register result, Register ra, Register rb,
     sdivw(result, ra, rb);
   } else {
     sdivw(scratch, ra, rb);
-    msubw(result, scratch, rb, ra);
+    Assembler::msubw(result, scratch, rb, ra);
   }
 
   return idivl_offset;
@@ -2366,7 +2339,7 @@ int MacroAssembler::corrected_idivq(Register result, Register ra, Register rb,
     sdiv(result, ra, rb);
   } else {
     sdiv(scratch, ra, rb);
-    msub(result, scratch, rb, ra);
+    Assembler::msub(result, scratch, rb, ra);
   }
 
   return idivq_offset;

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -437,13 +437,10 @@ class MacroAssembler: public Assembler {
     Assembler::INSN(Rd, Rn, Rm, Ra);                                          \
   }
 
-  WRAP(madd) WRAP(maddw)
+  WRAP(madd) WRAP(msub) WRAP(maddw) WRAP(msubw)
   WRAP(smaddl) WRAP(smsubl) WRAP(umaddl) WRAP(umsubl)
 #undef WRAP
 
-
-  void msub(Register Rd, Register Rn, Register Rm, Register Ra);
-  void msubw(Register Rd, Register Rn, Register Rm, Register Ra);
 
   // macro assembly operations needed for aarch64
 

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2015, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -212,7 +212,13 @@ void VM_Version::initialize() {
     }
   }
 
-  if (is_neoverse()) {
+  // Neoverse
+  //   N1: 0xd0c
+  //   N2: 0xd49
+  //   V1: 0xd40
+  //   V2: 0xd4f
+  if (_cpu == CPU_ARM && (model_is(0xd0c) || model_is(0xd49) ||
+                          model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseSIMDForMemoryOps)) {
       FLAG_SET_DEFAULT(UseSIMDForMemoryOps, true);
     }
@@ -241,7 +247,10 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseCRC32, false);
   }
 
-  if (is_neoverse_v_series()) {
+  // Neoverse
+  //   V1: 0xd40
+  //   V2: 0xd4f
+  if (_cpu == CPU_ARM && (model_is(0xd40) || model_is(0xd4f))) {
     if (FLAG_IS_DEFAULT(UseCryptoPmullForCRC32)) {
       FLAG_SET_DEFAULT(UseCryptoPmullForCRC32, true);
     }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
@@ -114,13 +114,6 @@ enum Ampere_CPU_Model {
     CPU_MODEL_AMPERE_1B = 0xac5  /* AMPERE_1B core Implements ARMv8.7 with CSSC, MTE, SM3/SM4 extensions */
 };
 
-enum Neoverse_CPU_Model {
-    CPU_MODEL_NEOVERSE_N1 = 0xd0c,
-    CPU_MODEL_NEOVERSE_N2 = 0xd49,
-    CPU_MODEL_NEOVERSE_V1 = 0xd40,
-    CPU_MODEL_NEOVERSE_V2 = 0xd4f,
-};
-
 #define CPU_FEATURE_FLAGS(decl)               \
     decl(FP,            fp,            0)     \
     decl(ASIMD,         asimd,         1)     \
@@ -161,23 +154,6 @@ enum Neoverse_CPU_Model {
 
   static bool model_is(int cpu_model) {
     return _model == cpu_model || _model2 == cpu_model;
-  }
-
-
-  static bool is_neoverse() {
-    switch(_model) {
-      case CPU_MODEL_NEOVERSE_N1:
-      case CPU_MODEL_NEOVERSE_N2:
-      case CPU_MODEL_NEOVERSE_V1:
-      case CPU_MODEL_NEOVERSE_V2:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  static bool is_neoverse_v_series() {
-    return (model_is(CPU_MODEL_NEOVERSE_V1) || model_is(CPU_MODEL_NEOVERSE_V2));
   }
 
   static bool is_zva_enabled() { return 0 <= _zva_length; }


### PR DESCRIPTION
Revert "8331558: AArch64: optimize integer remainder"
This reverts commit dab92c51c70767abcda3b1a91dd7d1a9b40290c1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332066](https://bugs.openjdk.org/browse/JDK-8332066): AArch64: Math test failures since JDK-8331558 (**Bug** - P1)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19177/head:pull/19177` \
`$ git checkout pull/19177`

Update a local copy of the PR: \
`$ git checkout pull/19177` \
`$ git pull https://git.openjdk.org/jdk.git pull/19177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19177`

View PR using the GUI difftool: \
`$ git pr show -t 19177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19177.diff">https://git.openjdk.org/jdk/pull/19177.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19177#issuecomment-2104593430)