### PR TITLE
8333334: C2: Make result of `Node::dominates` more precise to enhance scalar replacement

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1712,8 +1712,9 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
   PhaseIterGVN* igvn = phase->is_IterGVN();
   if (dom_result != DomResult::Dominate) {
     if (dom_result == DomResult::EncounteredDeadCode) {
-      // There is some dead code which eventually will be removed in IGVN. Once this is the case, we get an unambiguous 
-      // dominance result. Push the node to the worklist again until the dead code is removed.
+      // There is some dead code which eventually will be removed in IGVN.
+      // Once this is the case, we get an unambiguous dominance result.
+      // Push the node to the worklist again until the dead code is removed.
       igvn->_worklist.push(this);
     }
     return nullptr;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -472,7 +472,7 @@ bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
     // Check all control edges of 'dom'.
 
     ResourceMark rm;
-    Node_List nlist;
+    Node_Stack nstack(0);
     Unique_Node_List dom_list;
 
     dom_list.push(dom);
@@ -492,7 +492,7 @@ bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
       } else if (n->is_Con() || n->is_Start() || n->is_Root()) {
         only_dominating_controls = true;
       } else if (n->is_CFG()) {
-        if (n->dominates(sub, nlist))
+        if (n->dominates(sub, nstack))
           only_dominating_controls = true;
         else
           return false;

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -427,14 +427,21 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
 // Used by MemNode::find_previous_store to prove that the
 // control input of a memory operation predates (dominates)
 // an allocation it wants to look past.
-bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
-  if (dom == nullptr || dom->is_top() || sub == nullptr || sub->is_top())
+bool MemNode::all_controls_dominate(Node* dom, Node* sub, bool *dead_code) {
+  bool dummy_flag, &dead_code_flag = dead_code != nullptr ? *dead_code : dummy_flag;
+  dead_code_flag = false;
+
+  if (dom == nullptr || dom->is_top() || sub == nullptr || sub->is_top()) {
+    dead_code_flag = true;
     return false; // Conservative answer for dead code
+  }
 
   // Check 'dom'. Skip Proj and CatchProj nodes.
   dom = dom->find_exact_control(dom);
-  if (dom == nullptr || dom->is_top())
+  if (dom == nullptr || dom->is_top()) {
+    dead_code_flag = true;
     return false; // Conservative answer for dead code
+  }
 
   if (dom == sub) {
     // For the case when, for example, 'sub' is Initialize and the original
@@ -457,8 +464,10 @@ bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
   // Get control edge of 'sub'.
   Node* orig_sub = sub;
   sub = sub->find_exact_control(sub->in(0));
-  if (sub == nullptr || sub->is_top())
+  if (sub == nullptr || sub->is_top()) {
+    dead_code_flag = true;
     return false; // Conservative answer for dead code
+  }
 
   assert(sub->is_CFG(), "expecting control");
 
@@ -472,7 +481,7 @@ bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
     // Check all control edges of 'dom'.
 
     ResourceMark rm;
-    Node_Stack nstack(0);
+    Node_List nlist;
     Unique_Node_List dom_list;
 
     dom_list.push(dom);
@@ -485,23 +494,30 @@ bool MemNode::all_controls_dominate(Node* dom, Node* sub) {
       if (!n->is_CFG() && n->pinned()) {
         // Check only own control edge for pinned non-control nodes.
         n = n->find_exact_control(n->in(0));
-        if (n == nullptr || n->is_top())
+        if (n == nullptr || n->is_top()) {
+          dead_code_flag = true;
           return false; // Conservative answer for dead code
+        }
         assert(n->is_CFG(), "expecting control");
         dom_list.push(n);
       } else if (n->is_Con() || n->is_Start() || n->is_Root()) {
         only_dominating_controls = true;
       } else if (n->is_CFG()) {
-        if (n->dominates(sub, nstack))
+        bool dead_code;
+        if (n->dominates(sub, nlist, dead_code)) {
           only_dominating_controls = true;
-        else
+        } else {
+          if (dead_code) dead_code_flag = true;
           return false;
+        }
       } else {
         // First, own control edge.
         Node* m = n->find_exact_control(n->in(0));
         if (m != nullptr) {
-          if (m->is_top())
+          if (m->is_top()) {
+            dead_code_flag = true;
             return false; // Conservative answer for dead code
+          }
           dom_list.push(m);
         }
         // Now, the rest of edges.
@@ -1658,35 +1674,41 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
 
   // Select Region to split through.
   Node* region;
+  bool dead_code, can_not_split = false;
+  PhaseIterGVN* igvn = phase->is_IterGVN();
   if (!base_is_phi) {
     assert(mem->is_Phi(), "sanity");
     region = mem->in(0);
     // Skip if the region dominates some control edge of the address.
-    if (!MemNode::all_controls_dominate(address, region))
-      return nullptr;
+    if (!MemNode::all_controls_dominate(address, region, &dead_code))
+      can_not_split = true;
   } else if (!mem->is_Phi()) {
     assert(base_is_phi, "sanity");
     region = base->in(0);
     // Skip if the region dominates some control edge of the memory.
-    if (!MemNode::all_controls_dominate(mem, region))
-      return nullptr;
+    if (!MemNode::all_controls_dominate(mem, region, &dead_code))
+      can_not_split = true;
   } else if (base->in(0) != mem->in(0)) {
     assert(base_is_phi && mem->is_Phi(), "sanity");
     if (MemNode::all_controls_dominate(mem, base->in(0))) {
       region = base->in(0);
-    } else if (MemNode::all_controls_dominate(address, mem->in(0))) {
+    } else if (MemNode::all_controls_dominate(address, mem->in(0), &dead_code)) {
       region = mem->in(0);
     } else {
-      return nullptr; // complex graph
+      can_not_split = true; // complex graph
     }
   } else {
     assert(base->in(0) == mem->in(0), "sanity");
     region = mem->in(0);
   }
+  if (can_not_split) {
+    // Wait for the dead code to be removed.
+    if (dead_code) igvn->_worklist.push(this);
+    return nullptr;
+  }
 
   Node* phi = nullptr;
   const Type* this_type = this->bottom_type();
-  PhaseIterGVN* igvn = phase->is_IterGVN();
   if (t_oop != nullptr && (t_oop->is_known_instance_field() || load_boxed_values)) {
     int this_index = C->get_alias_index(t_oop);
     int this_offset = t_oop->offset();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -429,13 +429,15 @@ Node *MemNode::Ideal_common(PhaseGVN *phase, bool can_reshape) {
 // control input of a memory operation predates (dominates)
 // an allocation it wants to look past.
 Node::DomResult MemNode::all_controls_dominate(Node* dom, Node* sub) {
-  if (dom == nullptr || dom->is_top() || sub == nullptr || sub->is_top())
+  if (dom == nullptr || dom->is_top() || sub == nullptr || sub->is_top()) {
     return DomResult::EncounteredDeadCode; // Conservative answer for dead code
+  }
 
   // Check 'dom'. Skip Proj and CatchProj nodes.
   dom = dom->find_exact_control(dom);
-  if (dom == nullptr || dom->is_top())
+  if (dom == nullptr || dom->is_top()) {
     return DomResult::EncounteredDeadCode; // Conservative answer for dead code
+  }
 
   if (dom == sub) {
     // For the case when, for example, 'sub' is Initialize and the original
@@ -443,8 +445,9 @@ Node::DomResult MemNode::all_controls_dominate(Node* dom, Node* sub) {
     return DomResult::NotDominate;
   }
 
-  if (dom->is_Con() || dom->is_Start() || dom->is_Root() || dom == sub)
+  if (dom->is_Con() || dom->is_Start() || dom->is_Root() || dom == sub) {
     return DomResult::Dominate;
+  }
 
   // 'dom' dominates 'sub' if its control edge and control edges
   // of all its inputs dominate or equal to sub's control edge.
@@ -458,16 +461,19 @@ Node::DomResult MemNode::all_controls_dominate(Node* dom, Node* sub) {
   // Get control edge of 'sub'.
   Node* orig_sub = sub;
   sub = sub->find_exact_control(sub->in(0));
-  if (sub == nullptr || sub->is_top())
+  if (sub == nullptr || sub->is_top()) {
     return DomResult::EncounteredDeadCode; // Conservative answer for dead code
+  }
 
   assert(sub->is_CFG(), "expecting control");
 
-  if (sub == dom)
+  if (sub == dom) {
     return DomResult::Dominate;
+  }
 
-  if (sub->is_Start() || sub->is_Root())
+  if (sub->is_Start() || sub->is_Root()) {
     return DomResult::NotDominate;
+  }
 
   {
     // Check all control edges of 'dom'.
@@ -481,37 +487,42 @@ Node::DomResult MemNode::all_controls_dominate(Node* dom, Node* sub) {
 
     for (uint next = 0; next < dom_list.size(); next++) {
       Node* n = dom_list.at(next);
-      if (n == orig_sub)
+      if (n == orig_sub) {
         return DomResult::NotDominate; // One of dom's inputs dominated by sub.
+      }
       if (!n->is_CFG() && n->pinned()) {
         // Check only own control edge for pinned non-control nodes.
         n = n->find_exact_control(n->in(0));
-        if (n == nullptr || n->is_top())
+        if (n == nullptr || n->is_top()) {
           return DomResult::EncounteredDeadCode; // Conservative answer for dead code
+        }
         assert(n->is_CFG(), "expecting control");
         dom_list.push(n);
       } else if (n->is_Con() || n->is_Start() || n->is_Root()) {
         only_dominating_controls = true;
       } else if (n->is_CFG()) {
         DomResult dom_result = n->dominates(sub, nlist);
-        if (dom_result == DomResult::Dominate)
+        if (dom_result == DomResult::Dominate) {
           only_dominating_controls = true;
-        else
+        } else {
           return dom_result;
+        }
       } else {
         // First, own control edge.
         Node* m = n->find_exact_control(n->in(0));
         if (m != nullptr) {
-          if (m->is_top())
+          if (m->is_top()) {
             return DomResult::EncounteredDeadCode; // Conservative answer for dead code
+          }
           dom_list.push(m);
         }
         // Now, the rest of edges.
         uint cnt = n->req();
         for (uint i = 1; i < cnt; i++) {
           m = n->find_exact_control(n->in(i));
-          if (m == nullptr || m->is_top())
+          if (m == nullptr || m->is_top()) {
             continue;
+          }
           dom_list.push(m);
         }
       }
@@ -728,16 +739,18 @@ Node* MemNode::find_previous_store(PhaseValues* phase) {
     } else if (mem->is_Proj() && mem->in(0)->is_Initialize()) {
       InitializeNode* st_init = mem->in(0)->as_Initialize();
       AllocateNode*  st_alloc = st_init->allocation();
-      if (st_alloc == nullptr)
+      if (st_alloc == nullptr) {
         break;              // something degenerated
+      }
       bool known_identical = false;
       bool known_independent = false;
-      if (alloc == st_alloc)
+      if (alloc == st_alloc) {
         known_identical = true;
-      else if (alloc != nullptr)
+      } else if (alloc != nullptr) {
         known_independent = true;
-      else if (all_controls_dominate(this, st_alloc) == DomResult::Dominate)
+      } else if (all_controls_dominate(this, st_alloc) == DomResult::Dominate) {
         known_independent = true;
+      }
 
       if (known_independent) {
         // The bases are provably independent: Either they are
@@ -1568,8 +1581,9 @@ bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
   }
 
   if (!mem->is_Phi()) {
-    if (MemNode::all_controls_dominate(mem, base->in(0)) != DomResult::Dominate)
+    if (MemNode::all_controls_dominate(mem, base->in(0)) != DomResult::Dominate) {
       return false;
+    }
   } else if (base->in(0) != mem->in(0)) {
     if (MemNode::all_controls_dominate(mem, base->in(0)) != DomResult::Dominate) {
       return false;
@@ -4579,8 +4593,9 @@ bool InitializeNode::detect_init_independence(Node* value, PhaseGVN* phase) {
       // must have preceded the init, or else be equal to the init.
       // Even after loop optimizations (which might change control edges)
       // a store is never pinned *before* the availability of its inputs.
-      if (MemNode::all_controls_dominate(n, this) != DomResult::Dominate)
+      if (MemNode::all_controls_dominate(n, this) != DomResult::Dominate) {
         return false;                  // failed to prove a good control
+      }
     }
 
     // Check data edges for possible dependencies on 'this'.

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1675,7 +1675,6 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
   // Select Region to split through.
   Node* region;
   DomResult dom_result = DomResult::Dominate;
-  PhaseIterGVN* igvn = phase->is_IterGVN();
   if (!base_is_phi) {
     assert(mem->is_Phi(), "sanity");
     region = mem->in(0);
@@ -1698,12 +1697,14 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
       if (dom_result == DomResult::Dominate) {
         region = mem->in(0);
       }
-      // Otherwise we encounter a complex graph.
+      // Otherwise we encountered a complex graph.
     }
   } else {
     assert(base->in(0) == mem->in(0), "sanity");
     region = mem->in(0);
   }
+
+  PhaseIterGVN* igvn = phase->is_IterGVN();
   if (dom_result != DomResult::Dominate) {
     if (dom_result == DomResult::EncounteredDeadCode) {
       // Wait for the dead code to be removed.

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1712,9 +1712,8 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
   PhaseIterGVN* igvn = phase->is_IterGVN();
   if (dom_result != DomResult::Dominate) {
     if (dom_result == DomResult::EncounteredDeadCode) {
-      // Wait for the dead code to be removed.
-      // The dead code will eventually be removed in IGVN,
-      // so we have an unambiguous result whether it's dominated or not.
+      // There is some dead code which eventually will be removed in IGVN. Once this is the case, we get an unambiguous 
+      // dominance result. Push the node to the worklist again until the dead code is removed.
       igvn->_worklist.push(this);
     }
     return nullptr;

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -106,7 +106,7 @@ public:
   static Node *optimize_simple_memory_chain(Node *mchain, const TypeOopPtr *t_oop, Node *load, PhaseGVN *phase);
   static Node *optimize_memory_chain(Node *mchain, const TypePtr *t_adr, Node *load, PhaseGVN *phase);
   // This one should probably be a phase-specific function:
-  static bool all_controls_dominate(Node* dom, Node* sub);
+  static bool all_controls_dominate(Node* dom, Node* sub, bool *dead_code = nullptr);
 
   virtual const class TypePtr *adr_type() const;  // returns bottom_type of address
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -106,7 +106,7 @@ public:
   static Node *optimize_simple_memory_chain(Node *mchain, const TypeOopPtr *t_oop, Node *load, PhaseGVN *phase);
   static Node *optimize_memory_chain(Node *mchain, const TypePtr *t_adr, Node *load, PhaseGVN *phase);
   // This one should probably be a phase-specific function:
-  static bool all_controls_dominate(Node* dom, Node* sub, bool *dead_code = nullptr);
+  static DomResult all_controls_dominate(Node* dom, Node* sub);
 
   virtual const class TypePtr *adr_type() const;  // returns bottom_type of address
 

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -106,8 +106,12 @@ public:
 
   static Node *optimize_simple_memory_chain(Node *mchain, const TypeOopPtr *t_oop, Node *load, PhaseGVN *phase);
   static Node *optimize_memory_chain(Node *mchain, const TypePtr *t_adr, Node *load, PhaseGVN *phase);
-  // This one should probably be a phase-specific function:
-  static DomResult all_controls_dominate(Node* dom, Node* sub);
+  // The following two should probably be phase-specific functions:
+  static DomResult maybe_all_controls_dominate(Node* dom, Node* sub);
+  static bool all_controls_dominate(Node* dom, Node* sub) {
+    DomResult dom_result = maybe_all_controls_dominate(dom, sub);
+    return dom_result == DomResult::Dominate;
+  }
 
   virtual const class TypePtr *adr_type() const;  // returns bottom_type of address
 

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -1249,7 +1249,7 @@ Node* Node::find_exact_control(Node* ctrl) {
 // We already know that if any path back to Root or Start reaches 'this',
 // then all paths so, so this is a simple search for one example,
 // not an exhaustive search for a counterexample.
-bool Node::dominates(Node* sub, Node_Stack &nstack) {
+bool Node::dominates(Node* sub, Node_List &nlist, bool &dead_code) {
   assert(this->is_CFG(), "expecting control");
   assert(sub != nullptr && sub->is_CFG(), "expecting control");
 
@@ -1259,7 +1259,8 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
   Node* orig_sub = sub;
   Node* dom      = this;
   bool  met_dom  = false;
-  nstack.clear();
+  dead_code      = false;
+  nlist.clear();
 
   // Walk 'sub' backward up the chain to 'dom', watching for regions.
   // After seeing 'dom', continue up to Root or Start.
@@ -1270,28 +1271,12 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
   // (If we get confused, break out and return a conservative 'false'.)
   while (sub != nullptr) {
     if (sub->is_top()) {
-      // We reached a dead code, try another path of the last multi-input Region we met.
-      bool found = false;
-      for (uint i = nstack.size(); i > 0; i--) {
-        Node* n = nstack.node_at(i - 1);
-        for (uint index = nstack.index_at(i - 1); index < n->req(); index++) {
-          Node* in = n->in(index);
-          if (in != nullptr && !in->is_top()) {
-            found = true;
-            sub = n->find_exact_control(in);
-            nstack.set_index_at(i - 1, index + 1);
-            break;
-          }
-        }
-        if (found) break;
-      }
-      if (found) continue;
-      // Give a conservative answer if we have no other choices.
+      // Conservative answer for dead code.
+      dead_code = true;
       break;
     }
-
     if (sub == dom) {
-      if (nstack.is_empty()) {
+      if (nlist.size() == 0) {
         // No Region nodes except loops were visited before and the EntryControl
         // path was taken for loops: it did not walk in a cycle.
         return true;
@@ -1302,7 +1287,7 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
         // to make sure that it did not walk in a cycle.
         met_dom = true; // first time meet
         iterations_without_region_limit = DominatorSearchLimit; // Reset
-      }
+     }
     }
     if (sub->is_Start() || sub->is_Root()) {
       // Success if we met 'dom' along a path to Start or Root.
@@ -1310,7 +1295,6 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
       // (This assumption is up to the caller to ensure!)
       return met_dom;
     }
-
     Node* up = sub->in(0);
     // Normalize simple pass-through regions and projections:
     up = sub->find_exact_control(up);
@@ -1322,7 +1306,9 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
       // Take in(1) path on the way up to 'dom' for regions with only one input
       up = sub->in(1);
     } else if (sub == up && sub->is_Region()) {
-      // Try all paths for Regions with multiple input paths (it may be a loop head).
+      // Try both paths for Regions with 2 input paths (it may be a loop head).
+      // It could give conservative 'false' answer without information
+      // which region's input is the entry path.
       iterations_without_region_limit = DominatorSearchLimit; // Reset
 
       bool region_was_visited_before = false;
@@ -1331,38 +1317,40 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
       // loop-back edge from 'sub' back into the body of the loop,
       // and worked our way up again to the loop header 'sub'.
       // So, take the first unexplored path on the way up to 'dom'.
-      for (uint i = nstack.size(); i > 0; i--) {
-        Node* visited = nstack.node_at(i - 1);
+      for (int j = nlist.size() - 1; j >= 0; j--) {
+        intptr_t ni = (intptr_t)nlist.at(j);
+        Node* visited = (Node*)(ni & ~1);
+        bool  visited_twice_already = ((ni & 1) != 0);
         if (visited == sub) {
-          // The Region node was visited before, just visit the next input.
-          for (uint index = nstack.index_at(i - 1); index < sub->req(); index++) {
-            Node* in = sub->in(index);
-            if (in != nullptr && !in->is_top() && in != sub) {
-              region_was_visited_before = true;
-              up = in;
-              nstack.set_index_at(i - 1, index + 1);
-              break;
-            }
-          }
-          if (!region_was_visited_before) {
-            // Visited all paths, but still stuck in loop body. Give up.
+          if (visited_twice_already) {
+            // Visited 2 paths, but still stuck in loop body.  Give up.
             return false;
           }
+          // The Region node was visited before only once.
+          // (We will repush with the low bit set, below.)
+          nlist.remove(j);
+          // We will find a new edge and re-insert.
+          region_was_visited_before = true;
           break;
         }
       }
 
-      // Record this Region if it's not visited before, and visit its first input.
-      if (!region_was_visited_before) {
-        for (uint i = 1; i < sub->req(); i++) {
-          Node* in = sub->in(i);
-          if (in != nullptr && !in->is_top() && in != sub) {
+      // Find an incoming edge which has not been seen yet; walk through it.
+      assert(up == sub, "");
+      uint skip = region_was_visited_before ? 1 : 0;
+      for (uint i = 1; i < sub->req(); i++) {
+        Node* in = sub->in(i);
+        if (in != nullptr && !in->is_top() && in != sub) {
+          if (skip == 0) {
             up = in;
-            nstack.push(sub, i + 1);
             break;
           }
+          --skip;               // skip this nontrivial input
         }
       }
+
+      // Set 0 bit to indicate that both paths were taken.
+      nlist.push((Node*)((intptr_t)sub + (region_was_visited_before ? 1 : 0)));
     }
 
     if (up == sub) {
@@ -1375,8 +1363,7 @@ bool Node::dominates(Node* sub, Node_Stack &nstack) {
     if (--iterations_without_region_limit < 0) {
       break;    // dead cycle
     }
-    // Skip simple pass-through control nodes in chain.
-    sub = sub->find_exact_control(up);
+    sub = up;
   }
 
   // Did not meet Root or Start node in pred. chain.

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1110,7 +1110,7 @@ public:
   enum class DomResult {
     NotDominate,         // 'this' node does not dominate 'sub'.
     Dominate,            // 'this' node dominates or is equal to 'sub'.
-    EncounteredDeadCode, // Result is undefined due to encountering dead code.
+    EncounteredDeadCode  // Result is undefined due to encountering dead code.
   };
   // Check if 'this' node dominates or equal to 'sub'.
   DomResult dominates(Node* sub, Node_List &nlist);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1105,8 +1105,14 @@ public:
   // Skip Proj and CatchProj nodes chains. Check for Null and Top.
   Node* find_exact_control(Node* ctrl);
 
+  // Results of the dominance analysis.
+  enum class DomResult {
+    NotDominate,         // 'this' node does not dominate 'sub'.
+    Dominate,            // 'this' node dominates or is equal to 'sub'.
+    EncounteredDeadCode, // Result is undefined due to encountering dead code.
+  };
   // Check if 'this' node dominates or equal to 'sub'.
-  bool dominates(Node* sub, Node_List &nlist, bool &dead_code);
+  DomResult dominates(Node* sub, Node_List &nlist);
 
 protected:
   bool remove_dead_region(PhaseGVN *phase, bool can_reshape);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1106,7 +1106,7 @@ public:
   Node* find_exact_control(Node* ctrl);
 
   // Check if 'this' node dominates or equal to 'sub'.
-  bool dominates(Node* sub, Node_List &nlist);
+  bool dominates(Node* sub, Node_Stack &nstack);
 
 protected:
   bool remove_dead_region(PhaseGVN *phase, bool can_reshape);
@@ -1891,6 +1891,10 @@ public:
   }
   void set_index(uint i) {
     _inode_top->indx = i;
+  }
+  void set_index_at(uint i, uint index) {
+    assert(_inodes + i <= _inode_top, "in range");
+    _inodes[i].indx = index;
   }
   uint size_max() const { return (uint)pointer_delta(_inode_max, _inodes,  sizeof(INode)); } // Max size
   uint size() const { return (uint)pointer_delta((_inode_top+1), _inodes,  sizeof(INode)); } // Current size

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1106,7 +1106,7 @@ public:
   Node* find_exact_control(Node* ctrl);
 
   // Check if 'this' node dominates or equal to 'sub'.
-  bool dominates(Node* sub, Node_Stack &nstack);
+  bool dominates(Node* sub, Node_List &nlist, bool &dead_code);
 
 protected:
   bool remove_dead_region(PhaseGVN *phase, bool can_reshape);
@@ -1891,10 +1891,6 @@ public:
   }
   void set_index(uint i) {
     _inode_top->indx = i;
-  }
-  void set_index_at(uint i, uint index) {
-    assert(_inodes + i <= _inode_top, "in range");
-    _inodes[i].indx = index;
   }
   uint size_max() const { return (uint)pointer_delta(_inode_max, _inodes,  sizeof(INode)); } // Max size
   uint size() const { return (uint)pointer_delta((_inode_top+1), _inodes,  sizeof(INode)); } // Current size

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
@@ -44,6 +44,7 @@ public class ScalarReplacementWithGCBarrierTests {
             head = n;
         }
 
+        @ForceInline
         public Iter iter() {
             Iter iter = new Iter();
             iter.list = this;
@@ -63,6 +64,7 @@ public class ScalarReplacementWithGCBarrierTests {
         public Node n;
         public Integer sum;
 
+        @ForceInline
         public boolean next() {
             int lastSum = sum;
             while (sum - lastSum < 1000) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests.scalarReplacement;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8333334
+ * @summary Tests that dead barrier control flows do not affect the scalar replacement.
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.c2.irTests.scalarReplacement.ScalarReplacementWithGCBarrierTests
+ */
+public class ScalarReplacementWithGCBarrierTests {
+    static class List {
+        public Node head;
+
+        public void push(int value) {
+            Node n = new Node();
+            n.value = value;
+            n.next = head;
+            head = n;
+        }
+
+        public Iter iter() {
+            Iter iter = new Iter();
+            iter.list = this;
+            iter.n = head;
+            iter.sum = 0;
+            return iter;
+        }
+    }
+
+    static class Node {
+        public int value;
+        public Node next;
+    }
+
+    static class Iter {
+        public List list;
+        public Node n;
+        public Integer sum;
+
+        public boolean next() {
+            int lastSum = sum;
+            while (sum - lastSum < 1000) {
+                while (n != null && n.value < 30) n = n.next;
+                if (n == null) return false;
+                sum += n.value;
+                n = n.next;
+            }
+            return true;
+        }
+    }
+
+    private static final int SIZE = 1000;
+
+    public static void main(String[] args) {
+        // Must use G1 GC to ensure there is a pre-barrier
+        // before the first field write.
+        TestFramework.runWithFlags("-XX:+UseG1GC");
+    }
+
+    @Run(test = "testScalarReplacementWithGCBarrier")
+    private void runner() {
+        List list = new List();
+        for (int i = 0; i < SIZE; i++) {
+            list.push(i);
+        }
+        testScalarReplacementWithGCBarrier(list);
+    }
+
+    // Allocation of `Iter iter` should be eliminated by scalar replacement, and
+    // the allocation of `Integer sum` can not be eliminated, so there should be
+    // 1 allocation after allocations and locks elimination.
+    //
+    // Before the patch of JDK-8333334, both allocations of `Iter` and `Integer`
+    // could not be eliminated.
+    @Test
+    @IR(phase = { CompilePhase.AFTER_PARSING }, counts = { IRNode.ALLOC, "1" })
+    @IR(phase = { CompilePhase.INCREMENTAL_BOXING_INLINE }, counts = { IRNode.ALLOC, "2" })
+    @IR(applyIf = { "UseG1GC", "true" }, phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, counts = { IRNode.ALLOC, "1" })
+    private int testScalarReplacementWithGCBarrier(List list) {
+        Iter iter = list.iter();
+        for (;;) {
+            while (iter.next()) {}
+            if (list.head == null) break;
+            list.head = list.head.next;
+            iter.n = list.head;
+        }
+        return iter.sum;
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
@@ -31,6 +31,7 @@ import compiler.lib.ir_framework.*;
  * @summary Tests that dead barrier control flows do not affect the scalar replacement.
  * @library /test/lib /
  * @requires vm.compiler2.enabled
+ * @requires vm.gc.G1
  * @run driver compiler.c2.irTests.scalarReplacement.ScalarReplacementWithGCBarrierTests
  */
 public class ScalarReplacementWithGCBarrierTests {

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/ScalarReplacementWithGCBarrierTests.java
@@ -104,10 +104,10 @@ public class ScalarReplacementWithGCBarrierTests {
     @Test
     @IR(phase = { CompilePhase.AFTER_PARSING }, counts = { IRNode.ALLOC, "1" })
     @IR(phase = { CompilePhase.INCREMENTAL_BOXING_INLINE }, counts = { IRNode.ALLOC, "2" })
-    @IR(applyIf = { "UseG1GC", "true" }, phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, counts = { IRNode.ALLOC, "1" })
+    @IR(phase = { CompilePhase.ITER_GVN_AFTER_ELIMINATION }, counts = { IRNode.ALLOC, "1" })
     private int testScalarReplacementWithGCBarrier(List list) {
         Iter iter = list.iter();
-        for (;;) {
+        while (true) {
             while (iter.next()) {}
             if (list.head == null) break;
             list.head = list.head.next;

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
+++ b/test/micro/org/openjdk/bench/java/util/concurrent/Maps.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -125,6 +126,21 @@ public class Maps {
         }
         map.putAll(staticMap);
         return map;
+    }
+
+    @Benchmark
+    public int testConcurrentHashMapIterators() {
+        ConcurrentHashMap<Integer, Integer> map = (ConcurrentHashMap<Integer, Integer>) staticMap;
+        int sum = 0;
+        Enumeration it = map.elements();
+        while (it.hasMoreElements()) {
+            sum += (int) it.nextElement();
+        }
+        it = map.keys();
+        while (it.hasMoreElements()) {
+            sum += (int) it.nextElement();
+        }
+        return sum;
     }
 
     private static class SimpleRandom {


### PR DESCRIPTION
This patch changes the algorithm of `Node::dominates` to make the result more precise, and allows the iterators of `ConcurrentHashMap` to be scalar replaced.

The previous algorithm will return a conservative result when encountering a dead control flow, and only try the first two input paths of a multi-input Region node, which may prevent the scalar replacement in some cases.

For example, with G1 GC enabled, C2 generates GC barriers for `ConcurrentHashMap` iteration operations at some early phases, and then eliminates them in a later IGVN, but `LoadNode` is also idealized in the same IGVN. This causes `LoadNode::Ideal` to see some dead barrier control flows, and refuse to split some instance field loads through Phi due to the conservative result of `Node::dominates`, and thus the scalar replacement can not be applied to iterators in the later macro elimination phase.

This patch allows `Node::dominates` to try other paths of the last multi-input Region node when the first path is dead, and makes `ConcurrentHashMap` iteration ~30% faster:

```
Benchmark                            (nkeys)  Mode  Cnt        Score       Error  Units
Maps.testConcurrentHashMapIterators    10000  avgt   15   414099.085 ± 33230.945  ns/op   # baseline
Maps.testConcurrentHashMapIterators    10000  avgt   15   315490.281 ±  3037.056  ns/op   # patch
```

Testing: tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8333334](https://bugs.openjdk.org/browse/JDK-8333334): C2: Make result of `Node::dominates` more precise to enhance scalar replacement (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [8ee38498](https://git.openjdk.org/jdk/pull/19496/files/8ee384988889d79a60700b5732255269be6c50ab)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19496/head:pull/19496` \
`$ git checkout pull/19496`

Update a local copy of the PR: \
`$ git checkout pull/19496` \
`$ git pull https://git.openjdk.org/jdk.git pull/19496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19496`

View PR using the GUI difftool: \
`$ git pr show -t 19496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19496.diff">https://git.openjdk.org/jdk/pull/19496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19496#issuecomment-2141556384)