### PR TITLE
8333641: Serial: Remove Generation::supports_tlab_allocation

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -191,7 +191,6 @@ class DefNewGeneration: public Generation {
   size_t max_survivor_size() const          { return _max_survivor_size; }
 
   // Thread-local allocation buffers
-  bool supports_tlab_allocation() const { return true; }
   size_t tlab_capacity() const;
   size_t tlab_used() const;
   size_t unsafe_max_tlab_alloc() const;

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -114,9 +114,6 @@ class Generation: public CHeapObj<mtGC> {
   // Like "allocate", but performs any necessary locking internally.
   virtual HeapWord* par_allocate(size_t word_size, bool is_tlab) = 0;
 
-  // Thread-local allocation buffers
-  virtual bool supports_tlab_allocation() const { return false; }
-
   // Perform a heap collection, attempting to create (at least) enough
   // space to support an allocation of the given "word_size".  If
   // successful, perform the allocation and return the resulting

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -833,20 +833,15 @@ bool SerialHeap::block_is_obj(const HeapWord* addr) const {
 }
 
 size_t SerialHeap::tlab_capacity(Thread* thr) const {
-  assert(!_old_gen->supports_tlab_allocation(), "Old gen supports TLAB allocation?!");
-  assert(_young_gen->supports_tlab_allocation(), "Young gen doesn't support TLAB allocation?!");
+  // Only young-gen supports tlab allocation.
   return _young_gen->tlab_capacity();
 }
 
 size_t SerialHeap::tlab_used(Thread* thr) const {
-  assert(!_old_gen->supports_tlab_allocation(), "Old gen supports TLAB allocation?!");
-  assert(_young_gen->supports_tlab_allocation(), "Young gen doesn't support TLAB allocation?!");
   return _young_gen->tlab_used();
 }
 
 size_t SerialHeap::unsafe_max_tlab_alloc(Thread* thr) const {
-  assert(!_old_gen->supports_tlab_allocation(), "Old gen supports TLAB allocation?!");
-  assert(_young_gen->supports_tlab_allocation(), "Young gen doesn't support TLAB allocation?!");
   return _young_gen->unsafe_max_tlab_alloc();
 }
 

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -143,7 +143,7 @@ public:
   bool should_allocate(size_t word_size, bool is_tlab) {
     bool result = false;
     size_t overflow_limit = (size_t)1 << (BitsPerSize_t - LogHeapWordSize);
-    if (!is_tlab || supports_tlab_allocation()) {
+    if (!is_tlab) {
       result = (word_size > 0) && (word_size < overflow_limit);
     }
     return result;


### PR DESCRIPTION
Trivial removing useless generation-level API. It was probably useful when there are a list of generations which have diff support for tlab. Now that we have only two generations, this API can be inlined/hardcoded to simplify the flow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333641](https://bugs.openjdk.org/browse/JDK-8333641): Serial: Remove Generation::supports_tlab_allocation (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19554/head:pull/19554` \
`$ git checkout pull/19554`

Update a local copy of the PR: \
`$ git checkout pull/19554` \
`$ git pull https://git.openjdk.org/jdk.git pull/19554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19554`

View PR using the GUI difftool: \
`$ git pr show -t 19554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19554.diff">https://git.openjdk.org/jdk/pull/19554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19554#issuecomment-2149404667)