### PR TITLE
8331977: Crash: SIGSEGV in dlerror()

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -327,7 +327,7 @@ public final class HelloApp {
             String... args) {
         AppOutputVerifier av = assertMainLauncher(cmd, args);
         if (av != null) {
-            return av.saveOutput(true).executeWithRetries(args);
+            return av.saveOutput(true).execute(args);
         } else {
             return null;
         }
@@ -395,6 +395,8 @@ public final class HelloApp {
                 outputFilePath = Path.of(value);
             } else if ("jpackage.test.exitCode".equals(name)) {
                 expectedExitCode = Integer.parseInt(value);
+            } else if ("jpackage.test.noexit".equals(name)) {
+                launcherNoExit = Boolean.parseBoolean(value);
             }
             return this;
         }
@@ -438,15 +440,19 @@ public final class HelloApp {
         }
 
         public void executeAndVerifyOutput(String... args) {
-            executeWithRetries(args);
+            execute(args);
             verifyOutput(args);
         }
 
-        public Executor.Result executeWithRetries(String... args) {
-            final int attempts = 3;
-            final int waitBetweenAttemptsSeconds = 5;
-            return getExecutor(args).executeAndRepeatUntilExitCode(expectedExitCode, attempts,
-                    waitBetweenAttemptsSeconds);
+        public Executor.Result execute(String... args) {
+            if (launcherNoExit) {
+                return getExecutor(args).executeWithoutExitCodeCheck();
+            } else {
+                final int attempts = 3;
+                final int waitBetweenAttemptsSeconds = 5;
+                return getExecutor(args).executeAndRepeatUntilExitCode(expectedExitCode, attempts,
+                        waitBetweenAttemptsSeconds);
+            }
         }
 
         private Executor getExecutor(String...args) {
@@ -473,6 +479,7 @@ public final class HelloApp {
                     .addArguments(launcherArgs);
         }
 
+        private boolean launcherNoExit;
         private boolean removePath;
         private boolean saveOutput;
         private final Path launcherPath;

--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/HelloApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -317,20 +317,23 @@ public final class HelloApp {
 
     public static void executeLauncherAndVerifyOutput(JPackageCommand cmd,
             String... args) {
-        AppOutputVerifier av = getVerifier(cmd, args);
+        AppOutputVerifier av = assertMainLauncher(cmd, args);
         if (av != null) {
-            // when running app launchers, clear users environment
-            av.executeAndVerifyOutput(true, args);
+            av.executeAndVerifyOutput(args);
         }
     }
 
     public static Executor.Result executeLauncher(JPackageCommand cmd,
             String... args) {
-        AppOutputVerifier av = getVerifier(cmd, args);
-        return av.executeOnly(true, args);
+        AppOutputVerifier av = assertMainLauncher(cmd, args);
+        if (av != null) {
+            return av.saveOutput(true).executeWithRetries(args);
+        } else {
+            return null;
+        }
     }
 
-    private static AppOutputVerifier getVerifier(JPackageCommand cmd,
+    public static AppOutputVerifier assertMainLauncher(JPackageCommand cmd,
             String... args) {
         final Path launcherPath = cmd.appLauncherPath();
         if (!cmd.canRunLauncher(String.format("Not running [%s] launcher",
@@ -354,6 +357,26 @@ public final class HelloApp {
             this.outputFilePath = TKit.workDir().resolve(OUTPUT_FILENAME);
             this.params = new HashMap<>();
             this.defaultLauncherArgs = new ArrayList<>();
+
+            if (TKit.isWindows()) {
+                // When running app launchers on Windows, clear users environment (JDK-8254920)
+                removePath(true);
+            }
+        }
+
+        public AppOutputVerifier removePath(boolean v) {
+            removePath = v;
+            return this;
+        }
+
+        public AppOutputVerifier saveOutput(boolean v) {
+            saveOutput = v;
+            return this;
+        }
+
+        public AppOutputVerifier expectedExitCode(int v) {
+            expectedExitCode = v;
+            return this;
         }
 
         public AppOutputVerifier addDefaultArguments(String... v) {
@@ -415,36 +438,15 @@ public final class HelloApp {
         }
 
         public void executeAndVerifyOutput(String... args) {
-            executeAndVerifyOutput(false, args);
+            executeWithRetries(args);
+            verifyOutput(args);
         }
 
-        public void executeAndVerifyOutput(boolean removePath,
-                List<String> launcherArgs, List<String> appArgs) {
+        public Executor.Result executeWithRetries(String... args) {
             final int attempts = 3;
             final int waitBetweenAttemptsSeconds = 5;
-            getExecutor(launcherArgs.toArray(new String[0])).dumpOutput().setRemovePath(
-                    removePath).executeAndRepeatUntilExitCode(expectedExitCode,
-                            attempts, waitBetweenAttemptsSeconds);
-            verifyOutputFile(outputFilePath, appArgs, params);
-        }
-
-        public void executeAndVerifyOutput(boolean removePath, String... args) {
-            final List<String> launcherArgs = List.of(args);
-            final List<String> appArgs;
-            if (launcherArgs.isEmpty()) {
-                appArgs = defaultLauncherArgs;
-            } else {
-                appArgs = launcherArgs;
-            }
-
-            executeAndVerifyOutput(removePath, launcherArgs, appArgs);
-        }
-
-        public Executor.Result executeOnly(boolean removePath, String...args) {
-            return getExecutor(args)
-                    .saveOutput()
-                    .setRemovePath(removePath)
-                    .executeWithoutExitCodeCheck();
+            return getExecutor(args).executeAndRepeatUntilExitCode(expectedExitCode, attempts,
+                    waitBetweenAttemptsSeconds);
         }
 
         private Executor getExecutor(String...args) {
@@ -464,10 +466,15 @@ public final class HelloApp {
             final List<String> launcherArgs = List.of(args);
             return new Executor()
                     .setDirectory(outputFile.getParent())
+                    .saveOutput(saveOutput)
+                    .dumpOutput()
+                    .setRemovePath(removePath)
                     .setExecutable(executablePath)
                     .addArguments(launcherArgs);
         }
 
+        private boolean removePath;
+        private boolean saveOutput;
         private final Path launcherPath;
         private Path outputFilePath;
         private int expectedExitCode;

--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -52,7 +52,7 @@ public class ArgumentsFilteringTest {
         cmd.executeAndAssertHelloAppImageCreated();
         var appVerifier = HelloApp.assertMainLauncher(cmd);
         if (appVerifier != null) {
-            appVerifier.executeWithRetries("-psn_1_1");
+            appVerifier.execute("-psn_1_1");
             appVerifier.verifyOutput();
         }
     }
@@ -64,7 +64,7 @@ public class ArgumentsFilteringTest {
         cmd.executeAndAssertHelloAppImageCreated();
         var appVerifier = HelloApp.assertMainLauncher(cmd);
         if (appVerifier != null) {
-            appVerifier.executeWithRetries("-psn_1_1");
+            appVerifier.execute("-psn_1_1");
             appVerifier.verifyOutput("-psn_2_2");
         }        
     }

--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -66,6 +66,6 @@ public class ArgumentsFilteringTest {
         if (appVerifier != null) {
             appVerifier.execute("-psn_1_1");
             appVerifier.verifyOutput("-psn_2_2");
-        }        
+        }
     }
 }

--- a/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
+++ b/test/jdk/tools/jpackage/macosx/ArgumentsFilteringTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,6 @@
  * questions.
  */
 
-import java.nio.file.Path;
-import java.util.List;
-import java.util.ArrayList;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.HelloApp;
 import jdk.jpackage.test.Annotations.Test;
@@ -53,10 +50,11 @@ public class ArgumentsFilteringTest {
     public void test1() {
         JPackageCommand cmd = JPackageCommand.helloAppImage();
         cmd.executeAndAssertHelloAppImageCreated();
-        Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath)
-                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                        new ArrayList<>());
+        var appVerifier = HelloApp.assertMainLauncher(cmd);
+        if (appVerifier != null) {
+            appVerifier.executeWithRetries("-psn_1_1");
+            appVerifier.verifyOutput();
+        }
     }
 
     @Test
@@ -64,9 +62,10 @@ public class ArgumentsFilteringTest {
         JPackageCommand cmd = JPackageCommand.helloAppImage()
                 .addArguments("--arguments", "-psn_2_2");
         cmd.executeAndAssertHelloAppImageCreated();
-        Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath)
-                .executeAndVerifyOutput(false, List.of("-psn_1_1"),
-                        List.of("-psn_2_2"));
+        var appVerifier = HelloApp.assertMainLauncher(cmd);
+        if (appVerifier != null) {
+            appVerifier.executeWithRetries("-psn_1_1");
+            appVerifier.verifyOutput("-psn_2_2");
+        }        
     }
 }

--- a/test/jdk/tools/jpackage/share/ArgumentsTest.java
+++ b/test/jdk/tools/jpackage/share/ArgumentsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
 import java.nio.file.Path;
 import java.util.List;
 import jdk.jpackage.test.HelloApp;
-import jdk.jpackage.test.Functional.ThrowingConsumer;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.BeforeEach;
 import jdk.jpackage.test.Annotations.Test;
@@ -65,27 +64,19 @@ public class ArgumentsTest {
     @Parameter("Goodbye")
     @Parameter("com.hello/com.hello.Hello")
     public static void testApp(String javaAppDesc) {
-        testIt(javaAppDesc, null);
-    }
-
-    private static void testIt(String javaAppDesc,
-            ThrowingConsumer<JPackageCommand> initializer) {
-
         JPackageCommand cmd = JPackageCommand.helloAppImage(javaAppDesc).addArguments(
                 "--arguments", JPackageCommand.escapeAndJoin(TRICKY_ARGUMENTS));
-        if (initializer != null) {
-            ThrowingConsumer.toConsumer(initializer).accept(cmd);
-        }
 
         cmd.executeAndAssertImageCreated();
 
-        Path launcherPath = cmd.appLauncherPath();
-        if (!cmd.isFakeRuntime(String.format(
-                "Not running [%s] launcher", launcherPath))) {
-            HelloApp.assertApp(launcherPath)
-                    .addDefaultArguments(TRICKY_ARGUMENTS)
-                    .executeAndVerifyOutput();
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
         }
+
+        Path launcherPath = cmd.appLauncherPath();
+        HelloApp.assertApp(launcherPath)
+                .addDefaultArguments(TRICKY_ARGUMENTS)
+                .executeAndVerifyOutput();
     }
 
     private final static List<String> TRICKY_ARGUMENTS = List.of(

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
@@ -240,7 +240,7 @@ public final class MainClassTest {
                 List<String> output = appVerifier
                         .saveOutput(true)
                         .expectedExitCode(1)
-                        .executeWithRetries().getOutput();
+                        .execute().getOutput();
                 TKit.assertTextStream(String.format(
                         "Error: Could not find or load main class %s",
                         nonExistingMainClass)).apply(output.stream());

--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/MainClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,13 +235,12 @@ public final class MainClassTest {
             cmd.executeAndAssertHelloAppImageCreated();
         } else {
             cmd.executeAndAssertImageCreated();
-            if (!cmd.isFakeRuntime(String.format("Not running [%s]",
-                    cmd.appLauncherPath()))) {
-                List<String> output = new Executor()
-                    .setDirectory(cmd.outputDir())
-                    .setExecutable(cmd.appLauncherPath())
-                    .dumpOutput().saveOutput()
-                    .execute(1).getOutput();
+            var appVerifier = HelloApp.assertMainLauncher(cmd);
+            if (appVerifier != null) {
+                List<String> output = appVerifier
+                        .saveOutput(true)
+                        .expectedExitCode(1)
+                        .executeWithRetries().getOutput();
                 TKit.assertTextStream(String.format(
                         "Error: Could not find or load main class %s",
                         nonExistingMainClass)).apply(output.stream());

--- a/test/jdk/tools/jpackage/windows/WinRenameTest.java
+++ b/test/jdk/tools/jpackage/windows/WinRenameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import jdk.jpackage.test.HelloApp;
 import jdk.jpackage.test.TKit;
-import jdk.jpackage.test.Functional.ThrowingConsumer;
 import jdk.jpackage.test.JPackageCommand;
 import jdk.jpackage.test.Annotations.Test;
 
@@ -51,11 +50,16 @@ public class WinRenameTest {
 
         cmd.executeAndAssertImageCreated();
 
+        if (!cmd.canRunLauncher("Not running the test")) {
+            return;
+        }
+
+        HelloApp.executeLauncherAndVerifyOutput(cmd);
+
         Path launcherPath = cmd.appLauncherPath();
-        HelloApp.assertApp(launcherPath).executeAndVerifyOutput();
 
         String lp = launcherPath.toString();
-        TKit.assertTrue(lp.endsWith(".exe"), "UNexpected launcher path: " + lp);
+        TKit.assertTrue(lp.endsWith(".exe"), "Unexpected launcher path: " + lp);
 
         Path newLauncherPath = Path.of(lp.replaceAll(".exe", ".anything"));
         Files.move(launcherPath, newLauncherPath);


### PR DESCRIPTION
Fix MainClassTest class to use HelloApp.AppOutputVerifier class to run app launcher instead of raw Executor. This makes MainClassTest test run app launchers with retries. This change addresses the primary issue.

Fix inconsistencies in HelloApp.AppOutputVerifier class. It used to provide API allowing to run launchers without retries. It inconsistently allowed the execution of launchers with suppressed output (stdout and stderr). It inconsistently executed launchers with/without PATH removed from the environment.

These loopholes were eliminated:

 - stdout and stderr of app launchers is never suppressed;
 - PATH env variable is always deleted for app launchers on Windows. It is not deleted on other platforms. This change sets the correct scope of [JDK-8254920](https://bugs.openjdk.org/browse/JDK-8254920) fix that introduced the removal of PATH env variable for app launchers;
 - app launchers are always executed with retries unless the launcher is executed with `jpackage.test.noexit` system property set to `true` indicating the test app will not terminate on its own.

Other changes are due to changes in HelloApp.AppOutputVerifier class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331977](https://bugs.openjdk.org/browse/JDK-8331977): Crash: SIGSEGV in dlerror() (**Bug** - P2)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19502/head:pull/19502` \
`$ git checkout pull/19502`

Update a local copy of the PR: \
`$ git checkout pull/19502` \
`$ git pull https://git.openjdk.org/jdk.git pull/19502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19502`

View PR using the GUI difftool: \
`$ git pr show -t 19502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19502.diff">https://git.openjdk.org/jdk/pull/19502.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19502#issuecomment-2143130932)