### PR TITLE
8332119: Incorrect IllegalArgumentException for C2 compiled permute kernel

### DIFF
--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -350,7 +350,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_vector_frombits_coerced();
   bool inline_vector_shuffle_to_vector();
   bool inline_vector_shuffle_iota();
-  Node* wrap_indexes(Node* index_vec, int num_elem, BasicType type_bt);
+  Node* partially_wrap_indexes(Node* index_vec, int num_elem, BasicType type_bt);
   bool inline_vector_mask_operation();
   bool inline_vector_mem_operation(bool is_store);
   bool inline_vector_mem_masked_operation(bool is_store);

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -350,6 +350,7 @@ class LibraryCallKit : public GraphKit {
   bool inline_vector_frombits_coerced();
   bool inline_vector_shuffle_to_vector();
   bool inline_vector_shuffle_iota();
+  Node* wrap_indexes(Node* index_vec, int num_elem, BasicType type_bt);
   bool inline_vector_mask_operation();
   bool inline_vector_mem_operation(bool is_store);
   bool inline_vector_mem_masked_operation(bool is_store);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -511,6 +511,27 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   return true;
 }
 
+Node* LibraryCallKit::wrap_indexes(Node* index_vec, int num_elem, BasicType elem_bt) {
+  assert(elem_bt == T_BYTE, "");
+  const TypeVect * vt  = TypeVect::make(elem_bt, num_elem);
+  const Type * type_bt = Type::get_const_basic_type(elem_bt);
+
+  Node* mod_val = gvn().makecon(TypeInt::make(num_elem-1));
+  Node* bcast_mod  = gvn().transform(VectorNode::scalar2vector(mod_val, num_elem, type_bt));
+
+  BoolTest::mask pred = BoolTest::ugt;
+  ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(pred));
+  Node* lane_cnt  = gvn().makecon(TypeInt::make(num_elem));
+  Node* bcast_lane_cnt = gvn().transform(VectorNode::scalar2vector(lane_cnt, num_elem, type_bt));
+  const TypeVect* vmask_type = TypeVect::makemask(type_bt, num_elem);
+  Node*  mask = gvn().transform(new VectorMaskCmpNode(pred, bcast_lane_cnt, index_vec, pred_node, vmask_type));
+
+  // Make the indices greater than lane count as -ve values to match the java side implementation.
+  index_vec = gvn().transform(VectorNode::make(Op_AndV, index_vec, bcast_mod, vt));
+  Node* biased_val = gvn().transform(VectorNode::make(Op_SubVB, index_vec, bcast_lane_cnt, vt));
+  return gvn().transform(new VectorBlendNode(biased_val, index_vec, mask));
+}
+
 // <Sh extends VectorShuffle<E>,  E>
 //  Sh ShuffleIota(Class<?> E, Class<?> shuffleClass, Vector.Species<E> s, int length,
 //                  int start, int step, int wrap, ShuffleIotaOperation<Sh, E> defaultImpl)
@@ -598,16 +619,7 @@ bool LibraryCallKit::inline_vector_shuffle_iota() {
     // Wrap the indices greater than lane count.
      res = gvn().transform(VectorNode::make(Op_AndV, res, bcast_mod, vt));
   } else {
-    ConINode* pred_node = (ConINode*)gvn().makecon(TypeInt::make(BoolTest::ugt));
-    Node * lane_cnt  = gvn().makecon(TypeInt::make(num_elem));
-    Node * bcast_lane_cnt = gvn().transform(VectorNode::scalar2vector(lane_cnt, num_elem, type_bt));
-    const TypeVect* vmask_type = TypeVect::makemask(elem_bt, num_elem);
-    Node* mask = gvn().transform(new VectorMaskCmpNode(BoolTest::ugt, bcast_lane_cnt, res, pred_node, vmask_type));
-
-    // Make the indices greater than lane count as -ve values to match the java side implementation.
-    res = gvn().transform(VectorNode::make(Op_AndV, res, bcast_mod, vt));
-    Node * biased_val = gvn().transform(VectorNode::make(Op_SubVB, res, bcast_lane_cnt, vt));
-    res = gvn().transform(new VectorBlendNode(biased_val, res, mask));
+     res = wrap_indexes(res, num_elem, elem_bt);
   }
 
   ciKlass* sbox_klass = shuffle_klass->const_oop()->as_instance()->java_lang_Class_klass();
@@ -2286,6 +2298,16 @@ bool LibraryCallKit::inline_vector_convert() {
     return false;
   }
 
+
+  if (is_vector_shuffle(vbox_klass_to) &&
+      (!arch_supports_vector(Op_SubVB, num_elem_to, elem_bt_to, VecMaskNotUsed)           ||
+       !arch_supports_vector(Op_VectorBlend, num_elem_to, elem_bt_to, VecMaskNotUsed)     ||
+       !arch_supports_vector(Op_VectorMaskCmp, num_elem_to, elem_bt_to, VecMaskNotUsed)   ||
+       !arch_supports_vector(Op_AndV, num_elem_to, elem_bt_to, VecMaskNotUsed)            ||
+       !arch_supports_vector(Op_Replicate, num_elem_to, elem_bt_to, VecMaskNotUsed))) {
+    return false;
+  }
+
   // At this point, we know that both input and output vector registers are supported
   // by the architecture. Next check if the casted type is simply to same type - which means
   // that it is actually a resize and not a cast.
