### PR TITLE
8332936: Test vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java fails with no GC's recorded

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_0_1/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_0_1/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_10_20/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_10_20/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g

--- a/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_99_100/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/metaspace/gc/watermark_99_100/TestDescription.java
@@ -33,6 +33,7 @@
  * @requires vm.gc != null | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "G1" | !vm.opt.final.ClassUnloadingWithConcurrentMark
  * @requires vm.gc != "Z"
+ * @requires vm.compMode != "Xcomp"
  * @library /vmTestbase /test/lib
  * @run main/othervm
  *      -Xmx1g


### PR DESCRIPTION
Hi all,

  please review this change to exclude the watermark tests from use with -Xcomp.

The failures reported are related to -Xcomp triggering the wrong kind of garbage collection pauses (CodeCache related GCs instead of Metadata related GCs) the test then fails on.

The proposed solution is to just disable the tests with -Xcomp: the tests are not related to compilation at all.

Testing: local, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332936](https://bugs.openjdk.org/browse/JDK-8332936): Test vmTestbase/metaspace/gc/watermark_70_80/TestDescription.java fails with no GC's recorded (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19421/head:pull/19421` \
`$ git checkout pull/19421`

Update a local copy of the PR: \
`$ git checkout pull/19421` \
`$ git pull https://git.openjdk.org/jdk.git pull/19421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19421`

View PR using the GUI difftool: \
`$ git pr show -t 19421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19421.diff">https://git.openjdk.org/jdk/pull/19421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19421#issuecomment-2134758700)