### PR TITLE
8333353: Delete extra empty line in CodeBlob.java

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
@@ -125,7 +125,6 @@ public class CodeBlob extends VMObject {
   }
 
   /** OopMap for frame; can return null if none available */
-
   public ImmutableOopMapSet getOopMaps() {
     Address value = oopMapsField.getValue(addr);
     if (value == null) {


### PR DESCRIPTION
Hi all,
  This trivial fix, delete the extra empty line before `getOopMaps` function in `src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java` file.
  No risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333353](https://bugs.openjdk.org/browse/JDK-8333353): Delete extra empty line in CodeBlob.java (**Bug** - P5)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19499/head:pull/19499` \
`$ git checkout pull/19499`

Update a local copy of the PR: \
`$ git checkout pull/19499` \
`$ git pull https://git.openjdk.org/jdk.git pull/19499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19499`

View PR using the GUI difftool: \
`$ git pr show -t 19499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19499.diff">https://git.openjdk.org/jdk/pull/19499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19499#issuecomment-2142000853)