### PR TITLE
8332922: Test java/io/IO/IO.java fails when /usr/bin/expect not exist

### DIFF
--- a/test/jdk/java/io/IO/IO.java
+++ b/test/jdk/java/io/IO/IO.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
 
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
-import jtreg.SkippedException;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @bug 8305457
  * @summary java.io.IO tests
  * @library /test/lib
- * @run junit/othervm IO
+ * @run junit IO
  */
 public class IO {
 
@@ -61,8 +61,7 @@ public class IO {
         public static void prepareTTY() {
             expect = Paths.get("/usr/bin/expect"); // os-specific path
             if (!Files.exists(expect) || !Files.isExecutable(expect)) {
-                System.out.println("jtreg.SkippedException: '" + expect + "' not found");
-                System.exit(JCK_STATUS_BASE);
+                Assumptions.abort("'" + expect + "' not found");
             }
         }
 

--- a/test/jdk/java/io/IO/IO.java
+++ b/test/jdk/java/io/IO/IO.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @bug 8305457
  * @summary java.io.IO tests
  * @library /test/lib
- * @run junit IO
+ * @run junit/othervm IO
  */
 public class IO {
 
@@ -55,12 +55,14 @@ public class IO {
     public class OSSpecificTests {
 
         private static Path expect;
+        static final int JCK_STATUS_BASE = 95;
 
         @BeforeAll
         public static void prepareTTY() {
             expect = Paths.get("/usr/bin/expect"); // os-specific path
             if (!Files.exists(expect) || !Files.isExecutable(expect)) {
-                throw new SkippedException("'" + expect + "' not found");
+                System.out.println("jtreg.SkippedException: '" + expect + "' not found");
+                System.exit(JCK_STATUS_BASE);
             }
         }
 

--- a/test/jdk/java/io/IO/IO.java
+++ b/test/jdk/java/io/IO/IO.java
@@ -55,7 +55,6 @@ public class IO {
     public class OSSpecificTests {
 
         private static Path expect;
-        static final int JCK_STATUS_BASE = 95;
 
         @BeforeAll
         public static void prepareTTY() {


### PR DESCRIPTION
Hi all,
  When there is no `/usr/bin/expect` in system, `throw new SkippedException` will not make the jvm exit in `@BeforeAll` junit stage, thus this will cause this testcase run failed. So I make change from `throw new SkippedException` to `Assumptions.abort` to avoid this issue.
  Only change the testcase, no risk.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332922](https://bugs.openjdk.org/browse/JDK-8332922): Test java/io/IO/IO.java fails when /usr/bin/expect not exist (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19403/head:pull/19403` \
`$ git checkout pull/19403`

Update a local copy of the PR: \
`$ git checkout pull/19403` \
`$ git pull https://git.openjdk.org/jdk.git pull/19403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19403`

View PR using the GUI difftool: \
`$ git pr show -t 19403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19403.diff">https://git.openjdk.org/jdk/pull/19403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19403#issuecomment-2132042809)