### PR TITLE
8206447: InflaterInputStream.skip receives long but it's limited to Integer.MAX_VALUE

### DIFF
--- a/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
@@ -213,9 +213,11 @@ public class DeflaterInputStream extends FilterInputStream {
     /**
      * Skips over and discards data from the input stream.
      * This method may block until the specified number of bytes are read and
-     * skipped. <em>Note:</em> While {@code n} is given as a {@code long},
-     * the maximum number of bytes which can be skipped is
-     * {@code Integer.MAX_VALUE}.
+     * skipped.
+     *
+     * @implNote
+     * If {@code n} is greater than {@link Integer#MAX_VALUE} then this method
+     * will only skip at most {@code Integer.MAX_VALUE} bytes.
      *
      * @param n number of bytes to be skipped
      * @return the actual number of bytes skipped

--- a/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
@@ -216,13 +216,13 @@ public class DeflaterInputStream extends FilterInputStream {
      * skipped.
      *
      * @implNote
-     * If {@code n} is greater than {@link Integer#MAX_VALUE} then this method
-     * will only skip at most {@code Integer.MAX_VALUE} bytes.
+     * This method skips at most {@code Integer.MAX_VALUE} bytes.
      *
-     * @param n number of bytes to be skipped
-     * @return the actual number of bytes skipped
+     * @param n number of bytes to be skipped. If {@code n} is zero then no bytes are skipped.
+     * @return the actual number of bytes skipped, which might be zero
      * @throws IOException if an I/O error occurs or if this stream is
-     * already closed
+     *                     already closed
+     * @throws IllegalArgumentException if {@code n < 0}
      */
     public long skip(long n) throws IOException {
         if (n < 0) {

--- a/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/DeflaterInputStream.java
@@ -212,8 +212,8 @@ public class DeflaterInputStream extends FilterInputStream {
 
     /**
      * Skips over and discards data from the input stream.
-     * This method may block until the specified number of bytes are read and
-     * skipped.
+     * This method may block until the specified number of bytes are skipped
+     * or end of stream is reached.
      *
      * @implNote
      * This method skips at most {@code Integer.MAX_VALUE} bytes.

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -208,6 +208,8 @@ public class InflaterInputStream extends FilterInputStream {
 
     /**
      * Skips specified number of bytes of uncompressed data.
+     * This method may block until the specified number of bytes are read and
+     * skipped.
      *
      * @implNote
      * If {@code n} is greater than {@link Integer#MAX_VALUE} then this method

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -208,6 +208,11 @@ public class InflaterInputStream extends FilterInputStream {
 
     /**
      * Skips specified number of bytes of uncompressed data.
+     *
+     * @implNote
+     * If {@code n} is greater than {@link Integer#MAX_VALUE} then this method
+     * will only skip at most {@code Integer.MAX_VALUE} bytes.
+     *
      * @param n the number of bytes to skip
      * @return the actual number of bytes skipped.
      * @throws    IOException if an I/O error has occurred

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -208,8 +208,8 @@ public class InflaterInputStream extends FilterInputStream {
 
     /**
      * Skips specified number of bytes of uncompressed data.
-     * This method may block until the specified number of bytes are read and
-     * skipped.
+     * This method may block until the specified number of bytes are skipped
+     * or end of stream is reached.
      *
      * @implNote
      * This method skips at most {@code Integer.MAX_VALUE} bytes.

--- a/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/InflaterInputStream.java
@@ -212,12 +212,12 @@ public class InflaterInputStream extends FilterInputStream {
      * skipped.
      *
      * @implNote
-     * If {@code n} is greater than {@link Integer#MAX_VALUE} then this method
-     * will only skip at most {@code Integer.MAX_VALUE} bytes.
+     * This method skips at most {@code Integer.MAX_VALUE} bytes.
      *
-     * @param n the number of bytes to skip
-     * @return the actual number of bytes skipped.
-     * @throws    IOException if an I/O error has occurred
+     * @param n the number of bytes to skip. If {@code n} is zero then no bytes are skipped.
+     * @return the actual number of bytes skipped, which might be zero
+     * @throws IOException if an I/O error occurs or if this stream is
+     *                     already closed
      * @throws    IllegalArgumentException if {@code n < 0}
      */
     public long skip(long n) throws IOException {


### PR DESCRIPTION
Can I please get a review of this change which updates the API specification of `java.util.zip.InflaterInputStream.skip()` method to match its current implementation?

`InflaterInputStream.skip()`, just like `DeflaterInputStream.skip()`, takes a `long` value `n` representing the number of bytes to skip. When a value greater than `Integer.MAX_VALUE` is passed to this `InflaterInputStream.skip()` method, the current implementation in that method only skips at most `Integer.MAX_VALUE` bytes. `DeflaterInputStream.skip()` too has the same behaviour. However, in the case of `DeflaterInputStream.skip()`, this semantic is clearly noted in that method's API documentation. `InflaterInputStream.skip()` currently doesn't specify this behaviour.

The commit in this PR updates the `InflaterInputStream.skip()` to specify the current implementation.

I'll open a CSR for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8333400](https://bugs.openjdk.org/browse/JDK-8333400) to be approved

### Issues
 * [JDK-8206447](https://bugs.openjdk.org/browse/JDK-8206447): InflaterInputStream.skip receives long but it's limited to Integer.MAX_VALUE (**Enhancement** - P4)
 * [JDK-8333400](https://bugs.openjdk.org/browse/JDK-8333400): InflaterInputStream.skip receives long but it's limited to Integer.MAX_VALUE (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19515/head:pull/19515` \
`$ git checkout pull/19515`

Update a local copy of the PR: \
`$ git checkout pull/19515` \
`$ git pull https://git.openjdk.org/jdk.git pull/19515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19515`

View PR using the GUI difftool: \
`$ git pr show -t 19515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19515.diff">https://git.openjdk.org/jdk/pull/19515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19515#issuecomment-2144294234)