### PR TITLE
8332920: C2: Partial Peeling is wrongly applied for CmpU with negative limit

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3125,11 +3125,11 @@ IfNode* PhaseIdealLoop::insert_cmpi_loop_exit(IfNode* if_cmpu, IdealLoopTree* lo
     return nullptr;
   }
 
-  // From (SLE-full), we can extract a single signed loop exit condition depending on the stride:
+  // We prove below that we can extract a single signed loop exit condition from (SLE-full), depending on the stride:
   //   stride < 0:
-  //     i < 0        (SLE-negative)
+  //     i < 0        (SLE = SLE-negative)
   //   stride > 0:
-  //     i >= limit   (SLE-positive)
+  //     i >= limit   (SLE = SLE-positive)
   // such that we have the following graph before Partial Peeling with stride > 0 (similar for stride < 0):
   //
   // Loop:
@@ -3147,12 +3147,12 @@ IfNode* PhaseIdealLoop::insert_cmpi_loop_exit(IfNode* if_cmpu, IdealLoopTree* lo
   //   (SLE) IMPLIES (ULE)
   // This indeed holds when (COND) is given:
   // - stride > 0:
-  //       i >=  limit             // (SLE-positive)
+  //       i >=  limit             // (SLE = SLE-positive)
   //       i >=  limit >= 0        // (COND)
   //       i >=u limit >= 0        // (LEMMA)
   //     which is the unsigned loop exit condition (ULE).
   // - stride < 0:
-  //       i        <  0           // (SLE-negative)
+  //       i        <  0           // (SLE = SLE-negative)
   //       (uint) i >u MAX_INT     // (NEG) all negative values are greater than MAX_INT when converted to unsigned
   //       MAX_INT >= limit >= 0   // (COND)
   //       MAX_INT >=u limit >= 0  // (LEMMA)
@@ -3163,12 +3163,12 @@ IfNode* PhaseIdealLoop::insert_cmpi_loop_exit(IfNode* if_cmpu, IdealLoopTree* lo
   //
   // After Partial Peeling, we have the following structure for stride > 0 (similar for stride < 0):
   //   <cloned peeled section>
-  //   i >= limit (SLE)
+  //   i >= limit (SLE-positive)
   //   Loop:
   //     i >=u limit (ULE)
   //     <rest of unpeeled section>
   //     <peeled section>
-  //     i >= limit (SLE)
+  //     i >= limit (SLE-positive)
   //     goto Loop
   Node* rhs_cmpi;
   if (stride > 0) {

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3054,7 +3054,7 @@ RegionNode* PhaseIdealLoop::insert_region_before_proj(ProjNode* proj) {
 //        |         |
 //    dummy-if      |
 //     /  |         |
-// other  |         |
+// dead   |         |
 //        v         v
 //   exit-proj   stay-in-loop-proj
 //

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -3058,6 +3058,9 @@ RegionNode* PhaseIdealLoop::insert_region_before_proj(ProjNode* proj) {
 //        v         v
 //   exit-proj   stay-in-loop-proj
 //
+// Note: The dummy-if is inserted to create a region to merge the loop exits between the original to be killed unsigned
+//       loop exit test and its exit projection while keeping the exit projection (also see insert_region_before_proj()).
+//
 // Requirements
 // ------------
 // Note that we can only split off a signed loop exit test from the unsigned loop exit test when the behavior is exactly

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=Xbatch
+ * @bug 8332920
+ * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::test*
+ *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
+ */
+
+/*
+ * @test id=Xcomp-run-inline
+ * @bug 8332920
+ * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @run main/othervm -Xcomp -XX:-TieredCompilation
+ *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::run*
+ *                   -XX:CompileCommand=inline,*TestPartialPeelAtUnsignedTestsNegativeLimit::test*
+ *                   -XX:CompileCommand=dontinline,*TestPartialPeelAtUnsignedTestsNegativeLimit::check
+ *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
+ */
+
+/*
+ * @test id=Xcomp-compile-test
+ * @bug 8332920
+ * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @run main/othervm -Xcomp -XX:-TieredCompilation -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::test*
+ *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
+ */
+
+/*
+ * @test id=vanilla
+ * @bug 8332920
+ * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
+ * @run main compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit
+ */
+
+package compiler.loopopts;
+
+import static java.lang.Integer.*;
+
+public class TestPartialPeelAtUnsignedTestsNegativeLimit {
+    static int iFld = 10000;
+    static int iterations = 0;
+    static int iFld2;
+    static boolean flag;
+
+    public static void main(String[] args) {
+        compareUnsigned(3, 3); // Load Integer class for -Xcomp
+        for (int i = 0; i < 2; i++) {
+            if (!originalTest()) {
+                throw new RuntimeException("originalTest() failed");
+            }
+        }
+
+        for (int i = 0; i < 2000; i++) {
+            // For profiling
+            iFld = -1;
+            originalTestVariation1();
+
+            // Actual run
+            iFld = MAX_VALUE - 100_000;
+            if (!originalTestVariation1()) {
+                throw new RuntimeException("originalTestVariation1() failed");
+            }
+        }
+
+        for (int i = 0; i < 2000; ++i) {
+            // For profiling
+            iFld = MAX_VALUE;
+            originalTestVariation2();
+
+            // Actual run
+            iFld = MIN_VALUE + 100000;
+            if (!originalTestVariation2()) {
+                throw new RuntimeException("originalTestVariation2() failed");
+            }
+        }
+
+        runWhileLTIncr();
+        runWhileLTDecr();
+    }
+
+    // Originally reported simplified regression test with 2 variations (see below).
+    public static boolean originalTest() {
+        for (int i = MAX_VALUE - 50_000; compareUnsigned(i, -1) < 0; i++) {
+            if (compareUnsigned(MIN_VALUE, i) < 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean originalTestVariation1() {
+        int a = 0;
+        for (int i = iFld; compareUnsigned(i, -1) < 0; ++i) { // i <u -1
+
+            if (i >= Integer.MIN_VALUE + 1 && i <= 100) { // Transformed to unsigned test.
+                return true;
+            }
+            a *= 23;
+        }
+        return false;
+    }
+
+    public static boolean originalTestVariation2() {
+        int a = 0;
+        for (int i = iFld; compareUnsigned(i, -1000) < 0; i--) { // i <u -1
+            if (compareUnsigned(MAX_VALUE - 20, i) > 0) {
+                return true;
+            }
+            a = i;
+        }
+        System.out.println(a);
+        return false;
+    }
+
+
+    public static void testWhileLTIncr(int init, int limit) {
+        int i = init;
+        while (true) {
+            // <Peeled Section>
+
+            // Found as loop head in ciTypeFlow, but both path inside loop -> head not cloned.
+            // As a result, this head has the safepoint as backedge instead of the loop exit test
+            // and we cannot create a counted loop (yet). We first need to partial peel.
+            if (flag) {
+            }
+
+            iFld2++;
+
+            // Loop exit test i >=u limit (i.e. "while (i <u limit)") to partial peel with.
+            // insert_cmpi_loop_exit() changes this exit condition into a signed and an unsigned test:
+            //   i >= limit && i >=u limit
+            // where the signed condition can be used as proper loop exit condition for a counted loop
+            // (we cannot use an unsigned counted loop exit condition).
+            //
+            // After Partial Peeling, we have:
+            //   if (i >= limit) goto Exit
+            // Loop:
+            //   if (i >=u limit) goto Exit
+            //   ...
+            //   i++;
+            //   if (i >= limit) goto Exit
+            //   goto Loop
+            // Exit:
+            //   ...
+            //
+            // If init = MAX_VALUE and limit = MIN_VALUE:
+            //   i >= limit
+            //   MAX_VALUE >= MIN_VALUE
+            // which is true where
+            //   i >=u limit
+            //   MAX_VALUE >=u MIN_VALUE
+            //   MAX_VALUE >=u (uint)(MAX_INT + 1)
+            // is false and we wrongly never enter the loop even though we should have.
+            // This results in a wrong execution.
+            if (compareUnsigned(i, limit) >= 0) {
+                return;
+            }
+            // <-- Partial Peeling CUT -->
+            // Safepoint
+            // <Unpeeled Section>
+            iterations++;
+            i++;
+        }
+    }
+
+    // Same as testWhileLTIncr() but with decrement instead.
+    public static void testWhileLTDecr(int init, int limit) {
+        int i = init;
+        while (true) {
+            if (flag) {
+            }
+
+            // Loop exit test.
+            if (compareUnsigned(i, limit) >= 0) { // While (i <u limit)
+                return;
+            }
+
+            iterations++;
+            i--;
+        }
+    }
+
+    public static void runWhileLTIncr() {
+        // Currently works:
+        testWhileLTIncr(MAX_VALUE, -1);
+        check(MIN_VALUE); // MAX_VALUE + 1 iterations
+        testWhileLTIncr(-1, 1);
+        check(0);
+        flag = !flag; // Change profiling
+        testWhileLTIncr(MAX_VALUE - 2000, MAX_VALUE);
+        check(2000);
+        testWhileLTIncr(MAX_VALUE - 1990, MAX_VALUE);
+        check(1990);
+        testWhileLTIncr(MAX_VALUE - 1, MAX_VALUE);
+        check(1);
+        testWhileLTIncr(MIN_VALUE, MIN_VALUE + 2000);
+        check(2000);
+        testWhileLTIncr(MIN_VALUE, MIN_VALUE + 1990);
+        check(1990);
+        testWhileLTIncr(MIN_VALUE, MIN_VALUE + 1);
+        check(1);
+
+        flag = !flag;
+        // Overflow currently does not work with negative limit and is fixed with patch:
+        testWhileLTIncr(MAX_VALUE, MIN_VALUE);
+        check(1);
+        testWhileLTIncr(MAX_VALUE - 2000, MIN_VALUE);
+        check(2001);
+        testWhileLTIncr(MAX_VALUE, MIN_VALUE + 2000);
+        check(2001);
+        testWhileLTIncr(MAX_VALUE - 2000, MIN_VALUE + 2000);
+        check(4001);
+    }
+
+    public static void runWhileLTDecr() {
+        // Currently works:
+        testWhileLTDecr(1, -1);
+        check(2);
+        testWhileLTDecr(-1, 1);
+        check(0);
+        flag = !flag;
+        testWhileLTDecr(MAX_VALUE, MIN_VALUE);
+        check(MIN_VALUE); // MAX_VALUE + 1 iterations
+        testWhileLTDecr(MAX_VALUE, -1);
+        check(MIN_VALUE); // MAX_VALUE + 1 iterations
+        testWhileLTDecr(MAX_VALUE, MIN_VALUE);
+        check(MIN_VALUE); // MAX_VALUE + 1 iterations
+        testWhileLTDecr(MIN_VALUE, 0);
+        check(0);
+        testWhileLTDecr(MIN_VALUE, 1);
+        check(0);
+        flag = !flag;
+
+        // Underflow currently does not work with negative limit and is fixed with patch:
+        testWhileLTDecr(MIN_VALUE, -1);
+        check(MIN_VALUE + 1); // MAX_VALUE + 2 iterations
+        testWhileLTDecr(MIN_VALUE, -2000);
+        check(MIN_VALUE + 1); // MAX_VALUE + 2 iterations
+        testWhileLTDecr(MIN_VALUE, MIN_VALUE + 1);
+        check(MIN_VALUE + 1); // MAX_VALUE + 2 iterations
+        testWhileLTDecr(MIN_VALUE + 2000, -1);
+        check(MIN_VALUE + 2001); // MAX_VALUE + 2002 iterations
+        testWhileLTDecr(MIN_VALUE + 2000, -2000);
+        check(MIN_VALUE + 2001); // MAX_VALUE + 2002 iterations
+        testWhileLTDecr(MIN_VALUE + 2000, MIN_VALUE + 2001);
+        check(MIN_VALUE + 2001); // MAX_VALUE + 2002 iterations
+    }
+
+    static void check(int expectedIterations) {
+        if (expectedIterations != iterations) {
+            throw new RuntimeException("Expected " + expectedIterations + " iterations but only got " + iterations);
+        }
+        iterations = 0; // Reset
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
@@ -142,7 +142,7 @@ public class TestPartialPeelAtUnsignedTestsNegativeLimit {
         while (true) {
             // <Peeled Section>
 
-            // Found as loop head in ciTypeFlow, but both path inside loop -> head not cloned.
+            // Found as loop head in ciTypeFlow, but both paths inside loop -> head not cloned.
             // As a result, this head has the safepoint as backedge instead of the loop exit test
             // and we cannot create a counted loop (yet). We first need to partial peel.
             if (flag) {

--- a/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java
@@ -35,7 +35,7 @@
  * @bug 8332920
  * @summary Tests partial peeling at unsigned tests with limit being negative in exit tests "i >u limit".
  * @run main/othervm -Xcomp -XX:-TieredCompilation
- *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::run*
+ *                   -XX:CompileOnly=*TestPartialPeel*::original*,*TestPartialPeel*::run*,*TestPartialPeel*::test*
  *                   -XX:CompileCommand=inline,*TestPartialPeelAtUnsignedTestsNegativeLimit::test*
  *                   -XX:CompileCommand=dontinline,*TestPartialPeelAtUnsignedTestsNegativeLimit::check
  *                   compiler.loopopts.TestPartialPeelAtUnsignedTestsNegativeLimit


### PR DESCRIPTION
A signed test is wrongly split off an unsigned test during Partial Peeling which results in not entering a loop even though it should. 

#### Idea of Partial Peeling

Partial Peeling rotates a loop with the hope to being able to convert the loop into a counted loop later. It is therefore preferable to use signed tests over unsigned tests because counted loops must use a signed loop exit test (i.e. with a `BaseCountedLoopEnd`). 

#### Partial Peeling with Unsigned Test

However, if there is only a suitable unsigned test, we can still try to use it for Partial Peeling. The idea is to then split off a signed version of the unsigned test and place it right before the unsigned test which can then be used as a loop exit test and later as `BaseCountedLoopEnd`:

https://github.com/openjdk/jdk/blob/0ea3bacf48be90d93f9e6c8e6568a0b8c61afb46/src/hotspot/share/opto/loopopts.cpp#L3074-L3080

#### Requirements for Using an Unsigned Test

The Signed and Unsigned Loop Exit Test do not need have the same result at runtime. It is sufficient if the Signed Loop Exit Test implies the Unsigned Loop Exit Test:
- If the Signed Loop Exit Test is false, then the (original) Unsigned Loop Exit Test will make sure to exit the loop if required.
- If the Signed Loop Exit Test is true, then the (original) Unsigned Loop Exit Test must also be true. Otherwise, we would exit a loop that we should have continued to execute. 

#### The Requirements Are Currently Broken

This strong requirement for splitting off a signed test is currently broken as seen in the test cases (for example, `testWhileLTIncr()`): We split off the signed loop exit test `i >= limit`, then partial peel and we get the signed loop exit test `i >= limit` as entry guard to the loop which is wrong:

https://github.com/openjdk/jdk/blob/0ea3bacf48be90d93f9e6c8e6568a0b8c61afb46/test/hotspot/jtreg/compiler/loopopts/TestPartialPeelAtUnsignedTestsNegativeLimit.java#L159-L178

#### Why Are the Requirements Broken?

The reason is that 
```
i >=u limit
```
can only be converted into the two signed comparisons
```
i < 0 || i >= limit
```
if `limit` is non-negative (i.e. `limit >= 0`): 
https://github.com/openjdk/jdk/blob/0ea3bacf48be90d93f9e6c8e6568a0b8c61afb46/src/hotspot/share/opto/loopopts.cpp#L3054-L3061

This is currently missing and we wrongly use `i < 0` or `i >= limit` as split off signed test.

#### Fixing the Broken Requirements
To fix this, I've added a bailout when `limit` could be negative which is the same as checking if the type of `limit` contains a negative value:

https://github.com/openjdk/jdk/blob/0ea3bacf48be90d93f9e6c8e6568a0b8c61afb46/src/hotspot/share/opto/loopopts.cpp#L3062-L3066

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332920](https://bugs.openjdk.org/browse/JDK-8332920): C2: Partial Peeling is wrongly applied for CmpU with negative limit (**Bug** - P2)(⚠️ The fixVersion in this issue is [23] but the fixVersion in .jcheck/conf is 24, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [e0a18f06](https://git.openjdk.org/jdk/pull/19522/files/e0a18f0625ae9139b624a7f50ff21f8116f07cb9)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [33d89249](https://git.openjdk.org/jdk/pull/19522/files/33d89249886f434d8c96104f4b934e72c31d9d52)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19522/head:pull/19522` \
`$ git checkout pull/19522`

Update a local copy of the PR: \
`$ git checkout pull/19522` \
`$ git pull https://git.openjdk.org/jdk.git pull/19522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19522`

View PR using the GUI difftool: \
`$ git pr show -t 19522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19522.diff">https://git.openjdk.org/jdk/pull/19522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19522#issuecomment-2145162981)