### PR TITLE
8332153: RISC-V: enable tests and add comment for vector shift instruct (shared by vectorization and Vector API)

### DIFF
--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1793,7 +1793,7 @@ instruct replicateD(vReg dst, fRegD src) %{
 //  2. similarly, for long "with the mask value 0x3f (0b111111)"
 // check https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.19 for details.
 //
-// Shift behaviour in Vector APi is defined as:
+// Shift behaviour in Vector API is defined as:
 //   e.g. for ASHR, "a>>(n&(ESIZE*8-1))"
 //   this behaviour is the same as shift instrunction's in riscv vector extension.
 // check https://docs.oracle.com/en/java/javase/21/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorOperators.html#ASHR

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1782,6 +1782,32 @@ instruct replicateD(vReg dst, fRegD src) %{
 %}
 
 // vector shift
+//
+// Following shift instruct's are shared by vectorization (in SLP, superword.cpp) and vector API.
+//
+// Shift behaviour in vectorization is defined by java language spec, which includes:
+//  1. "If the promoted type of the left-hand operand is int, then only the five lowest-order bits of
+//      the right-hand operand are used as the shift distance. It is as if the right-hand operand were
+//      subjected to a bitwise logical AND operator & (§15.22.1) with the mask value 0x1f (0b11111).
+//      The shift distance actually used is therefore always in the range 0 to 31, inclusive."
+//  2. similarly, for long "with the mask value 0x3f (0b111111)"
+// check https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.19 for details.
+//
+// Shift behaviour in Vector APi is defined as:
+//   e.g. for ASHR, "a>>(n&(ESIZE*8-1))"
+//   this behaviour is the same as shift instrunction's in riscv vector extension.
+// check https://docs.oracle.com/en/java/javase/21/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorOperators.html#ASHR
+// and https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#116-vector-single-width-shift-instructions for details.
+//
+// Although the difference between these 2 behaviours, the same shift instruct's of byte and short are
+// still shared between vectorization and Vector API. The way it works is hidden inside the implementation
+// of vectorization and Vector API:
+//  1. when doing optimization vectorization masks the shift value with "(BitsPerInt - 1)" or "(BitsPerLong - 1)"
+//  2. in Vector API, shift value is masked with SHIFT_MASK (e.g. for ByteVector it's "Byte.SIZE - 1")
+//
+// If not because of this pre-processing of shift value respectively in vectorization and Vector API, then
+// e.g. for a byte shift value 16, the intrinsic behaviour will be different, and they can not share the same
+// instruct here, as vectorization requires x >> 16, but Vector API requires x >> (16 & 7).
 
 instruct vasrB(vReg dst, vReg src, vReg shift, vRegMask_V0 v0) %{
   match(Set dst (RShiftVB src shift));

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1783,7 +1783,7 @@ instruct replicateD(vReg dst, fRegD src) %{
 
 // vector shift
 //
-// Following shift instruct's are shared by vectorization (in SLP, superword.cpp) and vector API.
+// Following shift instruct's are shared by vectorization (in SLP, superword.cpp) and Vector API.
 //
 // Shift behaviour in vectorization is defined by java language spec, which includes:
 //  1. "If the promoted type of the left-hand operand is int, then only the five lowest-order bits of

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1799,7 +1799,7 @@ instruct replicateD(vReg dst, fRegD src) %{
 // check https://docs.oracle.com/en/java/javase/21/docs/api/jdk.incubator.vector/jdk/incubator/vector/VectorOperators.html#ASHR
 // and https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#116-vector-single-width-shift-instructions for details.
 //
-// Although the difference between these 2 behaviours, the same shift instruct's of byte and short are
+// Despite the difference between these 2 behaviours, the same shift instruct's of byte and short are
 // still shared between vectorization and Vector API. The way it works is hidden inside the implementation
 // of vectorization and Vector API:
 //  1. when doing optimization vectorization masks the shift value with "(BitsPerInt - 1)" or "(BitsPerLong - 1)"

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
@@ -28,7 +28,7 @@
  * @summary aarch64: fix SVE patterns for vector shift count
  *
  * @requires vm.compiler2.enabled
- * @requires os.arch == "aarch64" | os.arch == "riscv64"
+ * @requires os.arch == "aarch64"
  * @run main/othervm -XX:UseSVE=2 -Xbatch -XX:-TieredCompilation
  *      -XX:CompileCommand=compileonly,compiler.c2.aarch64.TestVectorShiftShorts::test_*
  *      compiler.c2.aarch64.TestVectorShiftShorts

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
@@ -27,8 +27,7 @@
  * @bug 8255287
  * @summary aarch64: fix SVE patterns for vector shift count
  *
- * @requires vm.compiler2.enabled
- * @requires os.arch == "aarch64"
+ * @requires os.arch == "aarch64" & vm.compiler2.enabled
  * @run main/othervm -XX:UseSVE=2 -Xbatch -XX:-TieredCompilation
  *      -XX:CompileCommand=compileonly,compiler.c2.aarch64.TestVectorShiftShorts::test_*
  *      compiler.c2.aarch64.TestVectorShiftShorts

--- a/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
+++ b/test/hotspot/jtreg/compiler/c2/aarch64/TestVectorShiftShorts.java
@@ -27,7 +27,8 @@
  * @bug 8255287
  * @summary aarch64: fix SVE patterns for vector shift count
  *
- * @requires os.arch == "aarch64" & vm.compiler2.enabled
+ * @requires vm.compiler2.enabled
+ * @requires os.arch == "aarch64" | os.arch == "riscv64"
  * @run main/othervm -XX:UseSVE=2 -Xbatch -XX:-TieredCompilation
  *      -XX:CompileCommand=compileonly,compiler.c2.aarch64.TestVectorShiftShorts::test_*
  *      compiler.c2.aarch64.TestVectorShiftShorts

--- a/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
@@ -483,7 +483,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_mulc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*VALUE);
@@ -495,7 +495,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_mulc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*(-VALUE));
@@ -535,7 +535,7 @@ public class TestIntVect {
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -563,7 +563,7 @@ public class TestIntVect {
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -686,7 +686,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_sllc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<VALUE);
@@ -698,7 +698,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_sllc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-VALUE));
@@ -715,7 +715,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_sllc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<SHIFT);
@@ -732,7 +732,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_sllc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-SHIFT));
@@ -744,7 +744,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_sllv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<b);
@@ -756,7 +756,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srlc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>VALUE);
@@ -768,7 +768,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srlc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-VALUE));
@@ -785,7 +785,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srlc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>SHIFT);
@@ -802,7 +802,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srlc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-SHIFT));
@@ -814,7 +814,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srlv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>b);
@@ -826,7 +826,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srac(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>VALUE);
@@ -838,7 +838,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srac_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-VALUE));
@@ -855,7 +855,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srac_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>SHIFT);
@@ -872,7 +872,7 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srac_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-SHIFT));
@@ -884,7 +884,7 @@ public class TestIntVect {
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"})
+        applyIfCPUFeature = {"v", "true"})
     void test_srav(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>b);

