### PR TITLE
8332955: ubsan: runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList'

### DIFF
--- a/src/hotspot/share/memory/metaspace/runningCounters.cpp
+++ b/src/hotspot/share/memory/metaspace/runningCounters.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,8 @@ size_t RunningCounters::reserved_words_class() {
 }
 
 size_t RunningCounters::reserved_words_nonclass() {
-  return VirtualSpaceList::vslist_nonclass()->reserved_words();
+  VirtualSpaceList* vs = VirtualSpaceList::vslist_nonclass();
+  return vs != nullptr ? vs->reserved_words() : 0;
 }
 
 // Return total committed size, in words, for Metaspace


### PR DESCRIPTION
When running jtreg HS :tier1 tests (with ubsan enabled binaries) this error can be seen on Linux ppc64.
Probably we should add a NULL check because calling into a nullptr is probably not a good idea (although no crash is observed).

runtime/os/TestHugePageDecisionsAtVMStartup_THP_enabled.jtr

/jdk/src/hotspot/share/memory/metaspace/runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList'
    #0 0x7fffabe667c8 in metaspace::RunningCounters::reserved_words_nonclass() (/images/jdk/lib/server/libjvm.so+0x78667c8)
    #1 0x7fffab6a25c0 in MetaspaceUtils::get_statistics(Metaspace::MetadataType) (/images/jdk/lib/server/libjvm.so+0x70a25c0)
    #2 0x7fffab6a2708 in MetaspaceUtils::get_combined_statistics() (/images/jdk/lib/server/libjvm.so+0x70a2708)
    #3 0x7fffab5ce630 in MemBaseline::baseline(bool) (/images/jdk/lib/server/libjvm.so+0x6fce630)
    #4 0x7fffab61bf10 in MemTracker::report(bool, outputStream*, unsigned long) (/images/jdk/lib/server/libjvm.so+0x701bf10)
    #5 0x7fffab61cb84 in MemTracker::error_report(outputStream*) (/images/jdk/lib/server/libjvm.so+0x701cb84)
    #6 0x7fffac93f1e8 in VMError::report(outputStream*, bool) (/images/jdk/lib/server/libjvm.so+0x833f1e8)
    #7 0x7fffac944630 in VMError::report_and_die(int, char const*, char const*, char*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long) (/images/jdk/lib/server/libjvm.so+0x8344630)
    #8 0x7fffa9d69ffc in report_fatal(VMErrorType, char const*, int, char const*, ...) (/images/jdk/lib/server/libjvm.so+0x5769ffc)
    #9 0x7fffaadff93c in TypedFlagAccessImpl<unsigned int, EventUnsignedIntFlagChanged>::check_constraint_and_set(JVMFlag*, void*, JVMFlagOrigin, bool) const [clone .part.0] (/images/jdk/lib/server/libjvm.so+0x67ff93c)
    #10 0x7fffaae12bb8 in RangedFlagAccessImpl<unsigned long, EventUnsignedLongFlagChanged>::set_impl(JVMFlag*, void*, JVMFlagOrigin) const (/images/jdk/lib/server/libjvm.so+0x6812bb8)
    #11 0x7fffaae04b8c in JVMFlagAccess::set_or_assert(JVMFlagsEnum, int, void*, JVMFlagOrigin) (/images/jdk/lib/server/libjvm.so+0x6804b8c)
    #12 0x7fffa9a79fa8 in CodeCache::initialize_heaps() (/images/jdk/lib/server/libjvm.so+0x5479fa8)
    #13 0x7fffa9a7ac10 in CodeCache::initialize() (/images/jdk/lib/server/libjvm.so+0x547ac10)
    #14 0x7fffaa81af08 in init_globals() (/images/jdk/lib/server/libjvm.so+0x621af08)
    #15 0x7fffac68baa8 in Threads::create_vm(JavaVMInitArgs*, bool*) (/images/jdk/lib/server/libjvm.so+0x808baa8)
    #16 0x7fffaaca20b4 in JNI_CreateJavaVM (/images/jdk/lib/server/libjvm.so+0x66a20b4)
    #17 0x7fffb17b3068 in InitializeJVM /jdk/src/java.base/share/native/libjli/java.c:1550
    #18 0x7fffb17b3068 in JavaMain /jdk/src/java.base/share/native/libjli/java.c:491
    #19 0x7fffb17bef1c in ThreadJavaMain /jdk/src/java.base/unix/native/libjli/java_md.c:642
    #20 0x7fffb16d9714 in start_thread (/lib64/libpthread.so.0+0x9714)
    #21 0x7fffb0a8b774 in __GI___clone (/lib64/libc.so.6+0x13b774)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8332955](https://bugs.openjdk.org/browse/JDK-8332955): ubsan: runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList' (**Bug** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19412/head:pull/19412` \
`$ git checkout pull/19412`

Update a local copy of the PR: \
`$ git checkout pull/19412` \
`$ git pull https://git.openjdk.org/jdk.git pull/19412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19412`

View PR using the GUI difftool: \
`$ git pr show -t 19412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19412.diff">https://git.openjdk.org/jdk/pull/19412.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19412#issuecomment-2133348568)