### PR TITLE
8333229: Parallel: Rename ParMarkBitMap::_region_start to _heap_start

### DIFF
--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -36,7 +36,7 @@
 bool
 ParMarkBitMap::initialize(MemRegion covered_region)
 {
-  const idx_t bits = bits_required(covered_region);
+  const idx_t bits = words_to_bits(covered_region.word_size());
 
   const size_t words = bits / BitsPerWord;
   const size_t raw_bytes = words * sizeof(idx_t);
@@ -55,15 +55,15 @@ ParMarkBitMap::initialize(MemRegion covered_region)
 
   _virtual_space = new PSVirtualSpace(rs, page_sz);
   if (_virtual_space != nullptr && _virtual_space->expand_by(_reserved_byte_size)) {
-    _region_start = covered_region.start();
-    _region_size = covered_region.word_size();
+    _heap_start = covered_region.start();
+    _heap_size = covered_region.word_size();
     BitMap::bm_word_t* map = (BitMap::bm_word_t*)_virtual_space->reserved_low_addr();
     _beg_bits = BitMapView(map, bits);
     return true;
   }
 
-  _region_start = 0;
-  _region_size = 0;
+  _heap_start = 0;
+  _heap_size = 0;
   if (_virtual_space != nullptr) {
     delete _virtual_space;
     _virtual_space = nullptr;

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
@@ -74,16 +74,11 @@ private:
   // granularity is 2, 64-bit is 1.
   static inline int obj_granularity_shift() { return LogMinObjAlignment; }
 
-  HeapWord*       _region_start;
-  size_t          _region_size;
+  HeapWord*       _heap_start;
+  size_t          _heap_size;
   BitMapView      _beg_bits;
   PSVirtualSpace* _virtual_space;
   size_t          _reserved_byte_size;
-
-  // Return the number of bits required to represent the specified number of
-  // HeapWords, or the specified region.
-  static inline idx_t bits_required(size_t words);
-  static inline idx_t bits_required(MemRegion covered_region);
 
   // Convert sizes from bits to HeapWords and back.  An object that is n bits
   // long will be bits_to_words(n) words long.  An object that is m words long
@@ -94,9 +89,9 @@ private:
   // Return word-aligned up range_end, which must not be greater than size().
   inline idx_t align_range_end(idx_t range_end) const;
 
-  inline HeapWord* region_start() const;
-  inline HeapWord* region_end() const;
-  inline size_t    region_size() const;
+  inline HeapWord* heap_start() const;
+  inline HeapWord* heap_end() const;
+  inline size_t    heap_size() const;
   inline size_t    size() const;
 
   // Convert a heap address to/from a bit index.

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.inline.hpp
@@ -31,7 +31,7 @@
 #include "utilities/bitMap.inline.hpp"
 
 inline ParMarkBitMap::ParMarkBitMap():
-  _region_start(nullptr), _region_size(0), _beg_bits(), _virtual_space(nullptr), _reserved_byte_size(0)
+  _heap_start(nullptr), _heap_size(0), _beg_bits(), _virtual_space(nullptr), _reserved_byte_size(0)
 { }
 
 inline void ParMarkBitMap::clear_range(HeapWord* beg, HeapWord* end) {
@@ -40,24 +40,16 @@ inline void ParMarkBitMap::clear_range(HeapWord* beg, HeapWord* end) {
   _beg_bits.clear_range(beg_bit, end_bit);
 }
 
-inline ParMarkBitMap::idx_t ParMarkBitMap::bits_required(size_t words) {
-  return words_to_bits(words);
+inline HeapWord* ParMarkBitMap::heap_start() const {
+  return _heap_start;
 }
 
-inline ParMarkBitMap::idx_t ParMarkBitMap::bits_required(MemRegion covered_region) {
-  return bits_required(covered_region.word_size());
+inline HeapWord* ParMarkBitMap::heap_end() const {
+  return heap_start() + heap_size();
 }
 
-inline HeapWord* ParMarkBitMap::region_start() const {
-  return _region_start;
-}
-
-inline HeapWord* ParMarkBitMap::region_end() const {
-  return region_start() + region_size();
-}
-
-inline size_t ParMarkBitMap::region_size() const {
-  return _region_size;
+inline size_t ParMarkBitMap::heap_size() const {
+  return _heap_size;
 }
 
 inline size_t ParMarkBitMap::size() const {
@@ -98,12 +90,12 @@ inline bool ParMarkBitMap::mark_obj(oop obj) {
 
 inline ParMarkBitMap::idx_t ParMarkBitMap::addr_to_bit(HeapWord* addr) const {
   DEBUG_ONLY(verify_addr(addr);)
-  return words_to_bits(pointer_delta(addr, region_start()));
+  return words_to_bits(pointer_delta(addr, heap_start()));
 }
 
 inline HeapWord* ParMarkBitMap::bit_to_addr(idx_t bit) const {
   DEBUG_ONLY(verify_bit(bit);)
-  return region_start() + bits_to_words(bit);
+  return heap_start() + bits_to_words(bit);
 }
 
 inline ParMarkBitMap::idx_t ParMarkBitMap::align_range_end(idx_t range_end) const {
@@ -136,10 +128,10 @@ inline void ParMarkBitMap::verify_bit(idx_t bit) const {
 
 inline void ParMarkBitMap::verify_addr(HeapWord* addr) const {
   // Allow one past the last valid address; useful for loop bounds.
-  assert(addr >= region_start(),
-         "addr too small, addr: " PTR_FORMAT " region start: " PTR_FORMAT, p2i(addr), p2i(region_start()));
-  assert(addr <= region_end(),
-         "addr too big, addr: " PTR_FORMAT " region end: " PTR_FORMAT, p2i(addr), p2i(region_end()));
+  assert(addr >= heap_start(),
+         "addr too small, addr: " PTR_FORMAT " heap start: " PTR_FORMAT, p2i(addr), p2i(heap_start()));
+  assert(addr <= heap_end(),
+         "addr too big, addr: " PTR_FORMAT " heap end: " PTR_FORMAT, p2i(addr), p2i(heap_end()));
 }
 #endif  // #ifdef ASSERT
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -520,7 +520,7 @@ inline size_t
 ParallelCompactData::region_offset(const HeapWord* addr) const
 {
   assert(addr >= _heap_start, "bad addr");
-  // would mistakenly return 0 for _heap_end
+  // This method would mistakenly return 0 for _heap_end; hence exclusive.
   assert(addr < _heap_end, "bad addr");
   return (size_t(addr) & RegionAddrOffsetMask) >> LogHeapWordSize;
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -520,7 +520,7 @@ inline size_t
 ParallelCompactData::region_offset(const HeapWord* addr) const
 {
   assert(addr >= _heap_start, "bad addr");
-  // would mistakenly return 0 for _region_end
+  // would mistakenly return 0 for _heap_end
   assert(addr < _heap_end, "bad addr");
   return (size_t(addr) & RegionAddrOffsetMask) >> LogHeapWordSize;
 }
@@ -528,8 +528,8 @@ ParallelCompactData::region_offset(const HeapWord* addr) const
 inline size_t
 ParallelCompactData::addr_to_region_idx(const HeapWord* addr) const
 {
-  assert(addr >= _heap_start, "bad addr " PTR_FORMAT " _region_start " PTR_FORMAT, p2i(addr), p2i(_heap_start));
-  assert(addr <= _heap_end, "bad addr " PTR_FORMAT " _region_end " PTR_FORMAT, p2i(addr), p2i(_heap_end));
+  assert(addr >= _heap_start, "bad addr " PTR_FORMAT " _heap_start " PTR_FORMAT, p2i(addr), p2i(_heap_start));
+  assert(addr <= _heap_end, "bad addr " PTR_FORMAT " _heap_end " PTR_FORMAT, p2i(addr), p2i(_heap_end));
   return pointer_delta(addr, _heap_start) >> Log2RegionSize;
 }
 


### PR DESCRIPTION
Trivial renaming to better capture that this class corresponds to the whole heap mem-region.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333229](https://bugs.openjdk.org/browse/JDK-8333229): Parallel: Rename ParMarkBitMap::_region_start to _heap_start (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19468/head:pull/19468` \
`$ git checkout pull/19468`

Update a local copy of the PR: \
`$ git checkout pull/19468` \
`$ git pull https://git.openjdk.org/jdk.git pull/19468/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19468`

View PR using the GUI difftool: \
`$ git pr show -t 19468`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19468.diff">https://git.openjdk.org/jdk/pull/19468.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19468#issuecomment-2138189299)