### PR TITLE
8332890: Module imports don't work inside the same module

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Modules.java
@@ -1598,6 +1598,9 @@ public class Modules extends JCTree.Visitor {
                 addVisiblePackages(msym, seen, exportsFrom, exports);
             }
         });
+
+        //module readability is reflexive:
+        msym.readModules.add(msym);
     }
 
     private void addVisiblePackages(ModuleSymbol msym,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TypeEnter.java
@@ -498,7 +498,7 @@ public class TypeEnter implements Completer {
                     }
 
                     for (ExportsDirective export : currentModule.exports) {
-                        if (export.modules != null && !export.modules.contains(env.toplevel.packge.modle)) {
+                        if (export.modules != null && !export.modules.contains(env.toplevel.modle)) {
                             continue;
                         }
 


### PR DESCRIPTION
Consider a module descriptor like:
```
import module m;
module m {
    exports api;
}
```

javac will complain `m` does not read `m`:
```
$ javac --enable-preview --source 23 module-info.java api/Api.java 
module-info.java:1: error: module m does not read: m
import module m;
^
Note: module-info.java uses preview features of Java SE 23.
Note: Recompile with -Xlint:preview for details.
1 error
```

But, readability is reflexive. The proposed solution is to simply include every module in its own readability set.

As a side fix, `env.toplevel.packge.modle` does not work for `module-info`, `env.toplevel.modle` should be used instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332890](https://bugs.openjdk.org/browse/JDK-8332890): Module imports don't work inside the same module (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19398/head:pull/19398` \
`$ git checkout pull/19398`

Update a local copy of the PR: \
`$ git checkout pull/19398` \
`$ git pull https://git.openjdk.org/jdk.git pull/19398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19398`

View PR using the GUI difftool: \
`$ git pr show -t 19398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19398.diff">https://git.openjdk.org/jdk/pull/19398.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19398#issuecomment-2129906098)