### PR TITLE
8333486: Parallel: Remove unused methods in psParallelCompact

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -280,21 +280,6 @@ PSParallelCompact::print_generic_summary_data(ParallelCompactData& summary_data,
   ::print_generic_summary_data(summary_data,beg_addr, end_addr);
 }
 
-void
-print_generic_summary_data(ParallelCompactData& summary_data,
-                           SpaceInfo* space_info)
-{
-  if (!log_develop_is_enabled(Trace, gc, compaction)) {
-    return;
-  }
-
-  for (unsigned int id = 0; id < PSParallelCompact::last_space_id; ++id) {
-    const MutableSpace* space = space_info[id].space();
-    print_generic_summary_data(summary_data, space->bottom(),
-                               MAX2(space->top(), space_info[id].new_top()));
-  }
-}
-
 static void
 print_initial_summary_data(ParallelCompactData& summary_data,
                            const MutableSpace* space) {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -166,7 +166,7 @@ inline bool SplitInfo::is_split(size_t region_idx) const
 
 class SpaceInfo
 {
- public:
+public:
   MutableSpace* space() const { return _space; }
 
   // Where the free space will start after the collection.  Valid only after the
@@ -679,7 +679,7 @@ ParallelCompactData::is_region_aligned(HeapWord* addr) const
 // https://doi.org/10.1145/3313808.3313820
 
 class PSParallelCompact : AllStatic {
- public:
+public:
   // Convenient access to type names.
   typedef ParMarkBitMap::idx_t idx_t;
   typedef ParallelCompactData::RegionData RegionData;
@@ -699,7 +699,7 @@ public:
 
   friend class PSParallelCompactTest;
 
- private:
+private:
   static STWGCTimer           _gc_timer;
   static ParallelOldTracer    _gc_tracer;
   static elapsedTimer         _accumulated_time;
@@ -714,10 +714,10 @@ public:
   static SpanSubjectToDiscoveryClosure  _span_based_discoverer;
   static ReferenceProcessor*  _ref_processor;
 
- public:
+public:
   static ParallelOldTracer* gc_tracer() { return &_gc_tracer; }
 
- private:
+private:
 
   static void initialize_space_info();
 
@@ -766,7 +766,7 @@ public:
 
   static void fill_range_in_dense_prefix(HeapWord* start, HeapWord* end);
 
- public:
+public:
   static void fill_dead_objs_in_dense_prefix(uint worker_id, uint num_workers);
 
   static bool invoke(bool maximum_heap_compaction);
@@ -883,12 +883,12 @@ public:
 };
 
 class MoveAndUpdateClosure: public StackObj {
- private:
+private:
   ParMarkBitMap* const        _bitmap;
   size_t                      _words_remaining; // Words left to copy.
   static inline size_t calculate_words_remaining(size_t region);
 
- protected:
+protected:
   HeapWord*               _source;          // Next addr that would be read.
   HeapWord*               _destination;     // Next addr to be written.
   ObjectStartArray* const _start_array;
@@ -898,7 +898,7 @@ class MoveAndUpdateClosure: public StackObj {
   // Update variables to indicate that word_count words were processed.
   inline void update_state(size_t words);
 
- public:
+public:
   typedef ParMarkBitMap::idx_t idx_t;
 
   ParMarkBitMap*        bitmap() const { return _bitmap; }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -190,9 +190,7 @@ class SpaceInfo
   void set_dense_prefix(HeapWord* addr)     { _dense_prefix = addr; }
   void set_start_array(ObjectStartArray* s) { _start_array = s; }
 
-  void publish_new_top() const              { _space->set_top(_new_top); }
-
- private:
+private:
   MutableSpace*     _space;
   HeapWord*         _new_top;
   HeapWord*         _dense_prefix;


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333486](https://bugs.openjdk.org/browse/JDK-8333486): Parallel: Remove unused methods in psParallelCompact (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19539/head:pull/19539` \
`$ git checkout pull/19539`

Update a local copy of the PR: \
`$ git checkout pull/19539` \
`$ git pull https://git.openjdk.org/jdk.git pull/19539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19539`

View PR using the GUI difftool: \
`$ git pr show -t 19539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19539.diff">https://git.openjdk.org/jdk/pull/19539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19539#issuecomment-2146934772)