### PR TITLE
8333235: vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with C1

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -167,7 +167,7 @@ class MyThread extends Thread {
             synchronized (kill001a.lock) { }
             // We need some code that does an invoke here to make sure the async exception
             // gets thrown before we leave the try block.
-            // The methodForException should work until exception is thrown
+            // The methodForException should work until exception is thrown.
             methodForException();
         } catch (Throwable t) {
             if (t == expectedException) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdb/kill/kill001/kill001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -141,6 +141,16 @@ class MyThread extends Thread {
         expectedException = e;
     }
 
+
+    static public int[] trash;
+
+    void methodForException() {
+        trash = new int[10];
+        for (int i = 0; ;i++) {
+            trash[i % trash.length] = i;
+        }
+    }
+
     public void run() {
         // Concatenate strings in advance to avoid lambda calculations later
         String ThreadFinished = "Thread finished: " + this.name;
@@ -156,8 +166,9 @@ class MyThread extends Thread {
         try {
             synchronized (kill001a.lock) { }
             // We need some code that does an invoke here to make sure the async exception
-            // gets thrown before we leave the try block. Printing a log message works well.
-            kill001a.log.display("exited synchronized");
+            // gets thrown before we leave the try block.
+            // The methodForException should work until exception is thrown
+            methodForException();
         } catch (Throwable t) {
             if (t == expectedException) {
                 kill001a.log.display(CaughtExpected);


### PR DESCRIPTION
The kill sends async exception that is thrown somewhere during log.display(...) method. 
The log shows that it is thrown while PrintStream locking moving it into an inconsistent state. 
So the fix is to use some method that could be safely interrupted by async exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333235](https://bugs.openjdk.org/browse/JDK-8333235): vmTestbase/nsk/jdb/kill/kill001/kill001.java fails with C1 (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19547/head:pull/19547` \
`$ git checkout pull/19547`

Update a local copy of the PR: \
`$ git checkout pull/19547` \
`$ git pull https://git.openjdk.org/jdk.git pull/19547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19547`

View PR using the GUI difftool: \
`$ git pr show -t 19547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19547.diff">https://git.openjdk.org/jdk/pull/19547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19547#issuecomment-2148059945)