### PR TITLE
8307193: Several Swing jtreg tests use class.forName on L&F classes

### DIFF
--- a/test/jdk/javax/swing/JMenuBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuBar/RightLeftOrientation.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4211731 4214512
+ * @summary
+ *     This test checks if menu bars lay out correctly when their
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT.  This test is
+ *     manual.  The tester is asked to compare left-to-right and
+ *     right-to-left menu bars and judge whether they are mirror images of each
+ *     other.
+ * @library /test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RightLeftOrientation
+ */
+
+import java.awt.ComponentOrientation;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.ButtonGroup;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class RightLeftOrientation {
+
+    static JFrame ltrFrame;
+    static JFrame rtlFrame;
+
+    private static final String INSTRUCTIONS = """
+        This test checks menu bars for correct Right-To-Left Component Orientation.
+
+        You should see two frames, each containing a menu bar.
+
+        One frame will be labelled "Left To Right" and will contain
+        a menu bar with menus starting on its left side.
+        The other frame will be labelled "Right To Left" and will
+        contain a menu bar with menus starting on its right side.
+
+        The test will also contain radio buttons that can be used to set
+        the look and feel of the menu bars.
+        For each look and feel, you should compare the two menu
+        bars and make sure they are mirror images of each other. """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                 .title("RTL test Instructions")
+                 .instructions(INSTRUCTIONS)
+                 .rows((int) INSTRUCTIONS.lines().count() + 2)
+                 .columns(30)
+                 .testUI(RightLeftOrientation::createTestUI)
+                 .build()
+                 .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("RightLeftOrientation");
+        JPanel panel = new JPanel();
+
+        ButtonGroup group = new ButtonGroup();
+        JRadioButton rb;
+        ActionListener plafChanger = new PlafChanger();
+
+        UIManager.LookAndFeelInfo[] lafInfos = UIManager.getInstalledLookAndFeels();
+        for (int i = 0; i < lafInfos.length; i++) {
+            rb = new JRadioButton(lafInfos[i].getName());
+            rb.setActionCommand(lafInfos[i].getClassName());
+            rb.addActionListener(plafChanger);
+            group.add(rb);
+            panel.add(rb);
+            if (i == 0) {
+                rb.setSelected(true);
+            }
+        }
+
+        frame.add(panel);
+
+
+        ltrFrame = new JFrame("Left To Right");
+        ltrFrame.setJMenuBar(createMenuBar(ComponentOrientation.LEFT_TO_RIGHT));
+        ltrFrame.setSize(400, 100);
+        ltrFrame.setLocation(new Point(10, 10));
+        ltrFrame.setVisible(true);
+
+        rtlFrame = new JFrame("Right To Left");
+        rtlFrame.setJMenuBar(createMenuBar(ComponentOrientation.RIGHT_TO_LEFT));
+        rtlFrame.setSize(400, 100);
+        rtlFrame.setLocation(new Point(10, 120));
+        rtlFrame.setVisible(true);
+        frame.pack();
+        return frame;
+    }
+
+    static class PlafChanger implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            String lnfName = e.getActionCommand();
+
+            try {
+                UIManager.setLookAndFeel(lnfName);
+                SwingUtilities.updateComponentTreeUI(ltrFrame);
+                SwingUtilities.updateComponentTreeUI(rtlFrame);
+            }
+            catch (Exception exc) {
+                System.err.println("Could not load LookAndFeel: " + lnfName);
+            }
+
+        }
+    }
+
+
+    static JMenuBar createMenuBar(ComponentOrientation o) {
+        JMenuBar menuBar = new JMenuBar();
+        menuBar.setComponentOrientation(o);
+
+        JMenu menu = new JMenu("One");
+        menu.setComponentOrientation(o);
+        menuBar.add(menu);
+
+        menu = new JMenu("Two");
+        menu.setComponentOrientation(o);
+        menuBar.add(menu);
+
+        menu = new JMenu("Three");
+        menu.setComponentOrientation(o);
+        menuBar.add(menu);
+
+        return menuBar;
+    }
+
+}

--- a/test/jdk/javax/swing/JMenuBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JMenuBar/RightLeftOrientation.java
@@ -25,7 +25,7 @@
  * @bug 4211731 4214512
  * @summary
  *     This test checks if menu bars lay out correctly when their
- *     ComponentOrientation property is set to RIGHT_TO_LEFT.  This test is
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT. This test is
  *     manual.  The tester is asked to compare left-to-right and
  *     right-to-left menu bars and judge whether they are mirror images of each
  *     other.
@@ -99,7 +99,6 @@ public class RightLeftOrientation {
         }
 
         frame.add(panel);
-
 
         ltrFrame = new JFrame("Left To Right");
         ltrFrame.setJMenuBar(createMenuBar(ComponentOrientation.LEFT_TO_RIGHT));

