### PR TITLE
8332112: Update nsk.share.Log to don't be Finalizable

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect001/plugAttachConnect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect001/plugAttachConnect001.java
@@ -147,7 +147,6 @@ public class plugAttachConnect001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String expectedPlugAttachConnectorName = "PlugAttachConnector001_Name";
         String expectedPlugAttachConnectorDescription = "PlugAttachConnector001_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect002/plugAttachConnect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect002/plugAttachConnect002.java
@@ -165,7 +165,6 @@ public class plugAttachConnect002 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String checkedPlugAttachConnectorName = "PlugAttachConnector002_Name";
         String checkedPlugAttachConnectorDescription = "PlugAttachConnector002_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect003/plugAttachConnect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect003/plugAttachConnect003.java
@@ -133,7 +133,6 @@ public class plugAttachConnect003 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/AttachConnector/plugAttachConnect003 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect001/plugLaunchConnect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect001/plugLaunchConnect001.java
@@ -149,7 +149,6 @@ public class plugLaunchConnect001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String expectedPlugLaunchConnectorName = "PlugLaunchConnector001_Name";
         String expectedPlugLaunchConnectorDescription = "PlugLaunchConnector001_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect002/plugLaunchConnect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect002/plugLaunchConnect002.java
@@ -165,7 +165,6 @@ public class plugLaunchConnect002 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String checkedPlugLaunchConnectorName = "PlugLaunchConnector002_Name";
         String checkedPlugLaunchConnectorDescription = "PlugLaunchConnector002_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect003/plugLaunchConnect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect003/plugLaunchConnect003.java
@@ -133,7 +133,6 @@ public class plugLaunchConnect003 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/LaunchConnector/plugLaunchConnect003 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect001/plugListenConnect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect001/plugListenConnect001.java
@@ -149,7 +149,6 @@ public class plugListenConnect001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String expectedPlugListenConnectorName = "PlugListenConnector001_Name";
         String expectedPlugListenConnectorDescription = "PlugListenConnector001_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect002/plugListenConnect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect002/plugListenConnect002.java
