### PR TITLE
8330847: G1 accesses uninitialized memory when predicting eden copy time

### DIFF
--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.cpp
@@ -23,7 +23,6 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/g1/g1CollectedHeap.inline.hpp"
 #include "gc/g1/g1HeapRegion.hpp"
 #include "gc/g1/g1Predictions.hpp"
 #include "gc/g1/g1SurvRateGroup.hpp"
@@ -57,10 +56,6 @@ void G1SurvRateGroup::reset() {
 
   // Seed initial _surv_rate_pred and _accum_surv_rate_pred values
   guarantee(_stats_arrays_length == 1, "invariant" );
-  guarantee(_surv_rate_predictors[0] != nullptr, "invariant" );
-  const double initial_surv_rate = 0.4;
-  _surv_rate_predictors[0]->add(initial_surv_rate);
-  _last_pred = _accum_surv_rate_pred[0] = initial_surv_rate;
 
   _num_added_regions = 0;
 }
@@ -75,8 +70,12 @@ void G1SurvRateGroup::stop_adding_regions() {
     _surv_rate_predictors = REALLOC_C_HEAP_ARRAY(TruncatedSeq*, _surv_rate_predictors, _num_added_regions, mtGC);
 
     for (size_t i = _stats_arrays_length; i < _num_added_regions; ++i) {
+      // Initialize predictors and accumulated survivor rate predictions.
       _surv_rate_predictors[i] = new TruncatedSeq(10);
+      _surv_rate_predictors[i]->add(InitialSurvivorRate);
+      _accum_surv_rate_pred[i] = ((i == 0) ? 0.0 : _accum_surv_rate_pred[i-1]) + InitialSurvivorRate;
     }
+    _last_pred = InitialSurvivorRate;
 
     _stats_arrays_length = _num_added_regions;
   }
@@ -94,6 +93,19 @@ void G1SurvRateGroup::all_surviving_words_recorded(const G1Predictions& predicto
     fill_in_last_surv_rates();
   }
   finalize_predictions(predictor);
+}
+
+double G1SurvRateGroup::accum_surv_rate_pred(uint age) const {
+  assert(_stats_arrays_length > 0, "invariant" );
+  double result;
+  if (age < _stats_arrays_length) {
+    result = _accum_surv_rate_pred[age];
+  } else {
+    double diff = (double)(age - _stats_arrays_length + 1);
+    result = _accum_surv_rate_pred[_stats_arrays_length - 1] + diff * _last_pred;
+  }
+  assert(result <= (age + 1.0), "Accumulated survivor rate %.2f must be smaller than age+1 %u", result, age + 1);
+  return result;
 }
 
 void G1SurvRateGroup::fill_in_last_surv_rates() {

--- a/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
+++ b/src/hotspot/share/gc/g1/g1SurvRateGroup.hpp
@@ -52,6 +52,9 @@ class G1SurvRateGroup : public CHeapObj<mtGC> {
   uint _stats_arrays_length;
   uint _num_added_regions;   // The number of regions in this survivor rate group.
 
+  // The initial survivor rate for predictors. Somewhat random value.
+  const double InitialSurvivorRate = 0.4;
+
   double* _accum_surv_rate_pred;
   double  _last_pred;
   TruncatedSeq** _surv_rate_predictors;
@@ -73,15 +76,7 @@ public:
   void record_surviving_words(uint age, size_t surv_words);
   void all_surviving_words_recorded(const G1Predictions& predictor, bool update_predictors);
 
-  double accum_surv_rate_pred(uint age) const {
-    assert(_stats_arrays_length > 0, "invariant" );
-    if (age < _stats_arrays_length)
-      return _accum_surv_rate_pred[age];
-    else {
-      double diff = (double)(age - _stats_arrays_length + 1);
-      return _accum_surv_rate_pred[_stats_arrays_length - 1] + diff * _last_pred;
-    }
-  }
+  double accum_surv_rate_pred(uint age) const;
 
   double surv_rate_pred(G1Predictions const& predictor, uint age) const {
     assert(is_valid_age(age), "must be");


### PR DESCRIPTION
Hi all,

  please review this change that fixes survivor rate predictor initialization when expanding the survivor rate prediction tables.

Before JDK-8231579 these predictors were not used when finalizing the collection set at gc start, and were always updated properly at the end of the GC. With that change G1 started using these uninitialized predictors.

There is an assert that should fail in the future if there is a bug.

Testing: tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330847](https://bugs.openjdk.org/browse/JDK-8330847): G1 accesses uninitialized memory when predicting eden copy time (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19364/head:pull/19364` \
`$ git checkout pull/19364`

Update a local copy of the PR: \
`$ git checkout pull/19364` \
`$ git pull https://git.openjdk.org/jdk.git pull/19364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19364`

View PR using the GUI difftool: \
`$ git pr show -t 19364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19364.diff">https://git.openjdk.org/jdk/pull/19364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19364#issuecomment-2128768504)