### PR TITLE
8332084: Ensure JdkConsoleImpl.restoreEcho visibility in a shutdown hook

### DIFF
--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -148,11 +148,13 @@ public final class JdkConsoleImpl implements JdkConsole {
                             false /* only register if shutdown is not in progress */,
                             new Runnable() {
                                 public void run() {
-                                    try {
-                                        if (restoreEcho) {
-                                            echo(true);
-                                        }
-                                    } catch (IOException x) { }
+                                    synchronized(readLock) {
+                                        try {
+                                            if (restoreEcho) {
+                                                echo(true);
+                                            }
+                                        } catch (IOException _) { }
+                                    }
                                 }
                             });
         } catch (IllegalStateException e) {


### PR DESCRIPTION
Making sure `restoreEcho` correctly reflects the state in the shutdown thread, which differs from the application's thread that issues the `readPassword()` method.