### PR TITLE
8332228: TypePollution.java: Unrecognized VM option 'UseSecondarySuperCache'

### DIFF
--- a/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
+++ b/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
@@ -105,28 +105,28 @@ public class TypePollution {
     int probe = 99;
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchLinearNoSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchLinearSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchTableNoSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchTableSCC() {
         return parallelInstanceOfInterfaceSwitch();
@@ -149,25 +149,25 @@ public class TypePollution {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchLinearNoSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchLinearSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchTableNoSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySuperCache"})
+    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchTableSCC() {
         return instanceOfInterfaceSwitch();
     }


### PR DESCRIPTION
Fix obvious typo in micro benchmark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332228](https://bugs.openjdk.org/browse/JDK-8332228): TypePollution.java: Unrecognized VM option 'UseSecondarySuperCache' (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19427/head:pull/19427` \
`$ git checkout pull/19427`

Update a local copy of the PR: \
`$ git checkout pull/19427` \
`$ git pull https://git.openjdk.org/jdk.git pull/19427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19427`

View PR using the GUI difftool: \
`$ git pr show -t 19427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19427.diff">https://git.openjdk.org/jdk/pull/19427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19427#issuecomment-2135307458)