### PR TITLE
8332401: G1: TestFromCardCacheIndex.java with -XX:GCCardSizeInBytes=128 triggers underflow assertion

### DIFF
--- a/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1BlockOffsetTable.inline.hpp
@@ -62,7 +62,8 @@ inline uint8_t* G1BlockOffsetTable::entry_for_addr(const void* const p) const {
 }
 
 inline HeapWord* G1BlockOffsetTable::addr_for_entry(const uint8_t* const p) const {
-  size_t delta = pointer_delta(p, _offset_base, sizeof(uint8_t));
+  // _offset_base can be "negative", so can't use pointer_delta().
+  size_t delta = p - _offset_base;
   HeapWord* result = (HeapWord*) (delta << CardTable::card_shift());
   assert(_reserved.contains(result),
          "out of bounds accessor from block offset table");

--- a/src/hotspot/share/gc/parallel/objectStartArray.hpp
+++ b/src/hotspot/share/gc/parallel/objectStartArray.hpp
@@ -57,7 +57,8 @@ class ObjectStartArray : public CHeapObj<mtGC> {
 
   // Mapping from object start array entry to address of first word
   HeapWord* addr_for_entry(const uint8_t* const p) const {
-    size_t delta = pointer_delta(p, _offset_base, sizeof(uint8_t));
+    // _offset_base can be "negative", so can't use pointer_delta().
+    size_t delta = p - _offset_base;
     HeapWord* result = (HeapWord*) (delta << CardTable::card_shift());
     assert(_covered_region.contains(result),
            "out of bounds accessor from card marking array");

--- a/src/hotspot/share/gc/serial/serialBlockOffsetTable.inline.hpp
+++ b/src/hotspot/share/gc/serial/serialBlockOffsetTable.inline.hpp
@@ -35,7 +35,8 @@ inline uint8_t* SerialBlockOffsetTable::entry_for_addr(const void* const p) cons
 }
 
 inline HeapWord* SerialBlockOffsetTable::addr_for_entry(const uint8_t* const p) const {
-  size_t delta = pointer_delta(p, _offset_base, sizeof(uint8_t));
+  // _offset_base can be "negative", so can't use pointer_delta().
+  size_t delta = p - _offset_base;
   HeapWord* result = (HeapWord*) (delta << CardTable::card_shift());
   assert(_reserved.contains(result),
          "out of bounds accessor from block offset array");


### PR DESCRIPTION
Remove too-strong assert -- heap and bot can be placed in arbitrary addresses, so one doesn't always get lower address than the other.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332401](https://bugs.openjdk.org/browse/JDK-8332401): G1: TestFromCardCacheIndex.java with -XX:GCCardSizeInBytes=128 triggers underflow assertion (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19303/head:pull/19303` \
`$ git checkout pull/19303`

Update a local copy of the PR: \
`$ git checkout pull/19303` \
`$ git pull https://git.openjdk.org/jdk.git pull/19303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19303`

View PR using the GUI difftool: \
`$ git pr show -t 19303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19303.diff">https://git.openjdk.org/jdk/pull/19303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19303#issuecomment-2119950302)