### PR TITLE
8333006: RISC-V: C2: Support vector-scalar and vector-immediate arithmetic instructions

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2163,7 +2163,19 @@ static bool is_vector_scalar_bitwise_pattern(Node* n, Node* m) {
   switch (n->Opcode()) {
     case Op_AndV:
     case Op_OrV:
-    case Op_XorV: {
+    case Op_XorV:
+    case Op_AddVB:
+    case Op_AddVS:
+    case Op_AddVI:
+    case Op_AddVL:
+    case Op_SubVB:
+    case Op_SubVS:
+    case Op_SubVI:
+    case Op_SubVL:
+    case Op_MulVB:
+    case Op_MulVS:
+    case Op_MulVI:
+    case Op_MulVL: {
       return true;
     }
     default:

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -408,8 +408,7 @@ instruct vadd_immL(vReg dst, vReg src1, immL5 con) %{
   match(Set dst (AddVL src1 (Replicate con)));
   format %{ "vadd_immL $dst, $src1, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                $con$$constant);
@@ -438,8 +437,7 @@ instruct vadd_regL(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (AddVL src1 (Replicate src2)));
   format %{ "vadd_regL $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -468,8 +466,7 @@ instruct vadd_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
   format %{ "vadd_immL_masked $dst_src, $dst_src, $con" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vi(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                $con$$constant, Assembler::v0_t);
@@ -498,8 +495,7 @@ instruct vadd_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vadd_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -592,8 +588,7 @@ instruct vsub_regL(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (SubVL src1 (Replicate src2)));
   format %{ "vsub_regL $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -622,8 +617,7 @@ instruct vsub_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vsub_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);
@@ -1668,8 +1662,7 @@ instruct vmul_regL(vReg dst, vReg src1, iRegL src2) %{
   match(Set dst (MulVL src1 (Replicate src2)));
   format %{ "vmul_regL $dst, $src1, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg),
                as_Register($src2$$reg));
@@ -1698,8 +1691,7 @@ instruct vmul_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
   match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
   format %{ "vmul_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
-    BasicType bt = Matcher::vector_element_basic_type(this);
-    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsetvli_helper(T_LONG, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
                as_Register($src2$$reg), Assembler::v0_t);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -389,29 +389,29 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-immediate add (unpredicated)
 
-instruct vadd_immI(vReg dst_src, immI5 con) %{
-  match(Set dst_src (AddVB dst_src (Replicate con)));
-  match(Set dst_src (AddVS dst_src (Replicate con)));
-  match(Set dst_src (AddVI dst_src (Replicate con)));
-  format %{ "vadd_immI $dst_src, $dst_src, $con" %}
+instruct vadd_immI(vReg dst, vReg src1, immI5 con) %{
+  match(Set dst (AddVB src1 (Replicate con)));
+  match(Set dst (AddVS src1 (Replicate con)));
+  match(Set dst (AddVI src1 (Replicate con)));
+  format %{ "vadd_immI $dst, $src1, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vadd_vi(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
+    __ vadd_vi(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
                $con$$constant);
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_immL(vReg dst_src, immL5 con) %{
-  match(Set dst_src (AddVL dst_src (Replicate con)));
-  format %{ "vadd_immL $dst_src, $dst_src, $con" %}
+instruct vadd_immL(vReg dst, vReg src1, immL5 con) %{
+  match(Set dst (AddVL src1 (Replicate con)));
+  format %{ "vadd_immL $dst, $src1, $con" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vadd_vi(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
+    __ vadd_vi(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
                $con$$constant);
   %}
   ins_pipe(pipe_slow);
@@ -419,30 +419,30 @@ instruct vadd_immL(vReg dst_src, immL5 con) %{
 
 // vector-scalar add (unpredicated)
 
-instruct vadd_regI(vReg dst_src, iRegIorL2I src) %{
-  match(Set dst_src (AddVB dst_src (Replicate src)));
-  match(Set dst_src (AddVS dst_src (Replicate src)));
-  match(Set dst_src (AddVI dst_src (Replicate src)));
-  format %{ "vadd_regI $dst_src, $dst_src, $src" %}
+instruct vadd_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+  match(Set dst (AddVB src1 (Replicate src2)));
+  match(Set dst (AddVS src1 (Replicate src2)));
+  match(Set dst (AddVI src1 (Replicate src2)));
+  format %{ "vadd_regI $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vadd_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vadd_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_regL(vReg dst_src, iRegL src) %{
-  match(Set dst_src (AddVL dst_src (Replicate src)));
-  format %{ "vadd_regL $dst_src, $dst_src, $src" %}
+instruct vadd_regL(vReg dst, vReg src1, iRegL src2) %{
+  match(Set dst (AddVL src1 (Replicate src2)));
+  format %{ "vadd_regL $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vadd_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vadd_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -479,30 +479,30 @@ instruct vadd_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
 
 // vector-scalar add (predicated)
 
-instruct vadd_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
-  match(Set dst_src (AddVB (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (AddVS (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (AddVI (Binary dst_src (Replicate src)) v0));
-  format %{ "vadd_regI_masked $dst_src, $dst_src, $src" %}
+instruct vadd_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVB (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (AddVS (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (AddVI (Binary dst_src (Replicate src2)) v0));
+  format %{ "vadd_regI_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vadd_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
-  match(Set dst_src (AddVL (Binary dst_src (Replicate src)) v0));
-  format %{ "vadd_regL_masked $dst_src, $dst_src, $src" %}
+instruct vadd_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVL (Binary dst_src (Replicate src2)) v0));
+  format %{ "vadd_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vadd_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -573,60 +573,60 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar sub (unpredicated)
 
-instruct vsub_regI(vReg dst_src, iRegIorL2I src) %{
-  match(Set dst_src (SubVB dst_src (Replicate src)));
-  match(Set dst_src (SubVS dst_src (Replicate src)));
-  match(Set dst_src (SubVI dst_src (Replicate src)));
-  format %{ "vsub_regI $dst_src, $dst_src, $src" %}
+instruct vsub_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+  match(Set dst (SubVB src1 (Replicate src2)));
+  match(Set dst (SubVS src1 (Replicate src2)));
+  match(Set dst (SubVI src1 (Replicate src2)));
+  format %{ "vsub_regI $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vsub_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vsub_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vsub_regL(vReg dst_src, iRegL src) %{
-  match(Set dst_src (SubVL dst_src (Replicate src)));
-  format %{ "vsub_regL $dst_src, $dst_src, $src" %}
+instruct vsub_regL(vReg dst, vReg src1, iRegL src2) %{
+  match(Set dst (SubVL src1 (Replicate src2)));
+  format %{ "vsub_regL $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vsub_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vsub_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
 // vector-scalar sub (predicated)
 
-instruct vsub_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
-  match(Set dst_src (SubVB (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (SubVS (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (SubVI (Binary dst_src (Replicate src)) v0));
-  format %{ "vsub_regI_masked $dst_src, $dst_src, $src" %}
+instruct vsub_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+  match(Set dst_src (SubVB (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (SubVS (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (SubVI (Binary dst_src (Replicate src2)) v0));
+  format %{ "vsub_regI_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vsub_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
-  match(Set dst_src (SubVL (Binary dst_src (Replicate src)) v0));
-  format %{ "vsub_regL_masked $dst_src, $dst_src, $src" %}
+instruct vsub_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+  match(Set dst_src (SubVL (Binary dst_src (Replicate src2)) v0));
+  format %{ "vsub_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vsub_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1649,60 +1649,60 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
 
 // vector-scalar mul (unpredicated)
 
-instruct vmul_regI(vReg dst_src, iRegIorL2I src) %{
-  match(Set dst_src (MulVB dst_src (Replicate src)));
-  match(Set dst_src (MulVS dst_src (Replicate src)));
-  match(Set dst_src (MulVI dst_src (Replicate src)));
-  format %{ "vmul_regI $dst_src, $dst_src, $src" %}
+instruct vmul_regI(vReg dst, vReg src1, iRegIorL2I src2) %{
+  match(Set dst (MulVB src1 (Replicate src2)));
+  match(Set dst (MulVS src1 (Replicate src2)));
+  match(Set dst (MulVI src1 (Replicate src2)));
+  format %{ "vmul_regI $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vmul_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vmul_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vmul_regL(vReg dst_src, iRegL src) %{
-  match(Set dst_src (MulVL dst_src (Replicate src)));
-  format %{ "vmul_regL $dst_src, $dst_src, $src" %}
+instruct vmul_regL(vReg dst, vReg src1, iRegL src2) %{
+  match(Set dst (MulVL src1 (Replicate src2)));
+  format %{ "vmul_regL $dst, $src1, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
-    __ vmul_vx(as_VectorRegister($dst_src$$reg),
-               as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg));
+    __ vmul_vx(as_VectorRegister($dst$$reg),
+               as_VectorRegister($src1$$reg),
+               as_Register($src2$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
 // vector-scalar mul (predicated)
 
-instruct vmul_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
-  match(Set dst_src (MulVB (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (MulVS (Binary dst_src (Replicate src)) v0));
-  match(Set dst_src (MulVI (Binary dst_src (Replicate src)) v0));
-  format %{ "vmul_regI_masked $dst_src, $dst_src, $src" %}
+instruct vmul_regI_masked(vReg dst_src, iRegIorL2I src2, vRegMask_V0 v0) %{
+  match(Set dst_src (MulVB (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (MulVS (Binary dst_src (Replicate src2)) v0));
+  match(Set dst_src (MulVI (Binary dst_src (Replicate src2)) v0));
+  format %{ "vmul_regI_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vmul_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
-  match(Set dst_src (MulVL (Binary dst_src (Replicate src)) v0));
-  format %{ "vmul_regL_masked $dst_src, $dst_src, $src" %}
+instruct vmul_regL_masked(vReg dst_src, iRegL src2, vRegMask_V0 v0) %{
+  match(Set dst_src (MulVL (Binary dst_src (Replicate src2)) v0));
+  format %{ "vmul_regL_masked $dst_src, $dst_src, $src2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vmul_vx(as_VectorRegister($dst_src$$reg),
                as_VectorRegister($dst_src$$reg),
-               as_Register($src$$reg), Assembler::v0_t);
+               as_Register($src2$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -387,6 +387,126 @@ instruct vadd_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
+// vector-immediate add (unpredicated)
+
+instruct vadd_immI(vReg dst_src, immI5 con) %{
+  match(Set dst_src (AddVB dst_src (Replicate con)));
+  match(Set dst_src (AddVS dst_src (Replicate con)));
+  match(Set dst_src (AddVI dst_src (Replicate con)));
+  format %{ "vadd_immI $dst_src, $dst_src, $con" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vi(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               $con$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vadd_immL(vReg dst_src, immL5 con) %{
+  match(Set dst_src (AddVL dst_src (Replicate con)));
+  format %{ "vadd_immL $dst_src, $dst_src, $con" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vi(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               $con$$constant);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar add (unpredicated)
+
+instruct vadd_regI(vReg dst_src, iRegIorL2I src) %{
+  match(Set dst_src (AddVB dst_src (Replicate src)));
+  match(Set dst_src (AddVS dst_src (Replicate src)));
+  match(Set dst_src (AddVI dst_src (Replicate src)));
+  format %{ "vadd_regI $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vadd_regL(vReg dst_src, iRegL src) %{
+  match(Set dst_src (AddVL dst_src (Replicate src)));
+  format %{ "vadd_regL $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-immediate add (predicated)
+
+instruct vadd_immI_masked(vReg dst_src, immI5 con, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVB (Binary dst_src (Replicate con)) v0));
+  match(Set dst_src (AddVS (Binary dst_src (Replicate con)) v0));
+  match(Set dst_src (AddVI (Binary dst_src (Replicate con)) v0));
+  format %{ "vadd_immI_masked $dst_src, $dst_src, $con" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vi(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               $con$$constant, Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vadd_immL_masked(vReg dst_src, immL5 con, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVL (Binary dst_src (Replicate con)) v0));
+  format %{ "vadd_immL_masked $dst_src, $dst_src, $con" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vi(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               $con$$constant, Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar add (predicated)
+
+instruct vadd_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVB (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (AddVS (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (AddVI (Binary dst_src (Replicate src)) v0));
+  format %{ "vadd_regI_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vadd_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+  match(Set dst_src (AddVL (Binary dst_src (Replicate src)) v0));
+  format %{ "vadd_regL_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vadd_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
 // vector sub
 
 instruct vsub(vReg dst, vReg src1, vReg src2) %{
@@ -447,6 +567,66 @@ instruct vsub_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfsub_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar sub (unpredicated)
+
+instruct vsub_regI(vReg dst_src, iRegIorL2I src) %{
+  match(Set dst_src (SubVB dst_src (Replicate src)));
+  match(Set dst_src (SubVS dst_src (Replicate src)));
+  match(Set dst_src (SubVI dst_src (Replicate src)));
+  format %{ "vsub_regI $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsub_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vsub_regL(vReg dst_src, iRegL src) %{
+  match(Set dst_src (SubVL dst_src (Replicate src)));
+  format %{ "vsub_regL $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsub_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar sub (predicated)
+
+instruct vsub_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+  match(Set dst_src (SubVB (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (SubVS (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (SubVI (Binary dst_src (Replicate src)) v0));
+  format %{ "vsub_regI_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsub_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vsub_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+  match(Set dst_src (SubVL (Binary dst_src (Replicate src)) v0));
+  format %{ "vsub_regL_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vsub_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1463,6 +1643,66 @@ instruct vmul_fp_masked(vReg dst_src1, vReg src2, vRegMask_V0 v0) %{
     __ vsetvli_helper(bt, Matcher::vector_length(this));
     __ vfmul_vv(as_VectorRegister($dst_src1$$reg), as_VectorRegister($dst_src1$$reg),
                 as_VectorRegister($src2$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar mul (unpredicated)
+
+instruct vmul_regI(vReg dst_src, iRegIorL2I src) %{
+  match(Set dst_src (MulVB dst_src (Replicate src)));
+  match(Set dst_src (MulVS dst_src (Replicate src)));
+  match(Set dst_src (MulVI dst_src (Replicate src)));
+  format %{ "vmul_regI $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmul_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmul_regL(vReg dst_src, iRegL src) %{
+  match(Set dst_src (MulVL dst_src (Replicate src)));
+  format %{ "vmul_regL $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmul_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg));
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+// vector-scalar mul (predicated)
+
+instruct vmul_regI_masked(vReg dst_src, iRegIorL2I src, vRegMask_V0 v0) %{
+  match(Set dst_src (MulVB (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (MulVS (Binary dst_src (Replicate src)) v0));
+  match(Set dst_src (MulVI (Binary dst_src (Replicate src)) v0));
+  format %{ "vmul_regI_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmul_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
+  %}
+  ins_pipe(pipe_slow);
+%}
+
+instruct vmul_regL_masked(vReg dst_src, iRegL src, vRegMask_V0 v0) %{
+  match(Set dst_src (MulVL (Binary dst_src (Replicate src)) v0));
+  format %{ "vmul_regL_masked $dst_src, $dst_src, $src" %}
+  ins_encode %{
+    BasicType bt = Matcher::vector_element_basic_type(this);
+    __ vsetvli_helper(bt, Matcher::vector_length(this));
+    __ vmul_vx(as_VectorRegister($dst_src$$reg),
+               as_VectorRegister($dst_src$$reg),
+               as_Register($src$$reg), Assembler::v0_t);
   %}
   ins_pipe(pipe_slow);
 %}


### PR DESCRIPTION
Hi, We want to support vector-scalar and vector-immediate arithmetic instructions, It was implemented by referring to RVV v1.0 [1]. please take a look and have some reviews. Thanks a lot.
We can use the Byte256VectorTests.java[2] to print the Opto JIT Code, verify and observe the generation of nodes.

For example, we can use the following command to print the Opto JIT Code of a jtreg test case:

```
/home/zifeihan/jtreg/bin/jtreg \
-v:default \
-concurrency:16 -timeout:50 \
-javaoption:-XX:+UnlockExperimentalVMOptions \
-javaoption:-XX:+UseRVV \
-javaoption:-XX:+PrintOptoAssembly \
-javaoption:-XX:LogFile=/home/zifeihan/jdk/Byte256VectorTests_PrintOptoAssembly.log \
-jdk:/home/zifeihan/jdk/build/linux-riscv64-server-fastdebug/jdk \
/home/zifeihan/jdk/test/jdk/jdk/incubator/vector/Byte256VectorTests.java
```


we can observe the specified compilation log `Byte256VectorTests_PrintOptoAssembly.log`, which contains the vector-scalar and vector-immediate arithmetic instructions for the PR implementation.

vadd_immI Node
```
16c     addw  R11, R10, zr	#@convI2L_reg_reg
170     add R9, R31, R11	# ptr, #@addP_reg_reg
174     addi  R9, R9, #16	# ptr, #@addP_reg_imm
176     loadV V1, [R9]	# vector (rvv)
17e     vadd_immI V1, V1, #7
186     add R11, R15, R11	# ptr, #@addP_reg_reg
188     addi  R11, R11, #16	# ptr, #@addP_reg_imm
18a     storeV [R11], V1	# vector (rvv)
```

vadd_immI_masked Node
```
1e8     B31: #	out( B37 B32 ) &lt;- in( B30 )  Freq: 76.2281
1e8     loadV V2, [R31]	# vector (rvv)
1f0     vloadmask V0, V1
1f8     vadd_immI_masked V2, V2, #7
200     addi  R31, R10, #48	# ptr, #@addP_reg_imm
204     bgeu  R30, R7, B37	#@cmpU_branch  P=0.000001 C=-1.000000
```

vadd_regI Node
```
0c4     B4: #	out( B9 B5 ) &lt;- in( B8 B3 )  Freq: 1
0c4     vloadcon V1	# generate iota indices
0cc     spill [sp, #4] -&gt; R30	# spill size = 32
0ce     vmul_regI V1, V1, R30
0d6     spill [sp, #0] -&gt; R29	# spill size = 32
0d8     vadd_regI V1, V1, R29
```

vadd_regI_masked Node
```
244     B36: #	out( B33 B37 ) &lt;- in( B35 )  Freq: 7427.81
244     # castII of R30, #@castII
244     addw  R31, R30, zr	#@convI2L_reg_reg
248     spill [sp, #32] -&gt; R10	# spill size = 64
24a     add R10, R10, R31	# ptr, #@addP_reg_reg
24c     addi  R10, R10, #16	# ptr, #@addP_reg_imm
24e     loadV V2, [R10]	# vector (rvv)
256     vloadmask V0, V1
25e     vadd_regI_masked V2, V2, R29
```

vsub_regI Node
```
112     B20: #	out( B63 B21 ) &lt;- in( B19 )  Freq: 77.0107
112     # castII of R20, #@castII
112     addw  R11, R20, zr	#@convI2L_reg_reg
116     add R12, R10, R11	# ptr, #@addP_reg_reg
11a     addi  R12, R12, #16	# ptr, #@addP_reg_imm
11c     loadV V1, [R12]	# vector (rvv)
124     vsub_regI V1, V1, R31
12c     bgeu  R20, R29, B63	#@cmpU_branch  P=0.000001 C=-1.000000
```

vsub_regI_masked Node
```
1e8     B31: #	out( B37 B32 ) &lt;- in( B30 )  Freq: 76.2281
1e8     loadV V2, [R31]	# vector (rvv)
1f0     vloadmask V0, V1
1f8     vsub_regI_masked V2, V2, R29
200     addi  R31, R10, #48	# ptr, #@addP_reg_imm
204     bgeu  R30, R7, B37	#@cmpU_branch  P=0.000001 C=-1.000000
```

vmul_regI Node
```
0ca     B4: #	out( B9 B5 ) &lt;- in( B8 B3 )  Freq: 1
0ca     vloadcon V1	# generate iota indices
0d2     spill [sp, #0] -&gt; R29	# spill size = 64
0d4     lwu  R7, [R29, #12]	# loadN, compressed ptr, #@loadN ! Field: jdk/internal/vm/vector/VectorSupport$VectorPayload.payload (constant)
0d8     decode_heap_oop  R7, R7	#@decodeHeapOop
0da     addi  R7, R7, #16	# ptr, #@addP_reg_imm
0dc     vmul_regI V1, V1, R30
0e4     loadV V2, [R7]	# vector (rvv)
```

vmul_regI_masked Node
```
198     addw  R30, R19, zr	#@convI2L_reg_reg
19c     spill [sp, #32] -&gt; R31	# spill size = 64
19e     add R31, R31, R30	# ptr, #@addP_reg_reg
1a0     addi  R10, R31, #16	# ptr, #@addP_reg_imm
1a4     loadV V2, [R10]	# vector (rvv)
1ac     vloadmask V0, V1
1b4     vmul_regI_masked V2, V2, R29
```



We can test test/jdk/jdk/incubator/vector/Long256VectorTests.java in the same way, and looking at the Opto logs, we will see nodes similar to vadd_immL, vadd_immL_masked, vadd_regL, vadd_regL_masked, vsub_regL, vsub_regL_masked, vmul_regL, vmul_regL_masked.

vadd_immL Node
```
112     addw  R11, R9, zr	#@convI2L_reg_reg
116     slli  R11, R11, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
118     add R14, R29, R11	# ptr, #@addP_reg_reg
11c     addi  R14, R14, #16	# ptr, #@addP_reg_imm
11e     loadV V1, [R14]	# vector (rvv)
126     vadd_immL V1, V1, #7
```

vadd_immL_masked Node
```
194     addw  R30, R19, zr	#@convI2L_reg_reg
198     slli  R30, R30, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
19a     spill [sp, #32] -&gt; R31	# spill size = 64
19c     add R31, R31, R30	# ptr, #@addP_reg_reg
19e     addi  R10, R31, #16	# ptr, #@addP_reg_imm
1a2     loadV V1, [R10]	# vector (rvv)
1aa     vadd_immL_masked V1, V1, #7
```

vadd_regL Node
```
104     B17: #	out( B20 ) &lt;- in( B16 )  Freq: 0.99999
104     replicateL_imm5 V4, #1
10c     vadd_regL V4, V4, R17
114      -- 	// R23=Thread::current(), empty, #@tlsLoadP
114     mv R31, #0	# int, #@loadConI
116     j  B20	#@branch
```

vadd_regL_masked Node
```
198     addw  R30, R19, zr	#@convI2L_reg_reg
19c     slli  R30, R30, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
19e     spill [sp, #32] -&gt; R31	# spill size = 64
1a0     add R31, R31, R30	# ptr, #@addP_reg_reg
1a2     addi  R10, R31, #16	# ptr, #@addP_reg_imm
1a6     loadV V1, [R10]	# vector (rvv)
1ae     vadd_regL_masked V1, V1, R11
```

vsub_regL Node
```
116     addw  R11, R19, zr	#@convI2L_reg_reg
11a     slli  R11, R11, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
11c     add R12, R31, R11	# ptr, #@addP_reg_reg
120     addi  R12, R12, #16	# ptr, #@addP_reg_imm
122     loadV V1, [R12]	# vector (rvv)
12a     vsub_regL V1, V1, R14
```

vsub_regL_masked Node
```
198     addw  R30, R19, zr	#@convI2L_reg_reg
19c     slli  R30, R30, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
19e     spill [sp, #32] -&gt; R31	# spill size = 64
1a0     add R31, R31, R30	# ptr, #@addP_reg_reg
1a2     addi  R10, R31, #16	# ptr, #@addP_reg_imm
1a6     loadV V1, [R10]	# vector (rvv)
1ae     vsub_regL_masked V1, V1, R11
```

vmul_regL Node
```
0c2     vloadcon V1	# generate iota indices
0ca     spill [sp, #0] -&gt; R29	# spill size = 64
0cc     lwu  R7, [R29, #12]	# loadN, compressed ptr, #@loadN ! Field: jdk/internal/vm/vector/VectorSupport$VectorPayload.payload (constant)
0d0     decode_heap_oop  R7, R7	#@decodeHeapOop
0d2     addi  R7, R7, #16	# ptr, #@addP_reg_imm
0d4     addw  R28, R30, zr	#@convI2L_reg_reg
0d8     loadV V2, [R7]	# vector (rvv)
0e0     vmul_regL V1, V1, R28
```

vmul_regL_masked Node
```
19c     slli  R30, R30, (#3 &amp; 0x3f)	#@lShiftL_reg_imm
19e     spill [sp, #32] -&gt; R31	# spill size = 64
1a0     add R31, R31, R30	# ptr, #@addP_reg_reg
1a2     addi  R10, R31, #16	# ptr, #@addP_reg_imm
1a6     loadV V1, [R10]	# vector (rvv)
1ae     vmul_regL_masked V1, V1, R11
1b6     spill [sp, #48] -&gt; R10	# spill size = 64
```

[1] https://github.com/riscv/riscv-v-spec/blob/v1.0/v-spec.adoc
[2] https://github.com/openjdk/jdk/blob/master/test/jdk/jdk/incubator/vector/Byte256VectorTests.java

### Testing
- [x] test/jdk/jdk/incubator/vector (fastdebug) qemu 8.1.50 with UseRVV
- [x] Run tier1-3 tests on SOPHON SG2042 (release)
- [x] Run tier1-3 tests (release)  on qemu 8.1.50 with UseRVV

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333006](https://bugs.openjdk.org/browse/JDK-8333006): RISC-V: C2: Support vector-scalar and vector-immediate arithmetic instructions (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [ac335baa](https://git.openjdk.org/jdk/pull/19415/files/ac335baab7a1746e675e49d30d186eac69ab6899)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19415/head:pull/19415` \
`$ git checkout pull/19415`

Update a local copy of the PR: \
`$ git checkout pull/19415` \
`$ git pull https://git.openjdk.org/jdk.git pull/19415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19415`

View PR using the GUI difftool: \
`$ git pr show -t 19415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19415.diff">https://git.openjdk.org/jdk/pull/19415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19415#issuecomment-2134235721)