### PR TITLE
8332154: Memory leak in SynchronousQueue

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/SynchronousQueue.java
@@ -194,6 +194,8 @@ public class SynchronousQueue<E> extends AbstractQueue<E>
                     if ((m = s.await(e, ns, this,  // spin if (nearly) empty
                                      p == null || p.waiter == null)) == e)
                         unspliceLifo(s);           // cancelled
+                    else if (m != null)
+                        s.selfLinkItem();
                     break;
                 }
             }

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -667,6 +667,7 @@ public class JSR166TestCase extends TestCase {
         if (atLeastJava20()) {
             String[] java20TestClassNames = {
                 "ForkJoinPool20Test",
+                "SynchronousQueue20Test",
             };
             addNamedTestClasses(suite, java20TestClassNames);
         }

--- a/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
+++ b/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
@@ -73,25 +73,13 @@ public class SynchronousQueue20Test extends JSR166TestCase {
                 executor.submit(() -> {
                     var item = new Item();
                     survivors.put(item, null);
-                    while(true) {
-                        try {
-                            queue.put(item);
-                            break;
-                        } catch (InterruptedException ie) {
-                            // Retry
-                        }
-                    }
+                    queue.put(item);
+                    return null;
                 });
 
                 executor.submit(() -> {
-                    while(true) {
-                        try {
-                            queue.take();
-                            break;
-                        } catch (InterruptedException ie) {
-                            // Retry
-                        }
-                    }
+                    queue.take();
+                    return null;
                 });
             }
         } // Close waits until all tasks are done

--- a/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
+++ b/test/jdk/java/util/concurrent/tck/SynchronousQueue20Test.java
@@ -1,0 +1,115 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * This file is available under and governed by the GNU General Public
+ * License version 2 only, as published by the Free Software Foundation.
+ * However, the following notice accompanied the original version of this
+ * file:
+ *
+ * Written by Doug Lea with assistance from members of JCP JSR-166
+ * Expert Group and released to the public domain, as explained at
+ * http://creativecommons.org/publicdomain/zero/1.0/
+ * Other contributors include Andrew Wright, Jeffrey Hayes,
+ * Pat Fisher, Mike Judd.
+ */
+
+import junit.framework.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
+
+public class SynchronousQueue20Test extends JSR166TestCase {
+
+    public static void main(String[] args) {
+        main(suite(), args);
+    }
+
+    public static Test suite() {
+        return newTestSuite(SynchronousQueue20Test.class);
+    }
+
+    public void testFairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(true));
+    }
+
+    public void testUnfairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(false));
+    }
+
+    private void assertDoesntLeak(SynchronousQueue<Object> queue) throws InterruptedException {
+        final int NUMBER_OF_ITEMS = 250;
+        final int MAX_ROUNDS = 200;
+        final int ROUND_WAIT_MILLIS = 50;
+
+        final CountDownLatch allProduced = new CountDownLatch(NUMBER_OF_ITEMS);
+        final CountDownLatch allConsumed = new CountDownLatch(NUMBER_OF_ITEMS);
+
+        class Item {}
+        final Map<Item, Void> survivors =
+                Collections.synchronizedMap(WeakHashMap.newWeakHashMap(NUMBER_OF_ITEMS));
+
+        for(int i = 0;i < NUMBER_OF_ITEMS;++i) {
+            Thread.ofVirtual().start(() -> {
+                var item = new Item();
+                survivors.put(item, null);
+                while(true) {
+                    try {
+                        queue.put(item);
+                        break;
+                    } catch (InterruptedException ie) {
+                        // Retry
+                    }
+                }
+                allProduced.countDown();
+            });
+
+            Thread.ofVirtual().start(() -> {
+                while(true) {
+                    try {
+                        queue.take();
+                        break;
+                    } catch (InterruptedException ie) {
+                        // Retry
+                    }
+                }
+                allConsumed.countDown();
+            });
+        }
+
+        assertTrue(allProduced.await(10, TimeUnit.SECONDS));
+        assertTrue(allConsumed.await(10, TimeUnit.SECONDS));
+        var round = 0;
+        while(!survivors.isEmpty() && round++ < MAX_ROUNDS) {
+            System.gc();
+            Thread.sleep(ROUND_WAIT_MILLIS); // We don't expect interruptions
+        }
+
+        assertTrue(survivors.isEmpty());
+        assertTrue(queue.isEmpty()); // Make sure that the queue survives until the end
+    }
+
+}

--- a/test/jdk/java/util/concurrent/tck/SynchronousQueueTest.java
+++ b/test/jdk/java/util/concurrent/tck/SynchronousQueueTest.java
@@ -38,13 +38,17 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.WeakHashMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.Test;
 
@@ -651,6 +655,66 @@ public class SynchronousQueueTest extends JSR166TestCase {
         Collection<?> q = new SynchronousQueue<>();
         assertFalse(q.contains(null));
         assertFalse(q.remove(null));
+    }
+
+    public void testFairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(true));
+    }
+
+    public void testUnfairDoesntLeak() throws InterruptedException {
+        assertDoesntLeak(new SynchronousQueue<>(false));
+    }
+
+    private void assertDoesntLeak(SynchronousQueue<Object> queue) throws InterruptedException {
+        final int NUMBER_OF_ITEMS = 250;
+        final int MAX_ROUNDS = 200;
+        final int ROUND_WAIT_MILLIS = 50;
+
+        final CountDownLatch allProduced = new CountDownLatch(NUMBER_OF_ITEMS);
+        final CountDownLatch allConsumed = new CountDownLatch(NUMBER_OF_ITEMS);
+
+        class Item {}
+        final Map<Item, Void> survivors =
+                Collections.synchronizedMap(WeakHashMap.newWeakHashMap(NUMBER_OF_ITEMS));
+
+        for(int i = 0;i < NUMBER_OF_ITEMS;++i) {
+            new Thread(() -> {
+                var item = new Item();
+                survivors.put(item, null);
+                while(true) {
+                    try {
+                        queue.put(item);
+                        break;
+                    } catch (InterruptedException ie) {
+                        // Retry
+                    }
+                }
+                allProduced.countDown();
+            }).start();
+
+            new Thread(() -> {
+                while(true) {
+                    try {
+                        queue.take();
+                        break;
+                    } catch (InterruptedException ie) {
+                        // Retry
+                    }
+                }
+                allConsumed.countDown();
+            }).start();
+        }
+
+        assertTrue(allProduced.await(10, TimeUnit.SECONDS));
+        assertTrue(allConsumed.await(10, TimeUnit.SECONDS));
+        var round = 0;
+        while(!survivors.isEmpty() && round++ < MAX_ROUNDS) {
+            System.gc();
+            Thread.sleep(ROUND_WAIT_MILLIS); // We don't expect interruptions
+        }
+
+        assertTrue(survivors.isEmpty());
+        assertTrue(queue.isEmpty()); // Make sure that the queue survives until the end
     }
 
 }


### PR DESCRIPTION
Local testing seems to indicate that this fix (which mirrors what's done in the FIFO mode) addresses the problem. Regression test added for JDK20+

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332154](https://bugs.openjdk.org/browse/JDK-8332154): Memory leak in SynchronousQueue (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19271/head:pull/19271` \
`$ git checkout pull/19271`

Update a local copy of the PR: \
`$ git checkout pull/19271` \
`$ git pull https://git.openjdk.org/jdk.git pull/19271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19271`

View PR using the GUI difftool: \
`$ git pr show -t 19271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19271.diff">https://git.openjdk.org/jdk/pull/19271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19271#issuecomment-2115488408)