### PR TITLE
8332615: RISC-V: Support vector unsigned comparison instructions for machines with RVV

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2762,6 +2762,10 @@ void C2_MacroAssembler::compare_integral_v(VectorRegister vd, VectorRegister src
     case BoolTest::ge: vmsge_vv(vd, src1, src2, vm); break;
     case BoolTest::lt: vmslt_vv(vd, src1, src2, vm); break;
     case BoolTest::gt: vmsgt_vv(vd, src1, src2, vm); break;
+    case BoolTest::ule: vmsleu_vv(vd, src1, src2, vm); break;
+    case BoolTest::uge: vmsgeu_vv(vd, src1, src2, vm); break;
+    case BoolTest::ult: vmsltu_vv(vd, src1, src2, vm); break;
+    case BoolTest::ugt: vmsgtu_vv(vd, src1, src2, vm); break;
     default:
       assert(false, "unsupported compare condition");
       ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -148,8 +148,8 @@
   }
 
   // Does the CPU supports vector unsigned comparison instructions?
-  static constexpr bool supports_vector_comparison_unsigned(int vlen, BasicType bt) {
-    return false;
+  static bool supports_vector_comparison_unsigned(int vlen, BasicType bt) {
+    return UseRVV;
   }
 
   // Some microarchitectures have mask registers used on vectors


### PR DESCRIPTION
Hi, I noticed the following warning in the Opto JIT Code for the Vector API in the `test/jdk/jdk/incubator/vector/Int256VectorTests.java: UNSIGNED_LTInt256VectorTests` test:
```
  ** not supported: unsigned comparison op=comp/1 vlen=8 etype=int ismask=usestore
``` 
After this Patch, We supports vector unsigned comparison instructions, the test passes normally and generates the Opto JIT Code such as:
```
23e     B46: #  out( B48 B47 ) &lt;- in( B25 B45 ) Loop( B46-B45 ) Freq: 955.829
23e     addw  R24, R29, zr  #@convI2L_reg_reg
242     slli  R30, R24, (#2 &amp; 0x3f) #@lShiftL_reg_imm
246     add R17, R8, R30  # ptr, #@addP_reg_reg
24a     add R19, R9, R30  # ptr, #@addP_reg_reg
24e     addi  R30, R17, #16 # ptr, #@addP_reg_imm
252     addi  R31, R19, #16 # ptr, #@addP_reg_imm
256     loadV V1, [R30] # vector (rvv)
25e     loadV V2, [R31] # vector (rvv)
266     vmaskcmp V0, V1, V2, #19
272     vmask_tolong R20, V0
280     vstoremask V1, V0 # elem size is #4 byte[s]
28c     lw  R31, [R17, #16] # int, #@loadI
290     lw  R11, [R19, #16] # int, #@loadI
294     andi  R10, R20, #1  #@andL_reg_imm
298     bne  R10, zr, B48 #@cmpL_reg_imm0_branch  P=0.669978 C=14596.000000
```
### Testing:
qemu 8.1.50 with UseRVV:
- [x] Run tier1-3 tests (release)
- [x] Run test/jdk/jdk/incubator/vector (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332615](https://bugs.openjdk.org/browse/JDK-8332615): RISC-V: Support vector unsigned comparison instructions for machines with RVV (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19328/head:pull/19328` \
`$ git checkout pull/19328`

Update a local copy of the PR: \
`$ git checkout pull/19328` \
`$ git pull https://git.openjdk.org/jdk.git pull/19328/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19328`

View PR using the GUI difftool: \
`$ git pr show -t 19328`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19328.diff">https://git.openjdk.org/jdk/pull/19328.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19328#issuecomment-2124033863)