### PR TITLE
8331854: ubsan: copy.hpp:218:10: runtime error: addition of unsigned offset to 0x7fc2b4024518 overflowed to 0x7fc2b4024510

### DIFF
--- a/src/hotspot/share/utilities/copy.hpp
+++ b/src/hotspot/share/utilities/copy.hpp
@@ -208,10 +208,10 @@ class Copy : AllStatic {
 
   // Copy word-aligned words from lower to higher addresses, not atomic on each word
   inline static void conjoint_words_to_higher(const HeapWord* from, HeapWord* to, size_t byte_count) {
-    if (byte_count == 0) return;
     // byte_count is in bytes to check its alignment
     assert_params_ok(from, to, HeapWordSize);
     assert_byte_count_ok(byte_count, HeapWordSize);
+    if (byte_count == 0) return;
 
     size_t count = align_up(byte_count, HeapWordSize) >> LogHeapWordSize;
     assert(from <= to || to + count <= from, "do not overwrite source data");

--- a/src/hotspot/share/utilities/copy.hpp
+++ b/src/hotspot/share/utilities/copy.hpp
@@ -208,6 +208,7 @@ class Copy : AllStatic {
 
   // Copy word-aligned words from lower to higher addresses, not atomic on each word
   inline static void conjoint_words_to_higher(const HeapWord* from, HeapWord* to, size_t byte_count) {
+    if (byte_count == 0) return;
     // byte_count is in bytes to check its alignment
     assert_params_ok(from, to, HeapWordSize);
     assert_byte_count_ok(byte_count, HeapWordSize);


### PR DESCRIPTION
When building with ubsan, we see a number of overflows at this code location :

/jdk/src/hotspot/share/utilities/copy.hpp:218:10: runtime error: addition of unsigned offset to 0x7fc2b4024518 overflowed to 0x7fc2b4024510
    #0 0x10b70896d in Copy::conjoint_words_to_higher(HeapWordImpl* const*, HeapWordImpl**, unsigned long) copy.hpp:218
    #1 0x10c4f78f1 in Node_Array::insert(unsigned int, Node*) node.cpp:2783
    #2 0x10b8a1386 in Block::insert_node(Node*, unsigned int) block.hpp:134
    #3 0x10c556630 in PhaseOutput::fill_buffer(C2_MacroAssembler*, unsigned int*) output.cpp:1792
    #4 0x10c552f6b in PhaseOutput::Output() output.cpp:367
    #5 0x10b9ba859 in Compile::Code_Gen() compile.cpp:3035
    #6 0x10b9b7cb1 in Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*) compile.cpp:896
    #7 0x10b859912 in C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) c2compiler.cpp:142
    #8 0x10b9dd4f1 in CompileBroker::invoke_compiler_on_method(CompileTask*) compileBroker.cpp:2305
    #9 0x10b9dc345 in CompileBroker::compiler_thread_loop() compileBroker.cpp:1963
    #10 0x10bfd5ebf in JavaThread::thread_main_inner() javaThread.cpp:760
    #11 0x10bfd5b62 in JavaThread::run() javaThread.cpp:745
    #12 0x10c9310d6 in Thread::call_run() thread.cpp:221
    #13 0x10c53ece4 in thread_native_entry(Thread*) os_bsd.cpp:598

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331854](https://bugs.openjdk.org/browse/JDK-8331854): ubsan: copy.hpp:218:10: runtime error: addition of unsigned offset to 0x7fc2b4024518 overflowed to 0x7fc2b4024510 (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [1f8ea858](https://git.openjdk.org/jdk/pull/19541/files/1f8ea8588ae5fdfeaeb7aa736460f7c49b8b45fa)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) ⚠️ Review applies to [1f8ea858](https://git.openjdk.org/jdk/pull/19541/files/1f8ea8588ae5fdfeaeb7aa736460f7c49b8b45fa)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19541/head:pull/19541` \
`$ git checkout pull/19541`

Update a local copy of the PR: \
`$ git checkout pull/19541` \
`$ git pull https://git.openjdk.org/jdk.git pull/19541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19541`

View PR using the GUI difftool: \
`$ git pr show -t 19541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19541.diff">https://git.openjdk.org/jdk/pull/19541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19541#issuecomment-2147992587)