### PR TITLE
8333786: Serial: Remove SerialHeap::_incremental_collection_failed

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -578,33 +578,6 @@ HeapWord* DefNewGeneration::block_start(const void* p) const {
   return block_start_const(to(), p);
 }
 
-// The last collection bailed out, we are running out of heap space,
-// so we try to allocate the from-space, too.
-HeapWord* DefNewGeneration::allocate_from_space(size_t size) {
-  bool should_try_alloc = should_allocate_from_space() || GCLocker::is_active_and_needs_gc();
-
-  // If the Heap_lock is not locked by this thread, this will be called
-  // again later with the Heap_lock held.
-  bool do_alloc = should_try_alloc && (Heap_lock->owned_by_self() || (SafepointSynchronize::is_at_safepoint() && Thread::current()->is_VM_thread()));
-
-  HeapWord* result = nullptr;
-  if (do_alloc) {
-    result = from()->allocate(size);
-  }
-
-  log_trace(gc, alloc)("DefNewGeneration::allocate_from_space(" SIZE_FORMAT "):  will_fail: %s  heap_lock: %s  free: " SIZE_FORMAT "%s%s returns %s",
-                        size,
-                        SerialHeap::heap()->incremental_collection_will_fail(false /* don't consult_young */) ?
-                          "true" : "false",
-                        Heap_lock->is_locked() ? "locked" : "unlocked",
-                        from()->free(),
-                        should_try_alloc ? "" : "  should_allocate_from_space: NOT",
-                        do_alloc ? "  Heap_lock is not owned by self" : "",
-                        result == nullptr ? "null" : "object");
-
-  return result;
-}
-
 HeapWord* DefNewGeneration::expand_and_allocate(size_t size, bool is_tlab) {
   // We don't attempt to expand the young generation (but perhaps we should.)
   return allocate(size, is_tlab);
@@ -707,21 +680,12 @@ bool DefNewGeneration::collect(bool clear_all_soft_refs) {
     assert(to()->is_empty(), "to space should be empty now");
 
     adjust_desired_tenuring_threshold();
-
-    assert(!heap->incremental_collection_failed(), "Should be clear");
   } else {
     assert(_promo_failure_scan_stack.is_empty(), "post condition");
     _promo_failure_scan_stack.clear(true); // Clear cached segments.
 
     remove_forwarding_pointers();
     log_info(gc, promotion)("Promotion failed");
-    // Add to-space to the list of space to compact
-    // when a promotion failure has occurred.  In that
-    // case there can be live objects in to-space
-    // as a result of a partial evacuation of eden
-    // and from-space.
-    swap_spaces();   // For uniformity wrt ParNewGeneration.
-    heap->set_incremental_collection_failed();
 
     _gc_tracer->report_promotion_failed(_promotion_failed_info);
 
@@ -883,51 +847,10 @@ bool DefNewGeneration::collection_attempt_is_safe() {
 }
 
 void DefNewGeneration::gc_epilogue(bool full) {
-  DEBUG_ONLY(static bool seen_incremental_collection_failed = false;)
-
   assert(!GCLocker::is_active(), "We should not be executing here");
-  // Check if the heap is approaching full after a collection has
-  // been done.  Generally the young generation is empty at
-  // a minimum at the end of a collection.  If it is not, then
-  // the heap is approaching full.
-  SerialHeap* gch = SerialHeap::heap();
-  if (full) {
-    DEBUG_ONLY(seen_incremental_collection_failed = false;)
-    if (!collection_attempt_is_safe() && !_eden_space->is_empty()) {
-      log_trace(gc)("DefNewEpilogue: cause(%s), full, not safe, set_failed, set_alloc_from, clear_seen",
-                            GCCause::to_string(gch->gc_cause()));
-      gch->set_incremental_collection_failed(); // Slight lie: a full gc left us in that state
-      set_should_allocate_from_space(); // we seem to be running out of space
-    } else {
-      log_trace(gc)("DefNewEpilogue: cause(%s), full, safe, clear_failed, clear_alloc_from, clear_seen",
-                            GCCause::to_string(gch->gc_cause()));
-      gch->clear_incremental_collection_failed(); // We just did a full collection
-      clear_should_allocate_from_space(); // if set
-    }
-  } else {
-#ifdef ASSERT
-    // It is possible that incremental_collection_failed() == true
-    // here, because an attempted scavenge did not succeed. The policy
-    // is normally expected to cause a full collection which should
-    // clear that condition, so we should not be here twice in a row
-    // with incremental_collection_failed() == true without having done
-    // a full collection in between.
-    if (!seen_incremental_collection_failed &&
-        gch->incremental_collection_failed()) {
-      log_trace(gc)("DefNewEpilogue: cause(%s), not full, not_seen_failed, failed, set_seen_failed",
-                            GCCause::to_string(gch->gc_cause()));
-      seen_incremental_collection_failed = true;
-    } else if (seen_incremental_collection_failed) {
-      log_trace(gc)("DefNewEpilogue: cause(%s), not full, seen_failed, will_clear_seen_failed",
-                            GCCause::to_string(gch->gc_cause()));
-      seen_incremental_collection_failed = false;
-    }
-#endif // ASSERT
-  }
-
   // update the generation and space performance counters
   update_counters();
-  gch->counters()->update_counters();
+  SerialHeap::heap()->counters()->update_counters();
 }
 
 void DefNewGeneration::update_counters() {
@@ -967,13 +890,6 @@ HeapWord* DefNewGeneration::allocate(size_t word_size, bool is_tlab) {
   // Note that since DefNewGeneration supports lock-free allocation, we
   // have to use it here, as well.
   HeapWord* result = eden()->par_allocate(word_size);
-  if (result == nullptr) {
-    // If the eden is full and the last collection bailed out, we are running
-    // out of heap space, and we try to allocate the from-space, too.
-    // allocate_from_space can't be inlined because that would introduce a
-    // circular dependency at compile time.
-    result = allocate_from_space(word_size);
-  }
   return result;
 }
 

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -225,7 +225,6 @@ class DefNewGeneration: public Generation {
   }
 
   HeapWord* allocate(size_t word_size, bool is_tlab);
-  HeapWord* allocate_from_space(size_t word_size);
 
   HeapWord* par_allocate(size_t word_size, bool is_tlab);
 

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -92,7 +92,6 @@ SerialHeap::SerialHeap() :
     _old_gen(nullptr),
     _rem_set(nullptr),
     _gc_policy_counters(new GCPolicyCounters("Copy:MSC", 2, 2)),
-    _incremental_collection_failed(false),
     _young_manager(nullptr),
     _old_manager(nullptr),
     _eden_pool(nullptr),
@@ -287,8 +286,7 @@ size_t SerialHeap::max_capacity() const {
 bool SerialHeap::should_try_older_generation_allocation(size_t word_size) const {
   size_t young_capacity = _young_gen->capacity_before_gc();
   return    (word_size > heap_word_size(young_capacity))
-         || GCLocker::is_active_and_needs_gc()
-         || incremental_collection_failed();
+         || GCLocker::is_active_and_needs_gc();
 }
 
 HeapWord* SerialHeap::expand_heap_and_allocate(size_t size, bool is_tlab) {

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -91,11 +91,6 @@ private:
 
   GCPolicyCounters* _gc_policy_counters;
 
-  // Indicates that the most recent previous incremental collection failed.
-  // The flag is cleared when an action is taken that might clear the
-  // condition that caused that incremental collection to fail.
-  bool _incremental_collection_failed;
-
   bool do_young_collection(bool clear_soft_refs);
 
   // Reserve aligned space for the heap as needed by the contained generations.
@@ -255,29 +250,6 @@ public:
   // in other generations, it should call this method.
   void save_marks();
 
-  // Returns true if an incremental collection is likely to fail.
-  // We optionally consult the young gen, if asked to do so;
-  // otherwise we base our answer on whether the previous incremental
-  // collection attempt failed with no corrective action as of yet.
-  bool incremental_collection_will_fail(bool consult_young) {
-    // The first disjunct remembers if an incremental collection failed, even
-    // when we thought (second disjunct) that it would not.
-    return incremental_collection_failed() ||
-           (consult_young && !_young_gen->collection_attempt_is_safe());
-  }
-
-  // If a generation bails out of an incremental collection,
-  // it sets this flag.
-  bool incremental_collection_failed() const {
-    return _incremental_collection_failed;
-  }
-  void set_incremental_collection_failed() {
-    _incremental_collection_failed = true;
-  }
-  void clear_incremental_collection_failed() {
-    _incremental_collection_failed = false;
-  }
-
 private:
   // Return true if an allocation should be attempted in the older generation
   // if it fails in the younger generation.  Return false, otherwise.
@@ -289,7 +261,6 @@ private:
   HeapWord* mem_allocate_work(size_t size,
                               bool is_tlab);
 
-private:
   MemoryPool* _eden_pool;
   MemoryPool* _survivor_pool;
   MemoryPool* _old_pool;


### PR DESCRIPTION
Removing logic around incremental-collection failure. Additionally, the decision to use from-space if `!collection_attempt_is_safe() && !_eden_space->is_empty()` can cause heap too full to be handled properly by full-gc, so the support alloc-in-from-space is also removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333786](https://bugs.openjdk.org/browse/JDK-8333786): Serial: Remove SerialHeap::_incremental_collection_failed (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19594/head:pull/19594` \
`$ git checkout pull/19594`

Update a local copy of the PR: \
`$ git checkout pull/19594` \
`$ git pull https://git.openjdk.org/jdk.git pull/19594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19594`

View PR using the GUI difftool: \
`$ git pr show -t 19594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19594.diff">https://git.openjdk.org/jdk/pull/19594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19594#issuecomment-2154562240)