### PR TITLE
8333108: Update vmTestbase/nsk/share/DebugeeProcess.java to don't use finalization

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/BScenarios/multithrd/tc04x001.java
@@ -110,6 +110,11 @@ public class tc04x001 {
             e.printStackTrace();
         } finally {
             debugee.resume();
+            int code = debugee.waitFor();
+            if (code != Consts.JCK_STATUS_BASE) {
+                log.complain("Debugee FAILED with exit code: " + code);
+                exitStatus = Consts.TEST_FAILED;
+            }
         }
         display("Test finished. exitStatus = " + exitStatus);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMDeathEvent/_itself_/vmdeath003.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VMDeathEvent/_itself_/vmdeath003.java
@@ -280,7 +280,12 @@ public class vmdeath003 extends JDIBase {
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
         log1("    TESTING ENDS");
-        return;
+        int code = debuggee.waitFor();
+        if (code != Consts.JCK_STATUS_BASE) {
+            log2("Debugee FAILED with exit code: " + code);
+            testExitCode = Consts.TEST_FAILED;
+        }
+
     }
 
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/exit/exit001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VirtualMachine/exit/exit001.java
@@ -173,6 +173,12 @@ public class exit001 {
             logHandler.complain("TEST FAILED");
         }
 
+        int code = debuggee.waitFor();
+        if (code != 0) {
+            log2("Debugee FAILED with exit code: " + code);
+            testExitCode = Consts.TEST_FAILED;
+        }
+
         return testExitCode;
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Binder.java
@@ -128,8 +128,6 @@ public class Binder extends DebugeeBinder {
      */
     public Debugee makeLocalDebugee(Process process) {
         LocalLaunchedDebugee debugee = new LocalLaunchedDebugee(process, this);
-
-        debugee.registerCleanup();
         return debugee;
     }
 
@@ -936,9 +934,6 @@ public class Binder extends DebugeeBinder {
         }
 
         RemoteLaunchedDebugee debugee = new RemoteLaunchedDebugee(this);
-
-        debugee.registerCleanup();
-
         return debugee;
     }
 
@@ -949,9 +944,6 @@ public class Binder extends DebugeeBinder {
     protected ManualLaunchedDebugee startManualDebugee(String cmd) {
         ManualLaunchedDebugee debugee = new ManualLaunchedDebugee(this);
         debugee.launchDebugee(cmd);
-
-        debugee.registerCleanup();
-
         return debugee;
     }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/Binder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,8 +105,6 @@ final public class Binder extends DebugeeBinder {
             debugee = launchDebugee(classToExecute);
             debugee.redirectOutput(log);
         }
-
-        debugee.registerCleanup();
 
         Transport transport = debugee.connect();
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ import java.util.function.Consumer;
  * @see nsk.share.jdi.Debugee
  * @see nsk.share.jdwp.Debugee
  */
-abstract public class DebugeeProcess extends FinalizableObject {
+abstract public class DebugeeProcess {
 
     /** Default prefix for log messages. */
     public static final String LOG_PREFIX = "binder> ";
@@ -84,9 +84,6 @@ abstract public class DebugeeProcess extends FinalizableObject {
     protected DebugeeProcess (DebugeeBinder binder) {
         this.binder = binder;
         this.log = binder.getLog();
-
-        // Register the cleanup() method to be called when this instance becomes unreachable.
-        registerCleanup();
     }
 
     /**
@@ -430,7 +427,7 @@ abstract public class DebugeeProcess extends FinalizableObject {
     /**
      * Kill the debugee VM if it is not terminated yet.
      *
-     * @throws Throwable if any throwable exception is thrown during finalization
+     * @throws Throwable if any throwable exception is thrown during shutdown
      */
     public void close() {
         if (checkTermination) {
@@ -458,12 +455,4 @@ abstract public class DebugeeProcess extends FinalizableObject {
         log.complain(prefix + message);
     }
 
-    /**
-     * Finalize debuggee VM wrapper by invoking <code>close()</code>.
-     *
-     * @throws Throwable if any throwable exception is thrown during finalization
-     */
-    public void cleanup() {
-        close();
-    }
 }


### PR DESCRIPTION
The 
test/hotspot/jtreg/vmTestbase/nsk/share/jpda/DebugeeProcess.java
uses cleanup() to kill debuggee process.

However, most tests kill the debuggee process explicitly. I verified that debuggee process is killed before test finishes. (Just by printing it's status.)

The fix adds a few checks debuggee.waitFor() int tests that didn't check debuggee process code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333108](https://bugs.openjdk.org/browse/JDK-8333108): Update vmTestbase/nsk/share/DebugeeProcess.java to don't use finalization (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19437/head:pull/19437` \
`$ git checkout pull/19437`

Update a local copy of the PR: \
`$ git checkout pull/19437` \
`$ git pull https://git.openjdk.org/jdk.git pull/19437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19437`

View PR using the GUI difftool: \
`$ git pr show -t 19437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19437.diff">https://git.openjdk.org/jdk/pull/19437.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19437#issuecomment-2136051255)