### PR TITLE
8329958: Windows x86 build fails: downcallLinker.cpp(36) redefinition

### DIFF
--- a/src/hotspot/share/prims/downcallLinker.hpp
+++ b/src/hotspot/share/prims/downcallLinker.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,8 @@ public:
                                          int captured_state_mask,
                                          bool needs_transition);
 
-  static void capture_state(int32_t* value_ptr, int captured_state_mask);
+  // This is defined as JVM_LEAF which adds the JNICALL modifier.
+  static void JNICALL capture_state(int32_t* value_ptr, int captured_state_mask);
 
   class StubGenerator : public StubCodeGenerator {
     BasicType* _signature;


### PR DESCRIPTION
Trivial fix to add JNICALL to the function declaration.

This will be backported to JDK 22.

Testing:
 - tier1 sanity builds

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329958](https://bugs.openjdk.org/browse/JDK-8329958): Windows x86 build fails: downcallLinker.cpp(36) redefinition (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19406/head:pull/19406` \
`$ git checkout pull/19406`

Update a local copy of the PR: \
`$ git checkout pull/19406` \
`$ git pull https://git.openjdk.org/jdk.git pull/19406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19406`

View PR using the GUI difftool: \
`$ git pr show -t 19406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19406.diff">https://git.openjdk.org/jdk/pull/19406.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19406#issuecomment-2132527471)