### PR TITLE
8332749: Broken link in MemorySegment.Scope.html

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -2611,7 +2611,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *     <li>Segments obtained from the {@linkplain Arena#global() global arena};</li>
      *     <li>Segments obtained from a raw address, using the
      *         {@link MemorySegment#ofAddress(long)} factory; and</li>
-     *     <li><a href="#wrapping-addresses">Zero-length memory segments.</a></li>
+     *     <li>{@link MemorySegment##wrapping-addresses Zero-length memory segments}.</li>
      * </ul>
      * <p>
      * Conversely, a bounded lifetime is modeled with a segment scope that can be


### PR DESCRIPTION
This PR proposes to fix a broken link in the `MemorySegment.Scope` class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332749](https://bugs.openjdk.org/browse/JDK-8332749): Broken link in MemorySegment.Scope.html (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19366/head:pull/19366` \
`$ git checkout pull/19366`

Update a local copy of the PR: \
`$ git checkout pull/19366` \
`$ git pull https://git.openjdk.org/jdk.git pull/19366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19366`

View PR using the GUI difftool: \
`$ git pr show -t 19366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19366.diff">https://git.openjdk.org/jdk/pull/19366.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19366#issuecomment-2126903733)