### PR TITLE
8333434: IGV: Print loop node for PHASE_BEFORE/AFTER_CLOOPS

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1781,7 +1781,7 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
   }
 
   assert(x->Opcode() == Op_Loop || x->Opcode() == Op_LongCountedLoop, "regular loops only");
-  C->print_method(PHASE_BEFORE_CLOOPS, 3);
+  C->print_method(PHASE_BEFORE_CLOOPS, 3, x);
 
   // ===================================================
   // We can only convert this loop to a counted loop if we can guarantee that the iv phi will never overflow at runtime.
@@ -2289,7 +2289,7 @@ bool PhaseIdealLoop::is_counted_loop(Node* x, IdealLoopTree*&loop, BasicType iv_
   }
 #endif
 
-  C->print_method(PHASE_AFTER_CLOOPS, 3);
+  C->print_method(PHASE_AFTER_CLOOPS, 3, l);
 
   // Capture bounds of the loop in the induction variable Phi before
   // subsequent transformation (iteration splitting) obscures the


### PR DESCRIPTION
This simple patch adds loop nodes for `PHASE_BEFORE_CLOOPS` (the `LoopNode` to be converted) and `PHASE_AFTER_CLOOPS` (the newly created `CountedLoopNode`) in IGV:

Before patch:
![image](https://github.com/openjdk/jdk/assets/17833009/6771160e-4d2e-423a-9578-40562c053a6f)

With patch:
![image](https://github.com/openjdk/jdk/assets/17833009/b6870a67-8c5e-42be-87f0-1b8de7269298)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333434](https://bugs.openjdk.org/browse/JDK-8333434): IGV: Print loop node for PHASE_BEFORE/AFTER_CLOOPS (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19524/head:pull/19524` \
`$ git checkout pull/19524`

Update a local copy of the PR: \
`$ git checkout pull/19524` \
`$ git pull https://git.openjdk.org/jdk.git pull/19524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19524`

View PR using the GUI difftool: \
`$ git pr show -t 19524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19524.diff">https://git.openjdk.org/jdk/pull/19524.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19524#issuecomment-2145142939)