### PR TITLE
8333462: Performance regression of new DecimalFormat() when compare to jdk11

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -863,8 +863,9 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      */
     private char findNonFormatChar(String src, char defChar) {
         for (int i = 0; i < src.length(); i++) {
-            if (Character.getType(src.charAt(i)) != Character.FORMAT) {
-                return src.charAt(i);
+            char c = src.charAt(i);
+            if (Character.getType(c) != Character.FORMAT) {
+                return c;
             }
         }
         return defChar;

--- a/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DecimalFormatSymbols.java
@@ -862,10 +862,12 @@ public class DecimalFormatSymbols implements Cloneable, Serializable {
      * Obtains non-format single character from String
      */
     private char findNonFormatChar(String src, char defChar) {
-        return (char)src.chars()
-            .filter(c -> Character.getType(c) != Character.FORMAT)
-            .findFirst()
-            .orElse(defChar);
+        for (int i = 0; i < src.length(); i++) {
+            if (Character.getType(src.charAt(i)) != Character.FORMAT) {
+                return src.charAt(i);
+            }
+        }
+        return defChar;
     }
 
     /**


### PR DESCRIPTION
Run the below benchmark test  ,it show the average time of new DecimalFormat()  increase 18% when compare to jdk 11.

the result with jdk 11:
```
Benchmark                          Mode  Cnt    Score   Error  Units
JmhDecimalFormat.testNewOnly       avgt   50  248.300 ? 5.158  ns/op
```

the result with current jdk:
```
Benchmark                          Mode  Cnt    Score   Error  Units
JmhDecimalFormat.testNewOnly       avgt   50  303.381 ? 5.252  ns/op
```

```
@BenchmarkMode(Mode.AverageTime)
@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
@State(Scope.Thread)
@OutputTimeUnit(TimeUnit.NANOSECONDS)
public class JmhDecimalFormat {

    @Setup(Level.Trial)
    public void setup() {
    }

    @Benchmark
    public void testNewOnly() throws InterruptedException {
        new DecimalFormat("#0.00000");
    }
}
```

Compare the flame graph it shows the java.text.DecimalFormatSymbols#findNonFormatChar takes a significant time. 
After replacing  the lambda implementation with a simple loop , it shows nearly the same performance as jdk 11.

```
Benchmark                          Mode  Cnt    Score   Error  Units
JmhDecimalFormat.testNewOnly       avgt   50  209.874 ? 9.951  ns/op
```

[flame-graph-jdk11-jdk21.zip](https://github.com/user-attachments/files/15541764/flame-graph-jdk11-jdk21.zip)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333462](https://bugs.openjdk.org/browse/JDK-8333462): Performance regression of new DecimalFormat() when compare to jdk11 (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [a230ce00](https://git.openjdk.org/jdk/pull/19534/files/a230ce00b020f120209f557609f9b846119a2f20)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) ⚠️ Review applies to [a230ce00](https://git.openjdk.org/jdk/pull/19534/files/a230ce00b020f120209f557609f9b846119a2f20)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer) ⚠️ Review applies to [a230ce00](https://git.openjdk.org/jdk/pull/19534/files/a230ce00b020f120209f557609f9b846119a2f20)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19534/head:pull/19534` \
`$ git checkout pull/19534`

Update a local copy of the PR: \
`$ git checkout pull/19534` \
`$ git pull https://git.openjdk.org/jdk.git pull/19534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19534`

View PR using the GUI difftool: \
`$ git pr show -t 19534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19534.diff">https://git.openjdk.org/jdk/pull/19534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19534#issuecomment-2146461231)