### PR TITLE
8332260: Mark tools/jlink/JLinkReproducibleTest.java as intermittent failure

### DIFF
--- a/test/jdk/tools/jlink/JLinkReproducibleTest.java
+++ b/test/jdk/tools/jlink/JLinkReproducibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import jdk.test.lib.process.ProcessTools;
 
 /*
  * @test
- * @bug 8214230
+ * @bug 8214230 8327181
  * @key intermittent
  * @summary Test that jlinks generates reproducible modules files
  * @library /test/lib

--- a/test/jdk/tools/jlink/JLinkReproducibleTest.java
+++ b/test/jdk/tools/jlink/JLinkReproducibleTest.java
@@ -32,6 +32,7 @@ import jdk.test.lib.process.ProcessTools;
 /*
  * @test
  * @bug 8214230
+ * @key intermittent
  * @summary Test that jlinks generates reproducible modules files
  * @library /test/lib
  * @run driver JLinkReproducibleTest


### PR DESCRIPTION
Hi all,
  The `tools/jlink/JLinkReproducibleTest.java` intermittent fails on linux aarch64. Should we mark this testcase as `@key intermittent`. No risk.

Thanks.
-sendao

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332260](https://bugs.openjdk.org/browse/JDK-8332260): Mark tools/jlink/JLinkReproducibleTest.java as intermittent failure (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19241/head:pull/19241` \
`$ git checkout pull/19241`

Update a local copy of the PR: \
`$ git checkout pull/19241` \
`$ git pull https://git.openjdk.org/jdk.git pull/19241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19241`

View PR using the GUI difftool: \
`$ git pr show -t 19241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19241.diff">https://git.openjdk.org/jdk/pull/19241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19241#issuecomment-2111516869)