@@ -2381,6 +2403,10 @@ bool LibraryCallKit::inline_vector_convert() {
   } else if (!Type::equals(src_type, dst_type)) {
     assert(!is_cast, "must be reinterpret");
     op = gvn().transform(new VectorReinterpretNode(op, src_type, dst_type));
+  }
+
+  if (is_vector_shuffle(vbox_klass_to)) {
+     op = wrap_indexes(op, num_elem_to, elem_bt_to);
   }
 
   const TypeInstPtr* vbox_type_to = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass_to);

--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -511,7 +511,7 @@ bool LibraryCallKit::inline_vector_nary_operation(int n) {
   return true;
 }
 
-Node* LibraryCallKit::wrap_indexes(Node* index_vec, int num_elem, BasicType elem_bt) {
+Node* LibraryCallKit::partially_wrap_indexes(Node* index_vec, int num_elem, BasicType elem_bt) {
   assert(elem_bt == T_BYTE, "");
   const TypeVect * vt  = TypeVect::make(elem_bt, num_elem);
   const Type * type_bt = Type::get_const_basic_type(elem_bt);
@@ -619,7 +619,7 @@ bool LibraryCallKit::inline_vector_shuffle_iota() {
     // Wrap the indices greater than lane count.
      res = gvn().transform(VectorNode::make(Op_AndV, res, bcast_mod, vt));
   } else {
-     res = wrap_indexes(res, num_elem, elem_bt);
+     res = partially_wrap_indexes(res, num_elem, elem_bt);
   }
 
   ciKlass* sbox_klass = shuffle_klass->const_oop()->as_instance()->java_lang_Class_klass();
@@ -2406,7 +2406,7 @@ bool LibraryCallKit::inline_vector_convert() {
   }
 
   if (is_vector_shuffle(vbox_klass_to)) {
-     op = wrap_indexes(op, num_elem_to, elem_bt_to);
+     op = partially_wrap_indexes(op, num_elem_to, elem_bt_to);
   }
 
   const TypeInstPtr* vbox_type_to = TypeInstPtr::make_exact(TypePtr::NotNull, vbox_klass_to);

--- a/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @bug 8332119
+* @summary Incorrect IllegalArgumentException for C2 compiled permute kernel
+* @modules jdk.incubator.vector
+* @requires vm.compiler2.enabled
+* @library /test/lib /
+* @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation -XX:CompileOnly=TestTwoVectorPermute::micro compiler.vectorapi.TestTwoVectorPermute
+* @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation compiler.vectorapi.TestTwoVectorPermute
+*/
+package compiler.vectorapi;
+
+
+import jdk.incubator.vector.*;
+import java.util.Arrays;
+import java.util.Random;
+
+public class TestTwoVectorPermute {
+   public static final VectorSpecies<Float> FSP = FloatVector.SPECIES_256;
+
+   public static void validate(float [] res, float [] shuf, float [] src1, float [] src2) {
+       for (int i = 0; i < res.length; i++) {
+           float expected = Float.NaN;
+           // Exceptional index.
+           if (shuf[i] < 0 || shuf[i] >= FSP.length()) {
+               int wrapped_index = ((int)shuf[i] & (FSP.length() - 1));
+               if (Integer.compareUnsigned((int)shuf[i], FSP.length()) > 0) {
+                   wrapped_index -= FSP.length();
+               }
+               wrapped_index = wrapped_index < 0 ? wrapped_index + FSP.length() : wrapped_index;
+               expected = src2[wrapped_index];
+           } else {
+               expected = src1[(int)shuf[i]];
+           }
+           if (res[i] != expected) {
+              throw new AssertionError("Result mismatch at " + i + " index, (actual = " + res[i] + ") != ( expected " +   expected + " )");
+           }
+       }
+   }
+
+   public static void micro(float [] res, float [] shuf, float [] src1, float [] src2) {
+       VectorShuffle<Float> vshuf = FloatVector.fromArray(FSP, shuf, 0).toShuffle();
+       VectorShuffle<Float> vshuf_wrapped = vshuf.wrapIndexes();
+       FloatVector.fromArray(FSP, src1, 0)
+         .rearrange(vshuf_wrapped)
+         .blend(FloatVector.fromArray(FSP, src2, 0)
+                           .rearrange(vshuf_wrapped),
+                           vshuf.laneIsValid().not())
+         .intoArray(res, 0);
+   }
+
+   public static void main(String [] args) {
+       float [] res  = new float[FSP.length()];
+       float [] shuf = new float[FSP.length()];
+       float [] src1 = new float[FSP.length()];
+       float [] src2 = new float[FSP.length()];
+
+       for (int i = 0; i < FSP.length(); i++) {
+           shuf[i] = i * 2;
+       }
+       for (int i = 0; i < FSP.length(); i++) {
+           src1[i] = i;
+           src2[i] = i + FSP.length();
+       }
+       for (int i = 0; i < 10000; i++) {
+           micro(res, shuf, src1, src2);
+       }
+       validate(res, shuf, src1, src2);
+       for (int i = 0; i < FSP.length(); i++) {
+           shuf[i] = -i * 2;
+       }
+       for (int i = 0; i < 10000; i++) {
+           micro(res, shuf, src1, src2);
+       }
+       validate(res, shuf, src1, src2);
+       System.out.println("PASSED");
+   }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
@@ -44,16 +44,17 @@ public class TestTwoVectorPermute {
    public static void validate(float [] res, float [] shuf, float [] src1, float [] src2) {
        for (int i = 0; i < res.length; i++) {
            float expected = Float.NaN;
+           int shuf_index = (int)shuf[i];
            // Exceptional index.
-           if (shuf[i] < 0 || shuf[i] >= FSP.length()) {
-               int wrapped_index = ((int)shuf[i] & (FSP.length() - 1));
-               if (Integer.compareUnsigned((int)shuf[i], FSP.length()) > 0) {
+           if (shuf_index < 0 || shuf_index >= FSP.length()) {
+               int wrapped_index = (shuf_index & (FSP.length() - 1));
+               if (Integer.compareUnsigned(shuf_index, FSP.length()) > 0) {
                    wrapped_index -= FSP.length();
                }
                wrapped_index = wrapped_index < 0 ? wrapped_index + FSP.length() : wrapped_index;
                expected = src2[wrapped_index];
            } else {
-               expected = src1[(int)shuf[i]];
+               expected = src1[shuf_index];
            }
            if (res[i] != expected) {
               throw new AssertionError("Result mismatch at " + i + " index, (actual = " + res[i] + ") != ( expected " +   expected + " )");

--- a/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/TestTwoVectorPermute.java
@@ -26,10 +26,10 @@
 * @bug 8332119
 * @summary Incorrect IllegalArgumentException for C2 compiled permute kernel
 * @modules jdk.incubator.vector
-* @requires vm.compiler2.enabled
 * @library /test/lib /
 * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation -XX:CompileOnly=TestTwoVectorPermute::micro compiler.vectorapi.TestTwoVectorPermute
 * @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:-TieredCompilation compiler.vectorapi.TestTwoVectorPermute
+* @run main/othervm -XX:+UnlockDiagnosticVMOptions -Xbatch -XX:TieredStopAtLevel=3 compiler.vectorapi.TestTwoVectorPermute
 */
 package compiler.vectorapi;
 
@@ -41,7 +41,7 @@ import java.util.Random;
 public class TestTwoVectorPermute {
    public static final VectorSpecies<Float> FSP = FloatVector.SPECIES_256;
 
-   public static void validate(float [] res, float [] shuf, float [] src1, float [] src2) {
+   public static void validate(float[] res, float[] shuf, float[] src1, float[] src2) {
        for (int i = 0; i < res.length; i++) {
            float expected = Float.NaN;
            int shuf_index = (int)shuf[i];
@@ -62,7 +62,7 @@ public class TestTwoVectorPermute {
        }
    }
 
-   public static void micro(float [] res, float [] shuf, float [] src1, float [] src2) {
+   public static void micro(float[] res, float[] shuf, float[] src1, float[] src2) {
        VectorShuffle<Float> vshuf = FloatVector.fromArray(FSP, shuf, 0).toShuffle();
        VectorShuffle<Float> vshuf_wrapped = vshuf.wrapIndexes();
        FloatVector.fromArray(FSP, src1, 0)


### PR DESCRIPTION
Currently inline expansion of vector to shuffle conversion simply type casts the vector holding indexes to byte vector[1] where as fallback implementation[2] also wraps the indexes to a valid index range [0, VEC_LEN-1) or generates a -ve index for exceptional / OOB indices.

This patch extends the conversion inline expander to match the fall back implementation. This imposes around 20% performance tax on Vector.toShuffle() intrinsic but fixes this functional bug.

Kindly review and share your feedback.

Best Regards,
Jatin

PS: Patch also fixes an incorrectness issue reported with [JDK-8332118](https://bugs.openjdk.org/browse/JDK-8332118)

[1] https://github.com/openjdk/jdk/blob/master/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java#L2352
[2] https://github.com/openjdk/jdk/blob/master/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/AbstractShuffle.java#L58

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332119](https://bugs.openjdk.org/browse/JDK-8332119): Incorrect IllegalArgumentException for C2 compiled permute kernel (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to [102b78ae](https://git.openjdk.org/jdk/pull/19442/files/102b78aec6b514ac43d40567e2e2cce00f130490)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [16996e57](https://git.openjdk.org/jdk/pull/19442/files/16996e5760e53d302519598a5b213bb3aa9de037)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19442/head:pull/19442` \
`$ git checkout pull/19442`

Update a local copy of the PR: \
`$ git checkout pull/19442` \
`$ git pull https://git.openjdk.org/jdk.git pull/19442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19442`

View PR using the GUI difftool: \
`$ git pr show -t 19442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19442.diff">https://git.openjdk.org/jdk/pull/19442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19442#issuecomment-2136602919)