### PR TITLE
8321292: SerialGC: NewSize vs InitialHeapSize check has an off-by-one error

### DIFF
--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -101,11 +101,11 @@ void GenArguments::initialize_heap_flags_and_sizes() {
 
   // Make sure NewSize allows an old generation to fit even if set on the command line
   if (FLAG_IS_CMDLINE(NewSize) && NewSize >= InitialHeapSize) {
-    size_t smaller_new_size = bound_minus_alignment(NewSize, InitialHeapSize, GenAlignment);
+    size_t revised_new_size = bound_minus_alignment(NewSize, InitialHeapSize, GenAlignment);
     log_warning(gc, ergo)("NewSize (%zuk) is equal to or greater than initial heap size (%zuk).  A new "
                           "NewSize of %zuk will be used to accomodate an old generation.",
-                          NewSize/K, InitialHeapSize/K, smaller_new_size/K);
-    FLAG_SET_ERGO(NewSize, smaller_new_size);
+                          NewSize/K, InitialHeapSize/K, revised_new_size/K);
+    FLAG_SET_ERGO(NewSize, revised_new_size);
   }
 
   // Now take the actual NewSize into account. We will silently increase NewSize

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -101,8 +101,11 @@ void GenArguments::initialize_heap_flags_and_sizes() {
 
   // Make sure NewSize allows an old generation to fit even if set on the command line
   if (FLAG_IS_CMDLINE(NewSize) && NewSize >= InitialHeapSize) {
-    log_warning(gc, ergo)("NewSize was set larger than initial heap size, will use initial heap size.");
-    FLAG_SET_ERGO(NewSize, bound_minus_alignment(NewSize, InitialHeapSize, GenAlignment));
+    size_t smaller_new_size = bound_minus_alignment(NewSize, InitialHeapSize, GenAlignment);
+    log_warning(gc, ergo)("NewSize (%zuk) is equal to or greater than initial heap size (%zuk).  A new "
+                          "NewSize of %zuk will be used to accomodate an old generation.",
+                          NewSize/K, InitialHeapSize/K, smaller_new_size/K);
+    FLAG_SET_ERGO(NewSize, smaller_new_size);
   }
 
   // Now take the actual NewSize into account. We will silently increase NewSize


### PR DESCRIPTION
Hi all,

  please review this change to the warning message to improve the understanding why the change is needed.
I tried to make the message similar to surrounding ones, adding actual values.

Testing: local compilation, manual testing

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321292](https://bugs.openjdk.org/browse/JDK-8321292): SerialGC: NewSize vs InitialHeapSize check has an off-by-one error (**Bug** - P5)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**) ⚠️ Review applies to [68e42bc8](https://git.openjdk.org/jdk/pull/19384/files/68e42bc84546f7e7f91d134d045c1e1ded929fee)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19384/head:pull/19384` \
`$ git checkout pull/19384`

Update a local copy of the PR: \
`$ git checkout pull/19384` \
`$ git pull https://git.openjdk.org/jdk.git pull/19384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19384`

View PR using the GUI difftool: \
`$ git pr show -t 19384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19384.diff">https://git.openjdk.org/jdk/pull/19384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19384#issuecomment-2128839980)