### PR TITLE
8333560: -Xlint:restricted does not work with --release

### DIFF
--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -338,6 +338,8 @@ public class CreateSymbols {
             "Ljdk/internal/PreviewFeature;";
     private static final String PREVIEW_FEATURE_ANNOTATION_NEW =
             "Ljdk/internal/javac/PreviewFeature;";
+    private static final String RESTRICTED_ANNOTATION =
+            "Ljdk/internal/javac/Restricted;";
     private static final String PREVIEW_FEATURE_ANNOTATION_INTERNAL =
             "Ljdk/internal/PreviewFeature+Annotation;";
     private static final String VALUE_BASED_ANNOTATION =
@@ -349,7 +351,8 @@ public class CreateSymbols {
                     "Lsun/Proprietary+Annotation;",
                     PREVIEW_FEATURE_ANNOTATION_OLD,
                     PREVIEW_FEATURE_ANNOTATION_NEW,
-                    VALUE_BASED_ANNOTATION));
+                    VALUE_BASED_ANNOTATION,
+                    RESTRICTED_ANNOTATION));
 
     private void stripNonExistentAnnotations(LoadDescriptions data) {
         Set<String> allClasses = data.classes.name2Class.keySet();

--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -340,6 +340,8 @@ public class CreateSymbols {
             "Ljdk/internal/javac/PreviewFeature;";
     private static final String RESTRICTED_ANNOTATION =
             "Ljdk/internal/javac/Restricted;";
+    private static final String RESTRICTED_ANNOTATION_INTERNAL =
+            "Ljdk/internal/javac/Restricted+Annotation;";
     private static final String PREVIEW_FEATURE_ANNOTATION_INTERNAL =
             "Ljdk/internal/PreviewFeature+Annotation;";
     private static final String VALUE_BASED_ANNOTATION =
@@ -1248,6 +1250,12 @@ public class CreateSymbols {
             //the non-public ValueBased annotation will not be available in ct.sym,
             //replace with purely synthetic javac-internal annotation:
             annotationType = VALUE_BASED_ANNOTATION_INTERNAL;
+        }
+
+        if (RESTRICTED_ANNOTATION.equals(annotationType)) {
+            //the non-public Restricted annotation will not be available in ct.sym,
+            //replace with purely synthetic javac-internal annotation:
+            annotationType = RESTRICTED_ANNOTATION_INTERNAL;
         }
 
         return new Annotation(null,

--- a/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
+++ b/make/langtools/src/classes/build/tools/symbolgenerator/CreateSymbols.java
@@ -338,12 +338,12 @@ public class CreateSymbols {
             "Ljdk/internal/PreviewFeature;";
     private static final String PREVIEW_FEATURE_ANNOTATION_NEW =
             "Ljdk/internal/javac/PreviewFeature;";
+    private static final String PREVIEW_FEATURE_ANNOTATION_INTERNAL =
+            "Ljdk/internal/PreviewFeature+Annotation;";
     private static final String RESTRICTED_ANNOTATION =
             "Ljdk/internal/javac/Restricted;";
     private static final String RESTRICTED_ANNOTATION_INTERNAL =
             "Ljdk/internal/javac/Restricted+Annotation;";
-    private static final String PREVIEW_FEATURE_ANNOTATION_INTERNAL =
-            "Ljdk/internal/PreviewFeature+Annotation;";
     private static final String VALUE_BASED_ANNOTATION =
             "Ljdk/internal/ValueBased;";
     private static final String VALUE_BASED_ANNOTATION_INTERNAL =

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -610,7 +610,7 @@ public class Symtab {
         previewFeatureType = enterClass("jdk.internal.javac.PreviewFeature");
         previewFeatureInternalType = enterSyntheticAnnotation("jdk.internal.PreviewFeature+Annotation");
         restrictedType = enterClass("jdk.internal.javac.Restricted");
-        restrictedInternalType = enterClass("jdk.internal.javac.Restricted+Annotation");
+        restrictedInternalType = enterSyntheticAnnotation("jdk.internal.javac.Restricted+Annotation");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -222,6 +222,7 @@ public class Symtab {
     public final Type previewFeatureType;
     public final Type previewFeatureInternalType;
     public final Type restrictedType;
+    public final Type restrictedInternalType;
     public final Type typeDescriptorType;
     public final Type recordType;
     public final Type switchBootstrapsType;
@@ -609,6 +610,7 @@ public class Symtab {
         previewFeatureType = enterClass("jdk.internal.javac.PreviewFeature");
         previewFeatureInternalType = enterSyntheticAnnotation("jdk.internal.PreviewFeature+Annotation");
         restrictedType = enterClass("jdk.internal.javac.Restricted");
+        restrictedInternalType = enterClass("jdk.internal.javac.Restricted+Annotation");
         typeDescriptorType = enterClass("java.lang.invoke.TypeDescriptor");
         recordType = enterClass("java.lang.Record");
         switchBootstrapsType = enterClass("java.lang.runtime.SwitchBootstraps");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -1544,7 +1544,7 @@ public class ClassReader {
             } else if (proxy.type.tsym.flatName() == syms.valueBasedInternalType.tsym.flatName()) {
                 Assert.check(sym.kind == TYP);
                 sym.flags_field |= VALUE_BASED;
-            } else if (proxy.type.tsym.flatName() == syms.restrictedType.tsym.flatName()) {
+            } else if (proxy.type.tsym.flatName() == syms.restrictedInternalType.tsym.flatName()) {
                 Assert.check(sym.kind == MTH);
                 sym.flags_field |= RESTRICTED;
             } else {

--- a/test/langtools/tools/javac/RestrictedMethods.java
+++ b/test/langtools/tools/javac/RestrictedMethods.java
@@ -3,6 +3,7 @@
  * @bug 8316971
  * @summary Smoke test for restricted method call warnings
  * @compile/fail/ref=RestrictedMethods.out -Xlint:restricted -Werror -XDrawDiagnostics RestrictedMethods.java
+ * @compile/fail/ref=RestrictedMethods.out --release ${jdk.version} -Xlint:restricted -Werror -XDrawDiagnostics RestrictedMethods.java
  * @compile -Werror RestrictedMethods.java
  */
 

--- a/test/langtools/tools/javac/RestrictedMethods.out
+++ b/test/langtools/tools/javac/RestrictedMethods.out
@@ -1,7 +1,7 @@
-RestrictedMethods.java:14:44: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
-RestrictedMethods.java:18:49: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
-RestrictedMethods.java:24:27: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
-RestrictedMethods.java:33:16: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:15:44: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:19:49: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:25:27: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
+RestrictedMethods.java:34:16: compiler.warn.restricted.method: java.lang.foreign.MemorySegment, reinterpret(long)
 - compiler.err.warnings.and.werror
 1 error
 4 warnings


### PR DESCRIPTION
Currently, `-Xlint:restricted` can be used to print out lint warnings when restricted methods are used in source code compiled by javac. However, this option doesn't work as intended when used in combination with `--release`, and instead no warnings are printed at all.

Javac relies on the internal `jdk.internal.javac.Restricted` annotation being present on a method in order to determine if a method is restricted. This annotation is however currently being stripped out when generating shim class files that are used by javac to get release-specific symbol information.

There are already some annotations that are exempt from being stripped away, such as `jdk.internal.javac.PreviewFeature`. The proposed fix is to add `jdk.internal.javac.Restricted` to the list of exempted annotations as well.

Testing: tier 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333560](https://bugs.openjdk.org/browse/JDK-8333560): -Xlint:restricted does not work with --release (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to [9dfaf070](https://git.openjdk.org/jdk/pull/19548/files/9dfaf070de6850391b2485bb32a95d57a98fbced)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [cadc668b](https://git.openjdk.org/jdk/pull/19548/files/cadc668be29ad368019ce30514fb2a5f621db678)


### Contributors
 * Jan Lahoda `<jlahoda@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19548/head:pull/19548` \
`$ git checkout pull/19548`

Update a local copy of the PR: \
`$ git checkout pull/19548` \
`$ git pull https://git.openjdk.org/jdk.git pull/19548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19548`

View PR using the GUI difftool: \
`$ git pr show -t 19548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19548.diff">https://git.openjdk.org/jdk/pull/19548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19548#issuecomment-2149288039)