### PR TITLE
8325984: 4 jcstress tests are failing in Tier6 4 times each

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -118,11 +118,6 @@ runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
 runtime/Thread/TestAlwaysPreTouchStacks.java 8324781 linux-all
 
-applications/jcstress/accessAtomic.java 8325984 generic-all
-applications/jcstress/acqrel.java 8325984 generic-all
-applications/jcstress/atomicity.java 8325984 generic-all
-applications/jcstress/coherence.java 8325984 generic-all
-
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/docker/TestJcmd.java 8278102 linux-all


### PR DESCRIPTION
These 4 tests were failing due to an incompatibility with jcstress. They were problemlisted in past (https://bugs.openjdk.org/browse/JDK-8326062).

Now that jcstress has been updated (https://github.com/openjdk/jdk/pull/19332) with the relevant fix (https://github.com/openjdk/jcstress/pull/147), we can re-enable these tests.

Testing: I've verified that all 4 tests now pass on Linux-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325984](https://bugs.openjdk.org/browse/JDK-8325984): 4 jcstress tests are failing in Tier6 4 times each (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19565/head:pull/19565` \
`$ git checkout pull/19565`

Update a local copy of the PR: \
`$ git checkout pull/19565` \
`$ git pull https://git.openjdk.org/jdk.git pull/19565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19565`

View PR using the GUI difftool: \
`$ git pr show -t 19565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19565.diff">https://git.openjdk.org/jdk/pull/19565.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19565#issuecomment-2150803654)