### PR TITLE
8332865: ubsan: os::attempt_reserve_memory_between  reports overflow

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1939,7 +1939,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   if ((uintptr_t)hi_end < bytes) {
     return nullptr; // no need to go on
   }
-  char* const hi_att = align_down(MIN2(max, absolute_max) - bytes, alignment_adjusted);
+  char* const hi_att = align_down(hi_end - bytes, alignment_adjusted);
   if (hi_att > max) {
     return nullptr; // overflow
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1889,6 +1889,9 @@ static void hemi_split(T* arr, unsigned num) {
 
 // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
 // If randomize is true, the location will be randomized.
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize) {
 
   // Please keep the following constants in sync with the companion gtests:

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1889,9 +1889,6 @@ static void hemi_split(T* arr, unsigned num) {
 
 // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
 // If randomize is true, the location will be randomized.
-#if defined(__clang__) || defined(__GNUC__)
-__attribute__((no_sanitize("undefined")))
-#endif
 char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize) {
 
   // Please keep the following constants in sync with the companion gtests:
@@ -1938,6 +1935,10 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     return nullptr; // overflow
   }
 
+  char* const hi_end = MIN2(max, absolute_max);
+  if ((uintptr_t)hi_end < bytes) {
+    return nullptr; // no need to go on
+  }
   char* const hi_att = align_down(MIN2(max, absolute_max) - bytes, alignment_adjusted);
   if (hi_att > max) {
     return nullptr; // overflow


### PR DESCRIPTION
When running by ubsan-enabled binaries on Linux x86_64, os::attempt_reserve_memory_between reports overflows.
This happens in the  :tier1 tests ( gtest/LargePageGtests_use-large-pages.jtr )


"runtime error: pointer index expression with base 0x000000001000 overflowed to 0xfffffffffffff000"

This coding triggers the ubsan issue

```
  char* const hi_att = align_down(MIN2(max, absolute_max) - bytes, alignment_adjusted);
  if (hi_att > max) {
    return nullptr; // overflow
  }

```
However the function already contains overflow handling, so probably it is sufficient to add an attribute to the function os::attempt_reserve_memory_between to disable ubsan checks for this function.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332865](https://bugs.openjdk.org/browse/JDK-8332865): ubsan: os::attempt_reserve_memory_between  reports overflow (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19543/head:pull/19543` \
`$ git checkout pull/19543`

Update a local copy of the PR: \
`$ git checkout pull/19543` \
`$ git pull https://git.openjdk.org/jdk.git pull/19543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19543`

View PR using the GUI difftool: \
`$ git pr show -t 19543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19543.diff">https://git.openjdk.org/jdk/pull/19543.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19543#issuecomment-2147996975)