### PR TITLE
8333394: C2: assert(bol->is_Opaque4() || bol->is_OpaqueInitializedAssertionPredicate()) failed: Opaque node of non-null-check or of Initialized Assertion Predicate

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1200,9 +1200,11 @@ bool IdealLoopTree::policy_range_check(PhaseIdealLoop* phase, bool provisional, 
         iff->Opcode() == Op_RangeCheck) { // Test?
 
       // Comparing trip+off vs limit
-      Node *bol = iff->in(1);
-      if (bol->req() < 2) {
-        continue; // dead constant test
+      Node* bol = iff->in(1);
+      if (bol->req() != 2) {
+        // Could be a dead constant test or another dead variant (e.g. a Phi with 2 inputs created with split_thru_phi).
+        // Either way, skip this test.
+        continue;
       }
       if (!bol->is_Bool()) {
         assert(bol->is_Opaque4() || bol->is_OpaqueInitializedAssertionPredicate(),

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestIfWithPhiInput.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestIfWithPhiInput.java
@@ -26,7 +26,7 @@
  * @test
  * @bug 8333394
  * @summary Test bailout of range check policy with an If with a Phi as condition.
- * @run main/othervm -XX:CompileCommand=compileonly,*TestIfWithPhiInput*::* -Xcomp
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestIfWithPhiInput*::* -Xcomp -XX:-TieredCompilation
  *                   compiler.predicates.assertion.TestIfWithPhiInput
  */
 

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestIfWithPhiInput.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestIfWithPhiInput.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8333394
+ * @summary Test bailout of range check policy with an If with a Phi as condition.
+ * @run main/othervm -XX:CompileCommand=compileonly,*TestIfWithPhiInput*::* -Xcomp
+ *                   compiler.predicates.assertion.TestIfWithPhiInput
+ */
+
+package compiler.predicates.assertion;
+
+public class TestIfWithPhiInput {
+    static int x;
+    static int y;
+
+    public static void main(String[] strArr) {
+        test();
+    }
+
+    static int test() {
+        int i = 1;
+        do {
+            try {
+                y = y / y;
+            } catch (ArithmeticException a_e) {
+            }
+            for (int j = i; j < 6; j++) {
+                y = i;
+            }
+        } while (++i < 52);
+        return x;
+    }
+}


### PR DESCRIPTION
[JDK-8330386](https://bugs.openjdk.org/browse/JDK-8330386) added some additional asserts to ensure that we are dealing with Template Assertion Predicates and/or non-null-checks which both use `Opaque4` nodes. I've also improved the following bailout from `!= 2` to `< 2` since the original comment suggested that if there is a test without 2 inputs, it must be a dead test (i.e. I assumed a `ConNode`):

https://github.com/openjdk/jdk/blob/91101f0d4fc8e06d0d74e06361db6ac87efeeb8e/src/hotspot/share/opto/loopTransform.cpp#L1204-L1206

But apparently, we could also have the following, also dead, `If` with a condition with 3 inputs (`505 Phi`) created by `split_thru_phi`:

![image](https://github.com/openjdk/jdk/assets/17833009/003ad32a-a675-49f2-a263-7ca28d1faf82)

I therefore revert the check back to `!= 2` and improved the comment.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333394](https://bugs.openjdk.org/browse/JDK-8333394): C2: assert(bol-&gt;is_Opaque4() || bol-&gt;is_OpaqueInitializedAssertionPredicate()) failed: Opaque node of non-null-check or of Initialized Assertion Predicate (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [5eb94738](https://git.openjdk.org/jdk/pull/19517/files/5eb9473803159837c17893ea7dd770c730ed11d7)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19517/head:pull/19517` \
`$ git checkout pull/19517`

Update a local copy of the PR: \
`$ git checkout pull/19517` \
`$ git pull https://git.openjdk.org/jdk.git pull/19517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19517`

View PR using the GUI difftool: \
`$ git pr show -t 19517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19517.diff">https://git.openjdk.org/jdk/pull/19517.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19517#issuecomment-2144607913)