### PR TITLE
8332898 failure_handler: log directory of commands

### DIFF
--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/action/ActionHelper.java
@@ -164,7 +164,7 @@ public class ActionHelper {
         Stopwatch stopwatch = new Stopwatch();
         stopwatch.start();
 
-        log.printf("%s%n[%tF %<tT] %s timeout=%s%n%1$s%n", line, new Date(), pb.command(), params.timeout);
+        log.printf("%s%n[%tF %<tT] %s timeout=%s in %s%n%1$s%n", line, new Date(), pb.command(), params.timeout, pb.directory());
 
         Process process;
         KillerTask killer;


### PR DESCRIPTION
Also log the directory in which the command used by failure_handler was executed. While often the same, it isn't always, and so it this should simplify troubleshooting for someone looking at this at a glance without being a failure_handler expert.

Example output after this change:
```
----------------------------------------
[2024-05-24 14:26:46] [/usr/bin/pmap, -p, 2233017] timeout=20000 in /<my-absolute-project-dir>/JTwork/scratch
----------------------------------------
```
before:
```
----------------------------------------
[2024-05-24 14:26:46] [/usr/bin/pmap, -p, 2233017] timeout=20000
----------------------------------------
```