### PR TITLE
8328107: Shenandoah/C2: TestVerifyLoopOptimizations test failure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1327,6 +1327,14 @@ void ShenandoahBarrierC2Support::pin_and_expand(PhaseIdealLoop* phase) {
       OuterStripMinedLoopNode* outer = head->as_OuterStripMinedLoop();
       hide_strip_mined_loop(outer, outer->unique_ctrl_out()->as_CountedLoop(), phase);
     }
+    if (head->is_BaseCountedLoop() && ctrl->is_IfProj() && ctrl->in(0)->is_BaseCountedLoopEnd() &&
+        head->as_BaseCountedLoop()->loopexit() == ctrl->in(0)) {
+      Node* entry = head->in(LoopNode::EntryControl);
+      Node* backedge = head->in(LoopNode::LoopBackControl);
+      Node* new_head = new LoopNode(entry, backedge);
+      phase->register_control(new_head, phase->get_loop(entry), entry);
+      phase->lazy_replace(head, new_head);
+    }
   }
 
   // Expand load-reference-barriers

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierOnLoopBackedge.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestBarrierOnLoopBackedge.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8328107
+ * @summary Barrier expanded on backedge break loop verification code
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:+UseShenandoahGC -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestBarrierOnLoopBackedge::notInlined
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyLoopOptimizations TestBarrierOnLoopBackedge
+ * @run main/othervm -XX:+UseShenandoahGC -XX:-BackgroundCompilation -XX:CompileCommand=dontinline,TestBarrierOnLoopBackedge::notInlined
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+VerifyLoopOptimizations -XX:-UseCountedLoopSafepoints TestBarrierOnLoopBackedge
+ */
+
+public class TestBarrierOnLoopBackedge {
+    private static A field = new A();
+    private static final A finalField = new A();
+    private static float floatField;
+
+    public static void main(String[] args) {
+        A[] array = new A[1];
+        array[0] = finalField;
+        for (int i = 0; i < 20_000; i++) {
+            test1();
+            test2();
+        }
+    }
+
+    private static void test1() {
+        floatField = field.f;
+        for (int i = 0; i < 1000; i++) {
+            notInlined(field); // load barrier split thru phi and ends up on back edge
+            if (i % 2 == 0) {
+                field = finalField;
+            }
+        }
+    }
+
+    private static void test2() {
+        A[] array = new A[1];
+        notInlined(array);
+        int i = 0;
+        A a = array[0];
+        for (;;) {
+            synchronized (new Object()) {
+            }
+            notInlined(a);
+            i++;
+            if (i >= 1000) {
+                break;
+            }
+            a = array[0]; // load barrier pinned on backedge
+        }
+    }
+
+    private static void notInlined(Object a) {
+
+    }
+
+    private static class A {
+        float f;
+    }
+}


### PR DESCRIPTION
The failure occurs because a load barrier is expanded on the backedge
of the counted loop. That breaks the expected counted loop shape. The
fix I propose is to replace the `CountedLoop` with a `Loop` node when
that happens. We're basically done with optimizations related to
counted loop at this point so this shouldn't make a difference.

/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328107](https://bugs.openjdk.org/browse/JDK-8328107): Shenandoah/C2: TestVerifyLoopOptimizations test failure (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19259/head:pull/19259` \
`$ git checkout pull/19259`

Update a local copy of the PR: \
`$ git checkout pull/19259` \
`$ git pull https://git.openjdk.org/jdk.git pull/19259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19259`

View PR using the GUI difftool: \
`$ git pr show -t 19259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19259.diff">https://git.openjdk.org/jdk/pull/19259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19259#issuecomment-2114293696)