### PR TITLE
8332961: Parallel: Limit PSParallelCompact::verify_complete range

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2130,14 +2130,14 @@ void PSParallelCompact::verify_filler_in_dense_prefix() {
 }
 
 void PSParallelCompact::verify_complete(SpaceId space_id) {
-  // All Regions between space bottom() to new_top() should be marked as filled
-  // and all Regions between new_top() and top() should be available (i.e.,
-  // should have been emptied).
+  // All Regions served as compaction targets, from dense_prefix() to
+  // new_top(), should be marked as filled and all Regions between new_top()
+  // and top() should be available (i.e., should have been emptied).
   ParallelCompactData& sd = summary_data();
   SpaceInfo si = _space_info[space_id];
   HeapWord* new_top_addr = sd.region_align_up(si.new_top());
   HeapWord* old_top_addr = sd.region_align_up(si.space()->top());
-  const size_t beg_region = sd.addr_to_region_idx(si.space()->bottom());
+  const size_t beg_region = sd.addr_to_region_idx(si.dense_prefix());
   const size_t new_top_region = sd.addr_to_region_idx(new_top_addr);
   const size_t old_top_region = sd.addr_to_region_idx(old_top_addr);
 


### PR DESCRIPTION
Trivial adjusting the verification range to skip regions in dense-prefix.

Test: checked the gc-log to see warnings are gone.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332961](https://bugs.openjdk.org/browse/JDK-8332961): Parallel: Limit PSParallelCompact::verify_complete range (**Bug** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19409/head:pull/19409` \
`$ git checkout pull/19409`

Update a local copy of the PR: \
`$ git checkout pull/19409` \
`$ git pull https://git.openjdk.org/jdk.git pull/19409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19409`

View PR using the GUI difftool: \
`$ git pr show -t 19409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19409.diff">https://git.openjdk.org/jdk/pull/19409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19409#issuecomment-2132941918)