### PR TITLE
split nonnmethod into compiler scratch buffer area and the code stubs

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -96,7 +96,7 @@ CodeBuffer::CodeBuffer(CodeBlob* blob) DEBUG_ONLY(: Scrubber(this, sizeof(*this)
   debug_only(verify_section_allocation();)
 }
 
-void CodeBuffer::initialize(csize_t code_size, csize_t locs_size) {
+void CodeBuffer::initialize(csize_t code_size, csize_t locs_size, bool executable_blob) {
   // Always allow for empty slop around each section.
   int slop = (int) CodeSection::end_slop();
 
@@ -104,7 +104,8 @@ void CodeBuffer::initialize(csize_t code_size, csize_t locs_size) {
   int total_size = code_size + _consts.alignment() + _insts.alignment() + _stubs.alignment() + SECT_LIMIT * slop;
 
   assert(blob() == nullptr, "only once");
-  set_blob(BufferBlob::create(_name, total_size));
+  set_blob(executable_blob ? BufferBlob::create(_name, total_size) :
+                             CompilerScratchBlob::create(_name, total_size));
   if (blob() == nullptr) {
     // The assembler constructor will throw a fatal on an empty CodeBuffer.
     return;  // caller must test this

--- a/src/hotspot/share/asm/codeBuffer.hpp
+++ b/src/hotspot/share/asm/codeBuffer.hpp
@@ -563,7 +563,7 @@ class CodeBuffer: public StackObj DEBUG_ONLY(COMMA private Scrubber) {
   // constructor 4 is equivalent to calling constructor 3 and then
   // calling this method.  It's been factored out for convenience of
   // construction.
-  void initialize(csize_t code_size, csize_t locs_size);
+  void initialize(csize_t code_size, csize_t locs_size, bool executable_blob = true);
 
   CodeSection* consts() { return &_consts; }
   CodeSection* insts() { return &_insts; }

--- a/src/hotspot/share/c1/c1_Compiler.cpp
+++ b/src/hotspot/share/c1/c1_Compiler.cpp
@@ -88,7 +88,7 @@ BufferBlob* Compiler::init_buffer_blob() {
 
   // setup CodeBuffer.  Preallocate a BufferBlob of size
   // NMethodSizeLimit plus some extra space for constants.
-  BufferBlob* buffer_blob = BufferBlob::create("C1 temporary CodeBuffer", code_buffer_size());
+  BufferBlob* buffer_blob = CompilerScratchBlob::create("C1 temporary CodeBuffer", code_buffer_size());
   if (buffer_blob != nullptr) {
     CompilerThread::current()->set_buffer_blob(buffer_blob);
   }

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -44,9 +44,10 @@ class OopMapSet;
 enum class CodeBlobType {
   MethodNonProfiled   = 0,    // Execution level 1 and 4 (non-profiled) nmethods (including native nmethods)
   MethodProfiled      = 1,    // Execution level 2 and 3 (profiled) nmethods
-  NonNMethod          = 2,    // Non-nmethods like Buffers, Adapters and Runtime Stubs
-  All                 = 3,    // All types (No code cache segmentation)
-  NumTypes            = 4     // Number of CodeBlobTypes
+  NonNMethod          = 2,    // Non-nmethods like Adapters and Runtime Stubs
+  NonExecutable       = 3,    // Non-executable buffers like blobs for compiler scratch data
+  All                 = 4,    // All types (No code cache segmentation)
+  NumTypes            = 5     // Number of CodeBlobTypes
 };
 
 // CodeBlob - superclass for all entries in the CodeCache.
@@ -58,6 +59,7 @@ enum class CodeBlobType {
 //    AdapterBlob        : Used to hold C2I/I2C adapters
 //    VtableBlob         : Used for holding vtable chunks
 //    MethodHandlesAdapterBlob : Used to hold MethodHandles adapters
+//    CompilerScratchBlob : A temporary blob used by compiler
 //   RuntimeStub         : Call to VM runtime methods
 //   SingletonBlob       : Super-class for all blobs that exist in only one instance
 //    DeoptimizationBlob : Used for deoptimization
@@ -299,6 +301,7 @@ class WhiteBox;
 
 class BufferBlob: public RuntimeBlob {
   friend class VMStructs;
+  friend class CompilerScratchBlob;
   friend class AdapterBlob;
   friend class VtableBlob;
   friend class MethodHandlesAdapterBlob;
@@ -326,6 +329,18 @@ class BufferBlob: public RuntimeBlob {
   void print_value_on(outputStream* st) const override;
 };
 
+
+//----------------------------------------------------------------------------------------------------
+// CompilerScratchBlob: used for compiler scratch buffer
+
+class CompilerScratchBlob: public BufferBlob {
+private:
+  CompilerScratchBlob(const char* name, uint buffer_size);
+  void* operator new(size_t s, unsigned size) throw();
+
+public:
+  static CompilerScratchBlob* create(const char* name, uint buffer_size);
+};
 
 //----------------------------------------------------------------------------------------------------
 // AdapterBlob: used to hold C2I/I2C adapters

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -327,10 +327,15 @@ void CodeCache::initialize_heaps() {
     add_heap(profiled_space, "CodeHeap 'profiled nmethods'", CodeBlobType::MethodProfiled);
   }
 
-  ReservedSpace non_method_space = rs.partition(offset, non_nmethod.size);
-  offset += non_nmethod.size;
+  ReservedSpace non_method_space = rs.partition(offset, non_nmethod.size/2);
+  offset += non_nmethod.size/2;
   // Non-nmethods (stubs, adapters, ...)
   add_heap(non_method_space, "CodeHeap 'non-nmethods'", CodeBlobType::NonNMethod);
+
+  ReservedSpace non_executable_space = rs.partition(offset, non_nmethod.size/2);
+  offset += non_nmethod.size/2;
+  // Non-executables (compilers scratch buffer area)
+  add_heap(non_executable_space, "CodeHeap 'non-executable'", CodeBlobType::NonExecutable);
 
   if (non_profiled.enabled) {
     ReservedSpace non_profiled_space  = rs.partition(offset, non_profiled.size);
@@ -522,6 +527,7 @@ CodeBlob* CodeCache::allocate(uint size, CodeBlobType code_blob_type, bool handl
         CodeBlobType type = code_blob_type;
         switch (type) {
         case CodeBlobType::NonNMethod:
+        case CodeBlobType::NonExecutable:
           type = CodeBlobType::MethodNonProfiled;
           break;
         case CodeBlobType::MethodNonProfiled:

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -3301,7 +3301,7 @@ void PhaseOutput::init_scratch_buffer_blob(int const_size) {
     ResourceMark rm;
     _scratch_const_size = const_size;
     int size = C2Compiler::initial_code_buffer_size(const_size);
-    blob = BufferBlob::create("Compile::scratch_buffer", size);
+    blob = CompilerScratchBlob::create("Compile::scratch_buffer", size);
     // Record the buffer blob for next time.
     set_scratch_buffer_blob(blob);
     // Have we run out of code space?

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1350,7 +1350,8 @@ CodeBuffer* PhaseOutput::init_buffer() {
     stub_req  += deopt_handler_req;
   }
   CodeBuffer* cb = code_buffer();
-  cb->initialize(total_req, _buf_sizes._reloc);
+  bool executable_blob = false;
+  cb->initialize(total_req, _buf_sizes._reloc, executable_blob);
 
   // Have we run out of code space?
   if ((cb->blob() == nullptr) || (!CompileBroker::should_compile_new_jobs())) {


### PR DESCRIPTION
This change introduces a non-executable code segment to separate temporary compiler data buffers from executable stubs within the non-nmethod segment. Compiler data buffers could be allocated outside the code cache with os::malloc, but this would cause problems with offset limits of PC relative jumps to compiled stubs. This change improves code density and hopefully reduces branch misses and cache misses (testing in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19262/head:pull/19262` \
`$ git checkout pull/19262`

Update a local copy of the PR: \
`$ git checkout pull/19262` \
`$ git pull https://git.openjdk.org/jdk.git pull/19262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19262`

View PR using the GUI difftool: \
`$ git pr show -t 19262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19262.diff">https://git.openjdk.org/jdk/pull/19262.diff</a>

</details>
