### PR TITLE
8333674: Disable CollectorPolicy.young_min_ergo_vm for PPC64

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -214,12 +214,15 @@ class TestGenCollectorPolicy {
 
 // If NewSize has been ergonomically set, the collector policy
 // should use it for min
+// This test doesn't work with 64k pages. See JDK-8331675.
+#if !defined(PPC)
 TEST_VM(CollectorPolicy, young_min_ergo) {
   TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
   TestGenCollectorPolicy::CheckYoungMin checker(20 * M);
 
   TestGenCollectorPolicy::TestWrapper::test(&setter, &checker);
 }
+#endif
 
 // If NewSize has been ergonomically set, the collector policy
 // should use it for min but calculate the initial young size


### PR DESCRIPTION
The test doesn't work on PPC64 and should be disabled until it is fixed. Subtask of [JDK-8331675](https://bugs.openjdk.org/browse/JDK-8331675).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333674](https://bugs.openjdk.org/browse/JDK-8333674): Disable CollectorPolicy.young_min_ergo_vm for PPC64 (**Sub-task** - P3)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19566/head:pull/19566` \
`$ git checkout pull/19566`

Update a local copy of the PR: \
`$ git checkout pull/19566` \
`$ git pull https://git.openjdk.org/jdk.git pull/19566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19566`

View PR using the GUI difftool: \
`$ git pr show -t 19566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19566.diff">https://git.openjdk.org/jdk/pull/19566.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19566#issuecomment-2150825833)