### PR TITLE
8216984: Deprecate for removal Socket constructors to create UDP sockets

### DIFF
--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -486,9 +486,9 @@ public class Socket implements java.io.Closeable {
      *             the specified range of valid port values, which is between
      *             0 and 65535, inclusive.
      * @see        SecurityManager#checkConnect
-     * @deprecated Use DatagramSocket instead for UDP transport.
+     * @deprecated Use {@link DatagramSocket} instead for UDP transport.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1")
     @SuppressWarnings("this-escape")
     public Socket(String host, int port, boolean stream) throws IOException {
         this(host != null ? new InetSocketAddress(host, port) :
@@ -529,9 +529,9 @@ public class Socket implements java.io.Closeable {
      *             0 and 65535, inclusive.
      * @throws     NullPointerException if {@code host} is null.
      * @see        SecurityManager#checkConnect
-     * @deprecated Use DatagramSocket instead for UDP transport.
+     * @deprecated Use {@link DatagramSocket} instead for UDP transport.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "1.1")
     @SuppressWarnings("this-escape")
     public Socket(InetAddress host, int port, boolean stream) throws IOException {
         this(host != null ? new InetSocketAddress(host, port) : null,

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -81,8 +81,9 @@ public abstract class SocketImpl implements SocketOptions {
      * Creates either a stream or a datagram socket.
      *
      * @apiNote
-     * {@code SocketImpl} should not be used for datagram sockets.
-     * Creating a datagram socket using this method is deprecated.
+     * The {@link Socket} constructors to create a datagram socket
+     * are deprecated for removal. This method will be re-specified
+     * in a future release to not support creating datagram sockets.
      *
      * @param      stream   if {@code true}, create a stream socket;
      *                      otherwise, create a datagram socket.

--- a/src/java.base/share/classes/java/net/SocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocketImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,10 @@ public abstract class SocketImpl implements SocketOptions {
 
     /**
      * Creates either a stream or a datagram socket.
+     *
+     * @apiNote
+     * {@code SocketImpl} should not be used for datagram sockets.
+     * Creating a datagram socket using this method is deprecated.
      *
      * @param      stream   if {@code true}, create a stream socket;
      *                      otherwise, create a datagram socket.


### PR DESCRIPTION
Can I please get a review of this change which marks 2 constructors on `java.net.Socket` as deprecated for removal?

As noted in https://bugs.openjdk.org/browse/JDK-8216984 these 2 `Socket` constructors, which allow for `stream=false` to construct a UDP socket, have been deprecated since several releases (starting Java 1.1). `java.net.DatagramSocket` has been a standard API for dealing with UDP sockets as noted in the already existing deprecation note on these constructors.

The commit in this PR marks these constructs as deprecated for removal to allow for their removal in some future release.

No new tests have been added for this change. tier1, tier2 and tier3 testing is currently in progress.

A CSR for this change is available at https://bugs.openjdk.org/browse/JDK-8333092

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8333092](https://bugs.openjdk.org/browse/JDK-8333092) to be approved

### Issues
 * [JDK-8216984](https://bugs.openjdk.org/browse/JDK-8216984): Deprecate for removal Socket constructors to create UDP sockets (**Enhancement** - P3)
 * [JDK-8333092](https://bugs.openjdk.org/browse/JDK-8333092): Deprecate for removal Socket constructors to create UDP sockets (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19441/head:pull/19441` \
`$ git checkout pull/19441`

Update a local copy of the PR: \
`$ git checkout pull/19441` \
`$ git pull https://git.openjdk.org/jdk.git pull/19441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19441`

View PR using the GUI difftool: \
`$ git pr show -t 19441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19441.diff">https://git.openjdk.org/jdk/pull/19441.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19441#issuecomment-2136336680)