### PR TITLE
8332106: VerifyError when using switch pattern in this(...) or super(...)

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -172,8 +172,8 @@ public class Gen extends JCTree.Visitor {
     Chain switchExpressionFalseChain;
     List<LocalItem> stackBeforeSwitchExpression;
     LocalItem switchResult;
-    Set<JCMethodInvocation> invocationsWithPatternMatchingCatch = Set.of();
-    ListBuffer<int[]> patternMatchingInvocationRanges;
+    PatternMatchingCatchConfigration patternMatchingCatchConfiguration =
+            new PatternMatchingCatchConfigration(Set.of(), null, null, null);
 
     /** Cache the symbol to reflect the qualifying type.
      *  key: corresponding type
@@ -1087,21 +1087,31 @@ public class Gen extends JCTree.Visitor {
     }
 
     private void visitBlockWithPatterns(JCBlock tree) {
-        Set<JCMethodInvocation> prevInvocationsWithPatternMatchingCatch = invocationsWithPatternMatchingCatch;
-        ListBuffer<int[]> prevRanges = patternMatchingInvocationRanges;
-        State startState = code.state.dup();
+        PatternMatchingCatchConfigration prevConfiguration = patternMatchingCatchConfiguration;
         try {
-            invocationsWithPatternMatchingCatch = tree.patternMatchingCatch.calls2Handle();
-            patternMatchingInvocationRanges = new ListBuffer<>();
+            patternMatchingCatchConfiguration =
+                    new PatternMatchingCatchConfigration(tree.patternMatchingCatch.calls2Handle(),
+                                                         new ListBuffer<int[]>(),
+                                                         tree.patternMatchingCatch.handler(),
+                                                         code.state.dup());
             internalVisitBlock(tree);
         } finally {
+            generatePatternMatchingCatch(env);
+            patternMatchingCatchConfiguration = prevConfiguration;
+        }
+    }
+
+    private void generatePatternMatchingCatch(Env<GenContext> env) {
+        if (patternMatchingCatchConfiguration.handler != null &&
+            !patternMatchingCatchConfiguration.ranges.isEmpty()) {
             Chain skipCatch = code.branch(goto_);
-            JCCatch handler = tree.patternMatchingCatch.handler();
-            code.entryPoint(startState, handler.param.sym.type);
-            genPatternMatchingCatch(handler, env, patternMatchingInvocationRanges.toList());
+            JCCatch handler = patternMatchingCatchConfiguration.handler();
+            code.entryPoint(patternMatchingCatchConfiguration.startState(),
+                            handler.param.sym.type);
+            genPatternMatchingCatch(handler,
+                                    env,
+                                    patternMatchingCatchConfiguration.ranges.toList());
             code.resolve(skipCatch);
-            invocationsWithPatternMatchingCatch = prevInvocationsWithPatternMatchingCatch;
-            patternMatchingInvocationRanges = prevRanges;
         }
     }
 
@@ -1926,12 +1936,26 @@ public class Gen extends JCTree.Visitor {
         if (!msym.isDynamic()) {
             code.statBegin(tree.pos);
         }
-        if (invocationsWithPatternMatchingCatch.contains(tree)) {
+        if (patternMatchingCatchConfiguration.invocations().contains(tree)) {
             int start = code.curCP();
             result = m.invoke();
-            patternMatchingInvocationRanges.add(new int[] {start, code.curCP()});
+            patternMatchingCatchConfiguration.ranges().add(new int[] {start, code.curCP()});
         } else {
-            result = m.invoke();
+            if (msym.isConstructor() && TreeInfo.isConstructorCall(tree)) {
+                //if this is a this(...) or super(...) call, there is a pending
+                //"uninitialized this" before this call. One catch handler cannot
+                //handle exceptions that may come from places with "uninitialized this"
+                //and (initialized) this, hence generate one set of handlers here
+                //for the "uninitialized this" case, and another set of handlers
+                //will be generated at the end of the method for the initialized this,
+                //if needed:
+                generatePatternMatchingCatch(env);
+                result = m.invoke();
+                patternMatchingCatchConfiguration =
+                        patternMatchingCatchConfiguration.restart(code.state.dup());
+            } else {
+                result = m.invoke();
+            }
         }
     }
 
@@ -2555,4 +2579,15 @@ public class Gen extends JCTree.Visitor {
         }
     }
 
+    record PatternMatchingCatchConfigration(Set<JCMethodInvocation> invocations,
+                                            ListBuffer<int[]> ranges,
+                                            JCCatch handler,
+                                            State startState) {
+        public PatternMatchingCatchConfigration restart(State newState) {
+            return new PatternMatchingCatchConfigration(invocations(),
+                                                        new ListBuffer<int[]>(),
+                                                        handler(),
+                                                        newState);
+        }
+    }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -172,8 +172,8 @@ public class Gen extends JCTree.Visitor {
     Chain switchExpressionFalseChain;
     List<LocalItem> stackBeforeSwitchExpression;
     LocalItem switchResult;
-    PatternMatchingCatchConfigration patternMatchingCatchConfiguration =
-            new PatternMatchingCatchConfigration(Set.of(), null, null, null);
+    PatternMatchingCatchConfiguration patternMatchingCatchConfiguration =
+            new PatternMatchingCatchConfiguration(Set.of(), null, null, null);
 
     /** Cache the symbol to reflect the qualifying type.
      *  key: corresponding type
@@ -1087,10 +1087,10 @@ public class Gen extends JCTree.Visitor {
     }
 
     private void visitBlockWithPatterns(JCBlock tree) {
-        PatternMatchingCatchConfigration prevConfiguration = patternMatchingCatchConfiguration;
+        PatternMatchingCatchConfiguration prevConfiguration = patternMatchingCatchConfiguration;
         try {
             patternMatchingCatchConfiguration =
-                    new PatternMatchingCatchConfigration(tree.patternMatchingCatch.calls2Handle(),
+                    new PatternMatchingCatchConfiguration(tree.patternMatchingCatch.calls2Handle(),
                                                          new ListBuffer<int[]>(),
                                                          tree.patternMatchingCatch.handler(),
                                                          code.state.dup());
@@ -2579,12 +2579,12 @@ public class Gen extends JCTree.Visitor {
         }
     }
 
-    record PatternMatchingCatchConfigration(Set<JCMethodInvocation> invocations,
+    record PatternMatchingCatchConfiguration(Set<JCMethodInvocation> invocations,
                                             ListBuffer<int[]> ranges,
                                             JCCatch handler,
                                             State startState) {
-        public PatternMatchingCatchConfigration restart(State newState) {
-            return new PatternMatchingCatchConfigration(invocations(),
+        public PatternMatchingCatchConfiguration restart(State newState) {
+            return new PatternMatchingCatchConfiguration(invocations(),
                                                         new ListBuffer<int[]>(),
                                                         handler(),
                                                         newState);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeInfo.java
@@ -303,6 +303,16 @@ public class TreeInfo {
         }
     }
 
+    /**
+     * Is the given method invocation an invocation of this(...) or super(...)?
+     */
+    public static boolean isConstructorCall(JCMethodInvocation invoke) {
+        Name name = TreeInfo.name(invoke.meth);
+        Names names = name.table.names;
+
+        return (name == names._this || name == names._super);
+    }
+
     /** Finds super() invocations and translates them using the given mapping.
      */
     public static void mapSuperCalls(JCBlock block, Function<? super JCExpressionStatement, ? extends JCStatement> mapper) {

--- a/test/langtools/tools/javac/patterns/UninitializedThisException.java
+++ b/test/langtools/tools/javac/patterns/UninitializedThisException.java
@@ -35,17 +35,16 @@ import java.io.StringWriter;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-public class UninitializedThisException {
+public class UninitializedThisException extends Base {
 
     public UninitializedThisException(String s1, String s2) {
-        Objects.requireNonNull(s1);
-        Objects.requireNonNull(s2);
+        super(s1, s2);
     }
 
     public UninitializedThisException(R o1, R o2, R o3) {
         out.println("-pre(" + o1.fail() + ")" +
-                           "-nest(" + o2.fail() + ")" +
-                           "-post(" + o3.fail() + ")");
+                    "-nest(" + o2.fail() + ")" +
+                    "-post(" + o3.fail() + ")");
         String val1 = o1 instanceof R(String s, _) ? s : null;
         out.println("check1");
         this(val1, o2 instanceof R(String s, _) ? s : null);
@@ -57,7 +56,7 @@ public class UninitializedThisException {
 
     public UninitializedThisException(String o1, R o2, R o3) {
         out.println("-nest(" + o2.fail() + ")" +
-                           "-post(" + o3.fail() + ")");
+                    "-post(" + o3.fail() + ")");
         String val1 = o1;
         out.println("check1");
         this(val1, o2 instanceof R(String s, _) ? s : null);
@@ -69,7 +68,7 @@ public class UninitializedThisException {
 
     public UninitializedThisException(R o1, String o2, R o3) {
         out.println("-pre(" + o1.fail() + ")" +
-                           "-post(" + o3.fail() + ")");
+                    "-post(" + o3.fail() + ")");
         String val1 = o1 instanceof R(String s, _) ? s : null;
         out.println("check1");
         this(val1, o2);
@@ -81,7 +80,7 @@ public class UninitializedThisException {
 
     public UninitializedThisException(R o1, R o2, String o3) {
         out.println("-pre(" + o1.fail() + ")" +
-                           "-nest(" + o2.fail() + ")");
+                    "-nest(" + o2.fail() + ")");
         String val1 = o1 instanceof R(String s, _) ? s : null;
         out.println("check1");
         this(val1, o2 instanceof R(String s, _) ? s : null);
@@ -118,6 +117,95 @@ public class UninitializedThisException {
         String val1 = o1;
         out.println("check1");
         this(val1, o2);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, R o2, R o3, boolean superMarker) {
+        out.println("-pre(" + o1.fail() + ")" +
+                    "-nest(" + o2.fail() + ")" +
+                    "-post(" + o3.fail() + ")" +
+                    "-super");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        super(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, R o2, R o3, boolean superMarker) {
+        out.println("-nest(" + o2.fail() + ")" +
+                    "-post(" + o3.fail() + ")" +
+                    "-super");
+        String val1 = o1;
+        out.println("check1");
+        super(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, String o2, R o3, boolean superMarker) {
+        out.println("-pre(" + o1.fail() + ")" +
+                    "-post(" + o3.fail() + ")" +
+                    "-super");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        super(val1, o2);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, R o2, String o3, boolean superMarker) {
+        out.println("-pre(" + o1.fail() + ")" +
+                    "-nest(" + o2.fail() + ")" +
+                    "-super");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        super(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, String o2, String o3, boolean superMarker) {
+        out.println("-pre(" + o1.fail() + ")" +
+                    "-super");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        super(val1, o2);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, R o2, String o3, boolean superMarker) {
+        out.println("-nest(" + o2.fail() + ")" +
+                    "-super");
+        String val1 = o1;
+        out.println("check1");
+        super(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, String o2, R o3, boolean superMarker) {
+        out.println("-post(" + o3.fail() + ")" +
+                    "-super");
+        String val1 = o1;
+        out.println("check1");
+        super(val1, o2);
         out.println("check2");
         String val2 = o3 instanceof R(String s, _) ? s : null;
         out.println("check3");
@@ -163,71 +251,111 @@ public class UninitializedThisException {
         runAndCatch(() -> new UninitializedThisException("", "", new R("", true)));
         new UninitializedThisException("", "", new R("", false));
 
-        String actualLog = log.toString().replaceAll("\\R", "\n");
+        runAndCatch(() -> new UninitializedThisException(new R("", true), new R("", false), new R("", false), true));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", true), new R("", false), true));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", false), new R("", true), true));
+        new UninitializedThisException(new R("", false), new R("", false), new R("", false), true);
 
-        if (!Objects.equals(actualLog, EXPECTED_LOG)) {
-            throw new AssertionError("Expected log:\n" + EXPECTED_LOG +
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", new R("", true), new R("", false), true));
+        runAndCatch(() -> new UninitializedThisException("", new R("", false), new R("", true), true));
+        new UninitializedThisException("", new R("", false), new R("", false), true);
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), "", new R("", false), true));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), "", new R("", true), true));
+        new UninitializedThisException(new R("", false), "", new R("", false), true);
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), new R("", false), "", true));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", true), "", true));
+        new UninitializedThisException(new R("", false), new R("", false), "", true);
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), "", "", true));
+        new UninitializedThisException(new R("", false), "", "", true);
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", new R("", true), "", true));
+        new UninitializedThisException("", new R("", false), "", true);
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", "", new R("", true), true));
+        new UninitializedThisException("", "", new R("", false), true);
+
+        String actualLog = log.toString().replaceAll("\\R", "\n");
+        String expectedLog = EXPECTED_LOG_PATTERN.replace("${super}", "") +
+                             EXPECTED_LOG_PATTERN.replace("${super}", "-super");
+
+        if (!Objects.equals(actualLog, expectedLog)) {
+            throw new AssertionError("Expected log:\n" + expectedLog +
                                      ", but got: " + actualLog);
         }
     }
 
