### PR TITLE
8332431: NullPointerException in JTable of SwingSet2

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -265,7 +265,11 @@ public final class ToolTipManager extends MouseAdapter implements MouseMotionLis
                 toFind = new Point(screenLocation.x + preferredLocation.x,
                         screenLocation.y + preferredLocation.y);
             } else {
-                toFind = mouseEvent.getLocationOnScreen();
+                if (mouseEvent != null) {
+                    toFind = mouseEvent.getLocationOnScreen();
+                } else {
+                    toFind = screenLocation;
+                }
             }
 
             GraphicsConfiguration gc = getDrawingGC(toFind);
@@ -303,8 +307,12 @@ public final class ToolTipManager extends MouseAdapter implements MouseMotionLis
             location.x -= size.width;
         }
             } else {
-                location = new Point(screenLocation.x + mouseEvent.getX(),
-                        screenLocation.y + mouseEvent.getY() + 20);
+                if (mouseEvent != null) {
+                    location = new Point(screenLocation.x + mouseEvent.getX(),
+                            screenLocation.y + mouseEvent.getY() + 20);
+                } else {
+                    location = screenLocation;
+                }
         if (!leftToRight) {
             if(location.x - size.width>=0) {
                 location.x -= size.width;

--- a/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
+++ b/src/java.desktop/share/classes/javax/swing/ToolTipManager.java
@@ -270,8 +270,10 @@ public final class ToolTipManager extends MouseAdapter implements MouseMotionLis
 
             GraphicsConfiguration gc = getDrawingGC(toFind);
             if (gc == null) {
-                toFind = mouseEvent.getLocationOnScreen();
-                gc = getDrawingGC(toFind);
+                if (mouseEvent != null) {
+                    toFind = mouseEvent.getLocationOnScreen();
+                    gc = getDrawingGC(toFind);
+                }
                 if (gc == null) {
                     gc = insideComponent.getGraphicsConfiguration();
                 }


### PR DESCRIPTION
Issue is observed in JTable demo in SwingSet2 whereby if we set the focus on a table cell (or click on a table cell) and Press Ctrl+F1 (show/hide tooltip) on a cell of JTable then NullpointerException is seen

> Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "java.awt.event.MouseEvent.getLocationOnScreen()" because "this.mouseEvent" is null 

This is because ToolTip associated with JTable demo button at top of SwingSet2 has MouseMotion Listener which causes [mouseEvent to be null](https://github.com/openjdk/jdk/blame/da3001daf79bf943d6194d9fd60250d519b9680d/src/java.desktop/share/classes/javax/swing/ToolTipManager.java#L573) when mouse exits the demo button area and enter the table cells area where show/hide tooltip causes showTipWindow to be called trying to access `mouseEvent` which is null.
Fix is made to check for null in this kind of cases..No regression test is added as it can be checked easily with SwingSet2..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332431](https://bugs.openjdk.org/browse/JDK-8332431): NullPointerException in JTable of SwingSet2 (**Bug** - P3)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [2e9c2337](https://git.openjdk.org/jdk/pull/19379/files/2e9c2337ffb2d9e7067902ce02c984ce9378adb3)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) ⚠️ Review applies to [2e9c2337](https://git.openjdk.org/jdk/pull/19379/files/2e9c2337ffb2d9e7067902ce02c984ce9378adb3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19379/head:pull/19379` \
`$ git checkout pull/19379`

Update a local copy of the PR: \
`$ git checkout pull/19379` \
`$ git pull https://git.openjdk.org/jdk.git pull/19379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19379`

View PR using the GUI difftool: \
`$ git pr show -t 19379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19379.diff">https://git.openjdk.org/jdk/pull/19379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19379#issuecomment-2128530041)