### PR TITLE
8332487: Regression in Crypto-AESGCMBench.encrypt (and others) after JDK-8328181

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1749,6 +1749,7 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
         return false;
       }
       break;
+    cast Op_ClearArray:
     case Op_VectorMaskGen:
     case Op_VectorCmpMasked:
       if (!is_LP64 || !VM_Version::supports_avx512bw()) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1749,7 +1749,7 @@ bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType bt) {
         return false;
       }
       break;
-    cast Op_ClearArray:
+    case Op_ClearArray:
     case Op_VectorMaskGen:
     case Op_VectorCmpMasked:
       if (!is_LP64 || !VM_Version::supports_avx512bw()) {


### PR DESCRIPTION
Re-instantiating the ClearArray opcode check in match_rule_supported_vector, this caused performance regressions in some worklets in Renaissance BM since it prevented small sized instance initialization using quadword stores which showed better performance on non-AVX512 targets.

Our intent was to save code bloating due to long sequences of quadword store with large InitArrayShortSize value to prevent any side effects on in-lining decisions. Performance of an existing [Benchmark](https://github.com/openjdk/jdk/blob/master/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java) does not show much performance variation. 

```
Baseline with -XX:InitArrayShortSize=100000000

Benchmark                        Mode  Cnt          Score   Error  Units
ClearMemory.testClearMemory16K  thrpt    2    2695259.360          ops/s
ClearMemory.testClearMemory1K   thrpt    2   48622330.474          ops/s
ClearMemory.testClearMemory1M   thrpt    2      79546.779          ops/s
ClearMemory.testClearMemory24B  thrpt    2  252740278.617          ops/s
ClearMemory.testClearMemory2K   thrpt    2   24781443.547          ops/s
ClearMemory.testClearMemory32B  thrpt    2  251588987.342          ops/s
ClearMemory.testClearMemory32K  thrpt    2    1487427.378          ops/s
ClearMemory.testClearMemory40B  thrpt    2  213856093.091          ops/s
ClearMemory.testClearMemory48B  thrpt    2  193701317.101          ops/s
ClearMemory.testClearMemory4K   thrpt    2   11961450.919          ops/s
ClearMemory.testClearMemory56B  thrpt    2  169003238.018          ops/s
ClearMemory.testClearMemory8K   thrpt    2    5871416.239          ops/s
ClearMemory.testClearMemory8M   thrpt    2      10663.044          ops/s


With patch and -XX:InitArrayShortSize=100000000

Benchmark                        Mode  Cnt          Score   Error  Units
ClearMemory.testClearMemory16K  thrpt    2    3147203.987          ops/s
ClearMemory.testClearMemory1K   thrpt    2   48225184.981          ops/s
ClearMemory.testClearMemory1M   thrpt    2      80016.400           ops/s
ClearMemory.testClearMemory24B  thrpt    2  253904943.981          ops/s
ClearMemory.testClearMemory2K   thrpt    2   24664594.490          ops/s
ClearMemory.testClearMemory32B  thrpt    2  255507231.954          ops/s
ClearMemory.testClearMemory32K  thrpt    2    1636220.531          ops/s
ClearMemory.testClearMemory40B  thrpt    2  220718255.832          ops/s
ClearMemory.testClearMemory48B  thrpt    2  196294911.715          ops/s
ClearMemory.testClearMemory4K   thrpt    2   12182133.488          ops/s
ClearMemory.testClearMemory56B  thrpt    2  168341797.370          ops/s
ClearMemory.testClearMemory8K   thrpt    2    5952488.407          ops/s
ClearMemory.testClearMemory8M   thrpt    2      10604.212          ops/s

java -jar renaissance-jmh-0.15.0-18-g65d596e-SNAPSHOT.jar -jvmArgs "-Xms10g -Xmx10g -Xlog:alloc* -XX:+UnlockDiagnosticVMOptions" -f 1 -i 5 -wi 2 -w 30 org.renaissance.jdk.streams.JmhMnemonics.run

Baseline:-
Benchmark         Mode  Cnt     Score    Error  Units
JmhMnemonics.run    ss    5  3202.478 ± 20.474  ms/op

With Patch:-
Benchmark         Mode  Cnt     Score    Error  Units
JmhMnemonics.run    ss    5  3241.956 ± 17.290  ms/op


```

Kindly review and share feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332487](https://bugs.openjdk.org/browse/JDK-8332487): Regression in Crypto-AESGCMBench.encrypt (and others) after JDK-8328181 (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [5df1290f](https://git.openjdk.org/jdk/pull/19447/files/5df1290fff45ee3be1d5e7cdfbe3013cf3e3b861)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19447/head:pull/19447` \
`$ git checkout pull/19447`

Update a local copy of the PR: \
`$ git checkout pull/19447` \
`$ git pull https://git.openjdk.org/jdk.git pull/19447/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19447`

View PR using the GUI difftool: \
`$ git pr show -t 19447`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19447.diff">https://git.openjdk.org/jdk/pull/19447.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19447#issuecomment-2136774912)