### PR TITLE
8160755: closed/com/sun/java/swing/plaf/gtk/6492108/bug6492108.java test fails in GTK L&F

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -747,12 +747,12 @@ class GTKStyle extends SynthStyle implements GTKConstants {
               region == Region.TOOL_TIP ||
               region == Region.TREE ||
               region == Region.VIEWPORT ||
-              region == Region.TEXT_PANE) {
+              region == Region.TEXT_PANE ||
+              region == Region.EDITOR_PANE) {
             return true;
         }
         if (!GTKLookAndFeel.is3()) {
-            if (region == Region.EDITOR_PANE ||
-                  region == Region.FORMATTED_TEXT_FIELD ||
+            if (region == Region.FORMATTED_TEXT_FIELD ||
                   region == Region.PASSWORD_FIELD ||
                   region == Region.SPINNER ||
                   region == Region.TEXT_FIELD) {

--- a/test/jdk/com/sun/java/swing/plaf/gtk/bug6492108.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/bug6492108.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.GridLayout;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+
+import javax.swing.JEditorPane;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTextArea;
+import javax.swing.JTextPane;
+import javax.swing.UIManager;
+import javax.swing.text.JTextComponent;
+
+/*
+ * @test
+ * @bug 6492108 8160755
+ * @key headful
+ * @summary Verifies that the background is painted the same for
+ *          JTextArea, JTextPane, and JEditorPane.
+ * @library /javax/swing/regtesthelpers
+ * @build SwingTestHelper
+ * @run main/othervm bug6492108
+ */
+
+public class bug6492108 extends SwingTestHelper {
+
+    private static boolean showText;
+    private JPanel panel;
+
+    public static void main(String[] args) throws Throwable {
+        try {
+            UIManager.setLookAndFeel(
+                "com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
+        } catch (Exception e) {
+            System.out.println("GTK LAF is not supported on this system; test passes");
+            return;
+        }
+        new bug6492108().run(args);
+    }
+
+    private static void addTextComps(Container parent,
+                                     Class<? extends JTextComponent> type)
+        throws Throwable
+    {
+        JTextComponent text = type.newInstance();
+        String name = text.getClass().getSimpleName() + " ";
+        if (showText) text.setText(name + "\neditable");
+        addTextComp(parent, text);
+
+        text = type.newInstance();
+        text.setEditable(false);
+        if (showText) text.setText(name + "\nuneditable");
+        addTextComp(parent, text);
+
+        text = type.newInstance();
+        if (showText) text.setText(name + "\ndisabled");
+        text.setEnabled(false);
+        addTextComp(parent, text);
+
+        text = type.newInstance();
+        if (showText) text.setText(name + "\ndisabled/uneditable");
+        text.setEnabled(false);
+        text.setEditable(false);
+        addTextComp(parent, text);
+    }
+
+    private static void addTextComp(Container parent, JTextComponent text) {
+        JScrollPane sp = new JScrollPane(text);
+        text.setFocusable(false); // to avoid showing the blinking caret
+        sp.setPreferredSize(new Dimension(150, 150));
+        sp.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        sp.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_NEVER);
+        parent.add(sp);
+    }
+
+    protected Component createContentPane() {
+        panel = new JPanel();
+        panel.setLayout(new GridLayout(3, 4));
+        try {
+            addTextComps(panel, JTextArea.class);
+            addTextComps(panel, JEditorPane.class);
+            addTextComps(panel, JTextPane.class);
+        } catch (Throwable t) {
+            fail("Problem creating text components");
+        }
+        return panel;
+    }
+
+    private void onEDT10() {
+        requestAndWaitForFocus(panel);
+    }
+
+    private void onBackgroundThread20() {
+        // For each component on the top row, compare against the two
+        // components below in the same column.  All three components in
+        // that column should be the same pixel-for-pixel.
+        for (int count = 0; count < 4; count++) {
+            Component ref = panel.getComponent(count);
+            Point loc = ref.getLocationOnScreen();
+            Rectangle refRect =
+                new Rectangle(loc.x, loc.y, ref.getWidth(), ref.getHeight());
+            BufferedImage refimg = robot.createScreenCapture(refRect);
+
+            for (int k = 1; k < 3; k++) {
+                int index = count + (k*4);
+                Component test = panel.getComponent(index);
+                loc = test.getLocationOnScreen();
+                Rectangle testRect =
+                    new Rectangle(loc.x, loc.y,
+                                  test.getWidth(), test.getHeight());
+                BufferedImage testimg = robot.createScreenCapture(testRect);
+
+                if (refimg.getWidth() != testimg.getWidth() ||
+                    refimg.getHeight() != testimg.getHeight())
+                {
+                    fail("Test image size must match reference image size");
+                }
+
+                for (int y = 0; y < refimg.getHeight(); y++) {
+                    for (int x = 0; x < refimg.getWidth(); x++) {
+                        int refPixel  = refimg.getRGB(x, y);
+                        int testPixel = testimg.getRGB(x, y);
+                        if (refPixel != testPixel) {
+                            fail("Image comparison failed at (" +
+                                 x + "," + y + ") for image " + index);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void onBackgroundThread30() {
+        // Allow enough time for visual verification
+        try { Thread.sleep(3000); } catch (Exception e) {}
+    }
+}


### PR DESCRIPTION
bug6492108.java test always fails in GTK L&F in single as well as dual screen linux machines. Since this test was not marked as "headful" in it's initial version, it never failed but after the fix of JDK-8287051 this test was problem listed as it always
failed which is captured in the JBS.
The reason of failure is the pixel color mismatch between JEditorPane and JTextArea/JTextPane which is caused by the JEditorPane's default opaque value which is false for GTK3 https://github.com/kumarabhi006/jdk/blob/c642f44bbe1e4cdbc23496a34ddaae30990ce7c0/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java#L767.
In initial load JEditorPane, JTextArea and JTextPane components are opaque https://github.com/kumarabhi006/jdk/blame/6c7656678916ff3f5c9fc70efcbb69ce76801458/jdk/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java#L718 but after the fix for JDK-8145547 the implementation was changed to provide conditional support for GTK3 on linux where few components like Editor Pane, Formatted text Field, Password Field etc are opaque only if the GTKversion is not 3 https://github.com/kumarabhi006/jdk/blame/73d2181d56063f6015e4fc42e130591bee39bc36/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java#L746C21-L746C21.
JTextPane's issue was observed by JDK-8218479 and then the default opacity is set to true for JTextPane irrespective of GTK version https://github.com/kumarabhi006/jdk/blame/c642f44bbe1e4cdbc23496a34ddaae30990ce7c0/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java#L750C16-L750C16.
Extending the fix in isOpaque() method in GTKStyle.java for JEditorPane similar to JTextPane resolves the issue.

Test verified in both single and dual screen linux machines.

