### PR TITLE
8322811: jcmd System.dump_map help info has conflicting statements

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1190,18 +1190,25 @@ void SystemMapDCmd::execute(DCmdSource source, TRAPS) {
   MemMapPrinter::print_all_mappings(output(), _human_readable.value());
 }
 
+static constexpr char default_filename[] = "vm_memory_map_<pid>.txt";
+
 SystemDumpMapDCmd::SystemDumpMapDCmd(outputStream* output, bool heap) :
     DCmdWithParser(output, heap),
   _human_readable("-H", "Human readable format", "BOOLEAN", false, "false"),
-  _filename("-F", "file path (defaults: \"vm_memory_map_<pid>.txt\")", "STRING", false) {
+  _filename("-F", "file path", "STRING", false, default_filename) {
   _dcmdparser.add_dcmd_option(&_human_readable);
   _dcmdparser.add_dcmd_option(&_filename);
 }
 
 void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
-  stringStream default_name;
-  default_name.print("vm_memory_map_%d.txt", os::current_process_id());
-  const char* name = _filename.is_set() ? _filename.value() : default_name.base();
+  stringStream defaultname;
+  const char* name = nullptr;
+  if (::strcmp(default_filename, _filename.value()) == 0) {
+    defaultname.print("vm_memory_map_%d.txt", os::current_process_id());
+    name = defaultname.base();
+  } else {
+    name = _filename.value();
+  }
   fileStream fs(name);
   if (fs.is_open()) {
     if (!MemTracker::enabled()) {


### PR DESCRIPTION
@dholmes-ora this is one of yours.

This was a tad annoying to fix (fix is simple though), since the jcmd framework has no good way to allow for default parameters that are not used literally. E.g. in this case, the real value for the file name will contain the process pid, which of course cannot be hard-coded.

New output:

```
Syntax : System.dump_map [options]

Options: (options must be specified using the <key> or <key>=<value> syntax)
        -H : [optional] Human readable format (BOOLEAN, false)
        -F : [optional] file path (STRING, vm_memory_map_<pid>.txt)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8322811: jcmd System.dump_map help info has conflicting statements`

### Issue
 * [JDK-8322811](https://bugs.openjdk.org/browse/JDK-8322811): jcmd System.dump_map help info has conflicting statements (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19596/head:pull/19596` \
`$ git checkout pull/19596`

Update a local copy of the PR: \
`$ git checkout pull/19596` \
`$ git pull https://git.openjdk.org/jdk.git pull/19596/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19596`

View PR using the GUI difftool: \
`$ git pr show -t 19596`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19596.diff">https://git.openjdk.org/jdk/pull/19596.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19596#issuecomment-2157275933)