### PR TITLE
Better JMX interoperability with older JDKs, after removing Subject Delegation.

### DIFF
--- a/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
+++ b/src/java.management.rmi/share/classes/javax/management/remote/rmi/RMIConnectionImpl.java
@@ -971,8 +971,14 @@ public class RMIConnectionImpl implements RMIConnection, Unreferenced {
         if (names == null || filters == null) {
             throw new IllegalArgumentException("Got null arguments.");
         }
+        // Accept an array of delegationSubjects from e.g. earlier JDKs,
+        // but throw if it contains any non-null values.
         if (delegationSubjects != null) {
-            throw new UnsupportedOperationException("Subject Delegation has been removed.");
+            for (Subject s: delegationSubjects) {
+                if (s != null) {
+                    throw new UnsupportedOperationException("Subject Delegation has been removed.");
+                }
+            }
         }
         Subject[] sbjs = new Subject[names.length];
         if (names.length != filters.length || filters.length != sbjs.length) {


### PR DESCRIPTION
Running JConsole from a previous JDK, and attaching to jdk-23 (after [JDK-8326666](https://bugs.openjdk.org/browse/JDK-8326666): Remove the Java Management Extension (JMX) Subject Delegation feature), the MBean tab is blank.

In javax/management/remote/rmi/RMIConnectionImpl.java:
addNotificationListener rejects a non-null delegationSubjects array, but older JDKs will send such an array. It could accept the array, and only reject/throw if it contains a non-null Subject (i.e. if an attempt to use subject delegation is really happening).