-    static final String EXPECTED_LOG =
+    static final String EXPECTED_LOG_PATTERN =
             """
-            -pre(true)-nest(false)-post(false)
-            -pre(false)-nest(true)-post(false)
+            -pre(true)-nest(false)-post(false)${super}
+            -pre(false)-nest(true)-post(false)${super}
             check1
-            -pre(false)-nest(false)-post(true)
-            check1
-            check2
-            -pre(false)-nest(false)-post(false)
+            -pre(false)-nest(false)-post(true)${super}
             check1
             check2
-            check3
-
-            -nest(true)-post(false)
-            check1
-            -nest(false)-post(true)
-            check1
-            check2
-            -nest(false)-post(false)
+            -pre(false)-nest(false)-post(false)${super}
             check1
             check2
             check3
 
-            -pre(true)-post(false)
-            -pre(false)-post(true)
+            -nest(true)-post(false)${super}
+            check1
+            -nest(false)-post(true)${super}
             check1
             check2
-            -pre(false)-post(false)
-            check1
-            check2
-            check3
-
-            -pre(true)-nest(false)
-            -pre(false)-nest(true)
-            check1
-            -pre(false)-nest(false)
+            -nest(false)-post(false)${super}
             check1
             check2
             check3
 
-            -pre(true)
-            -pre(false)
+            -pre(true)-post(false)${super}
+            -pre(false)-post(true)${super}
+            check1
+            check2
+            -pre(false)-post(false)${super}
             check1
             check2
             check3
 
-            -nest(true)
+            -pre(true)-nest(false)${super}
+            -pre(false)-nest(true)${super}
             check1
-            -nest(false)
+            -pre(false)-nest(false)${super}
             check1
             check2
             check3
 
-            -post(true)
+            -pre(true)${super}
+            -pre(false)${super}
             check1
             check2
-            -post(false)
+            check3
+
+            -nest(true)${super}
+            check1
+            -nest(false)${super}
+            check1
+            check2
+            check3
+
+            -post(true)${super}
+            check1
+            check2
+            -post(false)${super}
             check1
             check2
             check3
@@ -252,5 +380,11 @@ public class UninitializedThisException {
                 return s;
             }
         }
+    }
+}
+class Base {
+    public Base(String s1, String s2) {
+        Objects.requireNonNull(s1);
+        Objects.requireNonNull(s2);
     }
 }

--- a/test/langtools/tools/javac/patterns/UninitializedThisException.java
+++ b/test/langtools/tools/javac/patterns/UninitializedThisException.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8332106
+ * @summary Verify the synthetic catch clauses are generated correctly for constructors
+ * @enablePreview
+ * @compile UninitializedThisException.java
+ * @run main UninitializedThisException
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+public class UninitializedThisException {
+
+    public UninitializedThisException(String s1, String s2) {
+        Objects.requireNonNull(s1);
+        Objects.requireNonNull(s2);
+    }
+
+    public UninitializedThisException(R o1, R o2, R o3) {
+        out.println("-pre(" + o1.fail() + ")" +
+                           "-nest(" + o2.fail() + ")" +
+                           "-post(" + o3.fail() + ")");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        this(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, R o2, R o3) {
+        out.println("-nest(" + o2.fail() + ")" +
+                           "-post(" + o3.fail() + ")");
+        String val1 = o1;
+        out.println("check1");
+        this(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, String o2, R o3) {
+        out.println("-pre(" + o1.fail() + ")" +
+                           "-post(" + o3.fail() + ")");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        this(val1, o2);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, R o2, String o3) {
+        out.println("-pre(" + o1.fail() + ")" +
+                           "-nest(" + o2.fail() + ")");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        this(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(R o1, String o2, String o3) {
+        out.println("-pre(" + o1.fail() + ")");
+        String val1 = o1 instanceof R(String s, _) ? s : null;
+        out.println("check1");
+        this(val1, o2);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, R o2, String o3) {
+        out.println("-nest(" + o2.fail() + ")");
+        String val1 = o1;
+        out.println("check1");
+        this(val1, o2 instanceof R(String s, _) ? s : null);
+        out.println("check2");
+        String val2 = o3;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public UninitializedThisException(String o1, String o2, R o3) {
+        out.println("-post(" + o3.fail() + ")");
+        String val1 = o1;
+        out.println("check1");
+        this(val1, o2);
+        out.println("check2");
+        String val2 = o3 instanceof R(String s, _) ? s : null;
+        out.println("check3");
+        Objects.requireNonNull(val2);
+    }
+
+    public static void main(String... args) {
+        runAndCatch(() -> new UninitializedThisException(new R("", true), new R("", false), new R("", false)));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", true), new R("", false)));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", false), new R("", true)));
+        new UninitializedThisException(new R("", false), new R("", false), new R("", false));
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", new R("", true), new R("", false)));
+        runAndCatch(() -> new UninitializedThisException("", new R("", false), new R("", true)));
+        new UninitializedThisException("", new R("", false), new R("", false));
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), "", new R("", false)));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), "", new R("", true)));
+        new UninitializedThisException(new R("", false), "", new R("", false));
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), new R("", false), ""));
+        runAndCatch(() -> new UninitializedThisException(new R("", false), new R("", true), ""));
+        new UninitializedThisException(new R("", false), new R("", false), "");
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException(new R("", true), "", ""));
+        new UninitializedThisException(new R("", false), "", "");
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", new R("", true), ""));
+        new UninitializedThisException("", new R("", false), "");
+
+        out.println();
+
+        runAndCatch(() -> new UninitializedThisException("", "", new R("", true)));
+        new UninitializedThisException("", "", new R("", false));
+
+        String actualLog = log.toString().replaceAll("\\R", "\n");
+
+        if (!Objects.equals(actualLog, EXPECTED_LOG)) {
+            throw new AssertionError("Expected log:\n" + EXPECTED_LOG +
+                                     ", but got: " + actualLog);
+        }
+    }
+
+    static final String EXPECTED_LOG =
+            """
+            -pre(true)-nest(false)-post(false)
+            -pre(false)-nest(true)-post(false)
+            check1
+            -pre(false)-nest(false)-post(true)
+            check1
+            check2
+            -pre(false)-nest(false)-post(false)
+            check1
+            check2
+            check3
+
+            -nest(true)-post(false)
+            check1
+            -nest(false)-post(true)
+            check1
+            check2
+            -nest(false)-post(false)
+            check1
+            check2
+            check3
+
+            -pre(true)-post(false)
+            -pre(false)-post(true)
+            check1
+            check2
+            -pre(false)-post(false)
+            check1
+            check2
+            check3
+
+            -pre(true)-nest(false)
+            -pre(false)-nest(true)
+            check1
+            -pre(false)-nest(false)
+            check1
+            check2
+            check3
+
+            -pre(true)
+            -pre(false)
+            check1
+            check2
+            check3
+
+            -nest(true)
+            check1
+            -nest(false)
+            check1
+            check2
+            check3
+
+            -post(true)
+            check1
+            check2
+            -post(false)
+            check1
+            check2
+            check3
+            """;
+
+    static final StringWriter log = new StringWriter();
+    static final PrintWriter out = new PrintWriter(log);
+
+    static void runAndCatch(Supplier<Object> toRun) {
+        try {
+            toRun.get();
+            throw new AssertionError("Didn't get the expected exception!");
+        } catch (MatchException ex) {
+            //OK
+        }
+    }
+    record R(String s, boolean fail) {
+        public String s() {
+            if (fail) {
+                throw new NullPointerException();
+            } else {
+                return s;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Considering code like:
```
public class Test {

    public Test(int i) {
    }

    public Test(Object o) {
        this(o instanceof R(String s) ? s.length() : -1);
    }

    public static void main(String... args) {}

    record R(String s) {}
}
```

Running this crashes:
```
$ java .../Test.java
Exception in thread "main" java.lang.VerifyError: Stack map does not match the one at exception handler 36
Exception Details:
  Location:
    Test.<init>(Ljava/lang/Object;)V @36: astore_2
  Reason:
    Type uninitializedThis (current frame, locals[0]) is not assignable to 'Test' (stack map, locals[0])
  Current Frame:
    bci: @14
    flags: { flagThisUninit }
    locals: { uninitializedThis, 'java/lang/Object', top, 'Test$R' }
    stack: { 'java/lang/Throwable' }
  Stackmap Frame:
    bci: @36
    flags: { }
    locals: { 'Test', 'java/lang/Object' }
    stack: { 'java/lang/Throwable' }
  Bytecode:
    0000000: 2a2b c100 0799 0018 2bc0 0007 4e2d b600
    0000010: 093a 0419 044d 2cb6 000d a700 0402 b700
    0000020: 13a7 0011 4dbb 001a 592c b600 1c2c b700
    0000030: 1fbf b1                                
  Exception Handler Table:
    bci [14, 17] => handler: 36
  Stackmap Table:
    same_locals_1_stack_item_frame(@29,UninitializedThis)
    full_frame(@30,{UninitializedThis,Object[#2]},{UninitializedThis,Integer})
    full_frame(@36,{Object[#20],Object[#2]},{Object[#24]})
    same_frame(@50)

        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:534)
        at java.base/java.lang.Class.forName(Class.java:513)
        at jdk.compiler/com.sun.tools.javac.launcher.Main.execute(Main.java:432)
        at jdk.compiler/com.sun.tools.javac.launcher.Main.run(Main.java:208)
        at jdk.compiler/com.sun.tools.javac.launcher.Main.main(Main.java:135)
```

The reason is that there is a synthetic catch generated wrapping the record accessors inside the pattern matching. The range where the exception this catch is catching is before the real `this(...)` `invokespecial`, and hence the `this` is still an "uninitialized this". But the code for the catch is generated at the end of the constructor, when `this` is already initialized, and javac generates the stack maps as if `this` was initialized.

In general, the pattern matching code can be both before and after the `this` has been initialized. But, I don't think a stack map frame can be generated for the handler originating in places with both "uninitialized this " and (initialized) this.

The proposal here is to generate one set of the catch handlers for the state with "uninitialized this", and another for (initialized) this, if needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332106](https://bugs.openjdk.org/browse/JDK-8332106): VerifyError when using switch pattern in this(...) or super(...) (**Bug** - P2)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - Committer) ⚠️ Review applies to [9dacde8b](https://git.openjdk.org/jdk/pull/19217/files/9dacde8bc15a05f706041d11160ce4344d102766)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [9dacde8b](https://git.openjdk.org/jdk/pull/19217/files/9dacde8bc15a05f706041d11160ce4344d102766)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19217/head:pull/19217` \
`$ git checkout pull/19217`

Update a local copy of the PR: \
`$ git checkout pull/19217` \
`$ git pull https://git.openjdk.org/jdk.git pull/19217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19217`

View PR using the GUI difftool: \
`$ git pr show -t 19217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19217.diff">https://git.openjdk.org/jdk/pull/19217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19217#issuecomment-2107811673)