### PR TITLE
8332818: ubsan: archiveHeapLoader.cpp:70:27: runtime error: applying non-zero offset 18446744073707454464 to null pointer

### DIFF
--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -61,6 +61,10 @@ ptrdiff_t ArchiveHeapLoader::_mapped_heap_delta = 0;
 
 // Every mapped region is offset by _mapped_heap_delta from its requested address.
 // See FileMapInfo::heap_region_requested_address().
+// avoid adding to CompressedOops::base() == nullptr
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
 void ArchiveHeapLoader::init_mapped_heap_info(address mapped_heap_bottom, ptrdiff_t delta, int dumptime_oop_shift) {
   assert(!_mapped_heap_relocation_initialized, "only once");
   if (!UseCompressedOops) {

--- a/src/hotspot/share/cds/archiveHeapLoader.cpp
+++ b/src/hotspot/share/cds/archiveHeapLoader.cpp
@@ -61,7 +61,6 @@ ptrdiff_t ArchiveHeapLoader::_mapped_heap_delta = 0;
 
 // Every mapped region is offset by _mapped_heap_delta from its requested address.
 // See FileMapInfo::heap_region_requested_address().
-// avoid adding to CompressedOops::base() == nullptr
 #if defined(__clang__) || defined(__GNUC__)
 __attribute__((no_sanitize("undefined")))
 #endif


### PR DESCRIPTION
When running :tier1 hs tests, the following issue has been reported when running with ubsan enabled binaries (configure flag --enable-ubsan)  

 stderr: [/jdk/src/hotspot/share/cds/archiveHeapLoader.cpp:70:27: runtime error: applying non-zero offset 18446744073707454464 to null pointer
    #0 0x7f33db52823f in ArchiveHeapLoader::init_mapped_heap_info(unsigned char*, long, int) /jdk/src/hotspot/share/cds/archiveHeapLoader.cpp:70
    #1 0x7f33dc6d3ad4 in FileMapInfo::map_heap_region_impl() /jdk/src/hotspot/share/cds/filemap.cpp:2211
    #2 0x7f33dc6d4ba4 in FileMapInfo::map_heap_region() /jdk/src/hotspot/share/cds/filemap.cpp:2129
    #3 0x7f33dc6d52a7 in FileMapInfo::map_or_load_heap_region() /jdk/src/hotspot/share/cds/filemap.cpp:2019
    #4 0x7f33ddaf7fdb in MetaspaceShared::map_archives(FileMapInfo*, FileMapInfo*, bool) /jdk/src/hotspot/share/cds/metaspaceShared.cpp:1183
    #5 0x7f33ddaf8f54 in MetaspaceShared::initialize_runtime_shared_and_meta_spaces() /jdk/src/hotspot/share/cds/metaspaceShared.cpp:943
    #6 0x7f33ddadd60f in Metaspace::global_initialize() /jdk/src/hotspot/share/memory/metaspace.cpp:714
    #7 0x7f33de9bc7f9 in universe_init() /jdk/src/hotspot/share/memory/universe.cpp:866
    #8 0x7f33dcc93691 in init_globals() /jdk/src/hotspot/share/runtime/init.cpp:128
    #9 0x7f33de92a720 in Threads::create_vm(JavaVMInitArgs*, bool*) /jdk/src/hotspot/share/runtime/threads.cpp:553
    #10 0x7f33dd02d477 in JNI_CreateJavaVM_inner /jdk/src/hotspot/share/prims/jni.cpp:3581
    #11 0x7f33dd02d477 in JNI_CreateJavaVM /jdk/src/hotspot/share/prims/jni.cpp:3672
    #12 0x7f33e42a90e5 in InitializeJVM /jdk/src/java.base/share/native/libjli/java.c:1550
    #13 0x7f33e42a90e5 in JavaMain /jdk/src/java.base/share/native/libjli/java.c:491
    #14 0x7f33e42b2748 in ThreadJavaMain /jdk/src/java.base/unix/native/libjli/java_md.c:642
    #15 0x7f33e42616e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)
    #16 0x7f33e391550e in clone (/lib64/libc.so.6+0x11850e) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)


Seems that  `CompressedOops::base() ` can be nullptr , so adding to it some non-zero value triggers ubsan because of undefined behavior.  In the JBS-bug there was already a little discussion and it seems disabling this warning might be an option.

otherwise some workaround like
```
template<typename T>
T* add_to_ptr_maybe_null(T* ptr, uintptr_t val) {
  return (T*)((uintptr_t)ptr + val * sizeof(T));
}
```
could be used .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332818](https://bugs.openjdk.org/browse/JDK-8332818): ubsan: archiveHeapLoader.cpp:70:27: runtime error: applying non-zero offset 18446744073707454464 to null pointer (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [0d89b783](https://git.openjdk.org/jdk/pull/19597/files/0d89b783b77ae91f5a1054f1c578a347caeed64a)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) ⚠️ Review applies to [0d89b783](https://git.openjdk.org/jdk/pull/19597/files/0d89b783b77ae91f5a1054f1c578a347caeed64a)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19597/head:pull/19597` \
`$ git checkout pull/19597`

Update a local copy of the PR: \
`$ git checkout pull/19597` \
`$ git pull https://git.openjdk.org/jdk.git pull/19597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19597`

View PR using the GUI difftool: \
`$ git pr show -t 19597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19597.diff">https://git.openjdk.org/jdk/pull/19597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19597#issuecomment-2154687707)