### PR TITLE
8332537: C2: High memory usage reported for compiler/loopopts/superword/TestAlignVectorFuzzer.java

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java
@@ -30,7 +30,6 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
- *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
  *                                 compiler.loopopts.superword.TestAlignVectorFuzzer
@@ -45,7 +44,6 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
- *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
@@ -62,7 +60,6 @@
  * @requires vm.bits == 64
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
- *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*
@@ -79,7 +76,6 @@
  * @requires vm.compiler2.enabled
  * @key randomness
  * @run main/bootclasspath/othervm -XX:+IgnoreUnrecognizedVMOptions
- *                                 -XX:CompileCommand=MemLimit,*.*,0
  *                                 -XX:+AlignVector -XX:+VerifyAlignVector
  *                                 -XX:LoopUnrollLimit=250
  *                                 -XX:CompileCommand=printcompilation,compiler.loopopts.superword.TestAlignVectorFuzzer::*


### PR DESCRIPTION
This bug was a regression of:
[JDK-8324517](https://bugs.openjdk.org/browse/JDK-8324517); C2: crash in compiled code because of dependency on removed range check CastIIs

That change was backed out with:
[JDK-8332829](https://bugs.openjdk.org/browse/JDK-8332829): [BACKOUT] C2: crash in compiled code because of dependency on removed range check CastIIs

I `git revert` ed the BACKOUT change:
[JDK-8332829](https://bugs.openjdk.org/browse/JDK-8332829): [BACKOUT] C2: crash in compiled code because of dependency on removed range check CastIIs

And only then this reproduced (not on master, only with Roland's CastII regression code):
`~/Documents/jtreg/bin/jtreg -va -s -jdk:/oracle-work/jdk-fork2/build/linux-x64-debug/jdk -javaoptions:"-Djdk.test.lib.random.seed=3249981201344669190" -J-Djavatest.maxOutputSize=10000000 /oracle-work/jdk-fork2/open/test/hotspot/jtreg/compiler/loopopts/superword/TestAlignVectorFuzzer.java`

Now that we know that it is a regression of a backed-out change, we can enable the MemLimit check again.

Also the stack-traces were related to CastII code, and looked very similar to those in another duplicate:
[JDK-8332765](https://bugs.openjdk.org/browse/JDK-8332765): Test compiler/loopopts/superword/TestAlignVectorFuzzer.java still times out after JDK-8327978

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332537](https://bugs.openjdk.org/browse/JDK-8332537): C2: High memory usage reported for compiler/loopopts/superword/TestAlignVectorFuzzer.java (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19580/head:pull/19580` \
`$ git checkout pull/19580`

Update a local copy of the PR: \
`$ git checkout pull/19580` \
`$ git pull https://git.openjdk.org/jdk.git pull/19580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19580`

View PR using the GUI difftool: \
`$ git pr show -t 19580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19580.diff">https://git.openjdk.org/jdk/pull/19580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19580#issuecomment-2152730527)