### PR TITLE
8333093: Incorrect comment in zAddress_aarch64.cpp

### DIFF
--- a/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/gc/z/zAddress_aarch64.cpp
@@ -38,7 +38,7 @@
 
 // Default value if probing is not implemented for a certain platform
 // Max address bit is restricted by implicit assumptions in the code, for instance
-// the bit layout of XForwardingEntry or Partial array entry (see XMarkStackEntry) in mark stack
+// the bit layout of ZForwardingEntry or Partial array entry (see ZMarkStackEntry) in mark stack
 static const size_t DEFAULT_MAX_ADDRESS_BIT = 46;
 // Minimum value returned, if probing fail
 static const size_t MINIMUM_MAX_ADDRESS_BIT = 36;


### PR DESCRIPTION
This PR is just updating the comments, so no need for any testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333093](https://bugs.openjdk.org/browse/JDK-8333093): Incorrect comment in zAddress_aarch64.cpp (**Bug** - P5)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19428/head:pull/19428` \
`$ git checkout pull/19428`

Update a local copy of the PR: \
`$ git checkout pull/19428` \
`$ git pull https://git.openjdk.org/jdk.git pull/19428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19428`

View PR using the GUI difftool: \
`$ git pr show -t 19428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19428.diff">https://git.openjdk.org/jdk/pull/19428.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19428#issuecomment-2135421107)