### PR TITLE
8306580: Propagate CDS dumping errors instead of directly exiting the VM

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -329,7 +329,7 @@ address ArchiveBuilder::reserve_buffer() {
   ReservedSpace rs(buffer_size, MetaspaceShared::core_region_alignment(), os::vm_page_size());
   if (!rs.is_reserved()) {
     log_error(cds)("Failed to reserve " SIZE_FORMAT " bytes of output buffer.", buffer_size);
-    MetaspaceShared::unrecoverable_writing_error();
+    MetaspaceShared::writing_error();
   }
 
   // buffer_bottom is the lowest address of the 2 core regions (rw, ro) when
@@ -379,7 +379,7 @@ address ArchiveBuilder::reserve_buffer() {
     log_error(cds)("my_archive_requested_top    = " INTPTR_FORMAT, p2i(my_archive_requested_top));
     log_error(cds)("SharedBaseAddress (" INTPTR_FORMAT ") is too high. "
                    "Please rerun java -Xshare:dump with a lower value", p2i(_requested_static_archive_bottom));
-    MetaspaceShared::unrecoverable_writing_error();
+    MetaspaceShared::writing_error();
   }
 
   if (CDSConfig::is_dumping_static_archive()) {
@@ -1392,7 +1392,7 @@ void ArchiveBuilder::report_out_of_space(const char* name, size_t needed_bytes) 
   _ro_region.print_out_of_space_msg(name, needed_bytes);
 
   log_error(cds)("Unable to allocate from '%s' region: Please reduce the number of shared classes.", name);
-  MetaspaceShared::unrecoverable_writing_error();
+  MetaspaceShared::writing_error();
 }
 
 

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -329,7 +329,7 @@ address ArchiveBuilder::reserve_buffer() {
   ReservedSpace rs(buffer_size, MetaspaceShared::core_region_alignment(), os::vm_page_size());
   if (!rs.is_reserved()) {
     log_error(cds)("Failed to reserve " SIZE_FORMAT " bytes of output buffer.", buffer_size);
-    MetaspaceShared::writing_error();
+    MetaspaceShared::unrecoverable_writing_error();
   }
 
   // buffer_bottom is the lowest address of the 2 core regions (rw, ro) when
@@ -379,7 +379,7 @@ address ArchiveBuilder::reserve_buffer() {
     log_error(cds)("my_archive_requested_top    = " INTPTR_FORMAT, p2i(my_archive_requested_top));
     log_error(cds)("SharedBaseAddress (" INTPTR_FORMAT ") is too high. "
                    "Please rerun java -Xshare:dump with a lower value", p2i(_requested_static_archive_bottom));
-    MetaspaceShared::writing_error();
+    MetaspaceShared::unrecoverable_writing_error();
   }
 
   if (CDSConfig::is_dumping_static_archive()) {

--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -1392,12 +1392,5 @@ void ArchiveBuilder::report_out_of_space(const char* name, size_t needed_bytes) 
   _ro_region.print_out_of_space_msg(name, needed_bytes);
 
   log_error(cds)("Unable to allocate from '%s' region: Please reduce the number of shared classes.", name);
-  MetaspaceShared::writing_error();
+  MetaspaceShared::unrecoverable_writing_error();
 }
-
-
-#ifndef PRODUCT
-void ArchiveBuilder::assert_is_vm_thread() {
-  assert(Thread::current()->is_VM_thread(), "ArchiveBuilder should be used only inside the VMThread");
-}
-#endif

--- a/src/hotspot/share/cds/archiveBuilder.hpp
+++ b/src/hotspot/share/cds/archiveBuilder.hpp
@@ -343,8 +343,6 @@ public:
     return to_offset_u4(offset);
   }
 
-  static void assert_is_vm_thread() PRODUCT_RETURN;
-
 public:
   ArchiveBuilder();
   ~ArchiveBuilder();
@@ -427,7 +425,6 @@ public:
   }
 
   static ArchiveBuilder* current() {
-    assert_is_vm_thread();
     assert(_current != nullptr, "ArchiveBuilder must be active");
     return _current;
   }

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -201,7 +201,7 @@ char* DumpRegion::expand_top_to(char* newtop) {
       // happens only if you allocate more than 2GB of shared objects and would require
       // millions of shared classes.
       log_error(cds)("Out of memory in the CDS archive: Please reduce the number of shared classes.");
-      MetaspaceShared::unrecoverable_writing_error();
+      MetaspaceShared::writing_error();
     }
   }
 
