### PR TITLE
8331858: [nmt] VM.native_memory statistics should work in summary mode

### DIFF
--- a/src/hotspot/share/nmt/memTracker.cpp
+++ b/src/hotspot/share/nmt/memTracker.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/nmt/memTracker.cpp
+++ b/src/hotspot/share/nmt/memTracker.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,12 +146,17 @@ void MemTracker::report(bool summary_only, outputStream* output, size_t scale) {
 void MemTracker::tuning_statistics(outputStream* out) {
   // NMT statistics
   out->print_cr("Native Memory Tracking Statistics:");
-  out->print_cr("State: %s", NMTUtil::tracking_level_to_string(_tracking_level));
-  out->print_cr("Malloc allocation site table size: %d", MallocSiteTable::hash_buckets());
-  out->print_cr("             Tracking stack depth: %d", NMT_TrackingStackDepth);
-  out->cr();
-  MallocSiteTable::print_tuning_statistics(out);
-  out->cr();
+  out->print_cr("State: %s",
+                NMTUtil::tracking_level_to_string(_tracking_level));
+  if (_tracking_level == NMT_detail) {
+    out->print_cr("Malloc allocation site table size: %d",
+                  MallocSiteTable::hash_buckets());
+    out->print_cr("             Tracking stack depth: %d",
+                  NMT_TrackingStackDepth);
+    out->cr();
+    MallocSiteTable::print_tuning_statistics(out);
+    out->cr();
+  }
   out->print_cr("Preinit state:");
   NMTPreInit::print_state(out);
   MallocLimitHandler::print_on(out);

--- a/src/hotspot/share/nmt/nmtDCmd.cpp
+++ b/src/hotspot/share/nmt/nmtDCmd.cpp
@@ -137,11 +137,10 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
       output()->print_cr("No detail baseline for comparison");
     }
   } else if (_statistics.value()) {
-    NMT_TrackingLevel tracking = MemTracker::tracking_level();
-    if (tracking == NMT_detail || tracking == NMT_summary) {
+    if (MemTracker::enabled()) {
       MemTracker::tuning_statistics(output());
     } else {
-      output()->print_cr("Detail or summary tracking is not enabled");
+      output()->print_cr("Native memory tracking is not enabled");
     }
   } else {
     ShouldNotReachHere();

--- a/src/hotspot/share/nmt/nmtDCmd.cpp
+++ b/src/hotspot/share/nmt/nmtDCmd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -137,8 +137,11 @@ void NMTDCmd::execute(DCmdSource source, TRAPS) {
       output()->print_cr("No detail baseline for comparison");
     }
   } else if (_statistics.value()) {
-    if (check_detail_tracking_level(output())) {
+    NMT_TrackingLevel tracking = MemTracker::tracking_level();
+    if (tracking == NMT_detail || tracking == NMT_summary) {
       MemTracker::tuning_statistics(output());
+    } else {
+      output()->print_cr("Detail or summary tracking is not enabled");
     }
   } else {
     ShouldNotReachHere();

--- a/test/hotspot/jtreg/runtime/NMT/JcmdSummaryStatistics.java
+++ b/test/hotspot/jtreg/runtime/NMT/JcmdSummaryStatistics.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test the NMT scale parameter
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run main/othervm -XX:NativeMemoryTracking=summary JcmdSummaryStatistics
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.JDKToolFinder;
+
+public class JcmdSummaryStatistics {
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder();
+        OutputAnalyzer output;
+        // Grab my own PID
+        String pid = Long.toString(jdk.test.lib.process.ProcessTools.getProcessId());
+
+        // Run 'jcmd <pid> VM.native_memory statistics=true'
+        pb.command(new String[] { JDKToolFinder.getJDKTool("jcmd"), pid, "VM.native_memory", "statistics=true"});
+        output = new OutputAnalyzer(pb.start());
+
+        output.shouldContainMultiLinePattern(
+                "Native Memory Tracking Statistics:",
+                "State: summary",
+                "Preinit state:",
+                "entries:",
+                "pre-init mallocs:",
+                "MallocLimit:");
+    }
+}


### PR DESCRIPTION
Hi all, 

This PR addresses [8331858](https://bugs.openjdk.org/browse/JDK-8331858) enabling the "statistics" sub-option for jcmd VM.native_memory. 

Since [8256844](https://bugs.openjdk.org/browse/JDK-8256844), preinit state gets printed under "statistics" and this is also relevant for the summary state. 

Testing:
- [x] Added test case passes. 

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331858](https://bugs.openjdk.org/browse/JDK-8331858): [nmt] VM.native_memory statistics should work in summary mode (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19179/head:pull/19179` \
`$ git checkout pull/19179`

Update a local copy of the PR: \
`$ git checkout pull/19179` \
`$ git pull https://git.openjdk.org/jdk.git pull/19179/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19179`

View PR using the GUI difftool: \
`$ git pr show -t 19179`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19179.diff">https://git.openjdk.org/jdk/pull/19179.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19179#issuecomment-2104815291)