### PR TITLE
8333131: Source launcher should work with service loader SPI

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryClassLoader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryClassLoader.java
@@ -193,6 +193,20 @@ final class MemoryClassLoader extends ClassLoader {
         return foundOrCompiledClass;
     }
 
+    @Override
+    protected Class<?> findClass(String moduleName, String name) {
+        try {
+            if (moduleName == null) {
+                return findClass(name);
+            }
+            if (moduleDescriptor != null && moduleDescriptor.name().equals(moduleName)) {
+                return findClass(name);
+            }
+            return super.findClass(moduleName, name);
+        } catch (ClassNotFoundException ignore) { }
+        return null;
+    }
+
     private Class<?> findOrCompileClass(String name) {
         byte[] bytes = sourceFileClasses.get(name);
         if (bytes == null) {

--- a/test/langtools/tools/javac/launcher/ModuleSourceLauncherTests.java
+++ b/test/langtools/tools/javac/launcher/ModuleSourceLauncherTests.java
@@ -227,36 +227,30 @@ class ModuleSourceLauncherTests {
         var mainFile = Files.writeString(packageFolder.resolve("Main.java"),
                 """
                 package p;
-                
+
                 import java.util.ServiceLoader;
                 import java.util.spi.ToolProvider;
-                
+
                 class Main {
                     public static void main(String... args) throws Exception {
                         System.out.println(Main.class + " in " + Main.class.getModule());
-                
                         System.out.println("1");
                         System.out.println(Main.class.getResource("/p/Main.java"));
                         System.out.println(Main.class.getResource("/p/Main.class"));
-                
                         System.out.println("2");
                         System.out.println(Main.class.getResource("/p/Tool.java"));
                         System.out.println(Main.class.getResource("/p/Tool.class"));
-                
                         System.out.println("3");
                         System.out.println(ToolProvider.findFirst("p.Tool")); // empty due to SCL being used
-                
                         System.out.println("4");
                         listToolProvidersIn(Main.class.getModule().getLayer());
-                
                         System.out.println("5");
                         Class.forName("p.Tool"); // trigger compilation of "p/Tool.java"
                         System.out.println(Main.class.getResource("/p/Tool.class"));
-                
                         System.out.println("6");
                         listToolProvidersIn(Main.class.getModule().getLayer());
                     }
-                
+
                     static void listToolProvidersIn(ModuleLayer layer) {
                         try {
                             ServiceLoader.load(layer, ToolProvider.class).stream()
@@ -272,19 +266,19 @@ class ModuleSourceLauncherTests {
         Files.writeString(packageFolder.resolve("Tool.java"),
                 """
                 package p;
-                
+
                 import java.io.PrintWriter;
                 import java.util.spi.ToolProvider;
-                
+
                 public record Tool(String name) implements ToolProvider {
                    public static void main(String... args) {
                      System.exit(new Tool().run(System.out, System.err, args));
                    }
-                
+
                    public Tool() {
                      this(Tool.class.getName());
                    }
-                
+
                    @Override
                    public int run(PrintWriter out, PrintWriter err, String... args) {
                      out.println(name + "/out");

--- a/test/langtools/tools/javac/launcher/ModuleSourceLauncherTests.java
+++ b/test/langtools/tools/javac/launcher/ModuleSourceLauncherTests.java
@@ -220,4 +220,110 @@ class ModuleSourceLauncherTests {
                 () -> assertTrue(err.isEmpty())
         );
     }
+
+    @Test
+    void testServiceLoading(@TempDir Path base) throws Exception {
+        var packageFolder = Files.createDirectories(base.resolve("p"));
+        var mainFile = Files.writeString(packageFolder.resolve("Main.java"),
+                """
+                package p;
+                
+                import java.util.ServiceLoader;
+                import java.util.spi.ToolProvider;
+                
+                class Main {
+                    public static void main(String... args) throws Exception {
+                        System.out.println(Main.class + " in " + Main.class.getModule());
+                
+                        System.out.println("1");
+                        System.out.println(Main.class.getResource("/p/Main.java"));
+                        System.out.println(Main.class.getResource("/p/Main.class"));
+                
+                        System.out.println("2");
+                        System.out.println(Main.class.getResource("/p/Tool.java"));
+                        System.out.println(Main.class.getResource("/p/Tool.class"));
+                
+                        System.out.println("3");
+                        System.out.println(ToolProvider.findFirst("p.Tool")); // empty due to SCL being used
+                
+                        System.out.println("4");
+                        listToolProvidersIn(Main.class.getModule().getLayer());
+                
+                        System.out.println("5");
+                        Class.forName("p.Tool"); // trigger compilation of "p/Tool.java"
+                        System.out.println(Main.class.getResource("/p/Tool.class"));
+                
+                        System.out.println("6");
+                        listToolProvidersIn(Main.class.getModule().getLayer());
+                    }
+                
+                    static void listToolProvidersIn(ModuleLayer layer) {
+                        try {
+                            ServiceLoader.load(layer, ToolProvider.class).stream()
+                                .filter(service -> service.type().getModule().getLayer() == layer)
+                                .map(ServiceLoader.Provider::get)
+                                .forEach(System.out::println);
+                        } catch (java.util.ServiceConfigurationError error) {
+                            error.printStackTrace(System.err);
+                        }
+                    }
+                }
+                """);
+        Files.writeString(packageFolder.resolve("Tool.java"),
+                """
+                package p;
+                
+                import java.io.PrintWriter;
+                import java.util.spi.ToolProvider;
+                
+                public record Tool(String name) implements ToolProvider {
+                   public static void main(String... args) {
+                     System.exit(new Tool().run(System.out, System.err, args));
+                   }
+                
+                   public Tool() {
+                     this(Tool.class.getName());
+                   }
+                
+                   @Override
+                   public int run(PrintWriter out, PrintWriter err, String... args) {
+                     out.println(name + "/out");
+                     err.println(name + "/err");
+                     return 0;
+                   }
+                }
+                """);
+        Files.writeString(base.resolve("module-info.java"),
+                """
+                module m {
+                    uses java.util.spi.ToolProvider;
+                    provides java.util.spi.ToolProvider with p.Tool;
+                }
+                """);
+
+        var run = Run.of(mainFile);
+        assertAll("Run -> " + run,
+                () -> assertLinesMatch(
+                        """
+                        class p.Main in module m
+                        1
+                        .*/p/Main.java
+                        .*:p/Main.class
+                        2
+                        .*/p/Tool.java
+                        null
+                        3
+                        Optional.empty
+                        4
+                        Tool[name=p.Tool]
+                        5
+                        .*:p/Tool.class
+                        6
+                        Tool[name=p.Tool]
+                        """.lines(),
+                        run.stdOut().lines()),
+                () -> assertTrue(run.stdErr().isEmpty()),
+                () -> assertNull(run.exception())
+        );
+    }
 }


### PR DESCRIPTION
Please review this fix for the memory class loader to find classes defined by a modular source program; including classes referenced in its module descriptor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333131](https://bugs.openjdk.org/browse/JDK-8333131): Source launcher should work with service loader SPI (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19443/head:pull/19443` \
`$ git checkout pull/19443`

Update a local copy of the PR: \
`$ git checkout pull/19443` \
`$ git pull https://git.openjdk.org/jdk.git pull/19443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19443`

View PR using the GUI difftool: \
`$ git pr show -t 19443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19443.diff">https://git.openjdk.org/jdk/pull/19443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19443#issuecomment-2136642027)