### PR TITLE
8332880: JFR GCHelper class recognizes "Archive" regions as valid

### DIFF
--- a/test/lib/jdk/test/lib/jfr/GCHelper.java
+++ b/test/lib/jdk/test/lib/jfr/GCHelper.java
@@ -195,8 +195,7 @@ public class GCHelper {
                                                            "Survivor",
                                                            "Starts Humongous",
                                                            "Continues Humongous",
-                                                           "Old",
-                                                           "Archive"
+                                                           "Old"
                                                          };
 
         g1HeapRegionTypes = Collections.unmodifiableList(Arrays.asList(g1HeapRegionTypeLiterals));


### PR DESCRIPTION
Hi all,

  please review this small change to remove "Archive" regions from the possible types of the heap region type change events.

We removed Archive regions a long time ago.

Testing: tier5 (containing the JFR tests afaik)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332880](https://bugs.openjdk.org/browse/JDK-8332880): JFR GCHelper class recognizes "Archive" regions as valid (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19390/head:pull/19390` \
`$ git checkout pull/19390`

Update a local copy of the PR: \
`$ git checkout pull/19390` \
`$ git pull https://git.openjdk.org/jdk.git pull/19390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19390`

View PR using the GUI difftool: \
`$ git pr show -t 19390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19390.diff">https://git.openjdk.org/jdk/pull/19390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19390#issuecomment-2129469016)