### PR TITLE
8331683: Clean up GetCarrierThread

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2624,11 +2624,3 @@ GetFrameLocationClosure::do_vthread(Handle target_h) {
   _result = ((JvmtiEnvBase*)_env)->get_frame_location(target_h(), _depth,
                                                       _method_ptr, _location_ptr);
 }
-
-void
-VirtualThreadGetThreadClosure::do_thread(Thread *target) {
-  assert(target->is_Java_thread(), "just checking");
-  JavaThread *jt = JavaThread::cast(target);
-  oop carrier_thread = java_lang_VirtualThread::carrier_thread(_vthread_h());
-  *_carrier_thread_ptr = (jthread)JNIHandles::make_local(jt, carrier_thread);
-}

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -784,24 +784,6 @@ public:
   void do_vthread(Handle target_h);
 };
 
-// HandshakeClosure to get virtual thread thread at safepoint.
-class VirtualThreadGetThreadClosure : public HandshakeClosure {
-private:
-  Handle _vthread_h;
-  jthread* _carrier_thread_ptr;
-  jvmtiError _result;
-
-public:
-  VirtualThreadGetThreadClosure(Handle vthread_h, jthread* carrier_thread_ptr)
-    : HandshakeClosure("VirtualThreadGetThread"),
-      _vthread_h(vthread_h),
-      _carrier_thread_ptr(carrier_thread_ptr),
-      _result(JVMTI_ERROR_NONE) {}
-
-  void do_thread(Thread *target);
-  jvmtiError result() { return _result; }
-};
-
 // ResourceTracker
 //
 // ResourceTracker works a little like a ResourceMark. All allocates

--- a/src/hotspot/share/prims/jvmtiExtensions.cpp
+++ b/src/hotspot/share/prims/jvmtiExtensions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,6 +130,10 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   thread_ptr = va_arg(ap, jthread*);
   va_end(ap);
 
+  if (thread_ptr == nullptr) {
+    return JVMTI_ERROR_NULL_POINTER;
+  }
+
   MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, current_thread));
   ThreadInVMfromNative tiv(current_thread);
   JvmtiVTMSTransitionDisabler disabler;
@@ -156,12 +160,11 @@ static jvmtiError JNICALL GetCarrierThread(const jvmtiEnv* env, ...) {
   if (!java_lang_VirtualThread::is_instance(vthread_oop)) {
     return JVMTI_ERROR_INVALID_THREAD;
   }
-  if (thread_ptr == nullptr) {
-    return JVMTI_ERROR_NULL_POINTER;
-  }
-  VirtualThreadGetThreadClosure op(Handle(current_thread, vthread_oop), thread_ptr);
-  Handshake::execute(&op, &tlh, current_thread);
-  return op.result();
+
+  oop carrier_thread = java_lang_VirtualThread::carrier_thread(vthread_oop);
+  *thread_ptr = (jthread)JNIHandles::make_local(current_thread, carrier_thread);
+
+  return JVMTI_ERROR_NONE;
 }
 
 // register extension functions and events. In this implementation we


### PR DESCRIPTION
JVMTI GetCarrierThread extension function was introduced by loom for testing.
It's used by several tests in hotspot/jtreg/serviceability.

Testings: tier1..tier6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331683](https://bugs.openjdk.org/browse/JDK-8331683): Clean up GetCarrierThread (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19289/head:pull/19289` \
`$ git checkout pull/19289`

Update a local copy of the PR: \
`$ git checkout pull/19289` \
`$ git pull https://git.openjdk.org/jdk.git pull/19289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19289`

View PR using the GUI difftool: \
`$ git pr show -t 19289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19289.diff">https://git.openjdk.org/jdk/pull/19289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19289#issuecomment-2118535999)