### PR TITLE
8332226: "Invalid package name:" from source launcher

### DIFF
--- a/make/CompileInterimLangtools.gmk
+++ b/make/CompileInterimLangtools.gmk
@@ -116,6 +116,7 @@ define SetupInterimModule
           --patch-module java.base=$(BUILDTOOLS_OUTPUTDIR)/gensrc/java.base.interim \
           --add-exports java.base/jdk.internal.javac=java.compiler.interim \
           --add-exports java.base/jdk.internal.javac=jdk.compiler.interim \
+          --add-exports java.base/jdk.internal.module=jdk.compiler.interim \
           --add-exports jdk.internal.opt/jdk.internal.opt=jdk.compiler.interim \
           --add-exports jdk.internal.opt/jdk.internal.opt=jdk.javadoc.interim, \
   ))

--- a/make/CompileInterimLangtools.gmk
+++ b/make/CompileInterimLangtools.gmk
@@ -116,7 +116,6 @@ define SetupInterimModule
           --patch-module java.base=$(BUILDTOOLS_OUTPUTDIR)/gensrc/java.base.interim \
           --add-exports java.base/jdk.internal.javac=java.compiler.interim \
           --add-exports java.base/jdk.internal.javac=jdk.compiler.interim \
-          --add-exports java.base/jdk.internal.module=jdk.compiler.interim \
           --add-exports jdk.internal.opt/jdk.internal.opt=jdk.compiler.interim \
           --add-exports jdk.internal.opt/jdk.internal.opt=jdk.javadoc.interim, \
   ))

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
@@ -44,7 +44,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
-import jdk.internal.module.Checks;
 
 /**
  * Describes a launch-able Java compilation unit.
@@ -159,7 +158,7 @@ public record ProgramDescriptor(
         }
 
         String pn = parent.toString().replace(separator, ".");
-        if (Checks.isPackageName(pn)) {
+        if (SourceVersion.isName(pn)) {
             return Optional.of(pn);
         } else {
             // not a valid package name

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
@@ -32,6 +32,7 @@ import com.sun.tools.javac.resources.LauncherProperties.Errors;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.module.InvalidModuleDescriptorException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -39,8 +40,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
+import jdk.internal.module.Checks;
 
 /**
  * Describes a launch-able Java compilation unit.
@@ -115,37 +119,62 @@ public record ProgramDescriptor(
     }
 
     public Set<String> computePackageNames() {
-        try (var stream = Files.find(sourceRootPath, 99, (path, attr) -> attr.isDirectory())) {
-            var names = new TreeSet<String>();
-            stream.filter(ProgramDescriptor::containsAtLeastOneRegularFile)
-                  .map(sourceRootPath::relativize)
-                  .filter(ProgramDescriptor::composedOfValidPackageNameElements)
-                  .map(Path::toString)
-                  .filter(string -> !string.isEmpty())
-                  .map(string -> string.replace(File.separatorChar, '.'))
-                  .forEach(names::add);
-            return names;
-        } catch (IOException exception) {
-            throw new UncheckedIOException(exception);
+        return explodedPackages(sourceRootPath);
+    }
+
+    // -- exploded directories --> based on jdk.internal.module.ModulePath
+
+    private static Set<String> explodedPackages(Path dir) {
+        String separator = dir.getFileSystem().getSeparator();
+        try (Stream<Path> stream = Files.find(dir, Integer.MAX_VALUE,
+                (path, attrs) -> attrs.isRegularFile() && !isHidden(path))) {
+            return stream.map(dir::relativize)
+                    .map(path -> toPackageName(path, separator))
+                    .flatMap(Optional::stream)
+                    .collect(Collectors.toSet());
+        } catch (IOException x) {
+            throw new UncheckedIOException(x);
         }
     }
 
-    private static boolean composedOfValidPackageNameElements(Path path) {
-        if (path.getNameCount() == 0) return false;
-        for (var element : path) {
-            var name = element.toString();
-            if (!SourceVersion.isIdentifier(name)) {
-                return false;
+    /**
+     * Maps the relative path of an entry in an exploded module to a package
+     * name.
+     *
+     * @throws InvalidModuleDescriptorException if the name is a class file in
+     *         the top-level directory (and it's not module-info.class)
+     */
+    private static Optional<String> toPackageName(Path file, String separator) {
+        assert file.getRoot() == null;
+
+        Path parent = file.getParent();
+        if (parent == null) {
+            String name = file.toString();
+            if (name.endsWith(".class") && !name.equals("module-info.class")) {
+                String msg = name + " found in top-level directory"
+                        + " (unnamed package not allowed in module)";
+                throw new InvalidModuleDescriptorException(msg);
             }
+            return Optional.empty();
         }
-        return true;
+
+        String pn = parent.toString().replace(separator, ".");
+        if (Checks.isPackageName(pn)) {
+            return Optional.of(pn);
+        } else {
+            // not a valid package name
+            return Optional.empty();
+        }
     }
 
