### PR TITLE
8332360: JVM hangs at exit when running on a uniprocessor

### DIFF
--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -987,6 +987,13 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
     guarantee(v == ObjectWaiter::TS_ENTER || v == ObjectWaiter::TS_CXQ, "invariant");
     assert(owner_raw() != current, "invariant");
 
+    // This thread has been notified to reacquire the lock.
+    if (TryLock(current) == TryLockResult::Success) {
+      break;
+    }
+
+    // If that fails, spin again.  Note that spin count may be zero so the above TryLock
+    // is necessary.
     if (TrySpin(current)) {
         break;
     }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -987,7 +987,7 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
     guarantee(v == ObjectWaiter::TS_ENTER || v == ObjectWaiter::TS_CXQ, "invariant");
     assert(owner_raw() != current, "invariant");
 
-    // This thread has been notified to reacquire the lock.
+    // This thread has been notified so reacquire the lock.
     if (TryLock(current) == TryLockResult::Success) {
       break;
     }

--- a/src/hotspot/share/runtime/objectMonitor.cpp
+++ b/src/hotspot/share/runtime/objectMonitor.cpp
@@ -987,7 +987,7 @@ void ObjectMonitor::ReenterI(JavaThread* current, ObjectWaiter* currentNode) {
     guarantee(v == ObjectWaiter::TS_ENTER || v == ObjectWaiter::TS_CXQ, "invariant");
     assert(owner_raw() != current, "invariant");
 
-    // This thread has been notified so reacquire the lock.
+    // This thread has been notified so try to reacquire the lock.
     if (TryLock(current) == TryLockResult::Success) {
       break;
     }


### PR DESCRIPTION
Restored the TryLock in the ReenterI (wait) case with a comment.

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332360](https://bugs.openjdk.org/browse/JDK-8332360): JVM hangs at exit when running on a uniprocessor (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [5c1cf6b2](https://git.openjdk.org/jdk/pull/19293/files/5c1cf6b27e9fe83d5b05d9f11f68fed23bf9c1e5)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**) ⚠️ Review applies to [5c1cf6b2](https://git.openjdk.org/jdk/pull/19293/files/5c1cf6b27e9fe83d5b05d9f11f68fed23bf9c1e5)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19293/head:pull/19293` \
`$ git checkout pull/19293`

Update a local copy of the PR: \
`$ git checkout pull/19293` \
`$ git pull https://git.openjdk.org/jdk.git pull/19293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19293`

View PR using the GUI difftool: \
`$ git pr show -t 19293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19293.diff">https://git.openjdk.org/jdk/pull/19293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19293#issuecomment-2119384491)