### PR TITLE
8307778: com/sun/jdi/cds tests fail with jtreg's Virtual test thread factory

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -29,9 +29,6 @@ com/sun/jdi/EATests.java#id0                                    8264699 generic-
 
 com/sun/jdi/ExceptionEvents.java 8278470 generic-all
 com/sun/jdi/RedefineCrossStart.java 8278470 generic-all
-com/sun/jdi/cds/CDSBreakpointTest.java 8307778 generic-all
-com/sun/jdi/cds/CDSDeleteAllBkptsTest.java 8307778 generic-all
-com/sun/jdi/cds/CDSFieldWatchpoints.java 8307778 generic-all
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8308035 windows-x64
 

--- a/test/jdk/com/sun/jdi/cds/CDSJDITest.java
+++ b/test/jdk/com/sun/jdi/cds/CDSJDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ public class CDSJDITest {
             // pass them to the subprocess it will create for the debuggee. This
             // is how the -javaopts are passed to the debuggee. See
             // VMConnection.getDebuggeeVMOptions().
-            getPropOpt("test.classes"),
+            getPropOpt("test.class.path"),
             getPropOpt("test.java.opts"),
             getPropOpt("test.vm.opts"),
             // Pass -showversion to the JDI test just so we get a bit of trace output.


### PR DESCRIPTION
Can I please get a review of this change which removes the `test/jdk/com/sun/jdi/cds/` tests from being problem listed when jtreg launches these tests through a virtual thread?

These tests aren't actually incompatible with virtual threads. The real issue is that in https://bugs.openjdk.org/browse/JDK-8305608, a test infrastructure class `test/jdk/com/sun/jdi/VMConnection.java` was changed to use the `test.class.path` system property instead of the previously used `test.classes`.

That change missed out updating the `test/jdk/com/sun/jdi/cds/` tests to pass along the classpath through the `test.class.path` system property. As a result these tests still use the old `test.classes` system property to pass around the test classpath and thus causes these tests to fail. The reason why this only impacts virtual threads is noted by Chris in this JBS comment https://bugs.openjdk.org/browse/JDK-8305608?focusedId=14572100&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14572100.

The commit in this PR updates the `CDSJDITest` to pass along `test.class.path` instead of `test.classes`. The `CDSJDITest` is only used in the tests under `test/jdk/com/sun/jdi/cds/`, so nothing else should be impacted by this change.

I ran these changes against both launching with platform thread as well as virtual thread and these tests now pass in both these cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8307778: com/sun/jdi/cds tests fail with jtreg's Virtual test thread factory`

### Issue
 * [JDK-8307778](https://bugs.openjdk.org/browse/JDK-8307778): com/sun/jdi/cds tests fail with jtreg's Virtual test thread factory (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19244/head:pull/19244` \
`$ git checkout pull/19244`

Update a local copy of the PR: \
`$ git checkout pull/19244` \
`$ git pull https://git.openjdk.org/jdk.git pull/19244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19244`

View PR using the GUI difftool: \
`$ git pr show -t 19244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19244.diff">https://git.openjdk.org/jdk/pull/19244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19244#issuecomment-2111651451)