### PR TITLE
8332623: Remove setTTL()/getTTL() methods from DatagramSocketImpl/MulticastSocket and MulticastSocket.send(DatagramPacket, byte)

### DIFF
--- a/src/java.base/share/classes/java/net/DatagramSocketImpl.java
+++ b/src/java.base/share/classes/java/net/DatagramSocketImpl.java
@@ -164,30 +164,6 @@ public abstract class DatagramSocketImpl implements SocketOptions {
 
     /**
      * Set the TTL (time-to-live) option.
-     * @param ttl a byte specifying the TTL value
-     *
-     * @deprecated use setTimeToLive instead.
-     * @throws    IOException if an I/O exception occurs while setting
-     * the time-to-live option.
-     * @see #getTTL()
-     */
-    @Deprecated(forRemoval = true, since = "1.2")
-    protected abstract void setTTL(byte ttl) throws IOException;
-
-    /**
-     * Retrieve the TTL (time-to-live) option.
-     *
-     * @throws    IOException if an I/O exception occurs
-     * while retrieving the time-to-live option
-     * @deprecated use getTimeToLive instead.
-     * @return a byte representing the TTL value
-     * @see #setTTL(byte)
-     */
-    @Deprecated(forRemoval = true, since = "1.2")
-    protected abstract byte getTTL() throws IOException;
-
-    /**
-     * Set the TTL (time-to-live) option.
      * @param ttl an {@code int} specifying the time-to-live value
      * @throws    IOException if an I/O exception occurs
      * while setting the time-to-live option.

--- a/src/java.base/share/classes/java/net/MulticastSocket.java
+++ b/src/java.base/share/classes/java/net/MulticastSocket.java
@@ -216,26 +216,6 @@ public class MulticastSocket extends DatagramSocket {
      * on this {@code MulticastSocket} in order to control the
      * scope of the multicasts.
      *
-     * <p>The ttl is an <b>unsigned</b> 8-bit quantity, and so <B>must</B> be
-     * in the range {@code 0 <= ttl <= 0xFF }.
-     *
-     * @param      ttl the time-to-live
-     * @throws     IOException if an I/O exception occurs
-     *             while setting the default time-to-live value
-     * @deprecated use the {@link #setTimeToLive(int)} method instead, which uses
-     *             <b>int</b> instead of <b>byte</b> as the type for ttl.
-     * @see #getTTL()
-     */
-    @Deprecated(forRemoval = true, since = "1.2")
-    public void setTTL(byte ttl) throws IOException {
-        delegate().setTTL(ttl);
-    }
-
-    /**
-     * Set the default time-to-live for multicast packets sent out
-     * on this {@code MulticastSocket} in order to control the
-     * scope of the multicasts.
-     *
      * <P> The ttl <B>must</B> be in the range {@code  0 <= ttl <=
      * 255} or an {@code IllegalArgumentException} will be thrown.
      * Multicast packets sent with a TTL of {@code 0} are not transmitted
@@ -258,22 +238,6 @@ public class MulticastSocket extends DatagramSocket {
      */
     public void setTimeToLive(int ttl) throws IOException {
         delegate().setTimeToLive(ttl);
-    }
-
-    /**
-     * Get the default time-to-live for multicast packets sent out on
-     * the socket.
-     *
-     * @throws    IOException if an I/O exception occurs
-     * while getting the default time-to-live value
-     * @return the default time-to-live value
-     * @deprecated use the {@link #getTimeToLive()} method instead,
-     * which returns an <b>int</b> instead of a <b>byte</b>.
-     * @see #setTTL(byte)
-     */
-    @Deprecated(forRemoval = true, since = "1.2")
-    public byte getTTL() throws IOException {
-        return delegate().getTTL();
     }
 
     /**
@@ -504,66 +468,5 @@ public class MulticastSocket extends DatagramSocket {
     @Deprecated(since="14")
     public boolean getLoopbackMode() throws SocketException {
         return delegate().getLoopbackMode();
-    }
-
-    /**
-     * Sends a datagram packet to the destination, with a TTL (time-to-live)
-     * other than the default for the socket.  This method
-     * need only be used in instances where a particular TTL is desired;
-     * otherwise it is preferable to set a TTL once on the socket, and
-     * use that default TTL for all packets.  This method does <B>not
-     * </B> alter the default TTL for the socket. Its behavior may be
-     * affected by {@code setInterface}.
-     *
-     * <p>If there is a security manager, this method first performs some
-     * security checks. First, if {@code p.getAddress().isMulticastAddress()}
-     * is true, this method calls the
-     * security manager's {@code checkMulticast} method
-     * with {@code p.getAddress()} and {@code ttl} as its arguments.
-     * If the evaluation of that expression is false,
-     * this method instead calls the security manager's
-     * {@code checkConnect} method with arguments
-     * {@code p.getAddress().getHostAddress()} and
-     * {@code p.getPort()}. Each call to a security manager method
-     * could result in a SecurityException if the operation is not allowed.
-     *
-     * @param p is the packet to be sent. The packet should contain
-     * the destination multicast ip address and the data to be sent.
-     * One does not need to be the member of the group to send
-     * packets to a destination multicast address.
-     * @param ttl optional time to live for multicast packet.
-     * default ttl is 1.
-     *
-     * @throws     IOException is raised if an error occurs i.e
-     *             error while setting ttl.
-     * @throws     SecurityException  if a security manager exists and its
-     *             {@code checkMulticast} or {@code checkConnect}
-     *             method doesn't allow the send.
-     * @throws     PortUnreachableException may be thrown if the socket is connected
-     *             to a currently unreachable destination. Note, there is no
-     *             guarantee that the exception will be thrown.
-     * @throws     IllegalArgumentException if the socket is connected,
-     *             and connected address and packet address differ, or
-     *             if the socket is not connected and the packet address
-     *             is not set or if its port is out of range.
-     *
-     *
-     * @deprecated Use the following code or its equivalent instead:
-     *  <pre>{@code   ......
-     *  int ttl = mcastSocket.getOption(StandardSocketOptions.IP_MULTICAST_TTL);
-     *  mcastSocket.setOption(StandardSocketOptions.IP_MULTICAST_TTL, newttl);
-     *  mcastSocket.send(p);
-     *  mcastSocket.setOption(StandardSocketOptions.IP_MULTICAST_TTL, ttl);
-     *  ......}</pre>
-     *
-     * @see DatagramSocket#send
-     * @see DatagramSocket#receive
-     * @see SecurityManager#checkMulticast(java.net.InetAddress, byte)
-     * @see SecurityManager#checkConnect
-     */
-    @Deprecated(forRemoval = true, since = "1.4")
-    public void send(DatagramPacket p, byte ttl)
-        throws IOException {
-        delegate().send(p, ttl);
     }
 }

