### PR TITLE
JDK-8332473: ubsan: growableArray.hpp:290:10: runtime error: null pointer passed as argument 1, which is declared to never be null

### DIFF
--- a/src/hotspot/share/utilities/growableArray.hpp
+++ b/src/hotspot/share/utilities/growableArray.hpp
@@ -287,10 +287,12 @@ public:
   }
 
   void sort(int f(E*, E*)) {
+    if (_data == nullptr) return;
     qsort(_data, length(), sizeof(E), (_sort_Fn)f);
   }
   // sort by fixed-stride sub arrays:
   void sort(int f(E*, E*), int stride) {
+    if (_data == nullptr) return;
     qsort(_data, length() / stride, sizeof(E) * stride, (_sort_Fn)f);
   }
 


### PR DESCRIPTION
On Linux x86_64 fastdebug with ubsan enabled we run into this error

/jdk/src/hotspot/share/utilities/growableArray.hpp:290:10: runtime error: null pointer passed as argument 1, which is declared to never be null
    #0 0x150d701bb4b1 in GrowableArrayView<nmethod*>::sort(int (*)(nmethod**, nmethod**)) /jdk/src/hotspot/share/utilities/growableArray.hpp:290
    #1 0x150d701bb4b1 in ClassUnloadingContext::free_nmethods() /jdk/src/hotspot/share/gc/shared/classUnloadingContext.cpp:159
    #2 0x150d71f5cca3 in G1CollectedHeap::unload_classes_and_code(char const*, BoolObjectClosure*, GCTimer*) /jdk/src/hotspot/share/gc/g1/g1CollectedHeap.cpp:2538
    #3 0x150d71ffb009 in G1FullCollector::phase1_mark_live_objects() /jdk/src/hotspot/share/gc/g1/g1FullCollector.cpp:330
    #4 0x150d71ffc675 in G1FullCollector::collect() /jdk/src/hotspot/share/gc/g1/g1FullCollector.cpp:209
    #5 0x150d71f3e593 in G1CollectedHeap::do_full_collection(bool, bool) /jdk/src/hotspot/share/gc/g1/g1CollectedHeap.cpp:842
    #6 0x150d71f5b12d in G1CollectedHeap::satisfy_failed_allocation_helper(unsigned long, bool, bool, bool, bool*) /jdk/src/hotspot/share/gc/g1/g1CollectedHeap.cpp:917
    #7 0x150d71f5b3dc in G1CollectedHeap::satisfy_failed_allocation(unsigned long, bool*) /jdk/src/hotspot/share/gc/g1/g1CollectedHeap.cpp:930
    #8 0x150d721835f7 in VM_G1CollectForAllocation::doit() /jdk/src/hotspot/share/gc/g1/g1VMOperations.cpp:127
    #9 0x150d74291ec8 in VM_Operation::evaluate() /jdk/src/hotspot/share/runtime/vmOperations.cpp:75
    #10 0x150d742ca1be in VMThread::evaluate_operation(VM_Operation*) /jdk/src/hotspot/share/runtime/vmThread.cpp:283
    #11 0x150d742cb9e7 in VMThread::inner_execute(VM_Operation*) /jdk/src/hotspot/share/runtime/vmThread.cpp:427
    #12 0x150d742cc601 in VMThread::loop() /jdk/src/hotspot/share/runtime/vmThread.cpp:493
    #13 0x150d742cc601 in VMThread::loop() /jdk/src/hotspot/share/runtime/vmThread.cpp:478

seems we sometimes call qsort with nullptr as first parameter, this is not recommended.
When adding a guarantee the same can be seen (_data is null).
So better add a check and do not sort, if there is nothing provided to be sorted .