### PR TITLE
8332871: Parallel: Remove public bits APIs in ParMarkBitMap

### DIFF
--- a/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
@@ -31,8 +31,7 @@
 
 class PSVirtualSpace;
 
-class ParMarkBitMap: public CHeapObj<mtGC>
-{
+class ParMarkBitMap: public CHeapObj<mtGC> {
 public:
   typedef BitMap::idx_t idx_t;
 
@@ -46,9 +45,6 @@ public:
   inline bool mark_obj(HeapWord* addr);
   inline bool mark_obj(oop obj);
 
-  // Traditional interface for testing whether an object is marked or not (these
-  // test only the begin bits).
-  inline bool is_marked(idx_t bit)      const;
   inline bool is_marked(HeapWord* addr) const;
   inline bool is_marked(oop obj)        const;
 
@@ -57,18 +53,13 @@ public:
 
   size_t reserved_byte_size() const { return _reserved_byte_size; }
 
-  // Convert a heap address to/from a bit index.
-  inline idx_t     addr_to_bit(HeapWord* addr) const;
-  inline HeapWord* bit_to_addr(idx_t bit) const;
-
   inline HeapWord* find_obj_beg(HeapWord* beg, HeapWord* end) const;
 
   // Return the address of the last obj-start in the range [beg, end).  If no
   // object is found, return end.
   inline HeapWord* find_obj_beg_reverse(HeapWord* beg, HeapWord* end) const;
-  // Clear a range of bits or the entire bitmap (both begin and end bits are
-  // cleared).
-  inline void clear_range(idx_t beg, idx_t end);
+  // Clear a range of bits corresponding to heap address range [beg, end).
+  inline void clear_range(HeapWord* beg, HeapWord* end);
 
   void print_on_error(outputStream* st) const {
     st->print_cr("Marking Bits: (ParMarkBitMap*) " PTR_FORMAT, p2i(this));
@@ -110,6 +101,10 @@ private:
   inline HeapWord* region_end() const;
   inline size_t    region_size() const;
   inline size_t    size() const;
+
+  // Convert a heap address to/from a bit index.
+  inline idx_t     addr_to_bit(HeapWord* addr) const;
+  inline HeapWord* bit_to_addr(idx_t bit) const;
 
 #ifdef  ASSERT
   inline void verify_bit(idx_t bit) const;

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
@@ -34,8 +34,10 @@ inline ParMarkBitMap::ParMarkBitMap():
   _region_start(nullptr), _region_size(0), _beg_bits(), _virtual_space(nullptr), _reserved_byte_size(0)
 { }
 
-inline void ParMarkBitMap::clear_range(idx_t beg, idx_t end) {
-  _beg_bits.clear_range(beg, end);
+inline void ParMarkBitMap::clear_range(HeapWord* beg, HeapWord* end) {
+  const idx_t beg_bit = addr_to_bit(beg);
+  const idx_t end_bit = addr_to_bit(end);
+  _beg_bits.clear_range(beg_bit, end_bit);
 }
 
 inline ParMarkBitMap::idx_t ParMarkBitMap::bits_required(size_t words) {
@@ -62,12 +64,8 @@ inline size_t ParMarkBitMap::size() const {
   return _beg_bits.size();
 }
 
-inline bool ParMarkBitMap::is_marked(idx_t bit) const {
-  return _beg_bits.at(bit);
-}
-
 inline bool ParMarkBitMap::is_marked(HeapWord* addr) const {
-  return is_marked(addr_to_bit(addr));
+  return _beg_bits.at(addr_to_bit(addr));
 }
 
 inline bool ParMarkBitMap::is_marked(oop obj) const {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -826,9 +826,7 @@ PSParallelCompact::clear_data_covering_space(SpaceId id)
   HeapWord* const top = space->top();
   HeapWord* const max_top = MAX2(top, _space_info[id].new_top());
 
-  const idx_t beg_bit = _mark_bitmap.addr_to_bit(bot);
-  const idx_t end_bit = _mark_bitmap.addr_to_bit(top);
-  _mark_bitmap.clear_range(beg_bit, end_bit);
+  _mark_bitmap.clear_range(bot, top);
 
   const size_t beg_region = _summary_data.addr_to_region_idx(bot);
   const size_t end_region =
@@ -1001,10 +999,9 @@ void PSParallelCompact::fill_dense_prefix_end(SpaceId id) {
     return;
   }
   RegionData* const region_after_dense_prefix = _summary_data.addr_to_region_ptr(dense_prefix_end);
-  idx_t const dense_prefix_bit = _mark_bitmap.addr_to_bit(dense_prefix_end);
 
   if (region_after_dense_prefix->partial_obj_size() != 0 ||
-      _mark_bitmap.is_marked(dense_prefix_bit)) {
+      _mark_bitmap.is_marked(dense_prefix_end)) {
     // The region after the dense prefix starts with live bytes.
     return;
   }


### PR DESCRIPTION
Trivial unifying APIs to operate only on `HeapWord*`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332871](https://bugs.openjdk.org/browse/JDK-8332871): Parallel: Remove public bits APIs in ParMarkBitMap (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19388/head:pull/19388` \
`$ git checkout pull/19388`

Update a local copy of the PR: \
`$ git checkout pull/19388` \
`$ git pull https://git.openjdk.org/jdk.git pull/19388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19388`

View PR using the GUI difftool: \
`$ git pr show -t 19388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19388.diff">https://git.openjdk.org/jdk/pull/19388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19388#issuecomment-2129037704)