### PR TITLE
8329825: Clarify the value type for java.net.SocketOptions.SO_LINGER

### DIFF
--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -191,10 +191,9 @@ public interface SocketOptions {
     /**
      * See {@link StandardSocketOptions#SO_LINGER} for description of this socket option.
      * <p>
-     * Either {@linkplain Boolean#FALSE Boolean.FALSE} or an integer value lesser than {@code 0}
-     * can be passed to {@link #setOption(int, Object)} to disable this option. An integer
-     * value {@code >= 0} passed to {@code setOption(int, Object)} will enable the option and
-     * the value will represent the linger timeout.
+     * Set the value to {@code Boolean.FALSE} or an integer less than {@code 0} with
+     * {@link #setOption(int, Object)} to disable this option. An integer greater than or equal to
+     * {@code 0} will enable the option and will represent the linger timeout.
      * <p>
      * If this option is enabled then {@link #getOption(int)} will return an integer value
      * representing the linger timeout, else the return value will be {@code Boolean.FALSE}.

--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -193,10 +193,10 @@ public interface SocketOptions {
      * <p>
      * Set the value to {@code Boolean.FALSE} or an integer less than {@code 0} with
      * {@link #setOption(int, Object)} to disable this option. An integer greater than or equal to
-     * {@code 0} will enable the option and will represent the linger timeout.
+     * {@code 0} will enable the option and will represent the linger interval.
      * <p>
      * If this option is enabled then {@link #getOption(int)} will return an integer value
-     * representing the linger timeout, else the return value will be {@code Boolean.FALSE}.
+     * representing the linger interval, else the return value will be {@code Boolean.FALSE}.
      *
      * @see Socket#setSoLinger
      * @see Socket#getSoLinger

--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -190,6 +190,11 @@ public interface SocketOptions {
 
     /**
      * See {@link StandardSocketOptions#SO_LINGER} for description of this socket option.
+     * <p>
+     * The type of the value returned for this option, by {@link #getOption(int)} or accepted by
+     * {@link #setOption(int, Object)}, can either be a {@linkplain Boolean#FALSE Boolean.FALSE}
+     * or an integer value. {@code Boolean.FALSE} represents that this option is disabled whereas
+     * an integer value represents the linger timeout.
      *
      * @see Socket#setSoLinger
      * @see Socket#getSoLinger

--- a/src/java.base/share/classes/java/net/SocketOptions.java
+++ b/src/java.base/share/classes/java/net/SocketOptions.java
@@ -191,10 +191,13 @@ public interface SocketOptions {
     /**
      * See {@link StandardSocketOptions#SO_LINGER} for description of this socket option.
      * <p>
-     * The type of the value returned for this option, by {@link #getOption(int)} or accepted by
-     * {@link #setOption(int, Object)}, can either be a {@linkplain Boolean#FALSE Boolean.FALSE}
-     * or an integer value. {@code Boolean.FALSE} represents that this option is disabled whereas
-     * an integer value represents the linger timeout.
+     * Either {@linkplain Boolean#FALSE Boolean.FALSE} or an integer value lesser than {@code 0}
+     * can be passed to {@link #setOption(int, Object)} to disable this option. An integer
+     * value {@code >= 0} passed to {@code setOption(int, Object)} will enable the option and
+     * the value will represent the linger timeout.
+     * <p>
+     * If this option is enabled then {@link #getOption(int)} will return an integer value
+     * representing the linger timeout, else the return value will be {@code Boolean.FALSE}.
      *
      * @see Socket#setSoLinger
      * @see Socket#getSoLinger


### PR DESCRIPTION
Can I please get a review of this doc-only change which clarifies the value type for the `java.net.SocketOptions.SO_LINGER` option?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8332512](https://bugs.openjdk.org/browse/JDK-8332512) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8329825](https://bugs.openjdk.org/browse/JDK-8329825): Clarify the value type for java.net.SocketOptions.SO_LINGER (**Enhancement** - P4)
 * [JDK-8332512](https://bugs.openjdk.org/browse/JDK-8332512): Clarify the value type for java.net.SocketOptions.SO_LINGER (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19243/head:pull/19243` \
`$ git checkout pull/19243`

Update a local copy of the PR: \
`$ git checkout pull/19243` \
`$ git pull https://git.openjdk.org/jdk.git pull/19243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19243`

View PR using the GUI difftool: \
`$ git pr show -t 19243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19243.diff">https://git.openjdk.org/jdk/pull/19243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19243#issuecomment-2111597961)