### PR TITLE
8332516: Serial: Always sample promoted bytes to avoid getting stuck in Full GCs

### DIFF
--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -469,7 +469,10 @@ bool SerialHeap::do_young_collection(bool clear_soft_refs) {
 
   COMPILER2_OR_JVMCI_PRESENT(DerivedPointerTable::update_pointers());
 
-  update_gc_stats(_young_gen, false);
+  // Only update stats for successful young-gc
+  if (result) {
+    _old_gen->update_promote_stats();
+  }
 
   if (should_verify && VerifyAfterGC) {
     Universe::verify("After GC");
@@ -764,6 +767,8 @@ void SerialHeap::do_full_collection_no_gc_locker(bool clear_all_soft_refs) {
 
   // Need to clear claim bits for the next mark.
   ClassLoaderDataGraph::clear_claimed_marks();
+
+  _old_gen->update_promote_stats();
 
   // Resize the metaspace capacity after full collections
   MetaspaceGC::compute_new_size();

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -208,11 +208,6 @@ public:
                               size_t requested_size,
                               size_t* actual_size) override;
 
-  // Update the gc statistics for each generation.
-  void update_gc_stats(Generation* current_generation, bool full) {
-    _old_gen->update_gc_stats(current_generation, full);
-  }
-
   void prepare_for_verify() override;
   void verify(VerifyOption option) override;
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -389,25 +389,15 @@ void TenuredGeneration::compute_new_size() {
          " capacity: " SIZE_FORMAT, used(), used_after_gc, capacity());
 }
 
-void TenuredGeneration::update_gc_stats(Generation* current_generation,
-                                        bool full) {
-  // If the young generation has been collected, gather any statistics
-  // that are of interest at this point.
-  bool current_is_young = SerialHeap::heap()->is_young_gen(current_generation);
-  if (!full && current_is_young) {
-    // Calculate size of data promoted from the young generation
-    // before doing the collection.
-    size_t used_before_gc = used();
-
-    // If the young gen collection was skipped, then the
-    // number of promoted bytes will be 0 and adding it to the
-    // average will incorrectly lessen the average.  It is, however,
-    // also possible that no promotion was needed.
-    if (used_before_gc >= _used_at_prologue) {
-      size_t promoted_in_bytes = used_before_gc - _used_at_prologue;
-      _avg_promoted->sample(promoted_in_bytes);
-    }
+void TenuredGeneration::update_promote_stats() {
+  size_t used_after_gc = used();
+  size_t promoted_in_bytes;
+  if (used_after_gc > _used_at_prologue) {
+    promoted_in_bytes = used_after_gc - _used_at_prologue;
+  } else {
+    promoted_in_bytes = 0;
   }
+  _avg_promoted->sample(promoted_in_bytes);
 }
 
 void TenuredGeneration::update_counters() {

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -160,7 +160,7 @@ public:
 
   // Statistics
 
-  void update_gc_stats(Generation* current_generation, bool full);
+  void update_promote_stats();
 
   // Returns true if promotions of the specified amount are
   // likely to succeed without a promotion failure.


### PR DESCRIPTION
Simple heuristic update around how promoted-bytes are tracked. The real change is in `TenuredGeneration::update_promote_stats`, which uses `used-old-gen` before/after gc to derived promoted-bytes.

The metric is imprecise in the cases of promotion-failure, because those should be rare. Also, after full-gc, used-old-gen an be decreased; in this case, we'd set promoted bytes as the min value (zero), the best-effort estimate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332516](https://bugs.openjdk.org/browse/JDK-8332516): Serial: Always sample promoted bytes to avoid getting stuck in Full GCs (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19306/head:pull/19306` \
`$ git checkout pull/19306`

Update a local copy of the PR: \
`$ git checkout pull/19306` \
`$ git pull https://git.openjdk.org/jdk.git pull/19306/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19306`

View PR using the GUI difftool: \
`$ git pr show -t 19306`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19306.diff">https://git.openjdk.org/jdk/pull/19306.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19306#issuecomment-2120016543)