### PR TITLE
8333622: ubsan: relocInfo_x86.cpp:101:56: runtime error: pointer index expression with base (-1) overflowed

### DIFF
--- a/src/hotspot/cpu/x86/relocInfo_x86.cpp
+++ b/src/hotspot/cpu/x86/relocInfo_x86.cpp
@@ -98,7 +98,11 @@ address Relocation::pd_call_destination(address orig_addr) {
   if (ni->is_call()) {
     return nativeCall_at(addr())->destination() + adj;
   } else if (ni->is_jump()) {
-    return nativeJump_at(addr())->jump_destination() + adj;
+    address dest = nativeJump_at(addr())->jump_destination();
+    if (dest == (address) -1) {
+      return addr(); // jump to self
+    }
+    return dest + adj;
   } else if (ni->is_cond_jump()) {
     return nativeGeneralJump_at(addr())->jump_destination() + adj;
   } else if (ni->is_mov_literal64()) {


### PR DESCRIPTION
Add missing check to `pd_call_destination()` similar to check in `pd_set_call_destination()` to avoid arithmetic with `(address)(-1)`.

Tested tier1-3,stress,xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333622](https://bugs.openjdk.org/browse/JDK-8333622): ubsan: relocInfo_x86.cpp:101:56: runtime error: pointer index expression with base (-1) overflowed (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19568/head:pull/19568` \
`$ git checkout pull/19568`

Update a local copy of the PR: \
`$ git checkout pull/19568` \
`$ git pull https://git.openjdk.org/jdk.git pull/19568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19568`

View PR using the GUI difftool: \
`$ git pr show -t 19568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19568.diff">https://git.openjdk.org/jdk/pull/19568.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19568#issuecomment-2151070740)