### PR TITLE
8028127: Regtest java/security/Security/SynchronizedAccess.java is incorrect

### DIFF
--- a/test/jdk/java/security/Security/SynchronizedAccess.java
+++ b/test/jdk/java/security/Security/SynchronizedAccess.java
@@ -47,13 +47,15 @@ public class SynchronizedAccess {
     public static void main0(String[] args) throws Exception {
         var providersCountBefore = Security.getProviders().length;
         AccessorThread[] acc = new AccessorThread[200];
-        for (int i = 0; i < acc.length; i++)
+        for (int i = 0; i < acc.length; i++) {
             acc[i] = new AccessorThread("thread" + i);
-        for (int i = 0; i < acc.length; i++)
+        }
+        for (int i = 0; i < acc.length; i++) {
             acc[i].start();
-        for (int i = 0; i < acc.length; i++)
+        }
+        for (int i = 0; i < acc.length; i++) {
             acc[i].join();
-
+        }
         var providersCountAfter = Security.getProviders().length;
         Asserts.assertEquals(providersCountBefore + 1, providersCountAfter);
     }
@@ -66,8 +68,9 @@ public class SynchronizedAccess {
 
         public void run() {
             Provider[] provs = new Provider[10];
-            for (int i = 0; i < provs.length; i++)
+            for (int i = 0; i < provs.length; i++) {
                 provs[i] = new MyProvider("name" + i, "1", "test");
+            }
 
             int rounds = 20;
             while (rounds-- > 0) {
@@ -76,12 +79,13 @@ public class SynchronizedAccess {
                         Security.addProvider(provs[i]);
                     }
                     Signature.getInstance("sigalg");
-                    // skipping first provider so there is always 1 available for getInstance
+                    // Skip the first provider to ensure one is always available for getInstance.
+                    // This prevents issues if other threads remove providers in parallel.
                     for (int i = 1; i < provs.length; i++) {
                         Security.removeProvider("name" + i);
                     }
                 } catch (NoSuchAlgorithmException nsae) {
-                    throw new RuntimeException("Should not reach here " + nsae);
+                    throw new RuntimeException("Expected algorithm sigalg not found", nsae);
                 }
             } // while
         }


### PR DESCRIPTION
As highlighted in the bug description, The test **security/Security/SynchronizedAccess.java** have some issues:

1. it needs to implement the sigalg, otherwise it throws java.security.NoSuchAlgorithmException . Even though it does not fail as it catches the exception, it never reaches the removeProvider loop. Also, adding an extra assertion to verify the local providers were actually removed.
2. It is reassigning the **provs** variable with Security.getProviders(). This will start adding/removing some of the system providers, in addition to the local providers, which it is not the test intent.


Test runs in tier2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8028127](https://bugs.openjdk.org/browse/JDK-8028127): Regtest java/security/Security/SynchronizedAccess.java is incorrect (**Bug** - P3)


### Reviewers
 * [Matthew Donovan](https://openjdk.org/census#mdonovan) (@mpdonova - Committer) 🔄 Re-review required (review applies to [29465d73](https://git.openjdk.org/jdk/pull/19480/files/29465d7393d6495248760decf699df458829235e))
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**) 🔄 Re-review required (review applies to [29465d73](https://git.openjdk.org/jdk/pull/19480/files/29465d7393d6495248760decf699df458829235e))
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19480/head:pull/19480` \
`$ git checkout pull/19480`

Update a local copy of the PR: \
`$ git checkout pull/19480` \
`$ git pull https://git.openjdk.org/jdk.git pull/19480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19480`

View PR using the GUI difftool: \
`$ git pr show -t 19480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19480.diff">https://git.openjdk.org/jdk/pull/19480.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19480#issuecomment-2139858457)