### PR TITLE
8332885: Clarify failure_handler self-tests

### DIFF
--- a/make/test/BuildFailureHandler.gmk
+++ b/make/test/BuildFailureHandler.gmk
@@ -81,6 +81,10 @@ IMAGES_TARGETS += $(COPY_FH)
 # Use JTREG_TEST_OPTS for test VM options
 # Use JTREG_TESTS for jtreg tests parameter
 #
+# Most likely you want to select a specific test from test/failure_handler/test
+# and manually inspect the results. This target does not actually verify
+# anything about the failure_handler's output or even if it ran at all.
+#
 RUN_DIR := $(FH_SUPPORT)/test
 
 test:

--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -108,7 +108,7 @@ TESTING
 There are a few make targets for testing the failure_handler itself.
  - Everything in `test/failure_handler/Makefile`
  - The `test-failure-handler` target in `make/RunTests.gmk`
- - The `test` target in make/test/BuildFailureHandler.gmk
+ - The `test` target in `make/test/BuildFailureHandler.gmk`
 All of these targets are written for manual testing only. They rely on
 manual inspection of generated artifacts and cannot be run as part of a CI.
 They are tests which timeout, crash, fail in various ways and you can check

--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -109,7 +109,8 @@ There are a few make targets for testing the failure_handler itself.
  - Everythin in `test/failure_handler/Makefile`
  - The `test-failure-handler` target in `make/RunTests.gmk`
  - The `test` target in make/test/BuildFailureHandler.gmk
-All of these targets are written for manual testing only. They rely on manual inspection of
-generated artifacts and cannot be run as part of a CI. They are tests which timeout, crash,
-fail in various ways and you can check the failure_handler output yourself. They might also
-leave processes running on your machine so be extra careful about cleaning up.
+All of these targets are written for manual testing only. They rely on
+manual inspection of generated artifacts and cannot be run as part of a CI.
+They are tests which timeout, crash, fail in various ways and you can check
+the failure_handler output yourself. They might also leave processes running
+on your machine so be extra careful about cleaning up.

--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -102,3 +102,14 @@ $ ${JTREG_HOME}/bin/jtreg -jdk:${JAVA_HOME}                                   \
  -timeoutHandler:jdk.test.failurehandler.jtreg.GatherProcessInfoTimeoutHandler\
  -observer:jdk.test.failurehandler.jtreg.GatherDiagnosticInfoObserver         \
  ${WS}/hotspot/test/
+
+TESTING
+
+There are a few make targets for testing the failure_handler itself.
+ - Everythin in `test/failure_handler/Makefile`
+ - The `test-failure-handler` target in `make/RunTests.gmk`
+ - The `test` target in make/test/BuildFailureHandler.gmk
+All of these targets are written for manual testing only. They rely on manual inspection of
+generated artifacts and cannot be run as part of a CI. They are tests which timeout, crash,
+fail in various ways and you can check the failure_handler output yourself. They might also
+leave processes running on your machine so be extra careful about cleaning up.

--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -106,7 +106,7 @@ $ ${JTREG_HOME}/bin/jtreg -jdk:${JAVA_HOME}                                   \
 TESTING
 
 There are a few make targets for testing the failure_handler itself.
- - Everythin in `test/failure_handler/Makefile`
+ - Everything in `test/failure_handler/Makefile`
  - The `test-failure-handler` target in `make/RunTests.gmk`
  - The `test` target in make/test/BuildFailureHandler.gmk
 All of these targets are written for manual testing only. They rely on


### PR DESCRIPTION
Adding commetns to clarify that the failure_handler selftests are intended to be run manually. Ideally this would include a more thorough description of the exepcted outputs, but this is what I have time to add right now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332885](https://bugs.openjdk.org/browse/JDK-8332885): Clarify failure_handler self-tests (**Enhancement** - P5)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [26a7be5c](https://git.openjdk.org/jdk/pull/19393/files/26a7be5cabe722ea051bddfcf6ffafe6af679af4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19393/head:pull/19393` \
`$ git checkout pull/19393`

Update a local copy of the PR: \
`$ git checkout pull/19393` \
`$ git pull https://git.openjdk.org/jdk.git pull/19393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19393`

View PR using the GUI difftool: \
`$ git pr show -t 19393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19393.diff">https://git.openjdk.org/jdk/pull/19393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19393#issuecomment-2129400781)