### PR TITLE
8332462: ubsan: c1_ValueStack.hpp:229:49: runtime error: load of value 171, which is not a valid value for type 'bool'

### DIFF
--- a/src/hotspot/share/c1/c1_ValueStack.cpp
+++ b/src/hotspot/share/c1/c1_ValueStack.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ ValueStack::ValueStack(IRScope* scope, ValueStack* caller_state)
 , _locals(scope->method()->max_locals(), scope->method()->max_locals(), nullptr)
 , _stack(scope->method()->max_stack())
 , _locks(nullptr)
+, _force_reexecute(false)
 {
   verify();
 }
@@ -50,6 +51,7 @@ ValueStack::ValueStack(ValueStack* copy_from, Kind kind, int bci)
   , _locals(copy_from->locals_size_for_copy(kind))
   , _stack(copy_from->stack_size_for_copy(kind))
   , _locks(copy_from->locks_size() == 0 ? nullptr : new Values(copy_from->locks_size()))
+  , _force_reexecute(false)
 {
   switch (kind) {
   case EmptyExceptionState:


### PR DESCRIPTION
This coding, with ubsan enabled
  bool force_reexecute() const { return _force_reexecute; }

gives us on Linux x86_64 fastdebug the following warning :

/jdk/src/hotspot/share/c1/c1_ValueStack.hpp:229:49: runtime error: load of value 171, which is not a valid value for type 'bool'
    #0 0x14b3999f2921 in ValueStack::force_reexecute() const /jdk/src/hotspot/share/c1/c1_ValueStack.hpp:229
    #1 0x14b3999f2921 in LIRGenerator::do_ArrayCopy(Intrinsic*) /jdk/src/hotspot/cpu/x86/c1_LIRGenerator_x86.cpp:1008
    #2 0x14b39aa1c077 in LIRGenerator::do_root(Instruction*) /jdk/src/hotspot/share/c1/c1_LIRGenerator.cpp:379
    #3 0x14b39aa2df94 in non-virtual thunk to LIRGenerator::block_do(BlockBegin*) (/net/usr.work/d040975/open_jdk/jdk_6/build_clx209_fastdebug/jdk/lib/server/libjvm.so+0x5ad1f94)
    #4 0x14b39a971ff6 in BlockList::iterate_forward(BlockClosure*) /jdk/src/hotspot/share/c1/c1_Instruction.cpp:891
    #5 0x14b39a878114 in Compilation::emit_lir() /jdk/src/hotspot/share/c1/c1_Compilation.cpp:264
    #6 0x14b39a882076 in Compilation::compile_java_method() /jdk/src/hotspot/share/c1/c1_Compilation.cpp:407
    #7 0x14b39a884c48 in Compilation::compile_method() /jdk/src/hotspot/share/c1/c1_Compilation.cpp:479
    #8 0x14b39a88681a in Compilation::Compilation(AbstractCompiler*, ciEnv*, ciMethod*, int, BufferBlob*, bool, DirectiveSet*) /jdk/src/hotspot/share/c1/c1_Compilation.cpp:609
    #9 0x14b39a88bd63 in Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) /jdk/src/hotspot/share/c1/c1_Compiler.cpp:260
    #10 0x14b39b153241 in CompileBroker::invoke_compiler_on_method(CompileTask*) /jdk/src/hotspot/share/compiler/compileBroker.cpp:2303
    #11 0x14b39b154d3e in CompileBroker::compiler_thread_loop() /jdk/src/hotspot/share/compiler/compileBroker.cpp:1961
    #12 0x14b39bdb17bc in JavaThread::thread_main_inner() /jdk/src/hotspot/share/runtime/javaThread.cpp:759
    #13 0x14b39d8a828f in Thread::call_run() /jdk/src/hotspot/share/runtime/thread.cpp:225
   ... (rest of output omitted)

Seems we miss initializations of the variable _force_reexecute , and this can lead to arbitrary values at the address in memory where  _force_reexecute is stored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332462: ubsan: c1_ValueStack.hpp:229:49: runtime error: load of value 171, which is not a valid value for type 'bool'`

### Issue
 * [JDK-8332462](https://bugs.openjdk.org/browse/JDK-8332462): ubsan: c1_ValueStack.hpp:229:49: runtime error: load of value 171, which is not a valid value for type 'bool' (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19284/head:pull/19284` \
`$ git checkout pull/19284`

Update a local copy of the PR: \
`$ git checkout pull/19284` \
`$ git pull https://git.openjdk.org/jdk.git pull/19284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19284`

View PR using the GUI difftool: \
`$ git pr show -t 19284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19284.diff">https://git.openjdk.org/jdk/pull/19284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19284#issuecomment-2117664108)