### PR TITLE
8322332: Add API to access ZipEntry.extraAttributes

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -146,6 +146,24 @@ public class ZipEntry implements ZipConstants, Cloneable {
     }
 
     /**
+     * Returns the extraAttributes of the entry.
+     * @return the extraAttributes of the entry.
+     */
+    public int getExtraAttributes() {
+        return this.extraAttributes;
+    }
+
+    /**
+     * Set the extraAttributes of the entry.
+     *
+     * @param  extraAttributes
+     *         the extraAttributes of the entry.
+     */
+    public void setExtraAttributes(int extraAttributes) {
+        this.extraAttributes=extraAttributes;
+    }    
+
+    /**
      * Sets the last modification time of the entry.
      *
      * <p> If the entry is output to a ZIP file or ZIP file formatted


### PR DESCRIPTION
Add API to access ZipEntry.extraAttributes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322332](https://bugs.openjdk.org/browse/JDK-8322332): Add API to access ZipEntry.extraAttributes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19203/head:pull/19203` \
`$ git checkout pull/19203`

Update a local copy of the PR: \
`$ git checkout pull/19203` \
`$ git pull https://git.openjdk.org/jdk.git pull/19203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19203`

View PR using the GUI difftool: \
`$ git pr show -t 19203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19203.diff">https://git.openjdk.org/jdk/pull/19203.diff</a>

</details>
