### PR TITLE
8332955: ubsan: runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList'

### DIFF
--- a/src/hotspot/share/memory/metaspace/runningCounters.cpp
+++ b/src/hotspot/share/memory/metaspace/runningCounters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,7 +45,8 @@ size_t RunningCounters::reserved_words_class() {
 }
 
 size_t RunningCounters::reserved_words_nonclass() {
-  return VirtualSpaceList::vslist_nonclass()->reserved_words();
+  VirtualSpaceList* vs = VirtualSpaceList::vslist_nonclass();
+  return vs != nullptr ? vs->reserved_words() : 0;
 }
 
 // Return total committed size, in words, for Metaspace
@@ -59,7 +60,8 @@ size_t RunningCounters::committed_words_class() {
 }
 
 size_t RunningCounters::committed_words_nonclass() {
-  return VirtualSpaceList::vslist_nonclass()->committed_words();
+  VirtualSpaceList* vs = VirtualSpaceList::vslist_nonclass();
+  return vs != nullptr ? vs->committed_words() : 0;
 }
 
 // ---- used chunks -----
@@ -90,7 +92,8 @@ size_t RunningCounters::free_chunks_words_class() {
 }
 
 size_t RunningCounters::free_chunks_words_nonclass() {
-  return ChunkManager::chunkmanager_nonclass()->total_word_size();
+  ChunkManager* cm = ChunkManager::chunkmanager_nonclass();
+  return cm != nullptr ? cm->total_word_size() : 0;
 }
 
 } // namespace metaspace


### PR DESCRIPTION
@MBaesken and @dholmes-ora convinced me this needs fixing. Fix is trivial; for details, please see JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332955: ubsan: runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList'`

### Issue
 * [JDK-8332955](https://bugs.openjdk.org/browse/JDK-8332955): ubsan: runningCounters.cpp:48:61: runtime error: member call on null pointer of type 'struct VirtualSpaceList' (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19435/head:pull/19435` \
`$ git checkout pull/19435`

Update a local copy of the PR: \
`$ git checkout pull/19435` \
`$ git pull https://git.openjdk.org/jdk.git pull/19435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19435`

View PR using the GUI difftool: \
`$ git pr show -t 19435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19435.diff">https://git.openjdk.org/jdk/pull/19435.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19435#issuecomment-2136519630)