### PR TITLE
8333005: Deadlock when setting or updating the inline cache

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -148,18 +148,21 @@ public:
       return;
     }
 
-    ShenandoahReentrantLocker locker(nm_data->lock());
+    {
+      ShenandoahReentrantLocker locker(nm_data->lock());
 
-    // Heal oops and disarm
-    if (_bs->is_armed(nm)) {
-      ShenandoahEvacOOMScope oom_evac_scope;
-      ShenandoahNMethod::heal_nmethod_metadata(nm_data);
-      // Code cache unloading needs to know about on-stack nmethods. Arm the nmethods to get
-      // mark_as_maybe_on_stack() callbacks when they are used again.
-      _bs->set_guard_value(nm, 0);
+      // Heal oops and disarm
+      if (_bs->is_armed(nm)) {
+        ShenandoahEvacOOMScope oom_evac_scope;
+        ShenandoahNMethod::heal_nmethod_metadata(nm_data);
+        // Code cache unloading needs to know about on-stack nmethods. Arm the nmethods to get
+        // mark_as_maybe_on_stack() callbacks when they are used again.
+        _bs->set_guard_value(nm, 0);
+      }
     }
 
     // Clear compiled ICs and exception caches
+    ShenandoahReentrantLocker locker(nm_data->ic_lock());
     nm->unload_nmethod_caches(_unloading_occurred);
   }
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.cpp
@@ -32,7 +32,7 @@
 #include "runtime/continuation.hpp"
 
 ShenandoahNMethod::ShenandoahNMethod(nmethod* nm, GrowableArray<oop*>& oops, bool non_immediate_oops) :
