### PR TITLE
8333129: Move ShrinkHeapInSteps flag to Serial GC

### DIFF
--- a/src/hotspot/share/gc/serial/serial_globals.hpp
+++ b/src/hotspot/share/gc/serial/serial_globals.hpp
@@ -25,12 +25,16 @@
 #ifndef SHARE_GC_SERIAL_SERIAL_GLOBALS_HPP
 #define SHARE_GC_SERIAL_SERIAL_GLOBALS_HPP
 
-#define GC_SERIAL_FLAGS(develop,     \
-                        develop_pd,  \
-                        product,     \
-                        product_pd,  \
-                        range,       \
-                        constraint)
+#define GC_SERIAL_FLAGS(develop,                                            \
+                        develop_pd,                                         \
+                        product,                                            \
+                        product_pd,                                         \
+                        range,                                              \
+                        constraint)                                         \
+  product(bool, ShrinkHeapInSteps, true,                                    \
+          "When disabled, informs the GC to shrink the java heap directly"  \
+          " to the target size at the next full GC rather than requiring"   \
+          " smaller steps during multiple full GCs.")                       \
 
 // end of GC_SERIAL_FLAGS
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1425,11 +1425,6 @@ const int ObjectAlignmentInBytes = 8;
           range(0, 100)                                                     \
           constraint(MaxHeapFreeRatioConstraintFunc,AfterErgo)              \
                                                                             \
-  product(bool, ShrinkHeapInSteps, true,                                    \
-          "When disabled, informs the GC to shrink the java heap directly"  \
-          " to the target size at the next full GC rather than requiring"   \
-          " smaller steps during multiple full GCs.")                       \
-                                                                            \
   product(intx, SoftRefLRUPolicyMSPerMB, 1000,                              \
           "Number of milliseconds per MB of free space in the heap")        \
           range(0, max_intx)                                                \


### PR DESCRIPTION
A trivial change that moves Serial GC specific flag `ShrinkHeapInSteps` to `serial_globals.hpp`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333129](https://bugs.openjdk.org/browse/JDK-8333129): Move ShrinkHeapInSteps flag to Serial GC (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19452/head:pull/19452` \
`$ git checkout pull/19452`

Update a local copy of the PR: \
`$ git checkout pull/19452` \
`$ git pull https://git.openjdk.org/jdk.git pull/19452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19452`

View PR using the GUI difftool: \
`$ git pr show -t 19452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19452.diff">https://git.openjdk.org/jdk/pull/19452.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19452#issuecomment-2137321808)