### PR TITLE
8332463: Byte conditional pattern case element dominates short constant case element

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4818,7 +4818,6 @@ public class Check {
                     JCCaseLabel testCaseLabel = caseAndLabel.snd;
                     Type testType = labelType(testCaseLabel);
                     boolean dominated = false;
-                    if (unconditionalCaseLabel == testCaseLabel) unconditionalFound = true;
                     if (types.isUnconditionallyExact(currentType, testType) &&
                         !currentType.hasTag(ERROR) && !testType.hasTag(ERROR)) {
                         //the current label is potentially dominated by the existing (test) label, check:
@@ -4831,11 +4830,6 @@ public class Check {
                             dominated = patternDominated(testPatternCaseLabel.pat,
                                                          patternCL.pat);
                         }
-                    }
-
-                    // Domination can occur even when we have not an unconditional pair between case labels.
-                    if (unconditionalFound && unconditionalCaseLabel != label) {
-                        dominated = true;
                     }
 
                     if (dominated) {

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.java
@@ -1,6 +1,6 @@
 /*
  * @test /nodynamiccopyright/
- * @bug 8304487 8325653
+ * @bug 8304487 8325653 8332463
  * @summary Compiler Implementation for Primitive types in patterns, instanceof, and switch (Preview)
  * @enablePreview
  * @compile/fail/ref=PrimitivePatternsSwitchErrors.out -XDrawDiagnostics -XDshould-stop.at=FLOW PrimitivePatternsSwitchErrors.java
@@ -59,7 +59,7 @@ public class PrimitivePatternsSwitchErrors {
         int i = 42;
         return switch (i) {
             case Integer ib  -> ib;
-            case byte ip     -> ip; // Error - dominated!
+            case byte ip     -> ip; // OK - not dominated!
         };
     }
 

--- a/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/PrimitivePatternsSwitchErrors.out
@@ -1,7 +1,6 @@
 PrimitivePatternsSwitchErrors.java:15:18: compiler.err.pattern.dominated
 PrimitivePatternsSwitchErrors.java:24:18: compiler.err.pattern.dominated
 PrimitivePatternsSwitchErrors.java:31:24: compiler.err.prob.found.req: (compiler.misc.inconvertible.types: int, java.lang.Long)
-PrimitivePatternsSwitchErrors.java:62:18: compiler.err.pattern.dominated
 PrimitivePatternsSwitchErrors.java:70:18: compiler.err.pattern.dominated
 PrimitivePatternsSwitchErrors.java:78:18: compiler.err.pattern.dominated
 PrimitivePatternsSwitchErrors.java:84:18: compiler.err.prob.found.req: (compiler.misc.possible.loss.of.precision: long, byte)
@@ -44,4 +43,4 @@ PrimitivePatternsSwitchErrors.java:254:16: compiler.err.not.exhaustive
 PrimitivePatternsSwitchErrors.java:260:16: compiler.err.not.exhaustive
 - compiler.note.preview.filename: PrimitivePatternsSwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-44 errors
+43 errors

--- a/test/langtools/tools/javac/patterns/T8332463a.java
+++ b/test/langtools/tools/javac/patterns/T8332463a.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332463
+ * @summary Byte conditional pattern case element dominates short constant case element
+ * @compile --enable-preview --source ${jdk.version} T8332463a.java
+ */
+public class T8332463a {
+    public int test2() {
+        Byte i = (byte) 42;
+        return switch (i) {
+            case Byte ib  -> 1;
+            case short s  -> 2;
+        };
+    }
+
+    public int test4() {
+        int i = 42;
+        return switch (i) {
+            case Integer ib -> 1;
+            case byte ip    -> 2;
+        };
+    }
+
+    public int test3() {
+        int i = 42;
+        return switch (i) {
+            case Integer ib -> 1;
+            case (byte) 0   -> 2;
+        };
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8332463b.java
+++ b/test/langtools/tools/javac/patterns/T8332463b.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332463
+ * @summary Byte conditional pattern case element dominates short constant case element
+ * @enablePreview
+ * @compile T8332463b.java
+ *  @compile --enable-preview --source ${jdk.version} T8332463b.java
+ */
+public class T8332463b {
+    public int test1() {
+        Byte i = (byte) 42;
+        return switch (i) {
+            case Byte ib   -> 1;
+            case (short) 0 -> 2;
+        };
+    }
+}


### PR DESCRIPTION
It seems that the compiler introduced a rule that does not exist in the spec. The fix is simple, and it will fix the behaviour of JDK 23 according to the spec. For example the following is accepted by JDK 22 and needs to continue to be accepted by JDK 23:

```
public static int test() {
    Byte i = (byte) 42;
    return switch (i) {
        case Byte ib   -> 1;
        case (short) 0 -> 2; // OK - not dominated
    };
}
```

Similarly for primitive type patterns:

```java
public static int test() {
    Byte i = (byte) 42;
    return switch (i) {
        case Byte ib  -> 1;
        case short s  -> 2; // Also not dominated since there is no unconditionally exact conversion from short to Byte
    };
}

public static int test() {
    int i = 42;
    return switch (i) {
        case Integer ib -> 1;
        case byte ip    -> 2; // Also not dominated since there is no unconditionally exact conversion from byte to Integer
    };
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332463](https://bugs.openjdk.org/browse/JDK-8332463): Byte conditional pattern case element dominates short constant case element (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19301/head:pull/19301` \
`$ git checkout pull/19301`

Update a local copy of the PR: \
`$ git checkout pull/19301` \
`$ git pull https://git.openjdk.org/jdk.git pull/19301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19301`

View PR using the GUI difftool: \
`$ git pr show -t 19301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19301.diff">https://git.openjdk.org/jdk/pull/19301.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19301#issuecomment-2119945329)