### PR TITLE
8333522: JFR SwapSpace event might read wrong free swap space size

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -315,6 +315,7 @@ static jlong host_free_swap() {
 
 jlong os::free_swap_space() {
   jlong host_free_swap_val = MIN2(os::total_swap_space(), host_free_swap());
+  assert(host_free_swap_val >= 0, "sysinfo failed?")
   if (OSContainer::is_containerized()) {
     jlong mem_swap_limit = OSContainer::memory_and_swap_limit_in_bytes();
     jlong mem_limit = OSContainer::memory_limit_in_bytes();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -314,6 +314,8 @@ static jlong host_free_swap() {
 }
 
 jlong os::free_swap_space() {
+  // os::total_swap_space() might return the containerized limit which might be
+  // less than host_free_swap(). The upper bound of free swap needs to be the lower of the two.
   jlong host_free_swap_val = MIN2(os::total_swap_space(), host_free_swap());
   assert(host_free_swap_val >= 0, "sysinfo failed?");
   if (OSContainer::is_containerized()) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -314,7 +314,7 @@ static jlong host_free_swap() {
 }
 
 jlong os::free_swap_space() {
-  jlong host_free_swap_val = host_free_swap();
+  jlong host_free_swap_val = MIN2(os::total_swap_space(), host_free_swap());
   if (OSContainer::is_containerized()) {
     jlong mem_swap_limit = OSContainer::memory_and_swap_limit_in_bytes();
     jlong mem_limit = OSContainer::memory_limit_in_bytes();

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -315,7 +315,7 @@ static jlong host_free_swap() {
 
 jlong os::free_swap_space() {
   jlong host_free_swap_val = MIN2(os::total_swap_space(), host_free_swap());
-  assert(host_free_swap_val >= 0, "sysinfo failed?")
+  assert(host_free_swap_val >= 0, "sysinfo failed?");
   if (OSContainer::is_containerized()) {
     jlong mem_swap_limit = OSContainer::memory_and_swap_limit_in_bytes();
     jlong mem_limit = OSContainer::memory_limit_in_bytes();


### PR DESCRIPTION
In some cgroups v2 based test system , a too large free swap space value has been observed.
The value should not be larger than total swap space.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333522](https://bugs.openjdk.org/browse/JDK-8333522): JFR SwapSpace event might read wrong free swap space size (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19574/head:pull/19574` \
`$ git checkout pull/19574`

Update a local copy of the PR: \
`$ git checkout pull/19574` \
`$ git pull https://git.openjdk.org/jdk.git pull/19574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19574`

View PR using the GUI difftool: \
`$ git pr show -t 19574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19574.diff">https://git.openjdk.org/jdk/pull/19574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19574#issuecomment-2151822938)