### PR TITLE
8332236: javac crashes with module imports and implicitly declared class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4118,7 +4118,7 @@ public class JavacParser implements Parser {
         for (JCTree def : origDefs) {
             if (def.hasTag(Tag.PACKAGEDEF)) {
                 log.error(def.pos(), Errors.ImplicitClassShouldNotHavePackageDeclaration);
-            } else if (def.hasTag(Tag.IMPORT)) {
+            } else if (def.hasTag(Tag.IMPORT) || def.hasTag(Tag.MODULEIMPORT)) {
                 topDefs.append(def);
             } else if (!def.hasTag(Tag.SKIP)) {
                 defs.append(def);

--- a/test/langtools/tools/javac/ImportModule.java
+++ b/test/langtools/tools/javac/ImportModule.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8328481
+ * @bug 8328481 8332236
  * @summary Check behavior of module imports.
  * @library /tools/lib
  * @modules java.logging
@@ -710,6 +710,28 @@ public class ImportModule extends TestRunner {
 
         Files.createDirectories(classes);
         List<String> kinds = new ArrayList<>();
+
+        new JavacTask(tb)
+            .options("--enable-preview", "--release", SOURCE_VERSION)
+            .outdir(classes)
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.SUCCESS)
+            .writeAll();
+    }
+
+    @Test
+    public void testImplicitlyDeclaredClass(Path base) throws Exception {
+        Path current = base.resolve(".");
+        Path src = current.resolve("src");
+        Path classes = current.resolve("classes");
+        tb.writeFile(src.resolve("Test.java"),
+                     """
+                     import module java.base;
+                     void main() {
+                     }
+                     """);
+
+        Files.createDirectories(classes);
 
         new JavacTask(tb)
             .options("--enable-preview", "--release", SOURCE_VERSION)


### PR DESCRIPTION
When parsing implicitly declared class, javac wraps the elements it finds in the file by the implicitly declared (and created) class. But, it avoids wrapping imports. But, accidentally, it is wrapping the module imports into the class, which then inevitably fails.

The proposed fix is to simply handle the the module imports in the same way normal imports are handled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332236: javac crashes with module imports and implicitly declared class`

### Issue
 * [JDK-8332236](https://bugs.openjdk.org/browse/JDK-8332236): javac crashes with module imports and implicitly declared class (**Bug** - P2)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19232/head:pull/19232` \
`$ git checkout pull/19232`

Update a local copy of the PR: \
`$ git checkout pull/19232` \
`$ git pull https://git.openjdk.org/jdk.git pull/19232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19232`

View PR using the GUI difftool: \
`$ git pr show -t 19232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19232.diff">https://git.openjdk.org/jdk/pull/19232.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19232#issuecomment-2110470380)