### PR TITLE
8332786: When dumping static CDS archives, explicitly assert that we don't use a CDS archive

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -505,6 +505,8 @@ char* VM_PopulateDumpSharedSpace::dump_read_only_tables() {
 }
 
 void VM_PopulateDumpSharedSpace::doit() {
+  guarantee(!CDSConfig::is_using_archive(), "We should not be using an archive when we dump");
+
   DEBUG_ONLY(SystemDictionaryShared::NoClassLoadingMark nclm);
 
   FileMapInfo::check_nonempty_dir_in_shared_path_table();


### PR DESCRIPTION
Currently, we don't use a CDS archive when dumping the static archive. And that is fine.

It has security implications: if a customer re-generates the dump with `-Xshare:dump`, the content of the dump should depend on only the runtime parts of the JVM, resp. only on those parts that had been built on the build host. It should not depend on an archive that may or may not have been produced after the build and that may be tainted.

This just reduces the attack surface for possible supply chain attacks.

Since we already do this, I'd only like to add explicit asserts to ensure that we continue to do this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332786](https://bugs.openjdk.org/browse/JDK-8332786): When dumping static CDS archives, explicitly assert that we don't use a CDS archive (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19359/head:pull/19359` \
`$ git checkout pull/19359`

Update a local copy of the PR: \
`$ git checkout pull/19359` \
`$ git pull https://git.openjdk.org/jdk.git pull/19359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19359`

View PR using the GUI difftool: \
`$ git pr show -t 19359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19359.diff">https://git.openjdk.org/jdk/pull/19359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19359#issuecomment-2143370218)