### PR TITLE
if JfrTryLock is not acquired, there is no reason to generate RecordStackTrace

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.cpp
@@ -226,13 +226,13 @@ void ObjectSampler::sample(HeapWord* obj, size_t allocated, JavaThread* thread) 
   }
   const JfrBlobHandle bh = get_thread_blob(thread, thread_id, virtual_thread);
   assert(bh.valid(), "invariant");
-  RecordStackTrace rst(thread);
   // try enter critical section
   JfrTryLock tryLock(&_lock);
   if (!tryLock.acquired()) {
     log_trace(jfr, oldobject, sampling)("Skipping old object sample due to lock contention");
     return;
   }
+  RecordStackTrace rst(thread);
   instance().add(obj, allocated, thread_id, virtual_thread, bh, thread);
 }
 


### PR DESCRIPTION
if JfrTryLock is not acquired, there is no reason to generate RecordStackTrace and RecordStackTrace is a resource consuming operation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19268/head:pull/19268` \
`$ git checkout pull/19268`

Update a local copy of the PR: \
`$ git checkout pull/19268` \
`$ git pull https://git.openjdk.org/jdk.git pull/19268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19268`

View PR using the GUI difftool: \
`$ git pr show -t 19268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19268.diff">https://git.openjdk.org/jdk/pull/19268.diff</a>

</details>
