### PR TITLE
8333177: Invalid value used for enum Cell in ciTypeFlow::get_start_state

### DIFF
--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -404,7 +404,8 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
     state->push_translate(str.type());
   }
   // Set the rest of the locals to bottom.
-  while (state->stack_size() != 0) {
+  assert(state->stack_size() <= 0, "stack size should not be strictly positive");
+  while (state->stack_size() < 0) {
     state->push(state->bottom_type());
   }
   // Lock an object, if necessary.

--- a/src/hotspot/share/ci/ciTypeFlow.cpp
+++ b/src/hotspot/share/ci/ciTypeFlow.cpp
@@ -404,11 +404,8 @@ const ciTypeFlow::StateVector* ciTypeFlow::get_start_state() {
     state->push_translate(str.type());
   }
   // Set the rest of the locals to bottom.
-  Cell cell = state->next_cell(state->tos());
-  state->set_stack_size(0);
-  int limit = state->limit_cell();
-  for (; cell < limit; cell = state->next_cell(cell)) {
-    state->set_type_at(cell, state->bottom_type());
+  while (state->stack_size() != 0) {
+    state->push(state->bottom_type());
   }
   // Lock an object, if necessary.
   state->set_monitor_count(method()->is_synchronized() ? 1 : 0);


### PR DESCRIPTION
Ubsan detected undefined behavior in `ciTypeFlow::get_start_state` because an invalid value of `4294967295` is assigned to enum `Cell`:
https://github.com/openjdk/jdk/blob/ac7119f0d5319a3fb44dc67a938c3e1eb21b9202/src/hotspot/share/ci/ciTypeFlow.hpp#L150-L152

The problem is that if the C++ compiler decides to encode `Cell` with an unsigned int, casting a negative integer value will lead to an underflow and therefore a value > `Cell_max = INT_MAX`. Here, `state->tos()` returns a value < 0:
https://github.com/openjdk/jdk/blob/ac7119f0d5319a3fb44dc67a938c3e1eb21b9202/src/hotspot/share/ci/ciTypeFlow.cpp#L407

which is casted to a `Cell`:
https://github.com/openjdk/jdk/blob/ac7119f0d5319a3fb44dc67a938c3e1eb21b9202/src/hotspot/share/ci/ciTypeFlow.hpp#L211

I simply re-wrote the code to not require a negative `Cell` value to iterate over the locals and setting them to bottom type.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333177](https://bugs.openjdk.org/browse/JDK-8333177): Invalid value used for enum Cell in ciTypeFlow::get_start_state (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [ead0e611](https://git.openjdk.org/jdk/pull/19520/files/ead0e6119d0391854ef8a30260726b586e73fd72)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19520/head:pull/19520` \
`$ git checkout pull/19520`

Update a local copy of the PR: \
`$ git checkout pull/19520` \
`$ git pull https://git.openjdk.org/jdk.git pull/19520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19520`

View PR using the GUI difftool: \
`$ git pr show -t 19520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19520.diff">https://git.openjdk.org/jdk/pull/19520.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19520#issuecomment-2145020165)