### PR TITLE
8333303: Issues with DottedVersion class

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ToolValidator.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/ToolValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,10 @@ public final class ToolValidator {
     ToolValidator setMinimalVersion(Comparable<String> v) {
         minimalVersion = v;
         return this;
+    }
+
+    ToolValidator setMinimalVersion(DottedVersion v) {
+        return setMinimalVersion(t -> DottedVersion.compareComponents(v, DottedVersion.lazy(t)));
     }
 
     ToolValidator setVersionParser(Function<Stream<String>, String> v) {

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixAppImageFragmentBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -785,7 +785,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
         xml.writeStartElement("RegistryKey");
         xml.writeAttribute("Root", regRoot);
         xml.writeAttribute("Key", registryKeyPath);
-        if (getWixVersion().compareTo("3.6") < 0) {
+        if (DottedVersion.compareComponents(getWixVersion(), DottedVersion.lazy("3.6")) < 0) {
             xml.writeAttribute("Action", "createAndRemoveOnUninstall");
         }
         xml.writeStartElement("RegistryValue");
@@ -799,7 +799,7 @@ class WixAppImageFragmentBuilder extends WixFragmentBuilder {
 
     private String addDirectoryCleaner(XMLStreamWriter xml, Path path) throws
             XMLStreamException, IOException {
-        if (getWixVersion().compareTo("3.6") < 0) {
+        if (DottedVersion.compareComponents(getWixVersion(), DottedVersion.lazy("3.6")) < 0) {
             return null;
         }
 

--- a/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
+++ b/src/jdk.jpackage/windows/classes/jdk/jpackage/internal/WixFragmentBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ abstract class WixFragmentBuilder {
     }
 
     void logWixFeatures() {
-        if (wixVersion.compareTo("3.6") >= 0) {
+        if (DottedVersion.compareComponents(wixVersion, DottedVersion.lazy("3.6")) >= 0) {
             Log.verbose(MessageFormat.format(I18N.getString(
                     "message.use-wix36-features"), wixVersion));
         }

--- a/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/CompareDottedVersionTest.java
+++ b/test/jdk/tools/jpackage/junit/jdk.jpackage/jdk/jpackage/internal/CompareDottedVersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,8 @@ public class CompareDottedVersionTest {
 
         data.addAll(List.of(new Object[][] {
             { false, "", "1", -1 },
+            { false, "", "0", 0 },
+            { false, "0", "", 0 },
             { false, "1.2.4-R4", "1.2.4-R5", 0 },
             { false, "1.2.4.-R4", "1.2.4.R5", 0 },
             { false, "7+1", "7+4", 0 },
@@ -89,7 +91,7 @@ public class CompareDottedVersionTest {
     }
 
     private int compare(String x, String y) {
-        int result = createTestee.apply(x).compareTo(y);
+        int result = DottedVersion.compareComponents(createTestee.apply(x), createTestee.apply(y));
 
         if (result < 0) {
             return -1;


### PR DESCRIPTION
- Get rid of DottedVersion#greedy field.
 - Add support to save the unrecognizable remainder of the version string (required to handle Wix4 version string).
 - Implement DottedVersion#equals().
 - add DottedVersion#compareComponents(DottedVersion, DottedVersion) that compares recognized components of the given DottedVersion instances.
 - remove DottedVersion#compareTo(String)

[Edit](https://bugs.openjdk.org/secure/EditComment!default.jspa?id=5130726&commentId=14677610)
[Delete](https://bugs.openjdk.org/secure/DeleteComment!default.jspa?id=5130726&commentId=14677610)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333303](https://bugs.openjdk.org/browse/JDK-8333303): Issues with DottedVersion class (**Bug** - P4)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19488/head:pull/19488` \
`$ git checkout pull/19488`

Update a local copy of the PR: \
`$ git checkout pull/19488` \
`$ git pull https://git.openjdk.org/jdk.git pull/19488/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19488`

View PR using the GUI difftool: \
`$ git pr show -t 19488`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19488.diff">https://git.openjdk.org/jdk/pull/19488.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19488#issuecomment-2140799582)