### PR TITLE
8333265: De-duplicate method references in java.util.stream.FindOps

### DIFF
--- a/src/java.base/share/classes/java/util/stream/FindOps.java
+++ b/src/java.base/share/classes/java/util/stream/FindOps.java
@@ -194,13 +194,14 @@ final class FindOps {
                 return hasValue ? Optional.of(value) : null;
             }
 
-            static final TerminalOp<?, ?> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.REFERENCE, Optional.empty(),
-                    Optional::isPresent, FindSink.OfRef::new);
+            private static final Predicate<Optional<Object>> IS_PRESENT = Optional::isPresent;
+            private static final Supplier<TerminalSink<Object, Optional<Object>>> NEW
+                    = FindOps.FindSink.OfRef::new;
+            static final FindOp<?, ?> OP_FIND_FIRST = new FindOp<>(true,
+                    StreamShape.REFERENCE, Optional.empty(), IS_PRESENT, NEW);
 
-            static final TerminalOp<?, ?> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.REFERENCE, Optional.empty(),
-                    Optional::isPresent, FindSink.OfRef::new);
+            static final FindOp<?, ?> OP_FIND_ANY = new FindOp<>(false,
+                    StreamShape.REFERENCE, Optional.empty(), IS_PRESENT, NEW);
         }
 
         /** Specialization of {@code FindSink} for int streams */
@@ -217,12 +218,13 @@ final class FindOps {
                 return hasValue ? OptionalInt.of(value) : null;
             }
 
+            private static final Predicate<OptionalInt> IS_PRESENT = OptionalInt::isPresent;
+            private static final Supplier<TerminalSink<Integer, OptionalInt>> NEW
+                    = FindOps.FindSink.OfInt::new;
             static final TerminalOp<Integer, OptionalInt> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.INT_VALUE, OptionalInt.empty(),
-                    OptionalInt::isPresent, FindSink.OfInt::new);
+                    StreamShape.INT_VALUE, OptionalInt.empty(), IS_PRESENT, NEW);
             static final TerminalOp<Integer, OptionalInt> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.INT_VALUE, OptionalInt.empty(),
-                    OptionalInt::isPresent, FindSink.OfInt::new);
+                    StreamShape.INT_VALUE, OptionalInt.empty(), IS_PRESENT, NEW);
         }
 
         /** Specialization of {@code FindSink} for long streams */
@@ -239,12 +241,13 @@ final class FindOps {
                 return hasValue ? OptionalLong.of(value) : null;
             }
 
+            private static final Predicate<OptionalLong> IS_PRESENT = OptionalLong::isPresent;
+            private static final Supplier<TerminalSink<Long, OptionalLong>> NEW
+                    = FindOps.FindSink.OfLong::new;
             static final TerminalOp<Long, OptionalLong> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.LONG_VALUE, OptionalLong.empty(),
-                    OptionalLong::isPresent, FindSink.OfLong::new);
+                    StreamShape.LONG_VALUE, OptionalLong.empty(), IS_PRESENT, NEW);
             static final TerminalOp<Long, OptionalLong> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.LONG_VALUE, OptionalLong.empty(),
-                    OptionalLong::isPresent, FindSink.OfLong::new);
+                    StreamShape.LONG_VALUE, OptionalLong.empty(), IS_PRESENT, NEW);
         }
 
         /** Specialization of {@code FindSink} for double streams */
@@ -261,12 +264,13 @@ final class FindOps {
                 return hasValue ? OptionalDouble.of(value) : null;
             }
 
+            private static final Predicate<OptionalDouble> IS_PRESENT = OptionalDouble::isPresent;
+            private static final Supplier<TerminalSink<Double, OptionalDouble>> NEW
+                    = FindOps.FindSink.OfDouble::new;
             static final TerminalOp<Double, OptionalDouble> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(),
-                    OptionalDouble::isPresent, FindSink.OfDouble::new);
+                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(), IS_PRESENT, NEW);
             static final TerminalOp<Double, OptionalDouble> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(),
-                    OptionalDouble::isPresent, FindSink.OfDouble::new);
+                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(), IS_PRESENT, NEW);
         }
     }
 

