### PR TITLE
8331987: Enhance stacktrace clarity for CompletableFuture CancellationException

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CancellationException.java
+++ b/src/java.base/share/classes/java/util/concurrent/CancellationException.java
@@ -60,4 +60,13 @@ public class CancellationException extends IllegalStateException {
     public CancellationException(String message) {
         super(message);
     }
+
+    /**
+     * Only intended for in-package usage.
+     * Uses an empty String as message, and the passed-in cause as its cause.
+     * @param cause the underlying CancellationException
+     */
+    CancellationException(CancellationException cause) {
+        super("", cause);
+    }
 }

--- a/src/java.base/share/classes/java/util/concurrent/CancellationException.java
+++ b/src/java.base/share/classes/java/util/concurrent/CancellationException.java
@@ -63,10 +63,13 @@ public class CancellationException extends IllegalStateException {
 
     /**
      * Only intended for in-package usage.
-     * Uses an empty String as message, and the passed-in cause as its cause.
-     * @param cause the underlying CancellationException
+     * Constructs a {@code CancellationException} with the specified detail
+     * message and CancellationException cause.
+     *
+     * @param message the detail message
+     * @param cause the underlying cancellation exception
      */
-    CancellationException(CancellationException cause) {
-        super("", cause);
+    CancellationException(String message, CancellationException cause) {
+        super(message, cause);
     }
 }

--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -389,7 +389,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw (CancellationException)x;
+                throw new CancellationException((CancellationException)x);
             if ((x instanceof CompletionException) &&
                 (cause = x.getCause()) != null)
                 x = cause;
@@ -407,7 +407,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw (CancellationException)x;
+                throw new CancellationException((CancellationException)x);
             if (x instanceof CompletionException)
                 throw (CompletionException)x;
             throw new CompletionException(x);

--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -389,7 +389,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw new CancellationException((CancellationException)x);
+                throw new CancellationException("", (CancellationException)x);
             if ((x instanceof CompletionException) &&
                 (cause = x.getCause()) != null)
                 x = cause;
@@ -407,7 +407,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw new CancellationException((CancellationException)x);
+                throw new CancellationException("", (CancellationException)x);
             if (x instanceof CompletionException)
                 throw (CompletionException)x;
             throw new CompletionException(x);

--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -380,7 +380,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     /**
      * Reports result using Future.get conventions.
      */
-    private static Object reportGet(Object r)
+    private static Object reportGet(Object r, String details)
         throws InterruptedException, ExecutionException {
         if (r == null) // by convention below, null means interrupted
             throw new InterruptedException();
@@ -389,7 +389,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw new CancellationException("", (CancellationException)x);
+                throw new CancellationException(details, (CancellationException)x);
             if ((x instanceof CompletionException) &&
                 (cause = x.getCause()) != null)
                 x = cause;
@@ -401,13 +401,13 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     /**
      * Decodes outcome to return result or throw unchecked exception.
      */
-    private static Object reportJoin(Object r) {
+    private static Object reportJoin(Object r, String details) {
         if (r instanceof AltResult) {
             Throwable x;
             if ((x = ((AltResult)r).ex) == null)
                 return null;
             if (x instanceof CancellationException)
-                throw new CancellationException("", (CancellationException)x);
+                throw new CancellationException(details, (CancellationException)x);
             if (x instanceof CompletionException)
                 throw (CompletionException)x;
             throw new CompletionException(x);
@@ -2070,7 +2070,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         Object r;
         if ((r = result) == null)
             r = waitingGet(true);
-        return (T) reportGet(r);
+        return (T) reportGet(r, "get");
     }
 
     /**
@@ -2093,7 +2093,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         Object r;
         if ((r = result) == null)
             r = timedGet(nanos);
-        return (T) reportGet(r);
+        return (T) reportGet(r, "get");
     }
 
     /**
@@ -2115,7 +2115,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
         Object r;
         if ((r = result) == null)
             r = waitingGet(false);
-        return (T) reportJoin(r);
+        return (T) reportJoin(r, "join");
     }
 
     /**
@@ -2131,7 +2131,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     @SuppressWarnings("unchecked")
     public T getNow(T valueIfAbsent) {
         Object r;
-        return ((r = result) == null) ? valueIfAbsent : (T) reportJoin(r);
+        return ((r = result) == null) ? valueIfAbsent : (T) reportJoin(r, "getNow");
     }
 
     @Override

--- a/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
+++ b/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
@@ -199,8 +199,8 @@ public class CompletableFutureTest extends JSR166TestCase {
         checkCompletedExceptionally(f, false, t -> assertSame(t, ex));
     }
 
-    void checkCancellationException(CancellationException thrown) {
-        assertTrue("".equals(thrown.getMessage()));
+    void checkCancellationException(CancellationException thrown, String message) {
+        assertTrue(message.equals(thrown.getMessage()));
 
         assertTrue(thrown.getCause() instanceof CancellationException);
         assertTrue(thrown.getCause().getCause() == null);
@@ -212,7 +212,7 @@ public class CompletableFutureTest extends JSR166TestCase {
             f.get(LONG_DELAY_MS, MILLISECONDS);
             shouldThrow();
         } catch (CancellationException success) {
-            checkCancellationException(success);
+            checkCancellationException(success, "get");
         } catch (Throwable fail) { threadUnexpectedException(fail); }
         assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS / 2);
 
@@ -220,19 +220,19 @@ public class CompletableFutureTest extends JSR166TestCase {
             f.join();
             shouldThrow();
         } catch (CancellationException success) {
-            checkCancellationException(success);
+            checkCancellationException(success, "join");
         }
         try {
             f.getNow(null);
             shouldThrow();
         } catch (CancellationException success) {
-            checkCancellationException(success);
+            checkCancellationException(success, "getNow");
         }
         try {
             f.get();
             shouldThrow();
         } catch (CancellationException success) {
-            checkCancellationException(success);
+            checkCancellationException(success, "get");
         } catch (Throwable fail) { threadUnexpectedException(fail); }
 
         assertTrue(exceptionalCompletion(f) instanceof CancellationException);

--- a/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
+++ b/test/jdk/java/util/concurrent/tck/CompletableFutureTest.java
@@ -199,27 +199,40 @@ public class CompletableFutureTest extends JSR166TestCase {
         checkCompletedExceptionally(f, false, t -> assertSame(t, ex));
     }
 
+    void checkCancellationException(CancellationException thrown) {
+        assertTrue("".equals(thrown.getMessage()));
+
+        assertTrue(thrown.getCause() instanceof CancellationException);
+        assertTrue(thrown.getCause().getCause() == null);
+    }
+
     void checkCancelled(CompletableFuture<?> f) {
         long startTime = System.nanoTime();
         try {
             f.get(LONG_DELAY_MS, MILLISECONDS);
             shouldThrow();
         } catch (CancellationException success) {
+            checkCancellationException(success);
         } catch (Throwable fail) { threadUnexpectedException(fail); }
         assertTrue(millisElapsedSince(startTime) < LONG_DELAY_MS / 2);
 
         try {
             f.join();
             shouldThrow();
-        } catch (CancellationException success) {}
+        } catch (CancellationException success) {
+            checkCancellationException(success);
+        }
         try {
             f.getNow(null);
             shouldThrow();
-        } catch (CancellationException success) {}
+        } catch (CancellationException success) {
+            checkCancellationException(success);
+        }
         try {
             f.get();
             shouldThrow();
         } catch (CancellationException success) {
+            checkCancellationException(success);
         } catch (Throwable fail) { threadUnexpectedException(fail); }
 
         assertTrue(exceptionalCompletion(f) instanceof CancellationException);


### PR DESCRIPTION
This change adds wrapping of the CancellationException produced by CompletableFuture::get() and CompletableFuture::join() to add more diagnostic information and align better with FutureTask.

Running the sample code from the JBS issue in JShell will produce the following:

```
jshell> java.util.concurrent.CancellationException: get
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:392)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at REPL.$JShell$18.m2($JShell$18.java:10)
	at REPL.$JShell$17.m1($JShell$17.java:8)
	at REPL.$JShell$16B.lambda$main$0($JShell$16B.java:8)
	at java.base/java.lang.Thread.run(Thread.java:1575)
Caused by: java.util.concurrent.CancellationException
	at java.base/java.util.concurrent.CompletableFuture.cancel(CompletableFuture.java:2510)
	at REPL.$JShell$16B.lambda$main$1($JShell$16B.java:11)
	... 1 more
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331987](https://bugs.openjdk.org/browse/JDK-8331987): Enhance stacktrace clarity for CompletableFuture CancellationException (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19219/head:pull/19219` \
`$ git checkout pull/19219`

Update a local copy of the PR: \
`$ git checkout pull/19219` \
`$ git pull https://git.openjdk.org/jdk.git pull/19219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19219`

View PR using the GUI difftool: \
`$ git pr show -t 19219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19219.diff">https://git.openjdk.org/jdk/pull/19219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19219#issuecomment-2108202883)