### PR TITLE
8333264: Remove unused resolve_sub_helper declaration after JDK-8322630

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -46,8 +46,6 @@ class SharedRuntime: AllStatic {
   friend class VMStructs;
 
  private:
-  static methodHandle resolve_sub_helper(bool is_virtual, bool is_optimized, TRAPS);
-
   // Shared stub locations
 
   static RuntimeStub*        _wrong_method_blob;


### PR DESCRIPTION
The `resolve_sub_helper` declaration is unused. Noticed this when working on the Valhalla merge.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333264](https://bugs.openjdk.org/browse/JDK-8333264): Remove unused resolve_sub_helper declaration after JDK-8322630 (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19476/head:pull/19476` \
`$ git checkout pull/19476`

Update a local copy of the PR: \
`$ git checkout pull/19476` \
`$ git pull https://git.openjdk.org/jdk.git pull/19476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19476`

View PR using the GUI difftool: \
`$ git pr show -t 19476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19476.diff">https://git.openjdk.org/jdk/pull/19476.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19476#issuecomment-2139474479)