### PR TITLE
8332864: Parallel: Merge ParMarkBitMapClosure into MoveAndUpdateClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2526,7 +2526,7 @@ void PSParallelCompact::fill_region(ParCompactionManager* cm, MoveAndUpdateClosu
 
 void PSParallelCompact::fill_and_update_region(ParCompactionManager* cm, size_t region_idx)
 {
-  MoveAndUpdateClosure cl(mark_bitmap(), cm, region_idx);
+  MoveAndUpdateClosure cl(mark_bitmap(), region_idx);
   fill_region(cm, cl, region_idx);
 }
 
@@ -2540,7 +2540,7 @@ void PSParallelCompact::fill_and_update_shadow_region(ParCompactionManager* cm, 
   // so use MoveAndUpdateClosure to fill the normal region. Otherwise, use
   // MoveAndUpdateShadowClosure to fill the acquired shadow region.
   if (shadow_region == ParCompactionManager::InvalidShadow) {
-    MoveAndUpdateClosure cl(mark_bitmap(), cm, region_idx);
+    MoveAndUpdateClosure cl(mark_bitmap(), region_idx);
     region_ptr->shadow_to_normal();
     return fill_region(cm, cl, region_idx);
   } else {
@@ -2627,7 +2627,7 @@ void MoveAndUpdateClosure::complete_region(ParCompactionManager *cm, HeapWord *d
   region_ptr->set_completed();
 }
 
-ParMarkBitMapClosure::IterationStatus
+MoveAndUpdateClosure::IterationStatus
 MoveAndUpdateClosure::do_addr(HeapWord* addr, size_t words) {
   assert(destination() != nullptr, "sanity");
   _source = addr;


### PR DESCRIPTION
Trivial merging a class into its subclass. (Some unused fields/args/methods are also removed.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332864](https://bugs.openjdk.org/browse/JDK-8332864): Parallel: Merge ParMarkBitMapClosure into MoveAndUpdateClosure (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19383/head:pull/19383` \
`$ git checkout pull/19383`

Update a local copy of the PR: \
`$ git checkout pull/19383` \
`$ git pull https://git.openjdk.org/jdk.git pull/19383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19383`

View PR using the GUI difftool: \
`$ git pr show -t 19383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19383.diff">https://git.openjdk.org/jdk/pull/19383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19383#issuecomment-2128836938)