### PR TITLE
8332403: Anachronistic reference to Netscape Communicator in Swing API docs

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/CellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/CellEditor.java
@@ -87,7 +87,7 @@ public interface CellEditor {
      * Returns true if the editing cell should be selected, false otherwise.
      * Typically, the return value is true, because in most cases the editing
      * cell should be selected.  However, it is useful to return false to
-     * keep the selection from changing for some types of edits.
+     * keep the selection from changing for some types of edits,
      * eg. in a table that contains a column of check boxes, the user might
      * want to be able to change those checkboxes without altering the
      * selection.

--- a/src/java.desktop/share/classes/javax/swing/CellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/CellEditor.java
@@ -90,7 +90,7 @@ public interface CellEditor {
      * keep the selection from changing for some types of edits.
      * eg. A table that contains a column of check boxes, the user might
      * want to be able to change those checkboxes without altering the
-     * selection.  (See Netscape Communicator for just such an example)
+     * selection.
      * Of course, it is up to the client of the editor to use the return
      * value, but it doesn't need to if it doesn't want to.
      *

--- a/src/java.desktop/share/classes/javax/swing/CellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/CellEditor.java
@@ -88,7 +88,7 @@ public interface CellEditor {
      * Typically, the return value is true, because in most cases the editing
      * cell should be selected.  However, it is useful to return false to
      * keep the selection from changing for some types of edits,
-     * eg. in a table that contains a column of check boxes, the user might
+     * e.g. in a table that contains a column of check boxes, the user might
      * want to be able to change those checkboxes without altering the
      * selection.
      * Of course, it is up to the client of the editor to use the return

--- a/src/java.desktop/share/classes/javax/swing/CellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/CellEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/CellEditor.java
+++ b/src/java.desktop/share/classes/javax/swing/CellEditor.java
@@ -85,10 +85,10 @@ public interface CellEditor {
 
     /**
      * Returns true if the editing cell should be selected, false otherwise.
-     * Typically, the return value is true, because is most cases the editing
+     * Typically, the return value is true, because in most cases the editing
      * cell should be selected.  However, it is useful to return false to
      * keep the selection from changing for some types of edits.
-     * eg. A table that contains a column of check boxes, the user might
+     * eg. in a table that contains a column of check boxes, the user might
      * want to be able to change those checkboxes without altering the
      * selection.
      * Of course, it is up to the client of the editor to use the return


### PR DESCRIPTION
Inadvertent mention of Netscape in Javadoc is removed..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332403](https://bugs.openjdk.org/browse/JDK-8332403): Anachronistic reference to Netscape Communicator in Swing API docs (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [310635fc](https://git.openjdk.org/jdk/pull/19276/files/310635fca2e254b69b29a4b04c8bc2594fdead3b)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [fed045f8](https://git.openjdk.org/jdk/pull/19276/files/fed045f8303681ab19ac5ebfc761bcf0a629eb8c)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [fed045f8](https://git.openjdk.org/jdk/pull/19276/files/fed045f8303681ab19ac5ebfc761bcf0a629eb8c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19276/head:pull/19276` \
`$ git checkout pull/19276`

Update a local copy of the PR: \
`$ git checkout pull/19276` \
`$ git pull https://git.openjdk.org/jdk.git pull/19276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19276`

View PR using the GUI difftool: \
`$ git pr show -t 19276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19276.diff">https://git.openjdk.org/jdk/pull/19276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19276#issuecomment-2116569243)