### PR TITLE
8333756: java/lang/instrument/NativeMethodPrefixApp.java failed due to missing intrinsic

### DIFF
--- a/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
@@ -25,6 +25,7 @@
 import java.io.File;
 import java.nio.file.Path;
 import java.lang.management.*;
+import java.util.zip.CRC32;
 
 import bootreporter.*;
 import jdk.test.lib.helpers.ClassFileInstaller;
@@ -96,6 +97,10 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         final OutputAnalyzer oa = ProcessTools.executeTestJava(
                 "--enable-preview", // due to usage of ClassFile API PreviewFeature in the agent
                 "-javaagent:" + agentJar.toString(),
+                // we disable CheckIntrinsic because the NativeMethodPrefixAgent modifies
+                // the native method names, which then causes a failure in the VM check
+                // for the presence of an intrinsic on a @IntrinsicCandidate native method
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:-CheckIntrinsics",
                 NativeMethodPrefixApp.class.getName());
         oa.shouldHaveExitValue(0);
         // make available stdout/stderr in the logs, even in case of successful completion
@@ -109,6 +114,10 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         java.lang.reflect.Array.getLength(new short[5]);
         RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
         System.err.println(mxbean.getVmVendor());
+        // simply load a class containing an @IntrinsicCandidate on a native method
+        // to exercise the VM code which verifies the presence of the intrinsic
+        // implementation for that method
+        System.err.println(new CRC32());
 
         NativeMethodPrefixAgent.checkErrors();
 

--- a/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
+++ b/test/jdk/java/lang/instrument/NativeMethodPrefixApp.java
@@ -97,9 +97,9 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         final OutputAnalyzer oa = ProcessTools.executeTestJava(
                 "--enable-preview", // due to usage of ClassFile API PreviewFeature in the agent
                 "-javaagent:" + agentJar.toString(),
-                // we disable CheckIntrinsic because the NativeMethodPrefixAgent modifies
+                // We disable CheckIntrinsic because the NativeMethodPrefixAgent modifies
                 // the native method names, which then causes a failure in the VM check
-                // for the presence of an intrinsic on a @IntrinsicCandidate native method
+                // for the presence of an intrinsic on a @IntrinsicCandidate native method.
                 "-XX:+UnlockDiagnosticVMOptions", "-XX:-CheckIntrinsics",
                 NativeMethodPrefixApp.class.getName());
         oa.shouldHaveExitValue(0);
