### PR TITLE
8333200: Test containers/docker/TestPids.java fails Limit value -1 is not accepted as unlimited

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -113,12 +113,13 @@ public class TestPids {
 
                 Asserts.assertEquals(parts.length, 2);
                 String actual = parts[1].replaceAll("\\s","");
-                // Unlimited pids leads on some setups not to "max" in the output, but to a high number
                 if (expectedValue.equals("max")) {
-                    if (actual.equals("max")) {
-                        System.out.println("Found expected max for unlimited pids value.");
+                    // Unlimited pids accept max or -1
+                    if (actual.equals("max") || actual.equals("-1")) {
+                        System.out.println("Found expected " + actual + " for unlimited pids value.");
                     } else {
                         try {
+                            // Unlimited pids leads on some setups not to "max" in the output, but to a high number
                             int ai = Integer.parseInt(actual);
                             if (ai > 20000) {
                                 System.out.println("Limit value " + ai + " got accepted as unlimited, log line was " + line);


### PR DESCRIPTION
Hi all,
  The testcase `containers/docker/TestPids.java` seems to be failed after [JDK-8302744](https://bugs.openjdk.org/browse/JDK-8302744), I am not quiet sure.
  I think `max` or `-1` both acceptable as unlimited pids value.
  The change has been verified, only change the testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333200](https://bugs.openjdk.org/browse/JDK-8333200): Test containers/docker/TestPids.java fails Limit value -1 is not accepted as unlimited (**Bug** - P2)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19460/head:pull/19460` \
`$ git checkout pull/19460`

Update a local copy of the PR: \
`$ git checkout pull/19460` \
`$ git pull https://git.openjdk.org/jdk.git pull/19460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19460`

View PR using the GUI difftool: \
`$ git pr show -t 19460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19460.diff">https://git.openjdk.org/jdk/pull/19460.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19460#issuecomment-2137766424)