### PR TITLE
8332678: Serial: Remove use of should_clear_all_soft_refs in serial folder

### DIFF
--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -685,11 +685,6 @@ void SerialFullGC::invoke_at_safepoint(bool clear_all_softrefs) {
   assert(SafepointSynchronize::is_at_safepoint(), "must be at a safepoint");
 
   SerialHeap* gch = SerialHeap::heap();
-#ifdef ASSERT
-  if (gch->soft_ref_policy()->should_clear_all_soft_refs()) {
-    assert(clear_all_softrefs, "Policy should have been checked earlier");
-  }
-#endif
 
   gch->trace_heap_before_gc(_gc_tracer);
 

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -559,9 +559,6 @@ HeapWord* SerialHeap::satisfy_failed_allocation(size_t size, bool is_tlab) {
     return result;
   }
 
-  assert(!soft_ref_policy()->should_clear_all_soft_refs(),
-    "Flag should have been handled and cleared prior to this point");
-
   // What else?  We might try synchronous finalization later.  If the total
   // space available is large enough for the allocation, then a more
   // complete compaction phase than we've tried so far might be


### PR DESCRIPTION
Simple removing all accesses to `soft_ref_policy` in Serial code, because the decision to clear-soft-refs is made inside Serial and captured in local variables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332678](https://bugs.openjdk.org/browse/JDK-8332678): Serial: Remove use of should_clear_all_soft_refs in serial folder (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19346/head:pull/19346` \
`$ git checkout pull/19346`

Update a local copy of the PR: \
`$ git checkout pull/19346` \
`$ git pull https://git.openjdk.org/jdk.git pull/19346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19346`

View PR using the GUI difftool: \
`$ git pr show -t 19346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19346.diff">https://git.openjdk.org/jdk/pull/19346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19346#issuecomment-2124345865)