### PR TITLE
8332527: ZGC: generalize object cloning logic

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -814,7 +814,60 @@ Node* BarrierSetC2::obj_allocate(PhaseMacroExpand* macro, Node* mem, Node* toobi
   return old_tlab_top;
 }
 
+static const TypeFunc* clone_type() {
+  // Create input type (domain)
+  int argcnt = NOT_LP64(3) LP64_ONLY(4);
+  const Type** const domain_fields = TypeTuple::fields(argcnt);
+  int argp = TypeFunc::Parms;
+  domain_fields[argp++] = TypeInstPtr::NOTNULL;  // src
+  domain_fields[argp++] = TypeInstPtr::NOTNULL;  // dst
+  domain_fields[argp++] = TypeX_X;               // size lower
+  LP64_ONLY(domain_fields[argp++] = Type::HALF); // size upper
+  assert(argp == TypeFunc::Parms+argcnt, "correct decoding");
+  const TypeTuple* const domain = TypeTuple::make(TypeFunc::Parms + argcnt, domain_fields);
+
+  // Create result type (range)
+  const Type** const range_fields = TypeTuple::fields(0);
+  const TypeTuple* const range = TypeTuple::make(TypeFunc::Parms + 0, range_fields);
+
+  return TypeFunc::make(domain, range);
+}
+
 #define XTOP LP64_ONLY(COMMA phase->top())
+
+void BarrierSetC2::clone_instance_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
+                                             address clone_addr, const char* clone_name) const {
+  assert(ac->is_clone_inst(), "this function is only defined for cloning class instances");
+  Node* const ctrl = ac->in(TypeFunc::Control);
+  Node* const mem  = ac->in(TypeFunc::Memory);
+  Node* const src  = ac->in(ArrayCopyNode::Src);
+  Node* const dst  = ac->in(ArrayCopyNode::Dest);
+  Node* const size = ac->in(ArrayCopyNode::Length);
+
+  assert(size->bottom_type()->base() == Type_X,
+         "Should be of object size type (int for 32 bits, long for 64 bits)");
+
+  // The native clone we are calling here expects the instance size in words.
+  // Add header/offset size to payload size to get instance size.
+  Node* const base_offset = phase->MakeConX(arraycopy_payload_base_offset(ac->is_clone_array()) >> LogBytesPerLong);
+  Node* const full_size = phase->transform_later(new AddXNode(size, base_offset));
+  // HeapAccess<>::clone expects size in heap words.
+  // For 64-bits platforms, this is a no-operation.
+  // For 32-bits platforms, we need to multiply full_size by HeapWordsPerLong (2).
+  // There is no overflow risk at this point, since full_size is derived
+  // from a value expressing the size in bytes (see GraphKit::new_instance()).
+  Node* const full_size_in_heap_words = phase->transform_later(new LShiftXNode(full_size, phase->intcon(LogHeapWordsPerLong)));
+
+  Node* const call = phase->make_leaf_call(ctrl,
+                                           mem,
+                                           clone_type(),
+                                           clone_addr,
+                                           clone_name,
+                                           TypeRawPtr::BOTTOM,
+                                           src, dst, full_size_in_heap_words XTOP);
+  phase->transform_later(call);
+  phase->igvn().replace_node(ac, call);
+}
 
 void BarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* ac) const {
   Node* ctrl = ac->in(TypeFunc::Control);

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp
@@ -837,7 +837,7 @@ static const TypeFunc* clone_type() {
 
 void BarrierSetC2::clone_instance_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
                                              address clone_addr, const char* clone_name) const {
-  assert(ac->is_clone_inst(), "this function is only defined for cloning class instances");
+  assert(ac->is_clone_inst(), "this function is only defined for cloning instances");
   Node* const ctrl = ac->in(TypeFunc::Control);
   Node* const mem  = ac->in(TypeFunc::Memory);
   Node* const src  = ac->in(ArrayCopyNode::Src);
@@ -849,7 +849,7 @@ void BarrierSetC2::clone_instance_in_runtime(PhaseMacroExpand* phase, ArrayCopyN
 
   // The native clone we are calling here expects the instance size in words.
   // Add header/offset size to payload size to get instance size.
-  Node* const base_offset = phase->MakeConX(arraycopy_payload_base_offset(ac->is_clone_array()) >> LogBytesPerLong);
+  Node* const base_offset = phase->MakeConX(arraycopy_payload_base_offset(false /* is_array */) >> LogBytesPerLong);
   Node* const full_size = phase->transform_later(new AddXNode(size, base_offset));
   // HeapAccess<>::clone expects size in heap words.
   // For 64-bits platforms, this is a no-operation.

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -280,6 +280,8 @@ protected:
   virtual Node* atomic_xchg_at_resolved(C2AtomicParseAccess& access, Node* new_val, const Type* val_type) const;
   virtual Node* atomic_add_at_resolved(C2AtomicParseAccess& access, Node* new_val, const Type* val_type) const;
   void pin_atomic_op(C2AtomicParseAccess& access) const;
+  void clone_instance_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
+                                 address call_addr, const char* call_name) const;
 
 public:
   // This is the entry-point for the backend to perform accesses through the Access API.

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -280,8 +280,8 @@ protected:
   virtual Node* atomic_xchg_at_resolved(C2AtomicParseAccess& access, Node* new_val, const Type* val_type) const;
   virtual Node* atomic_add_at_resolved(C2AtomicParseAccess& access, Node* new_val, const Type* val_type) const;
   void pin_atomic_op(C2AtomicParseAccess& access) const;
-  void clone_instance_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
-                                 address call_addr, const char* call_name) const;
+  void clone_in_runtime(PhaseMacroExpand* phase, ArrayCopyNode* ac,
+                        address call_addr, const char* call_name) const;
 
 public:
   // This is the entry-point for the backend to perform accesses through the Access API.

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -462,7 +462,10 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
     return;
   }
 
