### PR TITLE
8332545: Fix handling of HTML5 entities in Markdown comments

### DIFF
--- a/make/modules/jdk.internal.md/Java.gmk
+++ b/make/modules/jdk.internal.md/Java.gmk
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+COPY += .txt

--- a/src/jdk.internal.md/share/classes/jdk/internal/org/commonmark/internal/util/Html5Entities.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/org/commonmark/internal/util/Html5Entities.java
@@ -44,7 +44,7 @@ import java.util.Map;
 public class Html5Entities {
 
     private static final Map<String, String> NAMED_CHARACTER_REFERENCES = readEntities();
-    private static final String ENTITY_PATH = "/org/commonmark/internal/util/entities.txt";
+    private static final String ENTITY_PATH = "/jdk/internal/org/commonmark/internal/util/entities.txt";
 
     public static String entityToString(String input) {
         if (!input.startsWith("&") || !input.endsWith(";")) {

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownEntities.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownEntities.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8332545
+ * @summary  Fix handling of HTML5 entities in Markdown comments
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestMarkdownEntities
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+
+/**
+ * Tests for use of HTML5 entities in Markdown.
+ */
+public class TestMarkdownEntities extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestMarkdownEntities();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void testEntities(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    /// Simple common &lt;entities&gt; &amp;
+                    /// less common &ldquo;entities&rdquo;.
+                    public class C {
+                        private C() { }
+                    }
+                    """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "--source-path", src.toString(),
+                "p");
+
+        checkOutput("p/C.html", true,
+                """
+                    <div class="block">Simple common &lt;entities&gt; &amp;
+                    less common \u201centities\u201d.</div>
+                    """);
+
+    }
+
+}


### PR DESCRIPTION
Please review a small fix to address a crash when handling HTML5 entities in a Markdown doc comment.

The path for the `entities.txt` (originally `entities.properties`) was not correctly imported when importing the latest version of `commonmark-java`. And, the makefiles need to be updated to include the `.txt` file in the image. (The interim module for the interim javadoc already had this fix.)

A simple new test is provided, containing entities that previously caused `javadoc` to crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332545](https://bugs.openjdk.org/browse/JDK-8332545): Fix handling of HTML5 entities in Markdown comments (**Bug** - P2)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19317/head:pull/19317` \
`$ git checkout pull/19317`

Update a local copy of the PR: \
`$ git checkout pull/19317` \
`$ git pull https://git.openjdk.org/jdk.git pull/19317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19317`

View PR using the GUI difftool: \
`$ git pr show -t 19317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19317.diff">https://git.openjdk.org/jdk/pull/19317.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19317#issuecomment-2121145982)