### PR TITLE
8333714: Cleanup the usages of CHECK_EXCEPTION_NULL_FAIL macro in java launcher

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -388,11 +388,9 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     } while (JNI_FALSE)
 
 /*
- * Locates a static main(String[]) method and invokes that method.
- * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
- * the method was not found.
- * Any exception thrown while locating the method or from within the invoked main
- * method will be available through ExceptionOccurred(JNIEnv *env).
+ * Invokes static main(String[]) method if found.
+ * Returns 0 with a pending exception if not found. Returns 1 if invoked, maybe
+ * a pending exception if the method threw.
  */
 int
 invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
@@ -407,11 +405,9 @@ invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
 }
 
 /*
- * Locates a main(String[]) instance method and invokes that method.
- * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
- * the method was not found.
- * Any exception thrown while locating the method or from within the invoked main
- * method will be available through ExceptionOccurred(JNIEnv *env).
+ * Invokes instance main(String[]) method if found.
+ * Returns 0 with a pending exception if not found. Returns 1 if invoked, maybe
+ * a pending exception if the method threw.
  */
 int
 invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
@@ -436,11 +432,9 @@ invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs)
 }
 
 /*
- * Locates a no-arg static "main" method and invokes that method.
- * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
- * the method was not found.
- * Any exception thrown while locating the method or from within the invoked main
- * method will be available through ExceptionOccurred(JNIEnv *env).
+ * Invokes no-arg static main() method if found.
+ * Returns 0 with a pending exception if not found. Returns 1 if invoked, maybe
+ * a pending exception if the method threw.
  */
 int
 invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
@@ -455,11 +449,9 @@ invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
 }
 
 /*
- * Locates a no-arg instance method "main" and invokes that method.
- * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
- * the method could not be found.
- * Any exception thrown while locating the method or from within the invoked main
- * method will be available through ExceptionOccurred(JNIEnv *env).
+ * Invokes no-arg instance main() method if found.
+ * Returns 0 with a pending exception if not found. Returns 1 if invoked, maybe
+ * a pending exception if the method threw.
  */
 int
 invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -388,12 +388,11 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     } while (JNI_FALSE)
 
 /*
- * Locates, on the mainClass, a static method named "main" which takes String[]
- * as an argument and invokes that method. Returns 1 (true) if the method was found
- * and invoked. Returns 0 (false) if the method could not be found. If an exception
- * occurred while trying to locate the method or the invoked main method threw an
- * exception, then that exception will be available through the
- * ExceptionOccurred(JNIEnv *env) JNI method.
+ * Locates a static main(String[]) method and invokes that method.
+ * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
+ * the method was not found.
+ * Any exception thrown while locating the method or from within the invoked main
+ * method will be available through ExceptionOccurred(JNIEnv *env).
  */
 int
 invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
@@ -408,12 +407,11 @@ invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
 }
 
 /*
- * Locates, on the mainClass, an instance method named "main" which takes String[]
- * as an argument and invokes that method. Returns 1 (true) if the method was found
- * and invoked. Returns 0 (false) if the method could not be found. If an exception
- * occurred while trying to locate the method or the invoked main method threw an
- * exception, then that exception will be available through the
- * ExceptionOccurred(JNIEnv *env) JNI method.
+ * Locates a main(String[]) instance method and invokes that method.
+ * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
+ * the method was not found.
+ * Any exception thrown while locating the method or from within the invoked main
+ * method will be available through ExceptionOccurred(JNIEnv *env).
  */
 int
 invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
@@ -438,12 +436,11 @@ invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs)
 }
 
 /*
- * Locates, on the mainClass, a static method named "main" which takes no arguments
- * and invokes that method. Returns 1 (true) if the method was found
- * and invoked. Returns 0 (false) if the method could not be found. If an exception
- * occurred while trying to locate the method or the invoked main method threw an
- * exception, then that exception will be available through the
- * ExceptionOccurred(JNIEnv *env) JNI method.
+ * Locates a no-arg static "main" method and invokes that method.
+ * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
+ * the method was not found.
+ * Any exception thrown while locating the method or from within the invoked main
+ * method will be available through ExceptionOccurred(JNIEnv *env).
  */
 int
 invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