--- a/src/java.base/share/classes/java/util/stream/FindOps.java
+++ b/src/java.base/share/classes/java/util/stream/FindOps.java
@@ -194,14 +194,16 @@ final class FindOps {
                 return hasValue ? Optional.of(value) : null;
             }
 
-            private static final Predicate<Optional<Object>> IS_PRESENT = Optional::isPresent;
-            private static final Supplier<TerminalSink<Object, Optional<Object>>> NEW
-                    = FindOps.FindSink.OfRef::new;
-            static final FindOp<?, ?> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.REFERENCE, Optional.empty(), IS_PRESENT, NEW);
-
-            static final FindOp<?, ?> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.REFERENCE, Optional.empty(), IS_PRESENT, NEW);
+            static final TerminalOp<?, ?> OP_FIND_FIRST, OP_FIND_ANY;
+            static {
+                Predicate<Optional<Object>> isPresent = Optional::isPresent;
+                Supplier<TerminalSink<Object, Optional<Object>>> newSink
+                        = FindSink.OfRef::new;
+                OP_FIND_FIRST = new FindOp<>(true, StreamShape.REFERENCE,
+                        Optional.empty(), isPresent, newSink);
+                OP_FIND_ANY = new FindOp<>(false, StreamShape.REFERENCE,
+                        Optional.empty(), isPresent, newSink);
+            }
         }
 
         /** Specialization of {@code FindSink} for int streams */
@@ -218,13 +220,16 @@ final class FindOps {
                 return hasValue ? OptionalInt.of(value) : null;
             }
 
-            private static final Predicate<OptionalInt> IS_PRESENT = OptionalInt::isPresent;
-            private static final Supplier<TerminalSink<Integer, OptionalInt>> NEW
-                    = FindOps.FindSink.OfInt::new;
-            static final TerminalOp<Integer, OptionalInt> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.INT_VALUE, OptionalInt.empty(), IS_PRESENT, NEW);
-            static final TerminalOp<Integer, OptionalInt> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.INT_VALUE, OptionalInt.empty(), IS_PRESENT, NEW);
+            static final TerminalOp<Integer, OptionalInt> OP_FIND_FIRST, OP_FIND_ANY;
+            static {
+                Predicate<OptionalInt> isPresent = OptionalInt::isPresent;
+                Supplier<TerminalSink<Integer, OptionalInt> newSink
+                        = FindSink.OfInt::new;
+                OP_FIND_FIRST = new FindOp<>(true, StreamShape.INT_VALUE,
+                        OptionalInt.empty(), isPresent, newSink);
+                OP_FIND_ANY = new FindOp<>(false, StreamShape.INT_VALUE,
+                        OptionalInt.empty(), isPresent, newSink);
+            }
         }
 
         /** Specialization of {@code FindSink} for long streams */
@@ -241,13 +246,16 @@ final class FindOps {
                 return hasValue ? OptionalLong.of(value) : null;
             }
 
-            private static final Predicate<OptionalLong> IS_PRESENT = OptionalLong::isPresent;
-            private static final Supplier<TerminalSink<Long, OptionalLong>> NEW
-                    = FindOps.FindSink.OfLong::new;
-            static final TerminalOp<Long, OptionalLong> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.LONG_VALUE, OptionalLong.empty(), IS_PRESENT, NEW);
-            static final TerminalOp<Long, OptionalLong> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.LONG_VALUE, OptionalLong.empty(), IS_PRESENT, NEW);
+            static final TerminalOp<Long, OptionalLong> OP_FIND_FIRST, OP_FIND_ANY;
+            static {
+                Predicate<OptionalLong> isPresent = OptionalLong::isPresent;
+                Supplier<TerminalSink<Long, OptionalLong> newSink
+                        = FindSink.OfLong::new;
+                OP_FIND_FIRST = new FindOp<>(true, StreamShape.LONG_VALUE,
+                        OptionalLong.empty(), isPresent, newSink);
+                OP_FIND_ANY = new FindOp<>(false, StreamShape.LONG_VALUE,
+                        OptionalLong.empty(), isPresent, newSink);
+            }
         }
 
         /** Specialization of {@code FindSink} for double streams */
