### PR TITLE
8333446: Add tests for hierarchical container support

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -128,6 +128,7 @@ applications/jcstress/copy.java 8229852 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 containers/docker/TestJFREvents.java 8327723 linux-x64
+containers/systemd/SystemdMemoryAwarenessTest.java 8322420 linux-all
 
 #############################################################################
 

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -87,6 +87,7 @@ requires.properties= \
     vm.musl \
     vm.flagless \
     docker.support \
+    systemd.support \
     jdk.containerized
 
 # Minimum jtreg version

--- a/test/hotspot/jtreg/containers/systemd/HelloSystemd.java
+++ b/test/hotspot/jtreg/containers/systemd/HelloSystemd.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+public class HelloSystemd {
+    public static void main(String args[]) {
+        System.out.println("Hello Systemd");
+    }
+}

--- a/test/hotspot/jtreg/containers/systemd/SystemdMemoryAwarenessTest.java
+++ b/test/hotspot/jtreg/containers/systemd/SystemdMemoryAwarenessTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @summary Memory/CPU awareness test for JDK-under-test inside a systemd slice.
+ * @requires systemd.support
+ * @library /test/lib
+ * @build HelloSystemd
+ * @run driver SystemdMemoryAwarenessTest
+ */
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import jdk.test.lib.containers.systemd.SystemdRunOptions;
+import jdk.test.lib.containers.systemd.SystemdTestUtils;
+import jdk.test.lib.containers.systemd.SystemdTestUtils.ResultFiles;
+
+
+public class SystemdMemoryAwarenessTest {
+
+    public static void main(String[] args) throws Exception {
+       testHelloSystemd();
+    }
+
+    private static void testHelloSystemd() throws Exception {
+        SystemdRunOptions opts = SystemdTestUtils.newOpts("HelloSystemd");
+        // 1 GB memory and 2 cores CPU
+        opts.memoryLimit("1000M").cpuLimit("200%");
+        opts.sliceName(SystemdMemoryAwarenessTest.class.getSimpleName());
+
+        ResultFiles files = SystemdTestUtils.buildSystemdSlices(opts);
+
+        try {
+            SystemdTestUtils.systemdRunJava(opts)
+                .shouldHaveExitValue(0)
+                .shouldContain("Hello Systemd")
+                .shouldContain("OSContainer::active_processor_count: 2")
+                .shouldContain("Memory Limit is: 1048576000"); // 1 GB
+        } finally {
+            try {
+                Files.delete(files.memory());
+                Files.delete(files.cpu());
+            } catch (NoSuchFileException e) {
+                // ignore
+            }
+        }
+    }
+
+}

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -100,6 +100,7 @@ requires.properties= \
     vm.jvmci.enabled \
     vm.jvmti \
     docker.support \
+    systemd.support \
     release.implementor \
     jdk.containerized \
     jdk.foreign.linker

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -133,6 +133,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
         map.put("docker.support", this::dockerSupport);
+        map.put("systemd.support", this::systemdSupport);
         map.put("vm.musl", this::isMusl);
         map.put("release.implementor", this::implementor);
         map.put("jdk.containerized", this::jdkContainerized);
@@ -611,13 +612,34 @@ public class VMProps implements Callable<Map<String, String>> {
 
         if (isSupported) {
            try {
-              isSupported = checkDockerSupport();
+              isSupported = checkProgramSupport("checkDockerSupport()", Container.ENGINE_COMMAND);
            } catch (Exception e) {
               isSupported = false;
            }
          }
 
         log("dockerSupport(): returning isSupported = " + isSupported);
+        return "" + isSupported;
+    }
+
+    /**
+     * A simple check for systemd support
+     *
+     * @return true if systemd is supported in a given environment
+     */
+    protected String systemdSupport() {
+        log("Entering systemdSupport()");
+
+        boolean isSupported = Platform.isLinux();
+        if (isSupported) {
+           try {
+              isSupported = checkProgramSupport("checkSystemdSupport()", "systemd-run");
+           } catch (Exception e) {
+              isSupported = false;
+           }
+         }
+
+        log("systemdSupport(): returning isSupported = " + isSupported);
         return "" + isSupported;
     }
 
@@ -655,17 +677,17 @@ public class VMProps implements Callable<Map<String, String>> {
                 });
     }
 
