### PR TITLE
8332538: Switch off JIT memory limit check for TestAlignVectorFuzzer.java

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
@@ -30,6 +30,7 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
  *                                 compiler.loopopts.superword.TestAlignVectorFuzzer
@@ -44,6 +45,7 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
@@ -60,6 +62,7 @@
  * @requires vm.bits == 64
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
@@ -76,6 +79,7 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
+ *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*


### PR DESCRIPTION
Add flag `-XX:CompileCommand=MemLimit,*.*,0` to TestAlignVectorFuzzer.java test until [JDK-8332537](https://bugs.openjdk.org/browse/JDK-8332537) is fixed.

Tested: tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332538](https://bugs.openjdk.org/browse/JDK-8332538): Switch off JIT memory limit check for TestAlignVectorFuzzer.java (**Sub-task** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19316/head:pull/19316` \
`$ git checkout pull/19316`

Update a local copy of the PR: \
`$ git checkout pull/19316` \
`$ git pull https://git.openjdk.org/jdk.git pull/19316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19316`

View PR using the GUI difftool: \
`$ git pr show -t 19316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19316.diff">https://git.openjdk.org/jdk/pull/19316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19316#issuecomment-2120999120)