### PR TITLE
8328611: Thread safety issue in com.sun.tools.jdi.ReferenceTypeImpl::classObject

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -222,8 +222,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public ClassLoaderReference classLoader() {
         if (!isClassLoaderCached) {
-            // Does not need synchronization, since worst-case
-            // static info is fetched twice
+            // Does not need synchronization. Worst-case case is static info is fetched twice
             try {
                 classLoader = JDWP.ReferenceType.ClassLoader.
                     process(vm, this).classLoader;
@@ -693,18 +692,13 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     }
 
     public ClassObjectReference classObject() {
+        // Does not need synchronization. Worst-case case is static info is fetched twice
         if (classObject == null) {
-            // Are classObjects unique for an Object, or
-            // created each time? Is this spec'ed?
-            synchronized(this) {
-                if (classObject == null) {
-                    try {
-                        classObject = JDWP.ReferenceType.ClassObject.
-                            process(vm, this).classObject;
-                    } catch (JDWPException exc) {
-                        throw exc.toJDIException();
-                    }
-                }
+            try {
+                classObject = JDWP.ReferenceType.ClassObject.
+                    process(vm, this).classObject;
+            } catch (JDWPException exc) {
+                throw exc.toJDIException();
             }
         }
         return classObject;

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -182,8 +182,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public String signature() {
         if (signature == null) {
-            // Does not need synchronization, since worst-case
-            // static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice
             if (vm.canGet1_5LanguageFeatures()) {
                 /*
                  * we might as well get both the signature and the
@@ -205,8 +204,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     public String genericSignature() {
         // This gets both the signature and the generic signature
         if (vm.canGet1_5LanguageFeatures() && !genericSignatureGotten) {
-            // Does not need synchronization, since worst-case
-            // static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice
             JDWP.ReferenceType.SignatureWithGeneric result;
             try {
                 result = JDWP.ReferenceType.SignatureWithGeneric.
@@ -222,7 +220,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public ClassLoaderReference classLoader() {
         if (!isClassLoaderCached) {
-            // Does not need synchronization. Worst-case case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice
             try {
                 classLoader = JDWP.ReferenceType.ClassLoader.
                     process(vm, this).classLoader;
@@ -238,9 +236,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
         if (module != null) {
             return module;
         }
-        // Does not need synchronization, since worst-case
-        // static info is fetched twice
         try {
+            // Does not need synchronization. Worst case is static info is fetched twice
             ModuleReferenceImpl m = JDWP.ReferenceType.Module.
                 process(vm, this).module;
             module = vm.getModule(m.ref());
@@ -692,8 +689,8 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     }
 
     public ClassObjectReference classObject() {
-        // Does not need synchronization. Worst-case case is static info is fetched twice
         if (classObject == null) {
+            // Does not need synchronization. Worst case is static info is fetched twice
             try {
                 classObject = JDWP.ReferenceType.ClassObject.
                     process(vm, this).classObject;
@@ -741,8 +738,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     String baseSourceName() throws AbsentInformationException {
         String bsn = baseSourceName;
         if (bsn == null) {
-            // Does not need synchronization, since worst-case
-            // static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice
             try {
                 bsn = JDWP.ReferenceType.SourceFile.
                     process(vm, this).sourceFile;
@@ -1059,13 +1055,12 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
         }
     }
 
-    // Does not need synchronization, since worst-case
-    // static info is fetched twice
     void getModifiers() {
         if (modifiers != -1) {
             return;
         }
         try {
+            // Does not need synchronization. Worst case is static info is fetched twice
             modifiers = JDWP.ReferenceType.Modifiers.
                                   process(vm, this).modBits;
         } catch (JDWPException exc) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/ReferenceTypeImpl.java
@@ -182,7 +182,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public String signature() {
         if (signature == null) {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             if (vm.canGet1_5LanguageFeatures()) {
                 /*
                  * we might as well get both the signature and the
@@ -204,7 +204,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     public String genericSignature() {
         // This gets both the signature and the generic signature
         if (vm.canGet1_5LanguageFeatures() && !genericSignatureGotten) {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             JDWP.ReferenceType.SignatureWithGeneric result;
             try {
                 result = JDWP.ReferenceType.SignatureWithGeneric.
@@ -220,7 +220,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public ClassLoaderReference classLoader() {
         if (!isClassLoaderCached) {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             try {
                 classLoader = JDWP.ReferenceType.ClassLoader.
                     process(vm, this).classLoader;
@@ -237,7 +237,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
             return module;
         }
         try {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             ModuleReferenceImpl m = JDWP.ReferenceType.Module.
                 process(vm, this).module;
             module = vm.getModule(m.ref());
@@ -690,7 +690,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
 
     public ClassObjectReference classObject() {
         if (classObject == null) {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             try {
                 classObject = JDWP.ReferenceType.ClassObject.
                     process(vm, this).classObject;
@@ -738,7 +738,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
     String baseSourceName() throws AbsentInformationException {
         String bsn = baseSourceName;
         if (bsn == null) {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             try {
                 bsn = JDWP.ReferenceType.SourceFile.
                     process(vm, this).sourceFile;
@@ -1060,7 +1060,7 @@ public abstract class ReferenceTypeImpl extends TypeImpl implements ReferenceTyp
             return;
         }
         try {
-            // Does not need synchronization. Worst case is static info is fetched twice
+            // Does not need synchronization. Worst case is static info is fetched twice.
             modifiers = JDWP.ReferenceType.Modifiers.
                                   process(vm, this).modBits;
         } catch (JDWPException exc) {


### PR DESCRIPTION
Fixed "double-checked-locking" bug in `ReferenceImplType.classObject()`. Details in the first comment. Tested with the following:
- com/sun/jdi
- nsk/jdi
- nsk/jdwp
- nsk/jdb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328611](https://bugs.openjdk.org/browse/JDK-8328611): Thread safety issue in com.sun.tools.jdi.ReferenceTypeImpl::classObject (**Bug** - P5)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [97376705](https://git.openjdk.org/jdk/pull/19439/files/97376705288ff8c215c073b12636cfefb1ba9600)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19439/head:pull/19439` \
`$ git checkout pull/19439`

Update a local copy of the PR: \
`$ git checkout pull/19439` \
`$ git pull https://git.openjdk.org/jdk.git pull/19439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19439`

View PR using the GUI difftool: \
`$ git pr show -t 19439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19439.diff">https://git.openjdk.org/jdk/pull/19439.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19439#issuecomment-2136260659)