### PR TITLE
8332100: Add missing `@since` to KeyValue::EC_TYPE in `java.xml.crypto`

### DIFF
--- a/src/java.xml.crypto/share/classes/javax/xml/crypto/dsig/keyinfo/KeyValue.java
+++ b/src/java.xml.crypto/share/classes/javax/xml/crypto/dsig/keyinfo/KeyValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,6 +152,8 @@ public interface KeyValue extends XMLStructure {
      * the value of the <code>type</code> parameter of the
      * {@link RetrievalMethod} class to describe a remote
      * <code>ECKeyValue</code> structure.
+     *
+     * @since 13
      */
     static final String EC_TYPE =
         "http://www.w3.org/2009/xmldsig11#ECKeyValue";


### PR DESCRIPTION
Simple code cleanup. I split my changes into 1 PR per module to make reviewing simpler.
This was added back in [JDK 13](https://github.com/openjdk/jdk/commit/71825293eb83d7c9ac122c11a12465c2acbec040) and should have an `@since`
If you're reviewing this change, thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332100](https://bugs.openjdk.org/browse/JDK-8332100): Add missing `@<!---->since` to KeyValue::EC_TYPE in `java.xml.crypto` (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19190/head:pull/19190` \
`$ git checkout pull/19190`

Update a local copy of the PR: \
`$ git checkout pull/19190` \
`$ git pull https://git.openjdk.org/jdk.git pull/19190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19190`

View PR using the GUI difftool: \
`$ git pr show -t 19190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19190.diff">https://git.openjdk.org/jdk/pull/19190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19190#issuecomment-2106344175)