### PR TITLE
8332065: Calling readLine(null...) or readPassword(null...) on System.console() hangs jshell

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
@@ -218,10 +218,11 @@ public class ConsoleImpl {
          */
         @Override
         public String readln(String prompt) {
+            char[] chars = (prompt == null ? "null" : prompt).toCharArray();
+
             try {
                 return sendAndReceive(() -> {
                     remoteInput.write(Task.READ_LINE.ordinal());
-                    char[] chars = (prompt == null ? "null" : prompt).toCharArray();
                     sendChars(chars, 0, chars.length);
                     char[] line = readChars();
                     return new String(line);
@@ -245,11 +246,12 @@ public class ConsoleImpl {
          */
         @Override
         public String readLine(Locale locale, String format, Object... args) {
+            String prompt = String.format(locale, format, args);
+            char[] chars = prompt.toCharArray();
+
             try {
                 return sendAndReceive(() -> {
                     remoteInput.write(Task.READ_LINE.ordinal());
-                    String prompt = String.format(locale, format, args);
-                    char[] chars = prompt.toCharArray();
                     sendChars(chars, 0, chars.length);
                     char[] line = readChars();
                     return new String(line);
@@ -272,11 +274,12 @@ public class ConsoleImpl {
          */
         @Override
         public char[] readPassword(Locale locale, String format, Object... args) {
+            String prompt = String.format(locale, format, args);
+            char[] chars = prompt.toCharArray();
+
             try {
                 return sendAndReceive(() -> {
                     remoteInput.write(Task.READ_PASSWORD.ordinal());
-                    String prompt = String.format(locale, format, args);
-                    char[] chars = prompt.toCharArray();
                     sendChars(chars, 0, chars.length);
                     return readChars();
                 });

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
@@ -35,6 +35,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Objects;
 
 import jdk.internal.io.JdkConsole;
 import jdk.internal.io.JdkConsoleProvider;
@@ -246,6 +247,8 @@ public class ConsoleImpl {
          */
         @Override
         public String readLine(Locale locale, String format, Object... args) {
+            Objects.requireNonNull(format, "the format String must be non-null");
+
             String prompt = String.format(locale, format, args);
             char[] chars = prompt.toCharArray();
 
@@ -274,6 +277,8 @@ public class ConsoleImpl {
          */
         @Override
         public char[] readPassword(Locale locale, String format, Object... args) {
+            Objects.requireNonNull(format, "the format String must be non-null");
+
             String prompt = String.format(locale, format, args);
             char[] chars = prompt.toCharArray();
 

--- a/test/langtools/jdk/jshell/ConsoleTest.java
+++ b/test/langtools/jdk/jshell/ConsoleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,10 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import jdk.jshell.EvalException;
 import jdk.jshell.JShell;
 import jdk.jshell.JShellConsole;
+import jdk.jshell.Snippet.Status;
 
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
@@ -181,6 +183,13 @@ public class ConsoleTest extends KullaTesting {
                       .replace("${output}", "" + output));
         String expected = "A".repeat(repeats * output);
         assertEquals(sb.toString(), expected);
+    }
+
+    @Test
+    public void testNPE() {
+        console = new ThrowingJShellConsole();
+        assertEval("System.console().readLine(null)", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
+        assertEval("System.console().readPassword(null)", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
     }
 
     @Override

--- a/test/langtools/jdk/jshell/ConsoleTest.java
+++ b/test/langtools/jdk/jshell/ConsoleTest.java
@@ -190,6 +190,8 @@ public class ConsoleTest extends KullaTesting {
         console = new ThrowingJShellConsole();
         assertEval("System.console().readLine(null)", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
         assertEval("System.console().readPassword(null)", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
+        assertEval("System.console().readLine(\"%d\", \"\")", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
+        assertEval("System.console().readPassword(\"%d\", \"\")", DiagCheck.DIAG_OK, DiagCheck.DIAG_OK, chain(added(Status.VALID), null, EvalException.class));
     }
 
     @Override


### PR DESCRIPTION
JShell supports using `System.console()` when running snippets in a separate VM (the agent). This works by re-sending requests from the agent to the main process.

For some `Console` methods, like `readLine`, this has two phases - first a prompt is sent, and then input is received. But, there's a mistake on the way this is handled: the protocol starts a "transaction", and then goes to process the prompt. And if the prompt processing fails, the "transaction" never ends, and the communication locks.

The proposal here is to do the prompt processing before starting the communication, so if it fails, there are no problems with the communication.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332065](https://bugs.openjdk.org/browse/JDK-8332065): Calling readLine(null...) or readPassword(null...) on System.console() hangs jshell (**Bug** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19420/head:pull/19420` \
`$ git checkout pull/19420`

Update a local copy of the PR: \
`$ git checkout pull/19420` \
`$ git pull https://git.openjdk.org/jdk.git pull/19420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19420`

View PR using the GUI difftool: \
`$ git pr show -t 19420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19420.diff">https://git.openjdk.org/jdk/pull/19420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19420#issuecomment-2134724119)