### PR TITLE
Add thread info in DataLoss Event

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -755,6 +755,7 @@
   </Event>
 
   <Event name="DataLoss" category="Flight Recorder" label="Data Loss"
+         thread="true"
          description="Data could not be copied out from a buffer, typically because of contention"
          startTime="false">
     <Field type="ulong" contentType="bytes" name="amount" label="Amount" description="Amount lost data" />

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorage.cpp
@@ -217,6 +217,7 @@ static void write_data_loss_event(JfrBuffer* buffer, u8 unflushed_size, Thread* 
     writer.begin_event_write(false);
     writer.write<u8>(EventDataLoss::eventId);
     writer.write(JfrTicks::now());
+    writer.write(JfrThreadLocal::thread_id(thread));
     writer.write(unflushed_size);
     writer.write(total_data_loss);
     writer.end_event_write(false);


### PR DESCRIPTION
total_data_loss of DataLoss Event is summarized by thread, but there is no thread info in DataLoss Event. Therefore, add thread info in DataLoss Event

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19416/head:pull/19416` \
`$ git checkout pull/19416`

Update a local copy of the PR: \
`$ git checkout pull/19416` \
`$ git pull https://git.openjdk.org/jdk.git pull/19416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19416`

View PR using the GUI difftool: \
`$ git pr show -t 19416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19416.diff">https://git.openjdk.org/jdk/pull/19416.diff</a>

</details>
