### PR TITLE
8331731: ubsan: relocInfo.cpp:155:30: runtime error: applying non-zero offset 18446744073709551614 to null pointer

### DIFF
--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -147,7 +147,9 @@ void RelocIterator::initialize(nmethod* nm, address begin, address limit) {
   set_limits(begin, limit);
 }
 
-
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 RelocIterator::RelocIterator(CodeSection* cs, address begin, address limit) {
   initialize_misc();
   assert(((cs->locs_start() != nullptr) && (cs->locs_end() != nullptr)) ||

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -151,7 +151,7 @@ RelocIterator::RelocIterator(CodeSection* cs, address begin, address limit) {
   initialize_misc();
   assert(((cs->locs_start() != nullptr) && (cs->locs_end() != nullptr)) ||
          ((cs->locs_start() == nullptr) && (cs->locs_end() == nullptr)), "valid start and end pointer");
-  _current = sub_from_ptr(cs->locs_start(), 1);
+  _current = sub_from_ptr_maybe_null(cs->locs_start(), 1);
   _end     = cs->locs_end();
   _addr    = cs->start();
   _code    = nullptr; // Not cb->blob();

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -147,14 +147,11 @@ void RelocIterator::initialize(nmethod* nm, address begin, address limit) {
   set_limits(begin, limit);
 }
 
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
 RelocIterator::RelocIterator(CodeSection* cs, address begin, address limit) {
   initialize_misc();
   assert(((cs->locs_start() != nullptr) && (cs->locs_end() != nullptr)) ||
          ((cs->locs_start() == nullptr) && (cs->locs_end() == nullptr)), "valid start and end pointer");
-  _current = cs->locs_start()-1;
+  _current = sub_from_ptr(cs->locs_start(), 1);
   _end     = cs->locs_end();
   _addr    = cs->start();
   _code    = nullptr; // Not cb->blob();

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -250,12 +250,12 @@ class RelocIterator;
 
 // helper templates to avoid undefined addition/subtraction from nullptr
 template<typename T>
-T* add_to_ptr(T* ptr, uintptr_t val) {
+T* add_to_ptr_maybe_null(T* ptr, uintptr_t val) {
   return (T*)((uintptr_t)ptr + val * sizeof(T));
 }
 
 template<typename T>
-T* sub_from_ptr(T* ptr, uintptr_t val) {
+T* sub_from_ptr_maybe_null(T* ptr, uintptr_t val) {
   return (T*)((uintptr_t)ptr - val * sizeof(T));
 }
 
@@ -614,7 +614,7 @@ class RelocIterator : public StackObj {
 
   // get next reloc info, return !eos
   bool next() {
-    _current = add_to_ptr(_current, 1);
+    _current = add_to_ptr_maybe_null(_current, 1);
     assert(_current <= _end, "must not overrun relocInfo");
     if (_current == _end) {
       set_has_current(false);

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -602,6 +602,9 @@ class RelocIterator : public StackObj {
   RelocIterator(CodeSection* cb, address begin = nullptr, address limit = nullptr);
 
   // get next reloc info, return !eos
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
   bool next() {
     _current++;
     assert(_current <= _end, "must not overrun relocInfo");

--- a/src/hotspot/share/code/relocInfo.hpp
+++ b/src/hotspot/share/code/relocInfo.hpp
@@ -248,6 +248,17 @@ class CodeBuffer;
 class CodeSection;
 class RelocIterator;
 
+// helper templates to avoid undefined addition/subtraction from nullptr
+template<typename T>
+T* add_to_ptr(T* ptr, uintptr_t val) {
+  return (T*)((uintptr_t)ptr + val * sizeof(T));
+}
+
+template<typename T>
+T* sub_from_ptr(T* ptr, uintptr_t val) {
+  return (T*)((uintptr_t)ptr - val * sizeof(T));
+}
+
 class relocInfo {
   friend class RelocIterator;
  public:
@@ -602,11 +613,8 @@ class RelocIterator : public StackObj {
   RelocIterator(CodeSection* cb, address begin = nullptr, address limit = nullptr);
 
   // get next reloc info, return !eos
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
   bool next() {
-    _current++;
+    _current = add_to_ptr(_current, 1);
     assert(_current <= _end, "must not overrun relocInfo");
     if (_current == _end) {
       set_has_current(false);


### PR DESCRIPTION
When running on macOS with ubsan enabled, we see some issues in relocInfo  (hpp and cpp); those already occur in the build quite early.

/jdk/src/hotspot/share/code/relocInfo.cpp:155:30: runtime error: applying non-zero offset 18446744073709551614 to null pointer

Similar happens when we add to the _current pointer
    _current++;
this gives :
relocInfo.hpp:606:13: runtime error: applying non-zero offset to non-null pointer 0xfffffffffffffffe produced null pointer

Seems the pointer subtraction/addition worked so far, so it might be an option to disable ubsan for those 2 functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8331731: ubsan: relocInfo.cpp:155:30: runtime error: applying non-zero offset 18446744073709551614 to null pointer`

### Issue
 * [JDK-8331731](https://bugs.openjdk.org/browse/JDK-8331731): ubsan: relocInfo.cpp:155:30: runtime error: applying non-zero offset 18446744073709551614 to null pointer (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19424/head:pull/19424` \
`$ git checkout pull/19424`

Update a local copy of the PR: \
`$ git checkout pull/19424` \
`$ git pull https://git.openjdk.org/jdk.git pull/19424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19424`

View PR using the GUI difftool: \
`$ git pr show -t 19424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19424.diff">https://git.openjdk.org/jdk/pull/19424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19424#issuecomment-2135124848)