@@ -165,7 +165,6 @@ public class plugListenConnect002 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         String checkedPlugListenConnectorName = "PlugListenConnector002_Name";
         String checkedPlugListenConnectorDescription = "PlugListenConnector002_Description";

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect003/plugListenConnect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect003/plugListenConnect003.java
@@ -133,7 +133,6 @@ public class plugListenConnect003 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/ListenConnector/plugListenConnect003 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect001/plugMultiConnect001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect001/plugMultiConnect001.java
@@ -176,7 +176,6 @@ public class plugMultiConnect001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect001 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect002/plugMultiConnect002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect002/plugMultiConnect002.java
@@ -201,7 +201,6 @@ public class plugMultiConnect002 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect002 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect003/plugMultiConnect003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect003/plugMultiConnect003.java
@@ -214,7 +214,6 @@ public class plugMultiConnect003 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect003 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect004/plugMultiConnect004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect004/plugMultiConnect004.java
@@ -233,7 +233,6 @@ public class plugMultiConnect004 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect004 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect005/plugMultiConnect005.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect005/plugMultiConnect005.java
@@ -238,7 +238,6 @@ public class plugMultiConnect005 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect005 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect006/plugMultiConnect006.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect006/plugMultiConnect006.java
@@ -263,7 +263,6 @@ public class plugMultiConnect006 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/MultiConnectors/plugMultiConnect006 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService001/transportService001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService001/transportService001.java
@@ -185,7 +185,6 @@ public class transportService001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/TransportService/transportService001 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService002/transportService002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService002/transportService002.java
@@ -185,7 +185,6 @@ public class transportService002 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/TransportService/transportService002 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService003/transportService003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/PlugConnectors/TransportService/transportService003/transportService003.java
@@ -136,7 +136,6 @@ public class transportService003 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/PlugConnectors/TransportService/transportService003 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature001.java
@@ -158,7 +158,6 @@ public class genericSignature001 {
         argsHandler = new ArgumentHandler(argv);
         verboseMode = argsHandler.verbose();
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/ReferenceType/genericSignature/genericSignature001 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature001a.java
@@ -113,7 +113,6 @@ public class genericSignature001a {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(System.err, argsHandler);
-        logHandler.enableErrorsSummary(false);
         IOPipe pipe = argsHandler.createDebugeeIOPipe();
 
         logOnVerbose(infoLogPrefixHead + "Debugee started!");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature002.java
@@ -140,7 +140,6 @@ public class genericSignature002 {
         argsHandler = new ArgumentHandler(argv);
         verboseMode = argsHandler.verbose();
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/ReferenceType/genericSignature/genericSignature002 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ReferenceType/genericSignature/genericSignature002a.java
@@ -86,7 +86,6 @@ public class genericSignature002a {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(System.err, argsHandler);
-        logHandler.enableErrorsSummary(false);
         IOPipe pipe = argsHandler.createDebugeeIOPipe();
 
         logOnVerbose(infoLogPrefixHead + "Debugee started!");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature001.java
@@ -183,7 +183,6 @@ public class genericSignature001 {
         argsHandler = new ArgumentHandler(argv);
         verboseMode = argsHandler.verbose();
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/TypeComponent/genericSignature/genericSignature001 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature001a.java
@@ -112,7 +112,6 @@ public class genericSignature001a {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(System.err, argsHandler);
-        logHandler.enableErrorsSummary(false);
         IOPipe pipe = argsHandler.createDebugeeIOPipe();
 
         logOnVerbose(infoLogPrefixHead + "Debugee started!");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature002.java
@@ -175,7 +175,6 @@ public class genericSignature002 {
         argsHandler = new ArgumentHandler(argv);
         verboseMode = argsHandler.verbose();
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/TypeComponent/genericSignature/genericSignature002 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/TypeComponent/genericSignature/genericSignature002a.java
@@ -288,7 +288,6 @@ public class genericSignature002a {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(System.err, argsHandler);
-        logHandler.enableErrorsSummary(false);
         IOPipe pipe = argsHandler.createDebugeeIOPipe();
 
         logOnVerbose(infoLogPrefixHead + "Debugee started!");

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM001.java
@@ -94,7 +94,6 @@ public class createVM001 {
 
         argsHandler = new ArgumentHandler(argv);
         logHandler = new Log(out, argsHandler);
-        logHandler.enableErrorsSummary(false);
 
         logAlways("==> nsk/jdi/VirtualMachineManager/createVirtualMachine/createVM001 test...");
         logOnVerbose

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,14 +69,11 @@ import nsk.share.test.LazyFormatString;
  * @see ArgumentParser
  * @see Log.Logger
  */
-public class Log extends FinalizableObject {
+public class Log {
     /**
      * Report step-by-step activity to this stream.
-     *
-     * @deprecated  Tests should not use this field directly.
      */
-    @Deprecated
-    protected PrintStream out = null;
+    private PrintStream out = null;
 
     /**
      * Is log-mode verbose?
@@ -111,22 +108,6 @@ public class Log extends FinalizableObject {
             NAME_TO_LEVEL_MAP.put("debug", TRACE_DEBUG);
             NAME_TO_LEVEL_MAP.put("default", DEFAULT);
         }
-
-        public static int nameToLevel(String value) throws IllegalArgumentException {
-            Integer level = NAME_TO_LEVEL_MAP.get(value.toLowerCase());
-            if ( level == null )
-                throw new IllegalArgumentException("Wrong trace level: " + value);
-
-            return level;
-        }
-
-        public static String getLevelsString() {
-            StringBuffer result = new StringBuffer();
-            for ( String s : NAME_TO_LEVEL_MAP.keySet() ) {
-                result.append(s).append(", ");
-            }
-            return result.substring(0, result.length() - 3);
-        }
     }
 
     /**
@@ -134,16 +115,6 @@ public class Log extends FinalizableObject {
      * Default value is <code>0</code> a.k.a. <code>TraceLevel.INFO</code>;
      */
     private int traceLevel = TraceLevel.DEFAULT;
-
-    /**
-     * Is printing errors summary enabled? Default value is <code>true</code>;
-     */
-    private boolean errorsSummaryEnabled = true;
-
-    /**
-     * Is printing saved verbose messages on error enabled? Default value is <code>true</code>;
-     */
-    private boolean verboseOnErrorEnabled = true;
 
     /**
      * This <code>errosBuffer</code> will keep all messages printed via
@@ -188,8 +159,6 @@ public class Log extends FinalizableObject {
      */
     @Deprecated
     protected Log() {
-        // install finalizer to print errors summary at exit
-        registerCleanup();
         // Don't log exceptions from this method. It would just add unnecessary logs.
         loggedExceptions.add("nsk.share.jdi.SerialExecutionDebugger.executeTests");
     }
@@ -232,34 +201,6 @@ public class Log extends FinalizableObject {
      */
     public boolean verbose() {
         return verbose;
-    }
-
-    /**
-     * Return <i>true</i> if printing errors summary at exit is enabled.
-     */
-    public boolean isErrorsSummaryEnabled() {
-        return errorsSummaryEnabled;
-    }
-
-    /**
-     * Enable or disable printing errors summary at exit.
-     */
-    public void enableErrorsSummary(boolean enable) {
-        errorsSummaryEnabled = enable;
-    }
-
-    /**
-     * Return <i>true</i> if printing saved verbose messages on error is enabled.
-     */
-    public boolean isVerboseOnErrorEnabled() {
-        return errorsSummaryEnabled;
-    }
-
-    /**
-     * Enable or disable printing saved verbose messages on error.
-     */
-    public void enableVerboseOnError(boolean enable) {
-        verboseOnErrorEnabled = enable;
     }
 
     /**
@@ -315,7 +256,7 @@ public class Log extends FinalizableObject {
     @Deprecated
     public synchronized void println(String message) {
         doPrint(message);
-        if (!verbose() && isVerboseOnErrorEnabled()) {
+        if (!verbose()) {
             keepLog(composeLine(message));
         }
     }
@@ -371,10 +312,8 @@ public class Log extends FinalizableObject {
     public synchronized void display(Object message) {
         if (verbose()) {
             doPrint(message.toString());
-        } else if (isVerboseOnErrorEnabled()) {
-            keepLog(composeLine(message.toString()));
         } else {
-            // ignore
+            keepLog(composeLine(message.toString()));
         }
     }
 
@@ -384,7 +323,7 @@ public class Log extends FinalizableObject {
      * into <code>errorsBuffer</code>.
      */
     public synchronized void complain(Object message) {
-        if (!verbose() && isVerboseOnErrorEnabled()) {
+        if (!verbose()) {
             PrintStream stream = findOutStream();
             stream.println("#>  ");
             stream.println("#>  WARNING: switching log to verbose mode,");
@@ -395,9 +334,6 @@ public class Log extends FinalizableObject {
         }
         String msgStr = message.toString();
         printError(msgStr);
-        if (isErrorsSummaryEnabled()) {
-            keepError(msgStr);
-        }
 
         logExceptionForFailureAnalysis(msgStr);
     }
@@ -469,7 +405,9 @@ public class Log extends FinalizableObject {
      */
     @Deprecated
     protected synchronized void logTo(PrintStream stream) {
-        cleanup(); // flush older log stream
+        if (out != null) {
+            out.flush();
+        }
         out = stream;
         verbose = true;
     }
@@ -571,59 +509,6 @@ public class Log extends FinalizableObject {
      */
     private synchronized void keepLog(String message) {
         logBuffer.addElement(message);
-    }
-
-    /**
-     * Keep the given error <code>message</code> into <code>errorsBuffer</code>.
-     */
-    private synchronized void keepError(String message) {
-        errorsBuffer.addElement(message);
-    }
-
-    /**
-     * Print errors messages summary from errors buffer if any;
-     * print a warning message first.
-     */
-    private synchronized void printErrorsSummary() {
-        if (errorsBuffer.size() <= 0)
-            return;
-
-        PrintStream stream = findOutStream();
-        stream.println();
-        stream.println();
-        stream.println("#>  ");
-        stream.println("#>  SUMMARY: Following errors occured");
-        stream.println("#>      during test execution:");
-        stream.println("#>  ");
-        stream.flush();
-
-        for (Enumeration e = errorsBuffer.elements(); e.hasMoreElements(); ) {
-            printError((String) e.nextElement());
-        }
-    }
-
-    /**
-     * Print errors summary if mode is verbose, flush and cancel output stream.
-     *
-     * This is replacement of the finalize() method and is called when this
-     * Log instance becomes unreachable.
-     *
-     */
-    @Override
-    public void cleanup() {
-        if (verbose() && isErrorsSummaryEnabled()) {
-            printErrorsSummary();
-        }
-        if (out != null)
-            out.flush();
-        out = null;
-    }
-
-    /**
-     * Perform finalization at the exit.
-     */
-    public void finalizeAtExit() {
-        cleanup();
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -108,6 +108,22 @@ public class Log {
             NAME_TO_LEVEL_MAP.put("debug", TRACE_DEBUG);
             NAME_TO_LEVEL_MAP.put("default", DEFAULT);
         }
+
+        public static int nameToLevel(String value) throws IllegalArgumentException {
+            Integer level = NAME_TO_LEVEL_MAP.get(value.toLowerCase());
+           if ( level == null )
+                throw new IllegalArgumentException("Wrong trace level: " + value);
+
+            return level;
+        }
+
+        public static String getLevelsString() {
+            StringBuffer result = new StringBuffer();
+            for ( String s : NAME_TO_LEVEL_MAP.keySet() ) {
+                result.append(s).append(", ");
+            }
+            return result.substring(0, result.length() - 3);
+        }
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/BindServer.java
@@ -147,8 +147,6 @@ public class BindServer implements Finalizable {
         }
 
         log = new Log(out, argHandler);
-        log.enableErrorsSummary(false);
-        log.enableVerboseOnError(false);
         logger = new Log.Logger(log, "");
 
         registerCleanup();

--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/share/MlvmTestExecutor.java
@@ -235,7 +235,6 @@ public class MlvmTestExecutor {
      * @see #runMlvmTest(Class<?> testClass, Object[] constructorArgs)
      */
     public static void launch(Class<?> testClass, Object[] constructorArgs) {
-        Env.getLog().enableVerboseOnError(true);
 
         long startTime = System.currentTimeMillis();
         boolean passed;


### PR DESCRIPTION
The nsk.share.Log doing some cleanup and reporting errors in the cleanup method. This method is supposed to be executed by finalizer originally. However, now it is called only during shutdown hook. 
The cleanup using Cleaner doesn't work. See https://bugs.openjdk.org/browse/JDK-8330760

The cleanup method flush stream and print summary which should be already printed by complain method.

This cleanup is not necessary and printing summary usually is just disabled. It is enabled if the test called 'complain' method. However, the error should have been printed already in this method.

Note: The 'verboseOnErrorEnabled' is just not used.

See isVerboseOnErrorEnabled.
    public boolean isVerboseOnErrorEnabled() {
- return errorsSummaryEnabled;
- }
