### PR TITLE
8332904: ubsan ppc64le: c1_LIRGenerator_ppc.cpp:581:21: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2012, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,9 @@ int Assembler::branch_destination(int inst, int pos) {
 
 // Low-level andi-one-instruction-macro.
 void Assembler::andi(Register a, Register s, const long ui16) {
-  if (is_power_of_2(((jlong) ui16)+1)) {
+  if (is_power_of_2(((unsigned long) ui16)+1)) {
     // pow2minus1
-    clrldi(a, s, 64 - log2i_exact((((jlong) ui16)+1)));
+    clrldi(a, s, 64 - log2i_exact((((unsigned long) ui16)+1)));
   } else if (is_power_of_2((jlong) ui16)) {
     // pow2
     rlwinm(a, s, 0, 31 - log2i_exact((jlong) ui16), 31 - log2i_exact((jlong) ui16));

--- a/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRGenerator_ppc.cpp
@@ -578,7 +578,7 @@ inline bool can_handle_logic_op_as_uimm(ValueType *type, Bytecodes::Code bc) {
        is_power_of_2(int_or_long_const) ||
        is_power_of_2(-int_or_long_const))) return true;
   if (bc == Bytecodes::_land &&
-      (is_power_of_2(int_or_long_const+1) ||
+      (is_power_of_2((unsigned long)int_or_long_const+1) ||
        (Assembler::is_uimm(int_or_long_const, 32) && is_power_of_2(int_or_long_const)) ||
        (int_or_long_const != min_jlong && is_power_of_2(-int_or_long_const)))) return true;
 


### PR DESCRIPTION
When using ubsan on Linux ppc64le we run into some overflows like this one

c1_LIRGenerator_ppc.cpp:581:21: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'

Seems we have to add casts to get defined behavior.
There are similar places in the coding as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332904: ubsan ppc64le: c1_LIRGenerator_ppc.cpp:581:21: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int'`

### Issue
 * [JDK-8332904](https://bugs.openjdk.org/browse/JDK-8332904): ubsan ppc64le: c1_LIRGenerator_ppc.cpp:581:21: runtime error: signed integer overflow: 9223372036854775807 + 1 cannot be represented in type 'long int' (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19413/head:pull/19413` \
`$ git checkout pull/19413`

Update a local copy of the PR: \
`$ git checkout pull/19413` \
`$ git pull https://git.openjdk.org/jdk.git pull/19413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19413`

View PR using the GUI difftool: \
`$ git pr show -t 19413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19413.diff">https://git.openjdk.org/jdk/pull/19413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19413#issuecomment-2133642368)