### PR TITLE
8333644: C2: assert(is_Bool()) failed: invalid node class: Phi

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -2154,18 +2154,19 @@ void PhaseIdealLoop::clone_loop_handle_data_uses(Node* old, Node_List &old_new,
 #endif
     if (!loop->is_member(use_loop) && !outer_loop->is_member(use_loop) && (!old->is_CFG() || !use->is_CFG())) {
 
-      // If the Data use is an IF, that means we have an IF outside of the
-      // loop that is switching on a condition that is set inside of the
+      // If the Data use is an IF, that means we have an IF outside the
+      // loop that is switching on a condition that is set inside the
       // loop.  Happens if people set a loop-exit flag; then test the flag
-      // in the loop to break the loop, then test is again outside of the
+      // in the loop to break the loop, then test is again outside the
       // loop to determine which way the loop exited.
-      // Loop predicate If node connects to Bool node through Opaque1 node.
       //
-      // If the use is an AllocateArray through its ValidLengthTest input,
-      // make sure the Bool/Cmp input is cloned down to avoid a Phi between
-      // the AllocateArray node and its ValidLengthTest input that could cause
+      // For several uses we need to make sure that there is no phi between,
+      // the use and the Bool/Cmp. We therefore clone the Bool/Cmp down here
+      // to avoid such a phi in between.
+      // For example, it is unexpected that there is a Phi between an
+      // AllocateArray node and its ValidLengthTest input that could cause
       // split if to break.
-      if (use->is_If() || use->is_CMove() || use->is_Opaque4() ||
+      if (use->is_If() || use->is_CMove() || use->is_Opaque4() || use->is_OpaqueInitializedAssertionPredicate() ||
           (use->Opcode() == Op_AllocateArray && use->in(AllocateNode::ValidLengthTest) == old)) {
         // Since this code is highly unlikely, we lazily build the worklist
         // of such Nodes to go split.

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestOpaqueInitializedAssertionPredicateNode.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestOpaqueInitializedAssertionPredicateNode.java
@@ -54,6 +54,17 @@
  * @run main compiler.predicates.assertion.TestOpaqueInitializedAssertionPredicateNode
  */
 
+/*
+ * @test id=clone_loop_handle_data_uses
+ * @bug 8333644
+ * @modules java.base/jdk.internal.misc:+open
+ * @summary Test that using OpaqueInitializedAssertionPredicate for Initialized Assertion Predicates instead of Opaque4
+ *          nodes also work with clone_loop_handle_data_uses() which missed a case before.
+ * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,*TestOpaqueInitializedAssertionPredicateNode::test*
+ *                   -XX:CompileCommand=dontinline,*TestOpaqueInitializedAssertionPredicateNode::dontInline
+ *                   compiler.predicates.assertion.TestOpaqueInitializedAssertionPredicateNode
+ */
+
 package compiler.predicates.assertion;
 
 import jdk.internal.misc.Unsafe;
@@ -63,6 +74,7 @@ public class TestOpaqueInitializedAssertionPredicateNode {
 
     static boolean flag, flag2;
     static int iFld;
+    static long lFld;
     static int x;
     static int y = 51;
     static int iArrLength;
@@ -95,6 +107,7 @@ public class TestOpaqueInitializedAssertionPredicateNode {
             testPolicyRangeCheck(a);
             testUnsafeAccess(a);
             testOpaqueOutsideLoop();
+            testOpaqueOutsideLoop8333644();
             testOpaqueInsideIfOutsideLoop();
         }
     }
@@ -346,6 +359,35 @@ public class TestOpaqueInitializedAssertionPredicateNode {
             // OpaqueInitializedAssertionPredicate of IAP is outside of i-loop.
             if (initializedAssertionPredicateBool) {
                 iFld = 3;
+            }
+        }
+    }
+
+    // Same as testOpaqueOutsideLoop() but we crash later when generating the Mach graph due to wrongly having an If
+    // with a Phi input instead of: If <- Bool <- CmpU <- [x, Phi]. Found by fuzzing.
+    static void testOpaqueOutsideLoop8333644() {
+        int a = 3, b = 7;
+        boolean bArr[] = new boolean[1];
+        for (int i = 1; i < 122; i++) {
+            float f = 1.729F;
+            while (++a < 7) {
+                iArr[a] *= lFld;
+                switch (i) {
+                    case 26:
+                        for (; b < 1; ) {}
+                    case 27:
+                        iArr[1] = 9;
+                    case 28:
+                        break;
+                    case 33:
+                        iArr[1] = a;
+                        break;
+                    case 35:
+                        lFld = b;
+                        break;
+                    default:
+                        ;
+                }
             }
         }
     }

--- a/test/hotspot/jtreg/compiler/predicates/assertion/TestOpaqueInitializedAssertionPredicateNode.java
+++ b/test/hotspot/jtreg/compiler/predicates/assertion/TestOpaqueInitializedAssertionPredicateNode.java
@@ -59,7 +59,7 @@
  * @bug 8333644
  * @modules java.base/jdk.internal.misc:+open
  * @summary Test that using OpaqueInitializedAssertionPredicate for Initialized Assertion Predicates instead of Opaque4
- *          nodes also work with clone_loop_handle_data_uses() which missed a case before.
+ *          nodes also works with clone_loop_handle_data_uses() which missed a case before.
  * @run main/othervm -Xcomp -XX:CompileCommand=compileonly,*TestOpaqueInitializedAssertionPredicateNode::test*
  *                   -XX:CompileCommand=dontinline,*TestOpaqueInitializedAssertionPredicateNode::dontInline
  *                   compiler.predicates.assertion.TestOpaqueInitializedAssertionPredicateNode


### PR DESCRIPTION
In the patch of [JDK-8330386](https://bugs.openjdk.org/browse/JDK-8330386), I've added a test case that took the code path in `clone_loop_handle_data_uses()` with the new `OpaqueInitializedAssertionPredicateNode`. So, it proved that we should also add a case for `OpaqueInitializedAssertionPredicate` - yet somehow, I forgot to do that. Unfortunately, I could not come up with a failing test if we do not handle this case separately and the mistake went unnoticed.

But the fuzzer has now found such a case where we crash when creating the Mach graph because we have an `If` with a `Phi` input instead of a `Bool`. This happens exactly because of not handling `OpaqueInitializedAssertionPredicate` in  `clone_loop_handle_data_uses()`. 

We have an outside use of a `4843 Bool` (`4193 RangeCheck`) which is also an input into a `OpaqueInitializedAssertionPredicate` node:

![image](https://github.com/openjdk/jdk/assets/17833009/7f43d987-6e29-449e-8392-58e76e111e80)

We should now clone this `Bool/Cmp` down to avoid having a `Phi` between the `OpaqueInitializedAssertionPredicate` and
the `Bool` node which currently wrongly happens:

![image](https://github.com/openjdk/jdk/assets/17833009/a10554a0-d48a-406c-a510-fef9666c45af)

and we crash later. With this simple patch, this is being avoided.

The good thing is that we now have a test that makes sure that this new condition is properly tested.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333644](https://bugs.openjdk.org/browse/JDK-8333644): C2: assert(is_Bool()) failed: invalid node class: Phi (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [68215366](https://git.openjdk.org/jdk/pull/19561/files/682153667fa45f29e7d7ede7f3518fa51bd9eb3c)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19561/head:pull/19561` \
`$ git checkout pull/19561`

Update a local copy of the PR: \
`$ git checkout pull/19561` \
`$ git pull https://git.openjdk.org/jdk.git pull/19561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19561`

View PR using the GUI difftool: \
`$ git pr show -t 19561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19561.diff">https://git.openjdk.org/jdk/pull/19561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19561#issuecomment-2149975813)