### PR TITLE
8326121: vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless.

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
@@ -150,8 +150,6 @@ public class UnloadingTest extends GCTestBase {
     }
 
     private static void checkGCCounters() {
-//        System.out.println("WhiteBox.getWhiteBox().g1GetTotalCollections() = \t" + WhiteBox.getWhiteBox().g1GetTotalCollections());
-//        System.out.println("WhiteBox.getWhiteBox().g1GetTotalFullCollections() = \t" + WhiteBox.getWhiteBox().g1GetTotalFullCollections());
         GarbageCollectorMXBean oldGenBean = null;
         for (GarbageCollectorMXBean bean : ManagementFactory.getGarbageCollectorMXBeans()) {
             System.out.println("bean.getName() = \t\"" + bean.getName() + "\", bean.getCollectionCount() = \t" + bean.getCollectionCount());
@@ -159,7 +157,7 @@ public class UnloadingTest extends GCTestBase {
                 oldGenBean = bean;
             }
         }
-//        if (WhiteBox.getWhiteBox().g1GetTotalFullCollections() != 0 || (oldGenBean != null && oldGenBean.getCollectionCount() != 0)) {
+
         if (oldGenBean != null && oldGenBean.getCollectionCount() != 0) {
             throw new SkippedException("Full gc happened, skip the test.");
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/g1/unloading/UnloadingTest.java
@@ -161,7 +161,7 @@ public class UnloadingTest extends GCTestBase {
         }
 //        if (WhiteBox.getWhiteBox().g1GetTotalFullCollections() != 0 || (oldGenBean != null && oldGenBean.getCollectionCount() != 0)) {
         if (oldGenBean != null && oldGenBean.getCollectionCount() != 0) {
-            throw new RuntimeException("Full gc happened. Test was useless.");
+            throw new SkippedException("Full gc happened, skip the test.");
         }
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
@@ -23,9 +23,10 @@
 
 package nsk.share.test;
 
+import jtreg.SkippedException;
+
 import nsk.share.log.*;
 import nsk.share.runner.*;
-import jtreg.SkippedException;
 import nsk.share.TestFailure;
 
 public class Tests {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
@@ -84,7 +84,7 @@ public class Tests {
                                         ((Runnable) o).run();
                                 if (o instanceof TestExitCode)
                                         exitCode = ((TestExitCode) o).getExitCode();
-                        }catch (SkippedException se) {
+                        } catch (SkippedException se) {
                                 throw se;
                         } catch (RuntimeException t) {
                                 getLog().error(t);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/test/Tests.java
@@ -25,6 +25,7 @@ package nsk.share.test;
 
 import nsk.share.log.*;
 import nsk.share.runner.*;
+import jtreg.SkippedException;
 import nsk.share.TestFailure;
 
 public class Tests {
@@ -82,6 +83,8 @@ public class Tests {
                                         ((Runnable) o).run();
                                 if (o instanceof TestExitCode)
                                         exitCode = ((TestExitCode) o).getExitCode();
+                        }catch (SkippedException se) {
+                                throw se;
                         } catch (RuntimeException t) {
                                 getLog().error(t);
                                 exitCode = 97;


### PR DESCRIPTION
Hi all,

Please review this change to trigger SkippedException instead of RunTimeExceptions when a test is deemed useless because of full-GCs. The test triggers frequent `System.gc()` calls which in some cases may aggressively shrink the heap, and subsequent allocations lead to full-GC. This may affect the usefulness of the test, but it is not a test failure. So we added  SkippedException to indicate this situation.

Testing: Local testing with very small heaps.
              Tier 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8326121: vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless.`
Found leading lowercase letter in issue title for `8326121: vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless.`

### Issue
 * [JDK-8326121](https://bugs.openjdk.org/browse/JDK-8326121): vmTestbase/gc/g1/unloading/tests/unloading_keepRef_rootClass_inMemoryCompilation_keep_cl failed with Full gc happened. Test was useless. (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) ⚠️ Review applies to [59d2462c](https://git.openjdk.org/jdk/pull/19432/files/59d2462cbd15851cf69016e89eb709924e18966d)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19432/head:pull/19432` \
`$ git checkout pull/19432`

Update a local copy of the PR: \
`$ git checkout pull/19432` \
`$ git pull https://git.openjdk.org/jdk.git pull/19432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19432`

View PR using the GUI difftool: \
`$ git pr show -t 19432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19432.diff">https://git.openjdk.org/jdk/pull/19432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19432#issuecomment-2135879617)