### PR TITLE
8333086: Using Console.println is unnecessarily slow due to JLine initalization

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -72,7 +72,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public PrintWriter writer() {
-            Terminal terminal = getTerminalOrNull(false);
+            Terminal terminal = getTerminalOrNull(true);
             if (terminal != null) {
                 return terminal.writer();
             }
@@ -81,7 +81,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public Reader reader() {
-            Terminal terminal = getTerminalOrNull(false);
+            Terminal terminal = getTerminalOrNull(true);
             if (terminal != null) {
                 return terminal.reader();
             } else {
@@ -91,15 +91,27 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public JdkConsole println(Object obj) {
-            writer().println(obj);
-            writer().flush();
+            Terminal terminal = getTerminalOrNull(false);
+            if (terminal != null) {
+                PrintWriter writer = terminal.writer();
+                writer.println(obj);
+                writer.flush();
+            } else {
+                delegate.print(obj);
+            }
             return this;
         }
 
         @Override
         public JdkConsole print(Object obj) {
-            writer().print(obj);
-            writer().flush();
+            Terminal terminal = getTerminalOrNull(false);
+            if (terminal != null) {
+                PrintWriter writer = terminal.writer();
+                writer.print(obj);
+                writer.flush();
+            } else {
+                delegate.print(obj);
+            }
             return this;
         }
 
@@ -119,7 +131,13 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public JdkConsole format(Locale locale, String format, Object ... args) {
-            writer().format(locale, format, args).flush();
+            Terminal terminal = getTerminalOrNull(false);
+            if (terminal != null) {
+                PrintWriter writer = terminal.writer();
+                writer.format(locale, format, args).flush();
+            } else {
+                delegate.format(locale, format, args);
+            }
             return this;
         }
 

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -97,7 +97,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
                 writer.println(obj);
                 writer.flush();
             } else {
-                delegate.print(obj);
+                delegate.println(obj);
             }
             return this;
         }
@@ -208,6 +208,8 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
             }
             synchronized (this) {
                 if (!terminalInitialized) {
+                    delegate.flush();
+
                     try {
                         Terminal terminal = TerminalBuilder.builder()
                                                            .encoding(charset)

--- a/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
+++ b/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
@@ -29,7 +29,7 @@
  * @modules jdk.internal.le/jdk.internal.org.jline.reader
  *          jdk.internal.le/jdk.internal.org.jline.terminal
  * @library /test/lib
- * @run main LazyJdkConsoleProvider
+ * @run main/othervm -Djdk.console=jdk.internal.le LazyJdkConsoleProvider
  */
 
 import java.io.IO;

--- a/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
+++ b/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
@@ -29,7 +29,7 @@
  * @modules jdk.internal.le/jdk.internal.org.jline.reader
  *          jdk.internal.le/jdk.internal.org.jline.terminal
  * @library /test/lib
- * @run main/othervm -Djdk.console=jdk.internal.le LazyJdkConsoleProvider
+ * @run main LazyJdkConsoleProvider
  */
 
 import java.io.IO;
@@ -72,6 +72,7 @@ public class LazyJdkConsoleProvider {
             ProcessBuilder builder =
                     ProcessTools.createTestJavaProcessBuilder("--enable-preview",
                                                               "-verbose:class",
+                                                              "-Djdk.console=jdk.internal.le",
                                                               LazyJdkConsoleProvider.class.getName(),
                                                               tc.testKey());
             OutputAnalyzer output = ProcessTools.executeProcess(builder, "");

--- a/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
+++ b/test/jdk/jdk/internal/jline/LazyJdkConsoleProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8333086
+ * @summary Verify the JLine backend is not initialized for simple printing.
+ * @enablePreview
+ * @modules jdk.internal.le/jdk.internal.org.jline.reader
+ *          jdk.internal.le/jdk.internal.org.jline.terminal
+ * @library /test/lib
+ * @run main LazyJdkConsoleProvider
+ */
+
+import java.io.IO;
+import jdk.internal.org.jline.reader.LineReader;
+import jdk.internal.org.jline.terminal.Terminal;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class LazyJdkConsoleProvider {
+
+    public static void main(String... args) throws Throwable {
+        switch (args.length > 0 ? args[0] : "default") {
+            case "write" -> {
+                System.console().println("Hello!");
+                System.console().print("Hello!");
+                System.console().format("\nHello!\n");
+                System.console().flush();
+                IO.println("Hello!");
+                IO.print("Hello!");
+            }
+            case "read" -> System.console().readLine("Hello!");
+            case "IO-read" -> {
+                IO.readln("Hello!");
+            }
+            case "default" -> {
+                new LazyJdkConsoleProvider().runTest();
+            }
+        }
+    }
+
+    void runTest() throws Exception {
+        record TestCase(String testKey, String expected, String notExpected) {}
+        TestCase[] testCases = new TestCase[] {
+            new TestCase("write", null, Terminal.class.getName()),
+            new TestCase("read", LineReader.class.getName(), null),
+            new TestCase("IO-read", LineReader.class.getName(), null)
+        };
+        for (TestCase tc : testCases) {
+            ProcessBuilder builder =
+                    ProcessTools.createTestJavaProcessBuilder("--enable-preview",
+                                                              "-verbose:class",
+                                                              LazyJdkConsoleProvider.class.getName(),
+                                                              tc.testKey());
+            OutputAnalyzer output = ProcessTools.executeProcess(builder, "");
+
+            output.waitFor();
+
+            if (output.getExitValue() != 0) {
+                throw new AssertionError("Unexpected return value: " + output.getExitValue() +
+                                         ", actualOut: " + output.getStdout() +
+                                         ", actualErr: " + output.getStderr());
+            }
+            if (tc.expected() != null) {
+                output.shouldContain(tc.expected());
+            }
+
+            if (tc.notExpected() != null) {
+                output.shouldNotContain(tc.notExpected());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Consider these two programs:

```
public class SystemPrint {
    public static void main(String... args) {
        System.err.println("Hello!");
    }
}
```
and:
```
public class IOPrint {
    public static void main(String... args) {
        java.io.IO.println("Hello!");
    }
}
```

They do the same conceptual thing - write a text to the output. But, `IO.println` delegates to `Console.println`, which then delegates to a `Console` backend, and the default backend is currently based on JLine.

The issues is that JLine takes a quite a long time to initialize, and in a program like this, JLine is not really needed - it is used to provide better editing experience when reading input, but there's no reading in these programs.

For example, on my computer:
```
$ time java -classpath /tmp SystemPrint 
Hello!

real    0m0,035s
user    0m0,019s
sys     0m0,019s

$ time java -classpath /tmp --enable-preview IOPrint 
Hello!

real    0m0,165s
user    0m0,324s
sys     0m0,042s
```

The proposal herein is to delegate to the simpler `Console` backend from `java.base` as long as the user only uses methods that print to output, and switch to the JLine delegate when other methods (typically input) is used. Note that while technically `writer()` is a method doing output, it will force JLine initialization to avoid possible problems if the client caches the writer and uses it after switching the delegates.

With this patch, I can get timing like this:
```
$ time java --enable-preview -classpath /tmp/ IOPrint 
Hello!

real    0m0,051s
user    0m0,038s
sys     0m0,020s
```

which seems much more acceptable.

There is also #19467, which may reduce the time further.

A future work might focus on making JLine initialize faster, but avoiding JLine initialization in case where we don't need it seems like a good step to me in any case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333086](https://bugs.openjdk.org/browse/JDK-8333086): Using Console.println is unnecessarily slow due to JLine initalization (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**) ⚠️ Review applies to [9886732e](https://git.openjdk.org/jdk/pull/19479/files/9886732e662f2065c1aa15adcedea8eec8ad33d2)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19479/head:pull/19479` \
`$ git checkout pull/19479`

Update a local copy of the PR: \
`$ git checkout pull/19479` \
`$ git pull https://git.openjdk.org/jdk.git pull/19479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19479`

View PR using the GUI difftool: \
`$ git pr show -t 19479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19479.diff">https://git.openjdk.org/jdk/pull/19479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19479#issuecomment-2139613228)