### PR TITLE
8332866: Crash in ImageIO JPEG decoding when MEM_STATS in enabled

### DIFF
--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
+++ b/src/java.desktop/share/native/libjavajpeg/imageioJPEG.c
@@ -666,8 +666,6 @@ static void imageio_reset(JNIEnv *env,
 static void imageio_dispose(j_common_ptr info) {
 
     if (info != NULL) {
-        free(info->err);
-        info->err = NULL;
         if (info->is_decompressor) {
             j_decompress_ptr dinfo = (j_decompress_ptr) info;
             free(dinfo->src);
@@ -678,6 +676,8 @@ static void imageio_dispose(j_common_ptr info) {
             cinfo->dest = NULL;
         }
         jpeg_destroy(info);
+        free(info->err);
+        info->err = NULL;
         free(info);
     }
 }


### PR DESCRIPTION
In IJG library's jmemmgr.c file we can define MEM_STATS(by default this flag is disabled and we don't see this issue) to enable printing of memory trace logs when we have OOM. But if we enable it we get crash while disposing IJG stored objects in jmemmgr->free-pool() function.

This is happening because we delete the error handler before we actually start deleting IJG stored objects and while freeing the IJG objects we try to access cinfo->err->trace_level of error handler. This early deletion of error handler is happening in imageioJPEG.c->imageio_dispose() function.

Moved the logic to delete error handler after we are done with deleting IJG stored objects, after this change there is no crash. There is no regression test because this issue is seen only when we enable MEM_STATS flag in IJG library. Ran jtreg ImageIO tests with code update and i don't see any regressions.

I have verified that this issue doesn't effect SplashScreen code path and disposing of IJG objects is handled differently in SplashScreen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332866](https://bugs.openjdk.org/browse/JDK-8332866): Crash in ImageIO JPEG decoding when MEM_STATS in enabled (**Bug** - P3)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [abe4de70](https://git.openjdk.org/jdk/pull/19386/files/abe4de70896c37a5f763f821a3800b99411333aa)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) ⚠️ Review applies to [abe4de70](https://git.openjdk.org/jdk/pull/19386/files/abe4de70896c37a5f763f821a3800b99411333aa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19386/head:pull/19386` \
`$ git checkout pull/19386`

Update a local copy of the PR: \
`$ git checkout pull/19386` \
`$ git pull https://git.openjdk.org/jdk.git pull/19386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19386`

View PR using the GUI difftool: \
`$ git pr show -t 19386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19386.diff">https://git.openjdk.org/jdk/pull/19386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19386#issuecomment-2128952123)