### PR TITLE
8333013: Update vmTestbase/nsk/share/LocalProcess.java to don't use finalization

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
@@ -204,27 +204,24 @@ public abstract class JdbTest {
                     }
                 }
 
-            } catch (Exception e) {
-                failure("Caught unexpected exception: " + e);
-                e.printStackTrace(out);
-
+            } catch (Throwable t) {
+                failure("Caught unexpected exception: " + t);
+                t.printStackTrace(out);
+            } finally {
                 if (jdb != null) {
+                    log.complain("jdb reference is not null, check for exception in the logs.");
                     try {
                         jdb.close();
                     } catch (Throwable ex) {
                         failure("Caught exception/error while closing jdb streams:\n\t" + ex);
                         ex.printStackTrace(log.getOutStream());
                     }
-                } else {
-                    log.complain("jdb reference is null, cannot run jdb.close() method");
                 }
 
-                if (debuggee != null) {
+                if (debuggee != null && debuggee.terminated()) {
+                    log.complain("debuggee is still running, check for exception in the logs.");
                     debuggee.killDebuggee();
-                } else {
-                    log.complain("debuggee reference is null, cannot run debuggee.killDebuggee() method");
                 }
-
             }
 
             if (!success) {
@@ -232,9 +229,9 @@ public abstract class JdbTest {
                 return FAILED;
             }
 
-        } catch (Exception e) {
-            out.println("Caught unexpected exception while starting the test: " + e);
-            e.printStackTrace(out);
+        } catch (Throwable t) {
+            out.println("Caught unexpected exception while starting the test: " + t);
+            t.printStackTrace(out);
             out.println("TEST FAILED");
             return FAILED;
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java
@@ -218,7 +218,7 @@ public abstract class JdbTest {
                     }
                 }
 
-                if (debuggee != null && debuggee.terminated()) {
+                if (debuggee != null && !debuggee.terminated()) {
                     log.complain("debuggee is still running, check for exception in the logs.");
                     debuggee.killDebuggee();
                 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/LocalProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/LocalProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,7 @@
  * questions.
  */
 
-package nsk.share;
-
-import nsk.share.*;
+package nsk.share.jdb;
 
 import java.io.*;
 
@@ -33,14 +31,9 @@ import java.io.*;
  * This class provides abilities to launch such process,
  * redirect standard output streams, wait for process terminates
  * or kill the process, and so on.
- * <p>
- * This object is finalized with <code>nsk.share.Finalizer</code>.
- *
- * @see nsk.share.FinalizableObject
- * @see nsk.share.Finalizer
  */
 
-public class LocalProcess extends FinalizableObject {
+class LocalProcess {
 
     public final static int PROCESS_IS_ALIVE = 222;
 
@@ -59,16 +52,11 @@ public class LocalProcess extends FinalizableObject {
         }
 
         process = Runtime.getRuntime().exec(args);
-
-        registerCleanup();
     }
 
     public void launch (String cmdLine) throws IOException {
         System.out.println("Launching process by command line: " + cmdLine);
-
         process = Runtime.getRuntime().exec(cmdLine);
-
-        registerCleanup();
     }
 
     /** Return exit status. */
@@ -163,12 +151,4 @@ public class LocalProcess extends FinalizableObject {
         process.destroy();
     }
 
-    /**
-     * This method is called at finalization and calls <code>kill()</code>.
-     *
-     */
-    @Override
-    public void cleanup() {
-        kill();
-    }
 }


### PR DESCRIPTION
The vmTestbase/nsk/share/LocalProcess.java is a wrapper for debuggee process. It extends FinalizableObject to kill the debuggee process.

The debuggee process is used by nsk.jdb tests only, see runTest(...) in vmTestbase/nsk/share/jdb/JdbTest.java:
https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/vmTestbase/nsk/share/jdb/JdbTest.java#L189

I verified that process is always already terminated when is cleaned during VM shutdown hook,
So the fix is just to remove the finalization.

I also moved LocalProcess into nsk.share.jdb to reduce the visibility of class and hardened checks in runTest.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333013](https://bugs.openjdk.org/browse/JDK-8333013): Update vmTestbase/nsk/share/LocalProcess.java to don't use finalization (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19418/head:pull/19418` \
`$ git checkout pull/19418`

Update a local copy of the PR: \
`$ git checkout pull/19418` \
`$ git pull https://git.openjdk.org/jdk.git pull/19418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19418`

View PR using the GUI difftool: \
`$ git pr show -t 19418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19418.diff">https://git.openjdk.org/jdk/pull/19418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19418#issuecomment-2134280500)