### PR TITLE
8333178: ubsan: jvmti_tools.cpp:149:16: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp
@@ -146,7 +146,9 @@ static int add_option(const char opt[], int opt_len, const char val[], int val_l
     } else {
         strncpy(name, opt, opt_len);
         name[opt_len] = '\0';
-        strncpy(value, val, val_len);
+        if (val != nullptr) {
+            strncpy(value, val, val_len);
+        }
         value[val_len] = '\0';
 
         if (!check_option(dashed_opt, name, value)) {


### PR DESCRIPTION
With ubsan enabled binaries we run into the following issue in HS :tier4 tests :
e.g. vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/TestDescription.jtr

/jdk/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp:149:16: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x7fa7a1049482 in add_option test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp:149
    #1 0x7fa7a1049482 in nsk_jvmti_parseOptions test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/jvmti_tools.cpp:242
    #2 0x7fa7a10634cd in Agent_Initialize test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/followref006.cpp:216
    #3 0x7fa79a9dbb36 in invoke_Agent_OnLoad src/hotspot/share/prims/jvmtiAgent.cpp:609
    #4 0x7fa79a9dbb36 in JvmtiAgent::load(outputStream*) src/hotspot/share/prims/jvmtiAgent.cpp:623
    #5 0x7fa79a9defd4 in load_agents src/hotspot/share/prims/jvmtiAgentList.cpp:179
    #6 0x7fa79a9defd4 in JvmtiAgentList::load_agents() src/hotspot/share/prims/jvmtiAgentList.cpp:190
    #7 0x7fa79bdad503 in Threads::create_vm(JavaVMInitArgs*, bool*) src/hotspot/share/runtime/threads.cpp:505
    #8 0x7fa79a6e531f in JNI_CreateJavaVM_inner src/hotspot/share/prims/jni.cpp:3581
    #9 0x7fa79a6e531f in JNI_CreateJavaVM src/hotspot/share/prims/jni.cpp:3672
    #10 0x7fa7a11277d5 in InitializeJVM src/java.base/share/native/libjli/java.c:1550
    #11 0x7fa7a11277d5 in JavaMain src/java.base/share/native/libjli/java.c:491
    #12 0x7fa7a1130f68 in ThreadJavaMain src/java.base/unix/native/libjli/java_md.c:653
    #13 0x7fa7a10df6e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)
    #14 0x7fa7a071550e in clone (/lib64/libc.so.6+0x11850e) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333178](https://bugs.openjdk.org/browse/JDK-8333178): ubsan: jvmti_tools.cpp:149:16: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 23, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19557/head:pull/19557` \
`$ git checkout pull/19557`

Update a local copy of the PR: \
`$ git checkout pull/19557` \
`$ git pull https://git.openjdk.org/jdk.git pull/19557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19557`

View PR using the GUI difftool: \
`$ git pr show -t 19557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19557.diff">https://git.openjdk.org/jdk/pull/19557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19557#issuecomment-2149847012)