### PR TITLE
8332369: C2: assert(false) failed: graph should be schedulable after JDK-8324517

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3620,15 +3620,13 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
 #endif
 
   case Op_ModI:
-    if (UseDivMod) {
+    if (UseDivMod && !n->has_prec_edges()) {
       // Check if a%b and a/b both exist
       Node* d = n->find_similar(Op_DivI);
-      if (d) {
+      if (d && !d->has_prec_edges()) {
         // Replace them with a fused divmod if supported
         if (Matcher::has_match_rule(Op_DivModI)) {
           DivModINode* divmod = DivModINode::make(n);
-          divmod->add_prec_from(n);
-          divmod->add_prec_from(d);
           d->subsume_by(divmod->div_proj(), this);
           n->subsume_by(divmod->mod_proj(), this);
         } else {
@@ -3642,15 +3640,13 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     break;
 
   case Op_ModL:
-    if (UseDivMod) {
+    if (UseDivMod && !n->has_prec_edges()) {
       // Check if a%b and a/b both exist
       Node* d = n->find_similar(Op_DivL);
-      if (d) {
+      if (d && !d->has_prec_edges()) {
         // Replace them with a fused divmod if supported
         if (Matcher::has_match_rule(Op_DivModL)) {
           DivModLNode* divmod = DivModLNode::make(n);
-          divmod->add_prec_from(n);
-          divmod->add_prec_from(d);
           d->subsume_by(divmod->div_proj(), this);
           n->subsume_by(divmod->mod_proj(), this);
         } else {
@@ -3664,15 +3660,13 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     break;
 
   case Op_UModI:
-    if (UseDivMod) {
+    if (UseDivMod && !n->has_prec_edges()) {
       // Check if a%b and a/b both exist
       Node* d = n->find_similar(Op_UDivI);
-      if (d) {
+      if (d && !d->has_prec_edges()) {
         // Replace them with a fused unsigned divmod if supported
         if (Matcher::has_match_rule(Op_UDivModI)) {
           UDivModINode* divmod = UDivModINode::make(n);
-          divmod->add_prec_from(n);
-          divmod->add_prec_from(d);
           d->subsume_by(divmod->div_proj(), this);
           n->subsume_by(divmod->mod_proj(), this);
         } else {
@@ -3686,15 +3680,13 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     break;
 
   case Op_UModL:
-    if (UseDivMod) {
+    if (UseDivMod && !n->has_prec_edges()) {
       // Check if a%b and a/b both exist
       Node* d = n->find_similar(Op_UDivL);
-      if (d) {
+      if (d && !d->has_prec_edges()) {
         // Replace them with a fused unsigned divmod if supported
         if (Matcher::has_match_rule(Op_UDivModL)) {
           UDivModLNode* divmod = UDivModLNode::make(n);
-          divmod->add_prec_from(n);
-          divmod->add_prec_from(d);
           d->subsume_by(divmod->div_proj(), this);
           n->subsume_by(divmod->mod_proj(), this);
         } else {

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2878,15 +2878,6 @@ void Node::ensure_control_or_add_prec(Node* c) {
   }
 }
 
-void Node::add_prec_from(Node* n) {
-  for (uint i = n->req(); i < n->len(); i++) {
-    Node* prec = n->in(i);
-    if (prec != nullptr) {
-      add_prec(prec);
-    }
-  }
-}
-
 bool Node::is_dead_loop_safe() const {
   if (is_Phi()) {
     return true;

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -560,6 +560,7 @@ public:
   // Add or remove precedence edges
   void add_prec( Node *n );
   void rm_prec( uint i );
+  bool has_prec_edges() const { return len() > req(); }
 
   // Note: prec(i) will not necessarily point to n if edge already exists.
   void set_prec( uint i, Node *n ) {
@@ -1143,7 +1144,6 @@ public:
 
   // Set control or add control as precedence edge
   void ensure_control_or_add_prec(Node* c);
-  void add_prec_from(Node* n);
 
   // Visit boundary uses of the node and apply a callback function for each.
   // Recursively traverse uses, stopping and applying the callback when

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -78,8 +78,6 @@ compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
 compiler/startup/StartupOutput.java 8326615 generic-x64
 
-compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java 8332369 generic-all
-
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
The issue occurs when a `Mod` node is processed during
final_graph_reshaping: if a `Div` node is found with the same inputs,
the `Mod` is replaced either by a `DivMod` node or a subgraph that has
the `Div` node as input. Finding the `Div` node is done
`find_similar()` which ignores the precedence edges. What happens is
that the `Div` node returned by `find_similar()` could have a
precedence edge that pins it at a control that doesn't dominate the
control of some of the uses of the `Mod` node.

The fix I propose is to simply not perfom the transformation if one of
the nodes has precedence edges (which should be a rare corner case).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332369](https://bugs.openjdk.org/browse/JDK-8332369): C2: assert(false) failed: graph should be schedulable after JDK-8324517 (**Bug** - P2) ⚠️ Issue is not open.


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19277/head:pull/19277` \
`$ git checkout pull/19277`

Update a local copy of the PR: \
`$ git checkout pull/19277` \
`$ git pull https://git.openjdk.org/jdk.git pull/19277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19277`

View PR using the GUI difftool: \
`$ git pr show -t 19277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19277.diff">https://git.openjdk.org/jdk/pull/19277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19277#issuecomment-2116963928)