### PR TITLE
8331432: Clean up comments in GenArguments::initialize_size_info()

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -301,8 +301,6 @@ void GenArguments::initialize_size_info() {
     // generation to fit as well.
     // If the user has explicitly set an OldSize that is inconsistent
     // with other command line flags, issue a warning.
-    // The generation minimums and the overall heap minimum should
-    // be within one generation alignment.
     if (initial_old_size > MaxOldSize) {
       log_warning(gc, ergo)("Inconsistency between maximum heap size and maximum "
                             "generation sizes: using maximum heap = " SIZE_FORMAT


### PR DESCRIPTION
Clean up comments in GenArguments::initialize_size_info()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331432](https://bugs.openjdk.org/browse/JDK-8331432): Clean up comments in GenArguments::initialize_size_info() (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19223/head:pull/19223` \
`$ git checkout pull/19223`

Update a local copy of the PR: \
`$ git checkout pull/19223` \
`$ git pull https://git.openjdk.org/jdk.git pull/19223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19223`

View PR using the GUI difftool: \
`$ git pr show -t 19223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19223.diff">https://git.openjdk.org/jdk/pull/19223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19223#issuecomment-2109064596)