### PR TITLE
8333290: NMT report should not print Metaspace info if Metaspace is not yet initialized

### DIFF
--- a/src/hotspot/share/memory/metaspace/runningCounters.cpp
+++ b/src/hotspot/share/memory/metaspace/runningCounters.cpp
@@ -45,6 +45,7 @@ size_t RunningCounters::reserved_words_class() {
 }
 
 size_t RunningCounters::reserved_words_nonclass() {
+  assert(VirtualSpaceList::vslist_nonclass() != nullptr, "Metaspace not yet initialized");
   return VirtualSpaceList::vslist_nonclass()->reserved_words();
 }
 
@@ -59,6 +60,7 @@ size_t RunningCounters::committed_words_class() {
 }
 
 size_t RunningCounters::committed_words_nonclass() {
+  assert(VirtualSpaceList::vslist_nonclass() != nullptr, "Metaspace not yet initialized");
   return VirtualSpaceList::vslist_nonclass()->committed_words();
 }
 
@@ -90,6 +92,7 @@ size_t RunningCounters::free_chunks_words_class() {
 }
 
 size_t RunningCounters::free_chunks_words_nonclass() {
+  assert(ChunkManager::chunkmanager_nonclass() != nullptr, "Metaspace not yet initialized");
   return ChunkManager::chunkmanager_nonclass()->total_word_size();
 }
 

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -272,6 +272,13 @@ void MemSummaryReporter::report_summary_of_type(MEMFLAGS flag,
 }
 
 void MemSummaryReporter::report_metadata(Metaspace::MetadataType type) const {
+
+  // NMT reports may be triggered (as part of error handling) very early. Make sure
+  // Metaspace is already initialized.
+  if (!Metaspace::initialized()) {
+    return;
+  }
+
   assert(type == Metaspace::NonClassType || type == Metaspace::ClassType,
     "Invalid metadata type");
   const char* name = (type == Metaspace::NonClassType) ?


### PR DESCRIPTION
Somewhat trivial fix to a small initialization problem ubsan uncovered. 

If hs-err file gets dumped after NMT initialization but before Metaspace initialization, we may see secondary crashes during error log writing, since NMT reports contain metaspace counters, and those are not ready yet. We should omit that info if metaspace has not yet been initialized.

(See prior discussions in https://github.com/openjdk/jdk/pull/19435)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333290](https://bugs.openjdk.org/browse/JDK-8333290): NMT report should not print Metaspace info if Metaspace is not yet initialized (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19493/head:pull/19493` \
`$ git checkout pull/19493`

Update a local copy of the PR: \
`$ git checkout pull/19493` \
`$ git pull https://git.openjdk.org/jdk.git pull/19493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19493`

View PR using the GUI difftool: \
`$ git pr show -t 19493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19493.diff">https://git.openjdk.org/jdk/pull/19493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19493#issuecomment-2142081198)