### PR TITLE
8333586: Improve syntax of @see tags in javax.lang.model

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor14.java
@@ -36,8 +36,8 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="AbstractAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractAnnotationValueVisitor6
  * @see AbstractAnnotationValueVisitor7
  * @see AbstractAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor7.java
@@ -37,8 +37,8 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="AbstractAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses"
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractAnnotationValueVisitor6
  * @see AbstractAnnotationValueVisitor8
  * @see AbstractAnnotationValueVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor8.java
@@ -37,8 +37,8 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="AbstractAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractAnnotationValueVisitor6
  * @see AbstractAnnotationValueVisitor7
  * @see AbstractAnnotationValueVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitor9.java
@@ -37,8 +37,8 @@ import javax.annotation.processing.SupportedSourceVersion;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="AbstractAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractAnnotationValueVisitor6
  * @see AbstractAnnotationValueVisitor7
  * @see AbstractAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor14.java
@@ -42,8 +42,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractElementVisitor6
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor7.java
@@ -41,8 +41,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractElementVisitor6
  * @see AbstractElementVisitor8
  * @see AbstractElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor8.java
@@ -41,8 +41,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractElementVisitor6
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitor9.java
@@ -43,8 +43,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractElementVisitor6
  * @see AbstractElementVisitor7
  * @see AbstractElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor14.java
@@ -39,8 +39,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractTypeVisitor6
  * @see AbstractTypeVisitor7
  * @see AbstractTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor7.java
@@ -41,8 +41,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractTypeVisitor6
  * @see AbstractTypeVisitor8
  * @see AbstractTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor8.java
@@ -41,8 +41,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractTypeVisitor6
  * @see AbstractTypeVisitor7
  * @see AbstractTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
@@ -41,8 +41,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="AbstractTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see AbstractTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see AbstractTypeVisitor6
  * @see AbstractTypeVisitor7
  * @see AbstractTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor14.java
@@ -53,8 +53,8 @@ import javax.lang.model.SourceVersion;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see ElementKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementKindVisitor6
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor7.java
@@ -51,8 +51,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see ElementKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementKindVisitor6
  * @see ElementKindVisitor8
  * @see ElementKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor8.java
@@ -51,8 +51,8 @@ import javax.lang.model.SourceVersion;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see ElementKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementKindVisitor6
  * @see ElementKindVisitor7
  * @see ElementKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
@@ -55,8 +55,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see ElementKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see ElementKindVisitor6
  * @see ElementKindVisitor7
  * @see ElementKindVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -71,7 +71,7 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementScanner6.html#note_for_subclasses"><strong>Compatibility note for subclasses</strong></a>
+ * @see ElementScanner6##note_for_subclasses <strong>Compatibility note for subclasses</strong>
  * @see ElementScanner6
  * @see ElementScanner7
  * @see ElementScanner8

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -69,7 +69,7 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementScanner6.html#note_for_subclasses"><strong>Compatibility note for subclasses</strong></a>
+ * @see ElementScanner6##note_for_subclasses <strong>Compatibility note for subclasses</strong>
  * @see ElementScanner6
  * @see ElementScanner8
  * @see ElementScanner9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner8.java
@@ -68,7 +68,7 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementScanner6.html#note_for_subclasses"><strong>Compatibility note for subclasses</strong></a>
+ * @see ElementScanner6##note_for_subclasses <strong>Compatibility note for subclasses</strong>
  * @see ElementScanner6
  * @see ElementScanner7
  * @see ElementScanner9

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -70,7 +70,7 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="ElementScanner6.html#note_for_subclasses"><strong>Compatibility note for subclasses</strong></a>
+ * @see ElementScanner6##note_for_subclasses <strong>Compatibility note for subclasses</strong>
  * @see ElementScanner6
  * @see ElementScanner7
  * @see ElementScanner8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor14.java
@@ -44,8 +44,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="SimpleAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleAnnotationValueVisitor6
  * @see SimpleAnnotationValueVisitor7
  * @see SimpleAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor7.java
