### PR TITLE
8332589: ubsan: unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -559,7 +559,9 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     }
     offset = copystrings(buf, 0, &c->argv[0]);
     offset = copystrings(buf, offset, &c->envv[0]);
-    memcpy(buf+offset, c->pdir, sp.dirlen);
+    if (c->pdir != NULL) {
+        memcpy(buf+offset, c->pdir, sp.dirlen);
+    }
     offset += sp.dirlen;
     offset = copystrings(buf, offset, parentPathv);
     assert(offset == bufsize);

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -559,9 +559,16 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     }
     offset = copystrings(buf, 0, &c->argv[0]);
     offset = copystrings(buf, offset, &c->envv[0]);
-    if (sp.dirlen > 0 && c->pdir != NULL) {
-        memcpy(buf+offset, c->pdir, sp.dirlen);
-        offset += sp.dirlen;
+    if (c->pdir != NULL) {
+        if (sp.dirlen > 0) {
+            memcpy(buf+offset, c->pdir, sp.dirlen);
+            offset += sp.dirlen;
+        }
+    } else {
+        if (sp.dirlen > 0) {
+            free(buf);
+            return -1;
+        }
     }
     offset = copystrings(buf, offset, parentPathv);
     assert(offset == bufsize);

--- a/src/java.base/unix/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/unix/native/libjava/ProcessImpl_md.c
@@ -559,10 +559,10 @@ spawnChild(JNIEnv *env, jobject process, ChildStuff *c, const char *helperpath) 
     }
     offset = copystrings(buf, 0, &c->argv[0]);
     offset = copystrings(buf, offset, &c->envv[0]);
-    if (c->pdir != NULL) {
+    if (sp.dirlen > 0 && c->pdir != NULL) {
         memcpy(buf+offset, c->pdir, sp.dirlen);
+        offset += sp.dirlen;
     }
-    offset += sp.dirlen;
     offset = copystrings(buf, offset, parentPathv);
     assert(offset == bufsize);
 


### PR DESCRIPTION
When building with ubsan enabled (--enable-uban) on Linux x86_64 and doing jtreg tests afterwards I run into this error :

/jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x7fd95bec78d8 in spawnChild /jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c:562
    #1 0x7fd95bec78d8 in startChild /jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c:612
    #2 0x7fd95bec78d8 in Java_java_lang_ProcessImpl_forkAndExec /jdk/src/java.base/unix/native/libjava/ProcessImpl_md.c:712
    #3 0x7fd93797a06d (<unknown module>)

this is the memcpy call getting an unexpected null pointer :
    memcpy(buf+offset, c->pdir, sp.dirlen); gets a second parameter null.
Something similar was discussed and fixed here https://bugs.python.org/issue27570 for Python .

Similar issue in OpenJDK _ 
https://bugs.openjdk.org/browse/JDK-8332473
8332473: ubsan: growableArray.hpp:290:10: runtime error: null pointer passed as argument 1, which is declared to never be null

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332589: ubsan: unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null`

### Issue
 * [JDK-8332589](https://bugs.openjdk.org/browse/JDK-8332589): ubsan: unix/native/libjava/ProcessImpl_md.c:562:5: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19329/head:pull/19329` \
`$ git checkout pull/19329`

Update a local copy of the PR: \
`$ git checkout pull/19329` \
`$ git pull https://git.openjdk.org/jdk.git pull/19329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19329`

View PR using the GUI difftool: \
`$ git pr show -t 19329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19329.diff">https://git.openjdk.org/jdk/pull/19329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19329#issuecomment-2122781210)