### PR TITLE
8332720: ubsan: instanceKlass.cpp:3550:76: runtime error: member call on null pointer of type 'struct Array'

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3547,13 +3547,13 @@ void InstanceKlass::print_on(outputStream* st) const {
     }
   }
   st->print(BULLET"method ordering:   "); method_ordering()->print_value_on(st);      st->cr();
-  st->print(BULLET"default_methods:   ");
-  if (default_methods() != nullptr) { default_methods()->print_value_on(st); }
-  st->cr();
-  if (Verbose && default_methods() != nullptr) {
-    Array<Method*>* method_array = default_methods();
-    for (int i = 0; i < method_array->length(); i++) {
-      st->print("%d : ", i); method_array->at(i)->print_value(); st->cr();
+  if (default_methods() != nullptr) {
+    st->print(BULLET"default_methods:   "); default_methods()->print_value_on(st);    st->cr();
+    if (Verbose) {
+      Array<Method*>* method_array = default_methods();
+      for (int i = 0; i < method_array->length(); i++) {
+        st->print("%d : ", i); method_array->at(i)->print_value(); st->cr();
+      }
     }
   }
   if (default_vtable_indices() != nullptr) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3547,7 +3547,9 @@ void InstanceKlass::print_on(outputStream* st) const {
     }
   }
   st->print(BULLET"method ordering:   "); method_ordering()->print_value_on(st);      st->cr();
-  st->print(BULLET"default_methods:   "); default_methods()->print_value_on(st);      st->cr();
+  st->print(BULLET"default_methods:   ");
+  if (default_methods() != nullptr) { default_methods()->print_value_on(st); }
+  st->cr();
   if (Verbose && default_methods() != nullptr) {
     Array<Method*>* method_array = default_methods();
     for (int i = 0; i < method_array->length(); i++) {


### PR DESCRIPTION
When running hs :tier1 tests, with ubsan enabled (configure flag --enable-ubsan), in test runtime/CommandLine/PrintClasses_id0.jtr
this error is reported ; seems we miss a nullptr check that is in place at similar coding in instanceKlass.cpp .

/jdk/src/hotspot/share/oops/instanceKlass.cpp:3550:76: runtime error: member call on null pointer of type 'struct Array'
    #0 0x7fed098d2362 in InstanceKlass::print_on(outputStream*) const /jdk/src/hotspot/share/oops/instanceKlass.cpp:3550
    #1 0x7fed09897cdc in PrintClassClosure::do_klass(Klass*) /jdk/src/hotspot/share/oops/instanceKlass.cpp:2228
    #2 0x7fed08bed334 in ClassLoaderData::classes_do(KlassClosure*) /jdk/src/hotspot/share/classfile/classLoaderData.cpp:387
    #3 0x7fed08c06403 in ClassLoaderDataGraph::classes_do(KlassClosure*) /jdk/src/hotspot/share/classfile/classLoaderDataGraph.cpp:303
    #4 0x7fed09108768 in VM_PrintClasses::doit() /jdk/src/hotspot/share/services/diagnosticCommand.cpp:989
    #5 0x7fed0b776c38 in VM_Operation::evaluate() /jdk/src/hotspot/share/runtime/vmOperations.cpp:75
    #6 0x7fed0b7af23e in VMThread::evaluate_operation(VM_Operation*) /jdk/src/hotspot/share/runtime/vmThread.cpp:283
    #7 0x7fed0b7b0a67 in VMThread::inner_execute(VM_Operation*) /jdk/src/hotspot/share/runtime/vmThread.cpp:427
    #8 0x7fed0b7b1681 in VMThread::loop() /jdk/src/hotspot/share/runtime/vmThread.cpp:493
    #9 0x7fed0b7b1681 in VMThread::loop() /jdk/src/hotspot/share/runtime/vmThread.cpp:478
    #10 0x7fed0b7b182d in VMThread::run() /jdk/src/hotspot/share/runtime/vmThread.cpp:177
    #11 0x7fed0b4e8b0f in Thread::call_run() /jdk/src/hotspot/share/runtime/thread.cpp:225
    #12 0x7fed0a9dae75 in thread_native_entry /jdk/src/hotspot/os/linux/os_linux.cpp:846
    #13 0x7fed10fed6e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)
    #14 0x7fed1051550e in clone (/lib64/libc.so.6+0x11850e) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332720: ubsan: instanceKlass.cpp:3550:76: runtime error: member call on null pointer of type 'struct Array'`

### Issue
 * [JDK-8332720](https://bugs.openjdk.org/browse/JDK-8332720): ubsan: instanceKlass.cpp:3550:76: runtime error: member call on null pointer of type 'struct Array' (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19349/head:pull/19349` \
`$ git checkout pull/19349`

Update a local copy of the PR: \
`$ git checkout pull/19349` \
`$ git pull https://git.openjdk.org/jdk.git pull/19349/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19349`

View PR using the GUI difftool: \
`$ git pr show -t 19349`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19349.diff">https://git.openjdk.org/jdk/pull/19349.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19349#issuecomment-2124965555)