### PR TITLE
8333169: javac NullPointerException record.type

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -6026,6 +6026,12 @@ public class Attr extends JCTree.Visitor {
         }
 
         @Override
+        public void visitRecordPattern(JCRecordPattern that) {
+            initTypeIfNeeded(that);
+            super.visitRecordPattern(that);
+        }
+
+        @Override
         public void visitNewClass(JCNewClass that) {
             if (that.constructor == null) {
                 that.constructor = new MethodSymbol(0, names.init,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -6028,6 +6028,13 @@ public class Attr extends JCTree.Visitor {
         @Override
         public void visitRecordPattern(JCRecordPattern that) {
             initTypeIfNeeded(that);
+            if (that.record == null) {
+                that.record = new ClassSymbol(0, TreeInfo.name(that.deconstructor),
+                                              that.type, syms.noSymbol);
+            }
+            if (that.fullComponentTypes == null) {
+                that.fullComponentTypes = List.nil();
+            }
             super.visitRecordPattern(that);
         }
 

--- a/test/langtools/tools/javac/patterns/Exhaustiveness.java
+++ b/test/langtools/tools/javac/patterns/Exhaustiveness.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215
+ * @bug 8262891 8268871 8274363 8281100 8294670 8311038 8311815 8325215 8333169
  * @summary Check exhaustiveness of switches over sealed types.
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2075,6 +2075,35 @@ public class Exhaustiveness extends TestRunner {
                }
                """);
     }
+
+   @Test //JDK-8333169
+   public void testFlowForNestedSwitch(Path base) throws Exception {
+       doTest(base,
+              new String[0],
+              """
+              class Main {
+
+                  record A() {};
+
+                  public static void main(String[] args) {
+                      A a1 = new A();
+                      A a2 = new A();
+
+                      String causesCompilationError = log(
+                              switch(a1) {
+                                  case A() -> switch(a2) {
+                                      case A() -> "A";
+                                  };
+                              }
+                      );
+                   }
+
+                  static <T> T log(T t) {
+                      System.out.println("LOG: " + t);
+                      return t;
+                  }
+              }""");
+   }
 
     private void doTest(Path base, String[] libraryCode, String testCode, String... expectedErrors) throws IOException {
         doTest(base, libraryCode, testCode, false, expectedErrors);


### PR DESCRIPTION
While attributing cases, `Attr` computes `completesNormally`, by invoking `Flow`. It will do `preFlow` before running the `Flow`, to make fill in missing types/symbols in the AST, as `Flow` generally requires them. But, the visitor filling the types is missing code to fill in the missing type for record patterns, and consequently `Flow` may crash on record pattern while computing `completesNormally`.

The proposal herein is to adjust the visitor to fill in the missing attributes for record patterns, as is done for other AST nodes.

I've also filled a follow-up to reconsider computing `completesNormally` in `Attr`, to get more performance. This will require moving some of the checks that are currently done in `Attr` to `Flow`, but it would probably pay off:
https://bugs.openjdk.org/browse/JDK-8333333
