### PR TITLE
8333412: [s390x] Add support for branch on count instruction

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -986,6 +986,9 @@ class Assembler : public AbstractAssembler {
 #define BCR_ZOPC    (unsigned  int)(7 << 8)
 #define BALR_ZOPC   (unsigned  int)(5 << 8)
 #define BASR_ZOPC   (unsigned  int)(13 << 8)
+#define BCT_ZOPC    (unsigned  int)(70 << 24)
+#define BCTR_ZOPC   (unsigned  int)(6 << 8)
+#define BCTG_ZOPC   (unsigned  int)(227L << 40 | 70)
 #define BCTGR_ZOPC  (unsigned long)(0xb946 << 16)
 // Absolute
 #define BC_ZOPC     (unsigned  int)(71 << 24)
@@ -1887,7 +1890,14 @@ class Assembler : public AbstractAssembler {
   //inline void z_brcl(branch_condition i1, int64_t i2);                        // branch  i1 ? pc = pc + i2_imm32
   inline void z_brcl(branch_condition i1, address a);                           // branch  i1 ? pc = a
   inline void z_brcl(branch_condition i1, Label& L);                            // branch  i1 ? pc = Label
-  inline void z_bctgr(Register r1, Register r2);         // branch on count r1 -= 1; (r1!=0) ? pc = r2  ; r1 is int64
+
+  // branch on count Instructions
+  inline void z_bct(  Register r1, int64_t d2, Register x2, Register b2); // branch on count r1 -= 1; (r1!=0) ? pc = (d2_uimm12+x2+b2) ; r1 is int32
+  inline void z_bct(  Register r1, const Address &a);                     // branch on count r1 -= 1; (r1!=0) ? pc = *(a); r1 is int32
+  inline void z_bctr( Register r1, Register r2);                          // branch on count r1 -= 1; (r1!=0) ? pc = r2  ; r1 is int32
+  inline void z_bctgr(Register r1, Register r2);                          // branch on count r1 -= 1; (r1!=0) ? pc = r2  ; r1 is int64
+  inline void z_bctg( Register r1, const Address &a);                     // branch on count r1 -= 1; (r1!=0) ? pc = *(a); r1 is int64
+  inline void z_bctg( Register r1, int64_t d2, Register x2, Register b2); // branch on count r1 -= 1; (r1!=0) ? pc = (d2_imm20+x2+b2)  ; r1 is int64
 
   // branch unconditional / always
   inline void z_br(Register r2);                         // branch to r2, nop if r2 == Z_R0
@@ -3060,6 +3070,10 @@ class Assembler : public AbstractAssembler {
   inline void z_brnaz(Label& L);
   inline void z_braz(Label& L);
   inline void z_brnp(Label& L);
+
+  // Branch on count;
+  inline void z_bct( Register r1, int64_t d2, Register b2);
+  inline void z_bctg(Register r1, int64_t d2, Register b2);
 
   inline void z_btrue( Label& L);
   inline void z_bfalse(Label& L);

--- a/src/hotspot/cpu/s390/assembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.inline.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2016, 2023 SAP SE. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -724,7 +724,14 @@ inline void Assembler::z_bcr( branch_condition m1, Register r2) { emit_16( BCR_Z
 inline void Assembler::z_brc( branch_condition i1, int64_t i2)  { emit_32( BRC_ZOPC   | uimm4(i1, 8, 32) | simm16(i2, 16, 32)); }
 inline void Assembler::z_brc( branch_condition i1, address a)   { emit_32( BRC_ZOPC   | uimm4(i1, 8, 32) | simm16(RelAddr::pcrel_off16(a, pc()), 16, 32)); }
 inline void Assembler::z_brcl(branch_condition i1, address a)   { emit_48( BRCL_ZOPC  | uimm4(i1, 8, 48) | simm32(RelAddr::pcrel_off32(a, pc()), 16, 48)); }
-inline void Assembler::z_bctgr(Register r1, Register r2)        { emit_32( BCTGR_ZOPC | reg( r1, 24, 32) | reg( r2, 28, 32)); };
+
+// branch on count
+inline void Assembler::z_bct(  Register r1, const Address &a)                     { z_bct(   r1, a.disp(), a.indexOrR0(), a.baseOrR0()); }
+inline void Assembler::z_bct(  Register r1, int64_t d2, Register x2, Register b2) { emit_32( BCT_ZOPC  | reg(r1, 8, 32) | rxmask_32(d2, x2, b2)); }
+inline void Assembler::z_bctr (Register r1, Register r2)                          { emit_16( BCTR_ZOPC  | reg( r1,  8, 16) | reg( r2, 12, 16)); };
+inline void Assembler::z_bctgr(Register r1, Register r2)                          { emit_32( BCTGR_ZOPC | reg( r1, 24, 32) | reg( r2, 28, 32)); };
+inline void Assembler::z_bctg( Register r1, const Address &a)                     { z_bctg(  r1, a.disp(), a.indexOrR0(), a.baseOrR0()); }
+inline void Assembler::z_bctg( Register r1, int64_t d2, Register x2, Register b2) { emit_48( BCTG_ZOPC | reg(r1, 8, 48) | rxymask_48(d2, x2, b2)); }
 
 inline void Assembler::z_basr( Register r1, Register r2) { emit_16( BASR_ZOPC  | regt(r1, 8, 16) | reg(r2, 12, 16)); }
 inline void Assembler::z_brasl(Register r1, address a)   { emit_48( BRASL_ZOPC | regt(r1, 8, 48) | simm32(RelAddr::pcrel_off32(a, pc()), 16, 48)); }
@@ -1396,6 +1403,8 @@ inline void Assembler::z_brno(  Label& L) { z_brc(bcondNotOrdered, target(L)); }
 inline void Assembler::z_brc( branch_condition m, Label& L) { z_brc(m, target(L)); }
 inline void Assembler::z_brcl(branch_condition m, Label& L) { z_brcl(m, target(L)); }
 
+inline void Assembler::z_bct( Register r1, int64_t d2, Register b2) { z_bct( r1, d2, Z_R0, b2);}
+inline void Assembler::z_bctg(Register r1, int64_t d2, Register b2) { z_bctg(r1, d2, Z_R0, b2);}
 
 // Instruction len bits must be stored right-justified in argument.
 inline unsigned int Assembler::instr_len(unsigned char len_bits) {


### PR DESCRIPTION
Adds support for BCT, BCTG, BCTR instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333412](https://bugs.openjdk.org/browse/JDK-8333412): [s390x] Add support for branch on count instruction (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19572/head:pull/19572` \
`$ git checkout pull/19572`

Update a local copy of the PR: \
`$ git checkout pull/19572` \
`$ git pull https://git.openjdk.org/jdk.git pull/19572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19572`

View PR using the GUI difftool: \
`$ git pr show -t 19572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19572.diff">https://git.openjdk.org/jdk/pull/19572.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19572#issuecomment-2151482353)