### PR TITLE
8332248: (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException

### DIFF
--- a/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
+++ b/test/jdk/java/nio/channels/FileChannel/BlockDeviceSize.java
@@ -25,6 +25,7 @@
  * @bug 8054029 8313368
  * @requires (os.family == "linux")
  * @summary FileChannel.size() should be equal to RandomAccessFile.size() and > 0 for block devs on Linux
+ * @library /test/lib
  */
 
 import java.io.RandomAccessFile;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static java.nio.file.StandardOpenOption.*;
 
+import jtreg.SkippedException;
 
 public class BlockDeviceSize {
     private static final List<String> BLK_FNAMES = List.of("/dev/sda1", "/dev/nvme0n1", "/dev/xvda1") ;
@@ -61,7 +63,7 @@ public class BlockDeviceSize {
                 System.err.println("File " + blkFname + " not found." +
                         " Skipping test");
             } catch (AccessDeniedException ade) {
-                throw new RuntimeException("Access to " + blkFname + " is denied."
+                throw new SkippedException("Access to " + blkFname + " is denied."
                         + " Run test as root.", ade);
             }
 


### PR DESCRIPTION
Throw `SkippedException` instead of `RuntimeException` when access to a block device is denied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332248](https://bugs.openjdk.org/browse/JDK-8332248): (fc) java/nio/channels/FileChannel/BlockDeviceSize.java failed with RuntimeException (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19236/head:pull/19236` \
`$ git checkout pull/19236`

Update a local copy of the PR: \
`$ git checkout pull/19236` \
`$ git pull https://git.openjdk.org/jdk.git pull/19236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19236`

View PR using the GUI difftool: \
`$ git pr show -t 19236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19236.diff">https://git.openjdk.org/jdk/pull/19236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19236#issuecomment-2110837492)