### PR TITLE
8333326: Linux Alpine build fails after 8302744

### DIFF
--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -34,6 +34,10 @@
 
 #include <stdio.h>
 
+#ifdef MUSL_LIBC
+#include <libgen.h> // for basename
+#endif
+
 typedef struct {
   const char* mount_path;
   const char* root_path;
@@ -89,7 +93,7 @@ static void fill_file(const char* path, const char* content) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_failure_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -135,7 +139,7 @@ TEST(cgroupTest, read_numerical_key_value_failure_cases) {
 }
 
 TEST(cgroupTest, read_numerical_key_value_success_cases) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -235,7 +239,7 @@ TEST(cgroupTest, read_numerical_key_value_null) {
 }
 
 TEST(cgroupTest, read_number_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   constexpr julong bad = 0xBAD;
   EXPECT_TRUE(b != nullptr) << "basename was null";
@@ -289,7 +293,7 @@ TEST(cgroupTest, read_number_tests) {
 }
 
 TEST(cgroupTest, read_string_tests) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;
@@ -355,7 +359,7 @@ TEST(cgroupTest, read_string_tests) {
 }
 
 TEST(cgroupTest, read_number_tuple_test) {
-  const char* test_file = temp_file("cgroups");
+  char* test_file = temp_file("cgroups");
   const char* b = basename(test_file);
   EXPECT_TRUE(b != nullptr) << "basename was null";
   stringStream path;

--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -34,9 +34,8 @@
 
 #include <stdio.h>
 
-#ifdef MUSL_LIBC
-#include <libgen.h> // for basename
-#endif
+// for basename, needed for Alpine
+#include <libgen.h>
 
 typedef struct {
   const char* mount_path;
@@ -51,6 +50,7 @@ static bool file_exists(const char* filename) {
   return os::stat(filename, &st) == 0;
 }
 
+// we rely on temp_file returning modifiable memory in resource area.
 static char* temp_file(const char* prefix) {
   const testing::TestInfo* test_info = ::testing::UnitTest::GetInstance()->current_test_info();
   stringStream path;

--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -34,7 +34,7 @@
 
 #include <stdio.h>
 
-// for basename, needed for Alpine
+// for basename
 #include <libgen.h>
 
 typedef struct {


### PR DESCRIPTION
we run into a basename related build issue on Alpine Linux

basename related issue :
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-linux_alpine_x86_64-opt/jdk/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp: In member function 'virtual void cgroupTest_read_numerical_key_value_success_cases_Test::TestBody()':
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-linux_alpine_x86_64-opt/jdk/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp:139:19: error: 'basename' was not declared in this scope; did you mean 'rename'?
  139 | const char* b = basename(test_file);
      | ^~~~~~~~
      | rename


Additionally giving a 'const char*'  to basename results in a warning as error because basename interface gets a char* .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333326](https://bugs.openjdk.org/browse/JDK-8333326): Linux Alpine build fails after 8302744 (**Bug** - P3)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [834b68f9](https://git.openjdk.org/jdk/pull/19497/files/834b68f979e3acc417f9f1143b87c465db6661d8)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [fabfcd22](https://git.openjdk.org/jdk/pull/19497/files/fabfcd22013adacab3dcd9c3c81c8d0606ecddbe)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19497/head:pull/19497` \
`$ git checkout pull/19497`

Update a local copy of the PR: \
`$ git checkout pull/19497` \
`$ git pull https://git.openjdk.org/jdk.git pull/19497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19497`

View PR using the GUI difftool: \
`$ git pr show -t 19497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19497.diff">https://git.openjdk.org/jdk/pull/19497.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19497#issuecomment-2141734466)