### PR TITLE
fix hasJDKEvents remove Network IO JFR events and file force events since they had been made static mirror events

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -302,14 +302,11 @@ final class DCmdStart extends AbstractDCmd {
     }
 
     private boolean hasJDKEvents(Map<String, String> settings) {
-        String[] eventNames = new String[7];
+        String[] eventNames = new String[4];
         eventNames[0] = "FileRead";
         eventNames[1] = "FileWrite";
-        eventNames[2] = "SocketRead";
-        eventNames[3] = "SocketWrite";
-        eventNames[4] = "JavaErrorThrow";
-        eventNames[5] = "JavaExceptionThrow";
-        eventNames[6] = "FileForce";
+        eventNames[2] = "JavaErrorThrow";
+        eventNames[3] = "JavaExceptionThrow";
         for (String eventName : eventNames) {
             if ("true".equals(settings.get(Type.EVENT_NAME_PREFIX + eventName + "#enabled"))) {
                 return true;


### PR DESCRIPTION
According to:
 - [https://github.com/openjdk/jdk/commit/f4caac8dea1c95234743712386cb28a1ecb11197](https://github.com/openjdk/jdk/commit/f4caac8dea1c95234743712386cb28a1ecb11197)
- [https://github.com/openjdk/jdk/commit/b275bdd9b55b567cfe60c389d5ef8b70615928f4](https://github.com/openjdk/jdk/commit/b275bdd9b55b567cfe60c389d5ef8b70615928f4)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19267/head:pull/19267` \
`$ git checkout pull/19267`

Update a local copy of the PR: \
`$ git checkout pull/19267` \
`$ git pull https://git.openjdk.org/jdk.git pull/19267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19267`

View PR using the GUI difftool: \
`$ git pr show -t 19267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19267.diff">https://git.openjdk.org/jdk/pull/19267.diff</a>

</details>
