### PR TITLE
8332825: ubsan: guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/src/hotspot/share/memory/guardedMemory.cpp
+++ b/src/hotspot/share/memory/guardedMemory.cpp
@@ -32,7 +32,9 @@ void* GuardedMemory::wrap_copy(const void* ptr, const size_t len, const void* ta
   if (outerp != nullptr) {
     GuardedMemory guarded(outerp, len, tag);
     void* innerp = guarded.get_user_ptr();
-    memcpy(innerp, ptr, len);
+    if (ptr != nullptr) {
+      memcpy(innerp, ptr, len);
+    }
     return innerp;
   }
   return nullptr; // OOM


### PR DESCRIPTION
When running :tier1 hs tests, the following issue has been reported with ubsan enabled (configure flag --enable-ubsan) the following issue is reported .
Reason is that gtest forces a call void* no_data_copy = GuardedMemory::wrap_copy(no_data, 0); with 0 length . This leads to a special case for memcpy .

gtest/GTestWrapper.jtr

/jdk/src/hotspot/share/memory/guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x7f174d684227 in GuardedMemory::wrap_copy(void const*, unsigned long, void const*) /jdk/src/hotspot/share/memory/guardedMemory.cpp:35
    #1 0x7f174dd210c3 in GuardedMemory_wrap_Test::TestBody() /jdk/test/hotspot/gtest/memory/test_guardedMemory.cpp:146
    #2 0x7f17526f8d63 in testing::Test::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:2687
    #3 0x7f17526f8d63 in testing::Test::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:2677
    #4 0x7f17526f946d in testing::TestInfo::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:2836
    #5 0x7f1752729ef8 in testing::TestSuite::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:3015
    #6 0x7f1752729ef8 in testing::TestSuite::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:2968
    #7 0x7f175272aec5 in testing::internal::UnitTestImpl::RunAllTests() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:5920
    #8 0x7f17526f0fcf in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:2670
    #9 0x7f17526f0fcf in testing::UnitTest::Run() /tools/gtest/googletest-1.14.0/googletest/src/gtest.cc:5484
    #10 0x7f174d8c84d7 in RUN_ALL_TESTS() /tools/gtest/googletest-1.14.0/googletest/include/gtest/gtest.h:2317
    #11 0x7f174d8c84d7 in runUnitTestsInner /jdk/test/hotspot/gtest/gtestMain.cpp:290
    #12 0x558be83647d8 in main /jdk/test/hotspot/gtest/gtestLauncher.cpp:40
    #13 0x7f174734c24c in __libc_start_main (/lib64/libc.so.6+0x3524c) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332825: ubsan: guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null`

### Issue
 * [JDK-8332825](https://bugs.openjdk.org/browse/JDK-8332825): ubsan: guardedMemory.cpp:35:11: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19382/head:pull/19382` \
`$ git checkout pull/19382`

Update a local copy of the PR: \
`$ git checkout pull/19382` \
`$ git pull https://git.openjdk.org/jdk.git pull/19382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19382`

View PR using the GUI difftool: \
`$ git pr show -t 19382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19382.diff">https://git.openjdk.org/jdk/pull/19382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19382#issuecomment-2128808899)