### PR TITLE
8332900: RISC-V: refactor nativeInst_riscv.cpp and macroAssembler_riscv.cpp

### DIFF
--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -629,7 +629,7 @@ void ZBarrierSetAssembler::patch_barrier_relocation(address addr, int format) {
     case ZBarrierRelocationFormatMarkBadMask:
     case ZBarrierRelocationFormatStoreGoodBits:
     case ZBarrierRelocationFormatStoreBadMask:
-      assert(NativeInstruction::is_li16u_at(addr), "invalide zgc barrier");
+      assert(MacroAssembler::is_li16u_at(addr), "invalide zgc barrier");
       bytes = MacroAssembler::pd_patch_instruction_size(addr, (address)(uintptr_t)value);
       break;
     default:

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -44,7 +44,217 @@ class MacroAssembler: public Assembler {
   enum {
     instruction_size = 4,
     compressed_instruction_size = 2,
+
+    // Refer to function emit_trampoline_stub.
+    trampoline_stub_instruction_size = 3 * instruction_size + wordSize, // auipc + ld + jr + target address
+    trampoline_stub_data_offset      = 3 * instruction_size,            // auipc + ld + jr
+
+    // movptr
+    movptr1_instruction_size = 6 * instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
+    movptr2_instruction_size = 5 * instruction_size, // lui, lui, slli, add, addi.  See movptr2().
+    load_pc_relative_instruction_size = 2 * instruction_size // auipc, ld
   };
+
+  static bool is_jal_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1101111; }
+  static bool is_jalr_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
+  static bool is_branch_at(address instr)     { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100011; }
+  static bool is_ld_at(address instr)         { assert_cond(instr != nullptr); return is_load_at(instr) && extract_funct3(instr) == 0b011; }
+  static bool is_load_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000011; }
+  static bool is_float_load_at(address instr) { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000111; }
+  static bool is_auipc_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010111; }
+  static bool is_jump_at(address instr)       { assert_cond(instr != nullptr); return is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr); }
+  static bool is_add_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110011 && extract_funct3(instr) == 0b000; }
+  static bool is_addi_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010011 && extract_funct3(instr) == 0b000; }
+  static bool is_addiw_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0011011 && extract_funct3(instr) == 0b000; }
+  static bool is_addiw_to_zr_at(address instr){ assert_cond(instr != nullptr); return is_addiw_at(instr) && extract_rd(instr) == zr; }
+  static bool is_lui_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110111; }
+  static bool is_lui_to_zr_at(address instr)  { assert_cond(instr != nullptr); return is_lui_at(instr) && extract_rd(instr) == zr; }
+
+  static bool is_srli_at(address instr) {
+    assert_cond(instr != nullptr);
+    return extract_opcode(instr) == 0b0010011 &&
+           extract_funct3(instr) == 0b101 &&
+           Assembler::extract(((unsigned*)instr)[0], 31, 26) == 0b000000;
+  }
+
+  static bool is_slli_shift_at(address instr, uint32_t shift) {
+    assert_cond(instr != nullptr);
+    return (extract_opcode(instr) == 0b0010011 && // opcode field
+            extract_funct3(instr) == 0b001 &&     // funct3 field, select the type of operation
+            Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
+  }
+
+  static Register extract_rs1(address instr);
+  static Register extract_rs2(address instr);
+  static Register extract_rd(address instr);
+  static uint32_t extract_opcode(address instr);
+  static uint32_t extract_funct3(address instr);
+
+  // the instruction sequence of movptr is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi/jalr/load
+  static bool check_movptr1_data_dependency(address instr) {
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address last_instr = slli2 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(last_instr) == extract_rd(slli2);
+  }
+
+  // the instruction sequence of movptr2 is as below:
+  //     lui
+  //     lui
+  //     slli
+  //     add
+  //     addi/jalr/load
+  static bool check_movptr2_data_dependency(address instr) {
+    address lui1 = instr;
+    address lui2 = lui1 + instruction_size;
+    address slli = lui2 + instruction_size;
+    address add  = slli + instruction_size;
+    address last_instr = add + instruction_size;
+    return extract_rd(add) == extract_rd(lui2) &&
+           extract_rs1(add) == extract_rd(lui2) &&
+           extract_rs2(add) == extract_rd(slli) &&
+           extract_rs1(slli) == extract_rd(lui1) &&
+           extract_rd(slli) == extract_rd(lui1) &&
+           extract_rs1(last_instr) == extract_rd(add);
+  }
+
+  // the instruction sequence of li64 is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi
+  static bool check_li64_data_dependency(address instr) {
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address addi3 = slli2 + instruction_size;
+    address slli3 = addi3 + instruction_size;
+    address addi4 = slli3 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(addi4);
+  }
+
+  // the instruction sequence of li16u is as below:
+  //     lui
+  //     srli
+  static bool check_li16u_data_dependency(address instr) {
+    address lui = instr;
+    address srli = lui + instruction_size;
+
+    return extract_rs1(srli) == extract_rd(lui) &&
+           extract_rs1(srli) == extract_rd(srli);
+  }
+
+  // the instruction sequence of li32 is as below:
+  //     lui
+  //     addiw
+  static bool check_li32_data_dependency(address instr) {
+    address lui = instr;
+    address addiw = lui + instruction_size;
+
+    return extract_rs1(addiw) == extract_rd(lui) &&
+           extract_rs1(addiw) == extract_rd(addiw);
+  }
+
+  // the instruction sequence of pc-relative is as below:
+  //     auipc
+  //     jalr/addi/load/float_load
+  static bool check_pc_relative_data_dependency(address instr) {
+    address auipc = instr;
+    address last_instr = auipc + instruction_size;
+
+    return extract_rs1(last_instr) == extract_rd(auipc);
+  }
+
+  // the instruction sequence of load_label is as below:
+  //     auipc
+  //     load
+  static bool check_load_pc_relative_data_dependency(address instr) {
+    address auipc = instr;
+    address load = auipc + instruction_size;
+
+    return extract_rd(load) == extract_rd(auipc) &&
+           extract_rs1(load) == extract_rd(load);
+  }
+
+  static bool is_movptr1_at(address instr);
+  static bool is_movptr2_at(address instr);
+  static bool is_li16u_at(address instr);
+  static bool is_li32_at(address instr);
+  static bool is_li64_at(address instr);
+  static bool is_pc_relative_at(address branch);
+  static bool is_load_pc_relative_at(address branch);
+
+  static bool is_call_at(address instr) {
+    if (is_jal_at(instr) || is_jalr_at(instr)) {
+      return true;
+    }
+    return false;
+  }
+  static bool is_lwu_to_zr(address instr);
+
+  static bool is_trampoline_stub_at(address addr) {
+    // Ensure that the stub is exactly
+    //      ld   t0, L--->auipc + ld
+    //      jr   t0
+    // L:
+
+    // judge inst + register + imm
+    // 1). check the instructions: auipc + ld + jalr
+    // 2). check if auipc[11:7] == t0 and ld[11:7] == t0 and ld[19:15] == t0 && jr[19:15] == t0
+    // 3). check if the offset in ld[31:20] equals the data_offset
+    assert_cond(addr != nullptr);
+    const int instr_size = instruction_size;
+    if (is_auipc_at(addr) &&
+        is_ld_at(addr + instr_size) &&
+        is_jalr_at(addr + 2 * instr_size) &&
+        (extract_rd(addr)                    == x5) &&
+        (extract_rd(addr + instr_size)       == x5) &&
+        (extract_rs1(addr + instr_size)      == x5) &&
+        (extract_rs1(addr + 2 * instr_size)  == x5) &&
+        (Assembler::extract(Assembler::ld_instr(addr + 4), 31, 20) == trampoline_stub_data_offset)) {
+      return true;
+    }
+    return false;
+  }
+
+
+ public:
 
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -41,229 +41,6 @@
 class MacroAssembler: public Assembler {
 
  public:
-  enum {
-    instruction_size = 4,
-    compressed_instruction_size = 2,
-
-    // Refer to function emit_trampoline_stub.
-    trampoline_stub_instruction_size = 3 * instruction_size + wordSize, // auipc + ld + jr + target address
-    trampoline_stub_data_offset      = 3 * instruction_size,            // auipc + ld + jr
-
-    // movptr
-    movptr1_instruction_size = 6 * instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
-    movptr2_instruction_size = 5 * instruction_size, // lui, lui, slli, add, addi.  See movptr2().
-    load_pc_relative_instruction_size = 2 * instruction_size // auipc, ld
-  };
-
-  static bool is_load_pc_relative_at(address branch);
-  static bool is_li16u_at(address instr);
-
-  static bool is_trampoline_stub_at(address addr) {
-    // Ensure that the stub is exactly
-    //      ld   t0, L--->auipc + ld
-    //      jr   t0
-    // L:
-
-    // judge inst + register + imm
-    // 1). check the instructions: auipc + ld + jalr
-    // 2). check if auipc[11:7] == t0 and ld[11:7] == t0 and ld[19:15] == t0 && jr[19:15] == t0
-    // 3). check if the offset in ld[31:20] equals the data_offset
-    assert_cond(addr != nullptr);
-    const int instr_size = instruction_size;
-    if (is_auipc_at(addr) &&
-        is_ld_at(addr + instr_size) &&
-        is_jalr_at(addr + 2 * instr_size) &&
-        (extract_rd(addr)                    == x5) &&
-        (extract_rd(addr + instr_size)       == x5) &&
-        (extract_rs1(addr + instr_size)      == x5) &&
-        (extract_rs1(addr + 2 * instr_size)  == x5) &&
-        (Assembler::extract(Assembler::ld_instr(addr + 4), 31, 20) == trampoline_stub_data_offset)) {
-      return true;
-    }
-    return false;
-  }
-
-  static bool is_call_at(address instr) {
-    if (is_jal_at(instr) || is_jalr_at(instr)) {
-      return true;
-    }
-    return false;
-  }
-
-  static bool is_jal_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1101111; }
-  static bool is_jalr_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
-  static bool is_branch_at(address instr)     { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100011; }
-  static bool is_ld_at(address instr)         { assert_cond(instr != nullptr); return is_load_at(instr) && extract_funct3(instr) == 0b011; }
-  static bool is_load_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000011; }
-  static bool is_float_load_at(address instr) { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000111; }
-  static bool is_auipc_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010111; }
-  static bool is_jump_at(address instr)       { assert_cond(instr != nullptr); return is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr); }
-  static bool is_add_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110011 && extract_funct3(instr) == 0b000; }
-  static bool is_addi_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010011 && extract_funct3(instr) == 0b000; }
-  static bool is_addiw_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0011011 && extract_funct3(instr) == 0b000; }
-  static bool is_addiw_to_zr_at(address instr){ assert_cond(instr != nullptr); return is_addiw_at(instr) && extract_rd(instr) == zr; }
-  static bool is_lui_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110111; }
-  static bool is_lui_to_zr_at(address instr)  { assert_cond(instr != nullptr); return is_lui_at(instr) && extract_rd(instr) == zr; }
-
-  static bool is_srli_at(address instr) {
-    assert_cond(instr != nullptr);
-    return extract_opcode(instr) == 0b0010011 &&
-           extract_funct3(instr) == 0b101 &&
-           Assembler::extract(((unsigned*)instr)[0], 31, 26) == 0b000000;
-  }
-
-  static bool is_slli_shift_at(address instr, uint32_t shift) {
-    assert_cond(instr != nullptr);
-    return (extract_opcode(instr) == 0b0010011 && // opcode field
-            extract_funct3(instr) == 0b001 &&     // funct3 field, select the type of operation
-            Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
-  }
-
-  static bool is_movptr1_at(address instr);
-  static bool is_movptr2_at(address instr);
-
-  static bool is_lwu_to_zr(address instr);
-
- private:
-  static Register extract_rs1(address instr);
-  static Register extract_rs2(address instr);
-  static Register extract_rd(address instr);
-  static uint32_t extract_opcode(address instr);
-  static uint32_t extract_funct3(address instr);
-
-  // the instruction sequence of movptr is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi/jalr/load
-  static bool check_movptr1_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address last_instr = slli2 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(last_instr) == extract_rd(slli2);
-  }
-
-  // the instruction sequence of movptr2 is as below:
-  //     lui
-  //     lui
-  //     slli
-  //     add
-  //     addi/jalr/load
-  static bool check_movptr2_data_dependency(address instr) {
-    address lui1 = instr;
-    address lui2 = lui1 + instruction_size;
-    address slli = lui2 + instruction_size;
-    address add  = slli + instruction_size;
-    address last_instr = add + instruction_size;
-    return extract_rd(add) == extract_rd(lui2) &&
-           extract_rs1(add) == extract_rd(lui2) &&
-           extract_rs2(add) == extract_rd(slli) &&
-           extract_rs1(slli) == extract_rd(lui1) &&
-           extract_rd(slli) == extract_rd(lui1) &&
-           extract_rs1(last_instr) == extract_rd(add);
-  }
-
-  // the instruction sequence of li64 is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  static bool check_li64_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address addi3 = slli2 + instruction_size;
-    address slli3 = addi3 + instruction_size;
-    address addi4 = slli3 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(addi4);
-  }
-
-  // the instruction sequence of li16u is as below:
-  //     lui
-  //     srli
-  static bool check_li16u_data_dependency(address instr) {
-    address lui = instr;
-    address srli = lui + instruction_size;
-
-    return extract_rs1(srli) == extract_rd(lui) &&
-           extract_rs1(srli) == extract_rd(srli);
-  }
-
-  // the instruction sequence of li32 is as below:
-  //     lui
-  //     addiw
-  static bool check_li32_data_dependency(address instr) {
-    address lui = instr;
-    address addiw = lui + instruction_size;
-
-    return extract_rs1(addiw) == extract_rd(lui) &&
-           extract_rs1(addiw) == extract_rd(addiw);
-  }
-
-  // the instruction sequence of pc-relative is as below:
-  //     auipc
-  //     jalr/addi/load/float_load
-  static bool check_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address last_instr = auipc + instruction_size;
-
-    return extract_rs1(last_instr) == extract_rd(auipc);
-  }
-
-  // the instruction sequence of load_label is as below:
-  //     auipc
-  //     load
-  static bool check_load_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address load = auipc + instruction_size;
-
-    return extract_rd(load) == extract_rd(auipc) &&
-           extract_rs1(load) == extract_rd(load);
-  }
-
-  static bool is_li32_at(address instr);
-  static bool is_li64_at(address instr);
-  static bool is_pc_relative_at(address branch);
-
-  static bool is_membar(address addr) {
-    return (Bytes::get_native_u4(addr) & 0x7f) == 0b1111 && extract_funct3(addr) == 0;
-  }
-  static uint32_t get_membar_kind(address addr);
-  static void set_membar_kind(address addr, uint32_t order_kind);
-
- public:
 
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
 
