### PR TITLE
8316131: runtime/cds/appcds/TestParallelGCWithCDS.java fails with JNI error

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -121,7 +121,7 @@ public class TestParallelGCWithCDS {
                         out.shouldMatch(pattern);
                     } catch (RuntimeException ex) {
                         // If the test is run with a very small heap, the above expected
-                        // output may not occurred as the JVM may fail in many locations
+                        // output may not occur as the JVM may fail in many locations
                         // with different messages. Just make sure the exit code is
                         // non-zero and the JVM has not crashed.
                         out.shouldNotHaveExitValue(0);

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,7 +117,16 @@ public class TestParallelGCWithCDS {
                     String pattern = "((Too small maximum heap)" +
                                        "|(GC triggered before VM initialization completed)" +
                                        "|(java.lang.OutOfMemoryError: Java heap space))";
-                    out.shouldMatch(pattern);
+                    try {
+                        out.shouldMatch(pattern);
+                    } catch (RuntimeException ex) {
+                        // If the test is run with a very small heap, the above expected
+                        // output may not occurred as the JVM may fail in many locations
+                        // with different messages. Just make sure the exit code is
+                        // non-zero and the JVM has not crashed.
+                        out.shouldNotHaveExitValue(0);
+                        out.shouldNotHaveFatalError();
+                    }
                 }
                 n++;
             }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -115,11 +115,11 @@ public class TestParallelGCWithCDS {
                     out.shouldContain(HELLO);
                 } else {
                     String pattern = "((Too small maximum heap)" +
-                                       "|(GC triggered before VM initialization completed)" +
-                                       "|(java.lang.OutOfMemoryError: Java heap space)" +
-                                       "|(Initial heap size set to a larger value than the maximum heap size))";
-                        out.shouldMatch(pattern);
-                        out.shouldNotHaveFatalError();
+                                     "|(GC triggered before VM initialization completed)" +
+                                     "|(java.lang.OutOfMemoryError: Java heap space)" +
+                                     "|(Initial heap size set to a larger value than the maximum heap size))";
+                    out.shouldMatch(pattern);
+                    out.shouldNotHaveFatalError();
                 }
                 n++;
             }

--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -116,17 +116,10 @@ public class TestParallelGCWithCDS {
                 } else {
                     String pattern = "((Too small maximum heap)" +
                                        "|(GC triggered before VM initialization completed)" +
-                                       "|(java.lang.OutOfMemoryError: Java heap space))";
-                    try {
+                                       "|(java.lang.OutOfMemoryError: Java heap space)" +
+                                       "|(Initial heap size set to a larger value than the maximum heap size))";
                         out.shouldMatch(pattern);
-                    } catch (RuntimeException ex) {
-                        // If the test is run with a very small heap, the above expected
-                        // output may not occur as the JVM may fail in many locations
-                        // with different messages. Just make sure the exit code is
-                        // non-zero and the JVM has not crashed.
-                        out.shouldNotHaveExitValue(0);
                         out.shouldNotHaveFatalError();
-                    }
                 }
                 n++;
             }


### PR DESCRIPTION
The `runtime/cds/appcds/TestParallelGCWithCDS.java` test currently expects specific output. When running with a small heap, JVM could fail at different places with different output.
Updating the test if the expected output isn't there, checks for non-zero exit value and that the JVM hasn't crashed.

Tested with the following jtreg options on linux-x64:
```
-javaoptions:"-Xcomp -ea -esa -XX:CompileThreshold=100 -XX:+UnlockExperimentalVMOptions -server -XX:-TieredCompilation -XX:-UseCompressedOops -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler -Xmx8m -Xms2m"
-timeout:25
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316131](https://bugs.openjdk.org/browse/JDK-8316131): runtime/cds/appcds/TestParallelGCWithCDS.java fails with JNI error (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [cdf76bbe](https://git.openjdk.org/jdk/pull/19506/files/cdf76bbed8d755e62ae21d1a9cbebe380f92e331)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19506/head:pull/19506` \
`$ git checkout pull/19506`

Update a local copy of the PR: \
`$ git checkout pull/19506` \
`$ git pull https://git.openjdk.org/jdk.git pull/19506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19506`

View PR using the GUI difftool: \
`$ git pr show -t 19506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19506.diff">https://git.openjdk.org/jdk/pull/19506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19506#issuecomment-2143066122)