### PR TITLE
8332424: Update IANA Language Subtag Registry to Version 2024-05-16

### DIFF
--- a/src/java.base/share/data/lsrdata/language-subtag-registry.txt
+++ b/src/java.base/share/data/lsrdata/language-subtag-registry.txt
@@ -1,4 +1,4 @@
-File-Date: 2024-03-07
+File-Date: 2024-05-16
 %%
 Type: language
 Subtag: aa
@@ -9402,6 +9402,7 @@ Macrolanguage: doi
 %%
 Type: language
 Subtag: dgr
+Description: Tlicho
 Description: Dogrib
 Description: Tłı̨chǫ
 Added: 2005-10-16
@@ -15253,6 +15254,11 @@ Type: language
 Subtag: isu
 Description: Isu (Menchum Division)
 Added: 2009-07-29
+%%
+Type: language
+Subtag: isv
+Description: Interslavic
+Added: 2024-05-15
 %%
 Type: language
 Subtag: itb

--- a/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
+++ b/test/jdk/java/util/Locale/LanguageSubtagRegistryTest.java
@@ -25,9 +25,9 @@
  * @test
  * @bug 8025703 8040211 8191404 8203872 8222980 8225435 8241082 8242010 8247432
  *      8258795 8267038 8287180 8302512 8304761 8306031 8308021 8313702 8318322
- *      8327631
+ *      8327631 8332424
  * @summary Checks the IANA language subtag registry data update
- *          (LSR Revision: 2024-03-07) with Locale and Locale.LanguageRange
+ *          (LSR Revision: 2024-05-16) with Locale and Locale.LanguageRange
  *          class methods.
  * @run main LanguageSubtagRegistryTest
  */


### PR DESCRIPTION
Please review this PR which is a trivial update to the IANA sub tag registry to version 2024-05-16. Locale tests pass as expected after update.

Associated announcement -> https://mm.icann.org/pipermail/ietf-languages-announcements/2024-May/000091.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332424](https://bugs.openjdk.org/browse/JDK-8332424): Update IANA Language Subtag Registry to Version 2024-05-16 (**Enhancement** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19286/head:pull/19286` \
`$ git checkout pull/19286`

Update a local copy of the PR: \
`$ git checkout pull/19286` \
`$ git pull https://git.openjdk.org/jdk.git pull/19286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19286`

View PR using the GUI difftool: \
`$ git pr show -t 19286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19286.diff">https://git.openjdk.org/jdk/pull/19286.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19286#issuecomment-2118142341)