### PR TITLE
8327854: Test java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java failed with RuntimeException

### DIFF
--- a/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java
+++ b/test/jdk/java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java
@@ -256,7 +256,7 @@ public class WhileOpStatefulTest extends OpTestCase {
                                                              EXECUTION_TIME_LIMIT);
             return s.peek(e -> {
                 if (!isWithinExecutionPeriod.getAsBoolean()) {
-                    throw new RuntimeException();
+                    throw new RuntimeException("Execution time limit exceeded!");
                 }
             });
         });
@@ -266,7 +266,7 @@ public class WhileOpStatefulTest extends OpTestCase {
             return s.parallel()
                     .peek(e -> {
                         if (!isWithinExecutionPeriod.getAsBoolean()) {
-                            throw new RuntimeException();
+                            throw new RuntimeException("Execution time limit exceeded!");
                         }
                     });
         });


### PR DESCRIPTION
This PR improves the test failure output for the failing test case, and the underlying issue is likely going to be addressed by https://github.com/openjdk/jdk/pull/19131 /cc @DougLea

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327854](https://bugs.openjdk.org/browse/JDK-8327854): Test java/util/stream/test/org/openjdk/tests/java/util/stream/WhileOpStatefulTest.java failed with RuntimeException (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19508/head:pull/19508` \
`$ git checkout pull/19508`

Update a local copy of the PR: \
`$ git checkout pull/19508` \
`$ git pull https://git.openjdk.org/jdk.git pull/19508/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19508`

View PR using the GUI difftool: \
`$ git pr show -t 19508`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19508.diff">https://git.openjdk.org/jdk/pull/19508.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19508#issuecomment-2143421533)