@@ -228,7 +228,7 @@ void DumpRegion::commit_to(char* newtop) {
   if (!_vs->expand_by(commit, false)) {
     log_error(cds)("Failed to expand shared space to " SIZE_FORMAT " bytes",
                     need_committed_size);
-    MetaspaceShared::unrecoverable_writing_error();
+    MetaspaceShared::writing_error();
   }
 
   const char* which;

--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -201,7 +201,7 @@ char* DumpRegion::expand_top_to(char* newtop) {
       // happens only if you allocate more than 2GB of shared objects and would require
       // millions of shared classes.
       log_error(cds)("Out of memory in the CDS archive: Please reduce the number of shared classes.");
-      MetaspaceShared::writing_error();
+      MetaspaceShared::unrecoverable_writing_error();
     }
   }
 
@@ -228,7 +228,7 @@ void DumpRegion::commit_to(char* newtop) {
   if (!_vs->expand_by(commit, false)) {
     log_error(cds)("Failed to expand shared space to " SIZE_FORMAT " bytes",
                     need_committed_size);
-    MetaspaceShared::writing_error();
+    MetaspaceShared::unrecoverable_writing_error();
   }
 
   const char* which;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1359,6 +1359,7 @@ void FileMapInfo::seek_to_position(size_t pos) {
   if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
     log_error(cds)("Unable to seek to position " SIZE_FORMAT, pos);
     MetaspaceShared::unrecoverable_loading_error();
+    //MetaspaceShared::writing_error();
   }
 }
 
@@ -1407,6 +1408,7 @@ void FileMapInfo::open_for_write() {
     log_error(cds)("Unable to create shared archive file %s: (%s).", _full_path,
                    os::strerror(errno));
     MetaspaceShared::writing_error();
+    return;
   }
   _fd = fd;
   _file_open = true;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1359,7 +1359,6 @@ void FileMapInfo::seek_to_position(size_t pos) {
   if (os::lseek(_fd, (long)pos, SEEK_SET) < 0) {
     log_error(cds)("Unable to seek to position " SIZE_FORMAT, pos);
     MetaspaceShared::unrecoverable_loading_error();
-    //MetaspaceShared::writing_error();
   }
 }
 

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1406,7 +1406,7 @@ void FileMapInfo::open_for_write() {
   if (fd < 0) {
     log_error(cds)("Unable to create shared archive file %s: (%s).", _full_path,
                    os::strerror(errno));
-    MetaspaceShared::unrecoverable_writing_error();
+    MetaspaceShared::writing_error();
   }
   _fd = fd;
   _file_open = true;
@@ -1659,7 +1659,7 @@ void FileMapInfo::write_bytes(const void* buffer, size_t nbytes) {
     // If the shared archive is corrupted, close it and remove it.
     close();
     remove(_full_path);
-    MetaspaceShared::unrecoverable_writing_error("Unable to write to shared archive file.");
+    MetaspaceShared::writing_error("Unable to write to shared archive file.");
   }
   _file_offset += nbytes;
 }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -272,7 +272,7 @@ void MetaspaceShared::initialize_for_static_dump() {
   _symbol_rs = ReservedSpace(symbol_rs_size);
   if (!_symbol_rs.is_reserved()) {
     log_error(cds)("Unable to reserve memory for symbols: " SIZE_FORMAT " bytes.", symbol_rs_size);
-    MetaspaceShared::writing_error();
+    MetaspaceShared::unrecoverable_writing_error();
   }
   _symbol_region.init(&_symbol_rs, &_symbol_vs);
 }

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -656,7 +656,7 @@ void MetaspaceShared::preload_and_dump(TRAPS) {
     } else {
       log_error(cds)("%s: %s", PENDING_EXCEPTION->klass()->external_name(),
                      java_lang_String::as_utf8_string(java_lang_Throwable::message(PENDING_EXCEPTION)));
-      MetaspaceShared::writing_error("VM exits due to exception, use -Xlog:cds,exceptions=trace for detail");
+      MetaspaceShared::writing_error("Unexpected exception, use -Xlog:cds,exceptions=trace for detail");
     }
   }
 }
@@ -803,10 +803,6 @@ bool MetaspaceShared::write_static_archive(ArchiveBuilder* builder, FileMapInfo*
     return false;
   }
   builder->write_archive(map_info, heap_info);
