### PR TITLE
8331896: JFR: Improve check for JDK classes

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -204,7 +204,7 @@ public final class MetadataRepository {
         // and assign the result to a long field is not enough to always get a proper
         // stack trace. Purpose of the mechanism is to transfer metadata, such as
         // native type IDs, without specialized Java logic for each type.
-        if (eventClass.getClassLoader() == null) {
+        if (Utils.isJDKClass(eventClass)) {
             Name name = eventClass.getAnnotation(Name.class);
             if (name != null) {
                 String n = name.value();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MirrorEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MirrorEvents.java
@@ -48,6 +48,7 @@ import jdk.jfr.events.VirtualThreadStartEvent;
 import jdk.jfr.events.VirtualThreadSubmitFailedEvent;
 import jdk.jfr.events.X509CertificateEvent;
 import jdk.jfr.events.X509ValidationEvent;
+import jdk.jfr.internal.util.Utils;
 
 /**
  * This class registers all mirror events.
@@ -85,7 +86,7 @@ final class MirrorEvents {
     }
 
     static Class<? extends MirrorEvent> find(Class<? extends jdk.internal.event.Event> eventClass) {
-        return find(eventClass.getClassLoader() == null, eventClass.getName());
+        return find(Utils.isJDKClass(eventClass), eventClass.getName());
     }
 
     static Class<? extends MirrorEvent> find(boolean bootClassLoader, String name) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/TypeLibrary.java
@@ -166,7 +166,9 @@ public final class TypeLibrary {
             for (ValueDescriptor v : type.getFields()) {
                 values.add(invokeAnnotation(annotation, v.getName()));
             }
-            return PrivateAccess.getInstance().newAnnotation(type, values, annotation.annotationType().getClassLoader() == null);
+            // Only annotation classes in the boot class loader can always be resolved.
+            boolean bootClassLoader = annotationType.getClassLoader() == null;
+            return PrivateAccess.getInstance().newAnnotation(type, values, bootClassLoader);
         }
         return null;
     }
@@ -220,7 +222,7 @@ public final class TypeLibrary {
             long id = Type.getTypeId(clazz);
             Type t;
             if (eventType) {
-                t = new PlatformEventType(typeName, id, clazz.getClassLoader() == null, true);
+                t = new PlatformEventType(typeName, id, Utils.isJDKClass(clazz), true);
             } else {
                 t = new Type(typeName, superType, id);
             }
@@ -283,7 +285,7 @@ public final class TypeLibrary {
         }
         addAnnotations(clazz, type, dynamicAnnotations);
 
-        if (clazz.getClassLoader() == null) {
+        if (Utils.isJDKClass(clazz)) {
             type.log("Added", LogTag.JFR_SYSTEM_METADATA, LogLevel.INFO);
         } else {
             type.log("Added", LogTag.JFR_METADATA, LogLevel.INFO);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/JDKEventTask.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/periodic/JDKEventTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package jdk.jfr.internal.periodic;
 
 import jdk.internal.event.Event;
+import jdk.jfr.internal.util.Utils;
 
 /**
  * Periodic task that runs trusted code that doesn't require an access control
@@ -39,11 +40,11 @@ final class JDKEventTask extends JavaEventTask {
         if (!getEventType().isJDK()) {
             throw new InternalError("Must be a JDK event");
         }
-        if (eventClass.getClassLoader() != null) {
-            throw new SecurityException("Periodic task can only be registered for event classes that are loaded by the bootstrap class loader");
+        if (!Utils.isJDKClass(eventClass)) {
+            throw new SecurityException("Periodic task can only be registered for event classes that belongs to the JDK");
         }
-        if (runnable.getClass().getClassLoader() != null) {
-            throw new SecurityException("Runnable class must be loaded by the bootstrap class loader");
+        if (!Utils.isJDKClass(runnable.getClass())) {
+            throw new SecurityException("Runnable class must belong to the JDK");
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
@@ -442,5 +442,5 @@ public final class Utils {
         // type.getClassLoader() == ClassLoader.getPlatformClassLoader();
         // but only if it is safe and there is a mechanism to register event
         // classes in other modules besides jdk.jfr and java.base.
-	}
+    }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/Utils.java
@@ -435,4 +435,12 @@ public final class Utils {
         }
         return sb.toString();
     }
+
+    public static boolean isJDKClass(Class<?> type) {
+        return type.getClassLoader() == null;
+        // In the future we might want to also do:
+        // type.getClassLoader() == ClassLoader.getPlatformClassLoader();
+        // but only if it is safe and there is a mechanism to register event
+        // classes in other modules besides jdk.jfr and java.base.
+	}
 }


### PR DESCRIPTION
Could I have a review of change that prepares for support for JDK events in other modules besides java.base.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331896](https://bugs.openjdk.org/browse/JDK-8331896): JFR: Improve check for JDK classes (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19542/head:pull/19542` \
`$ git checkout pull/19542`

Update a local copy of the PR: \
`$ git checkout pull/19542` \
`$ git pull https://git.openjdk.org/jdk.git pull/19542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19542`

View PR using the GUI difftool: \
`$ git pr show -t 19542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19542.diff">https://git.openjdk.org/jdk/pull/19542.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19542#issuecomment-2148389745)