### PR TITLE
8333774: Avoid eagerly loading various EmptySpliterator classes

### DIFF
--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -86,7 +86,6 @@ public final class Spliterators {
         return EmptySpliterator.OfLong.EMPTY_LONG_SPLITERATOR;
     }
 
-
     /**
      * Creates an empty {@code Spliterator.OfDouble}
      *

--- a/src/java.base/share/classes/java/util/Spliterators.java
+++ b/src/java.base/share/classes/java/util/Spliterators.java
@@ -57,11 +57,8 @@ public final class Spliterators {
      */
     @SuppressWarnings("unchecked")
     public static <T> Spliterator<T> emptySpliterator() {
-        return (Spliterator<T>) EMPTY_SPLITERATOR;
+        return (Spliterator<T>) EmptySpliterator.OfRef.EMPTY_SPLITERATOR;
     }
-
-    private static final Spliterator<Object> EMPTY_SPLITERATOR =
-            new EmptySpliterator.OfRef<>();
 
     /**
      * Creates an empty {@code Spliterator.OfInt}
@@ -73,11 +70,8 @@ public final class Spliterators {
      * @return An empty spliterator
      */
     public static Spliterator.OfInt emptyIntSpliterator() {
-        return EMPTY_INT_SPLITERATOR;
+        return EmptySpliterator.OfInt.EMPTY_INT_SPLITERATOR;
     }
-
-    private static final Spliterator.OfInt EMPTY_INT_SPLITERATOR =
-            new EmptySpliterator.OfInt();
 
     /**
      * Creates an empty {@code Spliterator.OfLong}
@@ -89,11 +83,9 @@ public final class Spliterators {
      * @return An empty spliterator
      */
     public static Spliterator.OfLong emptyLongSpliterator() {
-        return EMPTY_LONG_SPLITERATOR;
+        return EmptySpliterator.OfLong.EMPTY_LONG_SPLITERATOR;
     }
 
-    private static final Spliterator.OfLong EMPTY_LONG_SPLITERATOR =
-            new EmptySpliterator.OfLong();
 
     /**
      * Creates an empty {@code Spliterator.OfDouble}
@@ -105,11 +97,8 @@ public final class Spliterators {
      * @return An empty spliterator
      */
     public static Spliterator.OfDouble emptyDoubleSpliterator() {
-        return EMPTY_DOUBLE_SPLITERATOR;
+        return EmptySpliterator.OfDouble.EMPTY_DOUBLE_SPLITERATOR;
     }
-
-    private static final Spliterator.OfDouble EMPTY_DOUBLE_SPLITERATOR =
-            new EmptySpliterator.OfDouble();
 
     // Array-based spliterators
 
@@ -905,28 +894,40 @@ public final class Spliterators {
         private static final class OfRef<T>
                 extends EmptySpliterator<T, Spliterator<T>, Consumer<? super T>>
                 implements Spliterator<T> {
-            OfRef() { }
+            static final Spliterator<Object> EMPTY_SPLITERATOR =
+                    new EmptySpliterator.OfRef<>();
+
+            private OfRef() { }
         }
 
         @SuppressWarnings("overloads")
         private static final class OfInt
                 extends EmptySpliterator<Integer, Spliterator.OfInt, IntConsumer>
                 implements Spliterator.OfInt {
-            OfInt() { }
+            static final Spliterator.OfInt EMPTY_INT_SPLITERATOR =
+                    new EmptySpliterator.OfInt();
+
+            private OfInt() { }
         }
 
         @SuppressWarnings("overloads")
         private static final class OfLong
                 extends EmptySpliterator<Long, Spliterator.OfLong, LongConsumer>
                 implements Spliterator.OfLong {
-            OfLong() { }
+            static final Spliterator.OfLong EMPTY_LONG_SPLITERATOR =
+                    new EmptySpliterator.OfLong();
+
+            private OfLong() { }
         }
 
         @SuppressWarnings("overloads")
         private static final class OfDouble
                 extends EmptySpliterator<Double, Spliterator.OfDouble, DoubleConsumer>
                 implements Spliterator.OfDouble {
-            OfDouble() { }
+            static final Spliterator.OfDouble EMPTY_DOUBLE_SPLITERATOR =
+                    new EmptySpliterator.OfDouble();
+
+            private OfDouble() { }
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.SingleShotTime)
 @Fork(1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 5, time = 1)
+@Warmup(iterations = 5S, time = 1)
 @Measurement(iterations = 10, time = 2)
 @State(Scope.Benchmark)
 public class ProxyGenBench {

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.SingleShotTime)
 @Fork(1)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 5S, time = 1)
+@Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 2)
 @State(Scope.Benchmark)
 public class ProxyGenBench {


### PR DESCRIPTION
Trivially move a few private static finals to their respective source type to avoid eagerly loading a few small classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333774](https://bugs.openjdk.org/browse/JDK-8333774): Avoid eagerly loading various EmptySpliterator classes (**Enhancement** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [9d19bbe1](https://git.openjdk.org/jdk/pull/19591/files/9d19bbe1650a8de241fb37c37db486c76fe92dcf)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19591/head:pull/19591` \
`$ git checkout pull/19591`

Update a local copy of the PR: \
`$ git checkout pull/19591` \
`$ git pull https://git.openjdk.org/jdk.git pull/19591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19591`

View PR using the GUI difftool: \
`$ git pr show -t 19591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19591.diff">https://git.openjdk.org/jdk/pull/19591.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19591#issuecomment-2154349333)