-  clone_instance_in_runtime(phase, ac, ZBarrierSetRuntime::clone_addr(), "ZBarrierSetRuntime::clone");
+  // Clone instance or array where 'src' is only known to be an object (ary_ptr
+  // is null). This can happen in bytecode generated dynamically to implement
+  // reflective array clones.
+  clone_in_runtime(phase, ac, ZBarrierSetRuntime::clone_addr(), "ZBarrierSetRuntime::clone");
 }
 
 #undef XTOP

--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -407,23 +407,6 @@ bool ZBarrierSetC2::array_copy_requires_gc_barriers(bool tightly_coupled_alloc, 
   return type == T_OBJECT || type == T_ARRAY;
 }
 
-// This TypeFunc assumes a 64bit system
-static const TypeFunc* clone_type() {
-  // Create input type (domain)
-  const Type** const domain_fields = TypeTuple::fields(4);
-  domain_fields[TypeFunc::Parms + 0] = TypeInstPtr::NOTNULL;  // src
-  domain_fields[TypeFunc::Parms + 1] = TypeInstPtr::NOTNULL;  // dst
-  domain_fields[TypeFunc::Parms + 2] = TypeLong::LONG;        // size lower
-  domain_fields[TypeFunc::Parms + 3] = Type::HALF;            // size upper
-  const TypeTuple* const domain = TypeTuple::make(TypeFunc::Parms + 4, domain_fields);
-
-  // Create result type (range)
-  const Type** const range_fields = TypeTuple::fields(0);
-  const TypeTuple* const range = TypeTuple::make(TypeFunc::Parms + 0, range_fields);
-
-  return TypeFunc::make(domain, range);
-}
-
 #define XTOP LP64_ONLY(COMMA phase->top())
 
 void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* ac) const {
@@ -479,31 +462,7 @@ void ZBarrierSetC2::clone_at_expansion(PhaseMacroExpand* phase, ArrayCopyNode* a
     return;
   }
 
-  // Clone instance
-  Node* const ctrl       = ac->in(TypeFunc::Control);
-  Node* const mem        = ac->in(TypeFunc::Memory);
-  Node* const dst        = ac->in(ArrayCopyNode::Dest);
-  Node* const size       = ac->in(ArrayCopyNode::Length);
-
-  assert(size->bottom_type()->is_long(), "Should be long");
-
-  // The native clone we are calling here expects the instance size in words
-  // Add header/offset size to payload size to get instance size.
-  Node* const base_offset = phase->longcon(arraycopy_payload_base_offset(ac->is_clone_array()) >> LogBytesPerLong);
-  Node* const full_size = phase->transform_later(new AddLNode(size, base_offset));
-
-  Node* const call = phase->make_leaf_call(ctrl,
-                                           mem,
-                                           clone_type(),
-                                           ZBarrierSetRuntime::clone_addr(),
-                                           "ZBarrierSetRuntime::clone",
-                                           TypeRawPtr::BOTTOM,
-                                           src,
-                                           dst,
-                                           full_size,
-                                           phase->top());
-  phase->transform_later(call);
-  phase->igvn().replace_node(ac, call);
+  clone_instance_in_runtime(phase, ac, ZBarrierSetRuntime::clone_addr(), "ZBarrierSetRuntime::clone");
 }
 
 #undef XTOP


### PR DESCRIPTION
This changeset generalize the logic to produce a runtime call to clone a class instance so that it can be shared by other collectors adopting the late barrier expansion model (including G1 in the near future, see [JEP 475](https://openjdk.org/jeps/475)). The changeset moves the logic from `ZBarrierSetC2` to the GC-shared `BarrierSetC2` class and adds support for 32-bits platforms.

#### Testing

- tier1-3 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode).
- tier4-7 (linux-x64, linux-aarch64; release and debug mode; ZGC tests only).
- `compiler/arraycopy` tests (linux-x86-debug) with [an additional patch](https://github.com/openjdk/jdk/commit/ddcf777894e740b8e6ddbbf8821e82a173c23ef4) that implements cloning of large class instances with a runtime clone call rather than arraycopy when using G1 (to exercise the generalized logic on a 32-bits platform).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332527](https://bugs.openjdk.org/browse/JDK-8332527): ZGC: generalize object cloning logic (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19311/head:pull/19311` \
`$ git checkout pull/19311`

Update a local copy of the PR: \
`$ git checkout pull/19311` \
`$ git pull https://git.openjdk.org/jdk.git pull/19311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19311`

View PR using the GUI difftool: \
`$ git pr show -t 19311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19311.diff">https://git.openjdk.org/jdk/pull/19311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19311#issuecomment-2121712182)