### PR TITLE
8326705: Test CertMsgCheck.java fails to find alert certificate_required 

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -619,7 +619,6 @@ com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-all
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 

--- a/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
@@ -31,23 +31,20 @@
  *
  */
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class CertMsgCheck {
 
     public static void main(String[] args) throws Exception {
-        List<Exception> eList = new ArrayList<>();
         // Start server
         TLSBase.Server server = new TLSBase.ServerBuilder().setClientAuth(true).
             build();
-        TLSBase.Client client1;
+
         // Initial client session
-        client1 = new TLSBase.Client(true, false);
+        TLSBase.Client client1 = new TLSBase.Client(true, false);
+
         server.getSession(client1).getSessionContext();
         server.done();
 
-        eList.addAll(server.getExceptionList());
+        var eList = server.getExceptionList();
         System.out.println("Exception list size is " + eList.size());
 
         for (Exception e : eList) {

--- a/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
@@ -31,7 +31,6 @@
  *
  */
 
-import javax.net.ssl.SSLHandshakeException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,9 +46,6 @@ public class CertMsgCheck {
         client1 = new TLSBase.Client(true, false);
         server.getSession(client1).getSessionContext();
         server.done();
-        //while (!server.getSignal()) {
-//            Thread.sleep(100);
-//        }
 
         eList.addAll(server.getExceptionList());
         System.out.println("Exception list size is " + eList.size());

--- a/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
@@ -31,29 +31,41 @@
  *
  */
 
+import javax.net.ssl.SSLHandshakeException;
+import java.util.ArrayList;
+import java.util.List;
+
 public class CertMsgCheck {
 
     public static void main(String[] args) throws Exception {
+        List<Exception> eList = new ArrayList<>();
         // Start server
         TLSBase.Server server = new TLSBase.ServerBuilder().setClientAuth(true).
             build();
-
+        TLSBase.Client client1;
         // Initial client session
-        TLSBase.Client client1 = new TLSBase.Client(true, false);
-        if (server.getSession(client1).getSessionContext() == null) {
-            for (Exception e : server.getExceptionList()) {
-                System.out.println("Looking at " + e.getClass() + " " +
-                    e.getMessage());
-                if (e.getMessage().contains(args[0])) {
-                    System.out.println("Found correct exception: " + args[0] +
-                    " in " + e.getMessage());
-                    return;
-                } else {
-                    System.out.println("No \"" + args[0] + "\" found.");
-                }
-            }
+        client1 = new TLSBase.Client(true, false);
+        server.getSession(client1).getSessionContext();
+        server.done();
+        //while (!server.getSignal()) {
+//            Thread.sleep(100);
+//        }
 
-            throw new Exception("Failed to find expected alert: " + args[0]);
+        eList.addAll(server.getExceptionList());
+        System.out.println("Exception list size is " + eList.size());
+
+        for (Exception e : eList) {
+            System.out.println("Looking at " + e.getClass() + " " +
+                e.getMessage());
+            if (e.getMessage().contains(args[0])) {
+                System.out.println("Found correct exception: " + args[0] +
+                    " in " + e.getMessage());
+                return;
+            } else {
+                System.out.println("No \"" + args[0] + "\" found.");
+            }
         }
+
+        throw new Exception("Failed to find expected alert: " + args[0]);
     }
 }

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -178,8 +178,8 @@ abstract public class TLSBase {
                         try {
                             write(c, read(c));
                         } catch (Exception e) {
-                            System.out.println("Caught " + e.getMessage() +
-                                " put in list");
+                            System.out.println("Caught " + e.getMessage());
+                            e.printStackTrace();
                             exceptionList.add(e);
                         }
                     }
@@ -226,8 +226,8 @@ abstract public class TLSBase {
                             try {
                                 write(c, read(c));
                             } catch (Exception e) {
-                                System.out.println("Caught " + e.getMessage() +
-                                    " put in list");
+                                System.out.println("Caught " + e.getMessage());
+                                e.printStackTrace();
                                 exceptionList.add(e);
                             }
                         }

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -138,7 +138,6 @@ abstract public class TLSBase {
         return tmf.getTrustManagers();
     }
 
-
     /**
      * Server constructor must be called before any client operation so the
      * tls server is ready.  There should be no timing problems as the

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -62,7 +62,6 @@ abstract public class TLSBase {
     static int serverPort;
     // Name shown during read and write ops
     String name;
-    boolean connectionDone = false;
 
     TLSBase() {
         String keyFilename =
@@ -139,9 +138,6 @@ abstract public class TLSBase {
         return tmf.getTrustManagers();
     }
 
-    public boolean isDone() {
-        return connectionDone;
-    }
 
     /**
      * Server constructor must be called before any client operation so the
@@ -161,16 +157,15 @@ abstract public class TLSBase {
             name = "server";
             try {
                 sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(TLSBase.getKeyManager(builder.km)
-                    , TLSBase.getTrustManager(builder.tm), null);
+                sslContext.init(TLSBase.getKeyManager(builder.km),
+                    TLSBase.getTrustManager(builder.tm), null);
                 fac = sslContext.getServerSocketFactory();
                 ssock = (SSLServerSocket) fac.createServerSocket(0);
                 ssock.setNeedClientAuth(builder.clientauth);
                 serverPort = ssock.getLocalPort();
             } catch (Exception e) {
-                System.err.println(e.getMessage());
+                System.err.println("Failure during server initialization");
                 e.printStackTrace();
-                connectionDone = true;
             }
 
             // Thread to allow multiple clients to connect
@@ -192,8 +187,6 @@ abstract public class TLSBase {
                 } catch (Exception ex) {
                     System.err.println("Server Down");
                     ex.printStackTrace();
-                } finally {
-                    connectionDone = true;
                 }
             });
             t.start();
@@ -219,9 +212,8 @@ abstract public class TLSBase {
                 ssock.setNeedClientAuth(true);
                 serverPort = ssock.getLocalPort();
             } catch (Exception e) {
-                System.err.println(e.getMessage());
+                System.err.println("Failure during server initialization");
                 e.printStackTrace();
-                connectionDone = true;
             }
 
                 // Thread to allow multiple clients to connect
@@ -243,8 +235,6 @@ abstract public class TLSBase {
                     } catch (Exception ex) {
                         System.err.println("Server Down");
                         ex.printStackTrace();
-                    } finally {
-                        connectionDone = true;
                     }
                 });
                 t.start();


### PR DESCRIPTION
Hi,

I need a review for this simple change to fix a threading problem with the test. The server thread was not completing before the check occurred on the main thread.  The failure showed up in windows and macos, but not linux.  With this fix, running 100 times, windows & macos showed no failures.

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326705](https://bugs.openjdk.org/browse/JDK-8326705): Test CertMsgCheck.java fails to find alert certificate_required (**Bug** - P3)


### Reviewers
 * [Sibabrata Sahoo](https://openjdk.org/census#ssahoo) (@sisahoo - Committer)
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19553/head:pull/19553` \
`$ git checkout pull/19553`

Update a local copy of the PR: \
`$ git checkout pull/19553` \
`$ git pull https://git.openjdk.org/jdk.git pull/19553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19553`

View PR using the GUI difftool: \
`$ git pr show -t 19553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19553.diff">https://git.openjdk.org/jdk/pull/19553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19553#issuecomment-2150468317)