### PR TITLE
8333713: C2 SuperWord: cleanup in vectornode.cpp/hpp

### DIFF
--- a/src/hotspot/share/opto/vectornode.hpp
+++ b/src/hotspot/share/opto/vectornode.hpp
@@ -96,12 +96,10 @@ class VectorNode : public TypeNode {
   static int scalar_opcode(int vopc, BasicType bt);  // vector_opc -> scalar_opc
 
   // Limits on vector size (number of elements) for auto-vectorization.
-  static bool vector_size_supported_superword(const BasicType bt, int size);
+  static bool vector_size_supported_auto_vectorization(const BasicType bt, int size);
   static bool implemented(int opc, uint vlen, BasicType bt);
   static bool is_shift(Node* n);
   static bool is_vshift_cnt(Node* n);
-  static bool is_type_transition_short_to_int(Node* n);
-  static bool is_type_transition_to_int(Node* n);
   static bool is_muladds2i(const Node* n);
   static bool is_roundopD(Node* n);
   static bool is_scalar_rotate(Node* n);


### PR DESCRIPTION
Removed dead code and renamed `superword` -> `auto_vectorization`, just like I had done in [JDK-8324750](https://bugs.openjdk.org/browse/JDK-8324750).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333713](https://bugs.openjdk.org/browse/JDK-8333713): C2 SuperWord: cleanup in vectornode.cpp/hpp (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19575/head:pull/19575` \
`$ git checkout pull/19575`

Update a local copy of the PR: \
`$ git checkout pull/19575` \
`$ git pull https://git.openjdk.org/jdk.git pull/19575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19575`

View PR using the GUI difftool: \
`$ git pr show -t 19575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19575.diff">https://git.openjdk.org/jdk/pull/19575.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19575#issuecomment-2152132159)