### PR TITLE
8332851: Shenandoah: Update refs iterator does not need to be a member of ShenandoahHeap

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -973,7 +973,6 @@ void ShenandoahConcurrentGC::op_update_thread_roots() {
 void ShenandoahConcurrentGC::op_final_updaterefs() {
   ShenandoahHeap* const heap = ShenandoahHeap::heap();
   assert(ShenandoahSafepoint::is_at_shenandoah_safepoint(), "must be at safepoint");
-  assert(!heap->_update_refs_iterator.has_next(), "Should have finished update references");
 
   heap->finish_concurrent_roots();
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -239,7 +239,6 @@ private:
   bool      _heap_region_special;
   size_t    _num_regions;
   ShenandoahHeapRegion** _regions;
-  ShenandoahRegionIterator _update_refs_iterator;
 
 public:
 


### PR DESCRIPTION
The iterator is used outside of Shenandoah heap to support an assert, and must be 'reset' for correctness. These iterators are typically used as a local variable, and we can do that with this iterator as well to simplify the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332851](https://bugs.openjdk.org/browse/JDK-8332851): Shenandoah: Update refs iterator does not need to be a member of ShenandoahHeap (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19376/head:pull/19376` \
`$ git checkout pull/19376`

Update a local copy of the PR: \
`$ git checkout pull/19376` \
`$ git pull https://git.openjdk.org/jdk.git pull/19376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19376`

View PR using the GUI difftool: \
`$ git pr show -t 19376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19376.diff">https://git.openjdk.org/jdk/pull/19376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19376#issuecomment-2128272026)