### PR TITLE
8332858: References with escapes have broken positions after they are transformed

### DIFF
--- a/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
@@ -35,7 +35,6 @@ import java.util.stream.Stream;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.DocTreeVisitor;
-import com.sun.source.doctree.EscapeTree;
 import com.sun.source.doctree.RawTextTree;
 import com.sun.source.util.DocTreeScanner;
 import com.sun.source.util.DocTrees;
@@ -61,8 +60,6 @@ import jdk.internal.org.commonmark.parser.Parser;
 import jdk.internal.org.commonmark.parser.delimiter.DelimiterProcessor;
 
 import static com.sun.tools.javac.util.Position.NOPOS;
-import java.util.regex.Matcher;
-import jdk.internal.org.commonmark.internal.util.Escaping;
 
 /**
  * A class to transform a {@code DocTree} node into a similar one with
@@ -851,24 +848,12 @@ public class MarkdownTransformer implements JavacTrees.DocCommentTreeTransformer
                 if (index != -1) {
                     return new int[] {start + index, start + index + ref.length()};
                 } else {
-                    StringBuilder pattern = new StringBuilder(2 * ref.length());
-
-                    for (char c : ref.toCharArray()) {
-                        if (Escaping.ESCAPABLE.indexOf(c) >= 0) {
-                            pattern.append("\\\\?");
-                        }
-                        pattern.append(Pattern.quote(String.valueOf(c)));
+                    String escapedRef = ref.replace("[]", "\\[\\]");
+                    var escapedIndex = s.lastIndexOf(escapedRef);
+                    if (escapedIndex != -1) {
+                        return new int[] {start + escapedIndex,
+                                          start + escapedIndex + ref.length()};
                     }
-
-                    Matcher m = Pattern.compile(pattern.toString()).matcher(s);
-                    int[] result = new int[] {NOPOS, NOPOS};
-
-                    while (m.find()) {
-                        result[0] = start + m.start();
-                        result[1] = start + m.end();
-                    }
-
-                    return result;
                 }
             }
             return NOSPAN;

--- a/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
@@ -852,7 +852,7 @@ public class MarkdownTransformer implements JavacTrees.DocCommentTreeTransformer
                     var escapedIndex = s.lastIndexOf(escapedRef);
                     if (escapedIndex != -1) {
                         return new int[] {start + escapedIndex,
-                                          start + escapedIndex + ref.length()};
+                                          start + escapedIndex + escapedRef.length()};
                     }
                 }
             }

--- a/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
+++ b/src/jdk.internal.md/share/classes/jdk/internal/markdown/MarkdownTransformer.java
@@ -864,8 +864,8 @@ public class MarkdownTransformer implements JavacTrees.DocCommentTreeTransformer
                     int[] result = new int[] {NOPOS, NOPOS};
 
                     while (m.find()) {
-                        result[0] = m.start();
-                        result[1] = m.end();
+                        result[0] = start + m.start();
+                        result[1] = start + m.end();
                     }
 
                     return result;

--- a/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
@@ -85,6 +85,7 @@ public class MarkdownTransformerPositionTest {
 
     private void linkWithEscapes() throws Exception {
         runConvertedLinksTest("""
+                /// Markdown comment.
                 /// [java.util.Arrays#asList(Object\\[\\])]
                 public class Test {
                 }

--- a/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTransformerPositionTest.java
@@ -23,13 +23,16 @@
 
 /*
  * @test
+ * @bug 8332858
  * @summary test case for Markdown positions
  * @run main/othervm --limit-modules jdk.compiler MarkdownTransformerPositionTest
- * @run main MarkdownTransformerPositionTest
+ * @run main MarkdownTransformerPositionTest links
  */
 
 import com.sun.source.doctree.DocCommentTree;
+import com.sun.source.doctree.LinkTree;
 import com.sun.source.doctree.RawTextTree;
+import com.sun.source.doctree.ReferenceTree;
 import com.sun.source.tree.*;
 import com.sun.source.util.*;
 
