### PR TITLE
8332550: [macos] Voice Over: java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -31,7 +31,6 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
-import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.FocusListener;
@@ -1364,6 +1363,9 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
                 if (parent != null && parent.isShowing()) {
                     Point parentLocation = parent.getLocationOnScreen();
                     Point componentLocation = getLocation();
+                    if (parentLocation == null || componentLocation == null) {
+                        return null;
+                    }
                     componentLocation.translate(parentLocation.x, parentLocation.y);
                     return componentLocation;
                 } else {

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -1361,17 +1361,9 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             }
 
             public Point getLocationOnScreen() {
-                Point parentLocation;
-                if (parent != null) {
-                    try {
-                        parentLocation = parent.getLocationOnScreen();
-                    } catch (IllegalComponentStateException icse) {
-                        return null;
-                    }
+                if (parent != null && parent.isShowing()) {
+                    Point parentLocation = parent.getLocationOnScreen();
                     Point componentLocation = getLocation();
-                    if (parentLocation == null || componentLocation == null) {
-                        return null;
-                    }
                     componentLocation.translate(parentLocation.x, parentLocation.y);
                     return componentLocation;
                 } else {

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -31,6 +31,7 @@ import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
+import java.awt.IllegalComponentStateException;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.event.FocusListener;
@@ -1360,9 +1361,17 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             }
 
             public Point getLocationOnScreen() {
+                Point parentLocation;
                 if (parent != null) {
-                    Point parentLocation = parent.getLocationOnScreen();
+                    try {
+                        parentLocation = parent.getLocationOnScreen();
+                    } catch (IllegalComponentStateException icse) {
+                        return null;
+                    }
                     Point componentLocation = getLocation();
+                    if (parentLocation == null || componentLocation == null) {
+                        return null;
+                    }
                     componentLocation.translate(parentLocation.x, parentLocation.y);
                     return componentLocation;
                 } else {


### PR DESCRIPTION
"java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location" is thrown when getLocationOnScreen method is invoked for JTableHeader while testing JFileChooser demo. It seems that in getLocationOfScreen method we are trying to access the parent location but that is not visible and ICSE is thrown.

Fix is to handle the exception and can be verified using the steps mentioned in [JDK-8332550](https://bugs.openjdk.org/browse/JDK-8332550).
CI testing is green and link is mentioned in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332550](https://bugs.openjdk.org/browse/JDK-8332550): [macos] Voice Over: java.awt.IllegalComponentStateException: component must be showing on the screen to determine its location (**Bug** - P4)


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) ⚠️ Review applies to [7443451c](https://git.openjdk.org/jdk/pull/19391/files/7443451ce5f844949c067738bc4d8681a5999c79)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19391/head:pull/19391` \
`$ git checkout pull/19391`

Update a local copy of the PR: \
`$ git checkout pull/19391` \
`$ git pull https://git.openjdk.org/jdk.git pull/19391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19391`

View PR using the GUI difftool: \
`$ git pr show -t 19391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19391.diff">https://git.openjdk.org/jdk/pull/19391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19391#issuecomment-2129323490)