### PR TITLE
8333312: Incorrect since tags on new ClassReader and ConstantPool methods

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassReader.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassReader.java
@@ -126,7 +126,7 @@ public sealed interface ClassReader extends ConstantPool
      * @param cls the entry type
      * @throws ConstantPoolException if the index is out of range of the
      *         constant pool size, or zero, or the entry is not of the given type
-     * @since 24
+     * @since 23
      */
     <T extends PoolEntry> T readEntryOrNull(int offset, Class<T> cls);
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
@@ -69,7 +69,7 @@ public sealed interface ConstantPool extends Iterable<PoolEntry>
      * @param cls the entry type
      * @throws ConstantPoolException if the index is out of range of the
      *         constant pool, or the entry is not of the given type
-     * @since 24
+     * @since 23
      */
     <T extends PoolEntry> T entryByIndex(int index, Class<T> cls);
 


### PR DESCRIPTION
The new method additions ClassReader.readEntryOrNull(int, Class) and ConstantPool.entryByIndex(int, Class) have incorrect since tags; they should be `@since 23`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333312](https://bugs.openjdk.org/browse/JDK-8333312): Incorrect since tags on new ClassReader and ConstantPool methods (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19501/head:pull/19501` \
`$ git checkout pull/19501`

Update a local copy of the PR: \
`$ git checkout pull/19501` \
`$ git pull https://git.openjdk.org/jdk.git pull/19501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19501`

View PR using the GUI difftool: \
`$ git pr show -t 19501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19501.diff">https://git.openjdk.org/jdk/pull/19501.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19501#issuecomment-2142117815)