### PR TITLE
JDK-8332960: ubsan: classListParser.hpp:159:12: runtime error: load of value 2101478704, which is not a valid value for type 'ParseMode'

### DIFF
--- a/src/hotspot/share/cds/classListParser.cpp
+++ b/src/hotspot/share/cds/classListParser.cpp
@@ -59,7 +59,8 @@ ClassListParser::ClassListParser(const char* file, ParseMode parse_mode) :
     _classlist_file(file),
     _id2klass_table(INITIAL_TABLE_SIZE, MAX_TABLE_SIZE),
     _file_input(do_open(file), /* need_close=*/true),
-    _input_stream(&_file_input) {
+    _input_stream(&_file_input),
+    _parse_mode(parse_mode) {
   log_info(cds)("Parsing %s%s", file,
                 parse_lambda_forms_invokers_only() ? " (lambda form invokers only)" : "");
   if (!_file_input.is_open()) {
@@ -70,7 +71,6 @@ ClassListParser::ClassListParser(const char* file, ParseMode parse_mode) :
   _token = _line = nullptr;
   _interfaces = new (mtClass) GrowableArray<int>(10, mtClass);
   _indy_items = new (mtClass) GrowableArray<const char*>(9, mtClass);
-  _parse_mode = parse_mode;
 
   // _instance should only be accessed by the thread that created _instance.
   assert(_instance == nullptr, "must be singleton");


### PR DESCRIPTION
When running with ubsan enabled binaries, the following error occurs in some jtreg tests :

/jdk/src/hotspot/share/cds/classListParser.hpp:159:12: runtime error: load of value 2101478704, which is not a valid value for type 'ParseMode'
    #0 0x7fff7920f3dc in ClassListParser::ClassListParser(char const*, ClassListParser::ParseMode) (/images/jdk/lib/server/libjvm.so+0x534f3dc)
    #1 0x7fff7af824b8 in MetaspaceShared::preload_classes(JavaThread*) (/images/jdk/lib/server/libjvm.so+0x70c24b8)
    #2 0x7fff7af8ffa8 in MetaspaceShared::preload_and_dump_impl(JavaThread*) (/images/jdk/lib/server/libjvm.so+0x70cffa8)
    #3 0x7fff7af90978 in MetaspaceShared::preload_and_dump() (/images/jdk/lib/server/libjvm.so+0x70d0978)
    #4 0x7fff7bf4c7f4 in Threads::create_vm(JavaVMInitArgs*, bool*) (/images/jdk/lib/server/libjvm.so+0x808c7f4)
    #5 0x7fff7a5620b4 in JNI_CreateJavaVM (/images/jdk/lib/server/libjvm.so+0x66a20b4)
    #6 0x7fff81073068 in InitializeJVM /jdk/src/java.base/share/native/libjli/java.c:1550
    #7 0x7fff81073068 in JavaMain /jdk/src/java.base/share/native/libjli/java.c:491
    #8 0x7fff8107ef1c in ThreadJavaMain /jdk/src/java.base/unix/native/libjli/java_md.c:642
    #9 0x7fff80f99714 in start_thread (/lib64/libpthread.so.0+0x9714)
    #10 0x7fff8034b774 in __GI___clone (/lib64/libc.so.6+0x13b774)

Seems _parse_mode is initialized too late.