### PR TITLE
8333647: C2 SuperWord: some additional PopulateIndex tests

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayIndexFillTest.java
@@ -46,6 +46,8 @@ import compiler.lib.ir_framework.*;
 public class ArrayIndexFillTest extends VectorizationTestRunner {
 
     private static final int SIZE = 543;
+    private static int init = 0;
+    private static int limit = SIZE;
 
     private int[] a;
 
@@ -101,9 +103,73 @@ public class ArrayIndexFillTest extends VectorizationTestRunner {
     }
 
     @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // The ConvI2L can be split through the AddI, creating a mix of
+    // ConvI2L(AddI) and AddL(ConvI2L) cases, which do not vectorize.
+    // See: JDK-8332878
     public long[] fillLongArray() {
         long[] res = new long[SIZE];
         for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    // The variable init/limit has the consequence that we do not split
+    // the ConvI2L through the AddI.
+    public long[] fillLongArray2() {
+        long[] res = new long[SIZE];
+        for (int i = init; i < limit; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // See: JDK-8332878
+    public float[] fillFloatArray() {
+        float[] res = new float[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    public float[] fillFloatArray2() {
+        float[] res = new float[SIZE];
+        for (int i = init; i < limit; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, "=0"})
+    // See: JDK-8332878
+    public double[] fillDoubleArray() {
+        double[] res = new double[SIZE];
+        for (int i = 0; i < SIZE; i++) {
+            res[i] = i;
+        }
+        return res;
+    }
+
+    @Test
+    @IR(applyIfCPUFeatureOr = {"sve", "true", "avx2", "true"},
+        counts = {IRNode.POPULATE_INDEX, ">0"})
+    public double[] fillDoubleArray2() {
+        double[] res = new double[SIZE];
+        for (int i = init; i < limit; i++) {
             res[i] = i;
         }
         return res;

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2023, Arm Limited. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
When I did the deep refactoring in https://github.com/openjdk/jdk/pull/19261, I wanted some more tests for `PopulateIndex`. I push them separately to keep the other RFE smaller.

I filed a follow-up RFE for some cases that do not vectorize: https://bugs.openjdk.org/browse/JDK-8332878

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333647](https://bugs.openjdk.org/browse/JDK-8333647): C2 SuperWord: some additional PopulateIndex tests (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19558/head:pull/19558` \
`$ git checkout pull/19558`

Update a local copy of the PR: \
`$ git checkout pull/19558` \
`$ git pull https://git.openjdk.org/jdk.git pull/19558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19558`

View PR using the GUI difftool: \
`$ git pr show -t 19558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19558.diff">https://git.openjdk.org/jdk/pull/19558.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19558#issuecomment-2149873523)