### PR TITLE
8341427: JFR: Adjust object sampler span handling

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.hpp
+++ b/src/hotspot/share/jfr/leakprofiler/sampling/objectSampler.hpp
@@ -64,6 +64,7 @@ class ObjectSampler : public CHeapObj<mtTracing> {
   void add(HeapWord* object, size_t size, traceid thread_id, bool virtual_thread, const JfrBlobHandle& bh, JavaThread* thread);
   void scavenge();
   void remove_dead(ObjectSample* sample);
+  void push_span(ObjectSample* sample, size_t span);
 
   const ObjectSample* item_at(int index) const;
   ObjectSample* item_at(int index);


### PR DESCRIPTION
The span stored in each sample is not the calculated span, it's just the object's byte size (`allocated`). That means as soon as any object falls out of the queue, the spans in the queue no longer sum to cover the allocation timeline. This causes all future samples to be added to be unduly prioritized for adding to the queue, because they are given an artificially high span. In effect, future samples are weighted as if they cover both the interval between themselves and the older neighbor sample, plus all "missing spans" from nodes that have been discarded since the program started.

Changed object samples to store the calculated span rather than the bytes allocated for the sampled object.

When a sample is removed from the queue because a sample with a larger span is being added, the span of the removed node is not handed to the younger neighbor, this only happens when a sample is removed due to GC. This means that the span will be given to the next sample added to the queue. When the sample being removed is the youngest sample, this is fine, but when it's a sample that has a younger neighbor, the span should probably be given to that neighbor rather than the newcomer. Handing it to the newcomer gives the new sample a high weight it doesn't deserve. It ends up covering not just the span to the older neighbor, but also the span of the removed node, which is not what we want.

When replacing a sample in the queue, give the span of the removed sample to the younger neighbor. If there is no such neighbor, because the youngest sample is being replaced, give the span to the node being added instead, as that will become the new youngest sample.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341427](https://bugs.openjdk.org/browse/JDK-8341427): JFR: Adjust object sampler span handling (**Bug** - P2)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19334/head:pull/19334` \
`$ git checkout pull/19334`

Update a local copy of the PR: \
`$ git checkout pull/19334` \
`$ git pull https://git.openjdk.org/jdk.git pull/19334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19334`

View PR using the GUI difftool: \
`$ git pr show -t 19334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19334.diff">https://git.openjdk.org/jdk/pull/19334.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19334#issuecomment-2493734883)
</details>