-    private static boolean containsAtLeastOneRegularFile(Path directory) {
-        try (var stream = Files.newDirectoryStream(directory, Files::isRegularFile)) {
-            return stream.iterator().hasNext();
-        } catch (IOException exception) {
-            throw new UncheckedIOException(exception);
+    /**
+     * Returns true if the given file exists and is a hidden file
+     */
+    private static boolean isHidden(Path file) {
+        try {
+            return Files.isHidden(file);
+        } catch (IOException ioe) {
+            return false;
         }
     }
 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
@@ -40,6 +40,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 
+import javax.lang.model.SourceVersion;
+
 /**
  * Describes a launch-able Java compilation unit.
  *
@@ -117,6 +119,7 @@ public record ProgramDescriptor(
             var names = new TreeSet<String>();
             stream.filter(ProgramDescriptor::containsAtLeastOneRegularFile)
                   .map(sourceRootPath::relativize)
+                  .filter(ProgramDescriptor::composedOfValidPackageNameElements)
                   .map(Path::toString)
                   .filter(string -> !string.isEmpty())
                   .map(string -> string.replace(File.separatorChar, '.'))
@@ -125,6 +128,17 @@ public record ProgramDescriptor(
         } catch (IOException exception) {
             throw new UncheckedIOException(exception);
         }
+    }
+
+    private static boolean composedOfValidPackageNameElements(Path path) {
+        if (path.getNameCount() == 0) return false;
+        for (var element : path) {
+            var name = element.toString();
+            if (!SourceVersion.isIdentifier(name)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean containsAtLeastOneRegularFile(Path directory) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/ProgramDescriptor.java
@@ -32,7 +32,6 @@ import com.sun.tools.javac.resources.LauncherProperties.Errors;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.lang.module.InvalidModuleDescriptorException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -40,11 +39,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.lang.model.SourceVersion;
-import jdk.internal.module.Checks;
 
 /**
  * Describes a launch-able Java compilation unit.
@@ -119,62 +115,37 @@ public record ProgramDescriptor(
     }
 
     public Set<String> computePackageNames() {
-        return explodedPackages(sourceRootPath);
-    }
-
-    // -- exploded directories --> based on jdk.internal.module.ModulePath
-
-    private static Set<String> explodedPackages(Path dir) {
-        String separator = dir.getFileSystem().getSeparator();
-        try (Stream<Path> stream = Files.find(dir, Integer.MAX_VALUE,
-                (path, attrs) -> attrs.isRegularFile() && !isHidden(path))) {
-            return stream.map(dir::relativize)
-                    .map(path -> toPackageName(path, separator))
-                    .flatMap(Optional::stream)
-                    .collect(Collectors.toSet());
-        } catch (IOException x) {
-            throw new UncheckedIOException(x);
+        try (var stream = Files.find(sourceRootPath, 99, (path, attr) -> attr.isDirectory())) {
+            var names = new TreeSet<String>();
+            stream.filter(ProgramDescriptor::containsAtLeastOneRegularFile)
+                  .map(sourceRootPath::relativize)
+                  .filter(ProgramDescriptor::composedOfValidPackageNameElements)
+                  .map(Path::toString)
+                  .filter(string -> !string.isEmpty())
+                  .map(string -> string.replace(File.separatorChar, '.'))
+                  .forEach(names::add);
+            return names;
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
         }
     }
 
-    /**
-     * Maps the relative path of an entry in an exploded module to a package
-     * name.
-     *
-     * @throws InvalidModuleDescriptorException if the name is a class file in
-     *         the top-level directory (and it's not module-info.class)
-     */
-    private static Optional<String> toPackageName(Path file, String separator) {
-        assert file.getRoot() == null;
-
-        Path parent = file.getParent();
-        if (parent == null) {
-            String name = file.toString();
-            if (name.endsWith(".class") && !name.equals("module-info.class")) {
-                String msg = name + " found in top-level directory"
-                        + " (unnamed package not allowed in module)";
-                throw new InvalidModuleDescriptorException(msg);
+    private static boolean composedOfValidPackageNameElements(Path path) {
+        if (path.getNameCount() == 0) return false;
+        for (var element : path) {
+            var name = element.toString();
+            if (!SourceVersion.isIdentifier(name)) {
+                return false;
             }
-            return Optional.empty();
         }
-
-        String pn = parent.toString().replace(separator, ".");
-        if (Checks.isPackageName(pn)) {
-            return Optional.of(pn);
-        } else {
-            // not a valid package name
-            return Optional.empty();
-        }
+        return true;
     }
 
-    /**
-     * Returns true if the given file exists and is a hidden file
-     */
-    private static boolean isHidden(Path file) {
-        try {
-            return Files.isHidden(file);
-        } catch (IOException ioe) {
-            return false;
+    private static boolean containsAtLeastOneRegularFile(Path directory) {
+        try (var stream = Files.newDirectoryStream(directory, Files::isRegularFile)) {
+            return stream.iterator().hasNext();
+        } catch (IOException exception) {
+            throw new UncheckedIOException(exception);
         }
     }
 }


### PR DESCRIPTION
Please review this change excluding directory paths with invalid elements when computing the packages of a module in source-launch mode.

Note that this inital iteration of the change only fixes the in-memory computation of package names - the behaviour of the associated module reader implementation is untouched for the time being. This introduces a difference in the set of resources being readable at runtime. For example, see the modified test case: the new and invalid `.bar` directory doesn't show up in the contents of the module - but it is reported by the module reader's `list()` method.

Note additionally, that above's behaviour is also observed for compiled and exploded modules. Meaning, that with this change being applied, the source mode and compiled mode of the launcher are in line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332226](https://bugs.openjdk.org/browse/JDK-8332226): "Invalid package name:" from source launcher (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19245/head:pull/19245` \
`$ git checkout pull/19245`

Update a local copy of the PR: \
`$ git checkout pull/19245` \
`$ git pull https://git.openjdk.org/jdk.git pull/19245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19245`

View PR using the GUI difftool: \
`$ git pr show -t 19245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19245.diff">https://git.openjdk.org/jdk/pull/19245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19245#issuecomment-2111822800)