### PR TITLE
8324809: compiler can crash with SOE while proving if two recursive types are disjoint

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4791,7 +4791,7 @@ public class Types {
                     return t;
                 }
             } else {
-                return t;
+                return rewriteTypeVars ? makeExtendsWildcard(syms.objectType, t) : t;
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -4734,6 +4734,10 @@ public class Types {
 
         boolean high;
         boolean rewriteTypeVars;
+        // map to avoid visiting same type argument twice, like in Foo<T>.Bar<T>
+        Map<Type, Type> argMap = new HashMap<>();
+        // cycle detection within an argument, see JDK-8324809
+        Set<Type> seen = new HashSet<>();
 
         Rewriter(boolean high, boolean rewriteTypeVars) {
             this.high = high;
@@ -4745,7 +4749,10 @@ public class Types {
             ListBuffer<Type> rewritten = new ListBuffer<>();
             boolean changed = false;
             for (Type arg : t.allparams()) {
-                Type bound = visit(arg);
+                Type bound = argMap.get(arg);
+                if (bound == null) {
+                    argMap.put(arg, bound = visit(arg));
+                }
                 if (arg != bound) {
                     changed = true;
                 }
@@ -4774,11 +4781,15 @@ public class Types {
 
         @Override
         public Type visitTypeVar(TypeVar t, Void s) {
-            if (rewriteTypeVars) {
-                Type bound = t.getUpperBound().contains(t) ?
-                        erasure(t.getUpperBound()) :
-                        visit(t.getUpperBound());
-                return rewriteAsWildcardType(bound, t, EXTENDS);
+            if (seen.add(t)) {
+                if (rewriteTypeVars) {
+                    Type bound = t.getUpperBound().contains(t) ?
+                            erasure(t.getUpperBound()) :
+                            visit(t.getUpperBound());
+                    return rewriteAsWildcardType(bound, t, EXTENDS);
+                } else {
+                    return t;
+                }
             } else {
                 return t;
             }

--- a/test/langtools/tools/javac/generics/wildcards/SOEWhileProvingDisjointnessTest.java
+++ b/test/langtools/tools/javac/generics/wildcards/SOEWhileProvingDisjointnessTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8324809
+ * @summary compiler can crash with SOE while proving if two recursive types are disjoint
+ * @compile SOEWhileProvingDisjointnessTest.java
+ */
+
+class SOEWhileProvingDisjointnessTest {
+    class Criteria<B extends Builder<? extends Criteria>> {
+        public <D extends Builder<E>, E extends Criteria<D>> D builder() {
+            return (D) new Builder<>();
+        }
+    }
+
+    class Builder<C extends Criteria<? extends Builder<C>>> {}
+}


### PR DESCRIPTION
javac is crashing with SOE while compiling code like:

```
class Criteria<B extends Builder<? extends Criteria>> {
    public <D extends Builder<E>, E extends Criteria<D>> D builder() {
        return (D) new Builder<>();
    }

}

class Builder<C extends Criteria<? extends Builder<C>>> {}
```

here while attributing: `return (D)new Builder<>();` the compiler is trying to prove that: `Builder<C>` is castable to `D`, then as the upper bound of `D` is `Builder<E>`, we need to check if `Builder<C>` is castable to `Builder<E>`. Then the next step is to try to check if type variables C and E are disjoint. During this process is when the compiler gets out of resources given that

E <: Criteria<D>
D <: Builder<E> here we have E again and we start over in an infinite loop,

Here the proposal is to detect cycles in the type arguments graph and accept these type of casts if we find a cycle and thus can't prove if two types are disjoint,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8324809: compiler can crash with SOE while proving if two recursive types are disjoint`

### Issue
 * [JDK-8324809](https://bugs.openjdk.org/browse/JDK-8324809): compiler can crash with SOE while proving if two recursive types are disjoint (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19194/head:pull/19194` \
`$ git checkout pull/19194`

Update a local copy of the PR: \
`$ git checkout pull/19194` \
`$ git pull https://git.openjdk.org/jdk.git pull/19194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19194`

View PR using the GUI difftool: \
`$ git pr show -t 19194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19194.diff">https://git.openjdk.org/jdk/pull/19194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19194#issuecomment-2106045245)