### PR TITLE
8332777: Update JCStress test suite

### DIFF
--- a/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
+++ b/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,14 +42,14 @@ import java.util.List;
  * jcstress tests wrapper
  */
 @Artifact(organization = "org.openjdk.jcstress", name = "jcstress-tests-all",
-        revision = "0.16", extension = "jar", unpack = false)
+        revision = JcstressRunner.VERSION, extension = "jar", unpack = false)
 public class JcstressRunner {
 
+    public static final String VERSION = "0.17-SNAPSHOT-20240328";
     public static final String MAIN_CLASS = "org.openjdk.jcstress.Main";
 
-    // Allow to configure jcstress mode parameter.
-    // Test mode preset: sanity, quick, default, tough, stress.
-    public static final String MODE_PROPERTY = "jcstress.mode";
+    public static final String TIME_BUDGET_PROPERTY = "jcstress.time_budget";
+    public static String timeBudget = "5m";
 
     public static Path pathToArtifact() {
         Map<String, Path> artifacts;
@@ -59,7 +59,7 @@ public class JcstressRunner {
             throw new Error("TESTBUG: Can not resolve artifacts for "
                             + JcstressRunner.class.getName(), e);
         }
-        return artifacts.get("org.openjdk.jcstress.jcstress-tests-all-0.16")
+        return artifacts.get("org.openjdk.jcstress.jcstress-tests-all-" + VERSION)
                         .toAbsolutePath();
     }
 
@@ -109,21 +109,17 @@ public class JcstressRunner {
         extraFlags.add("--jvmArgs");
         extraFlags.add("-Djava.io.tmpdir=" + System.getProperty("user.dir"));
 
-        // The "default" preset might take days for some tests
-        // so use quick testing by default.
-        String mode = "quick";
         for (String jvmArg : Utils.getTestJavaOpts()) {
-            if(jvmArg.startsWith("-D" + MODE_PROPERTY)) {
-                String[] pair = jvmArg.split("=", 2);
-                mode = pair[1];
-                continue;
+            if(jvmArg.startsWith("-D" + TIME_BUDGET_PROPERTY)) {
+                timeBudget =  jvmArg.split("=", 2)[1];
+            } else {
+                extraFlags.add("--jvmArgs");
+                extraFlags.add(jvmArg);
             }
-            extraFlags.add("--jvmArgs");
-            extraFlags.add(jvmArg);
         }
 
-        extraFlags.add("-m");
-        extraFlags.add(mode);
+        extraFlags.add("-tb");
+        extraFlags.add(timeBudget);
 
         extraFlags.add("-sc");
         extraFlags.add("false");

--- a/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
+++ b/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
@@ -110,8 +110,8 @@ public class JcstressRunner {
         extraFlags.add("-Djava.io.tmpdir=" + System.getProperty("user.dir"));
 
         for (String jvmArg : Utils.getTestJavaOpts()) {
-            if(jvmArg.startsWith("-D" + TIME_BUDGET_PROPERTY)) {
-                timeBudget =  jvmArg.split("=", 2)[1];
+            if (jvmArg.startsWith("-D" + TIME_BUDGET_PROPERTY)) {
+                timeBudget = jvmArg.split("=", 2)[1];
             } else {
                 extraFlags.add("--jvmArgs");
                 extraFlags.add(jvmArg);

--- a/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
+++ b/test/hotspot/jtreg/applications/jcstress/JcstressRunner.java
@@ -49,7 +49,7 @@ public class JcstressRunner {
     public static final String MAIN_CLASS = "org.openjdk.jcstress.Main";
 
     public static final String TIME_BUDGET_PROPERTY = "jcstress.time_budget";
-    public static String timeBudget = "5m";
+    public static String timeBudget = "6m";
 
     public static Path pathToArtifact() {
         Map<String, Path> artifacts;


### PR DESCRIPTION
This PR updates the runner to use the latest JCStress version (latest 0.17 snapshot).
The only change is that JCStress have gotten rid of modes, 'quick', 'default', etc. The developer suggests to use so called 'time budget' instead.
I chose default time budget of 5 minutes as this gives approximately the same running time in CI and on my local machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332777](https://bugs.openjdk.org/browse/JDK-8332777): Update JCStress test suite (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19332/head:pull/19332` \
`$ git checkout pull/19332`

Update a local copy of the PR: \
`$ git checkout pull/19332` \
`$ git pull https://git.openjdk.org/jdk.git pull/19332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19332`

View PR using the GUI difftool: \
`$ git pr show -t 19332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19332.diff">https://git.openjdk.org/jdk/pull/19332.diff</a>

</details>
