### PR TITLE
8332122: [nmt] Totals for malloc should show total peak

### DIFF
--- a/src/hotspot/share/nmt/mallocTracker.hpp
+++ b/src/hotspot/share/nmt/mallocTracker.hpp
@@ -179,6 +179,16 @@ class MallocMemorySnapshot {
     return _all_mallocs.size() + malloc_overhead() + total_arena();
   }
 
+  // Total peak malloc
+  size_t total_peak() const {
+    return _all_mallocs.peak_size();
+  }
+
+  // Total peak count
+  size_t total_peak_count() const {
+    return _all_mallocs.peak_count();
+  }
+
   // Total malloc'd memory used by arenas
   size_t total_arena() const;
 

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -165,9 +165,11 @@ void MemSummaryReporter::report() {
   out->print("Total: ");
   print_total(total_reserved_amount, total_committed_amount);
   out->cr();
-  out->print_cr("       malloc: " SIZE_FORMAT "%s #" SIZE_FORMAT,
+  out->print_cr("       malloc: " SIZE_FORMAT "%s #" SIZE_FORMAT ", peak=" SIZE_FORMAT "%s #" SIZE_FORMAT,
                 amount_in_current_scale(total_malloced_bytes), current_scale(),
-                _malloc_snapshot->total_count());
+                _malloc_snapshot->total_count(),
+                amount_in_current_scale(_malloc_snapshot->total_peak()),
+                current_scale(), _malloc_snapshot->total_peak_count());
   out->print("       mmap:   ");
   print_total(total_mmap_reserved_bytes, total_mmap_committed_bytes);
   out->cr();

--- a/test/hotspot/jtreg/runtime/NMT/PeakMallocTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/PeakMallocTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332122
+ * @summary Test to verify correctness of peak malloc tracking
+ * @key randomness
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -XX:NativeMemoryTracking=summary -Xms8m -Xmx8m -Xint PeakMallocTest
+ *
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+import jdk.test.whitebox.WhiteBox;
+
+public class PeakMallocTest {
+
+    public static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) throws Exception {
+
+        // Measure early malloc total and peak
+        OutputAnalyzer output = NMTTestUtils.startJcmdVMNativeMemory();
+        long earlyTotal = getMallocTotal(output);
+        long earlyPeak = getMallocPeak(output);
+        System.out.println("Early malloc total: " + earlyTotal);
+        System.out.println("Early malloc peak: " + earlyPeak);
+
+
+        // Allocate a large amount of memory and then free
+        long allocSize = Math.max(8 * earlyPeak, 1000000000); // MAX(earlyPeak * 8, 1GB)
+        long addr = wb.NMTMalloc(allocSize);
+        System.out.println("Allocation size: " + allocSize);
+        wb.NMTFree(addr);
+
+        // Measure again
+        output = NMTTestUtils.startJcmdVMNativeMemory();
+        long currTotal = getMallocTotal(output);
+        long currPeak = getMallocPeak(output);
+        System.out.println("Current malloc total: " + currTotal);
+        System.out.println("Current malloc peak: " + currPeak);
+
+        // Verify total global malloc is similar
+        // Fudge factor of 10% to account for noise
+        if ((currTotal < earlyTotal * 0.9) || (currTotal > earlyTotal * 1.1)) {
+            throw new Exception("Global malloc measurement is incorrect");
+        }
+
+        // Verify global malloc peak reflects large allocation
+        long peakDiff = (currPeak - earlyPeak) * 1000; // Note, KB to Bytes conversion
+        System.out.println("Peak diff: " + peakDiff);
+        if ((peakDiff < allocSize * 0.9) || (peakDiff > allocSize * 1.1)) {
+            throw new Exception("Global malloc peak measurement is incorrect");
+        }
+    }
+
+    private static long getMallocPeak(OutputAnalyzer output) {
+        // First match should correspond to global malloc peak
+        String global = output.firstMatch("peak=\\d*");
+        return Long.parseLong(global.substring(global.indexOf("=") + 1));
+    }
+
+    private static long getMallocTotal(OutputAnalyzer output) {
+        // First match should correspond to global malloc total
+        String global = output.firstMatch("malloc: \\d*");
+        return Long.parseLong(global.substring(global.indexOf(" ") + 1));
+    }
+}


### PR DESCRIPTION
Hi all, 

This PR addresses [8332122](https://bugs.openjdk.org/browse/JDK-8332122). 

With this patch, we enable printing global malloc peaks in NMT when printing summary information. 

Testing: 
- [x] Added test case passes. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332122](https://bugs.openjdk.org/browse/JDK-8332122): [nmt] Totals for malloc should show total peak (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**) ⚠️ Review applies to [b42a80ea](https://git.openjdk.org/jdk/pull/19333/files/b42a80eacbe36b309bc08eb12dabd0bf79f103db)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19333/head:pull/19333` \
`$ git checkout pull/19333`

Update a local copy of the PR: \
`$ git checkout pull/19333` \
`$ git pull https://git.openjdk.org/jdk.git pull/19333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19333`

View PR using the GUI difftool: \
`$ git pr show -t 19333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19333.diff">https://git.openjdk.org/jdk/pull/19333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19333#issuecomment-2123276902)