### PR TITLE
8332894: ubsan: vmError.cpp:2090:26: runtime error: division by zero

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -2082,7 +2082,8 @@ bool VMError::check_timeout() {
 #ifdef ASSERT
 typedef void (*voidfun_t)();
 
-// Crash with an authentic sigfpe
+// Crash with an authentic sigfpe; behavior is subtly different from a real signal
+// compared to one generated with raise (asynchronous vs synchronous). See JDK-8065895.
 volatile int sigfpe_int = 0;
 
 #if defined(__clang__) || defined(__GNUC__)

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -2084,6 +2084,10 @@ typedef void (*voidfun_t)();
 
 // Crash with an authentic sigfpe
 volatile int sigfpe_int = 0;
+
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 static void ALWAYSINLINE crash_with_sigfpe() {
 
   // generate a native synchronous SIGFPE where possible;


### PR DESCRIPTION
When running with ubsan enabled on Linux x86_64, I get in the HS :tier1 tests this error :

runtime/ErrorHandling/TestDwarf_dontCheckDecoder.jtr

/jdk/src/hotspot/share/utilities/vmError.cpp:2090:26: runtime error: division by zero
    #0 0x7f16bc531f32 in crash_with_sigfpe /jdk/src/hotspot/share/utilities/vmError.cpp:2090
    #1 0x7f16bc531f32 in VMError::controlled_crash(int) /jdk/src/hotspot/share/utilities/vmError.cpp:2137
    #2 0x7f16bea2d8fd in JNI_CreateJavaVM_inner /jdk/src/hotspot/share/prims/jni.cpp:3621
    #3 0x7f16bea2d8fd in JNI_CreateJavaVM /jdk/src/hotspot/share/prims/jni.cpp:3672
    #4 0x7f16c5dbd0e5 in InitializeJVM /jdk/src/java.base/share/native/libjli/java.c:1550
    #5 0x7f16c5dbd0e5 in JavaMain /jdk/src/java.base/share/native/libjli/java.c:491
    #6 0x7f16c5dc6748 in ThreadJavaMain /jdk/src/java.base/unix/native/libjli/java_md.c:642
    #7 0x7f16c5d756e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)
    #8 0x7f16c531550e in clone (/lib64/libc.so.6+0x11850e) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)

Reason is that we do a float division by zero to get a signal . This is desired by us so not really an error but ubsan cannot know this.
So add an attribute to this function that it has undefined behavior.
See https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html   (division by zero) . "Floating point division by zero. This is undefined per the C and C++ standards"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332894: ubsan: vmError.cpp:2090:26: runtime error: division by zero`

### Issue
 * [JDK-8332894](https://bugs.openjdk.org/browse/JDK-8332894): ubsan: vmError.cpp:2090:26: runtime error: division by zero (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [c747e0c3](https://git.openjdk.org/jdk/pull/19394/files/c747e0c32bcced9d6ce9e1a9417ae87c72f57d86)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19394/head:pull/19394` \
`$ git checkout pull/19394`

Update a local copy of the PR: \
`$ git checkout pull/19394` \
`$ git pull https://git.openjdk.org/jdk.git pull/19394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19394`

View PR using the GUI difftool: \
`$ git pr show -t 19394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19394.diff">https://git.openjdk.org/jdk/pull/19394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19394#issuecomment-2129551424)