### PR TITLE
8332807: Parallel: Make some APIs in ParMarkBitMap private

### DIFF
--- a/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
@@ -29,9 +29,7 @@
 #include "oops/oop.hpp"
 #include "utilities/bitMap.hpp"
 
-class ParMarkBitMapClosure;
 class PSVirtualSpace;
-class ParCompactionManager;
 
 class ParMarkBitMap: public CHeapObj<mtGC>
 {
@@ -54,34 +52,14 @@ public:
   inline bool is_marked(HeapWord* addr) const;
   inline bool is_marked(oop obj)        const;
 
-  inline bool is_unmarked(idx_t bit)      const;
   inline bool is_unmarked(HeapWord* addr) const;
   inline bool is_unmarked(oop obj)        const;
-
-  // Convert sizes from bits to HeapWords and back.  An object that is n bits
-  // long will be bits_to_words(n) words long.  An object that is m words long
-  // will take up words_to_bits(m) bits in the bitmap.
-  inline static size_t bits_to_words(idx_t bits);
-  inline static idx_t  words_to_bits(size_t words);
-
-  inline HeapWord* region_start() const;
-  inline HeapWord* region_end() const;
-  inline size_t    region_size() const;
-  inline size_t    size() const;
 
   size_t reserved_byte_size() const { return _reserved_byte_size; }
 
   // Convert a heap address to/from a bit index.
   inline idx_t     addr_to_bit(HeapWord* addr) const;
   inline HeapWord* bit_to_addr(idx_t bit) const;
-
-  // Return word-aligned up range_end, which must not be greater than size().
-  inline idx_t align_range_end(idx_t range_end) const;
-
-  // Return the bit index of the first marked object that begins (or ends,
-  // respectively) in the range [beg, end).  If no object is found, return end.
-  // end must be word-aligned.
-  inline idx_t find_obj_beg(idx_t beg, idx_t end) const;
 
   inline HeapWord* find_obj_beg(HeapWord* beg, HeapWord* end) const;
 
@@ -92,11 +70,6 @@ public:
   // cleared).
   inline void clear_range(idx_t beg, idx_t end);
 
-  // Return the number of bits required to represent the specified number of
-  // HeapWords, or the specified region.
-  static inline idx_t bits_required(size_t words);
-  static inline idx_t bits_required(MemRegion covered_region);
-
   void print_on_error(outputStream* st) const {
     st->print_cr("Marking Bits: (ParMarkBitMap*) " PTR_FORMAT, p2i(this));
     _beg_bits.print_on_error(st, " Begin Bits: ");
@@ -104,8 +77,6 @@ public:
 
 #ifdef  ASSERT
   void verify_clear() const;
-  inline void verify_bit(idx_t bit) const;
-  inline void verify_addr(HeapWord* addr) const;
 #endif  // #ifdef ASSERT
 
 private:
@@ -113,7 +84,6 @@ private:
   // Each bit in the bitmap represents one unit of 'object granularity.' Objects
   // are double-word aligned in 32-bit VMs, but not in 64-bit VMs, so the 32-bit
   // granularity is 2, 64-bit is 1.
-  static inline size_t obj_granularity() { return size_t(MinObjAlignment); }
   static inline int obj_granularity_shift() { return LogMinObjAlignment; }
 
   HeapWord*       _region_start;
@@ -121,6 +91,30 @@ private:
   BitMapView      _beg_bits;
   PSVirtualSpace* _virtual_space;
   size_t          _reserved_byte_size;
+
+  // Return the number of bits required to represent the specified number of
+  // HeapWords, or the specified region.
+  static inline idx_t bits_required(size_t words);
+  static inline idx_t bits_required(MemRegion covered_region);
+
+  // Convert sizes from bits to HeapWords and back.  An object that is n bits
+  // long will be bits_to_words(n) words long.  An object that is m words long
+  // will take up words_to_bits(m) bits in the bitmap.
+  inline static size_t bits_to_words(idx_t bits);
+  inline static idx_t  words_to_bits(size_t words);
+
+  // Return word-aligned up range_end, which must not be greater than size().
+  inline idx_t align_range_end(idx_t range_end) const;
+
+  inline HeapWord* region_start() const;
+  inline HeapWord* region_end() const;
+  inline size_t    region_size() const;
+  inline size_t    size() const;
+
+#ifdef  ASSERT
+  inline void verify_bit(idx_t bit) const;
+  inline void verify_addr(HeapWord* addr) const;
+#endif  // #ifdef ASSERT
 };
 
 #endif // SHARE_GC_PARALLEL_PARMARKBITMAP_HPP

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
@@ -74,10 +74,6 @@ inline bool ParMarkBitMap::is_marked(oop obj) const {
   return is_marked(cast_from_oop<HeapWord*>(obj));
 }
 
-inline bool ParMarkBitMap::is_unmarked(idx_t bit) const {
-  return !is_marked(bit);
-}
-
 inline bool ParMarkBitMap::is_unmarked(HeapWord* addr) const {
   return !is_marked(addr);
 }
@@ -118,15 +114,12 @@ inline ParMarkBitMap::idx_t ParMarkBitMap::align_range_end(idx_t range_end) cons
   return align_up(range_end, BitsPerWord);
 }
 
-inline ParMarkBitMap::idx_t ParMarkBitMap::find_obj_beg(idx_t beg, idx_t end) const {
-  return _beg_bits.find_first_set_bit_aligned_right(beg, end);
-}
-
 inline HeapWord* ParMarkBitMap::find_obj_beg(HeapWord* beg, HeapWord* end) const {
   const idx_t beg_bit = addr_to_bit(beg);
   const idx_t end_bit = addr_to_bit(end);
   const idx_t search_end = align_range_end(end_bit);
-  const idx_t res_bit = MIN2(find_obj_beg(beg_bit, search_end), end_bit);
+  const idx_t res_bit = MIN2(_beg_bits.find_first_set_bit_aligned_right(beg_bit, search_end),
+                             end_bit);
   return bit_to_addr(res_bit);
 }
 


### PR DESCRIPTION
Trivial moving methods from public to private.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332807](https://bugs.openjdk.org/browse/JDK-8332807): Parallel: Make some APIs in ParMarkBitMap private (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19360/head:pull/19360` \
`$ git checkout pull/19360`

Update a local copy of the PR: \
`$ git checkout pull/19360` \
`$ git pull https://git.openjdk.org/jdk.git pull/19360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19360`

View PR using the GUI difftool: \
`$ git pr show -t 19360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19360.diff">https://git.openjdk.org/jdk/pull/19360.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19360#issuecomment-2126741954)