### PR TITLE
8332096: hotspot-ide-project fails with this-escape

### DIFF
--- a/make/ide/visualstudio/hotspot/src/classes/build/tools/projectcreator/FileTreeCreator.java
+++ b/make/ide/visualstudio/hotspot/src/classes/build/tools/projectcreator/FileTreeCreator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ public class FileTreeCreator extends SimpleFileVisitor<Path>
       attributes.push(new DirAttributes());
    }
 
-   public class DirAttributes {
+   public static class DirAttributes {
 
       private HashSet<BuildConfig> ignores;
       private HashSet<BuildConfig> disablePch;


### PR DESCRIPTION
The change fixes `make hotspot-ide-project` which fails with
```
\open\make\ide\visualstudio\hotspot\src\classes\build\tools\projectcreator\FileTreeCreator.java:54: warning: [this-escape] possible 'this' escape before subclass is fully initialized
      attributes.push(new DirAttributes());
                      ^
error: warnings found and -Werror specified 

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332096: hotspot-ide-project fails with this-escape`

### Issue
 * [JDK-8332096](https://bugs.openjdk.org/browse/JDK-8332096): hotspot-ide-project fails with this-escape (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19186/head:pull/19186` \
`$ git checkout pull/19186`

Update a local copy of the PR: \
`$ git checkout pull/19186` \
`$ git pull https://git.openjdk.org/jdk.git pull/19186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19186`

View PR using the GUI difftool: \
`$ git pr show -t 19186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19186.diff">https://git.openjdk.org/jdk/pull/19186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19186#issuecomment-2105392842)