@@ -114,9 +114,9 @@ public class NativeMethodPrefixApp implements StringIdCallback {
         java.lang.reflect.Array.getLength(new short[5]);
         RuntimeMXBean mxbean = ManagementFactory.getRuntimeMXBean();
         System.err.println(mxbean.getVmVendor());
-        // simply load a class containing an @IntrinsicCandidate on a native method
+        // Simply load a class containing an @IntrinsicCandidate on a native method
         // to exercise the VM code which verifies the presence of the intrinsic
-        // implementation for that method
+        // implementation for that method.
         System.err.println(new CRC32());
 
         NativeMethodPrefixAgent.checkErrors();


### PR DESCRIPTION
Can I please get a review of this test-only change which fixes an issue that was introduced due to the refactoring that we did in https://bugs.openjdk.org/browse/JDK-8333130? This PR addresses the failure reported in https://bugs.openjdk.org/browse/JDK-8333756.

The `NativeMethodPrefixApp` test uses a `javaagent` `NativeMethodPrefixAgent` which modifies the name of the native methods using the `java.lang.instrument.Instrumentation` instance:
```java
public static void premain (String agentArgs, Instrumentation instArg) {
    inst = instArg;
    System.out.println("Premain");

...
    instArg.setNativeMethodPrefix(t0, "wrapped_tr0_");
    instArg.setNativeMethodPrefix(t1, "wrapped_tr1_");
    instArg.setNativeMethodPrefix(t2, "wrapped_tr2_");
```

 The Hotspot VM allows for methods on a class to be annotated with an (VM internal) `jdk.internal.vm.annotation.IntrinsicCandidate` annotation. When a class that contains any methods that are annotated with `@IntrinsicCandidate` is loaded, the VM checks that the corresponding method(s) have an intrinsic available. It uses the method name to check for the presence of the intrinsic. In the absence of an intrinsic for a `@IntrinsicCandidate` method, the VM throws an error and exits. This behaviour is controlled by the `-XX:+/-CheckIntrinsics` option. By default that option is enabled, implying that an error will be thrown if the intrinsic isn't found.

In the case where/when this test fails, it so happens that the JVM loads a class which has a `@IntrinsicCandidate` on a `native` Java method. For example, on the failing host, I could see this class loading sequence:

```
tr2: Loading java/util/Date
tr1: Loading java/util/Date
tr0: Loading java/util/Date
tr2: Loading sun/util/calendar/CalendarSystem
tr1: Loading sun/util/calendar/CalendarSystem
tr0: Loading sun/util/calendar/CalendarSystem
tr2: Loading sun/util/calendar/CalendarSystem$GregorianHolder
tr1: Loading sun/util/calendar/CalendarSystem$GregorianHolder
tr0: Loading sun/util/calendar/CalendarSystem$GregorianHolder
...
tr2: Loading sun/util/calendar/ZoneInfoFile$Checksum
tr1: Loading sun/util/calendar/ZoneInfoFile$Checksum
tr0: Loading sun/util/calendar/ZoneInfoFile$Checksum
tr2: Loading java/util/zip/Checksum
tr1: Loading java/util/zip/Checksum
tr0: Loading java/util/zip/Checksum
tr2: Loading java/util/zip/CRC32
tr1: Loading java/util/zip/CRC32
tr0: Loading java/util/zip/CRC32
Method [java.util.zip.CRC32.wrapped_tr2_update(II)I] is annotated with @IntrinsicCandidate, but no compiler intrinsic is defined for the method. Exiting.
```
So a class loading sequence lead to loading of the `java.util.zip.CRC32` class which has a `native`  method  annotated with `@IntrinsicCandidate`:

```
   @IntrinsicCandidate
    private static native int update(int crc, int b);
```

Since the `NativeMethodPrefixAgent` modifies the native method names, the VM thus cannot find a matching intrinsic and thus fails with that error. 

The reason why this wasn't uncovered during the testing of changes for https://bugs.openjdk.org/browse/JDK-8333130 is purely incidental. Even now, the test fails only intermittently. That's because it's only triggered if some class with a `native` method with `@IntrinsicCandidate` gets loadded. As an additional reference, I also found https://bugs.openjdk.org/browse/JDK-8151100 which is when the `-XX:-CheckIntrinsics` was introduced in this test and that too explains this same issue.

The commit in this PR fixes the issue by reintroducing the `"-XX:+UnlockDiagnosticVMOptions", "-XX:-CheckIntrinsics"` when launching the test program. Additionally, the test program now intentionally loads the `CRC32` class to make the test more deterministic for cases like these and to prevent any accidental removal of the `-XX:-CheckIntrinsics` in future.

tier testing is currently in progress with this change in our CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333756](https://bugs.openjdk.org/browse/JDK-8333756): java/lang/instrument/NativeMethodPrefixApp.java failed due to missing intrinsic (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [95a939a1](https://git.openjdk.org/jdk/pull/19595/files/95a939a1ec83e18821307bd8e3d516c1dd4e184f)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19595/head:pull/19595` \
`$ git checkout pull/19595`

Update a local copy of the PR: \
`$ git checkout pull/19595` \
`$ git pull https://git.openjdk.org/jdk.git pull/19595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19595`

View PR using the GUI difftool: \
`$ git pr show -t 19595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19595.diff">https://git.openjdk.org/jdk/pull/19595.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19595#issuecomment-2154571412)