### PR TITLE
8332032: C2: Remove ExpandSubTypeCheckAtParseTime flag

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -767,9 +767,6 @@
   product(bool, UseProfiledLoopPredicate, true,                             \
           "Move predicates out of loops based on profiling data")           \
                                                                             \
-  product(bool, ExpandSubTypeCheckAtParseTime, false, DIAGNOSTIC,           \
-          "Do not use subtype check macro node")                            \
-                                                                            \
   develop(uintx, StressLongCountedLoop, 0,                                  \
           "if > 0, convert int counted loops to long counted loops"         \
           "to stress handling of long counted loops: run inner loop"        \

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2713,17 +2713,12 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
     // Here, the type of 'fa' is often exact, so the store check
     // of fa[1]=x will fold up, without testing the nullness of x.
     //
-    // Do not skip the static sub type check with StressReflectiveCode during
-    // parsing (i.e. with ExpandSubTypeCheckAtParseTime) because the
-    // associated CheckCastNodePP could already be folded when the type
-    // system can prove it's an impossible type. Therefore, we should also
-    // do the static sub type check here to ensure control is folded as well.
-    // Otherwise, the graph is left in a broken state.
     // At macro expansion, we would have already folded the SubTypeCheckNode
     // being expanded here because we always perform the static sub type
     // check in SubTypeCheckNode::sub() regardless of whether
-    // StressReflectiveCode is set or not.
-    switch (C->static_subtype_check(superk, subk, !ExpandSubTypeCheckAtParseTime)) {
+    // StressReflectiveCode is set or not. We can therefore skip this
+    // static check when StressReflectiveCode is on.
+    switch (C->static_subtype_check(superk, subk)) {
     case Compile::SSC_always_false:
       {
         Node* always_fail = *ctrl;
@@ -2904,8 +2899,7 @@ Node* Phase::gen_subtype_check(Node* subklass, Node* superklass, Node** ctrl, No
 }
 
 Node* GraphKit::gen_subtype_check(Node* obj_or_subklass, Node* superklass) {
-  bool expand_subtype_check = C->post_loop_opts_phase() ||   // macro node expansion is over
-                              ExpandSubTypeCheckAtParseTime; // forced expansion
+  bool expand_subtype_check = C->post_loop_opts_phase(); // macro node expansion is over
   if (expand_subtype_check) {
     MergeMemNode* mem = merged_memory();
     Node* ctrl = control();

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckMacroTrichotomy.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
  * @run main/othervm -XX:-BackgroundCompilation TestSubTypeCheckMacroTrichotomy
  * @run main/othervm -XX:-BackgroundCompilation
  *     -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
- *     -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
  *     -XX:-TieredCompilation -XX:CompileThreshold=100 TestSubTypeCheckMacroTrichotomy
  *
  */

--- a/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
+++ b/test/hotspot/jtreg/compiler/types/TestSubTypeCheckWithBottomArray.java
@@ -50,12 +50,10 @@
  *          either against an interface or an unrelated non-sub-class.
  *
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
  *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
  *                   compiler.types.TestSubTypeCheckWithBottomArray
  * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,compiler.types.TestSubTypeCheckWithBottomArray::test*
- *                   -XX:+UnlockDiagnosticVMOptions -XX:+ExpandSubTypeCheckAtParseTime
  *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+StressReflectiveCode
  *                   -XX:CompileCommand=inline,compiler.types.TestSubTypeCheckWithBottomArray::check*
  *                   compiler.types.TestSubTypeCheckWithBottomArray


### PR DESCRIPTION
With this patch I propose to remove the diagnostic product flag `ExpandSubTypeCheckAtParseTime` for the following reasons:
- Expanding sub type checks eagerly during parse time has a maintenance cost. We've had to make special fixes due to skipping `SubTypeCheckNodes` in the past (recent example: [JDK-8328702](https://bugs.openjdk.org/browse/JDK-8328702), where the idea of removing this flag was first discussed).
- This stress option has not helped much to find bugs. Going through JBS, maybe only 1 or 2 bugs can be attributed to this flag over the last 4 years - and even for those, it could have very well be that the flag was not required because it was often accompanied by other stress flags such as `StressReflecitiveCode`.
- We currently have a bug in Valhalla ([JDK-8331912](https://bugs.openjdk.org/browse/JDK-8331912)) which only happens with `ExpandSubTYpeCheckAtParseTime`. The reason is that we lose flatness information due to the eager sub type expansion. Later, data becomes top and the corresponding (already expanded) sub type check fails to fold control as well, leading to a broken graph. The simplest solution is to remove `ExpandSubTYpeCheckAtParseTime`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332032](https://bugs.openjdk.org/browse/JDK-8332032): C2: Remove ExpandSubTypeCheckAtParseTime flag (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19430/head:pull/19430` \
`$ git checkout pull/19430`

Update a local copy of the PR: \
`$ git checkout pull/19430` \
`$ git pull https://git.openjdk.org/jdk.git pull/19430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19430`

View PR using the GUI difftool: \
`$ git pr show -t 19430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19430.diff">https://git.openjdk.org/jdk/pull/19430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19430#issuecomment-2137157401)