### PR TITLE
8332675: test/hotspot/jtreg/gc/testlibrary/Helpers.java compileClass javadoc does not match after 8321812

### DIFF
--- a/test/hotspot/jtreg/gc/testlibrary/Helpers.java
+++ b/test/hotspot/jtreg/gc/testlibrary/Helpers.java
@@ -88,7 +88,7 @@ public class Helpers {
      * @param className class name
      * @param root      root directory - where .java and .class files will be put
      * @param source    class source
-     * @throws IOException if cannot write file to specified directory
+     * @throws Exception if cannot write file to specified directory
      */
     public static void compileClass(String className, Path root, String source) throws Exception {
         Path sourceFile = root.resolve(className + ".java");


### PR DESCRIPTION
The javadoc for compileClass needs updating after JDK-8321812 .
See
https://github.com/openjdk/jdk/commit/1d1cd32bc355a33448d8f15555e142570bb49c21#diff-aa21aa70a6334c4d148b2fd72ceaca1e60c9e18dffe4758004c216d3972231c8

where in line 93 the interface changed but the javadoc above stayed.  In the same file below the javadoc was updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332675: test/hotspot/jtreg/gc/testlibrary/Helpers.java compileClass javadoc does not match after 8321812`

### Issue
 * [JDK-8332675](https://bugs.openjdk.org/browse/JDK-8332675): test/hotspot/jtreg/gc/testlibrary/Helpers.java compileClass javadoc does not match after 8321812 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19348/head:pull/19348` \
`$ git checkout pull/19348`

Update a local copy of the PR: \
`$ git checkout pull/19348` \
`$ git pull https://git.openjdk.org/jdk.git pull/19348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19348`

View PR using the GUI difftool: \
`$ git pr show -t 19348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19348.diff">https://git.openjdk.org/jdk/pull/19348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19348#issuecomment-2124770225)