### PR TITLE
8332917: failure_handler should execute gdb "info threads" command on linux

### DIFF
--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -49,7 +49,7 @@ native.locks.app=lslocks
 native.locks.args=-u --pid %p
 
 native.stack.app=gdb
-native.stack.args=--pid=%p\0-batch\0-ex\0thread apply all backtrace
+native.stack.args=--pid=%p\0-batch\0-ex\0info thread\0-ex\0thread apply all backtrace
 native.stack.args.delimiter=\0
 native.stack.params.repeat=6
 
@@ -63,7 +63,7 @@ native.core.timeout=600000
 cores=native.gdb
 native.gdb.app=gdb
 # Assume that java standard laucher has been used
-native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0thread apply all backtrace
+native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0info thread\0-ex\0thread apply all backtrace
 native.gdb.args.delimiter=\0
 
 ################################################################################

--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -49,7 +49,7 @@ native.locks.app=lslocks
 native.locks.args=-u --pid %p
 
 native.stack.app=gdb
-native.stack.args=--pid=%p\0-batch\0-ex\0info thread\0-ex\0thread apply all backtrace
+native.stack.args=--pid=%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
 native.stack.args.delimiter=\0
 native.stack.params.repeat=6
 
@@ -63,7 +63,7 @@ native.core.timeout=600000
 cores=native.gdb
 native.gdb.app=gdb
 # Assume that java standard laucher has been used
-native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0info thread\0-ex\0thread apply all backtrace
+native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
 native.gdb.args.delimiter=\0
 
 ################################################################################


### PR DESCRIPTION
On linux, failure_handler dumps stack traces for all threads, but this dump does not include the name of each thread. The gdb "info threads" command will give a summary of all threads, and if debugging process, the summary will include each thread's name. If debugging a core file, for some reason the thread name is not included, but the summary is still useful.

Tested by running some tests that fail with a timeout, and looking at the failure_handler gdb output for both the process and the core file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332917: failure_handler should execute gdb "info threads" command on linux`

### Issue
 * [JDK-8332917](https://bugs.openjdk.org/browse/JDK-8332917): failure_handler should execute gdb "info threads" command on linux (**Enhancement** - P5)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19401/head:pull/19401` \
`$ git checkout pull/19401`

Update a local copy of the PR: \
`$ git checkout pull/19401` \
`$ git pull https://git.openjdk.org/jdk.git pull/19401/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19401`

View PR using the GUI difftool: \
`$ git pr show -t 19401`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19401.diff">https://git.openjdk.org/jdk/pull/19401.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19401#issuecomment-2130259544)