### PR TITLE
8332071: Add missing package-info and `@since` tags to `java.management.rmi`

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectorServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,8 @@ public class RMIConnectorServer extends JMXConnectorServer {
     * {@linkplain RMIServer} implementation.
     * If the attribute is not set then any class is deemed acceptable.
     * @see ObjectInputFilter
+     *
+     * @since 10
     */
     public static final String CREDENTIALS_FILTER_PATTERN =
         "jmx.remote.rmi.server.credentials.filter.pattern";
@@ -152,6 +154,8 @@ public class RMIConnectorServer extends JMXConnectorServer {
      * an allow-list that is too narrow or a reject-list that is too wide may
      * prevent legitimate clients from interoperating with the
      * {@code JMXConnectorServer}.
+     *
+     * @since 10
      */
     public static final String SERIAL_FILTER_PATTERN =
        "jmx.remote.rmi.server.serial.filter.pattern";

--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/package-info.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @since 1.5
+ */
+
+package javax.management.remote.rmi;


### PR DESCRIPTION
Please review this simple change. Added a missing package-info and corresponding `@since` tags.
I used the `@since` from package.html for the package-info

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332071](https://bugs.openjdk.org/browse/JDK-8332071): Add missing package-info and `@<!---->since` tags to `java.management.rmi` (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19195/head:pull/19195` \
`$ git checkout pull/19195`

Update a local copy of the PR: \
`$ git checkout pull/19195` \
`$ git pull https://git.openjdk.org/jdk.git pull/19195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19195`

View PR using the GUI difftool: \
`$ git pr show -t 19195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19195.diff">https://git.openjdk.org/jdk/pull/19195.diff</a>

</details>
