### PR TITLE
8332670: C1 clone intrinsic needs memory barriers

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -304,7 +304,12 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
     return;
   }
 
-  membar(StoreStore);
+  // Only add membar if zeroing the array.
+  // If not zeroing, subsequent instructions should populate the array (e.g. copy contents),
+  // and the membar should be set after the array has been populated accordingly.
+  if (zero_array) {
+    membar(StoreStore);
+  }
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == r0, "must be");

--- a/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c1_MacroAssembler_aarch64.cpp
@@ -304,12 +304,7 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register t1, 
     return;
   }
 
-  // Only add membar if zeroing the array.
-  // If not zeroing, subsequent instructions should populate the array (e.g. copy contents),
-  // and the membar should be set after the array has been populated accordingly.
-  if (zero_array) {
-    membar(StoreStore);
-  }
+  membar(StoreStore);
 
   if (CURRENT_ENV->dtrace_alloc_probes()) {
     assert(obj == r0, "must be");

--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -4472,6 +4472,7 @@ void GraphBuilder::append_alloc_array_copy(ciMethod* callee) {
   array_copy->set_flag(Instruction::OmitChecksFlag, true);
   append_split(array_copy);
   apush(new_array);
+  append(new MemBar(lir_membar_storestore));
 }
 
 void GraphBuilder::print_inlining(ciMethod* callee, const char* msg, bool success) {


### PR DESCRIPTION
Adds a storestore barrier after copying the contents in the primitive array intrinsic (credit @shipilev). The barrier is a no-op in platforms where not needed so no need for an ifdef.

The barrier after new array creation is only added if zeroing the array on aarch64 (credit @dean-long). Since the primitive array clone intrinsic does not zero the array, that means there's a single barrier added for this use case.

There's no barrier added on x86 c1 macro assembler for nothing to do there. 

I've run the following tests:
* tier 1 on darwin/aarch64
* tier 1 on linux/x86_64
* `hotspot_compiler` tests on darwin/aarch64
* `copy.clone.arrays` jcstress tests on darwin/aarch64.

I tried but was unable to create a standalone test for the jdk source tree that would fail.

FYI @bulasevich @TheRealMDoerr @RealFYang @RealLucy similar platform specific c1 macro assembler changes might be required for other platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332670](https://bugs.openjdk.org/browse/JDK-8332670): C1 clone intrinsic needs memory barriers (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19538/head:pull/19538` \
`$ git checkout pull/19538`

Update a local copy of the PR: \
`$ git checkout pull/19538` \
`$ git pull https://git.openjdk.org/jdk.git pull/19538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19538`

View PR using the GUI difftool: \
`$ git pr show -t 19538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19538.diff">https://git.openjdk.org/jdk/pull/19538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19538#issuecomment-2146897565)