### PR TITLE
8331975: Enable case-insensitive check in ccache and keytab entry lookup

### DIFF
--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1515,3 +1515,23 @@ jdk.tls.alpnCharset=ISO_8859_1
 #
 # [1] https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/bde93b0e-f3c9-4ddf-9f44-e1453be7af5a
 #jdk.security.krb5.s4u2proxy.acceptNonForwardableServiceTicket=false
+
+#
+# Policy for name comparison in keytab and ccache entry lookup
+#
+# When looking up a keytab or credentials cache (ccache) entry for a Kerberos
+# principal, the principal name is compared with the name in the entry.
+# The comparison is by default case-insensitive. However, many Kerberos
+# implementations consider principal names to be case-sensitive. Consequently,
+# if two principals have names that differ only in case, there is a risk that
+# an incorrect keytab or ccache entry might be selected.
+#
+# If this security property is set to "true", the comparison of principal
+# names at keytab and ccache entry lookup is case-sensitive.
+#
+# The default value is "false".
+#
+# If a system property of the same name is also specified, it supersedes the
+# security property value defined here.
+#
+#jdk.security.krb5.name.case.sensitive=false

--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -627,10 +627,8 @@ public class PrincipalName implements Cloneable {
      * @return true if two have identical values, otherwise, return false.
      */
     public boolean match(PrincipalName pname) {
-        //name type is just a hint, no two names can be the same ignoring name type.
-        // if (this.nameType != pname.nameType) {
-        //      matched = false;
-        // }
+        // No need to check name type. It's just a hint, no two names can be
+        // the same ignoring name type.
         if (NAME_CASE_SENSITIVE_IN_MATCH) {
             if (!(this.nameRealm.toString().equals(pname.nameRealm.toString()))) {
                 return false;

--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,6 +108,12 @@ public class PrincipalName implements Cloneable {
     public static final String NAME_COMPONENT_SEPARATOR_STR = "/";
     public static final String NAME_REALM_SEPARATOR_STR = "@";
     public static final String REALM_COMPONENT_SEPARATOR_STR = ".";
+
+    private static final boolean NAME_CASE_SENSITIVE_IN_MATCH
+            = "true".equalsIgnoreCase(
+                    SecurityProperties.privilegedGetOverridable(
+                            "jdk.security.krb5.name.case.sensitive"));
+
 
     // Instance fields.
 
@@ -607,12 +613,19 @@ public class PrincipalName implements Cloneable {
 
 
     /**
-     * Checks if two <code>PrincipalName</code> objects have identical values in their corresponding data fields.
+     * Checks if two <code>PrincipalName</code> objects have identical values
+     * in their corresponding data fields.
+     * <p>
+     * If {@systemProperty jdk.security.krb5.name.case.sensitive} is set to true,
+     * the name comparison is case-sensitive. Otherwise, it's case-insensitive.
+     * <p>
+     * It is used in {@link sun.security.krb5.internal.ccache.FileCredentialsCache}
+     * and {@link sun.security.krb5.internal.ktab.KeyTab} to retrieve ccache
+     * or keytab entry for a principal.
      *
      * @param pname the other <code>PrincipalName</code> object.
      * @return true if two have identical values, otherwise, return false.
      */
-    // It is used in <code>sun.security.krb5.internal.ccache</code> package.
     public boolean match(PrincipalName pname) {
         boolean matched = true;
         //name type is just a hint, no two names can be the same ignoring name type.
@@ -620,16 +633,28 @@ public class PrincipalName implements Cloneable {
         //      matched = false;
         // }
         if ((this.nameRealm != null) && (pname.nameRealm != null)) {
-            if (!(this.nameRealm.toString().equalsIgnoreCase(pname.nameRealm.toString()))) {
-                matched = false;
+            if (NAME_CASE_SENSITIVE_IN_MATCH) {
+                if (!(this.nameRealm.toString().equals(pname.nameRealm.toString()))) {
+                    matched = false;
+                }
+            } else {
+                if (!(this.nameRealm.toString().equalsIgnoreCase(pname.nameRealm.toString()))) {
+                    matched = false;
+                }
             }
         }
         if (this.nameStrings.length != pname.nameStrings.length) {
             matched = false;
         } else {
             for (int i = 0; i < this.nameStrings.length; i++) {
-                if (!(this.nameStrings[i].equalsIgnoreCase(pname.nameStrings[i]))) {
-                    matched = false;
+                if (NAME_CASE_SENSITIVE_IN_MATCH) {
+                    if (!(this.nameStrings[i].equals(pname.nameStrings[i]))) {
+                        matched = false;
+                    }
+                } else {
+                    if (!(this.nameStrings[i].equalsIgnoreCase(pname.nameStrings[i]))) {
+                        matched = false;
+                    }
                 }
             }
         }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/PrincipalName.java
@@ -627,38 +627,35 @@ public class PrincipalName implements Cloneable {
      * @return true if two have identical values, otherwise, return false.
      */
     public boolean match(PrincipalName pname) {
-        boolean matched = true;
         //name type is just a hint, no two names can be the same ignoring name type.
         // if (this.nameType != pname.nameType) {
         //      matched = false;
         // }
-        if ((this.nameRealm != null) && (pname.nameRealm != null)) {
-            if (NAME_CASE_SENSITIVE_IN_MATCH) {
-                if (!(this.nameRealm.toString().equals(pname.nameRealm.toString()))) {
-                    matched = false;
-                }
-            } else {
-                if (!(this.nameRealm.toString().equalsIgnoreCase(pname.nameRealm.toString()))) {
-                    matched = false;
-                }
+        if (NAME_CASE_SENSITIVE_IN_MATCH) {
+            if (!(this.nameRealm.toString().equals(pname.nameRealm.toString()))) {
+                return false;
+            }
+        } else {
+            if (!(this.nameRealm.toString().equalsIgnoreCase(pname.nameRealm.toString()))) {
+                return false;
             }
         }
         if (this.nameStrings.length != pname.nameStrings.length) {
-            matched = false;
+            return false;
         } else {
             for (int i = 0; i < this.nameStrings.length; i++) {
                 if (NAME_CASE_SENSITIVE_IN_MATCH) {
                     if (!(this.nameStrings[i].equals(pname.nameStrings[i]))) {
-                        matched = false;
+                        return false;
                     }
                 } else {
                     if (!(this.nameStrings[i].equalsIgnoreCase(pname.nameStrings[i]))) {
-                        matched = false;
+                        return false;
                     }
                 }
             }
         }
-        return matched;
+        return true;
     }
 
     /**

--- a/test/jdk/sun/security/krb5/auto/CaseSensitive.java
+++ b/test/jdk/sun/security/krb5/auto/CaseSensitive.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331975
+ * @summary ensure correct name comparison when a system property is set
+ * @library /test/lib
+ * @compile -XDignore.symbol.file CaseSensitive.java
+ * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts
+ *      -Djdk.security.krb5.name.case.sensitive=true CaseSensitive
+ */
+
+import jdk.test.lib.Asserts;
+import sun.security.jgss.GSSUtil;
+
+public class CaseSensitive {
+
+    public static void main(String[] args) throws Exception {
+
+        var kdc = new OneKDC(null).writeJAASConf();
+        kdc.addPrincipal("HELLO", "different".toCharArray());
+        kdc.addPrincipal("hello", "password".toCharArray());
+        kdc.writeKtab(OneKDC.KTAB);
+
+        Context c, s;
+        c = Context.fromJAAS("client");
+        s = Context.fromJAAS("com.sun.security.jgss.krb5.accept");
+
+        c.startAsClient("HELLO", GSSUtil.GSS_KRB5_MECH_OID);
+        s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
+        Context.handshake(c, s);
+        // Name could be partial without realm, so only compare the beginning
+        Asserts.assertTrue(c.x().getTargName().toString().startsWith("HELLO"),
+                c.x().getTargName().toString());
+        Asserts.assertTrue(s.x().getTargName().toString().startsWith("HELLO"),
+                s.x().getTargName().toString());
+
+        c.startAsClient("hello", GSSUtil.GSS_KRB5_MECH_OID);
+        s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
+        Context.handshake(c, s);
+        // Name could be partial without realm, so only compare the beginning
+        Asserts.assertTrue(c.x().getTargName().toString().startsWith("hello"),
+                c.x().getTargName().toString());
+        Asserts.assertTrue(s.x().getTargName().toString().startsWith("hello"),
+                s.x().getTargName().toString());
+    }
+}

--- a/test/jdk/sun/security/krb5/auto/CaseSensitive.java
+++ b/test/jdk/sun/security/krb5/auto/CaseSensitive.java
@@ -28,25 +28,46 @@
  * @library /test/lib
  * @compile -XDignore.symbol.file CaseSensitive.java
  * @run main jdk.test.lib.FileInstaller TestHosts TestHosts
+ * @run main/othervm -Djdk.net.hosts.file=TestHosts CaseSensitive no
  * @run main/othervm -Djdk.net.hosts.file=TestHosts
- *      -Djdk.security.krb5.name.case.sensitive=true CaseSensitive
+ *      -Djdk.security.krb5.name.case.sensitive=true CaseSensitive yes
  */
 
 import jdk.test.lib.Asserts;
+import org.ietf.jgss.GSSException;
 import sun.security.jgss.GSSUtil;
 
 public class CaseSensitive {
 
     public static void main(String[] args) throws Exception {
+        switch (args[0]) {
+            case "yes" -> testSensitive();
+            case "no" -> testInsensitive();
+        }
+    }
 
+    static void testSensitive() throws Exception {
         var kdc = new OneKDC(null).writeJAASConf();
-        kdc.addPrincipal("HELLO", "different".toCharArray());
         kdc.addPrincipal("hello", "password".toCharArray());
         kdc.writeKtab(OneKDC.KTAB);
 
-        Context c, s;
-        c = Context.fromJAAS("client");
-        s = Context.fromJAAS("com.sun.security.jgss.krb5.accept");
+        Context c = Context.fromJAAS("client");
+        Context s = Context.fromJAAS("com.sun.security.jgss.krb5.accept");
+
+        // There is only "hello". Cannot talk to "HELLO"
+        c.startAsClient("HELLO", GSSUtil.GSS_KRB5_MECH_OID);
+        s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
+        try {
+            Context.handshake(c, s);
+            throw new RuntimeException("Should not succeed");
+        } catch(GSSException ge) {
+            System.out.println(ge.getMessage());
+            System.out.println("No HELLO in db. Expected");
+        }
+
+        // Add "HELLO". Can talk to "HELLO" now.
+        kdc.addPrincipal("HELLO", "different".toCharArray());
+        kdc.writeKtab(OneKDC.KTAB);
 
         c.startAsClient("HELLO", GSSUtil.GSS_KRB5_MECH_OID);
         s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
@@ -57,13 +78,31 @@ public class CaseSensitive {
         Asserts.assertTrue(s.x().getTargName().toString().startsWith("HELLO"),
                 s.x().getTargName().toString());
 
+        // Can also talk to "hello", which has a different password.
         c.startAsClient("hello", GSSUtil.GSS_KRB5_MECH_OID);
         s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
         Context.handshake(c, s);
-        // Name could be partial without realm, so only compare the beginning
         Asserts.assertTrue(c.x().getTargName().toString().startsWith("hello"),
                 c.x().getTargName().toString());
         Asserts.assertTrue(s.x().getTargName().toString().startsWith("hello"),
+                s.x().getTargName().toString());
+    }
+
+    static void testInsensitive() throws Exception {
+        var kdc = new OneKDC(null).writeJAASConf();
+        kdc.addPrincipal("hello", "password".toCharArray());
+        kdc.writeKtab(OneKDC.KTAB);
+
+        Context c = Context.fromJAAS("client");
+        Context s = Context.fromJAAS("com.sun.security.jgss.krb5.accept");
+
+        // There is only "hello" but we can talk to "HELLO".
+        c.startAsClient("HELLO", GSSUtil.GSS_KRB5_MECH_OID);
+        s.startAsServer(GSSUtil.GSS_KRB5_MECH_OID);
+        Context.handshake(c, s);
+        Asserts.assertTrue(c.x().getTargName().toString().startsWith("HELLO"),
+                c.x().getTargName().toString());
+        Asserts.assertTrue(s.x().getTargName().toString().startsWith("HELLO"),
                 s.x().getTargName().toString());
     }
 }

--- a/test/jdk/sun/security/krb5/auto/KDC.java
+++ b/test/jdk/sun/security/krb5/auto/KDC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/krb5/auto/KDC.java
+++ b/test/jdk/sun/security/krb5/auto/KDC.java
@@ -143,6 +143,9 @@ public class KDC {
     private static final String SUPPORTED_ETYPES
             = System.getProperty("kdc.supported.enctypes");
 
+    private static final boolean NAME_CASE_SENSITIVE
+            = Boolean.getBoolean("jdk.security.krb5.name.case.sensitive");
+
     // The native KDC
     private final NativeKdc nativeKdc;
 
@@ -154,27 +157,28 @@ public class KDC {
     // Principal db. principal -> pass. A case-insensitive TreeMap is used
     // so that even if the client provides a name with different case, the KDC
     // can still locate the principal and give back correct salt.
-    private TreeMap<String,char[]> passwords = new TreeMap<>
-            (String.CASE_INSENSITIVE_ORDER);
+    private TreeMap<String,char[]> passwords = newTreeMap();
 
     // Non default salts. Precisely, there should be different salts for
     // different etypes, pretend they are the same at the moment.
-    private TreeMap<String,String> salts = new TreeMap<>
-            (String.CASE_INSENSITIVE_ORDER);
+    private TreeMap<String,String> salts = newTreeMap();
 
     // Non default s2kparams for newer etypes. Precisely, there should be
     // different s2kparams for different etypes, pretend they are the same
     // at the moment.
-    private TreeMap<String,byte[]> s2kparamses = new TreeMap<>
-            (String.CASE_INSENSITIVE_ORDER);
+    private TreeMap<String,byte[]> s2kparamses = newTreeMap();
 
     // Alias for referrals.
-    private TreeMap<String,KDC> aliasReferrals = new TreeMap<>
-            (String.CASE_INSENSITIVE_ORDER);
+    private TreeMap<String,KDC> aliasReferrals = newTreeMap();
 
     // Alias for local resolution.
-    private TreeMap<String,PrincipalName> alias2Principals = new TreeMap<>
-            (String.CASE_INSENSITIVE_ORDER);
+    private TreeMap<String,PrincipalName> alias2Principals = newTreeMap();
+
+    private static <T> TreeMap<String,T> newTreeMap() {
+        return NAME_CASE_SENSITIVE
+                ? new TreeMap<>()
+                : new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    }
 
     // Realm name
     private String realm;
@@ -354,7 +358,7 @@ public class KDC {
             }
             if (nativeKdc == null) {
                 char[] pass = passwords.get(name);
-                int kvno = 0;
+                int kvno = -1; // always create new keys
                 if (Character.isDigit(pass[pass.length - 1])) {
                     kvno = pass[pass.length - 1] - '0';
                 }


### PR DESCRIPTION
Add a new system property to control the name comparison in keytab and ccache entry lookup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331976](https://bugs.openjdk.org/browse/JDK-8331976) to be approved

### Issues
 * [JDK-8331975](https://bugs.openjdk.org/browse/JDK-8331975): Enable case-insensitive check in ccache and keytab entry lookup (**Enhancement** - P4)
 * [JDK-8331976](https://bugs.openjdk.org/browse/JDK-8331976): Enable case-insensitive check in ccache and keytab entry lookup (**CSR**)


### Reviewers
 * @michael-o (no known openjdk.org user name / role) ⚠️ Review applies to [f6ad0a8c](https://git.openjdk.org/jdk/pull/19216/files/f6ad0a8cfeb3b07108c29ba8524ca9d5a0c135b6)
 * [Mark Powers](https://openjdk.org/census#mpowers) (@mcpowers - Committer) ⚠️ Review applies to [f6ad0a8c](https://git.openjdk.org/jdk/pull/19216/files/f6ad0a8cfeb3b07108c29ba8524ca9d5a0c135b6)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19216/head:pull/19216` \
`$ git checkout pull/19216`

Update a local copy of the PR: \
`$ git checkout pull/19216` \
`$ git pull https://git.openjdk.org/jdk.git pull/19216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19216`

View PR using the GUI difftool: \
`$ git pr show -t 19216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19216.diff">https://git.openjdk.org/jdk/pull/19216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19216#issuecomment-2107802052)