### PR TITLE
8330981: ZGC: Should not dedup strings in the finalizer graph

### DIFF
--- a/src/hotspot/share/gc/x/xMark.cpp
+++ b/src/hotspot/share/gc/x/xMark.cpp
@@ -367,8 +367,10 @@ void XMark::mark_and_follow(XMarkContext* context, XMarkStackEntry entry) {
       const oop obj = XOop::from_address(addr);
       follow_object(obj, finalizable);
 
-      // Try deduplicate
-      try_deduplicate(context, obj);
+      if (!finalizable) {
+        // Try deduplicate
+        try_deduplicate(context, obj);
+      }
     }
   }
 }

--- a/src/hotspot/share/gc/z/zMark.cpp
+++ b/src/hotspot/share/gc/z/zMark.cpp
@@ -457,8 +457,10 @@ void ZMark::mark_and_follow(ZMarkContext* context, ZMarkStackEntry entry) {
       const oop obj = to_oop(addr);
       follow_object(obj, finalizable);
 
-      // Try deduplicate
-      try_deduplicate(context, obj);
+      if (!finalizable) {
+        // Try deduplicate
+        try_deduplicate(context, obj);
+      }
     }
   }
 }


### PR DESCRIPTION
The generic logic we have for deduplicating strings during marking in various GCs, relies on creating a phantom root to store strings to be deduplicated. When storing an oop into a phantom root, it is required that the oop is strongly reachable at that point. However, when ZGC marks through finalizers (as opposed to the strongly reachable graph), the oop has not been marked as strongly reachable, and hence it isn't really safe to create that phantom root.

The solution is quite simple, really. Just don't deduplicate strings when marking through the finalizer graph.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330981](https://bugs.openjdk.org/browse/JDK-8330981): ZGC: Should not dedup strings in the finalizer graph (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19444/head:pull/19444` \
`$ git checkout pull/19444`

Update a local copy of the PR: \
`$ git checkout pull/19444` \
`$ git pull https://git.openjdk.org/jdk.git pull/19444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19444`

View PR using the GUI difftool: \
`$ git pr show -t 19444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19444.diff">https://git.openjdk.org/jdk/pull/19444.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19444#issuecomment-2136712450)