### PR TITLE
8333721: C2: vectorization causes incorrect execution with unsafe and negative scale

### DIFF
--- a/src/hotspot/share/opto/vectorization.cpp
+++ b/src/hotspot/share/opto/vectorization.cpp
@@ -586,8 +586,18 @@ bool VPointer::scaled_iv_plus_offset(Node* n) {
       NOT_PRODUCT(_tracer.scaled_iv_plus_offset_6(n);)
       return true;
     }
-    if (offset_plus_k(n->in(1)) && scaled_iv_plus_offset(n->in(2))) {
-      _scale *= -1;
+    VPointer tmp(this);
+    if (offset_plus_k(n->in(1)) && tmp.scaled_iv_plus_offset(n->in(2))) {
+      assert(_scale == 0, "shouldn't be set yet");
+      _scale = tmp._scale * -1;
+      _offset -= tmp._offset;
+      if (tmp._invar != nullptr) {
+        maybe_add_to_invar(tmp._invar, true);
+#ifdef ASSERT
+        _debug_invar_scale = tmp._debug_invar_scale;
+        _debug_negate_invar = !tmp._debug_negate_invar;
+#endif
+      }
       NOT_PRODUCT(_tracer.scaled_iv_plus_offset_7(n);)
       return true;
     }

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorizationUnsafeNegativeScale.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorizationUnsafeNegativeScale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public class TestVectorizationUnsafeNegativeScale {
             }
         }
     }
-    
+
     static short[] shortArray = new short[1000];
 
     @Test
@@ -137,4 +137,3 @@ public class TestVectorizationUnsafeNegativeScale {
         }
     }
 }
-    

--- a/test/hotspot/jtreg/compiler/vectorization/TestVectorizationUnsafeNegativeScale.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestVectorizationUnsafeNegativeScale.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2018, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ *
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ * @requires vm.compiler2.enabled
+ * @run driver compiler.vectorization.TestVectorizationUnsafeNegativeScale
+ *
+ */
+
+package compiler.vectorization;
+
+import java.util.Arrays;
+import jdk.internal.misc.Unsafe;
+import compiler.lib.ir_framework.*;
+
+public class TestVectorizationUnsafeNegativeScale {
+
+    static Unsafe unsafe = Unsafe.getUnsafe();
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
+    }
+
+    static byte[] byteArray = new byte[1000];
+
+    @Test
+    @IR(counts = { IRNode.STORE_VECTOR , ">= 1"})
+    private static void testByteArray(byte[] array, int start) {
+        for (int i = start; i < array.length; i++) {
+            final long idx = (long)array.length - (long)(i + 1);
+            final long offset = Unsafe.ARRAY_BYTE_BASE_OFFSET + idx * Unsafe.ARRAY_BYTE_INDEX_SCALE;
+            unsafe.putByte(array, offset, (byte) 0x42);
+        }
+    }
+
+    @Run(test = "testByteArray")
+    private static void testByteArrayRunner() {
+        Arrays.fill(byteArray, (byte)0);
+        testByteArray(byteArray, 0);
+        for (int j = 0; j < byteArray.length; j++) {
+            if (byteArray[j] != 0x42) {
+                throw new RuntimeException("For index " + j + ": " + byteArray[j]);
+            }
+        }
+    }
+    
+    static short[] shortArray = new short[1000];
+
+    @Test
+    @IR(counts = { IRNode.STORE_VECTOR , ">= 1"})
+    private static void testShortArray(short[] array, int start) {
+        for (int i = start; i < array.length; i++) {
+            final long idx = (long)array.length - (long)(i + 1);
+            final long offset = Unsafe.ARRAY_SHORT_BASE_OFFSET + idx * Unsafe.ARRAY_SHORT_INDEX_SCALE;
+            unsafe.putShort(array, offset, (short) 0x42);
+        }
+    }
+
+    @Run(test = "testShortArray")
+    private static void testShortArrayRunner() {
+        Arrays.fill(shortArray, (short)0);
+        testShortArray(shortArray, 0);
+        for (int j = 0; j < shortArray.length; j++) {
+            if (shortArray[j] != 0x42) {
+                throw new RuntimeException("For index " + j + ": " + shortArray[j]);
+            }
+        }
+    }
+
+    static int[] intArray = new int[1000];
+
+    @Test
+    @IR(counts = { IRNode.STORE_VECTOR , ">= 1"})
+    private static void testIntArray(int[] array, int start) {
+        for (int i = start; i < array.length; i++) {
+            final long idx = (long)array.length - (long)(i + 1);
+            final long offset = Unsafe.ARRAY_INT_BASE_OFFSET + idx * Unsafe.ARRAY_INT_INDEX_SCALE;
+            unsafe.putInt(array, offset, (int) 0x42);
+        }
+    }
+
+    @Run(test = "testIntArray")
+    private static void testIntArrayRunner() {
+        Arrays.fill(intArray, (int)0);
+        testIntArray(intArray, 0);
+        for (int j = 0; j < intArray.length; j++) {
+            if (intArray[j] != 0x42) {
+                throw new RuntimeException("For index " + j + ": " + intArray[j]);
+            }
+        }
+    }
+
+    static long[] longArray = new long[1000];
+
+    @Test
+    @IR(counts = { IRNode.STORE_VECTOR , ">= 1"})
+    private static void testLongArray(long[] array, int start) {
+        for (int i = start; i < array.length; i++) {
+            final long idx = (long)array.length - (long)(i + 1);
+            final long offset = Unsafe.ARRAY_LONG_BASE_OFFSET + idx * Unsafe.ARRAY_LONG_INDEX_SCALE;
+            unsafe.putLong(array, offset, (long) 0x42);
+        }
+    }
+
+    @Run(test = "testLongArray")
+    private static void testLongArrayRunner() {
+        Arrays.fill(longArray, (long)0);
+        testLongArray(longArray, 0);
+        for (int j = 0; j < longArray.length; j++) {
+            if (longArray[j] != 0x42) {
+                throw new RuntimeException("For index " + j + ": " + longArray[j]);
+            }
+        }
+    }
+}
+    


### PR DESCRIPTION
This was initially a regresion from 8324517 (C2: crash in compiled
code because of dependency on removed range check CastIIs): 8332677
(jck test api/java_math/BigInteger/Bitwise.html fails (c2) on
aarch64). A simplified test case for that one is:

```
private static void test1(byte[] array, int start) {
    for (int i = start; i < array.length; i++) {
        array[array.length - i - 1] = 0x42;
    }
}
```

That method is vectorized but with 8324517, the resulting compiled
code is incorrect. I don't think that failure can be reproduced
without 8324517 other than by using unsafe which is what the included
test case does (I'll include the test method above in the redo of
8324517).

The bug is that `VPointer::scaled_iv_plus_offset()` computes an
incorrect offset when `n` is a `Sub` node and the scaled iv is on
input 2 of the `Sub` node and input 2 also includes an offset
component. In that case, the offset from input 2 is added to the
`VPointer` instead of being subtracted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333721](https://bugs.openjdk.org/browse/JDK-8333721): C2: vectorization causes incorrect execution with unsafe and negative scale (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19577/head:pull/19577` \
`$ git checkout pull/19577`

Update a local copy of the PR: \
`$ git checkout pull/19577` \
`$ git pull https://git.openjdk.org/jdk.git pull/19577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19577`

View PR using the GUI difftool: \
`$ git pr show -t 19577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19577.diff">https://git.openjdk.org/jdk/pull/19577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19577#issuecomment-2152508502)