### PR TITLE
8332086: Remove the usage of ServiceLoader in j.u.r.RandomGeneratorFactory

### DIFF
--- a/src/java.base/share/classes/java/security/SecureRandom.java
+++ b/src/java.base/share/classes/java/security/SecureRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package java.security;
 
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 import sun.security.jca.GetInstance;
 import sun.security.jca.GetInstance.Instance;
 import sun.security.jca.Providers;
@@ -149,10 +148,6 @@ import java.util.regex.Pattern;
  * @since 1.1
  */
 
-@RandomGeneratorProperties(
-        name = "SecureRandom",
-        isStochastic = true
-)
 public class SecureRandom extends java.util.Random {
 
     private static final Debug pdebug =

--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,6 @@ import java.util.random.RandomGenerator;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-
-import jdk.internal.util.random.RandomSupport.*;
 
 import static jdk.internal.util.random.RandomSupport.*;
 
@@ -77,11 +75,6 @@ import jdk.internal.misc.Unsafe;
  * @author  Frank Yellin
  * @since   1.0
  */
-@RandomGeneratorProperties(
-        name = "Random",
-        i = 48, j = 0, k = 0,
-        equidistribution = 0
-)
 public class Random implements RandomGenerator, java.io.Serializable {
 
     /**

--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A generator of uniform pseudorandom values (with period 2<sup>64</sup>)
@@ -87,11 +86,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @author  Doug Lea
  * @since   1.8
  */
-@RandomGeneratorProperties(
-        name = "SplittableRandom",
-        i = 64, j = 0, k = 0,
-        equidistribution = 1
-)
 public final class SplittableRandom implements RandomGenerator, SplittableGenerator {
 
     /*

--- a/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
+++ b/src/java.base/share/classes/java/util/concurrent/ThreadLocalRandom.java
@@ -85,12 +85,6 @@ import jdk.internal.misc.VM;
  * @since 1.7
  * @author Doug Lea
  */
-
-@RandomGeneratorProperties(
-        name = "ThreadLocalRandom",
-        i = 64, j = 0, k = 0,
-        equidistribution = 1
-)
 public final class ThreadLocalRandom extends Random {
     /*
      * This class implements the java.util.Random API (and subclasses

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -38,7 +38,6 @@ import jdk.internal.random.Xoshiro256PlusPlus;
 
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Objects;
 import java.util.Map;
 import java.util.Random;
@@ -195,11 +194,11 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
             );
         }
 
-        private static SimpleImmutableEntry<String, RandomGeneratorProperties>
+        private static Map.Entry<String, RandomGeneratorProperties>
         entry(Class<? extends RandomGenerator> rgClass, String name, String group,
                 int i, int j, int k, int equidistribution,
                 int flags) {
-            return new SimpleImmutableEntry<>(name,
+            return Map.entry(name,
                     new RandomGeneratorProperties(rgClass, name, group,
                             i, j, k, equidistribution,
                             flags | (rgClass.isAnnotationPresent(Deprecated.class) ? DEPRECATED : 0)));
@@ -624,7 +623,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
      * <a href="package-summary.html#algorithms">algorithm</a> chosen,
      * and providing a starting long seed.
      * If a long seed is not supported by the algorithm,
-     * an UnsupportedOperationException is thrown.
+     * an {@link UnsupportedOperationException} is thrown.
      *
      * @param seed long random seed value.
      *
@@ -643,7 +642,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
      * <a href="package-summary.html#algorithms">algorithm</a> chosen,
      * and providing a starting byte[] seed.
      * If a byte[] seed is not supported by the algorithm,
-     * an UnsupportedOperationException is thrown.
+     * an {@link UnsupportedOperationException} is thrown.
      *
      * @param seed byte array random seed value.
      *

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -126,6 +126,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
             int equidistribution,
             int flags) {
 
+        /* single bit masks composable with operator | */
         private static final int INSTANTIABLE       = 1 << 0;
         private static final int LONG_SEED          = 1 << 1;
         private static final int BYTE_ARRAY_SEED    = 1 << 2;
@@ -139,11 +140,11 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
 
         /**
          * Returns the factory map, lazily constructing it on first use.
-         * <p>
-         * Although {@link ThreadLocalRandom} can only be accessed via
+         * <p> Although {@link ThreadLocalRandom} can only be accessed via
          * {@link ThreadLocalRandom#current()}, a map entry is added nevertheless
          * to record its properties that are otherwise not documented
          * anywhere else.
+         * <p> Currently, no algorithm is deprecated.
          *
          * @return Map of RandomGeneratorProperties.
          */
@@ -151,13 +152,13 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
             return Map.ofEntries(
                     entry(SecureRandom.class, "SecureRandom", "Legacy",
                             0, 0, 0, Integer.MAX_VALUE,
-                            INSTANTIABLE | BYTE_ARRAY_SEED | STOCHASTIC),
+                            INSTANTIABLE | BYTE_ARRAY_SEED | STOCHASTIC | deprecationBit(SecureRandom.class)),
                     entry(Random.class, "Random", "Legacy",
                             48, 0, 0, 0,
-                            INSTANTIABLE | LONG_SEED),
+                            INSTANTIABLE | LONG_SEED | deprecationBit(Random.class)),
                     entry(SplittableRandom.class, "SplittableRandom", "Legacy",
                             64, 0, 0, 1,
-                            INSTANTIABLE | LONG_SEED),
+                            INSTANTIABLE | LONG_SEED | deprecationBit(SplittableRandom.class)),
                     entry(L32X64MixRandom.class, "L32X64MixRandom", "LXM",
                             64, 1, 32, 1,
                             ALL_CONSTRUCTORS),
@@ -190,7 +191,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
                             ALL_CONSTRUCTORS),
                     entry(ThreadLocalRandom.class, "ThreadLocalRandom", "Legacy",
                             64, 0, 0, 1,
-                            0)
+                            deprecationBit(ThreadLocalRandom.class))
             );
         }
 
