### PR TITLE
8210471: GZIPInputStream constructor could leak an un-end()ed Inflater

### DIFF
--- a/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/GZIPInputStream.java
@@ -31,6 +31,7 @@ import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.EOFException;
+import java.util.Objects;
 
 /**
  * This class implements a stream filter for reading compressed data in
@@ -75,9 +76,29 @@ public class GZIPInputStream extends InflaterInputStream {
      * @throws    IllegalArgumentException if {@code size <= 0}
      */
     public GZIPInputStream(InputStream in, int size) throws IOException {
-        super(in, in != null ? new Inflater(true) : null, size);
+        super(in, createInflater(in, size), size);
         usesDefaultInflater = true;
-        readHeader(in);
+        try {
+            readHeader(in);
+        } catch (IOException ioe) {
+            this.inf.end();
+            throw ioe;
+        }
+    }
+
+    /*
+     * Creates and returns an Inflater only if the input stream is not null and the
+     * buffer size is > 0.
+     * If the input stream is null, then this method throws a
+     * NullPointerException. If the size is <= 0, then this method throws
+     * an IllegalArgumentException
+     */
+    private static Inflater createInflater(InputStream in, int size) {
+        Objects.requireNonNull(in);
+        if (size <= 0) {
+            throw new IllegalArgumentException("buffer size <= 0");
+        }
+        return new Inflater(true);
     }
 
     /**

--- a/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
+++ b/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
@@ -22,6 +22,7 @@
  */
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.util.zip.GZIPInputStream;
 
 import org.junit.jupiter.api.Assertions;
@@ -51,5 +52,15 @@ public class BasicGZIPInputStreamTest {
         Assertions.assertThrows(IllegalArgumentException.class,
                 () -> new GZIPInputStream(new ByteArrayInputStream(new byte[0]), -1),
                 "GZIPInputStream did not throw IllegalArgumentException for size = -1");
+
+        // verify the constructor throws IOException when the underlying stream isn't
+        // a GZIP stream
+        final ByteArrayInputStream notGZIPContent = new ByteArrayInputStream(new byte[0]);
+        Assertions.assertThrows(IOException.class,
+                () -> new GZIPInputStream(notGZIPContent),
+                "GZIPInputStream did not throw IOException for non-gzip stream");
+        Assertions.assertThrows(IOException.class,
+                () -> new GZIPInputStream(notGZIPContent, 1024 /* buffer size */),
+                "GZIPInputStream did not throw IOException for non-gzip stream");
     }
 }

--- a/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
+++ b/test/jdk/java/util/zip/GZIP/BasicGZIPInputStreamTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/*
+ * @test
+ * @summary basic API verification tests for GZIPInputStream
+ * @run junit BasicGZIPInputStreamTest
+ */
+public class BasicGZIPInputStreamTest {
+
+    /*
+     * Verifies that the GZIPInputStream constructors throw the expected exceptions
+     */
+    @Test
+    public void testConstructors() throws Exception {
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new GZIPInputStream(null),
+                "GZIPInputStream did not throw NullPointerException for null InputStream");
+        Assertions.assertThrows(NullPointerException.class,
+                () -> new GZIPInputStream(null, 1),
+                "GZIPInputStream did not throw NullPointerException for null InputStream");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new GZIPInputStream(new ByteArrayInputStream(new byte[0]), 0),
+                "GZIPInputStream did not throw IllegalArgumentException for size = 0");
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new GZIPInputStream(new ByteArrayInputStream(new byte[0]), -1),
+                "GZIPInputStream did not throw IllegalArgumentException for size = -1");
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which proposes to address the issue noted in https://bugs.openjdk.org/browse/JDK-8210471?

`java.util.zip.Inflater` when instantiated will hold on the native resources which are freed only when `Inflater.end()` is called. The constructor of `java.util.zip.GZIPInputStream` instantiates an `Inflater` for its internal use. After instantiating the `Inflater`, the `GZIPInputStream` constructor before returning from the constructor, can run into either a `IllegalArgumentException` (because the `size` is `<=0`) or an `IOException` when trying to read a GZIP header from the underlying `InputStream`. In either of these cases, the `Inflater` that the `GZIPInputStream` created internally will end up leaking and the caller has no way to `end()` that `Inflater` or even knowledge of that `Inflater`.

The commit in this PR catches the `IOException` when reading the GZIP header and `end()`s the `Inflater`. Furthermore, to prevent instantiation of an `Inflater`, the `GZIPInputStream` constructor before calling `super(...)` will now check the `InputStream` to be non-null and `size` to be `>0`, both of which were being done by the `super` constructor.

Given the nature of the change, no new test has been added. Existing tests in `test/jdk/java/util/zip` continue to pass and tier1, tier2 and tier3 testing is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8210471](https://bugs.openjdk.org/browse/JDK-8210471): GZIPInputStream constructor could leak an un-end()ed Inflater (**Bug** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19475/head:pull/19475` \
`$ git checkout pull/19475`

Update a local copy of the PR: \
`$ git checkout pull/19475` \
`$ git pull https://git.openjdk.org/jdk.git pull/19475/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19475`

View PR using the GUI difftool: \
`$ git pr show -t 19475`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19475.diff">https://git.openjdk.org/jdk/pull/19475.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19475#issuecomment-2139432414)