--- a/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramSocketAdaptor.java
@@ -401,12 +401,6 @@ public class DatagramSocketAdaptor
     private InetAddress outgoingInetAddress;
 
     @Override
-    @SuppressWarnings("removal")
-    public void setTTL(byte ttl) throws IOException {
-        setTimeToLive(Byte.toUnsignedInt(ttl));
-    }
-
-    @Override
     public void setTimeToLive(int ttl) throws IOException {
         sendLock.lock();
         try {
@@ -414,12 +408,6 @@ public class DatagramSocketAdaptor
         } finally {
             sendLock.unlock();
         }
-    }
-
-    @Override
-    @SuppressWarnings("removal")
-    public byte getTTL() throws IOException {
-        return (byte) getTimeToLive();
     }
 
     @Override
@@ -589,23 +577,6 @@ public class DatagramSocketAdaptor
     public boolean getLoopbackMode() throws SocketException {
         boolean enabled = getBooleanOption(StandardSocketOptions.IP_MULTICAST_LOOP);
         return !enabled;
-    }
-
-    @Override
-    @SuppressWarnings("removal")
-    public void send(DatagramPacket p, byte ttl) throws IOException {
-        sendLock.lock();
-        try {
-            int oldValue = getTimeToLive();
-            try {
-                setTTL(ttl);
-                send(p);
-            } finally {
-                setTimeToLive(oldValue);
-            }
-        } finally {
-            sendLock.unlock();
-        }
     }
 
     /**


### PR DESCRIPTION
Remove setTTL()/getTTL() methods from DatagramSocketImpl/MulticastSocket and MulticastSocket.send(DatagramPacket, byte)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 24 to be approved (needs to be created)

### Issue
 * [JDK-8332623](https://bugs.openjdk.org/browse/JDK-8332623): Remove setTTL()/getTTL() methods from DatagramSocketImpl/MulticastSocket and MulticastSocket.send(DatagramPacket, byte) (**Bug** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 24, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19404/head:pull/19404` \
`$ git checkout pull/19404`

Update a local copy of the PR: \
`$ git checkout pull/19404` \
`$ git pull https://git.openjdk.org/jdk.git pull/19404/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19404`

View PR using the GUI difftool: \
`$ git pr show -t 19404`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19404.diff">https://git.openjdk.org/jdk/pull/19404.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19404#issuecomment-2132136158)