@@ -201,7 +202,11 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
             return Map.entry(name,
                     new RandomGeneratorProperties(rgClass, name, group,
                             i, j, k, equidistribution,
-                            flags | (rgClass.isAnnotationPresent(Deprecated.class) ? DEPRECATED : 0)));
+                            flags));
+        }
+
+        private static int deprecationBit(Class<? extends RandomGenerator> rgClass) {
+            return rgClass.isAnnotationPresent(Deprecated.class) ? DEPRECATED : 0;
         }
 
         private RandomGenerator create() {

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -207,8 +207,8 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
 
         private RandomGenerator create() {
             return switch (name) {
-                case "SecureRandom" -> new SecureRandom();
-                case "Random" -> new Random();
+                case "Random" ->                new Random();
+                case "SecureRandom" ->          new SecureRandom();
                 case "SplittableRandom" ->      new SplittableRandom();
                 case "L32X64MixRandom" ->       new L32X64MixRandom();
                 case "L64X128MixRandom" ->      new L64X128MixRandom();
@@ -230,7 +230,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
                         + name + " does not support a long seed");
             }
             return switch (name) {
-                case "Random" -> new Random(seed);
+                case "Random" ->                new Random(seed);
                 case "SplittableRandom" ->      new SplittableRandom(seed);
                 case "L32X64MixRandom" ->       new L32X64MixRandom(seed);
                 case "L64X128MixRandom" ->      new L64X128MixRandom(seed);
@@ -281,6 +281,20 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
 
         private boolean isDeprecated() {
             return (flags & DEPRECATED) != 0;
+        }
+
+        private BigInteger period() {
+            /*
+             * 0                if i = j = k = 0
+             * (2^i - j) 2^k    otherwise
+             */
+            return i == 0 && j == 0 && k == 0
+                    ? BigInteger.ZERO
+                    : BigInteger.ONE.shiftLeft(i).subtract(BigInteger.valueOf(j)).shiftLeft(k);
+        }
+
+        private int stateBits() {
+            return i == 0 && k == 0 ? Integer.MAX_VALUE : i + k;
         }
     }
 
@@ -472,10 +486,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
      *         to maintain state of seed.
      */
     public int stateBits() {
-        int i = properties.i();
-        int k = properties.k();
-
-        return i == 0 && k == 0 ? Integer.MAX_VALUE : i + k;
+        return properties.stateBits();
     }
 
     /**
@@ -495,13 +506,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
      * @return BigInteger period.
      */
     public BigInteger period() {
-        int i = properties.i();
-        int j = properties.j();
-        int k = properties.k();
-
-        return i == 0 && j == 0 && k == 0
-                ? BigInteger.ZERO
-                : BigInteger.ONE.shiftLeft(i).subtract(BigInteger.valueOf(j)).shiftLeft(k);
+        return properties.period();
     }
 
     /**

--- a/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
+++ b/src/java.base/share/classes/java/util/random/RandomGeneratorFactory.java
@@ -194,8 +194,8 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
             );
         }
 
-        private static Map.Entry<String, RandomGeneratorProperties>
-        entry(Class<? extends RandomGenerator> rgClass, String name, String group,
+        private static Map.Entry<String, RandomGeneratorProperties> entry(
+                Class<? extends RandomGenerator> rgClass, String name, String group,
                 int i, int j, int k, int equidistribution,
                 int flags) {
             return Map.entry(name,
@@ -610,7 +610,7 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
      * Create an instance of {@link RandomGenerator} based on the
      * <a href="package-summary.html#algorithms">algorithm</a> chosen.
      *
-     * @return new in instance of {@link RandomGenerator}.
+     * @return new instance of {@link RandomGenerator}.
      */
     public T create() {
         @SuppressWarnings("unchecked")
@@ -621,15 +621,17 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
     /**
      * Create an instance of {@link RandomGenerator} based on the
      * <a href="package-summary.html#algorithms">algorithm</a> chosen,
-     * and providing a starting long seed.
-     * If a long seed is not supported by the algorithm,
-     * an {@link UnsupportedOperationException} is thrown.
+     * and the provided {@code seed}.
+     * If the {@link RandomGenerator} doesn't support instantiation through
+     * a {@code seed} of type {@code long} then this method throws
+     * an {@link UnsupportedOperationException}.
      *
      * @param seed long random seed value.
      *
-     * @return new in instance of {@link RandomGenerator}.
+     * @return new instance of {@link RandomGenerator}.
      *
-     * @throws UnsupportedOperationException if a long seed in not supported.
+     * @throws UnsupportedOperationException
+     *      if a {@code seed} of type {@code long} in not supported.
      */
     public T create(long seed) {
         @SuppressWarnings("unchecked")
@@ -640,15 +642,18 @@ public final class RandomGeneratorFactory<T extends RandomGenerator> {
     /**
      * Create an instance of {@link RandomGenerator} based on the
      * <a href="package-summary.html#algorithms">algorithm</a> chosen,
-     * and providing a starting byte[] seed.
-     * If a byte[] seed is not supported by the algorithm,
-     * an {@link UnsupportedOperationException} is thrown.
+     * and the provided {@code seed}.
+     * If the {@link RandomGenerator} doesn't support instantiation through
+     * a {@code seed} of type {@code byte[]} then this method throws
+     * an {@link UnsupportedOperationException}.
      *
      * @param seed byte array random seed value.
      *
-     * @return new in instance of {@link RandomGenerator}.
+     * @return new instance of {@link RandomGenerator}.
      *
-     * @throws UnsupportedOperationException if a byte[] seed in not supported.
+     * @throws UnsupportedOperationException
+     *      if a {@code seed} of type {@code byte[]} in not supported.
+     *
      * @throws NullPointerException if seed is null.
      */
     public T create(byte[] seed) {

--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -126,7 +126,7 @@
  * <h2>Choosing a Random Number Generator Algorithm</h2>
  *
  * <p> Random number generator algorithms are organized in groups,
- * as described <a href="package-summary.html#algorithms">below</a>.
+ * as described {@linkplain java.util.random##algorithms below}.
  *
  * <p> The legacy group includes random number generators that existed
  * before JDK 17: Random, ThreadLocalRandom, SplittableRandom, and

--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -81,8 +81,8 @@
  * <blockquote>{@code import java.util.random.*;}</blockquote>
  *
  * Then one can choose a specific implementation by giving the name of a generator
- * algorithm to the static method {@link RandomGenerator#of}, in which case the
- * no-arguments constructor for that implementation is used:
+ * algorithm to the static method {@link RandomGenerator#of}, in which case no
+ * seed is specified by the caller:
  *
  * <blockquote>{@code RandomGenerator g = RandomGenerator.of("L64X128MixRandom");}</blockquote>
  *

--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -81,8 +81,8 @@
  * <blockquote>{@code import java.util.random.*;}</blockquote>
  *
  * Then one can choose a specific implementation by giving the name of a generator
- * algorithm to the static method {@link RandomGenerator#of}, in which case no
- * seed is specified by the caller:
+ * algorithm to the static method {@link RandomGenerator#of}, in which case
+ * a {@link RandomGenerator} is constructed without any seed value:
  *
  * <blockquote>{@code RandomGenerator g = RandomGenerator.of("L64X128MixRandom");}</blockquote>
  *
@@ -125,8 +125,8 @@
  *
  * <h2>Choosing a Random Number Generator Algorithm</h2>
  *
- * <p> There are three groups of random number generator algorithm provided
- * in Java: the Legacy group, the LXM group, and the Xoroshiro/Xoshiro group.
+ * <p> Random number generator algorithms are organized in groups,
+ * as described <a href="package-summary.html#algorithms">below</a>.
  *
  * <p> The legacy group includes random number generators that existed
  * before JDK 17: Random, ThreadLocalRandom, SplittableRandom, and

--- a/src/java.base/share/classes/java/util/random/package-info.java
+++ b/src/java.base/share/classes/java/util/random/package-info.java
@@ -304,6 +304,13 @@
  *      <td style="text-align:right">1</td>
  *  </tr>
  *  <tr>
+ *      <th scope="row" style="text-align:left">SecureRandom</th>
+ *      <td style="text-align:left">Legacy</td>
+ *      <td style="text-align:left">BigInteger.ZERO</td>
+ *      <td style="text-align:right">Integer.MAX_VALUE</td>
+ *      <td style="text-align:right">Integer.MAX_VALUE</td>
+ *  </tr>
+ *  <tr>
  *      <th scope="row" style="text-align:left">ThreadLocalRandom <sup>*</sup></th>
  *      <td style="text-align:left">Legacy</td>
  *      <td style="text-align:left">BigInteger.ONE.shiftLeft(64)</td>

--- a/src/java.base/share/classes/jdk/internal/random/L128X1024MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L128X1024MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L128X1024MixRandom",
-        group = "LXM",
-        i = 1024, j = 1, k = 128,
-        equidistribution = 1
-)
 public final class L128X1024MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L128X128MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L128X128MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L128X128MixRandom",
-        group = "LXM",
-        i = 128, j = 1, k = 128,
-        equidistribution = 1
-)
 public final class L128X128MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L128X256MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L128X256MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L128X256MixRandom",
-        group = "LXM",
-        i = 256, j = 1, k = 128,
-        equidistribution = 1
-)
 public final class L128X256MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L32X64MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L32X64MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L32X64MixRandom",
-        group = "LXM",
-        i = 64, j = 1, k = 32,
-        equidistribution = 1
-)
 public final class L32X64MixRandom extends AbstractSplittableWithBrineGenerator {
     /*
      * Implementation Overview.

--- a/src/java.base/share/classes/jdk/internal/random/L64X1024MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L64X1024MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L64X1024MixRandom",
-        group = "LXM",
-        i = 1024, j = 1, k = 64,
-        equidistribution = 16
-)
 public final class L64X1024MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L64X128MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L64X128MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L64X128MixRandom",
-        group = "LXM",
-        i = 128, j = 1, k = 64,
-        equidistribution = 2
-)
 public final class L64X128MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L64X128StarStarRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L64X128StarStarRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L64X128StarStarRandom",
-        group = "LXM",
-        i = 128, j = 1, k = 64,
-        equidistribution = 2
-)
 public final class L64X128StarStarRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/L64X256MixRandom.java
+++ b/src/java.base/share/classes/jdk/internal/random/L64X256MixRandom.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import jdk.internal.util.random.RandomSupport;
 import jdk.internal.util.random.RandomSupport.AbstractSplittableWithBrineGenerator;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "splittable" pseudorandom number generator (PRNG) whose period
@@ -75,12 +74,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "L64X256MixRandom",
-        group = "LXM",
-        i = 256, j = 1, k = 64,
-        equidistribution = 4
-)
 public final class L64X256MixRandom extends AbstractSplittableWithBrineGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/Xoroshiro128PlusPlus.java
+++ b/src/java.base/share/classes/jdk/internal/random/Xoroshiro128PlusPlus.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import java.util.random.RandomGenerator.LeapableGenerator;
 import jdk.internal.util.random.RandomSupport;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "jumpable and leapable" pseudorandom number generator (PRNG) whose period
@@ -72,12 +71,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "Xoroshiro128PlusPlus",
-        group = "Xoroshiro",
-        i = 128, j = 1, k = 0,
-        equidistribution = 1
-)
 public final class Xoroshiro128PlusPlus implements LeapableGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/random/Xoshiro256PlusPlus.java
+++ b/src/java.base/share/classes/jdk/internal/random/Xoshiro256PlusPlus.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.random.RandomGenerator;
 import java.util.random.RandomGenerator.LeapableGenerator;
 import jdk.internal.util.random.RandomSupport;
-import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
 
 /**
  * A "jumpable and leapable" pseudorandom number generator (PRNG) whose period
@@ -87,12 +86,6 @@ import jdk.internal.util.random.RandomSupport.RandomGeneratorProperties;
  * @since   17
  *
  */
-@RandomGeneratorProperties(
-        name = "Xoshiro256PlusPlus",
-        group = "Xoshiro",
-        i = 256, j = 1, k = 0,
-        equidistribution = 3
-)
 public final class Xoshiro256PlusPlus implements LeapableGenerator {
 
     /*

--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,7 @@
 
 package jdk.internal.util.random;
 
-import java.lang.annotation.*;
-import java.math.BigInteger;
 import java.util.Objects;
-import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 import java.util.function.IntConsumer;
@@ -53,49 +50,6 @@ import java.util.stream.StreamSupport;
  * @since 17
  */
 public class RandomSupport {
-    /**
-     * Annotation providing RandomGenerator properties.
-     */
-    @Retention(RetentionPolicy.RUNTIME)
-    @Target(ElementType.TYPE)
-    public @interface RandomGeneratorProperties {
-        /**
-         * Name of algorithm.
-         */
-        String name();
-
-        /**
-         * Category of algorithm.
-         */
-        String group() default "Legacy";
-
-        /**
-         * Algorithm period defined as:
-         *
-         * BigInteger.ONE.shiftLeft(i)
-         *               .subtract(j)
-         *               .shiftLeft(k)
-         */
-        int i() default 0;
-        int j() default 0;
-        int k() default 0;
-
-        /**
-         * The equidistribution of the algorithm.
-         */
-        int equidistribution() default Integer.MAX_VALUE;
-
-        /**
-         * Is the algorithm based on entropy (true random.)
-         */
-        boolean isStochastic() default false;
-
-        /**
-         * Is the algorithm assisted by hardware (fast true random.)
-         */
-        boolean isHardware() default false;
-    }
-
     /*
      * Implementation Overview.
      *

--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -419,19 +419,4 @@ module java.base {
     provides java.nio.file.spi.FileSystemProvider with
         jdk.internal.jrtfs.JrtFileSystemProvider;
 
-    provides java.util.random.RandomGenerator with
-        java.security.SecureRandom,
-        java.util.Random,
-        java.util.SplittableRandom,
-        jdk.internal.random.L32X64MixRandom,
-        jdk.internal.random.L64X128MixRandom,
-        jdk.internal.random.L64X128StarStarRandom,
-        jdk.internal.random.L64X256MixRandom,
-        jdk.internal.random.L64X1024MixRandom,
-        jdk.internal.random.L128X128MixRandom,
-        jdk.internal.random.L128X256MixRandom,
-        jdk.internal.random.L128X1024MixRandom,
-        jdk.internal.random.Xoroshiro128PlusPlus,
-        jdk.internal.random.Xoshiro256PlusPlus;
-
 }

--- a/test/jdk/java/util/Random/RandomTestCoverage.java
+++ b/test/jdk/java/util/Random/RandomTestCoverage.java
@@ -87,7 +87,7 @@ public class RandomTestCoverage {
         DoubleStream doubleStream4 = rng.doubles(5, 0.5, 1.0);
     }
 
-    static void checkPredicates(RandomGeneratorFactory factory) {
+    static void checkPredicates(RandomGeneratorFactory<RandomGenerator> factory) {
         RandomGenerator rng = factory.create();
         if (rng instanceof ArbitrarilyJumpableGenerator != factory.isArbitrarilyJumpable()) {
             throw new RuntimeException("isArbitrarilyJumpable failing");
@@ -156,7 +156,7 @@ public class RandomTestCoverage {
         coverFactory(RandomGeneratorFactory.of(name));
     }
 
-    static void coverFactory(RandomGeneratorFactory factory) {
+    static void coverFactory(RandomGeneratorFactory<RandomGenerator> factory) {
         String name = factory.name();
         String group = factory.group();
         int stateBits = factory.stateBits();
@@ -171,24 +171,33 @@ public class RandomTestCoverage {
         boolean isSplittable = factory.isSplittable();
 
         coverRandomGenerator(factory.create());
-        RandomGenerator rng;
-
-        rng = null;
-        try {
-            rng = factory.create(12345L);
-        } catch (UnsupportedOperationException ignore) {
+        // test create(long)
+        switch (factory.name()) {
+            // SecureRandom doesn't have long constructors so we expect
+            // UnsupportedOperationException
+            case "SecureRandom" -> {
+                try {
+                    factory.create(12345L);
+                    throw new AssertionError("RandomGeneratorFactory.create(long) was expected" +
+                            "to throw UnsupportedOperationException for " + factory.name() + " but didn't");
+                } catch (UnsupportedOperationException ignored) {
+                }
+            }
+            default -> coverRandomGenerator(factory.create(12345L));
         }
-        if (rng != null) {
-            coverRandomGenerator(rng);
-        }
-
-        rng = null;
-        try {
-            rng = factory.create(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
-        } catch (UnsupportedOperationException ignore) {
-        }
-        if (rng != null) {
-            coverRandomGenerator(rng);
+        // test create(byte[])
+        switch (factory.name()) {
+            // these don't have byte[] constructors so we expect UnsupportedOperationException
+            case "Random",
+                 "SplittableRandom" -> {
+                try {
+                    factory.create(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+                    throw new AssertionError("RandomGeneratorFactory.create(byte[]) was expected" +
+                            "to throw UnsupportedOperationException for " + factory.name() + " but didn't");
+                } catch (UnsupportedOperationException ignored) {
+                }
+            }
+            default -> coverRandomGenerator(factory.create(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
         }
     }
 
@@ -205,32 +214,35 @@ public class RandomTestCoverage {
                     coverOf(factory.name());
                  });
         RandomGeneratorFactory.all()
-                .filter(f -> f.isStreamable())
+                .filter(RandomGeneratorFactory::isStreamable)
                 .forEach(factory -> {
                     coverStreamable((StreamableGenerator)factory.create());
                 });
         RandomGeneratorFactory.all()
-                .filter(f -> f.isSplittable())
+                .filter(RandomGeneratorFactory::isSplittable)
                 .forEach(factory -> {
                     coverSplittable((SplittableGenerator)factory.create());
                 });
         RandomGeneratorFactory.all()
-                .filter(f -> f.isJumpable())
+                .filter(RandomGeneratorFactory::isJumpable)
                 .forEach(factory -> {
                     coverJumpable((JumpableGenerator)factory.create());
                 });
         RandomGeneratorFactory.all()
-                .filter(f -> f.isLeapable())
+                .filter(RandomGeneratorFactory::isLeapable)
                 .forEach(factory -> {
                     coverLeapable((LeapableGenerator)factory.create());
                 });
         RandomGeneratorFactory.all()
-                .filter(f -> f.isArbitrarilyJumpable())
+                .filter(RandomGeneratorFactory::isArbitrarilyJumpable)
                 .forEach(factory -> {
                     coverArbitrarilyJumpable((ArbitrarilyJumpableGenerator)factory.create());
                 });
+        RandomGeneratorFactory.all()
+                .forEach(RandomTestCoverage::checkPredicates);
 
         coverRandomGenerator(new SecureRandom());
         coverRandomGenerator(ThreadLocalRandom.current());
+        coverDefaults();
     }
 }

--- a/test/jdk/java/util/Random/RandomTestCoverage.java
+++ b/test/jdk/java/util/Random/RandomTestCoverage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,8 +171,25 @@ public class RandomTestCoverage {
         boolean isSplittable = factory.isSplittable();
 
         coverRandomGenerator(factory.create());
-        coverRandomGenerator(factory.create(12345L));
-        coverRandomGenerator(factory.create(new byte[] {1, 2, 3, 4, 5, 6, 7, 8}));
+        RandomGenerator rng;
+
+        rng = null;
+        try {
+            rng = factory.create(12345L);
+        } catch (UnsupportedOperationException ignore) {
+        }
+        if (rng != null) {
+            coverRandomGenerator(rng);
+        }
+
+        rng = null;
+        try {
+            rng = factory.create(new byte[] {1, 2, 3, 4, 5, 6, 7, 8});
+        } catch (UnsupportedOperationException ignore) {
+        }
+        if (rng != null) {
+            coverRandomGenerator(rng);
+        }
     }
 
     static void coverDefaults() {


### PR DESCRIPTION
All random number generator algorithms are implemented in module `java.base`. The usage of `ServiceLoader` in `j.u.r.RandomGeneratorFactory` is no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8332477](https://bugs.openjdk.org/browse/JDK-8332477) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332476: j.u.r.RandomGeneratorFactor.create(long|byte[]) should throw rather than silently fallback to no-arg create()`

### Issues
 * [JDK-8332086](https://bugs.openjdk.org/browse/JDK-8332086): Remove the usage of ServiceLoader in j.u.r.RandomGeneratorFactory (**Bug** - P4)
 * [JDK-8332476](https://bugs.openjdk.org/browse/JDK-8332476): j.u.r.RandomGeneratorFactor.create(long|byte[]) should throw rather than silently fallback to no-arg create() (**Bug** - P4)
 * [JDK-8332131](https://bugs.openjdk.org/browse/JDK-8332131): Remove the usage of ServiceLoader in j.u.r.RandomGeneratorFactory (**CSR**) (Withdrawn)
 * [JDK-8332477](https://bugs.openjdk.org/browse/JDK-8332477): j.u.r.RandomGeneratorFactor.create(long|byte[]) should throw rather than silently fallback to no-arg create() (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19212/head:pull/19212` \
`$ git checkout pull/19212`

Update a local copy of the PR: \
`$ git checkout pull/19212` \
`$ git pull https://git.openjdk.org/jdk.git pull/19212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19212`

View PR using the GUI difftool: \
`$ git pr show -t 19212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19212.diff">https://git.openjdk.org/jdk/pull/19212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19212#issuecomment-2107009978)