### PR TITLE
8331940: ClassFile API ArrayIndexOutOfBoundsException with certain class files

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -238,8 +238,8 @@ public final class CodeImpl
                 for (; p < pEnd; p += 4) {
                     int startPc = classReader.readU2(p);
                     if (startPc > codeLength) {
-                        throw new IllegalArgumentException(String.format("Line number out of range; start_pc=%d, codeLength=%d",
-                                                             startPc, codeLength));
+                        throw new IllegalArgumentException(String.format(
+                                "Line number start_pc out of range; start_pc=%d, codeLength=%d", startPc, codeLength));
                     }
                     int lineNumber = classReader.readU2(p + 2);
                     lineNumbers[startPc] = lineNumber;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,6 +237,10 @@ public final class CodeImpl
                 int pEnd = p + (nLn * 4);
                 for (; p < pEnd; p += 4) {
                     int startPc = classReader.readU2(p);
+                    if (startPc > codeLength) {
+                        throw new IllegalArgumentException(String.format("Line number out of range; start_pc=%d, codeLength=%d",
+                                                             startPc, codeLength));
+                    }
                     int lineNumber = classReader.readU2(p + 2);
                     lineNumbers[startPc] = lineNumber;
                 }

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360 8330684 8331320 8331655
+ * @bug 8320360 8330684 8331320 8331655 8331940
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */
@@ -35,8 +35,12 @@ import java.lang.constant.MethodTypeDesc;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.Opcode;
 import java.lang.classfile.attribute.CodeAttribute;
+import java.lang.classfile.attribute.LineNumberInfo;
+import java.lang.classfile.attribute.LineNumberTableAttribute;
 import java.lang.classfile.constantpool.ConstantPoolException;
 import java.lang.classfile.constantpool.IntegerEntry;
+import java.util.List;
+import jdk.internal.classfile.impl.DirectCodeBuilder;
 import jdk.internal.classfile.impl.DirectMethodBuilder;
 import jdk.internal.classfile.impl.LabelContext;
 import jdk.internal.classfile.impl.UnboundAttribute;
@@ -160,5 +164,15 @@ class LimitsTest {
                                     b.writeU2(0);//exception handlers
                                     b.writeU2(0);//attributes
                                 }})))).methods().get(0).code().get().elementList());
+    }
+
+    @Test
+    void testLineNumberOutOfBounds() {
+        assertThrows(IllegalArgumentException.class, () ->
+                ClassFile.of().parse(ClassFile.of().build(ClassDesc.of("LineNumberClass"), cb -> cb.withMethodBody(
+                "lineNumberMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, cob -> ((DirectCodeBuilder)cob
+                        .return_())
+                        .writeAttribute(LineNumberTableAttribute.of(List.of(LineNumberInfo.of(500, 0))))
+                ))).methods().get(0).code().get().elementList());
     }
 }


### PR DESCRIPTION
Class file with `LineNumberTable` attribute element pointing behind the bytecode array throws `ArrayIndexOutOfBoundsException`.
This patch performs the check and throws  expected `IllegalArgumentException` instead.
Relevant test is added.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331940](https://bugs.openjdk.org/browse/JDK-8331940): ClassFile API ArrayIndexOutOfBoundsException with certain class files (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19230/head:pull/19230` \
`$ git checkout pull/19230`

Update a local copy of the PR: \
`$ git checkout pull/19230` \
`$ git pull https://git.openjdk.org/jdk.git pull/19230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19230`

View PR using the GUI difftool: \
`$ git pr show -t 19230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19230.diff">https://git.openjdk.org/jdk/pull/19230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19230#issuecomment-2110242488)