### PR TITLE
8332287: When printing arguments in error logs, quote arguments with whitespaces

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1097,7 +1097,7 @@ void Arguments::print_jvm_args_on(outputStream* st) {
       const char* const s = _jvm_args_array[i];
       bool ws = false;
       for (const char* p = s; *p && !ws; p++) {
-        ws = isspace(*p);
+        ws = isspace((unsigned)*p);
       }
       if (ws) {
         st->print("\"%s\" ", s);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1093,7 +1093,17 @@ void Arguments::print_jvm_flags_on(outputStream* st) {
 void Arguments::print_jvm_args_on(outputStream* st) {
   if (_num_jvm_args > 0) {
     for (int i=0; i < _num_jvm_args; i++) {
-      st->print("%s ", _jvm_args_array[i]);
+      // quote any argument containing whitespaces
+      const char* const s = _jvm_args_array[i];
+      bool ws = false;
+      for (const char* p = s; *p && !ws; p++) {
+        ws = isspace(*p);
+      }
+      if (ws) {
+        st->print("\"%s\" ", s);
+      } else {
+        st->print("%s ", s);
+      }
     }
   }
 }

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1096,7 +1096,7 @@ void Arguments::print_jvm_args_on(outputStream* st) {
       // quote any argument containing whitespaces
       const char* const s = _jvm_args_array[i];
       bool ws = false;
-      for (const char* p = s; *p && !ws; p++) {
+      for (const char* p = s; *p != '\0' && !ws; p++) {
         ws = isspace((unsigned)*p);
       }
       if (ws) {


### PR DESCRIPTION
Trivial fix to a simple issue.

In hs-err files, when printing the arguments of the crashed JVM process, print arguments with whitespaces in them with quotes. Makes it easier to copy-paste them to terminals.

Before:
```
Command Line: -Dtest.vm.opts=-XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+StressArrayCopyMacroNode -XX:+StressLCM -XX:+StressGCM -XX:+StressIGVN -XX:+StressCCP -XX:+StressMacroExpansion -XX:+StressMethodHandleLinkerInlining -XX:+StressCompiledExceptionHandlers -XX:CompileCommand=memlimit,*.*,1G~crash -XX:CompileCommand=memstat,*::*,print -Dtest.tool.vm.opts=-J-XX:+UnlockDiagnosticVMOptions -J-XX:-TieredCompilation -J-XX:+StressArrayCopyMacroNode -J-XX:+StressLCM -J-XX:+StressGCM -J-XX:+StressIGVN -J-XX:+StressCCP -J-XX:+StressMacroExpansion -J-XX:+StressMethodHandleLinkerInlining -J-XX:+StressCompiledExceptionHandlers -J-XX:CompileCommand=memlimit,*.*,1G~crash -J-XX:CompileCommand=memstat,*::*,print -XX:+StressCompiledExceptionHandlers -XX:CompileCommand=memlimit,*.*,1G~crash -XX:CompileCommand=memstat,*::*,print -Djava.library.path=/shared/projects/openjdk/jdk-jdk/output-fastdebug/images/test/hotspot/jtreg/native -Xbatch -XX:CompileCommand=option,*::*,bool,Vectorize,true -XX:+PrintOpto -XX:+TraceLoopOpts com.sun.javatest.regtest.agent.MainWrapper /Users/thomas/shared/projects/openjdk/jtreg-runs/jtreg/JTwork/compiler/c2/TestFindNode.d/main.0.jta
```

Now (notice the gigantic -Dtest.vm.opts and -Dtest.tool.vm.opts that are actually just one large argument each)

```
Command Line: "-Dtest.vm.opts=-XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:+StressArrayCopyMacroNode -XX:+StressLCM -XX:+StressGCM -XX:+StressIGVN -XX:+StressCCP -XX:+StressMacroExpansion -XX:+StressMethodHandleLinkerInlining -XX:+StressCompiledExceptionHandlers -XX:CompileCommand=memlimit,*.*,1G~crash -XX:CompileCommand=memstat,*::*,print" "-Dtest.tool.vm.opts=-J-XX:+UnlockDiagnosticVMOptions -J-XX:-TieredCompilation -J-XX:+StressArrayCopyMacroNode -J-XX:+StressLCM -J-XX:+StressGCM -J-XX:+StressIGVN -J-XX:+StressCCP -J-XX:+StressMacroExpansion -J-XX:+StressMethodHandleLinkerInlining -J-XX:+StressCompiledExceptionHandlers -J-XX:CompileCommand=memlimit,*.*,1G~crash -J-XX:CompileCommand=memstat,*::*,print" -XX:+StressCompiledExceptionHandlers -XX:CompileCommand=memlimit,*.*,1G~crash -XX:CompileCommand=memstat,*::*,print -Djava.library.path=/shared/projects/openjdk/jdk-jdk/output-fastdebug/images/test/hotspot/jtreg/native -Xbatch -XX:CompileCommand=option,*::*,bool,Vectorize,true -XX:+PrintOpto -XX:+TraceLoopOpts com.sun.javatest.regtest.agent.MainWrapper /Users/thomas/shared/projects/openjdk/jtreg-runs/jtreg/JTwork/compiler/c2/TestFindNode.d/main.0.jta
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332287](https://bugs.openjdk.org/browse/JDK-8332287): When printing arguments in error logs, quote arguments with whitespaces (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [72343272](https://git.openjdk.org/jdk/pull/19248/files/723432728f89ee4c594cb786965f4706f317f57e)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19248/head:pull/19248` \
`$ git checkout pull/19248`

Update a local copy of the PR: \
`$ git checkout pull/19248` \
`$ git pull https://git.openjdk.org/jdk.git pull/19248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19248`

View PR using the GUI difftool: \
`$ git pr show -t 19248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19248.diff">https://git.openjdk.org/jdk/pull/19248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19248#issuecomment-2114019058)