### PR TITLE
8332245: C2: missing record_for_ign() call in GraphKit::must_be_not_null()

### DIFF
--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1468,7 +1468,9 @@ Node* GraphKit::must_be_not_null(Node* value, bool do_replace_in_map) {
   Node* opaq = _gvn.transform(new Opaque4Node(C, tst, intcon(1)));
   IfNode *iff = new IfNode(control(), opaq, PROB_MAX, COUNT_UNKNOWN);
   _gvn.set_type(iff, iff->Value(&_gvn));
-  if (!tst->is_Con())  record_for_igvn(iff);
+  if (!tst->is_Con()) {
+    record_for_igvn(iff);
+  }
   Node *if_f = _gvn.transform(new IfFalseNode(iff));
   Node *frame = _gvn.transform(new ParmNode(C->start(), TypeFunc::FramePtr));
   Node* halt = _gvn.transform(new HaltNode(if_f, frame, "unexpected null in intrinsic"));

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1468,6 +1468,7 @@ Node* GraphKit::must_be_not_null(Node* value, bool do_replace_in_map) {
   Node* opaq = _gvn.transform(new Opaque4Node(C, tst, intcon(1)));
   IfNode *iff = new IfNode(control(), opaq, PROB_MAX, COUNT_UNKNOWN);
   _gvn.set_type(iff, iff->Value(&_gvn));
+  if (!tst->is_Con())  record_for_igvn(iff);
   Node *if_f = _gvn.transform(new IfFalseNode(iff));
   Node *frame = _gvn.transform(new ParmNode(C->start(), TypeFunc::FramePtr));
   Node* halt = _gvn.transform(new HaltNode(if_f, frame, "unexpected null in intrinsic"));

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackMustBeNotNull.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackMustBeNotNull.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8332245
+ * @summary fusion of heap stable test causes GetAndSet node to be removed
+ *
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.TestBackToBackMustBeNotNull
+ */
+
+package compiler.c2.irTests;
+import jdk.internal.misc.Unsafe;
+import java.lang.reflect.Field;
+import compiler.lib.ir_framework.*;
+
+
+public class TestBackToBackMustBeNotNull {
+    static final jdk.internal.misc.Unsafe UNSAFE = Unsafe.getUnsafe();
+    static final long F_OFFSET;
+    private static A fieldA = new A();
+
+    static {
+        try {
+            Field fField = A.class.getDeclaredField("f");
+            F_OFFSET = UNSAFE.objectFieldOffset(fField);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    static public void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+    }
+
+    @Test
+    @IR(phase = { CompilePhase.ITER_GVN1 }, counts = { IRNode.IF, "1" })
+    private static void test1() {
+        final Object o1 = UNSAFE.getReference(fieldA, F_OFFSET);
+        final Object o2 = UNSAFE.getReference(fieldA, F_OFFSET);
+        notInlined(o1, o2);
+    }
+
+    @DontInline
+    private static void notInlined(Object o1, Object o2) {
+
+    }
+
+    static class A {
+        Object f;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackMustBeNotNull.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestBackToBackMustBeNotNull.java
@@ -24,7 +24,7 @@
 /**
  * @test
  * @bug 8332245
- * @summary fusion of heap stable test causes GetAndSet node to be removed
+ * @summary C2: missing record_for_ign() call in GraphKit::must_be_not_null()
  *
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /


### PR DESCRIPTION
The `If` node that's created by `GraphKit::must_be_not_null()` is not
enqueued for igvn when it's created. The test case shows it prevents 2
identical tests from commoning when the first igvn executes. This is a
minor issue I noticed whule working on something else.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332245](https://bugs.openjdk.org/browse/JDK-8332245): C2: missing record_for_ign() call in GraphKit::must_be_not_null() (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [48fb906c](https://git.openjdk.org/jdk/pull/19233/files/48fb906c53dd1a6ac8783678f23056288f2b53d8)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [48fb906c](https://git.openjdk.org/jdk/pull/19233/files/48fb906c53dd1a6ac8783678f23056288f2b53d8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19233/head:pull/19233` \
`$ git checkout pull/19233`

Update a local copy of the PR: \
`$ git checkout pull/19233` \
`$ git pull https://git.openjdk.org/jdk.git pull/19233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19233`

View PR using the GUI difftool: \
`$ git pr show -t 19233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19233.diff">https://git.openjdk.org/jdk/pull/19233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19233#issuecomment-2110643452)