### PR TITLE
8308642: Unhelpful pattern switch error: illegal fall-through to a pattern

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -571,11 +571,11 @@ compiler.err.constant.label.not.compatible=\
 
 compiler.err.flows.through.to.pattern=\
     illegal fall-through to a pattern\n\
-    the previous case label is missing a break
+    (the previous case label is missing a break)
 
 compiler.err.flows.through.from.pattern=\
     illegal fall-through from a pattern\n\
-    the current case label is missing a break
+    (the current case label is missing a break)
 
 compiler.err.invalid.case.label.combination=\
     invalid case label combination

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -570,10 +570,12 @@ compiler.err.constant.label.not.compatible=\
     constant label of type {0} is not compatible with switch selector type {1}
 
 compiler.err.flows.through.to.pattern=\
-    illegal fall-through to a pattern
+    illegal fall-through to a pattern\n\
+    the previous case label is missing a break
 
 compiler.err.flows.through.from.pattern=\
-    illegal fall-through from a pattern
+    illegal fall-through from a pattern\n\
+    the current case label is missing a break
 
 compiler.err.invalid.case.label.combination=\
     invalid case label combination


### PR DESCRIPTION
Improves two error messages regarding fall-through. Two examples source files after this patch is applied:

```java
> javac jdk/test/langtools/tools/javac/diags/examples/FlowsThroughFromPattern.java                                                                                                       1m 35s
jdk/test/langtools/tools/javac/diags/examples/FlowsThroughFromPattern.java:29: error: illegal fall-through from a pattern
            case String str:
                 ^
  the current case label is missing a break
1 error

> javac jdk/test/langtools/tools/javac/diags/examples/FlowsThroughToPattern.java  
jdk/test/langtools/tools/javac/diags/examples/FlowsThroughToPattern.java:30: error: illegal fall-through to a pattern
            case Object obj: break;
                 ^
  the previous case label is missing a break
1 error

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308642](https://bugs.openjdk.org/browse/JDK-8308642): Unhelpful pattern switch error: illegal fall-through to a pattern (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19361/head:pull/19361` \
`$ git checkout pull/19361`

Update a local copy of the PR: \
`$ git checkout pull/19361` \
`$ git pull https://git.openjdk.org/jdk.git pull/19361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19361`

View PR using the GUI difftool: \
`$ git pr show -t 19361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19361.diff">https://git.openjdk.org/jdk/pull/19361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19361#issuecomment-2126773761)