### PR TITLE
8332239: Improve CSS for block tags

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -372,9 +372,13 @@ dl.notes > dt {
     color:var(--body-text-color);
 }
 dl.notes > dd {
-    margin:5px 10px 10px 0;
+    margin:5px 10px 10px 15px;
     font-size:var(--block-font-size);
-    font-family:var(--block-font-family)
+    font-family:var(--block-font-family);
+}
+dl.notes > dd > ul, dl.notes > dd > ol {
+    margin-bottom: 1em;
+    margin-top: 1em;
 }
 dl.name-value > dt {
     margin-left:1px;
@@ -547,8 +551,9 @@ ul.ref-list > li {
     margin-top:0;
     margin-bottom:1px;
 }
-ul.tag-list, ul.tag-list-long {
+dl.notes > dd > ul.tag-list, dl.notes > dd > ul.tag-list-long {
     padding-left: 0;
+    margin: 0;
     list-style: none;
 }
 ul.tag-list li {


### PR DESCRIPTION
Please review a change to improve the layout of definition lists used to display block tags:

 - Add indentation to the `<dd>` elements used for block tag details
 - Set the margin of lists within block tag details so they do not appear as nested lists, except for lists with CSS classes `tag-list` or `tag-list-long`, which are used for block tags containing lists, such as `@see`. 

Before/after comparison (contains `java.base` and `java.compiler` modules):
https://cr.openjdk.org/~hannesw/8332239/api.00/index.html
https://cr.openjdk.org/~hannesw/8332239/api.01/index.html

Comparison for block tag layout:
https://cr.openjdk.org/~hannesw/8332239/api.00/java.base/java/lang/Object.html#hashCode()
https://cr.openjdk.org/~hannesw/8332239/api.01/java.base/java/lang/Object.html#hashCode()

Example of very long block tag details containing a list:
https://cr.openjdk.org/~hannesw/8332239/api.00/java.compiler/javax/lang/model/util/package-summary.html
https://cr.openjdk.org/~hannesw/8332239/api.01/java.compiler/javax/lang/model/util/package-summary.html

Note that the indentation also applies to the definition lists at the top of class/interface documentation as they use the same markup as block tags:
https://cr.openjdk.org/~hannesw/8332239/api.00/java.base/java/lang/Exception.html
https://cr.openjdk.org/~hannesw/8332239/api.01/java.base/java/lang/Exception.html

 This was not an intended change but might or might not be desirable. It could be avoided with some additional CSS changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332239](https://bugs.openjdk.org/browse/JDK-8332239): Improve CSS for block tags (**Enhancement** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19264/head:pull/19264` \
`$ git checkout pull/19264`

Update a local copy of the PR: \
`$ git checkout pull/19264` \
`$ git pull https://git.openjdk.org/jdk.git pull/19264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19264`

View PR using the GUI difftool: \
`$ git pr show -t 19264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19264.diff">https://git.openjdk.org/jdk/pull/19264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19264#issuecomment-2114930054)