### PR TITLE
8322008: Exclude some CDS tests from running with -Xshare:off

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -57,6 +57,13 @@ hotspot_runtime_no_cds = \
   runtime \
   -runtime/cds
 
+hotspot_runtime_non_cds_mode = \
+  runtime \
+  -runtime/cds/CheckSharingWithDefaultArchive.java \
+  -runtime/cds/appcds/dynamicArchive/DynamicSharedSymbols.java \
+  -runtime/cds/appcds/dynamicArchive/TestAutoCreateSharedArchive.java \
+  -runtime/cds/appcds/jcmd
+
 hotspot_handshake = \
   runtime/handshake
 


### PR DESCRIPTION
Some CDS tests throws a `SkippedException` when `-Xshare:off` is specified.
This change adds a `hotspot_runtime_non_cds_mode` test group for excluding those tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322008](https://bugs.openjdk.org/browse/JDK-8322008): Exclude some CDS tests from running with -Xshare:off (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19221/head:pull/19221` \
`$ git checkout pull/19221`

Update a local copy of the PR: \
`$ git checkout pull/19221` \
`$ git pull https://git.openjdk.org/jdk.git pull/19221/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19221`

View PR using the GUI difftool: \
`$ git pr show -t 19221`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19221.diff">https://git.openjdk.org/jdk/pull/19221.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19221#issuecomment-2108570420)