### PR TITLE
8331348: Some incremental builds deposit files in the make directory

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -374,7 +374,7 @@ public class Main {
         Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
         Path out = tmpDir.resolve(String.format("javac.%s.args",
                 new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime())));
-        String strOut = "";
+        String strOut = "# javac crashed, this report includes the parameters passed to it in the @-file format\n";
         try {
             try (Writer w = Files.newBufferedWriter(out)) {
                 for (String param : params) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/main/Main.java
@@ -371,7 +371,8 @@ public class Main {
     }
 
     void printArgumentsToFile(String... params) {
-        Path out = Paths.get(String.format("javac.%s.args",
+        Path tmpDir = Paths.get(System.getProperty("java.io.tmpdir"));
+        Path out = tmpDir.resolve(String.format("javac.%s.args",
                 new SimpleDateFormat("yyyyMMdd_HHmmss").format(Calendar.getInstance().getTime())));
         String strOut = "";
         try {


### PR DESCRIPTION
Please review this small change. Passes tier 1-3.

In case of fatal errors or if a hidden option is passed to the compiler, a report with the parameters passed to it is printed to a file in the `@-file` format, this makes it easier for us to reproduce the bug. And for users submitting bug reports.
Some of these files were being deposited in the current directory during OpenJDK builds, now they are moved to the temp dir.
Writing to the console only is not an option because of the large number of arguments that can be passed to the compiler.
By convention, a number of arguments is printed to the console if an error occurs while writing to the file.
Some also suggested adding a message as to why this file exist.

TIA

I see the bot is complaining due to the fix version but I think it can be changed, if this is approved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331348](https://bugs.openjdk.org/browse/JDK-8331348): Some incremental builds deposit files in the make directory (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19338/head:pull/19338` \
`$ git checkout pull/19338`

Update a local copy of the PR: \
`$ git checkout pull/19338` \
`$ git pull https://git.openjdk.org/jdk.git pull/19338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19338`

View PR using the GUI difftool: \
`$ git pr show -t 19338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19338.diff">https://git.openjdk.org/jdk/pull/19338.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19338#issuecomment-2123721304)