@@ -1765,6 +1542,226 @@ private:
 public:
   void lightweight_lock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
   void lightweight_unlock(Register obj, Register tmp1, Register tmp2, Register tmp3, Label& slow);
+
+public:
+  enum {
+    // Refer to function emit_trampoline_stub.
+    trampoline_stub_instruction_size = 3 * instruction_size + wordSize, // auipc + ld + jr + target address
+    trampoline_stub_data_offset      = 3 * instruction_size,            // auipc + ld + jr
+
+    // movptr
+    movptr1_instruction_size = 6 * instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
+    movptr2_instruction_size = 5 * instruction_size, // lui, lui, slli, add, addi.  See movptr2().
+    load_pc_relative_instruction_size = 2 * instruction_size // auipc, ld
+  };
+
+  static bool is_load_pc_relative_at(address branch);
+  static bool is_li16u_at(address instr);
+
+  static bool is_trampoline_stub_at(address addr) {
+    // Ensure that the stub is exactly
+    //      ld   t0, L--->auipc + ld
+    //      jr   t0
+    // L:
+
+    // judge inst + register + imm
+    // 1). check the instructions: auipc + ld + jalr
+    // 2). check if auipc[11:7] == t0 and ld[11:7] == t0 and ld[19:15] == t0 && jr[19:15] == t0
+    // 3). check if the offset in ld[31:20] equals the data_offset
+    assert_cond(addr != nullptr);
+    const int instr_size = instruction_size;
+    if (is_auipc_at(addr) &&
+        is_ld_at(addr + instr_size) &&
+        is_jalr_at(addr + 2 * instr_size) &&
+        (extract_rd(addr)                    == x5) &&
+        (extract_rd(addr + instr_size)       == x5) &&
+        (extract_rs1(addr + instr_size)      == x5) &&
+        (extract_rs1(addr + 2 * instr_size)  == x5) &&
+        (Assembler::extract(Assembler::ld_instr(addr + 4), 31, 20) == trampoline_stub_data_offset)) {
+      return true;
+    }
+    return false;
+  }
+
+  static bool is_call_at(address instr) {
+    if (is_jal_at(instr) || is_jalr_at(instr)) {
+      return true;
+    }
+    return false;
+  }
+
+  static bool is_jal_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1101111; }
+  static bool is_jalr_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
+  static bool is_branch_at(address instr)     { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100011; }
+  static bool is_ld_at(address instr)         { assert_cond(instr != nullptr); return is_load_at(instr) && extract_funct3(instr) == 0b011; }
+  static bool is_load_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000011; }
+  static bool is_float_load_at(address instr) { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000111; }
+  static bool is_auipc_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010111; }
+  static bool is_jump_at(address instr)       { assert_cond(instr != nullptr); return is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr); }
+  static bool is_add_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110011 && extract_funct3(instr) == 0b000; }
+  static bool is_addi_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010011 && extract_funct3(instr) == 0b000; }
+  static bool is_addiw_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0011011 && extract_funct3(instr) == 0b000; }
+  static bool is_addiw_to_zr_at(address instr){ assert_cond(instr != nullptr); return is_addiw_at(instr) && extract_rd(instr) == zr; }
+  static bool is_lui_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110111; }
+  static bool is_lui_to_zr_at(address instr)  { assert_cond(instr != nullptr); return is_lui_at(instr) && extract_rd(instr) == zr; }
+
+  static bool is_srli_at(address instr) {
+    assert_cond(instr != nullptr);
+    return extract_opcode(instr) == 0b0010011 &&
+           extract_funct3(instr) == 0b101 &&
+           Assembler::extract(((unsigned*)instr)[0], 31, 26) == 0b000000;
+  }
+
+  static bool is_slli_shift_at(address instr, uint32_t shift) {
+    assert_cond(instr != nullptr);
+    return (extract_opcode(instr) == 0b0010011 && // opcode field
+            extract_funct3(instr) == 0b001 &&     // funct3 field, select the type of operation
+            Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
+  }
+
+  static bool is_movptr1_at(address instr);
+  static bool is_movptr2_at(address instr);
+
+  static bool is_lwu_to_zr(address instr);
+
+private:
+  static Register extract_rs1(address instr);
+  static Register extract_rs2(address instr);
+  static Register extract_rd(address instr);
+  static uint32_t extract_opcode(address instr);
+  static uint32_t extract_funct3(address instr);
+
+  // the instruction sequence of movptr is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi/jalr/load
+  static bool check_movptr1_data_dependency(address instr) {
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address last_instr = slli2 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(last_instr) == extract_rd(slli2);
+  }
+
+  // the instruction sequence of movptr2 is as below:
+  //     lui
+  //     lui
+  //     slli
+  //     add
+  //     addi/jalr/load
+  static bool check_movptr2_data_dependency(address instr) {
+    address lui1 = instr;
+    address lui2 = lui1 + instruction_size;
+    address slli = lui2 + instruction_size;
+    address add  = slli + instruction_size;
+    address last_instr = add + instruction_size;
+    return extract_rd(add) == extract_rd(lui2) &&
+           extract_rs1(add) == extract_rd(lui2) &&
+           extract_rs2(add) == extract_rd(slli) &&
+           extract_rs1(slli) == extract_rd(lui1) &&
+           extract_rd(slli) == extract_rd(lui1) &&
+           extract_rs1(last_instr) == extract_rd(add);
+  }
+
+  // the instruction sequence of li64 is as below:
+  //     lui
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi
+  //     slli
+  //     addi
+  static bool check_li64_data_dependency(address instr) {
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address addi3 = slli2 + instruction_size;
+    address slli3 = addi3 + instruction_size;
+    address addi4 = slli3 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(addi4);
+  }
+
+  // the instruction sequence of li16u is as below:
+  //     lui
+  //     srli
+  static bool check_li16u_data_dependency(address instr) {
+    address lui = instr;
+    address srli = lui + instruction_size;
+
+    return extract_rs1(srli) == extract_rd(lui) &&
+           extract_rs1(srli) == extract_rd(srli);
+  }
+
+  // the instruction sequence of li32 is as below:
+  //     lui
+  //     addiw
+  static bool check_li32_data_dependency(address instr) {
+    address lui = instr;
+    address addiw = lui + instruction_size;
+
+    return extract_rs1(addiw) == extract_rd(lui) &&
+           extract_rs1(addiw) == extract_rd(addiw);
+  }
+
+  // the instruction sequence of pc-relative is as below:
+  //     auipc
+  //     jalr/addi/load/float_load
+  static bool check_pc_relative_data_dependency(address instr) {
+    address auipc = instr;
+    address last_instr = auipc + instruction_size;
+
+    return extract_rs1(last_instr) == extract_rd(auipc);
+  }
+
+  // the instruction sequence of load_label is as below:
+  //     auipc
+  //     load
+  static bool check_load_pc_relative_data_dependency(address instr) {
+    address auipc = instr;
+    address load = auipc + instruction_size;
+
+    return extract_rd(load) == extract_rd(auipc) &&
+           extract_rs1(load) == extract_rd(load);
+  }
+
+  static bool is_li32_at(address instr);
+  static bool is_li64_at(address instr);
+  static bool is_pc_relative_at(address branch);
+
+  static bool is_membar(address addr) {
+    return (Bytes::get_native_u4(addr) & 0x7f) == 0b1111 && extract_funct3(addr) == 0;
+  }
+  static uint32_t get_membar_kind(address addr);
+  static void set_membar_kind(address addr, uint32_t order_kind);
 };
 
 #ifdef ASSERT

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -40,12 +40,6 @@
 
 class MacroAssembler: public Assembler {
 
-  friend class NativeInstruction;
-  friend class NativeCall;
-  friend class NativeMovConstReg;
-  friend class NativeCallTrampolineStub;
-  friend class NativePostCallNop;
-
  public:
   enum {
     instruction_size = 4,
@@ -96,7 +90,6 @@ class MacroAssembler: public Assembler {
     return false;
   }
 
- private:
   static bool is_jal_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1101111; }
   static bool is_jalr_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
   static bool is_branch_at(address instr)     { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100011; }
@@ -126,6 +119,12 @@ class MacroAssembler: public Assembler {
             Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
   }
 
+  static bool is_movptr1_at(address instr);
+  static bool is_movptr2_at(address instr);
+
+  static bool is_lwu_to_zr(address instr);
+
+ private:
   static Register extract_rs1(address instr);
   static Register extract_rs2(address instr);
   static Register extract_rd(address instr);
@@ -254,13 +253,9 @@ class MacroAssembler: public Assembler {
            extract_rs1(load) == extract_rd(load);
   }
 
-  static bool is_movptr1_at(address instr);
-  static bool is_movptr2_at(address instr);
   static bool is_li32_at(address instr);
   static bool is_li64_at(address instr);
   static bool is_pc_relative_at(address branch);
-
-  static bool is_lwu_to_zr(address instr);
 
   static bool is_membar(address addr) {
     return (Bytes::get_native_u4(addr) & 0x7f) == 0b1111 && extract_funct3(addr) == 0;

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -30,7 +30,6 @@
 #include "asm/assembler.inline.hpp"
 #include "code/vmreg.hpp"
 #include "metaprogramming/enableIf.hpp"
-#include "nativeInst_riscv.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -42,6 +41,11 @@
 class MacroAssembler: public Assembler {
 
  public:
+  enum {
+    instruction_size = 4,
+    compressed_instruction_size = 2,
+  };
+
   MacroAssembler(CodeBuffer* code) : Assembler(code) {}
 
   void safepoint_poll(Label& slow_path, bool at_return, bool acquire, bool in_nmethod);
@@ -49,7 +53,7 @@ class MacroAssembler: public Assembler {
   // Alignment
   int align(int modulus, int extra_offset = 0);
 
-  static inline void assert_alignment(address pc, int alignment = NativeInstruction::instruction_size) {
+  static inline void assert_alignment(address pc, int alignment = MacroAssembler::instruction_size) {
     assert(is_aligned(pc, alignment), "bad alignment");
   }
 
@@ -1232,7 +1236,7 @@ public:
 
   address ic_call(address entry, jint method_index = 0);
   static int ic_check_size();
-  int ic_check(int end_alignment = NativeInstruction::instruction_size);
+  int ic_check(int end_alignment = MacroAssembler::instruction_size);
 
   // Support for memory inc/dec
   // n.b. increment/decrement calls with an Address destination will

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -253,6 +253,13 @@ class MacroAssembler: public Assembler {
     return false;
   }
 
+ private:
+
+  static bool is_membar(address addr) {
+    return (Bytes::get_native_u4(addr) & 0x7f) == 0b1111 && extract_funct3(addr) == 0;
+  }
+  static uint32_t get_membar_kind(address addr);
+  static void set_membar_kind(address addr, uint32_t order_kind);
 
  public:
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -336,30 +336,6 @@ void NativeCallTrampolineStub::set_destination(address new_destination) {
   OrderAccess::release();
 }
 
-uint32_t NativeMembar::get_kind() {
-  uint32_t insn = uint_at(0);
-
-  uint32_t predecessor = Assembler::extract(insn, 27, 24);
-  uint32_t successor = Assembler::extract(insn, 23, 20);
-
-  return MacroAssembler::pred_succ_to_membar_mask(predecessor, successor);
-}
-
-void NativeMembar::set_kind(uint32_t order_kind) {
-  uint32_t predecessor = 0;
-  uint32_t successor = 0;
-
-  MacroAssembler::membar_mask_to_pred_succ(order_kind, predecessor, successor);
-
-  uint32_t insn = uint_at(0);
-  address pInsn = (address) &insn;
-  Assembler::patch(pInsn, 27, 24, predecessor);
-  Assembler::patch(pInsn, 23, 20, successor);
-
-  address membar = addr_at(0);
-  Assembler::sd_instr(membar, insn);
-}
-
 void NativePostCallNop::make_deopt() {
   MacroAssembler::assert_alignment(addr_at(0));
   NativeDeoptInstruction::insert(addr_at(0));

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -39,112 +39,20 @@
 #include "c1/c1_Runtime1.hpp"
 #endif
 
-Register NativeInstruction::extract_rs1(address instr) {
-  assert_cond(instr != nullptr);
-  return as_Register(Assembler::extract(Assembler::ld_instr(instr), 19, 15));
-}
-
-Register NativeInstruction::extract_rs2(address instr) {
-  assert_cond(instr != nullptr);
-  return as_Register(Assembler::extract(Assembler::ld_instr(instr), 24, 20));
-}
-
-Register NativeInstruction::extract_rd(address instr) {
-  assert_cond(instr != nullptr);
-  return as_Register(Assembler::extract(Assembler::ld_instr(instr), 11, 7));
-}
-
-uint32_t NativeInstruction::extract_opcode(address instr) {
-  assert_cond(instr != nullptr);
-  return Assembler::extract(Assembler::ld_instr(instr), 6, 0);
-}
-
-uint32_t NativeInstruction::extract_funct3(address instr) {
-  assert_cond(instr != nullptr);
-  return Assembler::extract(Assembler::ld_instr(instr), 14, 12);
-}
-
-bool NativeInstruction::is_pc_relative_at(address instr) {
-  // auipc + jalr
-  // auipc + addi
-  // auipc + load
-  // auipc + fload_load
-  return (is_auipc_at(instr)) &&
-         (is_addi_at(instr + instruction_size) ||
-          is_jalr_at(instr + instruction_size) ||
-          is_load_at(instr + instruction_size) ||
-          is_float_load_at(instr + instruction_size)) &&
-         check_pc_relative_data_dependency(instr);
-}
-
-// ie:ld(Rd, Label)
-bool NativeInstruction::is_load_pc_relative_at(address instr) {
-  return is_auipc_at(instr) && // auipc
-         is_ld_at(instr + instruction_size) && // ld
-         check_load_pc_relative_data_dependency(instr);
-}
-
-bool NativeInstruction::is_movptr1_at(address instr) {
-  return is_lui_at(instr) && // Lui
-         is_addi_at(instr + instruction_size) && // Addi
-         is_slli_shift_at(instr + instruction_size * 2, 11) && // Slli Rd, Rs, 11
-         is_addi_at(instr + instruction_size * 3) && // Addi
-         is_slli_shift_at(instr + instruction_size * 4, 6) && // Slli Rd, Rs, 6
-         (is_addi_at(instr + instruction_size * 5) ||
-          is_jalr_at(instr + instruction_size * 5) ||
-          is_load_at(instr + instruction_size * 5)) && // Addi/Jalr/Load
-         check_movptr1_data_dependency(instr);
-}
-
-bool NativeInstruction::is_movptr2_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_lui_at(instr + instruction_size) && // lui
-         is_slli_shift_at(instr + instruction_size * 2, 18) && // slli Rd, Rs, 18
-         is_add_at(instr + instruction_size * 3) &&
-         (is_addi_at(instr + instruction_size * 4) ||
-          is_jalr_at(instr + instruction_size * 4) ||
-          is_load_at(instr + instruction_size * 4)) && // Addi/Jalr/Load
-         check_movptr2_data_dependency(instr);
-}
-
-bool NativeInstruction::is_li16u_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_srli_at(instr + instruction_size) && // srli
-         check_li16u_data_dependency(instr);
-}
-
-bool NativeInstruction::is_li32_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_addiw_at(instr + instruction_size) && // addiw
-         check_li32_data_dependency(instr);
-}
-
-bool NativeInstruction::is_li64_at(address instr) {
-  return is_lui_at(instr) && // lui
-         is_addi_at(instr + instruction_size) && // addi
-         is_slli_shift_at(instr + instruction_size * 2, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(instr + instruction_size * 3) && // addi
-         is_slli_shift_at(instr + instruction_size * 4, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(instr + instruction_size * 5) && // addi
-         is_slli_shift_at(instr + instruction_size * 6, 8) &&   // Slli Rd, Rs, 8
-         is_addi_at(instr + instruction_size * 7) && // addi
-         check_li64_data_dependency(instr);
-}
-
 void NativeCall::verify() {
-  assert(NativeCall::is_call_at((address)this), "unexpected code at call site");
+  assert(MacroAssembler::is_call_at((address)this), "unexpected code at call site");
 }
 
 address NativeCall::destination() const {
   address addr = (address)this;
-  assert(NativeInstruction::is_jal_at(instruction_address()), "inst must be jal.");
+  assert(MacroAssembler::is_jal_at(instruction_address()), "inst must be jal.");
   address destination = MacroAssembler::target_addr_for_insn(instruction_address());
 
   // Do we use a trampoline stub for this call?
   CodeBlob* cb = CodeCache::find_blob(addr);
   assert(cb && cb->is_nmethod(), "sanity");
   nmethod *nm = (nmethod *)cb;
-  if (nm != nullptr && nm->stub_contains(destination) && is_NativeCallTrampolineStub_at(destination)) {
+  if (nm != nullptr && nm->stub_contains(destination) && MacroAssembler::is_trampoline_stub_at(destination)) {
     // Yes we do, so get the destination from the trampoline stub.
     const address trampoline_stub_addr = destination;
     destination = nativeCallTrampolineStub_at(trampoline_stub_addr)->destination();
@@ -168,12 +76,12 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
          "concurrent code patching");
 
   address addr_call = addr_at(0);
-  assert(NativeCall::is_call_at(addr_call), "unexpected code at call site");
+  assert(MacroAssembler::is_call_at(addr_call), "unexpected code at call site");
 
   // Patch the constant in the call's trampoline stub.
   address trampoline_stub_addr = get_trampoline();
   if (trampoline_stub_addr != nullptr) {
-    assert (!is_NativeCallTrampolineStub_at(dest), "chained trampolines");
+    assert (!MacroAssembler::is_trampoline_stub_at(dest), "chained trampolines");
     nativeCallTrampolineStub_at(trampoline_stub_addr)->set_destination(dest);
   }
 
@@ -195,7 +103,7 @@ address NativeCall::get_trampoline() {
   assert(code != nullptr, "Could not find the containing code blob");
 
   address jal_destination = MacroAssembler::pd_call_destination(call_addr);
-  if (code != nullptr && code->contains(jal_destination) && is_NativeCallTrampolineStub_at(jal_destination)) {
+  if (code != nullptr && code->contains(jal_destination) && MacroAssembler::is_trampoline_stub_at(jal_destination)) {
     return jal_destination;
   }
 
@@ -341,14 +249,7 @@ address NativeGeneralJump::jump_destination() const {
 //-------------------------------------------------------------------
 
 bool NativeInstruction::is_safepoint_poll() {
-  return is_lwu_to_zr(address(this));
-}
-
-bool NativeInstruction::is_lwu_to_zr(address instr) {
-  assert_cond(instr != nullptr);
-  return (extract_opcode(instr) == 0b0000011 &&
-          extract_funct3(instr) == 0b110 &&
-          extract_rd(instr) == zr);         // zr
+  return MacroAssembler::is_lwu_to_zr(address(this));
 }
 
 // A 16-bit instruction with all bits ones is permanently reserved as an illegal instruction.
@@ -481,7 +382,7 @@ bool NativePostCallNop::patch(int32_t oopmap_slot, int32_t cb_offset) {
   }
   int32_t data = (oopmap_slot << 24) | cb_offset;
   assert(data != 0, "must be");
-  assert(is_lui_to_zr_at(addr_at(4)) && is_addiw_to_zr_at(addr_at(8)), "must be");
+  assert(MacroAssembler::is_lui_to_zr_at(addr_at(4)) && MacroAssembler::is_addiw_to_zr_at(addr_at(8)), "must be");
 
   MacroAssembler::patch_imm_in_li32(addr_at(4), data);
   return true; // successfully encoded

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -27,6 +27,7 @@
 #ifndef CPU_RISCV_NATIVEINST_RISCV_HPP
 #define CPU_RISCV_NATIVEINST_RISCV_HPP
 
+#include "macroAssembler_riscv.hpp"
 #include "asm/assembler.hpp"
 #include "runtime/continuation.hpp"
 #include "runtime/icache.hpp"
@@ -55,8 +56,8 @@ class NativeInstruction {
   friend bool is_NativeCallTrampolineStub_at(address);
  public:
   enum {
-    instruction_size = 4,
-    compressed_instruction_size = 2,
+    instruction_size = MacroAssembler::instruction_size,
+    compressed_instruction_size = MacroAssembler::compressed_instruction_size,
   };
 
   juint encoding() const {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -53,7 +53,6 @@ class NativeCall;
 
 class NativeInstruction {
   friend class Relocation;
-  friend bool is_NativeCallTrampolineStub_at(address);
  public:
   enum {
     instruction_size = MacroAssembler::instruction_size,
@@ -64,187 +63,14 @@ class NativeInstruction {
     return uint_at(0);
   }
 
-  bool is_jal()                             const { return is_jal_at(addr_at(0));         }
-  bool is_movptr()                          const { return is_movptr1_at(addr_at(0)) ||
-                                                           is_movptr2_at(addr_at(0));     }
-  bool is_movptr1()                         const { return is_movptr1_at(addr_at(0));     }
-  bool is_movptr2()                         const { return is_movptr2_at(addr_at(0));     }
-  bool is_auipc()                           const { return is_auipc_at(addr_at(0));       }
-  bool is_call()                            const { return is_call_at(addr_at(0));        }
-  bool is_jump()                            const { return is_jump_at(addr_at(0));        }
-
-  static bool is_jal_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1101111; }
-  static bool is_jalr_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
-  static bool is_branch_at(address instr)     { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b1100011; }
-  static bool is_ld_at(address instr)         { assert_cond(instr != nullptr); return is_load_at(instr) && extract_funct3(instr) == 0b011; }
-  static bool is_load_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000011; }
-  static bool is_float_load_at(address instr) { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0000111; }
-  static bool is_auipc_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010111; }
-  static bool is_jump_at(address instr)       { assert_cond(instr != nullptr); return is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr); }
-  static bool is_add_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110011 && extract_funct3(instr) == 0b000; }
-  static bool is_addi_at(address instr)       { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0010011 && extract_funct3(instr) == 0b000; }
-  static bool is_addiw_at(address instr)      { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0011011 && extract_funct3(instr) == 0b000; }
-  static bool is_addiw_to_zr_at(address instr){ assert_cond(instr != nullptr); return is_addiw_at(instr) && extract_rd(instr) == zr; }
-  static bool is_lui_at(address instr)        { assert_cond(instr != nullptr); return extract_opcode(instr) == 0b0110111; }
-  static bool is_lui_to_zr_at(address instr)  { assert_cond(instr != nullptr); return is_lui_at(instr) && extract_rd(instr) == zr; }
-
-  static bool is_srli_at(address instr) {
-    assert_cond(instr != nullptr);
-    return extract_opcode(instr) == 0b0010011 &&
-           extract_funct3(instr) == 0b101 &&
-           Assembler::extract(((unsigned*)instr)[0], 31, 26) == 0b000000;
-  }
-
-  static bool is_slli_shift_at(address instr, uint32_t shift) {
-    assert_cond(instr != nullptr);
-    return (extract_opcode(instr) == 0b0010011 && // opcode field
-            extract_funct3(instr) == 0b001 &&     // funct3 field, select the type of operation
-            Assembler::extract(Assembler::ld_instr(instr), 25, 20) == shift);    // shamt field
-  }
-
-  static Register extract_rs1(address instr);
-  static Register extract_rs2(address instr);
-  static Register extract_rd(address instr);
-  static uint32_t extract_opcode(address instr);
-  static uint32_t extract_funct3(address instr);
-
-  // the instruction sequence of movptr is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi/jalr/load
-  static bool check_movptr1_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address last_instr = slli2 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(last_instr) == extract_rd(slli2);
-  }
-
-  // the instruction sequence of movptr2 is as below:
-  //     lui
-  //     lui
-  //     slli
-  //     add
-  //     addi/jalr/load
-  static bool check_movptr2_data_dependency(address instr) {
-    address lui1 = instr;
-    address lui2 = lui1 + instruction_size;
-    address slli = lui2 + instruction_size;
-    address add  = slli + instruction_size;
-    address last_instr = add + instruction_size;
-    return extract_rd(add) == extract_rd(lui2) &&
-           extract_rs1(add) == extract_rd(lui2) &&
-           extract_rs2(add) == extract_rd(slli) &&
-           extract_rs1(slli) == extract_rd(lui1) &&
-           extract_rd(slli) == extract_rd(lui1) &&
-           extract_rs1(last_instr) == extract_rd(add);
-  }
-
-  // the instruction sequence of li64 is as below:
-  //     lui
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  //     slli
-  //     addi
-  static bool check_li64_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address addi3 = slli2 + instruction_size;
-    address slli3 = addi3 + instruction_size;
-    address addi4 = slli3 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(addi4);
-  }
-
-  // the instruction sequence of li16u is as below:
-  //     lui
-  //     srli
-  static bool check_li16u_data_dependency(address instr) {
-    address lui = instr;
-    address srli = lui + instruction_size;
-
-    return extract_rs1(srli) == extract_rd(lui) &&
-           extract_rs1(srli) == extract_rd(srli);
-  }
-
-  // the instruction sequence of li32 is as below:
-  //     lui
-  //     addiw
-  static bool check_li32_data_dependency(address instr) {
-    address lui = instr;
-    address addiw = lui + instruction_size;
-
-    return extract_rs1(addiw) == extract_rd(lui) &&
-           extract_rs1(addiw) == extract_rd(addiw);
-  }
-
-  // the instruction sequence of pc-relative is as below:
-  //     auipc
-  //     jalr/addi/load/float_load
-  static bool check_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address last_instr = auipc + instruction_size;
-
-    return extract_rs1(last_instr) == extract_rd(auipc);
-  }
-
-  // the instruction sequence of load_label is as below:
-  //     auipc
-  //     load
-  static bool check_load_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address load = auipc + instruction_size;
-
-    return extract_rd(load) == extract_rd(auipc) &&
-           extract_rs1(load) == extract_rd(load);
-  }
-
-  static bool is_movptr1_at(address instr);
-  static bool is_movptr2_at(address instr);
-  static bool is_li16u_at(address instr);
-  static bool is_li32_at(address instr);
-  static bool is_li64_at(address instr);
-  static bool is_pc_relative_at(address branch);
-  static bool is_load_pc_relative_at(address branch);
-
-  static bool is_call_at(address instr) {
-    if (is_jal_at(instr) || is_jalr_at(instr)) {
-      return true;
-    }
-    return false;
-  }
-  static bool is_lwu_to_zr(address instr);
+  bool is_jal()                             const { return MacroAssembler::is_jal_at(addr_at(0));         }
+  bool is_movptr()                          const { return MacroAssembler::is_movptr1_at(addr_at(0)) ||
+                                                           MacroAssembler::is_movptr2_at(addr_at(0));     }
+  bool is_movptr1()                         const { return MacroAssembler::is_movptr1_at(addr_at(0));     }
+  bool is_movptr2()                         const { return MacroAssembler::is_movptr2_at(addr_at(0));     }
+  bool is_auipc()                           const { return MacroAssembler::is_auipc_at(addr_at(0));       }
+  bool is_call()                            const { return MacroAssembler::is_call_at(addr_at(0));        }
+  bool is_jump()                            const { return MacroAssembler::is_jump_at(addr_at(0));        }
 
   inline bool is_nop() const;
   inline bool is_jump_or_nop();
@@ -273,11 +99,11 @@ class NativeInstruction {
   inline friend NativeInstruction* nativeInstruction_at(address addr);
 
   static bool maybe_cpool_ref(address instr) {
-    return is_auipc_at(instr);
+    return MacroAssembler::is_auipc_at(instr);
   }
 
   bool is_membar() {
-    return (uint_at(0) & 0x7f) == 0b1111 && extract_funct3(addr_at(0)) == 0;
+    return (uint_at(0) & 0x7f) == 0b1111 && MacroAssembler::extract_funct3(addr_at(0)) == 0;
   }
 };
 
@@ -333,7 +159,7 @@ class NativeCall: public NativeInstruction {
   inline friend NativeCall* nativeCall_before(address return_address);
 
   static bool is_call_before(address return_address) {
-    return is_call_at(return_address - NativeCall::return_address_offset);
+    return MacroAssembler::is_call_at(return_address - NativeCall::return_address_offset);
   }
 
   // MT-safe patching of a call instruction.
@@ -378,9 +204,9 @@ inline NativeCall* nativeCall_before(address return_address) {
 class NativeMovConstReg: public NativeInstruction {
  public:
   enum RISCV_specific_constants {
-    movptr1_instruction_size            =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
-    movptr2_instruction_size            =    5 * NativeInstruction::instruction_size, // lui, lui, slli, add, addi.  See movptr2().
-    load_pc_relative_instruction_size   =    2 * NativeInstruction::instruction_size  // auipc, ld
+    movptr1_instruction_size            =    MacroAssembler::movptr1_instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr1().
+    movptr2_instruction_size            =    MacroAssembler::movptr2_instruction_size, // lui, lui, slli, add, addi.  See movptr2().
+    load_pc_relative_instruction_size   =    MacroAssembler::load_pc_relative_instruction_size // auipc, ld
   };
 
   address instruction_address() const       { return addr_at(0); }
@@ -390,23 +216,23 @@ class NativeMovConstReg: public NativeInstruction {
     // and the next instruction address should be addr_at(6 * instruction_size).
     // However, when the instruction at 5 * instruction_size isn't addi,
     // the next instruction address should be addr_at(5 * instruction_size)
-    if (is_movptr1_at(instruction_address())) {
-      if (is_addi_at(addr_at(movptr1_instruction_size - NativeInstruction::instruction_size))) {
+    if (MacroAssembler::is_movptr1_at(instruction_address())) {
+      if (MacroAssembler::is_addi_at(addr_at(movptr1_instruction_size - NativeInstruction::instruction_size))) {
         // Assume: lui, addi, slli, addi, slli, addi
         return addr_at(movptr1_instruction_size);
       } else {
         // Assume: lui, addi, slli, addi, slli
         return addr_at(movptr1_instruction_size - NativeInstruction::instruction_size);
       }
-    } else if (is_movptr2_at(instruction_address())) {
-      if (is_addi_at(addr_at(movptr2_instruction_size - NativeInstruction::instruction_size))) {
+    } else if (MacroAssembler::is_movptr2_at(instruction_address())) {
+      if (MacroAssembler::is_addi_at(addr_at(movptr2_instruction_size - NativeInstruction::instruction_size))) {
         // Assume: lui, lui, slli, add, addi
         return addr_at(movptr2_instruction_size);
       } else {
         // Assume: lui, lui, slli, add
         return addr_at(movptr2_instruction_size - NativeInstruction::instruction_size);
       }
-    } else if (is_load_pc_relative_at(instruction_address())) {
+    } else if (MacroAssembler::is_load_pc_relative_at(instruction_address())) {
       // Assume: auipc, ld
       return addr_at(load_pc_relative_instruction_size);
     }
@@ -549,8 +375,8 @@ class NativeCallTrampolineStub : public NativeInstruction {
 
   enum RISCV_specific_constants {
     // Refer to function emit_trampoline_stub.
-    instruction_size = 3 * NativeInstruction::instruction_size + wordSize, // auipc + ld + jr + target address
-    data_offset      = 3 * NativeInstruction::instruction_size,            // auipc + ld + jr
+    instruction_size = MacroAssembler::trampoline_stub_instruction_size, // auipc + ld + jr + target address
+    data_offset      = MacroAssembler::trampoline_stub_data_offset,      // auipc + ld + jr
   };
 
   address destination(nmethod *nm = nullptr) const;
@@ -558,34 +384,9 @@ class NativeCallTrampolineStub : public NativeInstruction {
   ptrdiff_t destination_offset() const;
 };
 
-inline bool is_NativeCallTrampolineStub_at(address addr) {
-  // Ensure that the stub is exactly
-  //      ld   t0, L--->auipc + ld
-  //      jr   t0
-  // L:
-
-  // judge inst + register + imm
-  // 1). check the instructions: auipc + ld + jalr
-  // 2). check if auipc[11:7] == t0 and ld[11:7] == t0 and ld[19:15] == t0 && jr[19:15] == t0
-  // 3). check if the offset in ld[31:20] equals the data_offset
-  assert_cond(addr != nullptr);
-  const int instr_size = NativeInstruction::instruction_size;
-  if (NativeInstruction::is_auipc_at(addr) &&
-      NativeInstruction::is_ld_at(addr + instr_size) &&
-      NativeInstruction::is_jalr_at(addr + 2 * instr_size) &&
-      (NativeInstruction::extract_rd(addr)                    == x5) &&
-      (NativeInstruction::extract_rd(addr + instr_size)       == x5) &&
-      (NativeInstruction::extract_rs1(addr + instr_size)      == x5) &&
-      (NativeInstruction::extract_rs1(addr + 2 * instr_size)  == x5) &&
-      (Assembler::extract(Assembler::ld_instr(addr + 4), 31, 20) == NativeCallTrampolineStub::data_offset)) {
-    return true;
-  }
-  return false;
-}
-
 inline NativeCallTrampolineStub* nativeCallTrampolineStub_at(address addr) {
   assert_cond(addr != nullptr);
-  assert(is_NativeCallTrampolineStub_at(addr), "no call trampoline found");
+  assert(MacroAssembler::is_trampoline_stub_at(addr), "no call trampoline found");
   return (NativeCallTrampolineStub*)addr;
 }
 
@@ -614,7 +415,7 @@ public:
     // These instructions only ever appear together in a post-call
     // NOP, so it's unnecessary to check that the third instruction is
     // an addiw as well.
-    return is_nop() && is_lui_to_zr_at(addr_at(4));
+    return is_nop() && MacroAssembler::is_lui_to_zr_at(addr_at(4));
   }
   bool decode(int32_t& oopmap_slot, int32_t& cb_offset) const;
   bool patch(int32_t oopmap_slot, int32_t cb_offset);

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -101,10 +101,6 @@ class NativeInstruction {
   static bool maybe_cpool_ref(address instr) {
     return MacroAssembler::is_auipc_at(instr);
   }
-
-  bool is_membar() {
-    return (uint_at(0) & 0x7f) == 0b1111 && MacroAssembler::extract_funct3(addr_at(0)) == 0;
-  }
 };
 
 inline NativeInstruction* nativeInstruction_at(address addr) {
@@ -388,18 +384,6 @@ inline NativeCallTrampolineStub* nativeCallTrampolineStub_at(address addr) {
   assert_cond(addr != nullptr);
   assert(MacroAssembler::is_trampoline_stub_at(addr), "no call trampoline found");
   return (NativeCallTrampolineStub*)addr;
-}
-
-class NativeMembar : public NativeInstruction {
-public:
-  uint32_t get_kind();
-  void set_kind(uint32_t order_kind);
-};
-
-inline NativeMembar *NativeMembar_at(address addr) {
-  assert_cond(addr != nullptr);
-  assert(nativeInstruction_at(addr)->is_membar(), "no membar found");
-  return (NativeMembar*)addr;
 }
 
 // A NativePostCallNop takes the form of three instructions:

--- a/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
+++ b/src/hotspot/cpu/riscv/relocInfo_riscv.cpp
@@ -42,7 +42,7 @@ void Relocation::pd_set_data_value(address x, bool verify_only) {
     case relocInfo::oop_type: {
       oop_Relocation *reloc = (oop_Relocation *)this;
       // in movoop when BarrierSet::barrier_set()->barrier_set_nmethod() isn't null
-      if (NativeInstruction::is_load_pc_relative_at(addr())) {
+      if (MacroAssembler::is_load_pc_relative_at(addr())) {
         address constptr = (address)code()->oop_addr_at(reloc->oop_index());
         bytes = MacroAssembler::pd_patch_instruction_size(addr(), constptr);
         assert((address)Bytes::get_native_u8(constptr) == x, "error in oop relocation");
@@ -60,7 +60,7 @@ void Relocation::pd_set_data_value(address x, bool verify_only) {
 
 address Relocation::pd_call_destination(address orig_addr) {
   assert(is_call(), "should be an address instruction here");
-  if (NativeCall::is_call_at(addr())) {
+  if (MacroAssembler::is_call_at(addr())) {
     address trampoline = nativeCall_at(addr())->get_trampoline();
     if (trampoline != nullptr) {
       return nativeCallTrampolineStub_at(trampoline)->destination();
@@ -81,7 +81,7 @@ address Relocation::pd_call_destination(address orig_addr) {
 
 void Relocation::pd_set_call_destination(address x) {
   assert(is_call(), "should be an address instruction here");
-  if (NativeCall::is_call_at(addr())) {
+  if (MacroAssembler::is_call_at(addr())) {
     address trampoline = nativeCall_at(addr())->get_trampoline();
     if (trampoline != nullptr) {
       nativeCall_at(addr())->set_destination_mt_safe(x, /* assert_lock */false);
@@ -94,7 +94,7 @@ void Relocation::pd_set_call_destination(address x) {
 }
 
 address* Relocation::pd_address_in_code() {
-  assert(NativeCall::is_load_pc_relative_at(addr()), "Not the expected instruction sequence!");
+  assert(MacroAssembler::is_load_pc_relative_at(addr()), "Not the expected instruction sequence!");
   return (address*)(MacroAssembler::target_addr_for_insn(addr()));
 }
 


### PR DESCRIPTION
Hi,
Can you help to review the patch?
Currently, code in nativeInst_riscv.cpp and macroAssembler_riscv.cpp call each other, which is not right for readability and maintainance.
After refactoring, basically only code in nativeInst_riscv.cpp calls code in macroAssembler_riscv.cpp, but not in reverse direction.

Thanks!

* Tests are still running, so far so good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332900](https://bugs.openjdk.org/browse/JDK-8332900): RISC-V: refactor nativeInst_riscv.cpp and macroAssembler_riscv.cpp (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) ⚠️ Review applies to [ef11d6a7](https://git.openjdk.org/jdk/pull/19459/files/ef11d6a78a7d58016994bd5633ddbd76028e5013)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) ⚠️ Review applies to [ef11d6a7](https://git.openjdk.org/jdk/pull/19459/files/ef11d6a78a7d58016994bd5633ddbd76028e5013)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19459/head:pull/19459` \
`$ git checkout pull/19459`

Update a local copy of the PR: \
`$ git checkout pull/19459` \
`$ git pull https://git.openjdk.org/jdk.git pull/19459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19459`

View PR using the GUI difftool: \
`$ git pr show -t 19459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19459.diff">https://git.openjdk.org/jdk/pull/19459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19459#issuecomment-2137751764)