### PR TITLE
8321314: Reinstate disabling the compiler's default active annotation processing

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/JavaCompiler.java
@@ -1142,21 +1142,18 @@ public class JavaCompiler {
         if (processors != null && processors.iterator().hasNext())
             explicitAnnotationProcessingRequested = true;
 
-        // Process annotations if processing is not disabled and there
-        // is at least one Processor available.
         if (options.isSet(PROC, "none")) {
             processAnnotations = false;
         } else if (procEnvImpl == null) {
             procEnvImpl = JavacProcessingEnvironment.instance(context);
             procEnvImpl.setProcessors(processors);
-            processAnnotations = procEnvImpl.atLeastOneProcessor();
+
+            // Process annotations if processing is requested and there
+            // is at least one Processor available.
+            processAnnotations = procEnvImpl.atLeastOneProcessor() &&
+                explicitAnnotationProcessingRequested();
 
             if (processAnnotations) {
-                if (!explicitAnnotationProcessingRequested() &&
-                    !optionsCheckingInitiallyDisabled) {
-                    log.note(Notes.ImplicitAnnotationProcessing);
-                }
-
                 options.put("parameters", "parameters");
                 reader.saveParameterNames = true;
                 keepComments = true;
@@ -1165,9 +1162,9 @@ public class JavaCompiler {
                     taskListener.started(new TaskEvent(TaskEvent.Kind.ANNOTATION_PROCESSING));
                 deferredDiagnosticHandler = new Log.DeferredDiagnosticHandler(log);
                 procEnvImpl.getFiler().setInitialState(initialFiles, initialClassNames);
-            } else { // free resources
-                procEnvImpl.close();
             }
+        } else { // free resources
+            procEnvImpl.close();
         }
     }
 

--- a/test/langtools/tools/javac/6341866/T6341866.java
+++ b/test/langtools/tools/javac/6341866/T6341866.java
@@ -67,7 +67,6 @@ public class T6341866 {
 
     enum AnnoType {
         NONE,           // no annotation processing
-        SERVICE,        // implicit annotation processing, via ServiceLoader
         SPECIFY         // explicit annotation processing
     };
 
@@ -99,14 +98,14 @@ public class T6341866 {
         processorServices.delete();
 
         List<String> opts = new ArrayList<String>();
-        opts.addAll(Arrays.asList("-d", ".", "-sourcepath", testSrc, "-classpath", testClasses, "-Xlint:-options"));
+        opts.addAll(Arrays.asList("-d", ".",
+                                  "-sourcepath", testSrc,
+                                  "-classpath", testClasses,
+                                  "-proc:full"));
         if (implicitType.opt != null)
             opts.add(implicitType.opt);
 
         switch (annoType) {
-        case SERVICE:
-            createProcessorServices(Anno.class.getName());
-            break;
         case SPECIFY:
             opts.addAll(Arrays.asList("-processor", Anno.class.getName()));
             break;
@@ -145,9 +144,6 @@ public class T6341866 {
             String expectKey = null;
             if (implicitType == ImplicitType.OPT_UNSET) {
                 switch (annoType) {
-                case SERVICE:
-                    expectKey = "compiler.warn.proc.use.proc.or.implicit";
-                    break;
                 case SPECIFY:
                     expectKey = "compiler.warn.proc.use.implicit";
                     break;

--- a/test/langtools/tools/javac/diags/examples.not-yet.txt
+++ b/test/langtools/tools/javac/diags/examples.not-yet.txt
@@ -217,3 +217,7 @@ compiler.err.annotation.unrecognized.attribute.name
 
 # this one is transitional (waiting for FFM API to exit preview)
 compiler.warn.restricted.method
+
+# Pending removal
+compiler.note.implicit.annotation.processing
+compiler.warn.proc.use.proc.or.implicit

--- a/test/langtools/tools/javac/diags/examples/ProcUseProcOrImplicit/ProcUseProcOrImplicit.java
+++ b/test/langtools/tools/javac/diags/examples/ProcUseProcOrImplicit/ProcUseProcOrImplicit.java
@@ -21,8 +21,6 @@
  * questions.
  */
 
-// key: compiler.warn.proc.use.proc.or.implicit
-// key: compiler.note.implicit.annotation.processing
 // options: -Xprefer:source
 
 import p.SomeClass;

--- a/test/langtools/tools/javac/processing/options/TestNoteOnImplicitProcessing.java
+++ b/test/langtools/tools/javac/processing/options/TestNoteOnImplicitProcessing.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 8310061 8315534
- * @summary Verify a note is issued for implicit annotation processing
+ * @bug 8310061 8315534 8306819
+ * @summary Verify behavior around implicit annotation processing
  *
  * @library /tools/lib /tools/javac/lib
  * @modules
@@ -59,19 +59,27 @@ import toolbox.ToolBox;
 import toolbox.JarTask;
 
 /*
- * Generates note and the processor runs:
+ * Does not generates a note and the processor does not run:
  * $ javac -cp ImplicitProcTestProc.jar                                     HelloWorldTest.java
  *
- * Does _not_ generate a note and the processor runs:
+ * Does _not_ generate a note and the processor does run:
  * $ javac -processorpath ImplicitProcTestProc.jar                          HelloWorldTest.java
  * $ javac -cp ImplicitProcTestProc.jar -processor ImplicitProcTestProc.jar HelloWorldTest.java
  * $ javac -cp ImplicitProcTestProc.jar -proc:full                          HelloWorldTest.java
  * $ javac -cp ImplicitProcTestProc.jar -proc:only                          HelloWorldTest.java
+ *
+ * Does _not_ generate a note and the processor does _not_run:
  * $ javac -cp ImplicitProcTestProc.jar -Xlint:-options                     HelloWorldTest.java
  * $ javac -cp ImplicitProcTestProc.jar -Xlint:none                         HelloWorldTest.java
  *
  * Does _not_ generate a note and the processor _doesn't_ run.
  * $ javac -cp ImplicitProcTestProc.jar -proc:none                          HelloWorldTest.java
+ *
+ * (Previously, annotation processing was implicitly enabled and the
+ * the class path was searched for processors. This test was
+ * originally written to probe around a note warning of a potential
+ * future policy change to disable such implicit processing, a policy
+ * change now implemented and this test has been updated accordingly.)
  */
 
 public class TestNoteOnImplicitProcessing extends TestRunner {
@@ -165,8 +173,8 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
             .run(Expect.SUCCESS)
             .writeAll();
 
-        checkForProcessorMessage(javacResult, true);
-        checkForCompilerNote(javacResult, true);
+        checkForProcessorMessage(javacResult, false);
+        checkForCompilerNote(javacResult, false);
     }
 
     @Test
@@ -239,7 +247,7 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
             .run(Expect.SUCCESS)
             .writeAll();
 
-        checkForProcessorMessage(javacResult, true);
+        checkForProcessorMessage(javacResult, false);
         checkForCompilerNote(javacResult, false);
     }
 
@@ -254,7 +262,7 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
             .run(Expect.SUCCESS)
             .writeAll();
 
-        checkForProcessorMessage(javacResult, true);
+        checkForProcessorMessage(javacResult, false);
         checkForCompilerNote(javacResult, false);
     }
 
@@ -317,7 +325,7 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
 
                 task.call();
 
-                verifyMessages(out, compilerOut, true);
+                verifyMessages(out, compilerOut, false, false);
             }
 
             {
@@ -329,7 +337,7 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
                 task.setProcessors(List.of(processor));
                 task.call();
 
-                verifyMessages(out, compilerOut, false);
+                verifyMessages(out, compilerOut, false, true);
             }
 
             {
@@ -339,7 +347,7 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
 
                 task.analyze();
 
-                verifyMessages(out, compilerOut, true);
+                verifyMessages(out, compilerOut, false, false);
             }
 
             {
@@ -353,16 +361,21 @@ public class TestNoteOnImplicitProcessing extends TestRunner {
                 task.setProcessors(List.of(processor));
                 task.analyze();
 
-                verifyMessages(out, compilerOut, false);
+                verifyMessages(out, compilerOut, false, true);
             }
         } finally {
             System.setOut(oldOut);
         }
     }
 
-    private void verifyMessages(ByteArrayOutputStream out, StringWriter compilerOut, boolean expectedNotePresent) {
-        if (!out.toString(StandardCharsets.UTF_8).contains("ImplicitProcTestProc run")) {
-            throw new RuntimeException("Expected processor message not printed");
+    private void verifyMessages(ByteArrayOutputStream out, StringWriter compilerOut, boolean expectedNotePresent,
+                                boolean processorRunExpected) {
+        boolean processorRun = out.toString(StandardCharsets.UTF_8).contains("ImplicitProcTestProc run");
+
+        if (processorRun != processorRunExpected) {
+            throw new RuntimeException(processorRunExpected ?
+                                       "Expected processor message not printed" :
+                                       "Unexpected processor message printed");
         }
 
         out.reset();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8321319](https://bugs.openjdk.org/browse/JDK-8321319) to be approved

### Issues
 * [JDK-8321314](https://bugs.openjdk.org/browse/JDK-8321314): Reinstate disabling the compiler's default active annotation processing (**Enhancement** - P3)
 * [JDK-8321319](https://bugs.openjdk.org/browse/JDK-8321319): Reinstate disabling the compiler's default active annotation processing (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19331/head:pull/19331` \
`$ git checkout pull/19331`

Update a local copy of the PR: \
`$ git checkout pull/19331` \
`$ git pull https://git.openjdk.org/jdk.git pull/19331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19331`

View PR using the GUI difftool: \
`$ git pr show -t 19331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19331.diff">https://git.openjdk.org/jdk/pull/19331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19331#issuecomment-2127898339)