### PR TITLE
8332230: jshell throws AssertionError when processing annotations

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -1166,6 +1166,15 @@ public class Annotate {
             scan(tree.args);
             // the anonymous class instantiation if any will be visited separately.
         }
+
+        @Override
+        public void visitErroneous(JCErroneous tree) {
+            if (tree.errs != null) {
+                for (JCTree err : tree.errs) {
+                    scan(err);
+                }
+            }
+        }
     }
 
     /* *******************

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5255,6 +5255,8 @@ public class Attr extends JCTree.Visitor {
             default:
                 attribClass(env.tree.pos(), env.enclClass.sym);
         }
+
+        annotate.flush();
     }
 
     public void attribPackage(DiagnosticPosition pos, PackageSymbol p) {

--- a/test/langtools/jdk/jshell/ErrorRecoveryTest.java
+++ b/test/langtools/jdk/jshell/ErrorRecoveryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8270139 8273039 8286895
+ * @bug 8270139 8273039 8286895 8332230
  * @summary Verify error recovery in JShell
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -61,6 +61,14 @@ public class ErrorRecoveryTest extends KullaTesting {
     public void testBooleanPatternExpression() {
         assertEval("Number n = 0;");
         assertEval("if (!n instanceof Integer i) {}",
+                   DiagCheck.DIAG_ERROR,
+                   DiagCheck.DIAG_IGNORE,
+                   ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));
+    }
+
+    //JDK-8332230:
+    public void testAnnotationsd() {
+        assertEval("k=aa:a.@a",
                    DiagCheck.DIAG_ERROR,
                    DiagCheck.DIAG_IGNORE,
                    ste(MAIN_SNIPPET, NONEXISTENT, REJECTED, false, null));

--- a/test/langtools/tools/javac/annotations/typeAnnotations/QueuesAreFlushed.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/QueuesAreFlushed.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8332230
+ * @summary Verify that the last type in the last method has correct type annotations
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main QueuesAreFlushed
+*/
+
+import com.sun.source.tree.AnnotatedTypeTree;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskEvent.Kind;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.type.TypeMirror;
+
+import toolbox.TestRunner;
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class QueuesAreFlushed extends TestRunner {
+
+    private ToolBox tb;
+
+    public static void main(String... args) throws Exception {
+        new QueuesAreFlushed().runTests();
+    }
+
+    QueuesAreFlushed() {
+        super(System.err);
+        tb = new ToolBox();
+    }
+
+    public void runTests() throws Exception {
+        runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testTypeAnnotations(Path base) throws Exception {
+        Path current = base.resolve(".");
+        Path src = current.resolve("src");
+        Path classes = current.resolve("classes");
+        tb.writeJavaFiles(src,
+                          """
+                          package test;
+                          import java.lang.annotation.ElementType;
+                          import java.lang.annotation.Target;
+
+                          public class Test {
+                              @Target(ElementType.TYPE_USE)
+                              @interface Ann {}
+
+                              public static void main(Object o) {
+                                  boolean b;
+                                  b = o instanceof @Ann String;
+                              }
+
+                          }
+                          """);
+
+        Files.createDirectories(classes);
+
+        AtomicBoolean seenAnnotationMirror = new AtomicBoolean();
+
+        new JavacTask(tb)
+            .outdir(classes)
+            .callback(task -> {
+                task.addTaskListener(new TaskListener() {
+                    @Override
+                    public void finished(TaskEvent e) {
+                        if (e.getKind() != Kind.ANALYZE) {
+                            return ;
+                        }
+                        new TreePathScanner<Void, Void>() {
+                            @Override
+                            public Void visitAnnotatedType(AnnotatedTypeTree node, Void p) {
+                                TypeMirror type = Trees.instance(task).getTypeMirror(getCurrentPath());
+                                List<? extends AnnotationMirror> ams = type.getAnnotationMirrors();
+                                if (ams.size() != 1) {
+                                    throw new AssertionError("Expected a single annotation, but got: " + ams);
+                                }
+                                String expectedMirror = "@test.Test.Ann";
+                                String actualMirror = ams.get(0).toString();
+                                if (!Objects.equals(expectedMirror, actualMirror)) {
+                                    throw new AssertionError("Expected: " + expectedMirror +
+                                                             ", but got: " + actualMirror);
+                                }
+
+                                seenAnnotationMirror.set(true);
+
+                                return super.visitAnnotatedType(node, p);
+                            }
+                        }.scan(e.getCompilationUnit(), null);
+                    }
+                });
+            })
+            .files(tb.findJavaFiles(src))
+            .run(Task.Expect.SUCCESS)
+            .writeAll();
+
+        if (!seenAnnotationMirror.get()) {
+            throw new AssertionError("Didn't see the AnnotatedTypeTree!");
+        }
+    }
+
+}

--- a/test/langtools/tools/javac/recovery/AttrRecovery.java
+++ b/test/langtools/tools/javac/recovery/AttrRecovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8301580 8322159
+ * @bug 8301580 8322159 8332230
  * @summary Verify error recovery w.r.t. Attr
  * @library /tools/lib
  * @enablePreview
@@ -117,6 +117,39 @@ public class AttrRecovery extends TestRunner {
                 "C.java:6:20: compiler.warn.possible.this.escape",
                 "3 errors",
                 "1 warning"
+        );
+
+        if (!Objects.equals(actual, expected)) {
+            error("Expected: " + expected + ", but got: " + actual);
+        }
+    }
+
+    @Test //JDK-8332230
+    public void testAnnotationsInErroneousTree1() throws Exception {
+        String code = """
+                      package p;
+                      public class C {
+                          static int v;
+                          public void t() {
+                              //not a statement expression,
+                              //will be wrapped in an erroneous tree:
+                              p.@Ann C.v;
+                          }
+                          @interface Ann {}
+                      }
+                      """;
+        Path curPath = Path.of(".");
+        List<String> actual = new JavacTask(tb)
+                .options("-XDrawDiagnostics", "-XDdev", "-XDshould-stop.at=FLOW")
+                .sources(code)
+                .outdir(curPath)
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(OutputKind.DIRECT);
+
+        List<String> expected = List.of(
+                "C.java:7:17: compiler.err.not.stmt",
+                "1 error"
         );
 
         if (!Objects.equals(actual, expected)) {


### PR DESCRIPTION
Passing snippet `k=aa:a.@a` to JShell crashes it:
```
jshell> k=aa:a.@a
...
Caused by: java.lang.AssertionError
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:155)
        at jdk.compiler/com.sun.tools.javac.util.Assert.checkNonNull(Assert.java:62)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.fromAnnotations(Annotate.java:167)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.lambda$annotateTypeSecondStage$5(Annotate.java:1059)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.flush(Annotate.java:194)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.unblockAnnotations(Annotate.java:144)
```

There are two places where relevant work for type annotations is scheduled:
- Attr.visitMethodDef will schedule and perform first stage of type annotation processing before processing the method's body: https://github.com/openjdk/jdk/blob/90758f6735620776fcb60da9e0e2c91a4f53aaf1/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java#L1215
- Attr.visitAnnotatedType will schedule the second phase of type annotation processing: https://github.com/openjdk/jdk/blob/90758f6735620776fcb60da9e0e2c91a4f53aaf1/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java#L5224

There are two problems here:
a) it may happen that `visitAnnotatedType` schedules the second phase for the given type, but noone calls `Annotate.flush()` anymore before javac finishes. `flush` is in `Attr` called at the beginning of processing of classes, methods, many, but not all variables, etc., but if there's none of them in the source after the task has been scheduled, the task will remain in the queue. This has twofold effect: 1) the model for the type is slightly broken (if we ask of the type annotations on the type, we won't get the annotation); 2) since JShell is using `JavacTaskPool`, and reuses javac tasks, the pending type annotation task may remain in the queue, and be invoked when doing reusing the `JavacTask` for unrelated processing. My proposal here is to call `Annotate.flush()` after "top-level" declarations, to make sure all annotation tasks are always finished.

b) `Attr` visits even erroneous subtrees, so annotated types inside erroneous subtrees will have the second stage scheduled; but the first stage of type annotation processing is not looking inside erroneous subtrees, so the first stage is not done for annotated types inside these subtrees. And the second stage then crashes. My proposal is to let the first stage look into erroneous subtrees.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332230: jshell throws AssertionError when processing annotations`

### Issue
 * [JDK-8332230](https://bugs.openjdk.org/browse/JDK-8332230): jshell throws AssertionError when processing annotations (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19371/head:pull/19371` \
`$ git checkout pull/19371`

Update a local copy of the PR: \
`$ git checkout pull/19371` \
`$ git pull https://git.openjdk.org/jdk.git pull/19371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19371`

View PR using the GUI difftool: \
`$ git pr show -t 19371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19371.diff">https://git.openjdk.org/jdk/pull/19371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19371#issuecomment-2127505085)