### PR TITLE
8332101: Add an `@since` to `StandardOperation:REMOVE` in `jdk.dynalink`

### DIFF
--- a/src/jdk.dynalink/share/classes/jdk/dynalink/StandardOperation.java
+++ b/src/jdk.dynalink/share/classes/jdk/dynalink/StandardOperation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,8 @@ public enum StandardOperation implements Operation {
      * <code>(receiver)&rarr;void</code> when used with {@link NamedOperation},
      * with all parameters being of any type (either primitive
      * or reference). This operation must always be used as part of a {@link NamespaceOperation}.
+     *
+     * @since 10
      */
     REMOVE,
     /**


### PR DESCRIPTION
Code cleanup, please review this simple change. I split my changes into 1 PR per module to make reviewing simpler.
To help with the review, this was added back in https://bugs.openjdk.org/browse/JDK-8191905
TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332101](https://bugs.openjdk.org/browse/JDK-8332101): Add an `@<!---->since` to `StandardOperation:REMOVE` in `jdk.dynalink` (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19189/head:pull/19189` \
`$ git checkout pull/19189`

Update a local copy of the PR: \
`$ git checkout pull/19189` \
`$ git pull https://git.openjdk.org/jdk.git pull/19189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19189`

View PR using the GUI difftool: \
`$ git pr show -t 19189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19189.diff">https://git.openjdk.org/jdk/pull/19189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19189#issuecomment-2106344437)