### PR TITLE
8333382: [s390x] Enhance popcnt Instruction to use Z15 facilities

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -3092,7 +3092,7 @@ class Assembler : public AbstractAssembler {
 
   // Ppopulation count intrinsics.
   inline void z_flogr(Register r1, Register r2);    // find leftmost one
-  inline void z_popcnt(Register r1, Register r2, int64_t m3 = 0);   // population count
+  inline void z_popcnt(Register r1, Register r2, int64_t m3);   // population count
   inline void z_ahhhr(Register r1, Register r2, Register r3);   // ADD halfword high high
   inline void z_ahhlr(Register r1, Register r2, Register r3);   // ADD halfword high low
 

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -1607,6 +1607,9 @@ class Assembler : public AbstractAssembler {
   static int inv_simm32(long x)    { return (inv_s_field(x, 31,  0)); }                         // 6-byte instructions only
   static int inv_uimm12(long x)    { return (inv_u_field(x, 11,  0)); }                         // 4-byte instructions only
 
+  // NOTE: PLEASE DON'T USE IT NAKED UNTIL WE DROP SUPPORT FOR MACHINES OLDER THAN Z15!!!!
+  inline void z_popcnt(Register r1, Register r2, int64_t m3);   // population count
+
  private:
 
   // Encode u_field from long value.
@@ -3092,7 +3095,6 @@ class Assembler : public AbstractAssembler {
 
   // Ppopulation count intrinsics.
   inline void z_flogr(Register r1, Register r2);    // find leftmost one
-  inline void z_popcnt(Register r1, Register r2, int64_t m3);   // population count
   inline void z_ahhhr(Register r1, Register r2, Register r3);   // ADD halfword high high
   inline void z_ahhlr(Register r1, Register r2, Register r3);   // ADD halfword high low
 

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -3092,7 +3092,7 @@ class Assembler : public AbstractAssembler {
 
   // Ppopulation count intrinsics.
   inline void z_flogr(Register r1, Register r2);    // find leftmost one
-  inline void z_popcnt(Register r1, Register r2);   // population count
+  inline void z_popcnt(Register r1, Register r2, int64_t m3 = 0);   // population count
   inline void z_ahhhr(Register r1, Register r2, Register r3);   // ADD halfword high high
   inline void z_ahhlr(Register r1, Register r2, Register r3);   // ADD halfword high low
 

--- a/src/hotspot/cpu/s390/assembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.inline.hpp
@@ -741,7 +741,7 @@ inline void Assembler::z_brxhg(Register r1, Register r3, Label& L) {z_brxhg(r1, 
 inline void Assembler::z_brxlg(Register r1, Register r3, Label& L) {z_brxlg(r1, r3, target(L)); }
 
 inline void Assembler::z_flogr( Register r1, Register r2)              { emit_32( FLOGR_ZOPC  | reg(r1, 24, 32) | reg(r2, 28, 32)); }
-inline void Assembler::z_popcnt(Register r1, Register r2)              { emit_32( POPCNT_ZOPC | reg(r1, 24, 32) | reg(r2, 28, 32)); }
+inline void Assembler::z_popcnt(Register r1, Register r2, int64_t  m3) { emit_32( POPCNT_ZOPC | reg(r1, 24, 32) | reg(r2, 28, 32) | uimm4(m3, 16, 32)); }
 inline void Assembler::z_ahhhr( Register r1, Register r2, Register r3) { emit_32( AHHHR_ZOPC  | reg(r3, 16, 32) | reg(r1, 24, 32) | reg(r2, 28, 32)); }
 inline void Assembler::z_ahhlr( Register r1, Register r2, Register r3) { emit_32( AHHLR_ZOPC  | reg(r3, 16, 32) | reg(r1, 24, 32) | reg(r2, 28, 32)); }
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5812,11 +5812,10 @@ void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tm
     z_popcnt(r_dst, r_src, 8);
   } else {
 
-    z_illtrap(48); // fixme: remove
 #ifdef ASSERT
     assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
     assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-#endif
+#endif // ASSERT
 
     z_popcnt(r_dst, r_src);
     z_srlg(r_tmp, r_dst, 16);
@@ -5825,7 +5824,6 @@ void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tm
     z_alr(r_dst, r_tmp);
     // TODO: use risbgn instruction instead of srl below
     z_llgcr(r_dst, r_dst);
-
   }
 
   BLOCK_COMMENT("} pop_count_int");
@@ -5838,11 +5836,10 @@ void MacroAssembler::pop_count_long(Register r_dst, Register r_src, Register r_t
     z_popcnt(r_dst, r_src, 8);
   } else {
 
-    z_illtrap(48); // fixme: remove
 #ifdef ASSERT
     assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
     assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-#endif
+#endif // ASSERT
 
     z_popcnt(r_dst, r_src);
     z_ahhlr(r_dst, r_dst, r_dst);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5871,11 +5871,9 @@ void MacroAssembler::pop_count_long_pre_z15(Register r_dst, Register r_src, Regi
 void MacroAssembler::pop_count_long_post_z15(Register r_dst, Register r_src) {
   BLOCK_COMMENT("pop_count_long_post_z15 {");
 
-  if (VM_Version::has_MiscInstrExt3()) {
-    z_popcnt(r_dst, r_src, 8);
-  } else {
-    stop("this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
-  }
+  guarantee(VM_Version::has_MiscInstrExt3(),
+      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
+  z_popcnt(r_dst, r_src, 8);
 
   BLOCK_COMMENT("} pop_count_long_post_z15");
 }
@@ -5883,12 +5881,10 @@ void MacroAssembler::pop_count_long_post_z15(Register r_dst, Register r_src) {
 void MacroAssembler::pop_count_int_post_z15(Register r_dst, Register r_src) {
   BLOCK_COMMENT("pop_count_int_post_z15 {");
 
-  if (VM_Version::has_MiscInstrExt3()) {
-    z_llgfr(r_dst, r_src);
-    z_popcnt(r_dst, r_dst, 8);
-  } else {
-    stop("this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_int_post_z15 is used");
-  }
+  guarantee(VM_Version::has_MiscInstrExt3(),
+      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
+  z_llgfr(r_dst, r_src);
+  z_popcnt(r_dst, r_dst, 8);
 
   BLOCK_COMMENT("} pop_count_int_post_z15");
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5811,9 +5811,9 @@ void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tm
   assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
 
   if (VM_Version::has_MiscInstrExt3()) {
-    pop_count_int_post_z15(r_dst, r_src);
+    pop_count_int_with_ext3(r_dst, r_src);
   } else {
-    pop_count_int_pre_z15(r_dst, r_src, r_tmp);
+    pop_count_int_without_ext3(r_dst, r_src, r_tmp);
   }
 
   BLOCK_COMMENT("} pop_count_int");
@@ -5826,16 +5826,16 @@ void MacroAssembler::pop_count_long(Register r_dst, Register r_src, Register r_t
   assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
 
   if (VM_Version::has_MiscInstrExt3()) {
-    pop_count_long_post_z15(r_dst, r_src);
+    pop_count_long_with_ext3(r_dst, r_src);
   } else {
-    pop_count_long_pre_z15(r_dst, r_src, r_tmp);
+    pop_count_long_without_ext3(r_dst, r_src, r_tmp);
   }
 
   BLOCK_COMMENT("} pop_count_long");
 }
 
-void MacroAssembler::pop_count_int_pre_z15(Register r_dst, Register r_src, Register r_tmp) {
-  BLOCK_COMMENT("pop_count_int_pre_z15 {");
+void MacroAssembler::pop_count_int_without_ext3(Register r_dst, Register r_src, Register r_tmp) {
+  BLOCK_COMMENT("pop_count_int_without_ext3 {");
 
   assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
   assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
@@ -5848,11 +5848,11 @@ void MacroAssembler::pop_count_int_pre_z15(Register r_dst, Register r_src, Regis
   // TODO: use risbgn instruction instead of srl below
   z_llgcr(r_dst, r_dst);
 
-  BLOCK_COMMENT("} pop_count_int_pre_z15");
+  BLOCK_COMMENT("} pop_count_int_without_ext3");
 }
 
-void MacroAssembler::pop_count_long_pre_z15(Register r_dst, Register r_src, Register r_tmp) {
-  BLOCK_COMMENT("pop_count_long_pre_z15 {");
+void MacroAssembler::pop_count_long_without_ext3(Register r_dst, Register r_src, Register r_tmp) {
+  BLOCK_COMMENT("pop_count_long_without_ext3 {");
 
   assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
   assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
@@ -5865,26 +5865,26 @@ void MacroAssembler::pop_count_long_pre_z15(Register r_dst, Register r_src, Regi
   z_algr(r_dst, r_tmp);
   z_srlg(r_dst, r_dst, 56);
 
-  BLOCK_COMMENT("} pop_count_long_pre_z15");
+  BLOCK_COMMENT("} pop_count_long_without_ext3");
 }
 
-void MacroAssembler::pop_count_long_post_z15(Register r_dst, Register r_src) {
-  BLOCK_COMMENT("pop_count_long_post_z15 {");
+void MacroAssembler::pop_count_long_with_ext3(Register r_dst, Register r_src) {
+  BLOCK_COMMENT("pop_count_long_with_ext3 {");
 
   guarantee(VM_Version::has_MiscInstrExt3(),
-      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
+      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_with_ext3 is used");
   z_popcnt(r_dst, r_src, 8);
 
-  BLOCK_COMMENT("} pop_count_long_post_z15");
+  BLOCK_COMMENT("} pop_count_long_with_ext3");
 }
 
-void MacroAssembler::pop_count_int_post_z15(Register r_dst, Register r_src) {
-  BLOCK_COMMENT("pop_count_int_post_z15 {");
+void MacroAssembler::pop_count_int_with_ext3(Register r_dst, Register r_src) {
+  BLOCK_COMMENT("pop_count_int_with_ext3 {");
 
   guarantee(VM_Version::has_MiscInstrExt3(),
-      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
+      "this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_with_ext3 is used");
   z_llgfr(r_dst, r_src);
   z_popcnt(r_dst, r_dst, 8);
 
-  BLOCK_COMMENT("} pop_count_int_post_z15");
+  BLOCK_COMMENT("} pop_count_int_with_ext3");
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5845,7 +5845,6 @@ void MacroAssembler::pop_count_int_without_ext3(Register r_dst, Register r_src, 
   z_alr(r_dst, r_tmp);
   z_srlg(r_tmp, r_dst, 8);
   z_alr(r_dst, r_tmp);
-  // TODO: use risbgn instruction instead of srl below
   z_llgcr(r_dst, r_dst);
 
   BLOCK_COMMENT("} pop_count_int_without_ext3");

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5872,7 +5872,7 @@ void MacroAssembler::pop_count_long_post_z15(Register r_dst, Register r_src) {
   BLOCK_COMMENT("pop_count_long_post_z15 {");
 
   if (VM_Version::has_MiscInstrExt3()) {
-    z_popcnt(r_dst, r_dst, 8);
+    z_popcnt(r_dst, r_src, 8);
   } else {
     stop("this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
   }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5807,21 +5807,13 @@ void MacroAssembler::lightweight_unlock(Register obj, Register hdr, Register tmp
 void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tmp) {
   BLOCK_COMMENT("pop_count_int {");
 
+  assert(r_tmp != noreg, "temp register required for pop_count_int, as code may run on machine older than z15");
+  assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
+
   if (VM_Version::has_MiscInstrExt3()) {
-    z_llgfr(r_dst, r_src);
-    z_popcnt(r_dst, r_dst, 8);
+    pop_count_int_post_z15(r_dst, r_src);
   } else {
-
-    assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
-    assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-
-    z_popcnt(r_dst, r_src, 0);
-    z_srlg(r_tmp, r_dst, 16);
-    z_alr(r_dst, r_tmp);
-    z_srlg(r_tmp, r_dst, 8);
-    z_alr(r_dst, r_tmp);
-    // TODO: use risbgn instruction instead of srl below
-    z_llgcr(r_dst, r_dst);
+    pop_count_int_pre_z15(r_dst, r_src, r_tmp);
   }
 
   BLOCK_COMMENT("} pop_count_int");
@@ -5830,21 +5822,73 @@ void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tm
 void MacroAssembler::pop_count_long(Register r_dst, Register r_src, Register r_tmp) {
   BLOCK_COMMENT("pop_count_long {");
 
+  assert(r_tmp != noreg, "temp register required for pop_count_long, as code may run on machine older than z15");
+  assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
+
   if (VM_Version::has_MiscInstrExt3()) {
-    z_popcnt(r_dst, r_src, 8);
+    pop_count_long_post_z15(r_dst, r_src);
   } else {
-
-    assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
-    assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-
-    z_popcnt(r_dst, r_src, 0);
-    z_ahhlr(r_dst, r_dst, r_dst);
-    z_sllg(r_tmp, r_dst, 16);
-    z_algr(r_dst, r_tmp);
-    z_sllg(r_tmp, r_dst, 8);
-    z_algr(r_dst, r_tmp);
-    z_srlg(r_dst, r_dst, 56);
+    pop_count_long_pre_z15(r_dst, r_src, r_tmp);
   }
 
   BLOCK_COMMENT("} pop_count_long");
+}
+
+void MacroAssembler::pop_count_int_pre_z15(Register r_dst, Register r_src, Register r_tmp) {
+  BLOCK_COMMENT("pop_count_int_pre_z15 {");
+
+  assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
+  assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
+
+  z_popcnt(r_dst, r_src, 0);
+  z_srlg(r_tmp, r_dst, 16);
+  z_alr(r_dst, r_tmp);
+  z_srlg(r_tmp, r_dst, 8);
+  z_alr(r_dst, r_tmp);
+  // TODO: use risbgn instruction instead of srl below
+  z_llgcr(r_dst, r_dst);
+
+  BLOCK_COMMENT("} pop_count_int_pre_z15");
+}
+
+void MacroAssembler::pop_count_long_pre_z15(Register r_dst, Register r_src, Register r_tmp) {
+  BLOCK_COMMENT("pop_count_long_pre_z15 {");
+
+  assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
+  assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
+
+  z_popcnt(r_dst, r_src, 0);
+  z_ahhlr(r_dst, r_dst, r_dst);
+  z_sllg(r_tmp, r_dst, 16);
+  z_algr(r_dst, r_tmp);
+  z_sllg(r_tmp, r_dst, 8);
+  z_algr(r_dst, r_tmp);
+  z_srlg(r_dst, r_dst, 56);
+
+  BLOCK_COMMENT("} pop_count_long_pre_z15");
+}
+
+void MacroAssembler::pop_count_long_post_z15(Register r_dst, Register r_src) {
+  BLOCK_COMMENT("pop_count_long_post_z15 {");
+
+  if (VM_Version::has_MiscInstrExt3()) {
+    z_popcnt(r_dst, r_dst, 8);
+  } else {
+    stop("this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_long_post_z15 is used");
+  }
+
+  BLOCK_COMMENT("} pop_count_long_post_z15");
+}
+
+void MacroAssembler::pop_count_int_post_z15(Register r_dst, Register r_src) {
+  BLOCK_COMMENT("pop_count_int_post_z15 {");
+
+  if (VM_Version::has_MiscInstrExt3()) {
+    z_llgfr(r_dst, r_src);
+    z_popcnt(r_dst, r_dst, 8);
+  } else {
+    stop("this hardware doesn't support miscellaneous-instruction-extensions facility 3, still pop_count_int_post_z15 is used");
+  }
+
+  BLOCK_COMMENT("} pop_count_int_post_z15");
 }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5808,16 +5808,14 @@ void MacroAssembler::pop_count_int(Register r_dst, Register r_src, Register r_tm
   BLOCK_COMMENT("pop_count_int {");
 
   if (VM_Version::has_MiscInstrExt3()) {
-    z_llgfr(r_src, r_src);
-    z_popcnt(r_dst, r_src, 8);
+    z_llgfr(r_dst, r_src);
+    z_popcnt(r_dst, r_dst, 8);
   } else {
 
-#ifdef ASSERT
     assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
     assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-#endif // ASSERT
 
-    z_popcnt(r_dst, r_src);
+    z_popcnt(r_dst, r_src, 0);
     z_srlg(r_tmp, r_dst, 16);
     z_alr(r_dst, r_tmp);
     z_srlg(r_tmp, r_dst, 8);
@@ -5836,12 +5834,10 @@ void MacroAssembler::pop_count_long(Register r_dst, Register r_src, Register r_t
     z_popcnt(r_dst, r_src, 8);
   } else {
 
-#ifdef ASSERT
     assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
     assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
-#endif // ASSERT
 
-    z_popcnt(r_dst, r_src);
+    z_popcnt(r_dst, r_src, 0);
     z_ahhlr(r_dst, r_dst, r_dst);
     z_sllg(r_tmp, r_dst, 16);
     z_algr(r_dst, r_tmp);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -5807,27 +5807,33 @@ void MacroAssembler::lightweight_unlock(Register obj, Register hdr, Register tmp
 void MacroAssembler::population_count(Register r_dst, Register r_src, Register r_tmp, bool is_long) {
   BLOCK_COMMENT("population_count {");
 
+  if (VM_Version::has_MiscInstrExt3()) {
+    z_popcnt(r_dst, r_src, 8);
+  } else {
+
+    z_illtrap(48); // fixme: remove
 #ifdef ASSERT
-  assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
-  assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
+    assert(r_tmp != noreg, "temp register required for popcnt, for machines < z15");
+    assert_different_registers(r_dst, r_tmp); // if r_src is same as r_tmp, it should be fine
 #endif
 
-  if (is_long) {
-    z_popcnt(r_dst, r_src);
-    z_ahhlr(r_dst, r_dst, r_dst);
-    z_sllg(r_tmp, r_dst, 16);
-    z_algr(r_dst, r_tmp);
-    z_sllg(r_tmp, r_dst, 8);
-    z_algr(r_dst, r_tmp);
-    z_srlg(r_dst, r_dst, 56);
-  } else {
-    z_popcnt(r_dst, r_src);
-    z_srlg(r_tmp, r_dst, 16);
-    z_alr(r_dst, r_tmp);
-    z_srlg(r_tmp, r_dst, 8);
-    z_alr(r_dst, r_tmp);
-    // TODO: use risbgn instruction instead of srl below
-    z_llgcr(r_dst, r_dst);
+    if (is_long) {
+      z_popcnt(r_dst, r_src);
+      z_ahhlr(r_dst, r_dst, r_dst);
+      z_sllg(r_tmp, r_dst, 16);
+      z_algr(r_dst, r_tmp);
+      z_sllg(r_tmp, r_dst, 8);
+      z_algr(r_dst, r_tmp);
+      z_srlg(r_dst, r_dst, 56);
+    } else {
+      z_popcnt(r_dst, r_src);
+      z_srlg(r_tmp, r_dst, 16);
+      z_alr(r_dst, r_tmp);
+      z_srlg(r_tmp, r_dst, 8);
+      z_alr(r_dst, r_tmp);
+      // TODO: use risbgn instruction instead of srl below
+      z_llgcr(r_dst, r_dst);
+    }
   }
 
   BLOCK_COMMENT("} population_count");

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1027,8 +1027,7 @@ class MacroAssembler: public Assembler {
   void pop_count_int(Register dst, Register src, Register tmp);
   void pop_count_long(Register dst, Register src, Register tmp);
 
-  // Up for an adventure ? use these instructions :)
-  // Should be only used when you're sure that instruction will "only" run on hardware older than z15
+  // For legacy (pre-z15) use, but will work on all supported s390 implementations.
   void pop_count_int_pre_z15(Register dst, Register src, Register tmp);
   void pop_count_long_pre_z15(Register dst, Register src, Register tmp);
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1023,8 +1023,7 @@ class MacroAssembler: public Assembler {
                        Register tmp1, Register tmp2,
                        Register tmp3, Register tmp4, Register tmp5);
 
-  // if you're unsure whether your instruction will run on older hardware or newer hardware than Z15
-  // then please use these instruction to avoid the compatibility issues
+  // These generate optimized code for all supported s390 implementations, and are preferred for most uses.
   void pop_count_int(Register dst, Register src, Register tmp);
   void pop_count_long(Register dst, Register src, Register tmp);
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
+ * Copyright (c) 2024 IBM Corporation. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1032,8 +1032,7 @@ class MacroAssembler: public Assembler {
   void pop_count_int_pre_z15(Register dst, Register src, Register tmp);
   void pop_count_long_pre_z15(Register dst, Register src, Register tmp);
 
-  // Should be used in a case, where you're sure that instruction will never touch a hardware older than z15
-  // it will only run on either a z15 machine or successor of it
+  // Only for use on z15 or later s390 implementations.
   void pop_count_int_post_z15(Register dst, Register src);
   void pop_count_long_post_z15(Register dst, Register src);
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1028,12 +1028,12 @@ class MacroAssembler: public Assembler {
   void pop_count_long(Register dst, Register src, Register tmp);
 
   // For legacy (pre-z15) use, but will work on all supported s390 implementations.
-  void pop_count_int_pre_z15(Register dst, Register src, Register tmp);
-  void pop_count_long_pre_z15(Register dst, Register src, Register tmp);
+  void pop_count_int_without_ext3(Register dst, Register src, Register tmp);
+  void pop_count_long_without_ext3(Register dst, Register src, Register tmp);
 
   // Only for use on z15 or later s390 implementations.
-  void pop_count_int_post_z15(Register dst, Register src);
-  void pop_count_long_post_z15(Register dst, Register src);
+  void pop_count_int_with_ext3(Register dst, Register src);
+  void pop_count_long_with_ext3(Register dst, Register src);
 
 };
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1023,8 +1023,20 @@ class MacroAssembler: public Assembler {
                        Register tmp1, Register tmp2,
                        Register tmp3, Register tmp4, Register tmp5);
 
-  void pop_count_int(Register dst, Register src, Register tmp = noreg);
-  void pop_count_long(Register dst, Register src, Register tmp = noreg);
+  // if you're unsure whether your instruction will run on older hardware or newer hardware than Z15
+  // then please use these instruction to avoid the compatibility issues
+  void pop_count_int(Register dst, Register src, Register tmp);
+  void pop_count_long(Register dst, Register src, Register tmp);
+
+  // Up for an adventure ? use these instructions :)
+  // Should be only used when you're sure that instruction will "only" run on hardware older than z15
+  void pop_count_int_pre_z15(Register dst, Register src, Register tmp);
+  void pop_count_long_pre_z15(Register dst, Register src, Register tmp);
+
+  // Should be used in a case, where you're sure that instruction will never touch a hardware older than z15
+  // it will only run on either a z15 machine or successor of it
+  void pop_count_int_post_z15(Register dst, Register src);
+  void pop_count_long_post_z15(Register dst, Register src);
 
 };
 

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1021,6 +1021,17 @@ class MacroAssembler: public Assembler {
                        Register z,
                        Register tmp1, Register tmp2,
                        Register tmp3, Register tmp4, Register tmp5);
+
+  /*
+   * When the miscellaneous-instruction-extensions facility 3 is not installed or bit 0 of the M3 field is zero,
+   * a count of the number of "one" bits in each of the eight bytes of general register src is placed into the
+   * corresponding byte of general register dst. Each byte of general register dst is an 8-bit binary integer
+   * in the range of 0-8.
+   *
+   * For more information refer PofZ
+   */
+  void population_count(Register dst, Register src, Register tmp = noreg, bool is_long = false);
+
 };
 
 /**

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -1022,15 +1022,8 @@ class MacroAssembler: public Assembler {
                        Register tmp1, Register tmp2,
                        Register tmp3, Register tmp4, Register tmp5);
 
-  /*
-   * When the miscellaneous-instruction-extensions facility 3 is not installed or bit 0 of the M3 field is zero,
-   * a count of the number of "one" bits in each of the eight bytes of general register src is placed into the
-   * corresponding byte of general register dst. Each byte of general register dst is an 8-bit binary integer
-   * in the range of 0-8.
-   *
-   * For more information refer PofZ
-   */
-  void population_count(Register dst, Register src, Register tmp = noreg, bool is_long = false);
+  void pop_count_int(Register dst, Register src, Register tmp = noreg);
+  void pop_count_long(Register dst, Register src, Register tmp = noreg);
 
 };
 

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10675,7 +10675,49 @@ instruct countTrailingZerosL(revenRegI dst, iRegL src, roddRegL tmp, flagsReg cr
 
 // bit count
 
-// TODO: add another match node which doesn't use tmp, for machines >= z15
+instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
+  match(Set dst (PopCountI src));
+  effect(TEMP_DEF dst, KILL cr);
+  predicate(UsePopCountInstruction &&
+            VM_Version::has_PopCount() &&
+            VM_Version::has_MiscInstrExt3());
+  ins_cost(DEFAULT_COST);
+  size(8); // popcnt + llgfr
+  format %{ "POPCNT  $dst,$src\t # pop count int" %}
+  ins_encode %{
+    Register Rdst = $dst$$Register;
+    Register Rsrc = $src$$Register;
+
+    // Prefer compile-time assertion over run-time SIGILL.
+    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
+    __ z_llgfr(Rsrc, Rsrc);
+    __ population_count(Rdst, Rsrc, noreg /* tmp */, false /* is_long */);
+
+  %}
+  ins_pipe(pipe_class_dummy);
+%}
+
+instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
+  match(Set dst (PopCountL src));
+  effect(TEMP_DEF dst, KILL cr);
+  predicate(UsePopCountInstruction &&
+            VM_Version::has_PopCount() &&
+            VM_Version::has_MiscInstrExt3());
+  ins_cost(DEFAULT_COST);
+  size(4); // popcnt
+  // TODO: s390 port size(FIXED_SIZE);
+  format %{ "POPCNT  $dst,$src\t # pop count long" %}
+  ins_encode %{
+    Register Rdst = $dst$$Register;
+    Register Rsrc = $src$$Register;
+
+    // Prefer compile-time assertion over run-time SIGILL.
+    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
+    __ population_count(Rdst, Rsrc, noreg /* tmp */, true /* is_long */);
+  %}
+  ins_pipe(pipe_class_dummy);
+%}
+
 instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
   match(Set dst (PopCountI src));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10689,7 +10689,6 @@ instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
     Register Rsrc = $src$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for popCountI_Ext3");
     __ pop_count_int(Rdst, Rsrc);
 
   %}
@@ -10704,14 +10703,12 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
             VM_Version::has_MiscInstrExt3());
   ins_cost(DEFAULT_COST);
   size(4); // popcnt
-  // TODO: s390 port size(FIXED_SIZE);
   format %{ "POPCNT  $dst,$src\t # pop count long" %}
   ins_encode %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for popCountL_Ext3");
     __ pop_count_long(Rdst, Rsrc);
   %}
   ins_pipe(pipe_class_dummy);
@@ -10732,7 +10729,6 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
     Register Rtmp = $tmp$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for popCountI");
     __ pop_count_int(Rdst, Rsrc, Rtmp);
 
   %}
@@ -10754,7 +10750,6 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
     Register Rtmp = $tmp$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for popCountL");
     __ pop_count_long(Rdst, Rsrc, Rtmp);
   %}
   ins_pipe(pipe_class_dummy);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10688,7 +10688,6 @@ instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    // Prefer compile-time assertion over run-time SIGILL.
     __ pop_count_int(Rdst, Rsrc);
 
   %}
@@ -10708,7 +10707,6 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    // Prefer compile-time assertion over run-time SIGILL.
     __ pop_count_long(Rdst, Rsrc);
   %}
   ins_pipe(pipe_class_dummy);
@@ -10728,7 +10726,6 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    // Prefer compile-time assertion over run-time SIGILL.
     __ pop_count_int(Rdst, Rsrc, Rtmp);
 
   %}
@@ -10749,7 +10746,6 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    // Prefer compile-time assertion over run-time SIGILL.
     __ pop_count_long(Rdst, Rsrc, Rtmp);
   %}
   ins_pipe(pipe_class_dummy);

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10675,6 +10675,7 @@ instruct countTrailingZerosL(revenRegI dst, iRegL src, roddRegL tmp, flagsReg cr
 
 // bit count
 
+// TODO: add another match node which doesn't use tmp, for machines >= z15
 instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
   match(Set dst (PopCountI src));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
@@ -10689,15 +10690,8 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
 
     // Prefer compile-time assertion over run-time SIGILL.
     assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    assert_different_registers(Rdst, Rtmp);
+    __ population_count(Rdst, Rsrc, Rtmp, false /* is_long */);
 
-    // Version 2: shows 10%(z196) improvement over original.
-    __ z_popcnt(Rdst, Rsrc);
-    __ z_srlg(Rtmp, Rdst, 16); // calc  byte4+byte6 and byte5+byte7
-    __ z_alr(Rdst, Rtmp);      //   into byte6 and byte7
-    __ z_srlg(Rtmp, Rdst,  8); // calc (byte4+byte6) + (byte5+byte7)
-    __ z_alr(Rdst, Rtmp);      //   into byte7
-    __ z_llgcr(Rdst, Rdst);    // zero-extend sum
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10716,16 +10710,7 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
 
     // Prefer compile-time assertion over run-time SIGILL.
     assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    assert_different_registers(Rdst, Rtmp);
-
-    // Original version. Using LA instead of algr seems to be a really bad idea (-35%).
-    __ z_popcnt(Rdst, Rsrc);
-    __ z_ahhlr(Rdst, Rdst, Rdst);
-    __ z_sllg(Rtmp, Rdst, 16);
-    __ z_algr(Rdst, Rtmp);
-    __ z_sllg(Rtmp, Rdst,  8);
-    __ z_algr(Rdst, Rtmp);
-    __ z_srlg(Rdst, Rdst, 56);
+    __ population_count(Rdst, Rsrc, Rtmp, true /* is_long */);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10689,9 +10689,8 @@ instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
     Register Rsrc = $src$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    __ z_llgfr(Rsrc, Rsrc);
-    __ population_count(Rdst, Rsrc, noreg /* tmp */, false /* is_long */);
+    assert(VM_Version::has_PopCount(), "bad predicate for popCountI_Ext3");
+    __ pop_count_int(Rdst, Rsrc);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10712,8 +10711,8 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
     Register Rsrc = $src$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    __ population_count(Rdst, Rsrc, noreg /* tmp */, true /* is_long */);
+    assert(VM_Version::has_PopCount(), "bad predicate for popCountL_Ext3");
+    __ pop_count_long(Rdst, Rsrc);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10733,8 +10732,8 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
     Register Rtmp = $tmp$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    __ population_count(Rdst, Rsrc, Rtmp, false /* is_long */);
+    assert(VM_Version::has_PopCount(), "bad predicate for popCountI");
+    __ pop_count_int(Rdst, Rsrc, Rtmp);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10747,7 +10746,7 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
             VM_Version::has_PopCount() &&
             (!VM_Version::has_MiscInstrExt3()));
   ins_cost(DEFAULT_COST);
-  // TODO: s390 port size(FIXED_SIZE);
+  size(34);
   format %{ "POPCNT  $dst,$src\t # pop count long" %}
   ins_encode %{
     Register Rdst = $dst$$Register;
@@ -10755,8 +10754,8 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
     Register Rtmp = $tmp$$Register;
 
     // Prefer compile-time assertion over run-time SIGILL.
-    assert(VM_Version::has_PopCount(), "bad predicate for countLeadingZerosI");
-    __ population_count(Rdst, Rsrc, Rtmp, true /* is_long */);
+    assert(VM_Version::has_PopCount(), "bad predicate for popCountL");
+    __ pop_count_long(Rdst, Rsrc, Rtmp);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10721,7 +10721,9 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
 instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
   match(Set dst (PopCountI src));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
-  predicate(UsePopCountInstruction && VM_Version::has_PopCount());
+  predicate(UsePopCountInstruction &&
+            VM_Version::has_PopCount() &&
+            (!VM_Version::has_MiscInstrExt3()));
   ins_cost(DEFAULT_COST);
   size(24);
   format %{ "POPCNT  $dst,$src\t # pop count int" %}
@@ -10741,7 +10743,9 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
 instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
   match(Set dst (PopCountL src));
   effect(TEMP_DEF dst, TEMP tmp, KILL cr);
-  predicate(UsePopCountInstruction && VM_Version::has_PopCount());
+  predicate(UsePopCountInstruction &&
+            VM_Version::has_PopCount() &&
+            (!VM_Version::has_MiscInstrExt3()));
   ins_cost(DEFAULT_COST);
   // TODO: s390 port size(FIXED_SIZE);
   format %{ "POPCNT  $dst,$src\t # pop count long" %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10688,7 +10688,7 @@ instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    __ pop_count_int_post_z15(Rdst, Rsrc);
+    __ pop_count_int_with_ext3(Rdst, Rsrc);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10707,7 +10707,7 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    __ pop_count_long_post_z15(Rdst, Rsrc);
+    __ pop_count_long_with_ext3(Rdst, Rsrc);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10726,7 +10726,7 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    __ pop_count_int_pre_z15(Rdst, Rsrc, Rtmp);
+    __ pop_count_int_without_ext3(Rdst, Rsrc, Rtmp);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10746,7 +10746,7 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    __ pop_count_long_pre_z15(Rdst, Rsrc, Rtmp);
+    __ pop_count_long_without_ext3(Rdst, Rsrc, Rtmp);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10688,7 +10688,7 @@ instruct popCountI_Ext3(iRegI dst, iRegI src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    __ pop_count_int(Rdst, Rsrc);
+    __ pop_count_int_post_z15(Rdst, Rsrc);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10707,7 +10707,7 @@ instruct popCountL_Ext3(iRegI dst, iRegL src, flagsReg cr) %{
     Register Rdst = $dst$$Register;
     Register Rsrc = $src$$Register;
 
-    __ pop_count_long(Rdst, Rsrc);
+    __ pop_count_long_post_z15(Rdst, Rsrc);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10726,7 +10726,7 @@ instruct popCountI(iRegI dst, iRegI src, iRegI tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    __ pop_count_int(Rdst, Rsrc, Rtmp);
+    __ pop_count_int_pre_z15(Rdst, Rsrc, Rtmp);
 
   %}
   ins_pipe(pipe_class_dummy);
@@ -10746,7 +10746,7 @@ instruct popCountL(iRegI dst, iRegL src, iRegL tmp, flagsReg cr) %{
     Register Rsrc = $src$$Register;
     Register Rtmp = $tmp$$Register;
 
-    __ pop_count_long(Rdst, Rsrc, Rtmp);
+    __ pop_count_long_pre_z15(Rdst, Rsrc, Rtmp);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/test/micro/org/openjdk/bench/vm/compiler/PopCount.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PopCount.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024 IBM Corporation. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 4, time = 1)
+@Fork(value = 5)
+public class PopCount {
+    int numTests = 100_000;
+
+    @Setup
+    public void warmup() {
+        long l1 = 1, l2 = 2, l3 = 3, l4 = 4, l5 = 5;
+        for (long i = 0; i < numTests / 2; i++) {
+            l1 ^= Long.bitCount(l1) + i;
+            l2 ^= Long.bitCount(l2) + i;
+            l3 ^= Long.bitCount(l3) + i;
+            l4 ^= Long.bitCount(l4) + i;
+            l5 ^= Long.bitCount(l5) + i;
+        }
+        long x =  l1 + l2 + l3 + l4 + l5;
+    }
+
+    @Benchmark
+    public long test() {
+        long l1 = 1, l2 = 2, l3 = 3, l4 = 4, l5 = 5, l6 = 6, l7 = 7, l8 = 9, l9 = 9, l10 = 10;
+        for (long i = 0; i < numTests; i++) {
+            l1 ^= Long.bitCount(l1) + i;
+            l2 ^= Long.bitCount(l2) + i;
+            l3 ^= Long.bitCount(l3) + i;
+            l4 ^= Long.bitCount(l4) + i;
+            l5 ^= Long.bitCount(l5) + i;
+            l6 ^= Long.bitCount(l6) + i;
+            l7 ^= Long.bitCount(l7) + i;
+            l8 ^= Long.bitCount(l8) + i;
+            l9 ^= Long.bitCount(l9) + i;
+            l10 ^= Long.bitCount(l10) + i;
+        }
+        return l1 + l2 + l3 + l4 + l5 + l6 + l7 + l8 + l9 + l10;
+    }
+
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/PopCount.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/PopCount.java
@@ -28,26 +28,13 @@ import org.openjdk.jmh.annotations.*;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Warmup(iterations = 3, time = 1)
-@Measurement(iterations = 4, time = 1)
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 5, time = 1)
 @Fork(value = 5)
 public class PopCount {
     int numTests = 100_000;
-
-    @Setup
-    public void warmup() {
-        long l1 = 1, l2 = 2, l3 = 3, l4 = 4, l5 = 5;
-        for (long i = 0; i < numTests / 2; i++) {
-            l1 ^= Long.bitCount(l1) + i;
-            l2 ^= Long.bitCount(l2) + i;
-            l3 ^= Long.bitCount(l3) + i;
-            l4 ^= Long.bitCount(l4) + i;
-            l5 ^= Long.bitCount(l5) + i;
-        }
-        long x =  l1 + l2 + l3 + l4 + l5;
-    }
 
     @Benchmark
     public long test() {


### PR DESCRIPTION
We need to move popcnt instruction implementation out of s390.ad file as it is required to be required some methods present in [JDK-8331126.](https://bugs.openjdk.org/browse/JDK-8331126)

```
When the miscellaneous-instruction-extensions facility 3 is not installed or bit 0 of the M3
 field is zero, a count of the number of one bits in each of the eight bytes of general register
 R2 is placed into the corresponding byte of general register R1. Each byte of general register 
R1 is an 8-bit binary integer in the range of 0-8.
```

```
When the miscellaneous-instruction-extensions facility 3 is installed and bit 0 of the M3 field
is one, a count of the total number of one bits in the 64-bit general register R2 is placed into 
general register R1. The result is a 64-bit unsigned integer in the range 0 to 64.
```

Performed tier1 test on fastdebug build and didn't see any regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333382](https://bugs.openjdk.org/browse/JDK-8333382): [s390x] Enhance popcnt Instruction to use Z15 facilities (**Enhancement** - P3)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [53889759](https://git.openjdk.org/jdk/pull/19509/files/53889759eab483529c38facecaae3b06da92ca3f)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19509/head:pull/19509` \
`$ git checkout pull/19509`

Update a local copy of the PR: \
`$ git checkout pull/19509` \
`$ git pull https://git.openjdk.org/jdk.git pull/19509/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19509`

View PR using the GUI difftool: \
`$ git pr show -t 19509`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19509.diff">https://git.openjdk.org/jdk/pull/19509.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19509#issuecomment-2148224467)