-    private boolean checkDockerSupport() throws IOException, InterruptedException {
-        log("checkDockerSupport(): entering");
-        ProcessBuilder pb = new ProcessBuilder("which", Container.ENGINE_COMMAND);
+    private boolean checkProgramSupport(String logString, String cmd) throws IOException, InterruptedException {
+        log(logString + ": entering");
+        ProcessBuilder pb = new ProcessBuilder("which", cmd);
         Map<String, String> logFileNames =
-            redirectOutputToLogFile("checkDockerSupport(): which " + Container.ENGINE_COMMAND,
-                                                      pb, "which-container");
+            redirectOutputToLogFile(logString + ": which " + cmd,
+                                                      pb, "which-cmd");
         Process p = pb.start();
         p.waitFor(10, TimeUnit.SECONDS);
         int exitValue = p.exitValue();
 
-        log(String.format("checkDockerSupport(): exitValue = %s, pid = %s", exitValue, p.pid()));
+        log(String.format("%s: exitValue = %s, pid = %s", logString, exitValue, p.pid()));
         if (exitValue != 0) {
             printLogfileContent(logFileNames);
         }

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdRunOptions.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdRunOptions.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.containers.systemd;
+
+import static jdk.test.lib.Asserts.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+
+// This class represents options for running java inside systemd slices
+// in test environment.
+public class SystemdRunOptions {
+    public ArrayList<String> javaOpts = new ArrayList<>();
+    public String classToRun;  // class or "-version"
+    public ArrayList<String> classParams = new ArrayList<>();
+    public String memoryLimit; // used in slice for MemoryLimit property
+    public String cpuLimit;    // used in slice for CPUQuota property
+    public String sliceName;   // name of the slice (nests CPU in memory)
+
+    /**
+     * Convenience constructor for most common use cases in testing.
+     * @param classToRun  a class to run, or "-version"
+     * @param javaOpts  java options to use
+     *
+     * @return Default docker run options
+     */
+    public SystemdRunOptions(String classToRun, String... javaOpts) {
+        this.classToRun = classToRun;
+        Collections.addAll(this.javaOpts, javaOpts);
+        this.sliceName = defaultSliceName();
+    }
+
+    private static String defaultSliceName() {
+        // Create a unique name for a systemd slice
+        // jtreg guarantees that test.name is unique among all concurrently executing
+        // tests. For example, if you have two test roots:
+        //
+        //     $ find test -type f
+        //     test/foo/TEST.ROOT
+        //     test/foo/my/TestCase.java
+        //     test/bar/TEST.ROOT
+        //     test/bar/my/TestCase.java
+        //     $ jtreg -concur:2 test/foo test/bar
+        //
+        // jtreg will first run all the tests under test/foo. When they are all finished, then
+        // jtreg will run all the tests under test/bar. So you will never have two concurrent
+        // test cases whose test.name is "my/TestCase.java"
+        String testname = System.getProperty("test.name");
+        assertNotNull(testname, "must be set by jtreg");
+        testname = testname.replace(".java", "");
+        testname = testname.replace("/", "_");
+        testname = testname.replace("\\", "_");
+        testname = testname.replace("-", "_");
+
+        // Example:
+        //  Memory: "test_containers_systemd_TestMemoryAwareness"
+        //  CPU:    "test_containers_systemd_TestMemoryAwareness-cpu" => derived
+        return testname;
+    }
+
+    public SystemdRunOptions memoryLimit(String memLimit) {
+        this.memoryLimit = memLimit;
+        return this;
+    }
+
+    public SystemdRunOptions cpuLimit(String cpuLimit) {
+        this.cpuLimit = cpuLimit;
+        return this;
+    }
+
+    public SystemdRunOptions sliceName(String name) {
+        this.sliceName = name;
+        return this;
+    }
+
+    public SystemdRunOptions addJavaOpts(String... opts) {
+        Collections.addAll(javaOpts, opts);
+        return this;
+    }
+
+    public SystemdRunOptions addClassOptions(String... opts) {
+        Collections.addAll(classParams,opts);
+        return this;
+    }
+}

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.containers.systemd;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import jdk.test.lib.Utils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class SystemdTestUtils {
+
+    private static final Path SYSTEMD_CONFIG_HOME = Path.of("/", "etc", "systemd", "system");
+
+    // Specifies how many lines to copy from child STDOUT to main test output.
+    // Having too many lines in the main test output will result
+    // in JT harness trimming the output, and can lead to loss of useful
+    // diagnostic information.
+    private static final int MAX_LINES_TO_COPY_FOR_CHILD_STDOUT = 100;
+
+    public record ResultFiles(Path memory, Path cpu) {}
+
+    /**
+     * Run Java inside a systemd slice with specified parameters and options.
+     *
+     * @param DockerRunOptions options for running docker
+     *
+     * @return output of the run command
+     * @throws Exception
+     */
+    public static OutputAnalyzer systemdRunJava(SystemdRunOptions opts) throws Exception {
+        return execute(buildJavaCommand(opts));
+    }
+
+    // create commonly used options with class to be launched inside systemd slice
+    public static SystemdRunOptions newOpts(String testClass) {
+        return new SystemdRunOptions(testClass,
+                                     "-Xlog:os+container=trace",
+                                     "-cp",
+                                     Utils.TEST_CLASSES);
+    }
+
+    /**
+     * Create systemd slice files under /etc/systemd/system.
+     *
+     * The JDK will then run within that slice as provided by the SystemdRunOptions.
+     *
+     * @param          name of the image to be created, including version tag
+     * @param dockerfileContent content of the Dockerfile; use null to generate default content
+     * @throws Exception
+     */
+    public static ResultFiles buildSystemdSlices(SystemdRunOptions runOpts) throws Exception {
+        // Slice name may include '-' which is a hierarchical slice indicator.
+        // Replace '-' with '_' to avoid side-effects.
+        String sliceName = sliceName(runOpts);
+        String sliceNameCpu = sliceNameCpu(runOpts);
+
+        // Generate systemd slices for cpu/memory
+        String memorySliceContent = getMemorySlice(runOpts, sliceName);
+        String cpuSliceContent = getCpuSlice(runOpts, sliceName);
+
+        Path memory, cpu;
+        try {
+            // memory slice
+            memory = SYSTEMD_CONFIG_HOME.resolve(Path.of(sliceFileName(sliceName)));
+            cpu = SYSTEMD_CONFIG_HOME.resolve(Path.of(sliceFileName(sliceNameCpu)));
+            Files.writeString(memory, memorySliceContent);
+            Files.writeString(cpu, cpuSliceContent);
+        } catch (IOException e) {
+            throw new AssertionError("Failed to write systemd slice files");
+        }
+
+        systemdDaemonReload(cpu);
+
+        return new ResultFiles(memory, cpu);
+    }
+
+    private static String sliceName(SystemdRunOptions runOpts) {
+        return "jdk_internal_" + runOpts.sliceName.replace("-", "_");
+    }
+
+    private static String sliceNameCpu(SystemdRunOptions runOpts) {
+        String slice = sliceName(runOpts);
+        return String.format("%s-cpu", slice);
+    }
+
+    private static void systemdDaemonReload(Path cpu) throws Exception {
+        List<String> daemonReload = List.of("systemctl", "daemon-reload");
+        List<String> restartSlice = List.of("systemctl", "restart", cpu.getFileName().toString());
+
+        if (execute(daemonReload).getExitValue() != 0) {
+            throw new AssertionError("Failed to reload systemd daemon");
+        }
+        if (execute(restartSlice).getExitValue() != 0) {
+            throw new AssertionError("Failed to restart the systemd slice");
+        }
+    }
+
+    private static String getCpuSlice(SystemdRunOptions runOpts, String sliceName) {
+        String basicSliceFormat = getBasicSliceFormat();
+        return String.format(basicSliceFormat, sliceName, getMemoryCPUSliceContent(runOpts));
+    }
+
+    private static Object getMemoryCPUSliceContent(SystemdRunOptions runOpts) {
+        String format =
+                """
+                CPUAccounting=true
+                CPUQuota=%s
+                """;
+         return String.format(format, runOpts.cpuLimit);
+    }
+
+    private static String getMemorySlice(SystemdRunOptions runOpts, String sliceName) {
+        String basicSliceFormat = getBasicSliceFormat();
+        return String.format(basicSliceFormat, sliceName, getMemorySliceContent(runOpts));
+    }
+
+    private static Object getMemorySliceContent(SystemdRunOptions runOpts) {
+        String format =
+               """
+               MemoryAccounting=true
+               MemoryLimit=%s
+               """;
+        return String.format(format, runOpts.memoryLimit);
+    }
+
+    private static String getBasicSliceFormat() {
+        return """
+               [Unit]
+               Description=OpenJDK Tests Slice for %s
+               Before=slices.target
+
+               [Slice]
+               %s
+               """;
+    }
+
+    private static String sliceFileName(String sliceName) {
+        return String.format("%s.slice", sliceName);
+    }
+
+    /**
+     * Build the java command to run inside a systemd slice
+     *
+     * @param SystemdRunOptions options for running docker
+     *
+     * @return command
+     * @throws Exception
+     */
+    private static List<String> buildJavaCommand(SystemdRunOptions opts) throws Exception {
+        List<String> javaCmd = new ArrayList<>();
+        // systemd-run --slice slice-name.slice --scope <java>
+        javaCmd.add("systemd-run");
+        javaCmd.add("--slice");
+        javaCmd.add(sliceFileName(sliceNameCpu(opts)));
+        javaCmd.add("--scope");
+        // sudo systemctl daemon-reload && sudo systemctl restart test-cpu-mem.slice && sudo systemd-run --slice test-cpu-mem.slice --scope
+        javaCmd.add(Path.of(Utils.TEST_JDK, "bin", "java").toString());
+        javaCmd.addAll(opts.javaOpts);
+        javaCmd.add(opts.classToRun);
+        javaCmd.addAll(opts.classParams);
+        return javaCmd;
+    }
+
+    /**
+     * Execute a specified command in a process, report diagnostic info.
+     *
+     * @param command to be executed
+     * @return The output from the process
+     * @throws Exception
+     */
+    private static OutputAnalyzer execute(List<String> command) throws Exception {
+        return execute(command.toArray(String[]::new));
+    }
+
+    /**
+     * Execute a specified command in a process, report diagnostic info.
+     *
+     * @param command to be executed
+     * @return The output from the process
+     * @throws Exception
+     */
+    private static OutputAnalyzer execute(String... command) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(command);
+        System.out.println("[COMMAND]\n" + Utils.getCommandLine(pb));
+
+        Process p = pb.start();
+        long pid = p.pid();
+        OutputAnalyzer output = new OutputAnalyzer(p);
+
+        int max = MAX_LINES_TO_COPY_FOR_CHILD_STDOUT;
+        String stdout = output.getStdout();
+        String stdoutLimited = limitLines(stdout, max);
+        System.out.println("[STDERR]\n" + output.getStderr());
+        System.out.println("[STDOUT]\n" + stdoutLimited);
+        if (stdout != stdoutLimited) {
+            System.out.printf("Child process STDOUT is limited to %d lines\n",
+                              max);
+        }
+
+        String stdoutLogFile = String.format("systemd-stdout-%d.log", pid);
+        writeOutputToFile(stdout, stdoutLogFile);
+        System.out.println("Full child process STDOUT was saved to " + stdoutLogFile);
+
+        return output;
+    }
+
+    private static void writeOutputToFile(String output, String fileName) throws Exception {
+        try (FileWriter fw = new FileWriter(fileName)) {
+            fw.write(output, 0, output.length());
+        }
+    }
+
+    private static String limitLines(String buffer, int nrOfLines) {
+        List<String> l = Arrays.asList(buffer.split("\\R"));
+        if (l.size() < nrOfLines) {
+            return buffer;
+        }
+
+        return String.join("\n", l.subList(0, nrOfLines));
+    }
+}


### PR DESCRIPTION
Please review this PR which adds test support for systemd slices so that bugs like [JDK-8217338](https://bugs.openjdk.org/browse/JDK-8217338) can be verified. The added test, `SystemdMemoryAwarenessTest` currently passes on cgroups v1 and fails on cgroups v2 due to the way how [JDK-8217338](https://bugs.openjdk.org/browse/JDK-8217338) was implemented when JDK 13 was a thing. Therefore immediately problem-listed. It should get unlisted once [JDK-8322420](https://bugs.openjdk.org/browse/JDK-8322420) merges.

I'm adding those tests in order to not regress another time.

Testing:
- [x] Container tests on Linux x86_64 cgroups v2 and Linux x86_64 cgroups v1.
- [x] New systemd test on cg v1 (passes). Fails on cg v2 (due to  JDK-8322420)
- [ ] GHA