### PR TITLE
8325435: [macos] Menu or JPopupMenu not closed when main window is resized

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1024,7 +1024,11 @@ AWT_ASSERT_APPKIT_THREAD;
             NSRect contentRect = [self.nsWindow contentRectForFrameRect:frame];
 
             // Check if the click happened in the non-client area (title bar)
-            if (p.y >= (frame.origin.y + contentRect.size.height)) {
+            // Also, non-client area includes the edges at left, right and botton of frame
+            if ((p.y >= (frame.origin.y + contentRect.size.height)) ||
+                (p.x >= (frame.origin.x + contentRect.size.width)) ||
+                (fabs(frame.origin.x - p.x) < 4) || 
+                (fabs(frame.origin.y - p.y) < 4)) {
                 JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
                 jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
                 if (platformWindow != NULL) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1027,7 +1027,7 @@ AWT_ASSERT_APPKIT_THREAD;
             // Also, non-client area includes the edges at left, right and botton of frame
             if ((p.y >= (frame.origin.y + contentRect.size.height)) ||
                 (p.x >= (frame.origin.x + contentRect.size.width)) ||
-                (fabs(frame.origin.x - p.x) < 4) || 
+                (fabs(frame.origin.x - p.x) < 4) ||
                 (fabs(frame.origin.y - p.y) < 4)) {
                 JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
                 jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -1026,9 +1026,9 @@ AWT_ASSERT_APPKIT_THREAD;
             // Check if the click happened in the non-client area (title bar)
             // Also, non-client area includes the edges at left, right and botton of frame
             if ((p.y >= (frame.origin.y + contentRect.size.height)) ||
-                (p.x >= (frame.origin.x + contentRect.size.width)) ||
-                (fabs(frame.origin.x - p.x) < 4) ||
-                (fabs(frame.origin.y - p.y) < 4)) {
+                (p.x >= (frame.origin.x + contentRect.size.width - 3)) ||
+                (fabs(frame.origin.x - p.x) < 3) ||
+                (fabs(frame.origin.y - p.y) < 3)) {
                 JNIEnv *env = [ThreadUtilities getJNIEnvUncached];
                 jobject platformWindow = (*env)->NewLocalRef(env, self.javaPlatformWindow);
                 if (platformWindow != NULL) {

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class TestUngrab {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
-    
+
     public static void main(String[] args) throws Exception {
         try {
             Robot robot = new Robot();
@@ -101,5 +101,5 @@ public class TestUngrab {
             SwingUtilities.invokeAndWait(() -> frame.dispose());
         }
     }
-    
+
 }

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -1,20 +1,22 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates.All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES ON THIS FILE HEADER.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the free Software Foundation.
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied WARRANTY of MERCHANTIABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * version 2 for more details(a copy is included in the LICENSE file that
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy if the GNU General Public License version
+ * You should have received a copy of the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St. Fifth Floor, Boston, MA 02110-1301 USA.
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -53,6 +53,8 @@ public class TestUngrab {
     static JMenu menu;
     static JFrame frame;
     static volatile Point loc;
+    static volatile Point point;
+    static volatile Dimension dim;
     static volatile int width;
     static volatile int height;
 
@@ -65,7 +67,7 @@ public class TestUngrab {
         mb.add(menu);
 
         frame.setJMenuBar(mb);
-        frame.setSize(300,300);
+        frame.setSize(300, 300);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
@@ -74,12 +76,14 @@ public class TestUngrab {
         try {
             Robot robot = new Robot();
             robot.setAutoDelay(100);
-            SwingUtilities.invokeLater(() -> createAndShowGUI());
+            SwingUtilities.invokeAndWait(() -> createAndShowGUI());
             robot.waitForIdle();
             robot.delay(1000);
-            Point point = menu.getLocationOnScreen();
-            Dimension dim = menu.getSize();
-            robot.mouseMove(point.x + dim.width/2, point.y + dim.height/2);
+            SwingUtilities.invokeAndWait(() -> {
+                point = menu.getLocationOnScreen();
+                dim = menu.getSize();
+            });
+            robot.mouseMove(point.x + dim.width / 2, point.y + dim.height / 2);
             robot.waitForIdle();
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
@@ -98,7 +102,11 @@ public class TestUngrab {
                 throw new RuntimeException("popup menu not closed on resize");
             }
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -19,7 +19,7 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- */
+ *
 
 /*
  * @test

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8267374
+ * @key headful
+ * @requires (os.family == "mac")
+ * @summary Verifies menu closes when main window is resized
+ * @run main TestUngrab
+ */
+
+import java.awt.Point;
+import java.awt.Dimension;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.SwingUtilities;
+
+public class TestUngrab {
+    /**
+     * Menu (JMenuBar and JPopupMenu) not hidden when resizing the window.
+     * -> UngrabEvent not sent.
+     */
+    static JMenu menu;
+    static JFrame frame;
+    static volatile Point loc;
+    static volatile int width;
+    static volatile int height;
+
+    private static void createAndShowGUI() {
+        frame = new JFrame();
+        JMenuBar mb = new JMenuBar();
+        menu = new JMenu("Menu");
+        menu.add(new JMenuItem("Item 1"));
+        menu.add(new JMenuItem("Item 2"));
+        mb.add(menu);
+
+        frame.setJMenuBar(mb);
+        frame.setSize(300,300);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+    
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            robot.setAutoDelay(100);
+            SwingUtilities.invokeLater(() -> createAndShowGUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+            Point point = menu.getLocationOnScreen();
+            Dimension dim = menu.getSize();
+            robot.mouseMove(point.x + dim.width/2, point.y + dim.height/2);
+            robot.waitForIdle();
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            SwingUtilities.invokeAndWait(() -> {
+                loc = frame.getLocationOnScreen();
+                width = frame.getWidth();
+                height = frame.getHeight();
+            });
+            robot.mouseMove(loc.x + width, loc.y + height);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(1000);
+            System.out.println("isPopupMenuVisible " + menu.isPopupMenuVisible());
+            if (menu.isPopupMenuVisible()) {
+                throw new RuntimeException("popup menu not closed on resize");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> frame.dispose());
+        }
+    }
+    
+}

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -57,6 +57,7 @@ public class TestUngrab {
     static volatile Dimension dim;
     static volatile int width;
     static volatile int height;
+    static volatile boolean popupVisible;
 
     private static void createAndShowGUI() {
         frame = new JFrame();
@@ -79,6 +80,7 @@ public class TestUngrab {
             SwingUtilities.invokeAndWait(() -> createAndShowGUI());
             robot.waitForIdle();
             robot.delay(1000);
+
             SwingUtilities.invokeAndWait(() -> {
                 point = menu.getLocationOnScreen();
                 dim = menu.getSize();
@@ -88,6 +90,7 @@ public class TestUngrab {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
+
             SwingUtilities.invokeAndWait(() -> {
                 loc = frame.getLocationOnScreen();
                 width = frame.getWidth();
@@ -97,8 +100,12 @@ public class TestUngrab {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.delay(1000);
-            System.out.println("isPopupMenuVisible " + menu.isPopupMenuVisible());
-            if (menu.isPopupMenuVisible()) {
+
+            SwingUtilities.invokeAndWait(() -> {
+                popupVisible = menu.isPopupMenuVisible();
+            });
+            System.out.println("isPopupMenuVisible " + popupVisible);
+            if (popupVisible) {
                 throw new RuntimeException("popup menu not closed on resize");
             }
         } finally {

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -19,7 +19,7 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- *
+ */
 
 /*
  * @test

--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -1,20 +1,20 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * Copyright (c) 2024, Oracle and/or its affiliates.All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES ON THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.
+ * published by the free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * version 2 for more details (a copy is included in the LICENSE file that
+ * ANY WARRANTY; without even the implied WARRANTY of MERCHANTIABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details(a copy is included in the LICENSE file that
  * accompanied this code).
  *
- * You should have received a copy of the GNU General Public License version
+ * You should have received a copy if the GNU General Public License version
  * 2 along with this work; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ * Inc., 51 Franklin St. Fifth Floor, Boston, MA 02110-1301 USA.
  *
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any


### PR DESCRIPTION
Issue is in macosx, when a JMenu or JPopupmenu is opened and then window is resized from the lower right corner, then the Menu / JPopupmenu stays open unlike in native osx apps like Notes, Mail etc..

This is because when LMouseButton is pressed on non-client area, the window should get a UngrabEvent for it to close/cancel the popupmenu (as is done in [windows](https://github.com/openjdk/jdk/blob/f608918df3f887277845db383cf07b0863bba615/src/java.desktop/windows/native/libawt/windows/awt_Frame.cpp#L618-L620)) but it was seen that the mac AWTWindow code only recognizes the title-bar as the non-client area so [notifyNCMouseDown](https://github.com/openjdk/jdk/blob/f608918df3f887277845db383cf07b0863bba615/src/java.desktop/macosx/classes/sun/lwawt/LWWindowPeer.java#L797-L804) is not called.
Fix is made to recognize the edges of the window as non-client area

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325435](https://bugs.openjdk.org/browse/JDK-8325435): [macos] Menu or JPopupMenu not closed when main window is resized (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) ⚠️ Review applies to [d2f9256b](https://git.openjdk.org/jdk/pull/19474/files/d2f9256bc3838d0d67300f4f928c15ece4824e7f)
 * @abdelhak-zaaim (no known openjdk.org user name / role) ⚠️ Review applies to [d2f9256b](https://git.openjdk.org/jdk/pull/19474/files/d2f9256bc3838d0d67300f4f928c15ece4824e7f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19474/head:pull/19474` \
`$ git checkout pull/19474`

Update a local copy of the PR: \
`$ git checkout pull/19474` \
`$ git pull https://git.openjdk.org/jdk.git pull/19474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19474`

View PR using the GUI difftool: \
`$ git pr show -t 19474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19474.diff">https://git.openjdk.org/jdk/pull/19474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19474#issuecomment-2139514063)