### PR TITLE
8333128: Linux x86_32 configure fail with --with-hsdis=binutils --with-binutils-src

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -268,14 +268,16 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
     disasm_header="\"$BINUTILS_INSTALL_DIR/include/dis-asm.h\""
     if test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a && \
        test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a && \
-       (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a); then
+       (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a); then
       HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB -I$BINUTILS_INSTALL_DIR/include"
 
-      # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib or $BINUTILS_INSTALL_DIR/lib64
+      # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib, $BINUTILS_INSTALL_DIR/lib32 or $BINUTILS_INSTALL_DIR/lib64
       # depending on system setup
       LIBIBERTY_LIB=""
       if test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a; then
         LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib/libiberty.a"
+      elif test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a; then
+        LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib32/libiberty.a"
       else
         LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib64/libiberty.a"
       fi

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -271,8 +271,8 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
        (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a || test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a); then
       HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB -I$BINUTILS_INSTALL_DIR/include"
 
-      # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib, $BINUTILS_INSTALL_DIR/lib32 or $BINUTILS_INSTALL_DIR/lib64
-      # depending on system setup
+      # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib, $BINUTILS_INSTALL_DIR/lib32
+      # or $BINUTILS_INSTALL_DIR/lib64, depending on system setup
       LIBIBERTY_LIB=""
       if test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a; then
         LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib/libiberty.a"


### PR DESCRIPTION
Hi all,
  This PR try to fix linux x86_32 configure fail with `--with-hsdis=binutils --with-binutils-src`. The libiberty.a locates in `build/linux-x86-server-fastdebug/configure-support/binutils-install/lib32` on linux ubuntu20. The change has been verified, the risk is low.

Additional testing:

- [x] linux x86_32 centos7 configure
- [x] linux x86_64 centos7 configure
- [x] linux x86_32 ubuntu20 configure
- [x] linux x86_64 ubuntu20 configure


[configure-linux-centos7-x86_32.log](https://github.com/user-attachments/files/15523974/configure-linux-centos7-x86_32.log)
[configure-linux-centos7-x86_64.log](https://github.com/user-attachments/files/15523976/configure-linux-centos7-x86_64.log)
[configure-ubuntu20-x86_32.log](https://github.com/user-attachments/files/15523977/configure-ubuntu20-x86_32.log)
[configure-ubuntu20-x86_64.log](https://github.com/user-attachments/files/15523978/configure-ubuntu20-x86_64.log)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333128](https://bugs.openjdk.org/browse/JDK-8333128): Linux x86_32 configure fail with --with-hsdis=binutils --with-binutils-src (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to [16b59a95](https://git.openjdk.org/jdk/pull/19511/files/16b59a95ebc627f7cffd67e18488966dabd4c266)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19511/head:pull/19511` \
`$ git checkout pull/19511`

Update a local copy of the PR: \
`$ git checkout pull/19511` \
`$ git pull https://git.openjdk.org/jdk.git pull/19511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19511`

View PR using the GUI difftool: \
`$ git pr show -t 19511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19511.diff">https://git.openjdk.org/jdk/pull/19511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19511#issuecomment-2143676438)