### PR TITLE
8321622: ClassFile.verify(byte[] bytes) throws unexpected ConstantPoolException, IAE

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -285,7 +285,6 @@ public final class VerifierImpl {
         } catch (VerifyError err) {
             errorsCollector.add(err);
         } catch (Error | Exception e) {
-            e.printStackTrace();
             errorsCollector.add(new VerifyError(e.toString()));
         }
     }


### PR DESCRIPTION
Class-File API `VerifierImpl` contains debugging stack trace print causing unexpected output and confusion in specific verification cases.

This patch removes the stack trace print.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321622](https://bugs.openjdk.org/browse/JDK-8321622): ClassFile.verify(byte[] bytes) throws unexpected ConstantPoolException, IAE (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [235875ca](https://git.openjdk.org/jdk/pull/19258/files/235875ca58e6e3c6957d9127ce55f6f581a03570)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19258/head:pull/19258` \
`$ git checkout pull/19258`

Update a local copy of the PR: \
`$ git checkout pull/19258` \
`$ git pull https://git.openjdk.org/jdk.git pull/19258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19258`

View PR using the GUI difftool: \
`$ git pr show -t 19258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19258.diff">https://git.openjdk.org/jdk/pull/19258.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19258#issuecomment-2114186999)