### PR TITLE
Use lambda expression instead of anonymous inner class

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1091,13 +1091,11 @@ public final class StringConcatFactory {
             String className = getClassName(lookup.lookupClass());
 
             byte[] classBytes = ClassFile.of().build(ClassDesc.of(className),
-                    (ClassBuilder clb) -> {
-                        clb.withFlags(AccessFlag.FINAL, AccessFlag.SUPER, AccessFlag.SYNTHETIC)
-                            .withMethodBody(METHOD_NAME,
-                                    MethodTypeDesc.ofDescriptor(args.toMethodDescriptorString()),
-                                    ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.ACC_STATIC,
-                                    generateMethod(constants, args));
-                    });
+                    clb -> clb.withFlags(AccessFlag.FINAL, AccessFlag.SUPER, AccessFlag.SYNTHETIC)
+                        .withMethodBody(METHOD_NAME,
+                                MethodTypeDesc.ofDescriptor(args.toMethodDescriptorString()),
+                                ClassFile.ACC_FINAL | ClassFile.ACC_PRIVATE | ClassFile.ACC_STATIC,
+                                generateMethod(constants, args)));
             try {
                 Lookup hiddenLookup = lookup.makeHiddenClassDefiner(className, classBytes, SET_OF_STRONG, DUMPER)
                                             .defineClassAsLookup(true);
@@ -1109,7 +1107,7 @@ public final class StringConcatFactory {
         }
 
         private static Consumer<CodeBuilder> generateMethod(String[] constants, MethodType args) {
-            return (CodeBuilder cb) -> {
+            return cb -> {
                 cb.new_(STRING_BUILDER);
                 cb.dup();
 


### PR DESCRIPTION
This is a small improvement, no change in logic, just a common programming style change, using Lambda instead of anonymous inline class.

Most of the line changes here are due to indentation, and there are no logical changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19234/head:pull/19234` \
`$ git checkout pull/19234`

Update a local copy of the PR: \
`$ git checkout pull/19234` \
`$ git pull https://git.openjdk.org/jdk.git pull/19234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19234`

View PR using the GUI difftool: \
`$ git pr show -t 19234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19234.diff">https://git.openjdk.org/jdk/pull/19234.diff</a>

</details>