-  _nm(nm), _oops(nullptr), _oops_count(0), _unregistered(false) {
+  _nm(nm), _oops(nullptr), _oops_count(0), _unregistered(false), _lock(), _ic_lock() {
 
   if (!oops.is_empty()) {
     _oops_count = oops.length();

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
@@ -44,6 +44,7 @@ private:
   bool                    _has_non_immed_oops;
   bool                    _unregistered;
   ShenandoahReentrantLock _lock;
+  ShenandoahReentrantLock _ic_lock;
 
 public:
   ShenandoahNMethod(nmethod *nm, GrowableArray<oop*>& oops, bool has_non_immed_oops);
@@ -51,6 +52,7 @@ public:
 
   inline nmethod* nm() const;
   inline ShenandoahReentrantLock* lock();
+  inline ShenandoahReentrantLock* ic_lock();
   inline void oops_do(OopClosure* oops, bool fix_relocations = false);
   // Update oops when the nmethod is re-registered
   void update();
@@ -59,6 +61,7 @@ public:
 
   static ShenandoahNMethod* for_nmethod(nmethod* nm);
   static inline ShenandoahReentrantLock* lock_for_nmethod(nmethod* nm);
+  static inline ShenandoahReentrantLock* ic_lock_for_nmethod(nmethod* nm);
 
   static void heal_nmethod(nmethod* nm);
   static inline void heal_nmethod_metadata(ShenandoahNMethod* nmethod_data);

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.inline.hpp
@@ -39,6 +39,10 @@ ShenandoahReentrantLock* ShenandoahNMethod::lock() {
   return &_lock;
 }
 
+ShenandoahReentrantLock* ShenandoahNMethod::ic_lock() {
+  return &_ic_lock;
+}
+
 bool ShenandoahNMethod::is_unregistered() const {
   return _unregistered;
 }
@@ -83,6 +87,10 @@ void ShenandoahNMethod::attach_gc_data(nmethod* nm, ShenandoahNMethod* gc_data) 
 
 ShenandoahReentrantLock* ShenandoahNMethod::lock_for_nmethod(nmethod* nm) {
   return gc_data(nm)->lock();
+}
+
+ShenandoahReentrantLock* ShenandoahNMethod::ic_lock_for_nmethod(nmethod* nm) {
+  return gc_data(nm)->ic_lock();
 }
 
 bool ShenandoahNMethodTable::iteration_in_progress() const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -91,14 +91,14 @@ public:
 class ShenandoahCompiledICProtectionBehaviour : public CompiledICProtectionBehaviour {
 public:
   virtual bool lock(nmethod* nm) {
-    ShenandoahReentrantLock* const lock = ShenandoahNMethod::lock_for_nmethod(nm);
+    ShenandoahReentrantLock* const lock = ShenandoahNMethod::ic_lock_for_nmethod(nm);
     assert(lock != nullptr, "Not yet registered?");
     lock->lock();
     return true;
   }
 
   virtual void unlock(nmethod* nm) {
-    ShenandoahReentrantLock* const lock = ShenandoahNMethod::lock_for_nmethod(nm);
+    ShenandoahReentrantLock* const lock = ShenandoahNMethod::ic_lock_for_nmethod(nm);
     assert(lock != nullptr, "Not yet registered?");
     lock->unlock();
   }
@@ -108,7 +108,7 @@ public:
       return true;
     }
 
-    ShenandoahReentrantLock* const lock = ShenandoahNMethod::lock_for_nmethod(nm);
+    ShenandoahReentrantLock* const lock = ShenandoahNMethod::ic_lock_for_nmethod(nm);
     assert(lock != nullptr, "Not yet registered?");
     return lock->owned_by_self();
   }

--- a/src/hotspot/share/gc/x/xNMethod.hpp
+++ b/src/hotspot/share/gc/x/xNMethod.hpp
@@ -58,6 +58,7 @@ public:
   static void nmethods_do(NMethodClosure* cl);
 
   static XReentrantLock* lock_for_nmethod(nmethod* nm);
+  static XReentrantLock* ic_lock_for_nmethod(nmethod* nm);
 
   static void unlink(XWorkers* workers, bool unloading_occurred);
   static void purge();

--- a/src/hotspot/share/gc/x/xNMethodData.cpp
+++ b/src/hotspot/share/gc/x/xNMethodData.cpp
@@ -66,6 +66,7 @@ bool XNMethodDataOops::has_non_immediates() const {
 
 XNMethodData::XNMethodData() :
     _lock(),
+    _ic_lock(),
     _oops(nullptr) {}
 
 XNMethodData::~XNMethodData() {
@@ -74,6 +75,10 @@ XNMethodData::~XNMethodData() {
 
 XReentrantLock* XNMethodData::lock() {
   return &_lock;
+}
+
+XReentrantLock* XNMethodData::ic_lock() {
+  return &_ic_lock;
 }
 
 XNMethodDataOops* XNMethodData::oops() const {

--- a/src/hotspot/share/gc/x/xNMethodData.hpp
+++ b/src/hotspot/share/gc/x/xNMethodData.hpp
@@ -56,6 +56,7 @@ public:
 class XNMethodData : public CHeapObj<mtGC> {
 private:
   XReentrantLock             _lock;
+  XReentrantLock             _ic_lock;
   XNMethodDataOops* volatile _oops;
 
 public:
@@ -63,6 +64,7 @@ public:
   ~XNMethodData();
 
   XReentrantLock* lock();
+  XReentrantLock* ic_lock();
 
   XNMethodDataOops* oops() const;
   XNMethodDataOops* swap_oops(XNMethodDataOops* oops);

--- a/src/hotspot/share/gc/x/xUnload.cpp
+++ b/src/hotspot/share/gc/x/xUnload.cpp
@@ -87,13 +87,13 @@ public:
 class XCompiledICProtectionBehaviour : public CompiledICProtectionBehaviour {
 public:
   virtual bool lock(nmethod* nm) {
-    XReentrantLock* const lock = XNMethod::lock_for_nmethod(nm);
+    XReentrantLock* const lock = XNMethod::ic_lock_for_nmethod(nm);
     lock->lock();
     return true;
   }
 
   virtual void unlock(nmethod* nm) {
-    XReentrantLock* const lock = XNMethod::lock_for_nmethod(nm);
+    XReentrantLock* const lock = XNMethod::ic_lock_for_nmethod(nm);
     lock->unlock();
   }
 
@@ -102,7 +102,7 @@ public:
       return true;
     }
 
-    XReentrantLock* const lock = XNMethod::lock_for_nmethod(nm);
+    XReentrantLock* const lock = XNMethod::ic_lock_for_nmethod(nm);
     return lock->is_owned();
   }
 };

--- a/src/hotspot/share/gc/z/zNMethod.hpp
+++ b/src/hotspot/share/gc/z/zNMethod.hpp
@@ -63,6 +63,7 @@ public:
   static void nmethods_do(bool secondary, NMethodClosure* cl);
 
   static ZReentrantLock* lock_for_nmethod(nmethod* nm);
+  static ZReentrantLock* ic_lock_for_nmethod(nmethod* nm);
 
   static void unlink(ZWorkers* workers, bool unloading_occurred);
   static void purge();

--- a/src/hotspot/share/gc/z/zNMethodData.cpp
+++ b/src/hotspot/share/gc/z/zNMethodData.cpp
@@ -28,12 +28,17 @@
 
 ZNMethodData::ZNMethodData()
   : _lock(),
+    _ic_lock(),
     _barriers(),
     _immediate_oops(),
     _has_non_immediate_oops(false) {}
 
 ZReentrantLock* ZNMethodData::lock() {
   return &_lock;
+}
+
+ZReentrantLock* ZNMethodData::ic_lock() {
+  return &_ic_lock;
 }
 
 const ZArray<ZNMethodDataBarrier>* ZNMethodData::barriers() const {

--- a/src/hotspot/share/gc/z/zNMethodData.hpp
+++ b/src/hotspot/share/gc/z/zNMethodData.hpp
@@ -38,6 +38,7 @@ struct ZNMethodDataBarrier {
 class ZNMethodData : public CHeapObj<mtGC> {
 private:
   ZReentrantLock              _lock;
+  ZReentrantLock              _ic_lock;
   ZArray<ZNMethodDataBarrier> _barriers;
   ZArray<oop*>                _immediate_oops;
   bool                        _has_non_immediate_oops;
@@ -46,6 +47,7 @@ public:
   ZNMethodData();
 
   ZReentrantLock* lock();
+  ZReentrantLock* ic_lock();
 
   const ZArray<ZNMethodDataBarrier>* barriers() const;
   const ZArray<oop*>* immediate_oops() const;

--- a/src/hotspot/share/gc/z/zUnload.cpp
+++ b/src/hotspot/share/gc/z/zUnload.cpp
@@ -90,13 +90,13 @@ public:
 class ZCompiledICProtectionBehaviour : public CompiledICProtectionBehaviour {
 public:
   virtual bool lock(nmethod* nm) {
-    ZReentrantLock* const lock = ZNMethod::lock_for_nmethod(nm);
+    ZReentrantLock* const lock = ZNMethod::ic_lock_for_nmethod(nm);
     lock->lock();
     return true;
   }
 
   virtual void unlock(nmethod* nm) {
-    ZReentrantLock* const lock = ZNMethod::lock_for_nmethod(nm);
+    ZReentrantLock* const lock = ZNMethod::ic_lock_for_nmethod(nm);
     lock->unlock();
   }
 
@@ -105,7 +105,7 @@ public:
       return true;
     }
 
-    ZReentrantLock* const lock = ZNMethod::lock_for_nmethod(nm);
+    ZReentrantLock* const lock = ZNMethod::ic_lock_for_nmethod(nm);
     return lock->is_owned();
   }
 };


### PR DESCRIPTION
In our concurrently class unloading collectors (ZGC, Generational ZGC, Shenandoah), there is a per-nmethod lock. This lock is used to protect the nmethod oops, and is used by nmethod entry barriers and for lazily computing the value of is_unloading, for example. It is also used to protect some other random stuff, and it is also used to protect the state machine of inline caches, which is otherwise completely orthogonal to any of the GC stuff.

Because the lock is used to protect the inline caches (is taken by the CompiledICLocker), you are not allowed to call is_unloading() on *other* nmethods while holding it. Because when we need access to the oops to compute is_unloading, we need to take the nmethod lock. So if two nmethods have inline caches pointing at each other, and calls are resolved at the same time, while concurrent class unloading is going on, we can sometimes get a deadlock.

I accidentally introduced such a bug when I removed the ICStubs (https://bugs.openjdk.org/browse/JDK-8322630), where this has indeed been observed.

The intention with this patch is to make the system less fragile. While it's possible to move around the call to is_unloading() to get rid of the deadlocks, I think I will sleep better at night knowing that you can call is_unloading() anywhere, at least in the shared runtime code, without knowing the GC implementation details. So I'm adding a per-nmethod inline cache lock that protects the completely orthogonal inline cache state for the CompiledICLocker. This way these deadlocks can't happen.

Tested ZGC tests tier1-7, and it looks green. The reproducer that caught the problem, also has stopped reproducing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333005](https://bugs.openjdk.org/browse/JDK-8333005): Deadlock when setting or updating the inline cache (**Bug** - P2)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19446/head:pull/19446` \
`$ git checkout pull/19446`

Update a local copy of the PR: \
`$ git checkout pull/19446` \
`$ git pull https://git.openjdk.org/jdk.git pull/19446/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19446`

View PR using the GUI difftool: \
`$ git pr show -t 19446`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19446.diff">https://git.openjdk.org/jdk/pull/19446.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19446#issuecomment-2136739116)