### PR TITLE
8331723: Serial: Remove the unused parameter of the method SerialHeap::gc_prologue

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -519,7 +519,7 @@ void SerialHeap::do_collection(bool full,
       prepared_for_verification = true;
     }
 
-    gc_prologue(complete);
+    gc_prologue();
     increment_total_collections(complete);
 
     collect_generation(_young_gen,
@@ -569,7 +569,7 @@ void SerialHeap::do_collection(bool full,
     }
 
     if (!do_young_collection) {
-      gc_prologue(complete);
+      gc_prologue();
       increment_total_collections(complete);
     }
 
@@ -1019,7 +1019,7 @@ void SerialHeap::print_heap_change(const PreGenGCValues& pre_gc_values) const {
   MetaspaceUtils::print_metaspace_change(pre_gc_values.metaspace_sizes());
 }
 
-void SerialHeap::gc_prologue(bool full) {
+void SerialHeap::gc_prologue() {
   // Fill TLAB's and such
   ensure_parsability(true);   // retire TLABs
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -252,7 +252,7 @@ public:
   };
 
  protected:
-  virtual void gc_prologue(bool full);
+  virtual void gc_prologue();
   virtual void gc_epilogue(bool full);
 
  public:


### PR DESCRIPTION
Serial: Remove the unused parameter of the method SerialHeap::gc_prologue

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331723](https://bugs.openjdk.org/browse/JDK-8331723): Serial: Remove the unused parameter of the method SerialHeap::gc_prologue (**Enhancement** - P5)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19207/head:pull/19207` \
`$ git checkout pull/19207`

Update a local copy of the PR: \
`$ git checkout pull/19207` \
`$ git pull https://git.openjdk.org/jdk.git pull/19207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19207`

View PR using the GUI difftool: \
`$ git pr show -t 19207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19207.diff">https://git.openjdk.org/jdk/pull/19207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19207#issuecomment-2106184476)