### PR TITLE
8332899: RISC-V: add comment and make the code more readable (if possible) in MacroAssembler::movptr

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1680,6 +1680,23 @@ void MacroAssembler::movptr(Register Rd, address addr, int32_t &offset, Register
 
 void MacroAssembler::movptr1(Register Rd, uint64_t imm64, int32_t &offset) {
   // Load upper 31 bits
+  //
+  // In case of 11th bit of `lower` is 0, it's straightforward to understand.
+  // In case of 11th bit of `lower` is 1, it's a bit tricky, to help understand,
+  // image divide both `upper` and `lower` into 2 parts respectively, i.e.
+  // [upper_20, upper_12], [lower_20, lower_12], they are the same just before
+  // `lower = (lower << 52) >> 52;`.
+  // After `upper -= lower;`,
+  //    upper_20' = upper_20 - (-1) == upper_20 + 1
+  //    upper_12 = 0x000
+  // After `lui(Rd, upper);`, `Rd` = upper_20' << 12
+  // Also divide `Rd` into 2 parts [Rd_20, Rd_12],
+  //    Rd_20 == upper_20'
+  //    Rd_12 == 0x000
+  // After `addi(Rd, Rd, lower);`,
+  //    Rd_20 = upper_20' + (-1) == upper_20 + 1 - 1 = upper_20
+  //    Rd_12 = lower_12
+  // So, finally Rd == [upper_20, lower_12]
   int64_t imm = imm64 >> 17;
   int64_t upper = imm, lower = imm;
   lower = (lower << 52) >> 52;
@@ -1700,18 +1717,23 @@ void MacroAssembler::movptr1(Register Rd, uint64_t imm64, int32_t &offset) {
 void MacroAssembler::movptr2(Register Rd, uint64_t addr, int32_t &offset, Register tmp) {
   assert_different_registers(Rd, tmp, noreg);
 
-  uint32_t upper18 = (addr >> 30ull);
-  int32_t  lower30 = (addr & 0x3fffffffu);
-  int32_t  low12   = (lower30 << 20) >> 20;
-  int32_t  mid18   = ((lower30 - low12) >> 12);
+  // addr: [upper18, lower30[mid18, lower12]]
 
-  lui(tmp, upper18 << 12);
-  lui(Rd, mid18 << 12);
+  int64_t upper18 = addr >> 18;
+  lui(tmp, upper18);
+
+  int64_t lower30 = addr & 0x3fffffff;
+  int64_t mid18 = lower30, lower12 = lower30;
+  lower12 = (lower12 << 52) >> 52;
+  // For this tricky part (`mid18 -= lower12;` + `offset = lower12;`),
+  // please refer to movptr1 above.
+  mid18 -= (int32_t)lower12;
+  lui(Rd, mid18);
 
   slli(tmp, tmp, 18);
   add(Rd, Rd, tmp);
 
-  offset = low12;
+  offset = lower12;
 }
 
 void MacroAssembler::add(Register Rd, Register Rn, int64_t increment, Register temp) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1683,7 +1683,7 @@ void MacroAssembler::movptr1(Register Rd, uint64_t imm64, int32_t &offset) {
   //
   // In case of 11th bit of `lower` is 0, it's straightforward to understand.
   // In case of 11th bit of `lower` is 1, it's a bit tricky, to help understand,
-  // image divide both `upper` and `lower` into 2 parts respectively, i.e.
+  // imagine divide both `upper` and `lower` into 2 parts respectively, i.e.
   // [upper_20, upper_12], [lower_20, lower_12], they are the same just before
   // `lower = (lower << 52) >> 52;`.
   // After `upper -= lower;`,


### PR DESCRIPTION
Hi,
Can you help to review the patch?
As discussed, https://github.com/openjdk/jdk/pull/19246#discussion_r1613279908, it's worth to make the code more readable.
For movptr1, add some comments to help understand the tricky part.
For movptr2, it uses the similar (tricky) way as movptr1, so I align the code implementation with movptr1, and try to make it more straightforward.
I tried it, hope it's better.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332899](https://bugs.openjdk.org/browse/JDK-8332899): RISC-V: add comment and make the code more readable (if possible) in MacroAssembler::movptr (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [93de6315](https://git.openjdk.org/jdk/pull/19431/files/93de63154b26e9fcbd8595a4ccbfcdbf9877ccf9)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [93de6315](https://git.openjdk.org/jdk/pull/19431/files/93de63154b26e9fcbd8595a4ccbfcdbf9877ccf9)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19431/head:pull/19431` \
`$ git checkout pull/19431`

Update a local copy of the PR: \
`$ git checkout pull/19431` \
`$ git pull https://git.openjdk.org/jdk.git pull/19431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19431`

View PR using the GUI difftool: \
`$ git pr show -t 19431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19431.diff">https://git.openjdk.org/jdk/pull/19431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19431#issuecomment-2135570854)