@@ -264,13 +272,16 @@ final class FindOps {
                 return hasValue ? OptionalDouble.of(value) : null;
             }
 
-            private static final Predicate<OptionalDouble> IS_PRESENT = OptionalDouble::isPresent;
-            private static final Supplier<TerminalSink<Double, OptionalDouble>> NEW
-                    = FindOps.FindSink.OfDouble::new;
-            static final TerminalOp<Double, OptionalDouble> OP_FIND_FIRST = new FindOp<>(true,
-                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(), IS_PRESENT, NEW);
-            static final TerminalOp<Double, OptionalDouble> OP_FIND_ANY = new FindOp<>(false,
-                    StreamShape.DOUBLE_VALUE, OptionalDouble.empty(), IS_PRESENT, NEW);
+            static final TerminalOp<Double, OptionalDouble> OP_FIND_FIRST, OP_FIND_ANY;
+            static {
+                Predicate<OptionalDouble> isPresent = OptionalDouble::isPresent;
+                Supplier<TerminalSink<Double, OptionalDouble>> newSink
+                        = FindSink.OfDouble::new;
+                OP_FIND_FIRST = new FindOp<>(true, StreamShape.DOUBLE_VALUE,
+                        OptionalDouble.empty(), isPresent, newSink);
+                OP_FIND_ANY = new FindOp<>(false, StreamShape.DOUBLE_VALUE,
+                        OptionalDouble.empty(), isPresent, newSink);
+            }
         }
     }
 

--- a/src/java.base/share/classes/java/util/stream/FindOps.java
+++ b/src/java.base/share/classes/java/util/stream/FindOps.java
@@ -223,7 +223,7 @@ final class FindOps {
             static final TerminalOp<Integer, OptionalInt> OP_FIND_FIRST, OP_FIND_ANY;
             static {
                 Predicate<OptionalInt> isPresent = OptionalInt::isPresent;
-                Supplier<TerminalSink<Integer, OptionalInt> newSink
+                Supplier<TerminalSink<Integer, OptionalInt>> newSink
                         = FindSink.OfInt::new;
                 OP_FIND_FIRST = new FindOp<>(true, StreamShape.INT_VALUE,
                         OptionalInt.empty(), isPresent, newSink);
@@ -249,7 +249,7 @@ final class FindOps {
             static final TerminalOp<Long, OptionalLong> OP_FIND_FIRST, OP_FIND_ANY;
             static {
                 Predicate<OptionalLong> isPresent = OptionalLong::isPresent;
-                Supplier<TerminalSink<Long, OptionalLong> newSink
+                Supplier<TerminalSink<Long, OptionalLong>> newSink
                         = FindSink.OfLong::new;
                 OP_FIND_FIRST = new FindOp<>(true, StreamShape.LONG_VALUE,
                         OptionalLong.empty(), isPresent, newSink);

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindAny.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/FindAny.java
@@ -60,4 +60,10 @@ public class FindAny {
         return LongStream.range(0, size).parallel().boxed().findAny().get();
     }
 
+    public static void main(String... args) {
+        FindAny findAny = new FindAny();
+        findAny.size = 100000;
+        findAny.seq_invoke();
+        findAny.par_invoke();
+    }
 }


### PR DESCRIPTION
Extracting duplicate method references to static field reduce proxy class spinning and loading. In this case 2 less classes loaded when using `findAny()` on each type of stream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333265](https://bugs.openjdk.org/browse/JDK-8333265): De-duplicate method references in java.util.stream.FindOps (**Enhancement** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19477/head:pull/19477` \
`$ git checkout pull/19477`

Update a local copy of the PR: \
`$ git checkout pull/19477` \
`$ git pull https://git.openjdk.org/jdk.git pull/19477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19477`

View PR using the GUI difftool: \
`$ git pr show -t 19477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19477.diff">https://git.openjdk.org/jdk/pull/19477.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19477#issuecomment-2139497512)