### PR TITLE
8332919: SA PointerLocation needs to print a newline after dumping java thread info for JNI Local Ref

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/PointerLocation.java
@@ -359,7 +359,8 @@ public class PointerLocation {
       tty.print(" JNI handle block (" + handleBlock.top() + " handle slots present)");
       if (handleThread.isJavaThread()) {
         tty.print(" for JavaThread ");
-        ((JavaThread) handleThread).printThreadIDOn(tty); // includes "\n"
+        ((JavaThread) handleThread).printThreadIDOn(tty);
+        tty.println();
       } else {
         tty.println(" for a non-Java Thread");
       }


### PR DESCRIPTION
If PointerLocation discovers that an address is for a JNI local ref, it will print information about the thread that owns the JNI local ref. For JavaThreads it calls the printThreadIDOn(tty) method. There's a comment on the call that says that it 'includes "\n"'. This is actually not true, and a separate println() is needed. I noticed this when using the clhsdb findpc command on a JNI local ref and noted that the next "hdsb> " prompt was printed at the end of the findpc output instead of on a new line.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332919](https://bugs.openjdk.org/browse/JDK-8332919): SA PointerLocation needs to print a newline after dumping java thread info for JNI Local Ref (**Bug** - P5)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19402/head:pull/19402` \
`$ git checkout pull/19402`

Update a local copy of the PR: \
`$ git checkout pull/19402` \
`$ git pull https://git.openjdk.org/jdk.git pull/19402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19402`

View PR using the GUI difftool: \
`$ git pr show -t 19402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19402.diff">https://git.openjdk.org/jdk/pull/19402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19402#issuecomment-2130289046)