### PR TITLE
8333182: Add truncated tracing mode for TraceBytecodes

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -96,8 +96,8 @@ class BytecodePrinter {
   // the adjustments that BytecodeStream performs applies.
   void trace(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st) {
     ResourceMark rm;
-    bool methodChange = _current_method != method();
-    if (methodChange) {
+    bool method_changed = _current_method != method();
+    if (method_changed) {
       // Note 1: This code will not work as expected with true MT/MP.
       //         Need an explicit lock or a different solution.
       // It is possible for this block to be skipped, if a garbage
@@ -123,7 +123,7 @@ class BytecodePrinter {
     _next_pc = is_wide() ? bcp+2 : bcp+1;
     // Trace each bytecode unless we're truncating the tracing output, then only print the first
     // bytecode in every method as well as returns/throws that pop control flow
-    if (!TraceBytecodesTruncated || methodChange ||
+    if (!TraceBytecodesTruncated || method_changed ||
         code == Bytecodes::_athrow ||
         code == Bytecodes::_return_register_finalizer ||
         (code >= Bytecodes::_ireturn && code <= Bytecodes::_return)) {

--- a/src/hotspot/share/interpreter/bytecodeTracer.cpp
+++ b/src/hotspot/share/interpreter/bytecodeTracer.cpp
@@ -96,7 +96,8 @@ class BytecodePrinter {
   // the adjustments that BytecodeStream performs applies.
   void trace(const methodHandle& method, address bcp, uintptr_t tos, uintptr_t tos2, outputStream* st) {
     ResourceMark rm;
-    if (_current_method != method()) {
+    bool methodChange = _current_method != method();
+    if (methodChange) {
       // Note 1: This code will not work as expected with true MT/MP.
       //         Need an explicit lock or a different solution.
       // It is possible for this block to be skipped, if a garbage
@@ -119,17 +120,24 @@ class BytecodePrinter {
       code = Bytecodes::code_at(method(), bcp);
     }
     _code = code;
-     int bci = (int)(bcp - method->code_base());
-    st->print("[%ld] ", (long) Thread::current()->osthread()->thread_id());
-    if (Verbose) {
-      st->print("%8d  %4d  " INTPTR_FORMAT " " INTPTR_FORMAT " %s",
-           BytecodeCounter::counter_value(), bci, tos, tos2, Bytecodes::name(code));
-    } else {
-      st->print("%8d  %4d  %s",
-           BytecodeCounter::counter_value(), bci, Bytecodes::name(code));
-    }
     _next_pc = is_wide() ? bcp+2 : bcp+1;
-    print_attributes(bci, st);
+    // Trace each bytecode unless we're truncating the tracing output, then only print the first
+    // bytecode in every method as well as returns/throws that pop control flow
+    if (!TraceBytecodesTruncated || methodChange ||
+        code == Bytecodes::_athrow ||
+        code == Bytecodes::_return_register_finalizer ||
+        (code >= Bytecodes::_ireturn && code <= Bytecodes::_return)) {
+      int bci = (int)(bcp - method->code_base());
+      st->print("[%ld] ", (long) Thread::current()->osthread()->thread_id());
+      if (Verbose) {
+        st->print("%8d  %4d  " INTPTR_FORMAT " " INTPTR_FORMAT " %s",
+            BytecodeCounter::counter_value(), bci, tos, tos2, Bytecodes::name(code));
+      } else {
+        st->print("%8d  %4d  %s",
+            BytecodeCounter::counter_value(), bci, Bytecodes::name(code));
+      }
+      print_attributes(bci, st);
+    }
     // Set is_wide for the next one, since the caller of this doesn't skip
     // the next bytecode.
     _is_wide = (code == Bytecodes::_wide);
@@ -336,7 +344,8 @@ void BytecodePrinter::print_attributes(int bci, outputStream* st) {
   // If the code doesn't have any fields there's nothing to print.
   // note this is ==1 because the tableswitch and lookupswitch are
   // zero size (for some reason) and we want to print stuff out for them.
-  if (Bytecodes::length_for(code) == 1) {
+  // Also skip this if we're truncating bytecode output
+  if (TraceBytecodesTruncated || Bytecodes::length_for(code) == 1) {
     st->cr();
     return;
   }

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -869,6 +869,9 @@ const int ObjectAlignmentInBytes = 8;
   develop(bool, TraceBytecodes, false,                                      \
           "Trace bytecode execution")                                       \
                                                                             \
+  develop(bool, TraceBytecodesTruncated, false,                             \
+          "Truncate non control-flow bytecode when tracing bytecode")       \
+                                                                            \
   develop(bool, VerifyDependencies, trueInDebug,                            \
           "Exercise and verify the compilation dependency mechanism")       \
                                                                             \


### PR DESCRIPTION
We routinely use `-XX:+TraceBytecodes` to instrument what's going on during application startup. However, much of the information traced in this mode is not really used, and adding a mode which truncates non-relevant information would be helpful to speed up instrumentation, especially on larger apps.

To illustrate, running `-XX:+TraceBytecodes` on a version of netty can produce more than 844MB of output:
```
14759490 bytecodes executed in 151.1s (0.098MHz)
[BytecodeCounter::counter_value = 14759531]
```

A sample output block looks like this:
```
[34051] static jobject sun.reflect.annotation.AnnotationParser.parseAnnotations2(jobject, jobject, jobject, jobject)
[34051] 14759490    58  astore #9
[34051] 14759491    60  aload #9
[34051] 14759492    62  invokestatic 57 
... 19 more lines
[34051] 14759512    41  invokestatic 47 <sun/reflect/annotation/AnnotationParser.parseAnnotation2(Ljava/nio/ByteBuffer;Ljdk/internal/reflect/ConstantPool;Ljava/lang/Class;Z[Ljava/lang/Class;)Ljava/lang/annotation/Annotation;> 

[34051] static jboolean sun.reflect.annotation.AnnotationParser.contains(jobject, jobject)
[34051] 14759513     0  nofast_aload_0
[34051] 14759514     1  astore_2
[34051] 14759515     2  aload_2
...
```

This PR add a develop flag, `TraceBytecodesTruncated` meant to be used in addition to `TraceBytecodes`. It has the effect that all but the first bytecode in each method transition as well as returns and throws will be omitted. With the patch the output may look like this:

```
[42243] static jobject sun.reflect.annotation.AnnotationParser.parseAnnotations2(jobject, jobject, jobject, jobject)
[42243] 14858715    58  astore

[42243] static jboolean sun.reflect.annotation.AnnotationParser.contains(jobject, jobject)
[42243] 14858737     0  nofast_aload_0
[42243] 14858772    35  ireturn
```

This truncated output is sufficient for certain purposes such as when digesting the output with [bytestacks](https://github.com/cl4es/bytestacks).

Running the same application with the patch and the added flag, `-XX:+TraceBytecodes -XX:+TraceBytecodesTruncated` generates a file that is 177MB, and in about a third of the time:
```
14867664 bytecodes executed in 52.4s (0.284MHz)
[BytecodeCounter::counter_value = 14867704]
```

This enhancement would greatly speed up some of our diagnostics, and enable using these tools on even larger apps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333182](https://bugs.openjdk.org/browse/JDK-8333182): Add truncated tracing mode for TraceBytecodes (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) ⚠️ Review applies to [cab354e9](https://git.openjdk.org/jdk/pull/19457/files/cab354e925b1418adcd6a76e55528960a0b5a991)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [cab354e9](https://git.openjdk.org/jdk/pull/19457/files/cab354e925b1418adcd6a76e55528960a0b5a991)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19457/head:pull/19457` \
`$ git checkout pull/19457`

Update a local copy of the PR: \
`$ git checkout pull/19457` \
`$ git pull https://git.openjdk.org/jdk.git pull/19457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19457`

View PR using the GUI difftool: \
`$ git pr show -t 19457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19457.diff">https://git.openjdk.org/jdk/pull/19457.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19457#issuecomment-2137726038)