### PR TITLE
8333599: Improve description of \b matcher in j.u.r.Pattern

### DIFF
--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -160,7 +160,7 @@ import jdk.internal.util.regex.Grapheme;
  *     <td headers="matches predef any">Any character (may or may not match <a href="#lt">line terminators</a>)</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="digit">{@code \d}</th>
  *     <td headers="matches predef digit">A digit: {@code [0-9]} if <a href="#UNICODE_CHARACTER_CLASS">
- *  *         UNICODE_CHARACTER_CLASS</a> is not set. See <a href="#unicodesupport">Unicode Support</a>.</td></tr>
+ *          UNICODE_CHARACTER_CLASS</a> is not set. See <a href="#unicodesupport">Unicode Support</a>.</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="non_digit">{@code \D}</th>
  *     <td headers="matches predef non_digit">A non-digit: {@code [^0-9]}</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="horiz_white">{@code \h}</th>
@@ -251,8 +251,9 @@ import jdk.internal.util.regex.Grapheme;
  * <tr><th style="vertical-align:top; font-weight:normal" id="end_line">{@code $}</th>
  *     <td headers="matches bounds end_line">The end of a line</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="word_boundary">{@code \b}</th>
- *     <td headers="matches bounds word_boundary">A word boundary: {@code (?:(?<=\w)(?=\W)|(?<=\W)(?=\w))} (the location
- *     where a non-word character abuts a word character)</td></tr>
+ *     <td headers="matches bounds word_boundary">A word boundary:
+ *     at the beginning or at the end of a line if a word character ({@code \w}) appears there;
+ *     or between a word ({@code \w}) and a non-word character ({@code \W}), in either order.</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="grapheme_cluster_boundary">{@code \b{g}}</th>
  *     <td headers="matches bounds grapheme_cluster_boundary">A Unicode extended grapheme cluster boundary</td></tr>
  * <tr><th style="vertical-align:top; font-weight:normal" id="non_word_boundary">{@code \B}</th>


### PR DESCRIPTION
A documentation-only change to match the original intent and the implemented behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8333782](https://bugs.openjdk.org/browse/JDK-8333782) to be approved

### Issues
 * [JDK-8333599](https://bugs.openjdk.org/browse/JDK-8333599): Improve description of \b matcher in j.u.r.Pattern (**Bug** - P4)
 * [JDK-8333782](https://bugs.openjdk.org/browse/JDK-8333782): Improve description of \b matcher in j.u.r.Pattern (**CSR**)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19583/head:pull/19583` \
`$ git checkout pull/19583`

Update a local copy of the PR: \
`$ git checkout pull/19583` \
`$ git pull https://git.openjdk.org/jdk.git pull/19583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19583`

View PR using the GUI difftool: \
`$ git pr show -t 19583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19583.diff">https://git.openjdk.org/jdk/pull/19583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19583#issuecomment-2153135571)