### PR TITLE
8332032: C2: Remove ExpandSubTypeCheckAtParseTime flag

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -767,9 +767,6 @@
   product(bool, UseProfiledLoopPredicate, true,                             \
           "Move predicates out of loops based on profiling data")           \
                                                                             \
-  product(bool, ExpandSubTypeCheckAtParseTime, false, DIAGNOSTIC,           \
-          "Do not use subtype check macro node")                            \
-                                                                            \
   develop(uintx, StressLongCountedLoop, 0,                                  \
           "if > 0, convert int counted loops to long counted loops"         \
           "to stress handling of long counted loops: run inner loop"        \

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2711,7 +2711,7 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
     // of fa[1]=x will fold up, without testing the nullness of x.
     //
     // Do not skip the static sub type check with StressReflectiveCode during
-    // parsing (i.e. with ExpandSubTypeCheckAtParseTime) because the
+    // parsing because the
     // associated CheckCastNodePP could already be folded when the type
     // system can prove it's an impossible type. Therefore, we should also
     // do the static sub type check here to ensure control is folded as well.
@@ -2720,7 +2720,7 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
     // being expanded here because we always perform the static sub type
     // check in SubTypeCheckNode::sub() regardless of whether
     // StressReflectiveCode is set or not.
-    switch (C->static_subtype_check(superk, subk, !ExpandSubTypeCheckAtParseTime)) {
+    switch (C->static_subtype_check(superk, subk, true)) {
     case Compile::SSC_always_false:
       {
         Node* always_fail = *ctrl;
@@ -2901,8 +2901,7 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
 }
 
 Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
-  bool expand_subtype_check = C->post_loop_opts_phase() ||   // macro node expansion is over
-                              ExpandSubTypeCheckAtParseTime; // forced expansion
+  bool expand_subtype_check = C->post_loop_opts_phase();   // macro node expansion is over
   if (expand_subtype_check) {
     MergeMemNode* mem = merged_memory();
     Node* ctrl = control();

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -32,7 +32,7 @@
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
  * @run main/othervm -XX:-BackgroundCompilation
  *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
- *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *     -XX:+UnlockDiagnosticVMOptions
  *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
@@ -50,12 +50,12 @@
  *          either against an interface or an unrelated non-sub-class.
  *
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
  *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
  *                   compiler.types.TestSubTypeCheckWithBottomArray
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
+ *                   -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
  *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
  *                   compiler.types.TestSubTypeCheckWithBottomArray


### PR DESCRIPTION
C2: Remove ExpandSubTypeCheckAtParseTime flag

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332032](https://bugs.openjdk.org/browse/JDK-8332032): C2: Remove ExpandSubTypeCheckAtParseTime flag (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19205/head:pull/19205` \
`$ git checkout pull/19205`

Update a local copy of the PR: \
`$ git checkout pull/19205` \
`$ git pull https://git.openjdk.org/jdk.git pull/19205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19205`

View PR using the GUI difftool: \
`$ git pr show -t 19205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19205.diff">https://git.openjdk.org/jdk/pull/19205.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19205#issuecomment-2106101027)