@@ -50,6 +53,10 @@ public class MarkdownTransformerPositionTest {
 
         t.simpleTest();
         t.testWithReplacements();
+
+        if (args.length > 0 && "links".equals(args[0])) {
+            t.linkWithEscapes();
+        }
     }
 
     private void simpleTest() throws Exception {
@@ -76,6 +83,15 @@ public class MarkdownTransformerPositionTest {
                 "testAuthor");
     }
 
+    private void linkWithEscapes() throws Exception {
+        runConvertedLinksTest("""
+                /// [java.util.Arrays#asList(Object\\[\\])]
+                public class Test {
+                }
+                """,
+                "java.util.Arrays#asList(Object\\[\\])");
+    }
+
     private void runTest(String source, String... expectedRawSpans) throws Exception {
         JavaCompiler comp = ToolProvider.getSystemJavaCompiler();
         JavacTask task = (JavacTask)comp.getTask(null, null, null, null, null, Arrays.asList(new JavaSource(source)));
@@ -94,6 +110,46 @@ public class MarkdownTransformerPositionTest {
                 int end = (int) trees.getSourcePositions().getEndPosition(cu, docComment, node);
                 rawSpans.add(source.substring(start, end));
                 return super.visitRawText(node, p);
+            }
+        }.scan(docComment, null);
+
+        List<String> expectedRawSpansList = List.of(expectedRawSpans);
+
+        if (!expectedRawSpansList.equals(rawSpans)) {
+            throw new AssertionError("Incorrect raw text spans, should be: " +
+                    expectedRawSpansList + ", but is: " + rawSpans);
+        }
+
+        System.err.println("Test result: success, boot modules: " + ModuleLayer.boot().modules());
+    }
+
+    private void runConvertedLinksTest(String source, String... expectedRawSpans) throws Exception {
+        JavaCompiler comp = ToolProvider.getSystemJavaCompiler();
+        JavacTask task = (JavacTask)comp.getTask(null, null, null, null, null, Arrays.asList(new JavaSource(source)));
+        CompilationUnitTree cu = task.parse().iterator().next();
+        task.analyze();
+        DocTrees trees = DocTrees.instance(task);
+        List<String> rawSpans = new ArrayList<>();
+        TreePath clazzTP = new TreePath(new TreePath(cu), cu.getTypeDecls().get(0));
+        Element clazz = trees.getElement(clazzTP);
+        DocCommentTree docComment = trees.getDocCommentTree(clazz);
+
+        new DocTreeScanner<Void, Void>() {
+            @Override
+            public Void visitLink(LinkTree node, Void p) {
+                int start = (int) trees.getSourcePositions().getStartPosition(cu, docComment, node);
+                if (start != (-1)) {
+                    throw new AssertionError("UNexpected start position for synthetic link: " + start);
+                }
+                return super.visitLink(node, p);
+            }
+
+            @Override
+            public Void visitReference(ReferenceTree node, Void p) {
+                int start = (int) trees.getSourcePositions().getStartPosition(cu, docComment, node);
+                int end = (int) trees.getSourcePositions().getEndPosition(cu, docComment, node);
+                rawSpans.add(source.substring(start, end));
+                return super.visitReference(node, p);
             }
         }.scan(docComment, null);
 


### PR DESCRIPTION
If the javadoc comment contains a (Markdown) link like:
```
[java.util.Arrays#asList(Object\[\])]
```

The transformer that converts this link into the Javadoc link will not find the reference, as it is looking for `java.util.Arrays#asList(Object[])` (note the missing escapes), which is not present in the original text.

This patch tries to fix that by permitting optional escapes for all escapable character when searching for the reference, in case the literal search fails. This is done using regexp, although could presumably be done using a manual search.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8332858](https://bugs.openjdk.org/browse/JDK-8332858): References with escapes have broken positions after they are transformed (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [b75f896f](https://git.openjdk.org/jdk/pull/19387/files/b75f896fb35f1c0c4a1b7216e1062b787a769757)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19387/head:pull/19387` \
`$ git checkout pull/19387`

Update a local copy of the PR: \
`$ git checkout pull/19387` \
`$ git pull https://git.openjdk.org/jdk.git pull/19387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19387`

View PR using the GUI difftool: \
`$ git pr show -t 19387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19387.diff">https://git.openjdk.org/jdk/pull/19387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19387#issuecomment-2129027116)