### PR TITLE
8332724: x86 MacroAssembler may over-align code

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3836,7 +3836,7 @@ void Assembler::negl(Address dst) {
   emit_operand(as_Register(3), dst, 0);
 }
 
-void Assembler::nop(int i) {
+void Assembler::nop(uint i) {
 #ifdef ASSERT
   assert(i > 0, " ");
   // The fancy nops aren't currently recognized by debuggers making it a

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1730,7 +1730,7 @@ private:
   void negq(Address dst);
 #endif
 
-  void nop(int i = 1);
+  void nop(uint i = 1);
 
   void notl(Register dst);
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1150,11 +1150,11 @@ void MacroAssembler::addpd(XMMRegister dst, AddressLiteral src, Register rscratc
 // Stub code is generated once and never copied.
 // NMethods can't use this because they get copied and we can't force alignment > 32 bytes.
 void MacroAssembler::align64() {
-  align(64, (unsigned long long) pc());
+  align(64, (uint)(uintptr_t)pc());
 }
 
 void MacroAssembler::align32() {
-  align(32, (unsigned long long) pc());
+  align(32, (uint)(uintptr_t)pc());
 }
 
 void MacroAssembler::align(uint modulus) {

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1157,20 +1157,15 @@ void MacroAssembler::align32() {
   align(32, (unsigned long long) pc());
 }
 
-void MacroAssembler::align(int modulus) {
+void MacroAssembler::align(uint modulus) {
   // 8273459: Ensure alignment is possible with current segment alignment
   assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 
-void MacroAssembler::align(int modulus, int target) {
-  int mask = modulus - 1;
-  guarantee((modulus & mask) == 0, "Modulus must be a power of two");
-  int numNops = mask & (-target);
-  assert(numNops >= 0 && numNops < modulus, "Unexpected number of NOPs");
-  assert((target + numNops) % modulus == 0, "Incorrect number of NOPs");
-  if (numNops != 0) {
-    nop(numNops);
+void MacroAssembler::align(uint modulus, uint target) {
+  if (target % modulus != 0) {
+    nop(modulus - (target % modulus));
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1159,7 +1159,7 @@ void MacroAssembler::align32() {
 
 void MacroAssembler::align(uint modulus) {
   // 8273459: Ensure alignment is possible with current segment alignment
-  assert(modulus <= CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
+  assert(modulus <= (uintx)CodeEntryAlignment, "Alignment must be <= CodeEntryAlignment");
   align(modulus, offset());
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1167,8 +1167,8 @@ void MacroAssembler::align(int modulus, int target) {
   int mask = modulus - 1;
   guarantee((modulus & mask) == 0, "Modulus must be a power of two");
   int numNops = mask & (-target);
-  guarantee(numNops >= 0 && numNops < modulus, "Unexpected number of NOPs");
-  guarantee((target + numNops) % modulus == 0, "Incorrect number of NOPs");
+  assert(numNops >= 0 && numNops < modulus, "Unexpected number of NOPs");
+  assert((target + numNops) % modulus == 0, "Incorrect number of NOPs");
   if (numNops != 0) {
     nop(numNops);
   }

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -1164,8 +1164,13 @@ void MacroAssembler::align(int modulus) {
 }
 
 void MacroAssembler::align(int modulus, int target) {
-  if (target % modulus != 0) {
-    nop(modulus - (target % modulus));
+  int mask = modulus - 1;
+  guarantee((modulus & mask) == 0, "Modulus must be a power of two");
+  int numNops = mask & (-target);
+  guarantee(numNops >= 0 && numNops < modulus, "Unexpected number of NOPs");
+  guarantee((target + numNops) % modulus == 0, "Incorrect number of NOPs");
+  if (numNops != 0) {
+    nop(numNops);
   }
 }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.hpp
@@ -213,8 +213,8 @@ class MacroAssembler: public Assembler {
   // Alignment
   void align32();
   void align64();
-  void align(int modulus);
-  void align(int modulus, int target);
+  void align(uint modulus);
+  void align(uint modulus, uint target);
 
   void post_call_nop();
   // A 5 byte nop that is safe for patching (see patch_verified_entry)


### PR DESCRIPTION
The methods align32 and align64 are supposed to align the next instruction to the next 32 or 64 byte boundary using the minimum number of NOP bytes. However, when the target represented as a 32bit signed int is negative, the instructions generate 32 or 64 NOP bytes too many. This was observed in `jbyte_disjoint_arraycopy_avx3` on a Linux machine, where a single align32 invocation generated 63 bytes of NOPs.

This PR addresses the problem by using bit operations to calculate the required number of bytes.

Tier1-3 tests passed.

On a side note, `align64` and `align32` instructions were meant for aligning data for use with zmm / ymm loads, but nowadays they are frequently used in places where `align(CodeEntryAlignment)` or `align(OptoLoopAlignment)` would be more appropriate. I can address that in a separate PR if you think it's worth fixing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332724: x86 MacroAssembler may over-align code`

### Issue
 * [JDK-8332724](https://bugs.openjdk.org/browse/JDK-8332724): x86 MacroAssembler may over-align code (**Bug** - P5)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) ⚠️ Review applies to [d0220193](https://git.openjdk.org/jdk/pull/19353/files/d0220193538619b8f42c21c5bac70fff59547eeb)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19353/head:pull/19353` \
`$ git checkout pull/19353`

Update a local copy of the PR: \
`$ git checkout pull/19353` \
`$ git pull https://git.openjdk.org/jdk.git pull/19353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19353`

View PR using the GUI difftool: \
`$ git pr show -t 19353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19353.diff">https://git.openjdk.org/jdk/pull/19353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19353#issuecomment-2125698383)