### PR TITLE
8333653: Remove MallocHeader::get_stack

### DIFF
--- a/src/hotspot/share/nmt/mallocHeader.cpp
+++ b/src/hotspot/share/nmt/mallocHeader.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/src/hotspot/share/nmt/mallocHeader.cpp
+++ b/src/hotspot/share/nmt/mallocHeader.cpp
@@ -64,7 +64,3 @@ void MallocHeader::print_block_on_error(outputStream* st, address bad_address) c
     os::print_hex_dump(st, from1, to2, 1);
   }
 }
-
-bool MallocHeader::get_stack(NativeCallStack& stack) const {
-  return MallocSiteTable::access_stack(stack, _mst_marker);
-}

--- a/src/hotspot/share/nmt/mallocHeader.hpp
+++ b/src/hotspot/share/nmt/mallocHeader.hpp
@@ -130,7 +130,6 @@ public:
   inline size_t   size()  const { return _size; }
   inline MEMFLAGS flags() const { return _flags; }
   inline uint32_t mst_marker() const { return _mst_marker; }
-  bool get_stack(NativeCallStack& stack) const;
 
   // Return the necessary data to deaccount the block with NMT.
   FreeInfo free_info() {

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/nmt/mallocSiteTable.hpp
+++ b/src/hotspot/share/nmt/mallocSiteTable.hpp
@@ -131,8 +131,8 @@ class MallocSiteTable : AllStatic {
 
   // Access and copy a call stack from this table. Shared lock should be
   // acquired before access the entry.
-  static inline bool access_stack(NativeCallStack& stack, uint32_t marker) {
-    MallocSite* site = malloc_site(marker);
+  static inline bool access_stack(NativeCallStack& stack, const MallocHeader& header) {
+    MallocSite* site = malloc_site(header.mst_marker());
     if (site != nullptr) {
       stack = *site->call_stack();
       return true;

--- a/src/hotspot/share/nmt/mallocTracker.cpp
+++ b/src/hotspot/share/nmt/mallocTracker.cpp
@@ -299,7 +299,7 @@ bool MallocTracker::print_pointer_information(const void* p, outputStream* st) {
                  block->size(), NMTUtil::flag_to_enum_name(block->flags()));
     if (MemTracker::tracking_level() == NMT_detail) {
       NativeCallStack ncs;
-      if (block->get_stack(ncs)) {
+      if (MallocSiteTable::access_stack(ncs, *block)) {
         ncs.print_on(st);
         st->cr();
       }


### PR DESCRIPTION
Hi,

A small and trivial enhancement, I think. Today, MallocHeader knows about the `MallocSiteTable` and vice versa. That seems a bit strange to me, as it is just a data carrier. Just have only MallocSiteTable be aware of MallocHeader by deleting a method from MallocHeader.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333653](https://bugs.openjdk.org/browse/JDK-8333653): Remove MallocHeader::get_stack (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [cd0f0572](https://git.openjdk.org/jdk/pull/19562/files/cd0f0572f17b3a3174349715831fe24811ae57ac)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19562/head:pull/19562` \
`$ git checkout pull/19562`

Update a local copy of the PR: \
`$ git checkout pull/19562` \
`$ git pull https://git.openjdk.org/jdk.git pull/19562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19562`

View PR using the GUI difftool: \
`$ git pr show -t 19562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19562.diff">https://git.openjdk.org/jdk/pull/19562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19562#issuecomment-2150212447)