@@ -458,12 +455,11 @@ invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
 }
 
 /*
- * Locates, on the mainClass, an instance method named "main" which takes no arguments
- * and invokes that method. Returns 1 (true) if the method was found
- * and invoked. Returns 0 (false) if the method could not be found. If an exception
- * occurred while trying to locate the method or the invoked main method threw an
- * exception, then that exception will be available through the
- * ExceptionOccurred(JNIEnv *env) JNI method.
+ * Locates a no-arg instance method "main" and invokes that method.
+ * Returns 1 (true) if the method was found and invoked. Returns 0 (false) if
+ * the method could not be found.
+ * Any exception thrown while locating the method or from within the invoked main
+ * method will be available through ExceptionOccurred(JNIEnv *env).
  */
 int
 invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -387,73 +387,104 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
         } \
     } while (JNI_FALSE)
 
-#define CHECK_EXCEPTION_NULL_FAIL(obj) \
-    do { \
-        if ((*env)->ExceptionOccurred(env)) { \
-            return 0; \
-        } else if (obj == NULL) { \
-            return 0; \
-        } \
-    } while (JNI_FALSE)
-
 /*
- * Invoke a static main with arguments. Returns 1 (true) if successful otherwise
- * processes the pending exception from GetStaticMethodID and returns 0 (false).
+ * Locates, on the mainClass, a static method named "main" which takes String[]
+ * as an argument and invokes that method. Returns 1 (true) if the method was found
+ * and invoked. Returns 0 (false) if the method could not be found. If an exception
+ * occurred while trying to locate the method or the invoked main method threw an
+ * exception, then that exception will be available through the
+ * ExceptionOccurred(JNIEnv *env) JNI method.
  */
 int
 invokeStaticMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
     jmethodID mainID = (*env)->GetStaticMethodID(env, mainClass, "main",
                                   "([Ljava/lang/String;)V");
-    CHECK_EXCEPTION_NULL_FAIL(mainID);
+    if (mainID == NULL) {
+        // static main(String[]) not found
+        return 0;
+    }
     (*env)->CallStaticVoidMethod(env, mainClass, mainID, mainArgs);
-    return 1;
+    return 1; // method was invoked
 }
 
 /*
- * Invoke an instance main with arguments. Returns 1 (true) if successful otherwise
- * processes the pending exception from GetMethodID and returns 0 (false).
+ * Locates, on the mainClass, an instance method named "main" which takes String[]
+ * as an argument and invokes that method. Returns 1 (true) if the method was found
+ * and invoked. Returns 0 (false) if the method could not be found. If an exception
+ * occurred while trying to locate the method or the invoked main method threw an
+ * exception, then that exception will be available through the
+ * ExceptionOccurred(JNIEnv *env) JNI method.
  */
 int
 invokeInstanceMainWithArgs(JNIEnv *env, jclass mainClass, jobjectArray mainArgs) {
     jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
-    CHECK_EXCEPTION_NULL_FAIL(constructor);
+    if (constructor == NULL) {
+        // main class' no-arg constructor not found
+        return 0;
+    }
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
-    CHECK_EXCEPTION_NULL_FAIL(mainObject);
+    if (mainObject == NULL) {
+        // main class instance couldn't be constructed
+        return 0;
+    }
     jmethodID mainID =
         (*env)->GetMethodID(env, mainClass, "main", "([Ljava/lang/String;)V");
-    CHECK_EXCEPTION_NULL_FAIL(mainID);
+    if (mainID == NULL) {
+        // instance method main(String[]) method not found
+        return 0;
+    }
     (*env)->CallVoidMethod(env, mainObject, mainID, mainArgs);
-    return 1;
+    return 1; // method was invoked
 }
 
 /*
- * Invoke a static main without arguments. Returns 1 (true) if successful otherwise
- * processes the pending exception from GetStaticMethodID and returns 0 (false).
+ * Locates, on the mainClass, a static method named "main" which takes no arguments
+ * and invokes that method. Returns 1 (true) if the method was found
+ * and invoked. Returns 0 (false) if the method could not be found. If an exception
+ * occurred while trying to locate the method or the invoked main method threw an
+ * exception, then that exception will be available through the
+ * ExceptionOccurred(JNIEnv *env) JNI method.
  */
 int
 invokeStaticMainWithoutArgs(JNIEnv *env, jclass mainClass) {
     jmethodID mainID = (*env)->GetStaticMethodID(env, mainClass, "main",
                                        "()V");
-    CHECK_EXCEPTION_NULL_FAIL(mainID);
+    if (mainID == NULL) {
+        // static main() method couldn't be located
+        return 0;
+    }
     (*env)->CallStaticVoidMethod(env, mainClass, mainID);
-    return 1;
+    return 1; // method was invoked
 }
 
 /*
- * Invoke an instance main without arguments. Returns 1 (true) if successful otherwise
- * processes the pending exception from GetMethodID and returns 0 (false).
+ * Locates, on the mainClass, an instance method named "main" which takes no arguments
+ * and invokes that method. Returns 1 (true) if the method was found
+ * and invoked. Returns 0 (false) if the method could not be found. If an exception
+ * occurred while trying to locate the method or the invoked main method threw an
+ * exception, then that exception will be available through the
+ * ExceptionOccurred(JNIEnv *env) JNI method.
  */
 int
 invokeInstanceMainWithoutArgs(JNIEnv *env, jclass mainClass) {
     jmethodID constructor = (*env)->GetMethodID(env, mainClass, "<init>", "()V");
-    CHECK_EXCEPTION_NULL_FAIL(constructor);
+    if (constructor == NULL) {
+        // main class' no-arg constructor not found
+        return 0;
+    }
     jobject mainObject = (*env)->NewObject(env, mainClass, constructor);
-    CHECK_EXCEPTION_NULL_FAIL(mainObject);
+    if (mainObject == NULL) {
+        // couldn't create instance of main class
+        return 0;
+    }
     jmethodID mainID = (*env)->GetMethodID(env, mainClass, "main",
                                  "()V");
-    CHECK_EXCEPTION_NULL_FAIL(mainID);
+    if (mainID == NULL) {
+        // instance method main() not found
+        return 0;
+    }
     (*env)->CallVoidMethod(env, mainObject, mainID);
-    return 1;
+    return 1; // method was invoked
 }
 
 int
