### PR TITLE
8301464: Code in GenFullCP is still disabled after JDK-8079697 was fixed

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/vm/mlvm/cp/share/GenFullCP.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/mlvm/cp/share/GenFullCP.java
@@ -238,7 +238,7 @@ public abstract class GenFullCP extends ClassfileGenerator {
     public Klass[] generateBytecodes() {
 
         // COMPUTE_FRAMES were disabled due to JDK-8079697
-        ClassWriterExt cw = new ClassWriterExt(/*ClassWriter.COMPUTE_FRAMES |*/ ClassWriter.COMPUTE_MAXS);
+        ClassWriterExt cw = new ClassWriterExt(ClassWriter.COMPUTE_FRAMES | ClassWriter.COMPUTE_MAXS);
 
         String[] interfaces = new String[1];
         interfaces[0] = getDummyInterfaceClassName();


### PR DESCRIPTION
Code in GenFullCP is still disabled after JDK-8079697 was fixed.

note:I have not found any relevant information on why ClassWriter.COMPUTE_FRAMES is disabled in JDK-8079697.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301464](https://bugs.openjdk.org/browse/JDK-8301464): Code in GenFullCP is still disabled after JDK-8079697 was fixed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19227/head:pull/19227` \
`$ git checkout pull/19227`

Update a local copy of the PR: \
`$ git checkout pull/19227` \
`$ git pull https://git.openjdk.org/jdk.git pull/19227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19227`

View PR using the GUI difftool: \
`$ git pr show -t 19227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19227.diff">https://git.openjdk.org/jdk/pull/19227.diff</a>

</details>
