### PR TITLE
8332098: Add missing @ since tags to jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/package-info.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@
  * Methods may be added to the interfaces in the JDI packages in future
  * releases. Existing packages may be renamed if the JDI becomes a standard
  * extension.
+ *
+ * @since 1.3
  */
 
 package com.sun.jdi.connect;

--- a/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/package-info.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/connect/spi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,8 @@
  * This package comprises the interfaces and classes used to
  * develop new {@link com.sun.jdi.connect.spi.TransportService}
  * implementations.
+ *
+ * @since 1.5
  */
 
 package com.sun.jdi.connect.spi;

--- a/src/jdk.jdi/share/classes/com/sun/jdi/event/package-info.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/event/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,8 @@
  * Methods may be added to the interfaces in the JDI packages in future
  * releases. Existing packages may be renamed if the JDI becomes a standard
  * extension.
+ *
+ * @since 1.3
  */
 
 package com.sun.jdi.event;

--- a/src/jdk.jdi/share/classes/com/sun/jdi/package-info.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@
  * Methods may be added to the interfaces in the JDI packages in future
  * releases. Existing packages may be renamed if the JDI becomes a standard
  * extension.
+ *
+ * @since 1.3
  */
 
 package com.sun.jdi;

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/package-info.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@
  * Methods may be added to the interfaces in the JDI packages in future
  * releases. Existing packages may be renamed if the JDI becomes a standard
  * extension.
+ *
+ * @since 1.3
  */
 
 package com.sun.jdi.request;


### PR DESCRIPTION
Please review this simple change where I add "@ since" tags to the package-info file of the following packages

com.sun.jdi
com.sun.jdi.connect
com.sun.jdi.connect.spi
com.sun.jdi.event
com.sun.jdi.request

I used the unix grep command to find the oldest "@ since" in each package and used that value, as it's hard to get the source code of JDK 1-5
TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332098](https://bugs.openjdk.org/browse/JDK-8332098): Add missing @<!----> since tags to jdk.jdi (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19200/head:pull/19200` \
`$ git checkout pull/19200`

Update a local copy of the PR: \
`$ git checkout pull/19200` \
`$ git pull https://git.openjdk.org/jdk.git pull/19200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19200`

View PR using the GUI difftool: \
`$ git pr show -t 19200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19200.diff">https://git.openjdk.org/jdk/pull/19200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19200#issuecomment-2106351148)