### PR TITLE
8332394: Add friendly output when @IR rule missing value

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -158,22 +158,22 @@ public class IREncodingPrinter {
         checkIRAnnotations(irAnno);
         if (isIRNodeUnsupported(irAnno)) {
             return false;
-        } else if (irAnno.applyIfPlatform().length != 0 && !hasAllRequiredPlatform(irAnno.applyIfPlatform())) {
+        } else if (irAnno.applyIfPlatform().length != 0 && !hasAllRequiredPlatform(irAnno.applyIfPlatform(), "applyIfPlatform")) {
             printDisableReason(m, "Constraint not met (applyIfPlatform)", irAnno.applyIfPlatform(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfPlatformAnd().length != 0 && !hasAllRequiredPlatform(irAnno.applyIfPlatformAnd())) {
+        } else if (irAnno.applyIfPlatformAnd().length != 0 && !hasAllRequiredPlatform(irAnno.applyIfPlatformAnd(), "applyIfPlatformAnd")) {
             printDisableReason(m, "Not all constraints are met (applyIfPlatformAnd)", irAnno.applyIfPlatformAnd(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfPlatformOr().length != 0 && !hasAnyRequiredPlatform(irAnno.applyIfPlatformOr())) {
+        } else if (irAnno.applyIfPlatformOr().length != 0 && !hasAnyRequiredPlatform(irAnno.applyIfPlatformOr(), "applyIfPlatformOr")) {
             printDisableReason(m, "None of the constraints are met (applyIfPlatformOr)", irAnno.applyIfPlatformOr(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfCPUFeature().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeature())) {
+        } else if (irAnno.applyIfCPUFeature().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeature(), "applyIfCPUFeature")) {
             printDisableReason(m, "Feature constraint not met (applyIfCPUFeature)", irAnno.applyIfCPUFeature(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfCPUFeatureAnd().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeatureAnd())) {
+        } else if (irAnno.applyIfCPUFeatureAnd().length != 0 && !hasAllRequiredCPUFeature(irAnno.applyIfCPUFeatureAnd(), "applyIfCPUFeatureAnd")) {
             printDisableReason(m, "Not all feature constraints are met (applyIfCPUFeatureAnd)", irAnno.applyIfCPUFeatureAnd(), ruleIndex, ruleMax);
             return false;
-        } else if (irAnno.applyIfCPUFeatureOr().length != 0 && !hasAnyRequiredCPUFeature(irAnno.applyIfCPUFeatureOr())) {
+        } else if (irAnno.applyIfCPUFeatureOr().length != 0 && !hasAnyRequiredCPUFeature(irAnno.applyIfCPUFeatureOr(), "applyIfCPUFeatureOr")) {
             printDisableReason(m, "None of the feature constraints met (applyIfCPUFeatureOr)", irAnno.applyIfCPUFeatureOr(), ruleIndex, ruleMax);
             return false;
         } else if (irAnno.applyIf().length != 0 && !hasAllRequiredFlags(irAnno.applyIf(), "applyIf")) {
@@ -285,24 +285,24 @@ public class IREncodingPrinter {
         return returnValue;
     }
 
-    private boolean hasAllRequiredPlatform(String[] andRules) {
+    private boolean hasAllRequiredPlatform(String[] andRules, String ruleType) {
         boolean returnValue = true;
         for (int i = 0; i < andRules.length; i++) {
             String platform = andRules[i].trim();
             i++;
-            TestFormat.check(i < andRules.length, "Missing value for platform " + platform + failAt());
+            TestFormat.check(i < andRules.length, "Missing value for platform " + platform + " in " + ruleType + failAt());
             String value = andRules[i].trim();
             returnValue &= checkPlatform(platform, value);
         }
         return returnValue;
     }
 
-    private boolean hasAnyRequiredPlatform(String[] orRules) {
+    private boolean hasAnyRequiredPlatform(String[] orRules, String ruleType) {
         boolean returnValue = false;
         for (int i = 0; i < orRules.length; i++) {
             String platform = orRules[i].trim();
             i++;
-            TestFormat.check(i < orRules.length, "Missing value for platform " + platform + failAt());
+            TestFormat.check(i < orRules.length, "Missing value for platform " + platform + " in " + ruleType + failAt());
             String value = orRules[i].trim();
             returnValue |= checkPlatform(platform, value);
         }
@@ -363,24 +363,24 @@ public class IREncodingPrinter {
         return (trueValue && currentPlatform.contains(platform)) || (falseValue && !currentPlatform.contains(platform));
     }
 
-    private boolean hasAllRequiredCPUFeature(String[] andRules) {
+    private boolean hasAllRequiredCPUFeature(String[] andRules, String ruleType) {
         boolean returnValue = true;
         for (int i = 0; i < andRules.length; i++) {
             String feature = andRules[i].trim();
             i++;
-            TestFormat.check(i < andRules.length, "Missing value for cpu feature " + feature + failAt());
+            TestFormat.check(i < andRules.length, "Missing value for cpu feature " + feature + " in " + ruleType + failAt());
             String value = andRules[i].trim();
             returnValue &= checkCPUFeature(feature, value);
         }
         return returnValue;
     }
 
-    private boolean hasAnyRequiredCPUFeature(String[] orRules) {
+    private boolean hasAnyRequiredCPUFeature(String[] orRules, String ruleType) {
         boolean returnValue = false;
         for (int i = 0; i < orRules.length; i++) {
             String feature = orRules[i].trim();
             i++;
-            TestFormat.check(i < orRules.length, "Missing value for cpu feature " + feature + failAt());
+            TestFormat.check(i < orRules.length, "Missing value for cpu feature " + feature + " in " + ruleType + failAt());
             String value = orRules[i].trim();
             returnValue |= checkCPUFeature(feature, value);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -290,6 +290,7 @@ public class IREncodingPrinter {
         for (int i = 0; i < andRules.length; i++) {
             String platform = andRules[i].trim();
             i++;
+            TestFormat.check(i < andRules.length, "Missing value for platform " + platform + failAt());
             String value = andRules[i].trim();
             returnValue &= checkPlatform(platform, value);
         }
@@ -301,6 +302,7 @@ public class IREncodingPrinter {
         for (int i = 0; i < orRules.length; i++) {
             String platform = orRules[i].trim();
             i++;
+            TestFormat.check(i < orRules.length, "Missing value for platform " + platform + failAt());
             String value = orRules[i].trim();
             returnValue |= checkPlatform(platform, value);
         }
@@ -366,6 +368,7 @@ public class IREncodingPrinter {
         for (int i = 0; i < andRules.length; i++) {
             String feature = andRules[i].trim();
             i++;
+            TestFormat.check(i < andRules.length, "Missing value for cpu feature " + feature + failAt());
             String value = andRules[i].trim();
             returnValue &= checkCPUFeature(feature, value);
         }
@@ -377,6 +380,7 @@ public class IREncodingPrinter {
         for (int i = 0; i < orRules.length; i++) {
             String feature = orRules[i].trim();
             i++;
+            TestFormat.check(i < orRules.length, "Missing value for cpu feature " + feature + failAt());
             String value = orRules[i].trim();
             returnValue |= checkCPUFeature(feature, value);
         }


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
Currently, when a @IR rule like "applyIfPlatform" or "applyIfCPUFeature" miss a value, it will just throw ArrayIndexOutOfBoundsException, with no other information. This is confusing unless you dig into the test frame code.
It's helpful to output more meaningful information.
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332394](https://bugs.openjdk.org/browse/JDK-8332394): Add friendly output when @<!---->IR rule missing value (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [529257fd](https://git.openjdk.org/jdk/pull/19270/files/529257fd2903f9ef886c417848a8a86124045def)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19270/head:pull/19270` \
`$ git checkout pull/19270`

Update a local copy of the PR: \
`$ git checkout pull/19270` \
`$ git pull https://git.openjdk.org/jdk.git pull/19270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19270`

View PR using the GUI difftool: \
`$ git pr show -t 19270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19270.diff">https://git.openjdk.org/jdk/pull/19270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19270#issuecomment-2115342582)