### PR TITLE
8332826: Make hashCode methods in ArraysSupport friendlier

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterName.java
+++ b/src/java.base/share/classes/java/lang/CharacterName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/CharacterName.java
+++ b/src/java.base/share/classes/java/lang/CharacterName.java
@@ -113,7 +113,7 @@ class CharacterName {
     }
 
     private static int hashN(byte[] a, int off, int len) {
-        return ArraysSupport.vectorizedHashCode(a, off, len, 1, ArraysSupport.T_BYTE);
+        return ArraysSupport.hashCode(a, off, len, 1);
     }
 
     private int addCp(int idx, int hash, int next, int cp) {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -303,11 +303,7 @@ final class StringLatin1 {
     }
 
     public static int hashCode(byte[] value) {
-        return switch (value.length) {
-            case 0 -> 0;
-            case 1 -> value[0] & 0xff;
-            default -> ArraysSupport.vectorizedHashCode(value, 0, value.length, 0, ArraysSupport.T_BOOLEAN);
-        };
+        return ArraysSupport.hashCodeOfUnsigned(value, 0, value.length, 0);
     }
 
     // Caller must ensure that from- and toIndex are within bounds

--- a/src/java.base/share/classes/java/lang/StringUTF16.java
+++ b/src/java.base/share/classes/java/lang/StringUTF16.java
@@ -585,11 +585,7 @@ final class StringUTF16 {
     }
 
     public static int hashCode(byte[] value) {
-        return switch (value.length) {
-            case 0 -> 0;
-            case 2 -> getChar(value, 0);
-            default -> ArraysSupport.vectorizedHashCode(value, 0, value.length >> 1, 0, ArraysSupport.T_CHAR);
-        };
+        return ArraysSupport.hashCodeOfUTF16(value, 0, value.length >> 1, 0);
     }
 
     // Caller must ensure that from- and toIndex are within bounds

--- a/src/java.base/share/classes/java/math/BigInteger.java
+++ b/src/java.base/share/classes/java/math/BigInteger.java
@@ -4097,8 +4097,7 @@ public class BigInteger extends Number implements Comparable<BigInteger> {
      */
     @Override
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(mag, 0, mag.length, 0,
-                ArraysSupport.T_INT) * signum;
+        return ArraysSupport.hashCode(mag, 0, mag.length, 0) * signum;
     }
 
     /**

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -707,7 +707,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, ix(position()), remaining(), 1, ArraysSupport.T_BYTE);
+        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
     }
 
 #end[byte]
@@ -738,7 +738,7 @@ class Heap$Type$Buffer$RW$
     }
 
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(hb, ix(position()), remaining(), 1, ArraysSupport.T_CHAR);
+        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
     }
 #end[char]
 

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -4358,11 +4358,7 @@ public final class Arrays {
         if (a == null) {
             return 0;
         }
-        return switch (a.length) {
-            case 0 -> 1;
-            case 1 -> 31 + a[0];
-            default -> ArraysSupport.vectorizedHashCode(a, 0, a.length, 1, ArraysSupport.T_INT);
-        };
+        return ArraysSupport.hashCode(a, 0, a.length, 1);
     }
 
     /**
@@ -4385,11 +4381,7 @@ public final class Arrays {
         if (a == null) {
             return 0;
         }
-        return switch (a.length) {
-            case 0 -> 1;
-            case 1 -> 31 + (int)a[0];
-            default -> ArraysSupport.vectorizedHashCode(a, 0, a.length, 1, ArraysSupport.T_SHORT);
-        };
+        return ArraysSupport.hashCode(a, 0, a.length, 1);
     }
 
     /**
@@ -4412,11 +4404,7 @@ public final class Arrays {
         if (a == null) {
             return 0;
         }
-        return switch (a.length) {
-            case 0 -> 1;
-            case 1 -> 31 + (int)a[0];
-            default -> ArraysSupport.vectorizedHashCode(a, 0, a.length, 1, ArraysSupport.T_CHAR);
-        };
+        return ArraysSupport.hashCode(a, 0, a.length, 1);
     }
 
     /**
@@ -4439,11 +4427,7 @@ public final class Arrays {
         if (a == null) {
             return 0;
         }
-        return switch (a.length) {
-            case 0 -> 1;
-            case 1 -> 31 + (int)a[0];
-            default -> ArraysSupport.vectorizedHashCode(a, 0, a.length, 1, ArraysSupport.T_BYTE);
-        };
+        return ArraysSupport.hashCode(a, 0, a.length, 1);
     }
 
     /**
@@ -4549,15 +4533,10 @@ public final class Arrays {
      * @since 1.5
      */
     public static int hashCode(Object[] a) {
-        if (a == null)
+        if (a == null) {
             return 0;
-
-        int result = 1;
-
-        for (Object element : a)
-            result = 31 * result + Objects.hashCode(element);
-
-        return result;
+        }
+        return ArraysSupport.hashCode(a, 0, a.length, 1);
     }
 
     /**

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -290,8 +290,7 @@ class ZipCoder {
                 // exceptions eagerly when opening ZipFiles
                 return hash(JLA.newStringUTF8NoRepl(a, off, len));
             }
-            // T_BOOLEAN to treat the array as unsigned bytes, in line with StringLatin1.hashCode
-            int h = ArraysSupport.vectorizedHashCode(a, off, len, 0, ArraysSupport.T_BOOLEAN);
+            int h = ArraysSupport.hashCodeOfUnsigned(a, off, len, 0);
             if (a[end - 1] != '/') {
                 h = 31 * h + '/';
             }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -230,7 +230,7 @@ public abstract sealed class AbstractPoolEntry {
          */
         private void inflate() {
             int singleBytes = JLA.countPositives(rawBytes, offset, rawLen);
-            int hash = ArraysSupport.vectorizedHashCode(rawBytes, offset, singleBytes, 0, ArraysSupport.T_BOOLEAN);
+            int hash = ArraysSupport.hashCodeOfUnsigned(rawBytes, offset, singleBytes, 0);
             if (singleBytes == rawLen) {
                 this.hash = hashString(hash);
                 charLen = rawLen;

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -205,7 +205,7 @@ public class ArraysSupport {
     public static int hashCode(short[] a, int fromIndex, int length, int initialValue) {
         return switch (length) {
             case 0 -> initialValue;
-            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            case 1 -> 31 * initialValue + a[fromIndex];
             default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_SHORT);
         };
     }
@@ -227,7 +227,7 @@ public class ArraysSupport {
     public static int hashCode(char[] a, int fromIndex, int length, int initialValue) {
         return switch (length) {
             case 0 -> initialValue;
-            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            case 1 -> 31 * initialValue + a[fromIndex];
             default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_CHAR);
         };
     }
@@ -249,7 +249,7 @@ public class ArraysSupport {
     public static int hashCode(byte[] a, int fromIndex, int length, int initialValue) {
         return switch (length) {
             case 0 -> initialValue;
-            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            case 1 -> 31 * initialValue + a[fromIndex];
             default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_BYTE);
         };
     }

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -272,7 +272,7 @@ public class ArraysSupport {
     public static int hashCodeOfUnsigned(byte[] a, int fromIndex, int length, int initialValue) {
         return switch (length) {
             case 0 -> initialValue;
-            case 1 -> 31 * initialValue + (a[fromIndex] & 0xff);
+            case 1 -> 31 * initialValue + Byte.toUnsignedInt(a[fromIndex]);
             default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_BOOLEAN);
         };
     }
@@ -376,7 +376,7 @@ public class ArraysSupport {
     private static int unsignedHashCode(int result, byte[] a, int fromIndex, int length) {
         int end = fromIndex + length;
         for (int i = fromIndex; i < end; i++) {
-            result = 31 * result + (a[i] & 0xff);
+            result = 31 * result + Byte.toUnsignedInt(a[i]);
         }
         return result;
     }

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -297,8 +297,8 @@ public class ArraysSupport {
      */
     public static int hashCodeOfUTF16(byte[] a, int fromIndex, int length, int initialValue) {
         return switch (length) {
-            case 0 -> 0;
-            case 2 -> JLA.getUTF16Char(a, 0);
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + JLA.getUTF16Char(a, fromIndex);
             default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_CHAR);
         };
     }

--- a/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/ArraysSupport.java
@@ -26,6 +26,8 @@ package jdk.internal.util;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
+
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
@@ -164,17 +166,177 @@ public class ArraysSupport {
         }
     }
 
+    /**
+     * Calculates the hash code for the subrange of an integer array.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCode(int[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + a[fromIndex];
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_INT);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of a short array.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCode(short[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_SHORT);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of a char array.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCode(char[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_CHAR);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of a byte array.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCode(byte[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + (int) a[fromIndex];
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_BYTE);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of a byte array whose elements
+     * are treated as unsigned bytes.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCodeOfUnsigned(byte[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> initialValue;
+            case 1 -> 31 * initialValue + (a[fromIndex] & 0xff);
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_BOOLEAN);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of a byte array whose contents
+     * are treated as UTF-16 chars.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * <p> {@code fromIndex} and {@code length} must be scaled down to char
+     * indexes.
+     *
+     * @param a the array
+     * @param fromIndex the first index of a char in the subrange of the array
+     * @param length the number of chars in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCodeOfUTF16(byte[] a, int fromIndex, int length, int initialValue) {
+        return switch (length) {
+            case 0 -> 0;
+            case 2 -> JLA.getUTF16Char(a, 0);
+            default -> vectorizedHashCode(a, fromIndex, length, initialValue, T_CHAR);
+        };
+    }
+
+    /**
+     * Calculates the hash code for the subrange of an object array.
+     *
+     * <p> This method does not perform type checks or bounds checks. It is the
+     * responsibility of the caller to perform such checks before calling this
+     * method.
+     *
+     * @param a the array
+     * @param fromIndex the first index of the subrange of the array
+     * @param length the number of elements in the subrange
+     * @param initialValue the initial hash value, typically 0 or 1
+     *
+     * @return the calculated hash value
+     */
+    public static int hashCode(Object[] a, int fromIndex, int length, int initialValue) {
+        int result = initialValue;
+        int end = fromIndex + length;
+        for (int i = fromIndex; i < end; i++) {
+            result = 31 * result + Objects.hashCode(a[i]);
+        }
+        return result;
+    }
+
     // Possible values for the type operand of the NEWARRAY instruction.
     // See https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-6.html#jvms-6.5.newarray.
 
-    public static final int T_BOOLEAN = 4;
-    public static final int T_CHAR = 5;
-    public static final int T_FLOAT = 6;
-    public static final int T_DOUBLE = 7;
-    public static final int T_BYTE = 8;
-    public static final int T_SHORT = 9;
-    public static final int T_INT = 10;
-    public static final int T_LONG = 11;
+    private static final int T_BOOLEAN = 4;
+    private static final int T_CHAR = 5;
+    private static final int T_FLOAT = 6;
+    private static final int T_DOUBLE = 7;
+    private static final int T_BYTE = 8;
+    private static final int T_SHORT = 9;
+    private static final int T_INT = 10;
+    private static final int T_LONG = 11;
 
     /**
      * Calculate the hash code for an array in a way that enables efficient
@@ -197,8 +359,8 @@ public class ArraysSupport {
      * @return the calculated hash value
      */
     @IntrinsicCandidate
-    public static int vectorizedHashCode(Object array, int fromIndex, int length, int initialValue,
-                                         int basicType) {
+    private static int vectorizedHashCode(Object array, int fromIndex, int length, int initialValue,
+                                          int basicType) {
         return switch (basicType) {
             case T_BOOLEAN -> unsignedHashCode(initialValue, (byte[]) array, fromIndex, length);
             case T_CHAR -> array instanceof byte[]
@@ -255,7 +417,7 @@ public class ArraysSupport {
     /*
      * fromIndex and length must be scaled to char indexes.
      */
-    public static int utf16hashCode(int result, byte[] value, int fromIndex, int length) {
+    private static int utf16hashCode(int result, byte[] value, int fromIndex, int length) {
         int end = fromIndex + length;
         for (int i = fromIndex; i < end; i++) {
             result = 31 * result + JLA.getUTF16Char(value, i);

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/util/DerValue.java
+++ b/src/java.base/share/classes/sun/security/util/DerValue.java
@@ -1267,7 +1267,7 @@ public class DerValue {
      */
     @Override
     public int hashCode() {
-        return ArraysSupport.vectorizedHashCode(buffer, start, end - start, tag, ArraysSupport.T_BYTE);
+        return ArraysSupport.hashCode(buffer, start, end - start, tag);
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -803,8 +803,7 @@ class UnixPath implements Path {
         // OK if two or more threads compute hash
         int h = hash;
         if (h == 0) {
-            h = ArraysSupport.vectorizedHashCode(path, 0, path.length, 0,
-                    /* unsigned bytes */ ArraysSupport.T_BOOLEAN);
+            h = ArraysSupport.hashCodeOfUnsigned(path, 0, path.length, 0);
             hash = h;
         }
         return h;

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestArraysHashCode.java
@@ -25,43 +25,66 @@
  * @test
  * @bug 8301093
  * @summary Verify failure to intrinsify does not pollute control flow
- * @modules java.base/jdk.internal.util
+ * @modules java.base/jdk.internal.util:+open
  *
  * @run main/othervm -Xbatch -XX:-TieredCompilation compiler.intrinsics.TestArraysHashCode
  */
 
 package compiler.intrinsics;
 
-import jdk.internal.util.ArraysSupport;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public class TestArraysHashCode {
+
+    private static final Method vectorizedHashCode;
+    private static final int T_BOOLEAN;
+
+    static {
+        try {
+            var arraysSupport = Class.forName("jdk.internal.util.ArraysSupport");
+            vectorizedHashCode = arraysSupport.getDeclaredMethod("vectorizedHashCode",
+                    Object.class, int.class, int.class, int.class, int.class);
+            vectorizedHashCode.setAccessible(true);
+            Field f = arraysSupport.getDeclaredField("T_BOOLEAN");
+            f.setAccessible(true);
+            T_BOOLEAN = f.getInt(null);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     static int type;
     static byte[] bytes;
 
-    public static void main(String[] args) {
+    public static void main(String[] args)
+            throws InvocationTargetException, IllegalAccessException {
         // read
         bytes = new byte[256];
-        type = ArraysSupport.T_BOOLEAN;
+        type = T_BOOLEAN;
         testIntrinsicWithConstantType();
         testIntrinsicWithNonConstantType();
     }
 
-    private static void testIntrinsicWithConstantType() {
+    private static void testIntrinsicWithConstantType()
+            throws InvocationTargetException, IllegalAccessException {
         for (int i = 0; i < 20_000; i++) {
-            testIntrinsic(bytes, ArraysSupport.T_BOOLEAN);
+            testIntrinsic(bytes, T_BOOLEAN);
         }
     }
 
     // ok, but shouldn't be intrinsified due the non-constant type
-    private static void testIntrinsicWithNonConstantType() {
-        type = ArraysSupport.T_BOOLEAN;
+    private static void testIntrinsicWithNonConstantType()
+            throws InvocationTargetException, IllegalAccessException {
+        type = T_BOOLEAN;
         for (int i = 0; i < 20_000; i++) {
             testIntrinsic(bytes, type);
         }
     }
 
-    private static int testIntrinsic(byte[] bytes, int type) {
-        return ArraysSupport.vectorizedHashCode(bytes, 0, 256, 1, type);
+    private static int testIntrinsic(byte[] bytes, int type)
+            throws InvocationTargetException, IllegalAccessException {
+        return (int) vectorizedHashCode.invoke(null, bytes, 0, 256, 1, type);
     }
 }

--- a/test/jdk/java/util/Arrays/HashCode.java
+++ b/test/jdk/java/util/Arrays/HashCode.java
@@ -24,7 +24,8 @@
 /**
  * @test
  * @summary Basic array hashCode functionality
- * @run main/othervm --add-exports java.base/jdk.internal.util=ALL-UNNAMED -Xcomp -Xbatch HashCode
+ * @run main/othervm --add-exports java.base/jdk.internal.util=ALL-UNNAMED
+ *     --add-opens java.base/jdk.internal.util=ALL-UNNAMED -Xcomp -Xbatch HashCode
  */
 
 import java.lang.reflect.Method;


### PR DESCRIPTION
Please review this PR, which supersedes a now withdrawn https://github.com/openjdk/jdk/pull/14831.

This PR replaces `ArraysSupport.vectorizedHashCode` with a set of more user-friendly methods. Here's a summary:

- Made the operand constants (i.e. `T_BOOLEAN` and friends) and the `vectorizedHashCode` method private

- Made the `vectorizedHashCode` method private, but didn't rename it. Renaming would dramatically increase this PR review cost, because that method's name is used by a lot of VM code. On a bright side, since the method is now private, it's no longer callable by clients of `ArraysSupport`, thus a problem of an inaccurate name is less severe.

- Made the `ArraysSupport.utf16HashCode` method private

- Moved tiny cases (i.e. 0, 1, 2) to `ArraysSupport`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332826](https://bugs.openjdk.org/browse/JDK-8332826): Make hashCode methods in ArraysSupport friendlier (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [adc7557d](https://git.openjdk.org/jdk/pull/19414/files/adc7557ddaa25bfa7dee9f0388d22574a2dfa96f)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [adc7557d](https://git.openjdk.org/jdk/pull/19414/files/adc7557ddaa25bfa7dee9f0388d22574a2dfa96f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19414/head:pull/19414` \
`$ git checkout pull/19414`

Update a local copy of the PR: \
`$ git checkout pull/19414` \
`$ git pull https://git.openjdk.org/jdk.git pull/19414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19414`

View PR using the GUI difftool: \
`$ git pr show -t 19414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19414.diff">https://git.openjdk.org/jdk/pull/19414.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19414#issuecomment-2133808353)