### PR TITLE
8332297: annotation processor that generates records sometimes fails due to NPE in javac

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1552,9 +1552,11 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
             RecordComponent toRemove = null;
             for (RecordComponent rc : recordComponents) {
                 /* it could be that a record erroneously declares two record components with the same name, in that
-                 * case we need to use the position to disambiguate
+                 * case we need to use the position to disambiguate, but if we loaded the record from a class file
+                 * all positions will be -1, in that case we have to ignore the position and match only based on the
+                 * name
                  */
-                if (rc.name == var.name && var.pos == rc.pos) {
+                if (rc.name == var.name && (var.pos == rc.pos || rc.pos == -1)) {
                     toRemove = rc;
                 }
             }

--- a/test/langtools/tools/javac/processing/RecordGenerationTest.java
+++ b/test/langtools/tools/javac/processing/RecordGenerationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8332297
+ * @summary annotation processor that generates records sometimes fails due to NPE in javac
+ * @library /tools/lib /tools/javac/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask toolbox.Task
+ * @build RecordGenerationTest JavacTestingAbstractProcessor
+ * @run main RecordGenerationTest
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+
+import javax.annotation.processing.FilerException;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedOptions;
+import javax.annotation.processing.SupportedAnnotationTypes;
+
+import javax.lang.model.element.TypeElement;
+import javax.tools.StandardLocation;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class RecordGenerationTest {
+    public static void main(String... args) throws Exception {
+        new RecordGenerationTest().run();
+    }
+
+    Path[] findJavaFiles(Path... paths) throws Exception {
+        return tb.findJavaFiles(paths);
+    }
+
+    ToolBox tb = new ToolBox();
+
+    void run() throws Exception {
+        Path allInOne = Paths.get("allInOne");
+        if (Files.isDirectory(allInOne)) {
+            tb.cleanDirectory(allInOne);
+        }
+        Files.deleteIfExists(allInOne);
+        tb.createDirectories(allInOne);
+
+        tb.writeJavaFiles(allInOne,
+                """
+                import java.io.IOException;
+                import java.io.OutputStream;
+                import java.io.Writer;
+                import java.nio.file.Files;
+                import java.nio.file.Path;
+                import java.nio.file.Paths;
+                import java.util.Set;
+
+                import javax.annotation.processing.AbstractProcessor;
+                import javax.annotation.processing.FilerException;
+                import javax.annotation.processing.RoundEnvironment;
+                import javax.annotation.processing.SupportedOptions;
+                import javax.annotation.processing.SupportedAnnotationTypes;
+
+                import javax.lang.model.element.TypeElement;
+                import javax.tools.StandardLocation;
+
+                @SupportedAnnotationTypes("*")
+                public class AP extends AbstractProcessor {
+                    @Override
+                    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+                        if (roundEnv.processingOver()) {
+                            try (Writer w = processingEnv.getFiler().createSourceFile("ConfRecord").openWriter()) {
+                                w.append("@RecordBuilder public record ConfRecord(int maxConcurrency) implements Conf {}");
+                            } catch (IOException ex) {
+                                throw new IllegalStateException(ex);
+                            }
+                        }
+                        return true;
+                    }
+                }
+                """
+        );
+
+        new JavacTask(tb).options("-d", allInOne.toString())
+                .files(findJavaFiles(allInOne))
+                .run()
+                .writeAll();
+
+        tb.writeJavaFiles(allInOne,
+                """
+                interface Conf {
+                    int maxConcurrency( );
+                }
+                """,
+                """
+                import java.lang.annotation.*;
+                public @interface RecordBuilder {
+                }
+                """
+        );
+
+        Path confSource = Paths.get(allInOne.toString(), "Conf.java");
+        new JavacTask(tb).options("-processor", "AP",
+                "-cp", allInOne.toString(),
+                "-d", allInOne.toString())
+                .files(confSource)
+                .run()
+                .writeAll();
+
+        /* the bug reported at JDK-8332297 was reproducible only every other time this is why we reproduce
+         * the same compilation command as above basically the second time the compiler is completing the
+         * record symbol from the class file produced during the first compilation
+         */
+        new JavacTask(tb).options("-processor", "AP",
+                "-cp", allInOne.toString(),
+                "-d", allInOne.toString())
+                .files(confSource)
+                .run()
+                .writeAll();
+    }
+}


### PR DESCRIPTION
This bug is a bit particular regarding how to reproduce it. Having:
```
import java.lang.annotation.*;
public @interface RecordBuilder {}

interface Conf {
    int maxConcurrency( );
}
```
and:
```
import java.lang.annotation.*;
public @interface RecordBuilder {
}
```
and:
```
import java.util.*;
import java.io.*;

import javax.annotation.processing.*;
import javax.lang.model.element.TypeElement;
import javax.tools.StandardLocation;

@SupportedAnnotationTypes("*")
public class SimplestAP extends AbstractProcessor {
    @Override
    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
        if (roundEnv.processingOver()) {
            try (Writer w = processingEnv.getFiler().createSourceFile("ConfRecord").openWriter()) {
                w.append("@RecordBuilder public record ConfRecord(int maxConcurrency) implements Conf {}");
            } catch (IOException ex) {
                throw new IllegalStateException(ex);
            }
        }
        return true;
    }
}
```
do:
```
javac SimplestAP.java

javac -processor SimplestAP Conf.java //compiles fine
javac -processor SimplestAP Conf.java // fails with:
```
```
warning: No SupportedSourceVersion annotation found on SimplestAP, returning RELEASE_6.
warning: Supported source version 'RELEASE_6' from annotation processor 'SimplestAP' less than -source '23'
warning: File for type 'ConfRecord' created in the last round will not be subject to annotation processing.
3 warnings
An exception has occurred in the compiler (23-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot invoke "com.sun.tools.javac.code.Symbol$MethodSymbol.flags()" because "rc.accessor" is null
at jdk.compiler/com.sun.tools.javac.comp.Lower.lambda$generateMandatedAccessors$6(Lower.java:2403)
at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:196)
at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)
at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)
at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)
at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:727)
at jdk.compiler/com.sun.tools.javac.comp.Lower.generateMandatedAccessors(Lower.java:2410)
at jdk.compiler/com.sun.tools.javac.comp.Lower.visitRecordDef(Lower.java:2607)
at jdk.compiler/com.sun.tools.javac.comp.Lower.visitClassDef(Lower.java:2300)
at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:855)
at jdk.compiler/com.sun.tools.javac.tree.TreeTranslator.translate(TreeTranslator.java:58)
at jdk.compiler/com.sun.tools.javac.comp.Lower.translate(Lower.java:2192)
at jdk.compiler/com.sun.tools.javac.comp.Lower.translate(Lower.java:2211)
at jdk.compiler/com.sun.tools.javac.comp.Lower.translateTopLevelClass(Lower.java:4475)
at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.desugar(JavaCompiler.java:1647)
at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.desugar(JavaCompiler.java:1467)
at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:977)
at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:66)
at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:52)
```
so the first time file ConfRecord.java is produced by the annotation processor, and later compiled by javac so all the information is gathered from a source file. The second time, ConfRecord.class is found, loaded and symbol for ConfRecord is completed from there. As the class file doesn't store the position of the record components in the original source file, method `ClassSymbol::findRecordComponentToRemove` won't find a match when trying to remove a record component and then two record components with the same name gets added to the record, currently we try to match on name and position. But for one of them there won't be an accessor assigned. We remove record components when dealing with annotation processors to make sure that later on we are propagating the correct annotations to other record elements the annotations could be applicable to.

The proposal here is to match only on name if the position is `-1` which is the default for all record components when the record class has been loaded from a class file.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332297: annotation processor that generates records sometimes fails due to NPE in javac`

### Issue
 * [JDK-8332297](https://bugs.openjdk.org/browse/JDK-8332297): annotation processor that generates records sometimes fails due to NPE in javac (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19288/head:pull/19288` \
`$ git checkout pull/19288`

Update a local copy of the PR: \
`$ git checkout pull/19288` \
`$ git pull https://git.openjdk.org/jdk.git pull/19288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19288`

View PR using the GUI difftool: \
`$ git pr show -t 19288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19288.diff">https://git.openjdk.org/jdk/pull/19288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19288#issuecomment-2118211011)