### PR TITLE
8332074: Create a "jdk.exploded" test property to check if the testee jdk is exploded

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -29,6 +29,7 @@
 #include "cds/filemap.hpp"
 #include "cds/heapShared.hpp"
 #include "cds/metaspaceShared.hpp"
+#include "classfile/classLoader.hpp"
 #include "classfile/classLoaderDataGraph.hpp"
 #include "classfile/classLoaderStats.hpp"
 #include "classfile/classPrinter.hpp"
@@ -2121,6 +2122,10 @@ WB_ENTRY(jboolean, WB_IsCDSIncluded(JNIEnv* env))
 #endif // INCLUDE_CDS
 WB_END
 
+WB_ENTRY(jboolean, WB_IsJdkExploded(JNIEnv* env))
+  return  !ClassLoader::has_jrt_entry();
+WB_END
+
 WB_ENTRY(jboolean, WB_isC2OrJVMCIIncluded(JNIEnv* env))
 #if COMPILER2_OR_JVMCI
   return true;
@@ -2875,6 +2880,7 @@ static JNINativeMethod methods[] = {
   {CC"linkClass",          CC"(Ljava/lang/Class;)V",  (void*)&WB_LinkClass},
   {CC"areOpenArchiveHeapObjectsMapped",   CC"()Z",    (void*)&WB_AreOpenArchiveHeapObjectsMapped},
   {CC"isCDSIncluded",                     CC"()Z",    (void*)&WB_IsCDSIncluded },
+  {CC"isJdkExploded",                     CC"()Z",    (void*)&WB_IsJdkExploded },
   {CC"isJFRIncluded",                     CC"()Z",    (void*)&WB_IsJFRIncluded },
   {CC"isDTraceIncluded",                  CC"()Z",    (void*)&WB_IsDTraceIncluded },
   {CC"hasLibgraal",                       CC"()Z",    (void*)&WB_HasLibgraal },

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,8 @@ requires.properties= \
     vm.musl \
     vm.flagless \
     docker.support \
-    jdk.containerized
+    jdk.containerized \
+    jdk.exploded
 
 # Minimum jtreg version
 requiredVersion=7.3.1+1

--- a/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
+++ b/test/hotspot/jtreg/runtime/CompressedOops/CompressedCPUSpecificClassSpaceReservation.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +27,9 @@
  * @summary Test the various CPU-specific reservation schemes
  * @requires vm.bits == 64 & !vm.graal.enabled & vm.debug == true
  * @requires vm.flagless
+ * @requires vm.cds
+ * @requires !jdk.exploded
+ *
  * @requires (os.family != "windows") & (os.family != "aix")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -102,7 +102,8 @@ requires.properties= \
     docker.support \
     release.implementor \
     jdk.containerized \
-    jdk.foreign.linker
+    jdk.foreign.linker \
+    jdk.exploded
 
 # Minimum jtreg version
 requiredVersion=7.3.1+1

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -120,6 +120,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.cds", this::vmCDS);
         map.put("vm.cds.custom.loaders", this::vmCDSForCustomLoaders);
         map.put("vm.cds.write.archived.java.heap", this::vmCDSCanWriteArchivedJavaHeap);
+        map.put("jdk.exploded", this::jdkExploded);
         map.put("vm.continuations", this::vmContinuations);
         // vm.graal.enabled is true if Graal is used as JIT
         map.put("vm.graal.enabled", this::isGraalEnabled);
@@ -135,6 +136,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("jdk.containerized", this::jdkContainerized);
         map.put("vm.flagless", this::isFlagless);
         map.put("jdk.foreign.linker", this::jdkForeignLinker);
+
         vmGC(map); // vm.gc.X = true/false
         vmGCforCDS(map); // may set vm.gc
         vmOptFinalFlags(map);
@@ -463,6 +465,15 @@ public class VMProps implements Callable<Map<String, String>> {
      */
     protected String vmCDSCanWriteArchivedJavaHeap() {
         return "" + ("true".equals(vmCDS()) && WB.canWriteJavaHeapArchive());
+    }
+
+    /**
+     * Check whether the test JDK is exploded. An exploded JDK will prohibit use of CDS.
+     *
+     * @return true if JDK is exploded
+     */
+    protected String jdkExploded() {
+        return "" + WB.isJdkExploded();
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -734,6 +734,7 @@ public class WhiteBox {
   public native boolean areSharedStringsMapped();
   public native boolean isSharedInternedString(String s);
   public native boolean isCDSIncluded();
+  public native boolean isJdkExploded();
   public native boolean isJFRIncluded();
   public native boolean isDTraceIncluded();
   public native boolean canWriteJavaHeapArchive();


### PR DESCRIPTION
Since we cannot run CDS operations on an exploded JDK, excluding tests like these for exploded JDKs makes sense.

However, being an exploded JDK is not the same as not having CDS built into the JVM. Plus, exploded JDKs have effects beyond their inability to run with CDS. Therefore a property makes sense.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332074](https://bugs.openjdk.org/browse/JDK-8332074): Create a "jdk.exploded" test property to check if the testee jdk is exploded (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19178/head:pull/19178` \
`$ git checkout pull/19178`

Update a local copy of the PR: \
`$ git checkout pull/19178` \
`$ git pull https://git.openjdk.org/jdk.git pull/19178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19178`

View PR using the GUI difftool: \
`$ git pr show -t 19178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19178.diff">https://git.openjdk.org/jdk/pull/19178.diff</a>

</details>
