### PR TITLE
8327650: Test java/nio/channels/DatagramChannel/StressNativeSignal.java timed out

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
@@ -66,7 +66,7 @@ public class StressNativeSignal {
         ServerSocketThread aServerSocketThread = null;
         try {
             aServerSocketThread = new ServerSocketThread();
- 
+
         } catch (Exception z) {
             System.err.println("failed to create and start a ServerSocketThread");
             z.printStackTrace();
@@ -119,7 +119,6 @@ public class StressNativeSignal {
         private final CountDownLatch threadStarted = new CountDownLatch(1);
 
         public ServerSocketThread () throws Exception {
-
             socket = new ServerSocket(1122);
         }
 
@@ -162,7 +161,6 @@ public class StressNativeSignal {
         private DatagramChannel channel;
         private volatile boolean shouldTerminate;
         private final CountDownLatch threadStarted = new CountDownLatch(1);
-
 
         public UDPThread () throws Exception {
 

--- a/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
@@ -136,9 +136,9 @@ public class StressNativeSignal {
         public void waitTestThreadStart() {
             try {
                 threadStarted.await();
-            } catch (InterruptedException intEx) {
-                System.err.println("ServerSocketThread.waitTestThreadStart:" +
-                                   " InterruptException caught ... continue");
+            } catch (Exception z) {
+                z.printStackTrace(System.err);
+                // ignore
             }
         }
     }
@@ -188,9 +188,9 @@ public class StressNativeSignal {
         public void waitTestThreadStart() {
             try {
                 threadStarted.await();
-            } catch (InterruptedException intEx) {
-                System.err.println("UDPThread.waitTestThreadStart:" +
-                                   " InterruptException caught ... continue");
+            } catch (Exception z) {
+                z.printStackTrace(System.err);
+                // ignore
             }
         }
     }

--- a/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
@@ -81,7 +81,7 @@ public class StressNativeSignal {
             } catch (Exception z) {
                 z.printStackTrace(System.err);
             }
-        }        
+        }
     }
 
     public void waitForTestThreadsToStart() {

--- a/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/StressNativeSignal.java
@@ -148,7 +148,7 @@ public class StressNativeSignal {
                 try {
                     buf.rewind();
                     channel.receive(buf);
-                } catch (IOException z) { 
+                } catch (IOException z) {
                     System.err.println("UDPThread: caught exception " + z.getClass().getName());
                     if (!shouldTerminate) {
                         z.printStackTrace(System.err);


### PR DESCRIPTION
JDK-8327650 Test java/nio/channels/DatagramChannel/StressNativeSignal.java timed out 

Please oblige and review the following test only fix to alleviate a race condition within the test.

A race condition exists, in the test  StressNativeSignal, due to the setting of a condition variable, shouldTerminate, in the main thread’s invocation of UDPThread::terminate and the setting of shouldTerminate in the main run method of UDPThread.  A similar scenario exists for the ServerSocketThread.  The variable shouldTerminate is a member variable, and is by default set to false, so the setting to false in the run methods is not required. Removing shouldTerminate = false; statement mitigates the race condition.

Additionally, a number of other minor changes have been added to the test:
* it is desired to test the asynchronous close of the DatagramChannel::receive method which may trigger the NativeThread::signal issue, thus the while loop has been changed to a do { } while(); loop to invoke the DC receive method.

* The Thread::sleep has been replaced with a CountDownLatch to make the test slightly more deterministic.

It is noted in passing the ServerSocket::run method contains a redundant while loop for reading from an established connection stream, which is never created. This code is never reached as there is no peer to connect to the ServerSocket and the test is on the ServerSocket::accept method.

Another issue of note is that the test is using a hardcoded IANA assigned port 1122 (availant-mgr). But, this has not been altered. The ServerSocket test scenario could use an ephemeral port i.e. new ServerSocket(0);

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327650](https://bugs.openjdk.org/browse/JDK-8327650): Test java/nio/channels/DatagramChannel/StressNativeSignal.java timed out (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19312/head:pull/19312` \
`$ git checkout pull/19312`

Update a local copy of the PR: \
`$ git checkout pull/19312` \
`$ git pull https://git.openjdk.org/jdk.git pull/19312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19312`

View PR using the GUI difftool: \
`$ git pr show -t 19312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19312.diff">https://git.openjdk.org/jdk/pull/19312.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19312#issuecomment-2120611123)