### PR TITLE
8333366: C2: CmpU3Nodes are not pushed back to worklist in PhaseCCP leading to non-fixpoint assertion failure

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1921,8 +1921,9 @@ void PhaseCCP::push_cmpu(Unique_Node_List& worklist, const Node* use) const {
   if (use_op == Op_AddI || use_op == Op_SubI) {
     for (DUIterator_Fast imax, i = use->fast_outs(imax); i < imax; i++) {
       Node* cmpu = use->fast_out(i);
-      if (cmpu->Opcode() == Op_CmpU) {
-        // Got a CmpU which might need the new type information from node n.
+      const uint cmpu_opcode = cmpu->Opcode();
+      if (cmpu_opcode == Op_CmpU || cmpu_opcode == Op_CmpU3) {
+        // Got a CmpU or CmpU3 which might need the new type information from node n.
         push_if_not_bottom_type(worklist, cmpu);
       }
     }

--- a/test/hotspot/jtreg/compiler/ccp/TestPushCmpU3Node.java
+++ b/test/hotspot/jtreg/compiler/ccp/TestPushCmpU3Node.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8333366
+ * @summary Test that CmpU3Nodes are pushed back to the CCP worklist such that the type can be re-evaluated.
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,*TestPushCmpU3Node::test
+ *                   compiler.ccp.TestPushCmpU3Node
+ */
+
+package compiler.ccp;
+
+import static java.lang.Integer.*;
+
+public class TestPushCmpU3Node {
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; ++i) {
+            test();
+        }
+    }
+
+    public static void test() {
+        for (int i = MAX_VALUE - 50_000; compareUnsigned(i, -1) < 0; ++i) {
+            if (compareUnsigned(MIN_VALUE, i) < 0) {
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
The current code to push uses back to the worklist during CCP handles `CmpU` nodes but misses `CmpU3` nodes. This leads to an assertion failure that we have not reached a fixpoint.

The fix is straight forward to add a case for `CmpU3` at the case where we already handle `CmpU` nodes such that they can be added back to the worklist like `CmpU` nodes during CCP.

This was found during the analysis of [JDK-8332920](https://bugs.openjdk.org/browse/JDK-8332920) by trying to simplify the regression test (thanks to @TobiHartmann!). To properly add regression tests for JDK-8332920 and avoid hitting this bug here with some flag combination, we should fix this first. I will soon propose a PR for JDK-8332920 as well. 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333366](https://bugs.openjdk.org/browse/JDK-8333366): C2: CmpU3Nodes are not pushed back to worklist in PhaseCCP leading to non-fixpoint assertion failure (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19504/head:pull/19504` \
`$ git checkout pull/19504`

Update a local copy of the PR: \
`$ git checkout pull/19504` \
`$ git pull https://git.openjdk.org/jdk.git pull/19504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19504`

View PR using the GUI difftool: \
`$ git pr show -t 19504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19504.diff">https://git.openjdk.org/jdk/pull/19504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19504#issuecomment-2142708325)