### PR TITLE
8332181: Deprecate for removal the java.net.MulticastSocket.setTTL/getTTL and the 2-arg send methods

### DIFF
--- a/src/java.base/share/classes/java/net/MulticastSocket.java
+++ b/src/java.base/share/classes/java/net/MulticastSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -226,7 +226,7 @@ public class MulticastSocket extends DatagramSocket {
      *             <b>int</b> instead of <b>byte</b> as the type for ttl.
      * @see #getTTL()
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public void setTTL(byte ttl) throws IOException {
         delegate().setTTL(ttl);
     }
@@ -271,7 +271,7 @@ public class MulticastSocket extends DatagramSocket {
      * which returns an <b>int</b> instead of a <b>byte</b>.
      * @see #setTTL(byte)
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public byte getTTL() throws IOException {
         return delegate().getTTL();
     }
@@ -561,7 +561,7 @@ public class MulticastSocket extends DatagramSocket {
      * @see SecurityManager#checkMulticast(java.net.InetAddress, byte)
      * @see SecurityManager#checkConnect
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public void send(DatagramPacket p, byte ttl)
         throws IOException {
         delegate().send(p, ttl);

--- a/src/java.base/share/classes/java/net/NetMulticastSocket.java
+++ b/src/java.base/share/classes/java/net/NetMulticastSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -652,6 +652,7 @@ final class NetMulticastSocket extends MulticastSocket {
 
     @Deprecated
     @Override
+    @SuppressWarnings("removal")
     public void setTTL(byte ttl) throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");
@@ -670,6 +671,7 @@ final class NetMulticastSocket extends MulticastSocket {
 
     @Deprecated
     @Override
+    @SuppressWarnings("removal")
     public byte getTTL() throws IOException {
         if (isClosed())
             throw new SocketException("Socket is closed");

--- a/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -402,6 +402,7 @@ public class DatagramSocketAdaptor
 
     @Override
     @Deprecated
+    @SuppressWarnings("removal")
     public void setTTL(byte ttl) throws IOException {
         setTimeToLive(Byte.toUnsignedInt(ttl));
     }
@@ -418,6 +419,7 @@ public class DatagramSocketAdaptor
 
     @Override
     @Deprecated
+    @SuppressWarnings("removal")
     public byte getTTL() throws IOException {
         return (byte) getTimeToLive();
     }
@@ -593,6 +595,7 @@ public class DatagramSocketAdaptor
 
     @Override
     @Deprecated
+    @SuppressWarnings("removal")
     public void send(DatagramPacket p, byte ttl) throws IOException {
         sendLock.lock();
         try {


### PR DESCRIPTION
Can I please get a review of this change which proposes to deprecate for removal 3 methods on `java.net.MulticastSocket`? This addresses https://bugs.openjdk.org/browse/JDK-8332181.

As noted in that issue these methods have been deprecated since Java 1.2 and 1.4 days. They currently have replacement methods (noted in their javadoc) which have been in use for several releases. This commit updates these deprecated methods to deprecated for removal, to allow for their removal in a future release.

No new tests have been added and existing tests in tier1, tier2 and tier3 continue to pass.
