### PR TITLE
8333105: Shenandoah: Results of concurrent mark may be lost for degenerated cycle

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -127,21 +127,11 @@ bool ShenandoahConcurrentGC::collect(GCCause::Cause cause) {
   // Complete marking under STW, and start evacuation
   vmop_entry_final_mark();
 
-  // If the GC was cancelled just before final mark (but after the preceding cancellation check),
-  // then the safepoint operation will do nothing and the concurrent mark will still be in progress.
-  // In this case it is safe (and necessary) to resume the degenerated cycle from the marking phase.
-  //
-  // On the other hand, if the GC is cancelled after final mark (but before this check), then the
-  // final mark safepoint operation will have finished the mark (setting concurrent mark in progress
-  // to false). In this case (final mark has completed), we need control to fall past the next
-  // cancellation check and resume the degenerated cycle from the evacuation phase.
+  // If the GC was cancelled before final mark, nothing happens on the safepoint. We are still
+  // in the marking phase and must resume the degenerated cycle from there. If the GC was cancelled
+  // after final mark, then we've entered the evacuation phase and must resume the degenerated cycle
+  // from that phase.
   if (heap->is_concurrent_mark_in_progress()) {
-    // If the concurrent mark is still in progress after the final mark safepoint, then the GC has
-    // been cancelled. The degenerated cycle must resume from the marking phase. Without this check,
-    // the non-generational mode may fall all the way to the end of this collect routine without
-    // having done anything (besides mark most of the heap). Without having collected anything, we
-    // can expect an 'out of cycle' degenerated GC which will again mark the entire heap. This is
-    // not optimal.
     bool cancelled = check_cancellation_and_abort(ShenandoahDegenPoint::_degenerated_mark);
     assert(cancelled, "GC must have been cancelled between concurrent and final mark");
     return false;

--- a/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahGC.hpp
@@ -56,6 +56,7 @@ public:
     _DEGENERATED_LIMIT
   };
 
+  // Returns false if the collection was cancelled, true otherwise.
   virtual bool collect(GCCause::Cause cause) = 0;
   static const char* degen_point_to_string(ShenandoahDegenPoint point);
 


### PR DESCRIPTION
If Shenandoah does not detect a cancellation after completing concurrent mark, but before completing final mark it will fall through the concurrent cycle without collecting anything. This will shortly lead to a degenerated cycle which will _not_ use the results from the nearly complete concurrent mark. This will result in an unnecessarily longer degenerated cycle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333105](https://bugs.openjdk.org/browse/JDK-8333105): Shenandoah: Results of concurrent mark may be lost for degenerated cycle (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role) ⚠️ Review applies to [165b3f76](https://git.openjdk.org/jdk/pull/19434/files/165b3f76c98a435dd8b2c8046de98a4abdeeec2a)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [165b3f76](https://git.openjdk.org/jdk/pull/19434/files/165b3f76c98a435dd8b2c8046de98a4abdeeec2a)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [165b3f76](https://git.openjdk.org/jdk/pull/19434/files/165b3f76c98a435dd8b2c8046de98a4abdeeec2a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19434/head:pull/19434` \
`$ git checkout pull/19434`

Update a local copy of the PR: \
`$ git checkout pull/19434` \
`$ git pull https://git.openjdk.org/jdk.git pull/19434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19434`

View PR using the GUI difftool: \
`$ git pr show -t 19434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19434.diff">https://git.openjdk.org/jdk/pull/19434.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19434#issuecomment-2135837072)