### PR TITLE
8333270: HandlersOnComplexResetUpdate and HandlersOnComplexUpdate tests fail with "Unexpected reference" if timeoutFactor is less than 1/3

### DIFF
--- a/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java
+++ b/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexResetUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class HandlersOnComplexResetUpdate {
         TIMEOUT_FACTOR = Double.parseDouble(toFactor);
     }
     static int adjustCount(int count) {
-        return (int) Math.ceil(TIMEOUT_FACTOR * count);
+        return Math.min(count, (int) Math.ceil(TIMEOUT_FACTOR * count));
     }
 
     private static final String PREFIX =
@@ -216,16 +216,15 @@ public class HandlersOnComplexResetUpdate {
                     + fooChild.getParent() +"\n\texpected: " + fooRef.get());
         }
         WeakReference<Logger> barRef = new WeakReference<>(Logger.getLogger("com.bar"), queue);
-        if (barRef.get() != barChild.getParent()) {
+        if (!barRef.refersTo(barChild.getParent())) {
             throw new RuntimeException("Unexpected parent logger: "
                     + barChild.getParent() +"\n\texpected: " + barRef.get());
         }
         Reference<? extends Logger> ref2;
-        int max = adjustCount(3);
+        int max = adjustCount(6);
         barChild = null;
-        while ((ref2 = queue.poll()) == null) {
+        while ((ref2 = queue.remove(500)) == null) {
             System.gc();
-            Thread.sleep(1000);
             if (--max == 0) break;
         }
 

--- a/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
+++ b/test/jdk/java/util/logging/LogManager/Configuration/updateConfiguration/HandlersOnComplexUpdate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ public class HandlersOnComplexUpdate {
         TIMEOUT_FACTOR = Double.parseDouble(toFactor);
     }
     static int adjustCount(int count) {
-        return (int) Math.ceil(TIMEOUT_FACTOR * count);
+        return Math.min(count, (int) Math.ceil(TIMEOUT_FACTOR * count));
     }
 
     private static final String PREFIX =
@@ -221,11 +221,10 @@ public class HandlersOnComplexUpdate {
                     + barChild.getParent() +"\n\texpected: " + barRef.get());
         }
         Reference<? extends Logger> ref2;
-        int max = adjustCount(3);
+        int max = adjustCount(6);
         barChild = null;
-        while ((ref2 = queue.poll()) == null) {
+        while ((ref2 = queue.remove(500)) == null) {
             System.gc();
-            Thread.sleep(1000);
             if (--max == 0) break;
         }
 


### PR DESCRIPTION
HandlersOnComplexResetUpdate and HandlersOnComplexUpdate tests verify that loggers are GC'ed (or not GC'ed) after a reset or an update. For that they poll a ReferenceQueue in a loop. The number of iteration is adjusted according to the jtreg timeout factor. However, the logic in the test did not expect that the timeout might be less than 1.

This fix does two things:

1. fix the adjustCount logic - so that the number of iteration can only be increased
2. use remove(timeout) instead of poll() in order to minimize the waiting time.