-
-  if (PrintSystemDictionaryAtExit) {
-    SystemDictionary::print();
-  }
 
   if (AllowArchivingWithJavaAgent) {
     log_warning(cds)("This archive was created with AllowArchivingWithJavaAgent. It should be used "

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -170,7 +170,7 @@ public:
 
 private:
   static void read_extra_data(JavaThread* current, const char* filename) NOT_CDS_RETURN;
-  static void write_static_archive(ArchiveBuilder* builder, FileMapInfo *mapinfo, ArchiveHeapInfo* heap_info);
+  static void write_static_archive(ArchiveBuilder* builder, FileMapInfo* map_info, ArchiveHeapInfo* heap_info);
   static FileMapInfo* open_static_archive();
   static FileMapInfo* open_dynamic_archive();
   // use_requested_addr: If true (default), attempt to map at the address the

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -170,7 +170,7 @@ public:
 
 private:
   static void read_extra_data(JavaThread* current, const char* filename) NOT_CDS_RETURN;
-  static void write_static_archive(ArchiveBuilder* builder, FileMapInfo* map_info, ArchiveHeapInfo* heap_info);
+  static bool write_static_archive(ArchiveBuilder* builder, FileMapInfo* map_info, ArchiveHeapInfo* heap_info);
   static FileMapInfo* open_static_archive();
   static FileMapInfo* open_dynamic_archive();
   // use_requested_addr: If true (default), attempt to map at the address the

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -31,9 +31,12 @@
 #include "oops/oop.hpp"
 #include "utilities/macros.hpp"
 
+class ArchiveBuilder;
+class ArchiveHeapInfo;
 class FileMapInfo;
 class outputStream;
 class SerializeClosure;
+class StaticArchiveBuilder;
 
 template<class E> class GrowableArray;
 
@@ -72,7 +75,7 @@ class MetaspaceShared : AllStatic {
 #endif
 
 private:
-  static void preload_and_dump_impl(TRAPS) NOT_CDS_RETURN;
+  static void preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS) NOT_CDS_RETURN;
   static void preload_classes(TRAPS) NOT_CDS_RETURN;
 
 public:
@@ -167,6 +170,7 @@ public:
 
 private:
   static void read_extra_data(JavaThread* current, const char* filename) NOT_CDS_RETURN;
+  static void write_static_archive(ArchiveBuilder* builder, FileMapInfo *mapinfo, ArchiveHeapInfo* heap_info);
   static FileMapInfo* open_static_archive();
   static FileMapInfo* open_dynamic_archive();
   // use_requested_addr: If true (default), attempt to map at the address the

--- a/src/hotspot/share/cds/metaspaceShared.hpp
+++ b/src/hotspot/share/cds/metaspaceShared.hpp
@@ -66,7 +66,7 @@ class MetaspaceShared : AllStatic {
   };
 
   static void prepare_for_dumping() NOT_CDS_RETURN;
-  static void preload_and_dump() NOT_CDS_RETURN;
+  static void preload_and_dump(TRAPS) NOT_CDS_RETURN;
 #ifdef _LP64
   static void adjust_heap_sizes_for_dumping() NOT_CDS_JAVA_HEAP_RETURN;
 #endif
@@ -105,6 +105,7 @@ public:
 
   static void unrecoverable_loading_error(const char* message = nullptr);
   static void unrecoverable_writing_error(const char* message = nullptr);
+  static void writing_error(const char* message = nullptr);
 
   static void serialize(SerializeClosure* sc) NOT_CDS_RETURN;
 

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -825,7 +825,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
 #endif
 
   if (CDSConfig::is_dumping_static_archive()) {
-    MetaspaceShared::preload_and_dump();
+    MetaspaceShared::preload_and_dump(CHECK_JNI_ERR);
   }
 
   return JNI_OK;

--- a/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
+++ b/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test the writing error when archive file cannot be created
+ * @requires vm.cds
+ * @library /test/lib
+ * @run driver StaticWritingError
+ */
+
+import java.io.File;
+import java.util.ArrayList;
+import jdk.test.lib.cds.CDSOptions;
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class StaticWritingError {
+    public static void main(String[] args) throws Exception {
+        String directoryName = "unwritable";
+        String archiveName = "staticWritingError.jsa";
+
+        // Create directory that cannot be written to
+        File directory = new File(directoryName);
+        directory.mkdir();
+        directory.setReadable(false);
+        directory.setWritable(false);
+
+        // Perform static dump and attempt to write archive in unwritable directory
+        CDSOptions opts = (new CDSOptions())
+            .addPrefix("-Xlog:cds")
+            .setArchiveName(directoryName + File.separator + archiveName);
+        OutputAnalyzer out = CDSTestUtils.createArchive(opts);
+        out.shouldHaveExitValue(1);
+        out.shouldContain("Unable to create shared archive file");
+        out.shouldContain("(Permission denied)");
+        out.shouldContain("Encountered error while dumping");
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
+++ b/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
+++ b/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
@@ -23,6 +23,7 @@
 
 /**
  * @test
+ * @bug 8306580
  * @summary Test the writing error when archive file cannot be created
  * @requires vm.cds
  * @library /test/lib

--- a/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
+++ b/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
@@ -30,7 +30,16 @@
  */
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.AclEntry;
+import java.nio.file.attribute.AclEntryPermission;
+import java.nio.file.attribute.AclEntryType;
+import java.nio.file.attribute.AclFileAttributeView;
+import java.nio.file.attribute.UserPrincipal;
 import java.util.ArrayList;
+import java.util.List;
+
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
@@ -40,11 +49,16 @@ public class StaticWritingError {
         String directoryName = "unwritable";
         String archiveName = "staticWritingError.jsa";
 
-        // Create directory that cannot be written to
-        File directory = new File(directoryName);
-        directory.mkdir();
-        directory.setReadable(false);
-        directory.setWritable(false);
+       if (System.getProperty("os.name").startsWith("Windows")) {
+            String windir = System.getenv("$Env:windir");
+            directoryName = windir + File.separator + "System32";
+       } else {
+            // Create directory that cannot be written to
+            File directory = new File(directoryName);
+            directory.mkdir();
+            directory.setReadable(false);
+            directory.setWritable(false);
+       }
 
         // Perform static dump and attempt to write archive in unwritable directory
         CDSOptions opts = (new CDSOptions())
@@ -53,7 +67,6 @@ public class StaticWritingError {
         OutputAnalyzer out = CDSTestUtils.createArchive(opts);
         out.shouldHaveExitValue(1);
         out.shouldContain("Unable to create shared archive file");
-        out.shouldContain("(Permission denied)");
         out.shouldContain("Encountered error while dumping");
     }
 }

--- a/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
+++ b/test/hotspot/jtreg/runtime/cds/StaticWritingError.java
@@ -31,47 +31,14 @@
  */
 
 import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.attribute.AclEntry;
-import java.nio.file.attribute.AclEntryPermission;
-import java.nio.file.attribute.AclEntryType;
-import java.nio.file.attribute.AclFileAttributeView;
-import java.nio.file.attribute.UserPrincipal;
-import java.util.List;
-
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.process.OutputAnalyzer;
 
 public class StaticWritingError {
     public static void main(String[] args) throws Exception {
-        String directoryName = "unwritable";
+        String directoryName = "nosuchdir";
         String archiveName = "staticWritingError.jsa";
-
-        // Create directory that cannot be written to
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            // Windows filesystem uses Access Control Lists instead of permissions
-            Path dir = Files.createTempDirectory(directoryName);
-            AclFileAttributeView view = Files.getFileAttributeView(dir, AclFileAttributeView.class);
-                UserPrincipal owner = view.getOwner();
-                List<AclEntry> acl = view.getAcl();
-
-            // Insert entry to deny WRITE and EXECUTE
-            AclEntry entry = AclEntry.newBuilder()
-                .setType(AclEntryType.DENY)
-                .setPrincipal(owner)
-                .setPermissions(AclEntryPermission.WRITE_DATA,
-                                AclEntryPermission.EXECUTE)
-                .build();
-            acl.add(0, entry);
-            view.setAcl(acl);
-       } else {
-            File directory = new File(directoryName);
-            directory.mkdir();
-            directory.setReadable(false);
-            directory.setWritable(false);
-       }
 
         // Perform static dump and attempt to write archive in unwritable directory
         CDSOptions opts = (new CDSOptions())


### PR DESCRIPTION
Currently, when CDS dumping run into an unrecoverable error (e.g., file I/O error, out of memory), it calls MetaspaceShared::unrecoverable_writing_error(), which directly exits the VM.  Some of these errors can be propagated to the caller for a normal exit. 

This change introduces `MetaspaceShared::writing_error()` to report errors without exiting the VM. The function `MetaspaceShared::unrecoverable_writing_error()` now should only be used for errors that require the VM to exit. Verified with tier1-5 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306580](https://bugs.openjdk.org/browse/JDK-8306580): Propagate CDS dumping errors instead of directly exiting the VM (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19370/head:pull/19370` \
`$ git checkout pull/19370`

Update a local copy of the PR: \
`$ git checkout pull/19370` \
`$ git pull https://git.openjdk.org/jdk.git pull/19370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19370`

View PR using the GUI difftool: \
`$ git pr show -t 19370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19370.diff">https://git.openjdk.org/jdk/pull/19370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19370#issuecomment-2127443630)