### PR TITLE
8280990: [XWayland] XTest emulated mouse click does not bring window to front

### DIFF
--- a/test/jdk/java/awt/Modal/ToFront/FrameToFrontModelessTest.java
+++ b/test/jdk/java/awt/Modal/ToFront/FrameToFrontModelessTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,9 @@ public class FrameToFrontModelessTest {
     private final ExtendedRobot robot;
 
     private boolean isModeless;
+
+    private static final boolean IS_ON_WAYLAND =
+            System.getenv("WAYLAND_DISPLAY") != null;
 
     public FrameToFrontModelessTest(boolean modeless) throws Exception {
         isModeless = modeless;
@@ -76,6 +79,9 @@ public class FrameToFrontModelessTest {
             robot.waitForIdle(delay);
 
             // show the right frame appear on top of the dialog
+            if (IS_ON_WAYLAND) {
+                rightFrame.toFront();
+            }
             rightFrame.clickDummyButton(robot);
             robot.waitForIdle(delay);
 

--- a/test/jdk/java/awt/Modal/helpers/TestDialog.java
+++ b/test/jdk/java/awt/Modal/helpers/TestDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,9 @@ public class TestDialog extends Dialog implements ActionListener,
 
     public static int delay = 500;
     public static int keyDelay = 100;
+
+    private static final boolean IS_ON_WAYLAND =
+            System.getenv("WAYLAND_DISPLAY") != null;
 
     public TestDialog(Frame frame) {
         super(frame);
@@ -287,6 +290,9 @@ public class TestDialog extends Dialog implements ActionListener,
                                       String message,
                                       Button b) throws Exception {
         focusGained.reset();
+        if (IS_ON_WAYLAND) {
+            toFront();
+        }
         clickInside(robot);
         focusGained.waitForFlagTriggered();
         assertTrue(focusGained.flag(),
@@ -303,6 +309,9 @@ public class TestDialog extends Dialog implements ActionListener,
                                              String message,
                                              Button b) throws Exception {
         focusGained.reset();
+        if (IS_ON_WAYLAND) {
+            toFront();
+        }
         clickInside(robot);
         robot.waitForIdle(delay);
 

--- a/test/jdk/java/awt/Modal/helpers/TestFrame.java
+++ b/test/jdk/java/awt/Modal/helpers/TestFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,8 @@ public class TestFrame extends Frame implements ActionListener,
 
     public static int delay = 500;
     public static int keyDelay = 100;
+    private static final boolean IS_ON_WAYLAND =
+            System.getenv("WAYLAND_DISPLAY") != null;
 
     public TestFrame() {
         super();
@@ -251,7 +253,7 @@ public class TestFrame extends Frame implements ActionListener,
                                  String        message) throws Exception {
         dummyClicked.reset();
         clickButton(dummyButton, robot);
-        dummyClicked.waitForFlagTriggered();
+        dummyClicked.waitForFlagTriggered(attempts);
 
         String msg = "Clicking the frame Dummy button " + (refState ?
             "did not trigger an action." :
@@ -277,6 +279,9 @@ public class TestFrame extends Frame implements ActionListener,
                                      String message,
                                      Button b) throws Exception {
         focusGained.reset();
+        if (IS_ON_WAYLAND) {
+            toFront();
+        }
         clickInside(robot);
 
         focusGained.waitForFlagTriggered();
@@ -293,6 +298,9 @@ public class TestFrame extends Frame implements ActionListener,
                                             String message,
                                             Button b) throws Exception {
         focusGained.reset();
+        if (IS_ON_WAYLAND) {
+            toFront();
+        }
         clickInside(robot);
 
         robot.waitForIdle(delay);


### PR DESCRIPTION
Some of the modal tests fail in X11 compatibility mode on Wayland, because a mouse click emulated with XTEST does not not cause the windows to be reordered.

This is a known limitation because these click events do not leave the XWayland server and are not reported to the Wayland compositor.

There is a [libei](https://gitlab.freedesktop.org/libinput/libei) that can be used to emulate input events in Wayland.
And there is a [bridge that allows emulated events from XTEST to be passed to the compositor](https://gitlab.freedesktop.org/libinput/libei/-/blob/main/README.md?ref_type=heads#xwayland-and-xtest).
Support for this has been added in [Gnome 45 and XWayland 23.2](https://gitlab.gnome.org/GNOME/mutter/-/issues/3194#note_1937109), but it is optional and not yet enabled in Ubuntu.

This change adds `toFront` calls for mouse clicks that are only intended to bring a window to the front in the window stacking order.

The testing is green on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280990](https://bugs.openjdk.org/browse/JDK-8280990): [XWayland] XTest emulated mouse click does not bring window to front (**Bug** - P3)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19417/head:pull/19417` \
`$ git checkout pull/19417`

Update a local copy of the PR: \
`$ git checkout pull/19417` \
`$ git pull https://git.openjdk.org/jdk.git pull/19417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19417`

View PR using the GUI difftool: \
`$ git pr show -t 19417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19417.diff">https://git.openjdk.org/jdk/pull/19417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19417#issuecomment-2134250725)