### PR TITLE
8333276: RISC-V: client VM build failure after JDK-8241503

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2791,6 +2791,21 @@ void C2_MacroAssembler::compare_fp_v(VectorRegister vd, VectorRegister src1, Vec
   }
 }
 
+// In Matcher::scalable_predicate_reg_slots,
+// we assume each predicate register is one-eighth of the size of
+// scalable vector register, one mask bit per vector byte.
+void C2_MacroAssembler::spill_vmask(VectorRegister v, int offset) {
+  vsetvli_helper(T_BYTE, MaxVectorSize >> 3);
+  add(t0, sp, offset);
+  vse8_v(v, t0);
+}
+
+void C2_MacroAssembler::unspill_vmask(VectorRegister v, int offset) {
+  vsetvli_helper(T_BYTE, MaxVectorSize >> 3);
+  add(t0, sp, offset);
+  vle8_v(v, t0);
+}
+
 void C2_MacroAssembler::integer_extend_v(VectorRegister dst, BasicType dst_bt, uint vector_length,
                                          VectorRegister src, BasicType src_bt, bool is_signed) {
   assert(type2aelembytes(dst_bt) > type2aelembytes(src_bt) && type2aelembytes(dst_bt) <= 8 && type2aelembytes(src_bt) <= 4, "invalid element size");

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -251,20 +251,9 @@
   void compare_fp_v(VectorRegister dst, VectorRegister src1, VectorRegister src2, int cond,
                     BasicType bt, uint vector_length, VectorMask vm = Assembler::unmasked);
 
-  // In Matcher::scalable_predicate_reg_slots,
-  // we assume each predicate register is one-eighth of the size of
-  // scalable vector register, one mask bit per vector byte.
-  void spill_vmask(VectorRegister v, int offset){
-    vsetvli_helper(T_BYTE, MaxVectorSize >> 3);
-    add(t0, sp, offset);
-    vse8_v(v, t0);
-  }
+  void spill_vmask(VectorRegister v, int offset);
 
-  void unspill_vmask(VectorRegister v, int offset){
-    vsetvli_helper(T_BYTE, MaxVectorSize >> 3);
-    add(t0, sp, offset);
-    vle8_v(v, t0);
-  }
+  void unspill_vmask(VectorRegister v, int offset);
 
   void spill_copy_vmask_stack_to_stack(int src_offset, int dst_offset, uint vector_length_in_bytes) {
     assert(vector_length_in_bytes % 4 == 0, "unexpected vector mask reg size");


### PR DESCRIPTION
Hi, please review this patch that fix the client VM build failed for riscv.

Error log for client VM build to see: [JDK-8333276](https://bugs.openjdk.org/browse/JDK-8333276)

The root cause is that `src/hotspot/share/code/compiledIC.hpp` include `"opto/c2_MacroAssembler.hpp"`, after that `opto/c2_MacroAssembler.hpp` include `c2_MacroAssembler_riscv.hpp`.

The fix is that we extracted the `spill_vmask, unspill_vmask` function definitions into `c2_MacroAssembler_riscv.cpp`. `c2_MacroAssembler_riscv.cpp` will only compile if the `COMPILER2` macro is present.
### Testing
- [x] linux-riscv client VM fastdebug native build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333276](https://bugs.openjdk.org/browse/JDK-8333276): RISC-V: client VM build failure after JDK-8241503 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19481/head:pull/19481` \
`$ git checkout pull/19481`

Update a local copy of the PR: \
`$ git checkout pull/19481` \
`$ git pull https://git.openjdk.org/jdk.git pull/19481/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19481`

View PR using the GUI difftool: \
`$ git pr show -t 19481`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19481.diff">https://git.openjdk.org/jdk/pull/19481.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19481#issuecomment-2141120639)