### PR TITLE
8332725: Binding patterns with inferred type have erroneous node in the AST

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4202,6 +4202,10 @@ public class Attr extends JCTree.Visitor {
         if (chk.checkUnique(tree.var.pos(), v, env.info.scope)) {
             chk.checkTransparentVar(tree.var.pos(), v, env.info.scope);
         }
+        if (tree.var.isImplicitlyTyped()) {
+            setSyntheticVariableType(tree.var, type == Type.noType ? syms.errType
+                                                                   : type);
+        }
         annotate.annotateLater(tree.var.mods.annotations, env, v, tree.pos());
         if (!tree.var.isImplicitlyTyped()) {
             annotate.queueScanTreeAndTypeAnnotate(tree.var.vartype, env, v, tree.var.pos());

--- a/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
+++ b/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332725
+ * @summary Verify the AST model works correctly for binding patterns with var
+ */
+
+import com.sun.source.tree.BindingPatternTree;
+import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreeScanner;
+import java.net.URI;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.ToolProvider;
+
+public class BindingPatternVarTypeModel {
+    private final JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+    public static void main(String... args) throws Exception {
+        new BindingPatternVarTypeModel().run();
+    }
+
+    private void run() throws Exception {
+        JavaFileObject input =
+                SimpleJavaFileObject.forSource(URI.create("mem://Test.java"),
+                                               """
+                                               public class Test {
+                                                   record R(int i) {}
+                                                   int test(Object o) {
+                                                       return switch (o) {
+                                                           case R(var v) -> 0;
+                                                           default -> 0;
+                                                       };
+                                                   }
+                                               }
+                                               """);
+        JavacTask task =
+                (JavacTask) compiler.getTask(null, null, null, null, null, List.of(input));
+        CompilationUnitTree cut = task.parse().iterator().next();
+
+        task.analyze();
+
+        AtomicBoolean foundBindingPattern = new AtomicBoolean();
+
+        new TreeScanner<Void, Void>() {
+            @Override
+            public Void visitBindingPattern(BindingPatternTree node, Void p) {
+                if (node.getVariable().getType().getKind() != Tree.Kind.PRIMITIVE_TYPE) {
+                    throw new AssertionError("Unexpected type for var: " +
+                                             node.getVariable().getType().getKind() +
+                                             ":" + node.getVariable().getType());
+                }
+                foundBindingPattern.set(true);
+                return super.visitBindingPattern(node, p);
+            }
+        }.scan(cut, null);
+
+        if (!foundBindingPattern.get()) {
+            throw new AssertionError("Didn't find the binding pattern!");
+        }
+    }
+}


### PR DESCRIPTION
For local variable type inference, javac will set a synthetic type tree/AST for the variable. I.e. having `var v = 0;`, javac will set synthetic `int` to `JCVariableDecl.vartype`.

For binding patterns, this is not done. I.e. having `R(var v)`, the `vartype` in the `JCVariableDecl` inside the binding pattern will not be set. If `Attr.preFlow` or `Attr.postAttr` is called, the missing `vartype` will be set of an erroneous tree node, despite the original code being valid.

The proposal in this PR is to simply set the synthetic type tree, as is done for other cases where `var` is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332725](https://bugs.openjdk.org/browse/JDK-8332725): Binding patterns with inferred type have erroneous node in the AST (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19357/head:pull/19357` \
`$ git checkout pull/19357`

Update a local copy of the PR: \
`$ git checkout pull/19357` \
`$ git pull https://git.openjdk.org/jdk.git pull/19357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19357`

View PR using the GUI difftool: \
`$ git pr show -t 19357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19357.diff">https://git.openjdk.org/jdk/pull/19357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19357#issuecomment-2126332769)