### PR TITLE
8333743: Change .jcheck/conf branches property to match valid branches

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -9,7 +9,7 @@ warning=issuestitle
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)
-branches=
+branches=.*
 
 [census]
 version=0


### PR DESCRIPTION
Clean backport of `.jcheck/conf` change to jdk23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333743](https://bugs.openjdk.org/browse/JDK-8333743): Change .jcheck/conf branches property to match valid branches (**Bug** - P2)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19584/head:pull/19584` \
`$ git checkout pull/19584`

Update a local copy of the PR: \
`$ git checkout pull/19584` \
`$ git pull https://git.openjdk.org/jdk.git pull/19584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19584`

View PR using the GUI difftool: \
`$ git pr show -t 19584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19584.diff">https://git.openjdk.org/jdk/pull/19584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19584#issuecomment-2153149058)