### PR TITLE
8332327: Return _methods_jmethod_ids field back in VMStructs

### DIFF
--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -253,6 +253,7 @@
   nonstatic_field(InstanceKlass,               _jni_ids,                                      JNIid*)                                \
   nonstatic_field(InstanceKlass,               _osr_nmethods_head,                            nmethod*)                              \
   JVMTI_ONLY(nonstatic_field(InstanceKlass,    _breakpoints,                                  BreakpointInfo*))                      \
+  volatile_nonstatic_field(InstanceKlass,      _methods_jmethod_ids,                          jmethodID*)                            \
   volatile_nonstatic_field(InstanceKlass,      _idnum_allocated_count,                        u2)                                    \
   nonstatic_field(InstanceKlass,               _annotations,                                  Annotations*)                          \
   nonstatic_field(InstanceKlass,               _method_ordering,                              Array<int>*)                           \


### PR DESCRIPTION
The fix for [JDK-8313332](https://bugs.openjdk.org/browse/JDK-8313332) has [removed](https://github.com/openjdk/jdk/commit/21867c929a2f2c961148f2cd1e79d672ac278d27#diff-7d448441e80a0b784429d5d8aee343fcb131c224b8ec7bc70ea636f78d561ecd
) `InstanceKlass::_methods_jmethod_ids` field from VMStructs.

This broke [async-profiler](https://github.com/async-profiler/async-profiler/), since the profiler needs this field to obtain jmethodID in some corner cases.

There was no actual need for removal, as the field is still there in InstanceKlass. So, I propose to return the field back to restore the broken functionality of async-profiler. This is a no risk change, because it only exports an offset of one field and does not affect the JVM otherwise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332327](https://bugs.openjdk.org/browse/JDK-8332327): Return _methods_jmethod_ids field back in VMStructs (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19254/head:pull/19254` \
`$ git checkout pull/19254`

Update a local copy of the PR: \
`$ git checkout pull/19254` \
`$ git pull https://git.openjdk.org/jdk.git pull/19254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19254`

View PR using the GUI difftool: \
`$ git pr show -t 19254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19254.diff">https://git.openjdk.org/jdk/pull/19254.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19254#issuecomment-2113470884)