### PR TITLE
8332528: Generate code in SwitchBootstraps.generateTypeSwitch that require fewer adaptations

### DIFF
--- a/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
+++ b/make/jdk/src/classes/build/tools/classlist/HelloClasslist.java
@@ -151,6 +151,17 @@ public class HelloClasslist {
 
         LOGGER.log(Level.FINE, "New Date: " + newDate + " - old: " + oldDate);
 
+        // Pull SwitchBootstraps and associated classes into the classlist
+        record A(int a) { }
+        record B(int b) { }
+        Object o = new A(4711);
+        int value = switch (o) {
+            case A a -> a.a;
+            case B b -> b.b;
+            default -> 17;
+        };
+        LOGGER.log(Level.FINE, "Value: " + value);
+
         // The Striped64$Cell is loaded rarely only when there's a contention among
         // multiple threads performing LongAdder.increment(). This results in
         // an inconsistency in the classlist between builds (see JDK-8295951).

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -50,7 +50,6 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.Label;
 import java.lang.classfile.instruction.SwitchCase;
 
-import jdk.internal.constant.MethodTypeDescImpl;
 import jdk.internal.constant.ReferenceClassDescImpl;
 import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.vm.annotation.Stable;

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -164,9 +164,10 @@ public class SwitchBootstraps {
             || (!invocationType.returnType().equals(int.class))
             || !invocationType.parameterType(1).equals(int.class))
             throw new IllegalArgumentException("Illegal invocation type " + invocationType);
-        requireNonNull(labels);
 
-        Stream.of(labels).forEach(l -> verifyLabel(l, selectorType));
+        for (Object l : labels) { // implicit null-check
+            verifyLabel(l, selectorType);
+        }
 
         MethodHandle target = generateTypeSwitch(lookup, selectorType, labels);
 

--- a/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
@@ -67,7 +67,7 @@ public final class MethodTypeDescImpl implements MethodTypeDesc {
      * @param returnType a {@link ClassDesc} describing the return type
      * @param trustedArgTypes {@link ClassDesc}s describing the trusted parameter types
      */
-    public static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
+    public static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc... trustedArgTypes) {
         requireNonNull(returnType);
         // implicit null checks of trustedArgTypes and all elements
         for (ClassDesc cd : trustedArgTypes) {
@@ -89,7 +89,7 @@ public final class MethodTypeDescImpl implements MethodTypeDesc {
      * @param returnType a {@link ClassDesc} describing the return type
      * @param trustedArgTypes {@link ClassDesc}s describing the trusted parameter types
      */
-    public static MethodTypeDescImpl ofValidated(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
+    public static MethodTypeDescImpl ofValidated(ClassDesc returnType, ClassDesc... trustedArgTypes) {
         if (trustedArgTypes.length == 0)
             return new MethodTypeDescImpl(returnType, ConstantUtils.EMPTY_CLASSDESC);
         return new MethodTypeDescImpl(returnType, trustedArgTypes);

--- a/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/MethodTypeDescImpl.java
@@ -67,7 +67,7 @@ public final class MethodTypeDescImpl implements MethodTypeDesc {
      * @param returnType a {@link ClassDesc} describing the return type
      * @param trustedArgTypes {@link ClassDesc}s describing the trusted parameter types
      */
-    public static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc... trustedArgTypes) {
+    public static MethodTypeDescImpl ofTrusted(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
         requireNonNull(returnType);
         // implicit null checks of trustedArgTypes and all elements
         for (ClassDesc cd : trustedArgTypes) {
@@ -89,7 +89,7 @@ public final class MethodTypeDescImpl implements MethodTypeDesc {
      * @param returnType a {@link ClassDesc} describing the return type
      * @param trustedArgTypes {@link ClassDesc}s describing the trusted parameter types
      */
-    public static MethodTypeDescImpl ofValidated(ClassDesc returnType, ClassDesc... trustedArgTypes) {
+    public static MethodTypeDescImpl ofValidated(ClassDesc returnType, ClassDesc[] trustedArgTypes) {
         if (trustedArgTypes.length == 0)
             return new MethodTypeDescImpl(returnType, ConstantUtils.EMPTY_CLASSDESC);
         return new MethodTypeDescImpl(returnType, trustedArgTypes);

--- a/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ReferenceClassDescImpl.java
@@ -69,6 +69,17 @@ public final class ReferenceClassDescImpl implements ClassDesc {
         return new ReferenceClassDescImpl(descriptor);
     }
 
+    /**
+     * Creates a {@linkplain ClassDesc} from a pre-validated descriptor string
+     * for a class or interface type or an array type.
+     *
+     * @param descriptor a field descriptor string for a class or interface type
+     * @jvms 4.3.2 Field Descriptors
+     */
+    public static ClassDesc ofValidatedBinaryName(String typeSwitchClassName) {
+        return ofValidated("L" + binaryToInternal(typeSwitchClassName) + ";");
+    }
+
     @Override
     public String descriptorString() {
         return descriptor;

--- a/test/micro/org/openjdk/bench/java/lang/runtime/SwitchSanity.java
+++ b/test/micro/org/openjdk/bench/java/lang/runtime/SwitchSanity.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.runtime;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(3)
+public class SwitchSanity {
+
+    public record A(int a) { }
+    public record B(int b) { }
+    public record C(int c) { }
+
+    public Object[] inputs = new Object[10];
+    @Setup
+    public void setup() {
+        for (int i = 0; i < 10; i++) {
+            if (i % 2 == 0) {
+                inputs[i] = new A(i + 17);
+            } else if (i % 3 == 0) {
+                inputs[i] = new B(i + 4711);
+            } else {
+                inputs[i] = new C(i + 174711);
+            }
+        }
+    }
+
+    @Benchmark
+    public int switchSum() {
+        int sum = 0;
+        for (Object o : inputs) {
+            sum += switch (o) {
+                case A a -> a.a;
+                case B b -> b.b;
+                case C c -> c.c;
+                default -> 17;
+            };
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/runtime/SwitchSanity.java
+++ b/test/micro/org/openjdk/bench/java/lang/runtime/SwitchSanity.java
@@ -74,4 +74,10 @@ public class SwitchSanity {
         }
         return sum;
     }
+
+    public static void main(String[] args) {
+        SwitchSanity s = new SwitchSanity();
+        s.setup();
+        System.out.println(s.switchSum());
+    }
 }


### PR DESCRIPTION
We can fold the call to `Objects.checkIndex` into the code generated in generateTypeSwitchSkeleton instead of doing so by filtering the MH argument. This loads 9 less classes (of which 8 generated LFs and Species classes) on a minimal test, while being neutral on a throughput sanity test:

```
Name                   Cnt  Base   Error   Test   Error  Unit  Change
SwitchSanity.switchSum  15 8,162 ± 0,117  8,152 ± 0,131 ns/op   1,00x (p = 0,800 )
  * = significant
  ```

A few additional optimizations includes moving some seldom used `findStatic` calls to a holder. All in all this means a reduction by 22M cycles to bootstrap a trivial switch expression on my M1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332528](https://bugs.openjdk.org/browse/JDK-8332528): Generate code in SwitchBootstraps.generateTypeSwitch that require fewer adaptations (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [f04d78ea](https://git.openjdk.org/jdk/pull/19307/files/f04d78ea53ed0074026311f82eb0d4eafee3438d)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19307/head:pull/19307` \
`$ git checkout pull/19307`

Update a local copy of the PR: \
`$ git checkout pull/19307` \
`$ git pull https://git.openjdk.org/jdk.git pull/19307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19307`

View PR using the GUI difftool: \
`$ git pr show -t 19307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19307.diff">https://git.openjdk.org/jdk/pull/19307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19307#issuecomment-2121191868)