### PR TITLE
8332039: Cannot invoke "com.sun.source.util.DocTreePath.getTreePath()" because "path" is null

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -500,31 +500,36 @@ public class CommentHelper {
     }
 
     public DocTreePath getDocTreePath(DocTree dtree) {
-        if (dcTree == null && element instanceof ExecutableElement ee) {
-            return getInheritedDocTreePath(dtree, ee);
+        if (dcTree == null) {
+            // Element does not have a doc comment.
+            return getInheritedDocTreePath(dtree);
         }
-        if (path == null || dcTree == null || dtree == null) {
+        if (path == null || dtree == null) {
             return null;
         }
         DocTreePath dtPath = DocTreePath.getPath(path, dcTree, dtree);
-        if (dtPath == null && element instanceof ExecutableElement ee) {
-            // The overriding element has a doc tree, but it doesn't contain what we're looking for.
-            return getInheritedDocTreePath(dtree, ee);
-        }
-        return dtPath;
+        // Doc tree isn't in current element's comment, it must be inherited.
+        return dtPath == null ? getInheritedDocTreePath(dtree) : dtPath;
     }
 
-    private DocTreePath getInheritedDocTreePath(DocTree dtree, ExecutableElement ee) {
+    private DocTreePath getInheritedDocTreePath(DocTree dtree) {
         Utils utils = configuration.utils;
-        var docFinder = utils.docFinder();
-        Optional<ExecutableElement> inheritedDoc = docFinder.search(ee,
-                (m -> {
-                    Optional<ExecutableElement> optional = utils.getFullBody(m).isEmpty() ? Optional.empty() : Optional.of(m);
-                    return Result.fromOptional(optional);
-                })).toOptional();
-        return inheritedDoc.isEmpty() || inheritedDoc.get().equals(ee)
-                ? null
-                : utils.getCommentHelper(inheritedDoc.get()).getDocTreePath(dtree);
+        if (element instanceof ExecutableElement ee) {
+            var docFinder = utils.docFinder();
+            Optional<ExecutableElement> inheritedDoc = docFinder.search(ee,
+                    (m -> {
+                        Optional<ExecutableElement> optional = utils.getFullBody(m).isEmpty() ? Optional.empty() : Optional.of(m);
+                        return Result.fromOptional(optional);
+                    })).toOptional();
+            return inheritedDoc.isEmpty() || inheritedDoc.get().equals(ee)
+                    ? null
+                    : utils.getCommentHelper(inheritedDoc.get()).getDocTreePath(dtree);
+        } else if (element instanceof TypeElement te
+                && te.getEnclosingElement() instanceof TypeElement enclType) {
+            // Block tags can be inherited from enclosing types.
+            return utils.getCommentHelper(enclType).getDocTreePath(dtree);
+        }
+        return null;
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      7180906 8026567 8239804 8324342
+ * @bug      7180906 8026567 8239804 8324342 8332039
  * @summary  Test to make sure that the since tag works correctly
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -144,6 +144,47 @@ public class TestSinceTag extends JavadocTester {
                     <dl class="notes">
                     <dt>Since:</dt>
                     <dd>99</dd>""");
+
+    }
+
+    @Test
+    public void testSinceDefault_NestedTag(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package p;
+                /**
+                 * Class C.
+                 * @since 99 {@link C}
+                 */
+                 public class C {
+                     public static class Nested1 {
+                         /** Class Nested, with no explicit at-since. */
+                         public static class Nested { }
+                     }
+                 }""");
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                """
+                    <dl class="notes">
+                    <dt>Since:</dt>
+                    <dd>99 <a href="C.html" title="class in p"><code>C</code></a></dd>""");
+
+        checkOutput("p/C.Nested1.html", true,
+                """
+                    <dl class="notes">
+                    <dt>Since:</dt>
+                    <dd>99 <a href="C.html" title="class in p"><code>C</code></a></dd>""");
+
+        checkOutput("p/C.Nested1.Nested.html", true,
+                """
+                    <dl class="notes">
+                    <dt>Since:</dt>
+                    <dd>99 <a href="C.html" title="class in p"><code>C</code></a></dd>""");
 
     }
 }


### PR DESCRIPTION
Please review a patch to fix a NPE thrown when a `@since` tag inherited by a nested class contains a nested inline tag. The solution is to make `CommentHelper.getDocTreePath(DocTree)` able to handle block tags inherited by nested classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332039](https://bugs.openjdk.org/browse/JDK-8332039): Cannot invoke "com.sun.source.util.DocTreePath.getTreePath()" because "path" is null (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19363/head:pull/19363` \
`$ git checkout pull/19363`

Update a local copy of the PR: \
`$ git checkout pull/19363` \
`$ git pull https://git.openjdk.org/jdk.git pull/19363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19363`

View PR using the GUI difftool: \
`$ git pr show -t 19363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19363.diff">https://git.openjdk.org/jdk/pull/19363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19363#issuecomment-2126796106)