### PR TITLE
8332751: Broken link in VirtualMachine.html

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/VirtualMachine.java
@@ -262,7 +262,7 @@ public interface VirtualMachine extends Mirror {
      * with <a href="{@docRoot}/../specs/jni/index.html">JNI code</a>.
      *
      * <p> It is implementation dependent if the list contains elements for live
-     * <a href=../../api/java.base/java/lang/Thread.html#virtual-threads>virtual threads</a>
+     * <a href={@docRoot}/java.base/java/lang/Thread.html#virtual-threads>virtual threads</a>
      * in the target VM. The target VM may not return any references to virtual threads,
      * or it may be configured to return a reference to some or all virtual threads.
      * Tools that want to track all virtual threads may enable {@link ThreadStartRequest}


### PR DESCRIPTION
Fixed broken javadoc link. I confirmed that it currently is broken as can be seen in the JDK 22 javadocs:

https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/jdk.jdi/com/sun/jdi/VirtualMachine.html#allThreads()

Click on the "virtual threads" link within the allThreads() description to see the broken link. 

I verified the fix by building the javadocs and checking that the link now works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332751](https://bugs.openjdk.org/browse/JDK-8332751): Broken link in VirtualMachine.html (**Sub-task** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19469/head:pull/19469` \
`$ git checkout pull/19469`

Update a local copy of the PR: \
`$ git checkout pull/19469` \
`$ git pull https://git.openjdk.org/jdk.git pull/19469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19469`

View PR using the GUI difftool: \
`$ git pr show -t 19469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19469.diff">https://git.openjdk.org/jdk/pull/19469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19469#issuecomment-2138200486)