--- a/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
@@ -481,6 +481,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_mulc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*VALUE);
@@ -490,6 +493,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_mulc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*(-VALUE));
@@ -522,6 +528,14 @@ public class TestIntVect {
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
         applyIfCPUFeatureOr = {"avx2", "true", "sve", "true"})
+    @IR(counts = { IRNode.ADD_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                   IRNode.RSHIFT_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                   IRNode.SUB_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -542,6 +556,14 @@ public class TestIntVect {
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
         applyIfCPUFeatureOr = {"avx2", "true", "sve", "true"})
+    @IR(counts = { IRNode.ADD_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                   IRNode.RSHIFT_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
+                   IRNode.SUB_VI,
+                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -662,6 +684,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_sllc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<VALUE);
@@ -671,6 +696,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_sllc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-VALUE));
@@ -683,6 +711,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_sllc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<SHIFT);
@@ -695,6 +728,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_sllc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-SHIFT));
@@ -704,6 +742,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_sllv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<b);
@@ -713,6 +754,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srlc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>VALUE);
@@ -722,6 +766,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srlc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-VALUE));
@@ -734,6 +781,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srlc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>SHIFT);
@@ -746,6 +798,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srlc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-SHIFT));
@@ -755,6 +812,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srlv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>b);
@@ -764,6 +824,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srac(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>VALUE);
@@ -773,6 +836,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srac_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-VALUE));
@@ -785,6 +851,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srac_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>SHIFT);
@@ -797,6 +868,11 @@ public class TestIntVect {
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
+                   IRNode.LOAD_VECTOR_I, "> 0",
+                   IRNode.STORE_VECTOR,  "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srac_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-SHIFT));
@@ -806,6 +882,9 @@ public class TestIntVect {
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
         applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
+        applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"})
     void test_srav(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>b);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -34,7 +34,8 @@ import jdk.test.lib.Utils;
  * @bug 8283307
  * @key randomness
  * @summary Auto-vectorization enhancement for unsigned shift right on signed subword types
- * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64"
+ * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64" |
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeURShiftSubword
  */

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -104,6 +104,7 @@ public class IREncodingPrinter {
         "asimd",
         "sve",
         // Riscv64
+        "v",
         "zvbb"
     ));
 

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -100,7 +100,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistConstant() {
         int[] res = new int[SIZE];
@@ -114,7 +114,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistInvariant() {
         int[] res = new int[SIZE];
@@ -128,7 +128,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistConstant() {
         short[] res = new short[SIZE];
@@ -142,7 +142,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistInvariant() {
         short[] res = new short[SIZE];
@@ -156,7 +156,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] longShiftLargeDistConstant() {
         long[] res = new long[SIZE];
@@ -170,7 +170,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] longShiftLargeDistInvariant() {
         long[] res = new long[SIZE];
@@ -206,7 +206,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.ArrayShiftOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -99,6 +99,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistConstant() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -109,6 +112,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.RSHIFT_VI, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistInvariant() {
         int[] res = new int[SIZE];
@@ -121,6 +127,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistConstant() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -131,6 +140,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.RSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistInvariant() {
         short[] res = new short[SIZE];
@@ -143,6 +155,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] longShiftLargeDistConstant() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -153,6 +168,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.URSHIFT_VL, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] longShiftLargeDistInvariant() {
         long[] res = new long[SIZE];
@@ -186,6 +204,9 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.RSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -191,6 +191,9 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.LSHIFT_VB, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VB, ">0"})
     public byte[] vectorShiftLeft() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -202,6 +205,9 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorSignedShiftRight() {
         byte[] res = new byte[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -212,6 +218,9 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
+        counts = {IRNode.RSHIFT_VB, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorUnsignedShiftRight() {
         byte[] res = new byte[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -192,7 +192,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.LSHIFT_VB, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VB, ">0"})
     public byte[] vectorShiftLeft() {
         byte[] res = new byte[SIZE];
@@ -206,7 +206,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorSignedShiftRight() {
         byte[] res = new byte[SIZE];
@@ -220,7 +220,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorUnsignedShiftRight() {
         byte[] res = new byte[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -194,7 +194,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VC, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VC, ">0"})
     public char[] vectorShiftLeft() {
         char[] res = new char[SIZE];
@@ -208,7 +208,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorSignedShiftRight() {
         char[] res = new char[SIZE];
@@ -222,7 +222,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorUnsignedShiftRight() {
         char[] res = new char[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -193,6 +193,9 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VC, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VC, ">0"})
     public char[] vectorShiftLeft() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -204,6 +207,9 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorSignedShiftRight() {
         char[] res = new char[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -214,6 +220,9 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.URSHIFT_VC, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorUnsignedShiftRight() {
         char[] res = new char[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -201,7 +201,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VI, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VI, ">0"})
     public int[] vectorShiftLeft() {
         int[] res = new int[SIZE];
@@ -215,7 +215,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] vectorSignedShiftRight() {
         int[] res = new int[SIZE];
@@ -229,7 +229,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VI, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.URSHIFT_VI, ">0"})
     public int[] vectorUnsignedShiftRight() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -200,6 +200,9 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VI, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VI, ">0"})
     public int[] vectorShiftLeft() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -211,6 +214,9 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] vectorSignedShiftRight() {
         int[] res = new int[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -221,6 +227,9 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.URSHIFT_VI, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.URSHIFT_VI, ">0"})
     public int[] vectorUnsignedShiftRight() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -36,7 +36,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   compiler.vectorization.runner.BasicLongOpTest
  *
- * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64")
+ * @requires (os.simpleArch == "x64") | (os.simpleArch == "aarch64") | (os.simpleArch == "riscv64")
  * @requires vm.compiler2.enabled
  */
 
@@ -192,6 +192,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] vectorShiftLeft() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -203,6 +206,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VL, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.RSHIFT_VL, ">0"})
     public long[] vectorSignedShiftRight() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -213,6 +219,9 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.URSHIFT_VL, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] vectorUnsignedShiftRight() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -193,7 +193,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] vectorShiftLeft() {
         long[] res = new long[SIZE];
@@ -207,7 +207,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VL, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VL, ">0"})
     public long[] vectorSignedShiftRight() {
         long[] res = new long[SIZE];
@@ -221,7 +221,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] vectorUnsignedShiftRight() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -191,6 +191,9 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
+        counts = {IRNode.LSHIFT_VS, ">0"})
     public short[] vectorShiftLeft() {
         short[] res = new short[SIZE];
         for (int i = 0; i < SIZE; i++) {
@@ -201,6 +204,9 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.RSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorSignedShiftRight() {
         short[] res = new short[SIZE];
@@ -237,6 +243,9 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     @Test
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
+        counts = {IRNode.RSHIFT_VS, ">0"})
+    @IR(applyIfPlatform = {"riscv64", "true"},
+        applyIfCPUFeature = {" v ", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -192,7 +192,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.LSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.LSHIFT_VS, ">0"})
     public short[] vectorShiftLeft() {
         short[] res = new short[SIZE];
@@ -206,7 +206,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorSignedShiftRight() {
         short[] res = new short[SIZE];
@@ -245,7 +245,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {" v ", "true"},
+        applyIfCPUFeature = {"v", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];


### PR DESCRIPTION
Hi,
Can you help to review this patch?
For vector shift instruct, some corresponding tests are not enabled, this is to enable them.
And the way how vector shift instruct works is not clear, especially both vectorization (SLP in jdk) and Vector API share the same instruct's in riscv_v.ad, so also added some comment to clarify it.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332153](https://bugs.openjdk.org/browse/JDK-8332153): RISC-V: enable tests and add comment for vector shift instruct (shared by vectorization and Vector API) (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19265/head:pull/19265` \
`$ git checkout pull/19265`

Update a local copy of the PR: \
`$ git checkout pull/19265` \
`$ git pull https://git.openjdk.org/jdk.git pull/19265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19265`

View PR using the GUI difftool: \
`$ git pr show -t 19265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19265.diff">https://git.openjdk.org/jdk/pull/19265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19265#issuecomment-2114951877)