### PR TITLE
8332253: Linux arm32 build fails after 8292591

### DIFF
--- a/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
+++ b/src/hotspot/os/linux/systemMemoryBarrier_linux.cpp
@@ -41,6 +41,8 @@
   #define SYS_membarrier 365
   #elif defined(AARCH64)
   #define SYS_membarrier 283
+  #elif defined(ARM32)
+  #define SYS_membarrier 389
   #elif defined(ALPHA)
   #define SYS_membarrier 517
   #else


### PR DESCRIPTION
The build on arm32 may fail during cross-compilation if the toolchain is old.

The raw constant "389" is described [here](https://github.com/torvalds/linux/blob/4b95dc87362aa57bdd0dcbad109ca5e5ef3cbb6c/arch/arm/tools/syscall.tbl#L406C12-L406C22) and [here ](https://chromium.googlesource.com/chromiumos/docs/+/master/constants/syscalls.md#arm-32_bit_EABI)

Also verified by the next code example: [test.c](https://github.com/openjdk/jdk/pull/10721#issuecomment-1280598034)

Note: similar bugs in the past: https://github.com/openjdk/jdk/pull/10771 and https://github.com/openjdk/jdk/pull/10721

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332253](https://bugs.openjdk.org/browse/JDK-8332253): Linux arm32 build fails after 8292591 (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19237/head:pull/19237` \
`$ git checkout pull/19237`

Update a local copy of the PR: \
`$ git checkout pull/19237` \
`$ git pull https://git.openjdk.org/jdk.git pull/19237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19237`

View PR using the GUI difftool: \
`$ git pr show -t 19237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19237.diff">https://git.openjdk.org/jdk/pull/19237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19237#issuecomment-2111215351)