### PR TITLE
8079167: Fix documentation for G1SATBBufferEnqueueingThresholdPercent == 0

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -149,12 +149,11 @@
           "Number of completed buffers that triggers log processing.")      \
           range(0, max_jint)                                                \
                                                                             \
-  product(uint, G1SATBBufferEnqueueingThresholdPercent, 60,                \
+  product(uint, G1SATBBufferEnqueueingThresholdPercent, 60,                 \
           "Before enqueueing them, each mutator thread tries to do some "   \
           "filtering on the SATB buffers it generates. If post-filtering "  \
           "the percentage of retained entries is over this threshold "      \
-          "the buffer will be enqueued for processing. A value of 0 "       \
-          "specifies that mutator threads should not do such filtering.")   \
+          "the buffer will be enqueued for processing.")                    \
           range(0, 100)                                                     \
                                                                             \
   product(uint, G1ExpandByPercentOfAvailable, 20, EXPERIMENTAL,             \


### PR DESCRIPTION
Hi all,

  please review this change to the documentation of `G1SATBBufferEnqueueingThresholdPercent`: since
the filtering is necessary to facilitate termination (see comments in CR), we can't completely disable filtering and the text is just misleading.

Testing: local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8079167](https://bugs.openjdk.org/browse/JDK-8079167): Fix documentation for G1SATBBufferEnqueueingThresholdPercent == 0 (**Bug** - P5)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19385/head:pull/19385` \
`$ git checkout pull/19385`

Update a local copy of the PR: \
`$ git checkout pull/19385` \
`$ git pull https://git.openjdk.org/jdk.git pull/19385/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19385`

View PR using the GUI difftool: \
`$ git pr show -t 19385`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19385.diff">https://git.openjdk.org/jdk/pull/19385.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19385#issuecomment-2128850909)