### PR TITLE
8241550: [macOS] SSLSocketImpl/ReuseAddr.java failed due to "BindException: Address already in use"

### DIFF
--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ReuseAddr.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ReuseAddr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/ssl/SSLSocketImpl/ReuseAddr.java
+++ b/test/jdk/sun/security/ssl/SSLSocketImpl/ReuseAddr.java
@@ -34,8 +34,11 @@
  */
 
 import java.net.ServerSocket;
+import java.net.BindException;
 
 public class ReuseAddr extends SSLSocketTemplate {
+
+    private static final int MAX_ATTEMPTS = 3;
 
     @Override
     protected void doServerSide() throws Exception {
@@ -50,6 +53,21 @@ public class ReuseAddr extends SSLSocketTemplate {
     }
 
     public static void main(String[] args) throws Exception {
-        new ReuseAddr().run();
+        for (int i=1 ; i <= MAX_ATTEMPTS; i++) {
+            try {
+                new ReuseAddr().run();
+                System.out.println("Test succeeded at attempt " + i);
+                break;
+            } catch (BindException x) {
+                System.out.println("attempt " + i + " failed: " + x);
+                if (i == MAX_ATTEMPTS) {
+                    String msg = "Could not succeed after " + i + " attempts";
+                    System.err.println(msg);
+                    throw new AssertionError("Failed to reuse address: " + msg, x);
+                } else {
+                    System.out.println("Retrying...");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
This is one of these tests that is not really fixable if any other process that might open a socket runs concurrently with it on the same machine: nothing can guarantee that if you open a socket, close it, then open a new socket on the same port, that port will still be free. It might work most of the time, but success can’t be guaranteed.

The only thing we can do in order to attempt to minimize noisy intermittent failures is retry the whole test if a BindException is thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8241550](https://bugs.openjdk.org/browse/JDK-8241550): [macOS] SSLSocketImpl/ReuseAddr.java failed due to "BindException: Address already in use" (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19358/head:pull/19358` \
`$ git checkout pull/19358`

Update a local copy of the PR: \
`$ git checkout pull/19358` \
`$ git pull https://git.openjdk.org/jdk.git pull/19358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19358`

View PR using the GUI difftool: \
`$ git pr show -t 19358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19358.diff">https://git.openjdk.org/jdk/pull/19358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19358#issuecomment-2126568547)