### PR TITLE
8322568: JFR: Improve metadata for IEEE rounding mode fields

### DIFF
--- a/src/hotspot/share/jfr/metadata/metadata.xml
+++ b/src/hotspot/share/jfr/metadata/metadata.xml
@@ -952,8 +952,8 @@
     <Field type="string" name="name" label="Name" />
     <Field type="boolean" name="success" label="Success" description="Success or failure of the load operation" />
     <Field type="string" name="errorMessage" label="Error Message" description="In case of a load error, error description" />
-    <Field type="boolean" name="fpEnvCorrectionAttempt" label="FPU Environment correction" description="In case of IEEE conformance issues we might reset the FP environment" />
-    <Field type="boolean" name="fpEnvCorrectionSuccess" label="FPU Environment correction result" description="Stores the result in the case of an FP environment correction" />
+    <Field type="boolean" name="fpuCorrectionAttempt" label="FPU Environment Correction" description="In case of IEEE conformance issues we might reset the FP environment" />
+    <Field type="boolean" name="fpuCorrectionSuccess" label="FPU Environment Correction Result" description="Stores the result in the case of an FP environment correction" />
   </Event>
 
   <Event name="NativeLibraryUnload" category="Java Virtual Machine, Runtime" label="Native Library Unload" thread="true" stackTrace="true" startTime="true"

--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -91,8 +91,8 @@ void NativeLibraryUnloadEvent::set_result(bool result) {
 }
 
 static void set_additional_data(EventNativeLibraryLoad& event, const NativeLibraryLoadEvent& helper) {
-  event.set_fpEnvCorrectionAttempt(helper.get_fp_env_correction_attempt());
-  event.set_fpEnvCorrectionSuccess(helper.get_fp_env_correction_success());
+  event.set_fpuCorrectionAttempt(helper.get_fp_env_correction_attempt());
+  event.set_fpuCorrectionSuccess(helper.get_fp_env_correction_success());
 }
 
 static void set_additional_data(EventNativeLibraryUnload& event, const NativeLibraryUnloadEvent& helper) {


### PR DESCRIPTION
Could I have review of a couple of changes that align the style of the new event fields with other events, no abbreviations (env) and headline-style capitalization for the label.

Testring: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322568](https://bugs.openjdk.org/browse/JDK-8322568): JFR: Improve metadata for IEEE rounding mode fields (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19560/head:pull/19560` \
`$ git checkout pull/19560`

Update a local copy of the PR: \
`$ git checkout pull/19560` \
`$ git pull https://git.openjdk.org/jdk.git pull/19560/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19560`

View PR using the GUI difftool: \
`$ git pr show -t 19560`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19560.diff">https://git.openjdk.org/jdk/pull/19560.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19560#issuecomment-2150503810)