### PR TITLE
JDK-8332498

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -16230,7 +16230,7 @@ instruct partialSubtypeCheckConstSuper(iRegP_R4 sub, iRegP_R0 super_reg, immP su
   effect(KILL cr, TEMP tempR1, TEMP tempR2, TEMP tempR3, TEMP vtemp);
 
   ins_cost(700);  // smaller than the next version
-  format %{ "partialSubtypeCheck $result, $sub, super" %}
+  format %{ "partialSubtypeCheck $result, $sub, $super_reg, $super_con" %}
 
   ins_encode %{
     bool success = false;

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12094,7 +12094,7 @@ instruct partialSubtypeCheckConstSuper(rsi_RegP sub, rax_RegP super_reg, immP su
   effect(KILL cr, TEMP temp1, TEMP temp2, TEMP temp3, TEMP temp4);
 
   ins_cost(700);  // smaller than the next version
-  format %{ "partialSubtypeCheck $result, $sub, super" %}
+  format %{ "partialSubtypeCheck $result, $sub, $super_reg, $super_con" %}
 
   ins_encode %{
     u1 super_klass_slot = ((Klass*)$super_con$$constant)->hash_slot();


### PR DESCRIPTION
format method generated previously:
```
void partialSubtypeCheckConstSuperNode::format(PhaseRegAlloc *ra, outputStream *st) const {
  // Start at oper_input_base() and count operands
  unsigned idx0 = 1;
  unsigned idx1 = 1; 	// sub
  unsigned idx2 = idx1 + opnd_array(1)->num_edges(); 	// super_reg
  unsigned idx3 = idx2 + opnd_array(2)->num_edges(); 	// super_con
  unsigned idx4 = idx3 + opnd_array(3)->num_edges(); 	// vtemp
  unsigned idx5 = idx4 + opnd_array(4)->num_edges(); 	// tempR1
  unsigned idx6 = idx5 + opnd_array(5)->num_edges(); 	// tempR2
  unsigned idx7 = idx6 + opnd_array(6)->num_edges(); 	// tempR3
  st->print_raw("partialSubtypeCheck ");
  opnd_array(0)->int_format(ra, this, st); // result
  st->print_raw(", ");
  opnd_array(1)->ext_format(ra, this,idx1, st); // sub
  st->print_raw(", super");
}
```

format method generated with this change:
```
void partialSubtypeCheckConstSuperNode::format(PhaseRegAlloc *ra, outputStream *st) const {
  // Start at oper_input_base() and count operands
  unsigned idx0 = 1;
  unsigned idx1 = 1; 	// sub
  unsigned idx2 = idx1 + opnd_array(1)->num_edges(); 	// super_reg
  unsigned idx3 = idx2 + opnd_array(2)->num_edges(); 	// super_con
  unsigned idx4 = idx3 + opnd_array(3)->num_edges(); 	// vtemp
  unsigned idx5 = idx4 + opnd_array(4)->num_edges(); 	// tempR1
  unsigned idx6 = idx5 + opnd_array(5)->num_edges(); 	// tempR2
  unsigned idx7 = idx6 + opnd_array(6)->num_edges(); 	// tempR3
  st->print_raw("partialSubtypeCheck ");
  opnd_array(0)->int_format(ra, this, st); // result
  st->print_raw(", ");
  opnd_array(1)->ext_format(ra, this,idx1, st); // sub
  st->print_raw(", ");
  opnd_array(2)->ext_format(ra, this,idx2, st); // super_reg
  st->print_raw(", ");
  opnd_array(3)->ext_format(ra, this,idx3, st); // super_con
}
```