### PR TITLE
8333554: Parallel: Remove unused PSParallelCompact::is_in

### DIFF
--- a/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.hpp
@@ -32,9 +32,9 @@
 class PSVirtualSpace;
 
 class ParMarkBitMap: public CHeapObj<mtGC> {
-public:
   typedef BitMap::idx_t idx_t;
 
+public:
   inline ParMarkBitMap();
   bool initialize(MemRegion covered_region);
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -44,7 +44,6 @@ class PSOldGen;
 class ParCompactionManager;
 class PSParallelCompact;
 class MoveAndUpdateClosure;
-class RefProcTaskExecutor;
 class ParallelOldTracer;
 class STWGCTimer;
 
@@ -681,7 +680,6 @@ ParallelCompactData::is_region_aligned(HeapWord* addr) const
 class PSParallelCompact : AllStatic {
 public:
   // Convenient access to type names.
-  typedef ParMarkBitMap::idx_t idx_t;
   typedef ParallelCompactData::RegionData RegionData;
 
   typedef enum {
@@ -800,11 +798,6 @@ public:
 
   template <class T> static inline void adjust_pointer(T* p);
 
-  // Compaction support.
-  // Return true if p is in the range [beg_addr, end_addr).
-  static inline bool is_in(HeapWord* p, HeapWord* beg_addr, HeapWord* end_addr);
-  static inline bool is_in(oop* p, HeapWord* beg_addr, HeapWord* end_addr);
-
   // Convenience wrappers for per-space data kept in _space_info.
   static inline MutableSpace*     space(SpaceId space_id);
   static inline HeapWord*         new_top(SpaceId space_id);
@@ -899,8 +892,6 @@ protected:
   inline void update_state(size_t words);
 
 public:
-  typedef ParMarkBitMap::idx_t idx_t;
-
   ParMarkBitMap*        bitmap() const { return _bitmap; }
 
   size_t    words_remaining()    const { return _words_remaining; }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -40,14 +40,6 @@ inline bool PSParallelCompact::is_marked(oop obj) {
   return mark_bitmap()->is_marked(obj);
 }
 
-inline bool PSParallelCompact::is_in(HeapWord* p, HeapWord* beg_addr, HeapWord* end_addr) {
-  return p >= beg_addr && p < end_addr;
-}
-
-inline bool PSParallelCompact::is_in(oop* p, HeapWord* beg_addr, HeapWord* end_addr) {
-  return is_in((HeapWord*)p, beg_addr, end_addr);
-}
-
 inline MutableSpace* PSParallelCompact::space(SpaceId id) {
   assert(id < last_space_id, "id out of range");
   return _space_info[id].space();


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333554](https://bugs.openjdk.org/browse/JDK-8333554): Parallel: Remove unused PSParallelCompact::is_in (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19546/head:pull/19546` \
`$ git checkout pull/19546`

Update a local copy of the PR: \
`$ git checkout pull/19546` \
`$ git pull https://git.openjdk.org/jdk.git pull/19546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19546`

View PR using the GUI difftool: \
`$ git pr show -t 19546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19546.diff">https://git.openjdk.org/jdk/pull/19546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19546#issuecomment-2148009059)