### PR TITLE
8332490: JMH org.openjdk.bench.java.util.zip.InflaterInputStreams.inflaterInputStreamRead OOM

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
@@ -108,7 +108,8 @@ public class InflaterInputStreams {
     @Benchmark
     public void inflaterInputStreamRead() throws IOException {
         deflated.reset();
-        InflaterInputStream iis = new InflaterInputStream(deflated);
-        while (iis.read(inflated, 0, inflated.length) != -1);
+        try (InflaterInputStream iis = new InflaterInputStream(deflated)) {
+            while (iis.read(inflated, 0, inflated.length) != -1);
+        }
     }
 }

--- a/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
+++ b/test/micro/org/openjdk/bench/java/util/zip/InflaterInputStreams.java
@@ -108,6 +108,8 @@ public class InflaterInputStreams {
     @Benchmark
     public void inflaterInputStreamRead() throws IOException {
         deflated.reset();
+        // We close the InflaterInputStream to release underlying native resources of the Inflater.
+        // The "deflated" ByteArrayInputStream remains unaffected.
         try (InflaterInputStream iis = new InflaterInputStream(deflated)) {
             while (iis.read(inflated, 0, inflated.length) != -1);
         }


### PR DESCRIPTION
Can I please get a review of this test-only change for addressing https://bugs.openjdk.org/browse/JDK-8332490?

The jmh test opens a `InflaterInputStream`, reads the stream contents, but then doesn't close the stream. This can lead to resource leak which can then cause OOM as noted in that JBS issue.

The commit in this PR closes the `InflaterInputStream` when the reads complete.

```
make test TEST=micro:org.openjdk.bench.java.util.zip.InflaterInputStreams
```
and

```
./build/macosx-aarch64/images/jdk/bin/java -jar ./build/macosx-aarch64/images/test/micro/benchmarks.jar org.openjdk.bench.java.util.zip.InflaterInputStreams.inflaterInputStreamRead -t max -f 1 -wi 2 -foe true
```
pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332490](https://bugs.openjdk.org/browse/JDK-8332490): JMH org.openjdk.bench.java.util.zip.InflaterInputStreams.inflaterInputStreamRead OOM (**Bug** - P4)


### Reviewers
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer) ⚠️ Review applies to [f8687c3f](https://git.openjdk.org/jdk/pull/19340/files/f8687c3f3d88ebb550582be26408b3e4385a4377)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19340/head:pull/19340` \
`$ git checkout pull/19340`

Update a local copy of the PR: \
`$ git checkout pull/19340` \
`$ git pull https://git.openjdk.org/jdk.git pull/19340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19340`

View PR using the GUI difftool: \
`$ git pr show -t 19340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19340.diff">https://git.openjdk.org/jdk/pull/19340.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19340#issuecomment-2123888241)