### PR TITLE
8322332: Add API to access ZipEntry.extraAttributes

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -146,6 +146,23 @@ public class ZipEntry implements ZipConstants, Cloneable {
     }
 
     /**
+     * Returns the extraAttributes of the entry.
+     * @return the extraAttributes of the entry.
+     */
+    public int getExtraAttributes() {
+        return this.extraAttributes;
+    }
+
+    /**
+     * Set the extraAttributes of the entry.
+     * @param  extraAttributes
+     *         the extraAttributes of the entry
+     */
+    public void setExtraAttributes(int extraAttributes) {
+        this.extraAttributes=extraAttributes;
+    }
+
+    /**
      * Sets the last modification time of the entry.
      *
      * <p> If the entry is output to a ZIP file or ZIP file formatted


### PR DESCRIPTION
Add API to access ZipEntry.extraAttributes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 24 to be approved (needs to be created)

### Issue
 * [JDK-8322332](https://bugs.openjdk.org/browse/JDK-8322332): Add API to access ZipEntry.extraAttributes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19204/head:pull/19204` \
`$ git checkout pull/19204`

Update a local copy of the PR: \
`$ git checkout pull/19204` \
`$ git pull https://git.openjdk.org/jdk.git pull/19204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19204`

View PR using the GUI difftool: \
`$ git pr show -t 19204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19204.diff">https://git.openjdk.org/jdk/pull/19204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19204#issuecomment-2106098348)