### PR TITLE
8332486: ClassFile API ArrayIndexOutOfBoundsException with label metadata

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -221,6 +221,9 @@ public final class CodeImpl
     }
 
     private void inflateLabel(int bci) {
+        if (bci < 0 || bci > codeLength)
+            throw new IllegalArgumentException(String.format("Bytecode offset out of range; bci=%d, codeLength=%d",
+                                                             bci, codeLength));
         if (labels[bci] == null)
             labels[bci] = new LabelImpl(this, bci);
     }

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360 8330684 8331320 8331655 8331940
+ * @bug 8320360 8330684 8331320 8331655 8331940 8332486
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */
@@ -37,8 +37,11 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.attribute.CodeAttribute;
 import java.lang.classfile.attribute.LineNumberInfo;
 import java.lang.classfile.attribute.LineNumberTableAttribute;
+import java.lang.classfile.attribute.LocalVariableInfo;
+import java.lang.classfile.attribute.LocalVariableTableAttribute;
 import java.lang.classfile.constantpool.ConstantPoolException;
 import java.lang.classfile.constantpool.IntegerEntry;
+import java.lang.classfile.instruction.LocalVariable;
 import java.util.List;
 import jdk.internal.classfile.impl.DirectCodeBuilder;
 import jdk.internal.classfile.impl.DirectMethodBuilder;
@@ -173,6 +176,18 @@ class LimitsTest {
                 "lineNumberMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, cob -> ((DirectCodeBuilder)cob
                         .return_())
                         .writeAttribute(LineNumberTableAttribute.of(List.of(LineNumberInfo.of(500, 0))))
+                ))).methods().get(0).code().get().elementList());
+    }
+
+    @Test
+    void testLocalVariableOutOfBounds() {
+        assertThrows(IllegalArgumentException.class, () ->
+                ClassFile.of().parse(ClassFile.of().build(ClassDesc.of("LocalVariableClass"), cb -> cb.withMethodBody(
+                "localVariableMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, cob -> ((DirectCodeBuilder)cob
+                        .return_())
+                        .writeAttribute(LocalVariableTableAttribute.of(List.of(
+                                new UnboundAttribute.UnboundLocalVariableInfo(0, 200,
+                                        cob.constantPool().utf8Entry("a"), cob.constantPool().utf8Entry("A"), 0))))
                 ))).methods().get(0).code().get().elementList());
     }
 }


### PR DESCRIPTION
Parsing of a specifically corrupted class file cause unexpected `ArrayIndexOutOfBoundsException` during label inflation.
This patch checks the valid range and throws expected `IllegalArgumentException` instead.
Relevant test is added.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332486](https://bugs.openjdk.org/browse/JDK-8332486): ClassFile API ArrayIndexOutOfBoundsException with label metadata (**Bug** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19304/head:pull/19304` \
`$ git checkout pull/19304`

Update a local copy of the PR: \
`$ git checkout pull/19304` \
`$ git pull https://git.openjdk.org/jdk.git pull/19304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19304`

View PR using the GUI difftool: \
`$ git pr show -t 19304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19304.diff">https://git.openjdk.org/jdk/pull/19304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19304#issuecomment-2119964340)