### PR TITLE
8331873: Improve/expand info in `New API In` on Help page

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HelpWriter.java
@@ -108,6 +108,10 @@ public class HelpWriter extends HtmlDocletWriter {
                 .add(getNavigationSection())
                 .add(new HtmlTree(TagName.HR))
                 .add(getPageKindSection())
+                .add(options.noSince()
+                        ? new ContentBuilder()
+                        : new ContentBuilder(new HtmlTree(TagName.HR),
+                                             getReleasesSection()))
                 .add(new HtmlTree(TagName.HR))
                 .add(HtmlTree.SPAN(HtmlStyle.helpFootnote,
                         getContent("doclet.help.footnote")));
@@ -395,6 +399,26 @@ public class HelpWriter extends HtmlDocletWriter {
         tableOfContents.popNestedList();
 
         return pageKindsSection;
+    }
+
+    private Content getReleasesSection() {
+        Content releasesHeading = contents.getContent("doclet.help.releases.head");
+        var releasesSection = HtmlTree.DIV(HtmlStyle.subTitle)
+                .add(HtmlTree.HEADING(Headings.CONTENT_HEADING, releasesHeading).setId(HtmlIds.HELP_RELEASES))
+                .add(HtmlTree.P(contents.getContent("doclet.help.releases.body.specify.top-level")))
+                .add(HtmlTree.P(contents.getContent("doclet.help.releases.body.specify.member")));
+
+        if (configuration.conditionalPages.contains(HtmlConfiguration.ConditionalPage.DEPRECATED)
+                || configuration.conditionalPages.contains(HtmlConfiguration.ConditionalPage.NEW)) {
+            releasesSection.add(HtmlTree.P(contents.getContent("doclet.help.releases.body.refer")));
+        }
+
+        tableOfContents.addLink(HtmlIds.HELP_RELEASES, releasesHeading);
+        tableOfContents.pushNestedList();
+        tableOfContents.popNestedList();
+
+        return releasesSection;
+
     }
 
     private Content getContent(String key) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -91,6 +91,7 @@ public class HtmlIds {
     static final HtmlId FOR_REMOVAL = HtmlId.of("for-removal");
     static final HtmlId HELP_NAVIGATION = HtmlId.of("help-navigation");
     static final HtmlId HELP_PAGES = HtmlId.of("help-pages");
+    static final HtmlId HELP_RELEASES = HtmlId.of("help-releases");
     static final HtmlId METHOD_DETAIL = HtmlId.of("method-detail");
     static final HtmlId METHOD_SUMMARY = HtmlId.of("method-summary");
     static final HtmlId METHOD_SUMMARY_TABLE = HtmlId.of("method-summary-table");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -378,6 +378,18 @@ doclet.help.search.refer=Refer to the {0} for a full description of search featu
 doclet.help.search.spec.url=https://docs.oracle.com/en/java/javase/{0}/docs/specs/javadoc/javadoc-search-spec.html
 # The title for the Javadoc Search Specification
 doclet.help.search.spec.title=Javadoc Search Specification
+doclet.help.releases.head=Release Details
+doclet.help.releases.body.specify.top-level=\
+    The details for each module, package, class or interface \
+    normally include the release in which the declaration was introduced.
+doclet.help.releases.body.specify.member=\
+    The details for each member of a class or interface normally \
+    include the release in which the member was introduced, in those situations \
+    where the member was added after the initial introduction of the \
+    enclosing class or interface.
+doclet.help.releases.body.refer=\
+    Some summary pages allow you to filter the contents of the page according to \
+    the release in which the declaration was introduced or deprecated.
 
 doclet.ClassUse_Packages.that.use.0=Packages that use {0}
 doclet.ClassUse_Uses.of.0.in.1=Uses of {0} in {1}


### PR DESCRIPTION
Please review a relatively simple update to the generated Help page, as part of the ongoing campaign to improve the documentation around the overall use of `@since` tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ Found copyright format issue for oracle in [test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java]

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8331873](https://bugs.openjdk.org/browse/JDK-8331873): Improve/expand info in `New API In` on Help page (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19222/head:pull/19222` \
`$ git checkout pull/19222`

Update a local copy of the PR: \
`$ git checkout pull/19222` \
`$ git pull https://git.openjdk.org/jdk.git pull/19222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19222`

View PR using the GUI difftool: \
`$ git pr show -t 19222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19222.diff">https://git.openjdk.org/jdk/pull/19222.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19222#issuecomment-2108963399)
</details>