@@ -43,8 +43,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="SimpleAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleAnnotationValueVisitor6
  * @see SimpleAnnotationValueVisitor8
  * @see SimpleAnnotationValueVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor8.java
@@ -43,8 +43,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="SimpleAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleAnnotationValueVisitor6
  * @see SimpleAnnotationValueVisitor7
  * @see SimpleAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitor9.java
@@ -45,8 +45,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <R> the return type of this visitor's methods
  * @param <P> the type of the additional parameter to this visitor's methods.
  *
- * @see <a href="SimpleAnnotationValueVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleAnnotationValueVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleAnnotationValueVisitor6
  * @see SimpleAnnotationValueVisitor7
  * @see SimpleAnnotationValueVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor14.java
@@ -50,8 +50,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @see <a href="SimpleElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleElementVisitor6
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
@@ -50,8 +50,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @see <a href="SimpleElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleElementVisitor6
  * @see SimpleElementVisitor8
  * @see SimpleElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor8.java
@@ -48,8 +48,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @see <a href="SimpleElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleElementVisitor6
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor9.java
@@ -50,8 +50,8 @@ import static javax.lang.model.SourceVersion.*;
  * @param <P> the type of the additional parameter to this visitor's methods.  Use {@code Void}
  *              for visitors that do not need an additional parameter.
  *
- * @see <a href="SimpleElementVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleElementVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleElementVisitor6
  * @see SimpleElementVisitor7
  * @see SimpleElementVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor14.java
@@ -48,8 +48,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="SimpleTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleTypeVisitor6
  * @see SimpleTypeVisitor7
  * @see SimpleTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
@@ -50,8 +50,8 @@ import javax.lang.model.type.TypeVisitor;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="SimpleTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleTypeVisitor6
  * @see SimpleTypeVisitor8
  * @see SimpleTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor8.java
@@ -50,8 +50,8 @@ import javax.lang.model.type.TypeVisitor;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="SimpleTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleTypeVisitor6
  * @see SimpleTypeVisitor7
  * @see SimpleTypeVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
@@ -50,8 +50,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="SimpleTypeVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see SimpleTypeVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see SimpleTypeVisitor6
  * @see SimpleTypeVisitor7
  * @see SimpleTypeVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor14.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor14.java
@@ -53,8 +53,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="TypeKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see TypeKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see TypeKindVisitor6
  * @see TypeKindVisitor7
  * @see TypeKindVisitor8

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor7.java
@@ -51,8 +51,8 @@ import javax.lang.model.SourceVersion;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="TypeKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see TypeKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see TypeKindVisitor6
  * @see TypeKindVisitor8
  * @see TypeKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor8.java
@@ -51,8 +51,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="TypeKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see TypeKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see TypeKindVisitor6
  * @see TypeKindVisitor7
  * @see TypeKindVisitor9

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitor9.java
@@ -54,8 +54,8 @@ import static javax.lang.model.SourceVersion.*;
  *            methods.  Use {@code Void} for visitors that do not need an
  *            additional parameter.
  *
- * @see <a href="TypeKindVisitor6.html#note_for_subclasses">
- * <strong>Compatibility note for subclasses</strong></a>
+ * @see TypeKindVisitor6##note_for_subclasses
+ * <strong>Compatibility note for subclasses</strong>
  * @see TypeKindVisitor6
  * @see TypeKindVisitor7
  * @see TypeKindVisitor8


### PR DESCRIPTION
Avoid using `<a href=..>` when alternative syntax will do.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333586](https://bugs.openjdk.org/browse/JDK-8333586): Improve syntax of @<!---->see tags in javax.lang.model (**Enhancement** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19552/head:pull/19552` \
`$ git checkout pull/19552`

Update a local copy of the PR: \
`$ git checkout pull/19552` \
`$ git pull https://git.openjdk.org/jdk.git pull/19552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19552`

View PR using the GUI difftool: \
`$ git pr show -t 19552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19552.diff">https://git.openjdk.org/jdk/pull/19552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19552#issuecomment-2148542428)