### PR TITLE
8333590: UnmodifiableHeaders.toString() returns a value that represents empty headers

### DIFF
--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/UnmodifiableHeaders.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/UnmodifiableHeaders.java
@@ -122,6 +122,6 @@ public class UnmodifiableHeaders extends Headers {
 
     @Override
     public String toString() {
-        return this.headers.toString();
+        return headers.toString();
     }
 }

--- a/src/jdk.httpserver/share/classes/sun/net/httpserver/UnmodifiableHeaders.java
+++ b/src/jdk.httpserver/share/classes/sun/net/httpserver/UnmodifiableHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,73 +32,96 @@ import com.sun.net.httpserver.*;
 public class UnmodifiableHeaders extends Headers {
 
     private final Headers headers;  // modifiable, but no reference to it escapes
-    private final Map<String, List<String>> map;  // unmodifiable
+    private final Map<String, List<String>> unmodifiableView;  // unmodifiable
 
     public UnmodifiableHeaders(Headers headers) {
         var h = headers;
         var unmodHeaders = new Headers();
         h.forEach((k, v) -> unmodHeaders.put(k, Collections.unmodifiableList(v)));
-        this.map = Collections.unmodifiableMap(unmodHeaders);
+        this.unmodifiableView = Collections.unmodifiableMap(unmodHeaders);
         this.headers = unmodHeaders;
     }
 
+    @Override
     public int size() {return headers.size();}
 
+    @Override
     public boolean isEmpty() {return headers.isEmpty();}
 
+    @Override
     public boolean containsKey(Object key) { return headers.containsKey(key); }
 
+    @Override
     public boolean containsValue(Object value) { return headers.containsValue(value); }
 
+    @Override
     public List<String> get(Object key) { return headers.get(key); }
 
+    @Override
     public String getFirst(String key) { return headers.getFirst(key); }
 
+    @Override
     public List<String> put(String key, List<String> value) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public void add(String key, String value) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public void set(String key, String value) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public List<String> remove(Object key) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public void putAll(Map<? extends String,? extends List<String>> t)  {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public void clear() {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
-    public Set<String> keySet() { return map.keySet(); }
+    @Override
+    public Set<String> keySet() { return unmodifiableView.keySet(); }
 
-    public Collection<List<String>> values() { return map.values(); }
+    @Override
+    public Collection<List<String>> values() { return unmodifiableView.values(); }
 
-    /* TODO check that contents of set are not modifable : security */
+    @Override
+    public Set<Map.Entry<String, List<String>>> entrySet() { return unmodifiableView.entrySet(); }
 
-    public Set<Map.Entry<String, List<String>>> entrySet() { return map.entrySet(); }
-
+    @Override
     public List<String> replace(String key, List<String> value) {
         throw new UnsupportedOperationException("unsupported operation");
     }
 
+    @Override
     public boolean replace(String key, List<String> oldValue, List<String> newValue) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public void replaceAll(BiFunction<? super String, ? super List<String>, ? extends List<String>> function) {
         throw new UnsupportedOperationException ("unsupported operation");
     }
 
+    @Override
     public boolean equals(Object o) {return headers.equals(o);}
 
+    @Override
     public int hashCode() {return headers.hashCode();}
+
+    @Override
+    public String toString() {
+        return this.headers.toString();
+    }
 }


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8333590?

As noted in that issue the `sun.net.httpserver.UnmodifiableHeaders`, an internal class, within the `jdk.httpserver` module doesn't override the `toString()` method. `UnmodifiableHeaders` is of type `com.sun.net.httpserver.Headers` which is a public API in the `jdk.httpserver` module.

When applications call `Headers.toString()`, if the instance is of type `UnmodifiableHeaders`, then the returned `String` representation shows empty headers, even when it isn't empty. The commit in this PR fixes the issue by implementing `toString()` in the `UnmodifiableHeaders` to return the correct representation of the headers.

An existing jtreg test has been updated to reproduce this issue and verify the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333590](https://bugs.openjdk.org/browse/JDK-8333590): UnmodifiableHeaders.toString() returns a value that represents empty headers (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19555/head:pull/19555` \
`$ git checkout pull/19555`

Update a local copy of the PR: \
`$ git checkout pull/19555` \
`$ git pull https://git.openjdk.org/jdk.git pull/19555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19555`

View PR using the GUI difftool: \
`$ git pr show -t 19555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19555.diff">https://git.openjdk.org/jdk/pull/19555.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19555#issuecomment-2149484706)