### PR TITLE
8333742: ProcessImpl and ProcessHandleImpl may mishandle processes that exit with code 259

### DIFF
--- a/src/java.base/windows/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/windows/classes/java/lang/ProcessImpl.java
@@ -557,8 +557,14 @@ final class ProcessImpl extends Process {
 
     public int exitValue() {
         int exitCode = getExitCodeProcess(handle);
-        if (exitCode == STILL_ACTIVE)
-            throw new IllegalThreadStateException("process has not exited");
+        if (exitCode == STILL_ACTIVE) {
+            // STILL_ACTIVE (259) might be the real exit code
+            if (isProcessAlive(handle)) {
+                throw new IllegalThreadStateException("process has not exited");
+            }
+            // call again, in case the process just exited
+            return getExitCodeProcess(handle);
+        }
         return exitCode;
     }
     private static native int getExitCodeProcess(long handle);

--- a/src/java.base/windows/classes/java/lang/ProcessImpl.java
+++ b/src/java.base/windows/classes/java/lang/ProcessImpl.java
@@ -588,7 +588,7 @@ final class ProcessImpl extends Process {
         throws InterruptedException
     {
         long remainingNanos = unit.toNanos(timeout);    // throw NPE before other conditions
-        if (getExitCodeProcess(handle) != STILL_ACTIVE) return true;
+        if (!isProcessAlive(handle)) return true;
         if (timeout <= 0) return false;
 
         long deadline = System.nanoTime() + remainingNanos;
@@ -607,13 +607,13 @@ final class ProcessImpl extends Process {
             }
             if (Thread.interrupted())
                 throw new InterruptedException();
-            if (getExitCodeProcess(handle) != STILL_ACTIVE) {
+            if (!isProcessAlive(handle)) {
                 return true;
             }
             remainingNanos = deadline - System.nanoTime();
         } while (remainingNanos > 0);
 
-        return (getExitCodeProcess(handle) != STILL_ACTIVE);
+        return !isProcessAlive(handle);
     }
 
     private static native void waitForTimeoutInterruptibly(

--- a/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
+++ b/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
@@ -118,7 +118,7 @@ Java_java_lang_ProcessHandleImpl_waitForProcessExit0(JNIEnv* env,
         events[1] = JVM_GetThreadInterruptEvent();
         // Interrupt and process termination are treated equally.
         // In case of an interrupt, if the process is still active,
-        // returned exit code is incorrect.
+        // the method returns STILL_ACTIVE (259).
         if (WaitForMultipleObjects(sizeof(events)/sizeof(events[0]), events,
                                    FALSE,    /* Wait for ANY event */
                                    INFINITE) /* Wait forever */

--- a/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
+++ b/src/java.base/windows/native/libjava/ProcessHandleImpl_win.c
@@ -113,18 +113,10 @@ Java_java_lang_ProcessHandleImpl_waitForProcessExit0(JNIEnv* env,
         JNU_ThrowByNameWithLastError(env,
             "java/lang/RuntimeException", "GetExitCodeProcess");
     } else if (exitValue == STILL_ACTIVE) {
-        HANDLE events[2];
-        events[0] = handle;
-        events[1] = JVM_GetThreadInterruptEvent();
-        // Interrupt and process termination are treated equally.
-        // In case of an interrupt, if the process is still active,
-        // the method returns STILL_ACTIVE (259).
-        if (WaitForMultipleObjects(sizeof(events)/sizeof(events[0]), events,
-                                   FALSE,    /* Wait for ANY event */
-                                   INFINITE) /* Wait forever */
-                == WAIT_FAILED) {
+        if (WaitForSingleObject(handle, INFINITE) /* Wait forever */
+            == WAIT_FAILED) {
             JNU_ThrowByNameWithLastError(env,
-                "java/lang/RuntimeException", "WaitForMultipleObjects");
+                "java/lang/RuntimeException", "WaitForSingleObjects");
         } else if (!GetExitCodeProcess(handle, &exitValue)) {
             JNU_ThrowByNameWithLastError(env,
                 "java/lang/RuntimeException", "GetExitCodeProcess");

--- a/src/java.base/windows/native/libjava/ProcessImpl_md.c
+++ b/src/java.base/windows/native/libjava/ProcessImpl_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -467,9 +467,8 @@ Java_java_lang_ProcessImpl_terminateProcess(JNIEnv *env, jclass ignored, jlong h
 JNIEXPORT jboolean JNICALL
 Java_java_lang_ProcessImpl_isProcessAlive(JNIEnv *env, jclass ignored, jlong handle)
 {
-    DWORD dwExitStatus;
-    GetExitCodeProcess((HANDLE) handle, &dwExitStatus);
-    return dwExitStatus == STILL_ACTIVE;
+    return WaitForSingleObject((HANDLE) handle, 0) /* don't wait */
+                       == WAIT_TIMEOUT;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import org.testng.TestNG;
 
 /*
  * @test
+ * @bug 8333742
  * @requires vm.flagless
  * @library /test/lib
  * @modules jdk.management
@@ -65,7 +66,7 @@ public class OnExitTest extends ProcessUtil {
     @Test
     public static void test1() {
         try {
-            int[] exitValues = {0, 1, 10};
+            int[] exitValues = {0, 1, 10, 259};
             for (int value : exitValues) {
                 Process p = JavaChild.spawn("exit", Integer.toString(value));
                 CompletableFuture<Process> future = p.onExit();

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 
 import org.testng.annotations.Test;
@@ -68,6 +69,8 @@ public class OnExitTest extends ProcessUtil {
         try {
             int[] exitValues = {0, 1, 10, 259};
             for (int value : exitValues) {
+                // Linux & Mac don't support exit codes longer than 8 bits, skip
+                if (value == 259 && !Platform.isWindows()) continue;
                 Process p = JavaChild.spawn("exit", Integer.toString(value));
                 CompletableFuture<Process> future = p.onExit();
                 future.thenAccept( (ph) -> {

--- a/test/jdk/java/lang/ProcessHandle/OnExitTest.java
+++ b/test/jdk/java/lang/ProcessHandle/OnExitTest.java
@@ -82,7 +82,9 @@ public class OnExitTest extends ProcessUtil {
                 Assert.assertEquals(h, p);
                 Assert.assertEquals(p.exitValue(), value);
                 Assert.assertFalse(p.isAlive(), "Process should not be alive");
-                p.waitFor();
+                Assert.assertEquals(p.waitFor(), value);
+                Assert.assertTrue(p.waitFor(1, TimeUnit.MILLISECONDS),
+                        "waitFor should return true");
             }
         } catch (IOException | InterruptedException | ExecutionException ex) {
             Assert.fail(ex.getMessage(), ex);


### PR DESCRIPTION
`GetExitCodeProcess` method is not reliable for checking if a process exited already; it returns 259 (STILL_ACTIVE) if the process hasn't exited yet, but the same value is returned when the process exited with code 259. In order to check if the process exited, we need to check if its handle is in a signaled state using one of the wait methods.

This PR fixes the onExit, exitValue, isAlive, and waitFor(timeout) methods to correctly handle the problematic exit code.

I haven't fixed the ProcessImpl.toString method. I'm not sure the problem is important enough to justify an extra JNI call in the (probably typical) still-alive case.

Tier1-3 testing clean. I modified the existing OnExitTest to cover this case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333742](https://bugs.openjdk.org/browse/JDK-8333742): ProcessImpl and ProcessHandleImpl may mishandle processes that exit with code 259 (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19586/head:pull/19586` \
`$ git checkout pull/19586`

Update a local copy of the PR: \
`$ git checkout pull/19586` \
`$ git pull https://git.openjdk.org/jdk.git pull/19586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19586`

View PR using the GUI difftool: \
`$ git pr show -t 19586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19586.diff">https://git.openjdk.org/jdk/pull/19586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19586#issuecomment-2154490562)