### PR TITLE
8333716: Shenandoah: Check for disarmed method before taking the nmethod lock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -36,13 +36,19 @@
 #include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
+  if (!is_armed(nm)) {
+    // Some other thread got here first and healed the oops
+    // and disarmed the nmethod. No need to continue.
+    return true;
+  }
+
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
   assert(lock != nullptr, "Must be");
   ShenandoahReentrantLocker locker(lock);
 
   if (!is_armed(nm)) {
-    // Some other thread got here first and healed the oops
-    // and disarmed the nmethod.
+    // Some other thread managed to complete while we were
+    // waiting for lock. No need to continue.
     return true;
   }
 


### PR DESCRIPTION
**Notes**
We are spending significant time on acquiring the per-nmethod as all the
threads are in same nmethod.
Adding double-check lock by calling is_armed before lock acquisition.

**Verification**
1. hotspot_gc tests

2. Benchmarking on [c6a.12xlarge](https://aws.amazon.com/ec2/instance-types/c6a/)
**Prior to this PR:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"
[0.697s][info][gc] GC(0) Concurrent marking roots 82.772ms
[0.800s][info][gc] GC(1) Concurrent marking roots 82.675ms
[0.883s][info][gc] GC(2) Concurrent marking roots 67.893ms
[0.976s][info][gc] GC(3) Concurrent marking roots 76.811ms
[1.064s][info][gc] GC(4) Concurrent marking roots 73.170ms
[1.276s][info][gc] GC(5) Concurrent marking roots 68.098ms
[1.386s][info][gc] GC(6) Concurrent marking roots 78.548ms
[1.496s][info][gc] GC(7) Concurrent marking roots 77.666ms
[1.601s][info][gc] GC(8) Concurrent marking roots 69.263ms
[1.714s][info][gc] GC(9) Concurrent marking roots 70.956ms
[1.838s][info][gc] GC(10) Concurrent marking roots 75.879ms
[1.956s][info][gc] GC(11) Concurrent marking roots 71.753ms
[2.085s][info][gc] GC(12) Concurrent marking roots 78.325ms
[2.214s][info][gc] GC(13) Concurrent marking roots 72.238ms
[2.337s][info][gc] GC(14) Concurrent marking roots 75.127ms
```

**After:**

```
dev-dsk-neethp-jdk-2c-ad54955c % jdk/build/linux-x86_64-server-release/images/jdk/bin/java -Xmx1g -Xms1g -XX:+UseShenandoahGC -Xlog:gc ManyThreadsStacks.java 2>&1 | grep "marking roots"  
[0.617s][info][gc] GC(0) Concurrent marking roots 5.553ms
[0.643s][info][gc] GC(1) Concurrent marking roots 3.148ms
[0.666s][info][gc] GC(2) Concurrent marking roots 3.219ms
[0.687s][info][gc] GC(3) Concurrent marking roots 2.796ms
[0.708s][info][gc] GC(4) Concurrent marking roots 2.892ms
[0.946s][info][gc] GC(5) Concurrent marking roots 3.393ms
[1.023s][info][gc] GC(6) Concurrent marking roots 2.710ms
[1.095s][info][gc] GC(7) Concurrent marking roots 2.466ms
[1.173s][info][gc] GC(8) Concurrent marking roots 2.734ms
[1.247s][info][gc] GC(9) Concurrent marking roots 2.706ms
[1.325s][info][gc] GC(10) Concurrent marking roots 2.451ms
[1.397s][info][gc] GC(11) Concurrent marking roots 2.381ms
[1.477s][info][gc] GC(12) Concurrent marking roots 2.411ms
[1.555s][info][gc] GC(13) Concurrent marking roots 2.222ms
[1.628s][info][gc] GC(14) Concurrent marking roots 2.599ms
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716): Shenandoah: Check for disarmed method before taking the nmethod lock (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19587/head:pull/19587` \
`$ git checkout pull/19587`

Update a local copy of the PR: \
`$ git checkout pull/19587` \
`$ git pull https://git.openjdk.org/jdk.git pull/19587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19587`

View PR using the GUI difftool: \
`$ git pr show -t 19587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19587.diff">https://git.openjdk.org/jdk/pull/19587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19587#issuecomment-2153763841)