@@ -639,6 +670,8 @@ JavaMain(void* _args)
         }
     }
     if (!ret) {
+        // An appropriate main method couldn't be located, check and report
+        // any exception and LEAVE()
         CHECK_EXCEPTION_LEAVE(1);
     }
 
@@ -646,8 +679,15 @@ JavaMain(void* _args)
      * The launcher's exit code (in the absence of calls to
      * System.exit) will be non-zero if main threw an exception.
      */
-    ret = (*env)->ExceptionOccurred(env) == NULL ? 0 : 1;
-
+    if (ret && (*env)->ExceptionOccurred(env) == NULL) {
+        // main method was invoked and no exception was thrown from it,
+        // return success.
+        ret = 0;
+    } else {
+        // Either the main method couldn't be located or an exception occurred
+        // in the invoked main method, return failure.
+        ret = 1;
+    }
     LEAVE();
 }
 


### PR DESCRIPTION
Can I please get a review for this change which proposes to remove the `CHECK_EXCEPTION_NULL_FAIL` macro from the `java` launcher code?

This addresses https://bugs.openjdk.org/browse/JDK-8333714. As noted in that JBS issue, in a recent PR discussion, it was suggested https://github.com/openjdk/jdk/pull/18786#issuecomment-2147452633 that this macro should be removed and the failure of a JNI specified operation (the ones for which this macro is being used) should be determined based on a `NULL` value returned from that function. The commit in this PR removes this macros and updates the call sites to do a `NULL` check.

Given the nature of this change, no new tests have been added. tier1, tier2 and tier3 testing passed successfully with these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333714](https://bugs.openjdk.org/browse/JDK-8333714): Cleanup the usages of CHECK_EXCEPTION_NULL_FAIL macro in java launcher (**Task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19576/head:pull/19576` \
`$ git checkout pull/19576`

Update a local copy of the PR: \
`$ git checkout pull/19576` \
`$ git pull https://git.openjdk.org/jdk.git pull/19576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19576`

View PR using the GUI difftool: \
`$ git pr show -t 19576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19576.diff">https://git.openjdk.org/jdk/pull/19576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19576#issuecomment-2152433096)