### PR TITLE
8332923: ObjectMonitorUsage.java failed with unexpected waiter_count

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1503,7 +1503,6 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
   ResourceMark rm(current_thread);
   GrowableArray<JavaThread*>* wantList = nullptr;
 
-  jint nWant_Skip = 0;
   if (mark.has_monitor()) {
     mon = mark.monitor();
     assert(mon != nullptr, "must have monitor");
@@ -1515,13 +1514,6 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
     // Get the actual set of threads trying to enter, or re-enter, the monitor.
     wantList = Threads::get_pending_threads(tlh.list(), nWant + nWait, (address)mon);
     nWant = wantList->length();
-    for(jint i = 0; i < nWant; i++) {
-      JavaThread* w = wantList->at(i);
-      oop thread_oop = get_vthread_or_thread_oop(w);
-      if (thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
-        nWant_Skip++;
-      }
-    }
   } else {
     // this object has a lightweight monitor
   }
@@ -1544,7 +1536,7 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
       nWait++;
     }
   }
-  ret.waiter_count = nWant - nWant_Skip;
+  ret.waiter_count = nWant;
   ret.notify_waiter_count = nWait - skipped;
 
   // Allocate memory for heavyweight and lightweight monitor.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1196,7 +1196,7 @@ GrowableArray<JavaThread*>* Threads::get_pending_threads(ThreadsList * t_list,
     if (!p->can_call_java()) continue;
 
     oop thread_oop = JvmtiEnvBase::get_vthread_or_thread_oop(p);
-    if (java_lang_VirtualThread::is_instance(thread_oop)) {
+    if (thread_oop->is_a(vmClasses::BaseVirtualThread_klass())) {
       continue;
     }
     // The first stage of async deflation does not affect any field

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
@@ -40,6 +40,7 @@
  *         waiting to re-enter, from N to 0 threads waiting to be notified
  *       - all the above scenarios are executed with platform and virtual threads
  * @requires vm.jvmti
+ * @requires vm.continuations
  * @run main/othervm/native
  *     -Djdk.virtualThreadScheduler.parallelism=10
  *     -agentlib:ObjectMonitorUsage ObjectMonitorUsage

--- a/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/ObjectMonitorUsage/ObjectMonitorUsage.java
@@ -40,7 +40,6 @@
  *         waiting to re-enter, from N to 0 threads waiting to be notified
  *       - all the above scenarios are executed with platform and virtual threads
  * @requires vm.jvmti
- * @requires vm.continuations
  * @run main/othervm/native
  *     -Djdk.virtualThreadScheduler.parallelism=10
  *     -agentlib:ObjectMonitorUsage ObjectMonitorUsage


### PR DESCRIPTION
Hi all,
  ObjectMonitorUsage.java failed with `unexpected waiter_count` after [JDK-8328083](https://bugs.openjdk.org/browse/JDK-8328083) on linux x86_32.
  There are two changes in this PR:
1. In `JvmtiEnvBase::get_object_monitor_usage` function, change from `java_lang_VirtualThread::is_instance(thread_oop)` to `thread_oop->is_a(vmClasses::BaseVirtualThread_klass())`to support the alternative implementation.
2. In `Threads::get_pending_threads(ThreadsList *, int, address)` function of threads.cpp file, change from `java_lang_VirtualThread::is_instance(thread_oop)` to `thread_oop->is_a(vmClasses::BaseVirtualThread_klass())`to support the alternative implementation. This modified function only used by `JvmtiEnvBase::get_object_monitor_usage(JavaThread*, jobject, jvmtiMonitorUsage*)`, so the risk of the modified on threads.cpp file is low.

  

Additional testing:
- [x] linux x86_32 run all testcases in serviceability/jvmti, all testcases run successed expect `serviceability/jvmti/vthread/GetThreadState/GetThreadStateTest.java#default` run failed. This test also run failed before this PR, which has been recorded in [JDK-8333140](https://bugs.openjdk.org/browse/JDK-8333140)
- [x] linux x86_64 run all testcases in serviceability/jvmti, all testcases run successed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332923](https://bugs.openjdk.org/browse/JDK-8332923): ObjectMonitorUsage.java failed with unexpected waiter_count (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)


### Contributors
 * Jiawei Tang `<jwtang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19405/head:pull/19405` \
`$ git checkout pull/19405`

Update a local copy of the PR: \
`$ git checkout pull/19405` \
`$ git pull https://git.openjdk.org/jdk.git pull/19405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19405`

View PR using the GUI difftool: \
`$ git pr show -t 19405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19405.diff">https://git.openjdk.org/jdk/pull/19405.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19405#issuecomment-2132152882)