### PR TITLE
8327368: javac crash when computing exhaustiveness checks

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -937,7 +937,7 @@ public class Flow {
                             for (PatternDescription pdOther : patterns) {
                                 if (pdOther instanceof BindingPattern bpOther) {
                                     Set<Symbol> currentPermittedSubTypes =
-                                            allPermittedSubTypes((ClassSymbol) bpOther.type.tsym, s -> true);
+                                            allPermittedSubTypes(bpOther.type.tsym, s -> true);
 
                                     PERMITTED: for (Iterator<Symbol> it = permitted.iterator(); it.hasNext();) {
                                         Symbol perm = it.next();
@@ -973,9 +973,9 @@ public class Flow {
             return patterns;
         }
 
-        private Set<Symbol> allPermittedSubTypes(ClassSymbol root, Predicate<ClassSymbol> accept) {
+        private Set<Symbol> allPermittedSubTypes(TypeSymbol root, Predicate<ClassSymbol> accept) {
             Set<Symbol> permitted = new HashSet<>();
-            List<ClassSymbol> permittedSubtypesClosure = List.of(root);
+            List<ClassSymbol> permittedSubtypesClosure = baseClasses(root);
 
             while (permittedSubtypesClosure.nonEmpty()) {
                 ClassSymbol current = permittedSubtypesClosure.head;
@@ -997,6 +997,20 @@ public class Flow {
             }
 
             return permitted;
+        }
+
+        private List<ClassSymbol> baseClasses(TypeSymbol root) {
+            if (root instanceof ClassSymbol clazz) {
+                return List.of(clazz);
+            } else if (root instanceof TypeVariableSymbol tvar) {
+                ListBuffer<ClassSymbol> result = new ListBuffer<>();
+                for (Type bound : tvar.getBounds()) {
+                    result.appendList(baseClasses(bound.tsym));
+                }
+                return result.toList();
+            } else {
+                return List.nil();
+            }
         }
 
         /* Among the set of patterns, find sub-set of patterns such:
@@ -1144,7 +1158,7 @@ public class Flow {
                         reducedNestedPatterns[i] = newNested;
                     }
 
-                    covered &= isBpCovered(componentType[i], newNested);
+                    covered &= checkCovered(componentType[i], List.of(newNested));
                 }
                 if (covered) {
                     return new BindingPattern(rpOne.recordType);
@@ -1174,8 +1188,8 @@ public class Flow {
                                 }
                             }
                         }
-                    } else if (pd instanceof BindingPattern bp && bp.type.tsym instanceof ClassSymbol clazz) {
-                        Set<Symbol> permittedSymbols = allPermittedSubTypes(clazz, cs -> true);
+                    } else if (pd instanceof BindingPattern bp) {
+                        Set<Symbol> permittedSymbols = allPermittedSubTypes(bp.type.tsym, cs -> true);
 
                         if (!permittedSymbols.isEmpty()) {
                             for (Symbol permitted : permittedSymbols) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1174,8 +1174,8 @@ public class Flow {
                                 }
                             }
                         }
-                    } else if (pd instanceof BindingPattern bp) {
-                        Set<Symbol> permittedSymbols = allPermittedSubTypes((ClassSymbol) bp.type.tsym, cs -> true);
+                    } else if (pd instanceof BindingPattern bp && bp.type.tsym instanceof ClassSymbol clazz) {
+                        Set<Symbol> permittedSymbols = allPermittedSubTypes(clazz, cs -> true);
 
                         if (!permittedSymbols.isEmpty()) {
                             for (Symbol permitted : permittedSymbols) {


### PR DESCRIPTION
Consider code like:
```
package test;

public class Test {

    sealed interface A permits T, U {}

    sealed interface B permits V, W {}

    static final class T implements A {}

    static final class U implements A {}

    static final class V implements B {}

    static final class W implements B {}

    final static record R(A a, B b) {}

    static int r(R r) {
        return switch (r) {
            case R(A a, V b) -> 1;
            case R(T a, B b) -> 2;
            case R(U a, W b) -> 3;
        };
    }
}
```

To properly evaluate exhaustiveness, we need to consider `R(T a, B b)` to act as `R(T a, W b)`, so that we can reduce `R(T a, W b)` and `R(U a, W b)` to `R(A a, W b)`. Which is then reduced together with `R(A a, V b)` to `R(A a, B b)` and consequently to just `R`.

This was done under JDK-8325215, by expanding `B` into all possible subtypes, from which we can pick patterns for reduction. Eventually, that patch may need a more complete revamp, but the idea herein is just to prevent a `ClassCastException` when the type of the binding pattern is not a class-based type - typically, when it is a type variable. This patch uses the type variable's bounds as the based from which the permitted subtypes are computed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8327368: javac crash when computing exhaustiveness checks`

### Issue
 * [JDK-8327368](https://bugs.openjdk.org/browse/JDK-8327368): javac crash when computing exhaustiveness checks (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19523/head:pull/19523` \
`$ git checkout pull/19523`

Update a local copy of the PR: \
`$ git checkout pull/19523` \
`$ git pull https://git.openjdk.org/jdk.git pull/19523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19523`

View PR using the GUI difftool: \
`$ git pr show -t 19523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19523.diff">https://git.openjdk.org/jdk/pull/19523.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19523#issuecomment-2145125919)