### PR TITLE
8333444: Parallel: Inline PSParallelCompact::mark_obj

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -106,16 +106,18 @@ inline void ParCompactionManager::mark_and_push(T* p) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(ParallelScavengeHeap::heap()->is_in(obj), "should be in heap");
 
-    if (mark_bitmap()->is_unmarked(obj) && PSParallelCompact::mark_obj(obj)) {
-      assert(_marking_stats_cache != nullptr, "inv");
-      _marking_stats_cache->push(obj, obj->size());
-      push(obj);
-
+    if (mark_bitmap()->mark_obj(obj)) {
       if (StringDedup::is_enabled() &&
           java_lang_String::is_instance(obj) &&
           psStringDedup::is_candidate_from_mark(obj)) {
         _string_dedup_requests.add(obj);
       }
+
+      ContinuationGCSupport::transform_stack_chunk(obj);
+
+      assert(_marking_stats_cache != nullptr, "inv");
+      _marking_stats_cache->push(obj, obj->size());
+      push(obj);
     }
   }
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -798,8 +798,6 @@ public:
 
   static CollectorCounters* counters()    { return _counters; }
 
-  // Marking support
-  static inline bool mark_obj(oop obj);
   static inline bool is_marked(oop obj);
 
   template <class T> static inline void adjust_pointer(T* p);

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -77,15 +77,6 @@ inline void PSParallelCompact::check_new_location(HeapWord* old_addr, HeapWord* 
 }
 #endif // ASSERT
 
-inline bool PSParallelCompact::mark_obj(oop obj) {
-  if (mark_bitmap()->mark_obj(obj)) {
-    ContinuationGCSupport::transform_stack_chunk(obj);
-    return true;
-  } else {
-    return false;
-  }
-}
-
 template <class T>
 inline void PSParallelCompact::adjust_pointer(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);


### PR DESCRIPTION
Trivial inlining a method and removing redundant `is_unmarked` check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333444](https://bugs.openjdk.org/browse/JDK-8333444): Parallel: Inline PSParallelCompact::mark_obj (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19526/head:pull/19526` \
`$ git checkout pull/19526`

Update a local copy of the PR: \
`$ git checkout pull/19526` \
`$ git pull https://git.openjdk.org/jdk.git pull/19526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19526`

View PR using the GUI difftool: \
`$ git pr show -t 19526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19526.diff">https://git.openjdk.org/jdk/pull/19526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19526#issuecomment-2145565745)