### PR TITLE
8332547: Unloaded signature classes in DirectMethodHandles

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -632,7 +632,7 @@ class InvokerBytecodeGenerator {
         else if (c == Object[].class)      return OBJARY;
         else if (c == Class.class)         return CLS;
         else if (c == MethodHandle.class)  return MH;
-        assert(VerifyAccess.isTypeVisible(c, Object.class)) : c.getName();
+        assert(VerifyAccess.ensureTypeVisible(c, Object.class)) : c.getName();
 
         if (c == lastClass) {
             return lastInternalName;

--- a/src/java.base/share/classes/java/lang/invoke/MemberName.java
+++ b/src/java.base/share/classes/java/lang/invoke/MemberName.java
@@ -800,7 +800,7 @@ final class MemberName implements Member, Cloneable {
         assert(isResolved() == isResolved);
     }
 
-    void checkForTypeAlias(Class<?> refc) {
+    void ensureTypeVisible(Class<?> refc) {
         if (isInvocable()) {
             MethodType type;
             if (this.type instanceof MethodType mt)
@@ -808,7 +808,7 @@ final class MemberName implements Member, Cloneable {
             else
                 this.type = type = getMethodType();
             if (type.erase() == type)  return;
-            if (VerifyAccess.isTypeVisible(type, refc))  return;
+            if (VerifyAccess.ensureTypeVisible(type, refc))  return;
             throw new LinkageError("bad method type alias: "+type+" not visible from "+refc);
         } else {
             Class<?> type;
@@ -816,7 +816,7 @@ final class MemberName implements Member, Cloneable {
                 type = cl;
             else
                 this.type = type = getFieldType();
-            if (VerifyAccess.isTypeVisible(type, refc))  return;
+            if (VerifyAccess.ensureTypeVisible(type, refc))  return;
             throw new LinkageError("bad field type alias: "+type+" not visible from "+refc);
         }
     }
@@ -958,7 +958,7 @@ final class MemberName implements Member, Cloneable {
                 if (m == null && speculativeResolve) {
                     return null;
                 }
-                m.checkForTypeAlias(m.getDeclaringClass());
+                m.ensureTypeVisible(m.getDeclaringClass());
                 m.resolution = null;
             } catch (ClassNotFoundException | LinkageError ex) {
                 // JVM reports that the "bytecode behavior" would get an error

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -268,7 +268,7 @@ public class VerifyAccess {
      * @param type the supposed type of a member or symbolic reference of refc
      * @param refc the class attempting to make the reference
      */
-    public static boolean isTypeVisible(Class<?> type, Class<?> refc) {
+    public static boolean ensureTypeVisible(Class<?> type, Class<?> refc) {
         if (type == refc) {
             return true;  // easy check
         }
@@ -340,12 +340,12 @@ public class VerifyAccess {
      * @param type the supposed type of a member or symbolic reference of refc
      * @param refc the class attempting to make the reference
      */
-    public static boolean isTypeVisible(java.lang.invoke.MethodType type, Class<?> refc) {
-        if (!isTypeVisible(type.returnType(), refc)) {
+    public static boolean ensureTypeVisible(java.lang.invoke.MethodType type, Class<?> refc) {
+        if (!ensureTypeVisible(type.returnType(), refc)) {
             return false;
         }
         for (int n = 0, max = type.parameterCount(); n < max; n++) {
-            if (!isTypeVisible(type.parameterType(n), refc)) {
+            if (!ensureTypeVisible(type.parameterType(n), refc)) {
                 return false;
             }
         }

--- a/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
+++ b/src/java.base/share/classes/sun/invoke/util/VerifyAccess.java
@@ -284,12 +284,14 @@ public class VerifyAccess {
         if (refcLoader == null && typeLoader != null) {
             return false;
         }
-        if (typeLoader == null && type.getName().startsWith("java.")) {
-            // Note:  The API for actually loading classes, ClassLoader.defineClass,
-            // guarantees that classes with names beginning "java." cannot be aliased,
-            // because class loaders cannot load them directly.
-            return true;
-        }
+
+        // The API for actually loading classes, ClassLoader.defineClass,
+        // guarantees that classes with names beginning "java." cannot be aliased,
+        // because class loaders cannot load them directly. However, it is beneficial
+        // for JIT-compilers to ensure all signature classes are loaded.
+        // JVM doesn't install any loader contraints when performing MemberName resolution,
+        // so eagerly resolving signature classes is a way to match what JVM achieves
+        // with loader constraints during method resolution for invoke bytecodes.
 
         // Do it the hard way:  Look up the type name from the refc loader.
         //

--- a/test/hotspot/jtreg/compiler/runtime/unloaded/TestUnloadedSignatureClass.java
+++ b/test/hotspot/jtreg/compiler/runtime/unloaded/TestUnloadedSignatureClass.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @run driver compiler.runtime.unloaded.TestUnloadedSignatureClass
+ */
+
+package compiler.runtime.unloaded;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class TestUnloadedSignatureClass {
+    static class Test {
+        static int test(Integer i) {
+            // Bound to a wrapper around a method with (Ljava/lang/Object;ILjava/util/function/BiPredicate;Ljava/util/List;)I signature.
+            // Neither BiPredicate nor List are guaranteed to be resolved by the context class loader.
+            return switch (i) {
+                case null -> -1;
+                case 0    ->  0;
+                default   ->  1;
+            };
+        }
+
+        public static void main(String[] args) {
+            for (int i = 0; i < 20_000; i++) {
+                test(i);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                "-Xbatch", "-XX:-TieredCompilation",
+                "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly,*::test",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintCompilation", "-XX:+PrintInlining",
+                Test.class.getName()
+        );
+
+        OutputAnalyzer out = new OutputAnalyzer(pb.start());
+        out.shouldHaveExitValue(0);
+        out.shouldNotContain("unloaded signature classes");
+    }
+}


### PR DESCRIPTION
JVM routinely installs loader constraints for unloaded signature classes when method resolution takes place. MethodHandle resolution took a different route and eagerly resolves signature classes instead (see `java.lang.invoke.MemberName$Factory::resolve` and `sun.invoke.util.VerifyAccess::isTypeVisible` for details). 

There's a micro-optimization which bypasses eager resolution for `java.*` classes. The downside is that `java.*` signature classes can show up as unloaded. It manifests as inlining failures during JIT-compilation and may cause severe performance issues.

Proposed fix removes the aforementioned special case logic during `MethodHandle` resolution. 

In some cases it may slow down `MethodHandle` construction a bit (e.g., when repeatedly constructing `DirectMethodHandle`s with lots of arguments), but `MethodHandle` construction step is not performance critical.  

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332547](https://bugs.openjdk.org/browse/JDK-8332547): Unloaded signature classes in DirectMethodHandles (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19319/head:pull/19319` \
`$ git checkout pull/19319`

Update a local copy of the PR: \
`$ git checkout pull/19319` \
`$ git pull https://git.openjdk.org/jdk.git pull/19319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19319`

View PR using the GUI difftool: \
`$ git pr show -t 19319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19319.diff">https://git.openjdk.org/jdk/pull/19319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19319#issuecomment-2121285439)