--- a/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4214514
+ * @summary
+ *     This test checks if tool bars lay out correctly when their
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT.  This test is
+ *     manual.  The tester is asked to compare left-to-right and
+ *     right-to-left tool bars and judge whether they are mirror images of each
+ *     other.
+ * @library /test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RightLeftOrientation
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.ComponentOrientation;
+import java.awt.Container;
+import java.awt.Point;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+public class RightLeftOrientation {
+
+    static JFrame ltrFrame;
+    static JFrame rtlFrame;
+
+    private static final String INSTRUCTIONS = """
+        This test checks tool bars for correct Right-To-Left Component Orientation.
+
+        You should see two frames, each containing a tool bar.
+
+        One frame will be labelled "Left To Right" and will contain
+        a tool bar with buttons starting on its left side.
+        The other frame will be labelled "Right To Left" and will
+        contain a tool bar with buttons starting on its right side.
+
+        The test will also contain radio buttons that can be used to set
+        the look and feel of the tool bars.
+        For each look and feel, you should compare the two tool bars and
+        make sure they are mirror images of each other.
+        You should also drag the tool bars to each corner of the frame
+        to make sure the docking behavior is consistent between the two frames.""";
+
+     public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                 .title("RTL test Instructions")
+                 .instructions(INSTRUCTIONS)
+                 .rows((int) INSTRUCTIONS.lines().count() + 2)
+                 .columns(35)
+                 .testUI(RightLeftOrientation::createTestUI)
+                 .build()
+                 .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("RightLeftOrientation");
+        JPanel panel = new JPanel();
+
+        ButtonGroup group = new ButtonGroup();
+        JRadioButton rb;
+        ActionListener plafChanger = new PlafChanger();
+
+        UIManager.LookAndFeelInfo[] lafInfos = UIManager.getInstalledLookAndFeels();
+        for (int i = 0; i < lafInfos.length; i++) {
+            rb = new JRadioButton(lafInfos[i].getName());
+            rb.setActionCommand(lafInfos[i].getClassName());
+            rb.addActionListener(plafChanger);
+            group.add(rb);
+            panel.add(rb);
+            if (i == 0) {
+                rb.setSelected(true);
+            }
+        }
+
+        frame.add(panel);
+
+
+        ltrFrame = new JFrame("Left To Right");
+        Container contentPane = ltrFrame.getContentPane();
+        contentPane.setLayout(new BorderLayout());
+        panel = new JPanel();
+        panel.setBackground( Color.white );
+        contentPane.add("Center",panel);
+        contentPane.add("North",
+                        createToolBar(ComponentOrientation.LEFT_TO_RIGHT));
+        ltrFrame.setSize(400, 140);
+        ltrFrame.setLocation(new Point(10, 10));
+        ltrFrame.setVisible(true);
+
+        rtlFrame = new JFrame("Right To Left");
+        contentPane = rtlFrame.getContentPane();
+        contentPane.setLayout(new BorderLayout());
+        panel = new JPanel();
+        panel.setBackground( Color.white );
+        contentPane.add("Center",panel);
+        contentPane.add("North",
+                        createToolBar(ComponentOrientation.RIGHT_TO_LEFT));
+        rtlFrame.setSize(400, 140);
+        rtlFrame.setLocation(new Point(420, 10));
+        rtlFrame.setVisible(true);
+
+        frame.pack();
+        return frame;
+    }
+
+    static class PlafChanger implements ActionListener {
+        public void actionPerformed(ActionEvent e) {
+            String lnfName = e.getActionCommand();
+
+            try {
+                UIManager.setLookAndFeel(lnfName);
+                SwingUtilities.updateComponentTreeUI(ltrFrame);
+                SwingUtilities.updateComponentTreeUI(rtlFrame);
+            }
+            catch (Exception exc) {
+                System.err.println("Could not load LookAndFeel: " + lnfName);
+            }
+
+        }
+    }
+
+
+    static JToolBar createToolBar(ComponentOrientation o) {
+        JToolBar toolBar = new JToolBar();
+        toolBar.setComponentOrientation(o);
+
+        JButton button = new JButton("One");
+        button.setComponentOrientation(o);
+        toolBar.add(button);
+
+        button = new JButton("Two");
+        button.setComponentOrientation(o);
+        toolBar.add(button);
+
+        button = new JButton("Three");
+        button.setComponentOrientation(o);
+        toolBar.add(button);
+
+        return toolBar;
+    }
+
+}

--- a/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
+++ b/test/jdk/javax/swing/JToolBar/RightLeftOrientation.java
@@ -25,7 +25,7 @@
  * @bug 4214514
  * @summary
  *     This test checks if tool bars lay out correctly when their
- *     ComponentOrientation property is set to RIGHT_TO_LEFT.  This test is
+ *     ComponentOrientation property is set to RIGHT_TO_LEFT. This test is
  *     manual.  The tester is asked to compare left-to-right and
  *     right-to-left tool bars and judge whether they are mirror images of each
  *     other.
@@ -105,12 +105,11 @@ public class RightLeftOrientation {
 
         frame.add(panel);
 
-
         ltrFrame = new JFrame("Left To Right");
         Container contentPane = ltrFrame.getContentPane();
         contentPane.setLayout(new BorderLayout());
         panel = new JPanel();
-        panel.setBackground( Color.white );
+        panel.setBackground(Color.white);
         contentPane.add("Center",panel);
         contentPane.add("North",
                         createToolBar(ComponentOrientation.LEFT_TO_RIGHT));
@@ -122,7 +121,7 @@ public class RightLeftOrientation {
         contentPane = rtlFrame.getContentPane();
         contentPane.setLayout(new BorderLayout());
         panel = new JPanel();
-        panel.setBackground( Color.white );
+        panel.setBackground(Color.white);
         contentPane.add("Center",panel);
         contentPane.add("North",
                         createToolBar(ComponentOrientation.RIGHT_TO_LEFT));


### PR DESCRIPTION
Opensource couple RTL tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307193](https://bugs.openjdk.org/browse/JDK-8307193): Several Swing jtreg tests use class.forName on L&amp;F classes (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [e9c1da0e](https://git.openjdk.org/jdk/pull/19341/files/e9c1da0e496281832b5c81aa1bce1ed13d9a8eea)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19341/head:pull/19341` \
`$ git checkout pull/19341`

Update a local copy of the PR: \
`$ git checkout pull/19341` \
`$ git pull https://git.openjdk.org/jdk.git pull/19341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19341`

View PR using the GUI difftool: \
`$ git pr show -t 19341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19341.diff">https://git.openjdk.org/jdk/pull/19341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19341#issuecomment-2123910206)