### PR TITLE
8333103: Re-examine the console provider loading

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -655,8 +655,9 @@ public sealed class Console implements Flushable permits ProxyingConsole {
              * The JdkConsole provider used for Console instantiation can be specified
              * with the system property "jdk.console", whose value designates the module
              * name of the implementation, and which defaults to the value of
-             * {@code JdkConsoleProvider.DEFAULT_PROVIDER_MODULE_NAME}. If no
-             * providers are available, or instantiation failed, java.base built-in
+             * {@code JdkConsoleProvider.DEFAULT_PROVIDER_MODULE_NAME}. If multiple
+             * provider implementations exist in that module, the first one found is used.
+             * If no providers are available, or instantiation failed, java.base built-in
              * Console implementation is used.
              */
             c = AccessController.doPrivileged(new PrivilegedAction<Console>() {


### PR DESCRIPTION
There is an initialization code in `Console` class that searches for the Console implementations. Refactoring the init code not to use lambda/stream would reduce the (initial) number of loaded classes by about 100 for java.base implementations. This would become relevant when the java.io.IO (JEP 477) uses Console as the underlying framework.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333103](https://bugs.openjdk.org/browse/JDK-8333103): Re-examine the console provider loading (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [ae06bb2c](https://git.openjdk.org/jdk/pull/19467/files/ae06bb2c3a0d5be1079c1bf41accbe2ea82598c7)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**) ⚠️ Review applies to [ae06bb2c](https://git.openjdk.org/jdk/pull/19467/files/ae06bb2c3a0d5be1079c1bf41accbe2ea82598c7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19467/head:pull/19467` \
`$ git checkout pull/19467`

Update a local copy of the PR: \
`$ git checkout pull/19467` \
`$ git pull https://git.openjdk.org/jdk.git pull/19467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19467`

View PR using the GUI difftool: \
`$ git pr show -t 19467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19467.diff">https://git.openjdk.org/jdk/pull/19467.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19467#issuecomment-2138217070)