### PR TITLE
8333793: Improve BootstrapMethodInvoker for ConstantBootstraps and ProxyGenerator

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -103,12 +103,10 @@ final class BootstrapMethodInvoker {
                 // Call to StringConcatFactory::makeConcatWithConstants
                 // with empty constant arguments?
                 if (bootstrapMethod.type() == SCF_MT) {
-                    result = (CallSite)bootstrapMethod
-                            .invokeExact(caller, name, (MethodType)type,
+                    result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type,
                                          (String)info, new Object[0]);
                 } else if (bootstrapMethod.type() == CONDY_INVOKE) {
-                    result = (CallSite)bootstrapMethod
-                            .invokeExact(caller, name, (Class<?>)type,
+                    result = bootstrapMethod.invokeExact(caller, name, (Class<?>)type,
                                     (MethodHandle)info, new Object[0]);
                 } else {
                     info = maybeReBox(info);
@@ -153,7 +151,7 @@ final class BootstrapMethodInvoker {
                 } else if (bsmType == CONDY_INVOKE) {
                     Object[] shiftedArgs = Arrays.copyOfRange(argv, 1, argv.length);
                     maybeReBoxElements(shiftedArgs);
-                    result = (Object)bootstrapMethod.invokeExact(caller, name, (Class<?>)type, (MethodHandle)argv[0], shiftedArgs);
+                    result = bootstrapMethod.invokeExact(caller, name, (Class<?>)type, (MethodHandle)argv[0], shiftedArgs);
                 } else if (bsmType == LMF_ALT_MT) {
                     maybeReBoxElements(argv);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);

--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -27,6 +27,7 @@ package java.lang.invoke;
 import sun.invoke.util.Wrapper;
 
 import java.lang.invoke.AbstractConstantGroup.BSCIWithCache;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import static java.lang.invoke.BootstrapCallInfo.makeBootstrapCallInfo;
@@ -87,7 +88,11 @@ final class BootstrapMethodInvoker {
             if (info == null) {
                 // VM is allowed to pass up a null meaning no BSM args
                 if (type instanceof Class<?> c) {
-                    result = bootstrapMethod.invoke(caller, name, c);
+                    if (bootstrapMethod.type() == CONDY_GET_STATIC_FINAL_MT) {
+                        result = bootstrapMethod.invokeExact(caller, name, c);
+                    } else {
+                        result = bootstrapMethod.invoke(caller, name, c);
+                    }
                 } else {
                     result = bootstrapMethod.invoke(caller, name, (MethodType)type);
                 }
@@ -97,14 +102,18 @@ final class BootstrapMethodInvoker {
 
                 // Call to StringConcatFactory::makeConcatWithConstants
                 // with empty constant arguments?
-                if (isStringConcatFactoryBSM(bootstrapMethod.type())) {
+                if (bootstrapMethod.type() == SCF_MT) {
                     result = (CallSite)bootstrapMethod
                             .invokeExact(caller, name, (MethodType)type,
                                          (String)info, new Object[0]);
                 } else {
                     info = maybeReBox(info);
                     if (type instanceof Class<?> c) {
-                        result = bootstrapMethod.invoke(caller, name, c, info);
+                        if (bootstrapMethod.type() == CONDY_GET_STATIC_FINAL_CLASS_MT) {
+                            result = bootstrapMethod.invokeExact(caller, name, c, (Class<?>)info);
+                        } else {
+                            result = bootstrapMethod.invoke(caller, name, c, info);
+                        }
                     } else {
                         result = bootstrapMethod.invoke(caller, name, (MethodType)type, info);
                     }
@@ -129,25 +138,27 @@ final class BootstrapMethodInvoker {
                 Object[] argv = (Object[]) info;
 
                 MethodType bsmType = bootstrapMethod.type();
-                if (isLambdaMetafactoryIndyBSM(bsmType) && argv.length == 3) {
+                if (bsmType == LMF_INDY_MT) {
                     result = (CallSite)bootstrapMethod
                             .invokeExact(caller, name, (MethodType)type, (MethodType)argv[0],
                                     (MethodHandle)argv[1], (MethodType)argv[2]);
-                } else if (isLambdaMetafactoryCondyBSM(bsmType) && argv.length == 3) {
-                    result = bootstrapMethod
-                            .invokeExact(caller, name, (Class<?>)type, (MethodType)argv[0],
-                                    (MethodHandle)argv[1], (MethodType)argv[2]);
-                } else if (isStringConcatFactoryBSM(bsmType) && argv.length >= 1) {
+                } else if (argv.length >= 1 && bsmType == SCF_MT) {
                     String recipe = (String)argv[0];
                     Object[] shiftedArgs = Arrays.copyOfRange(argv, 1, argv.length);
                     maybeReBoxElements(shiftedArgs);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, recipe, shiftedArgs);
-                } else if (isLambdaMetafactoryAltMetafactoryBSM(bsmType)) {
+                } else if (bsmType == LMF_ALT_MT) {
                     maybeReBoxElements(argv);
                     result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);
-                } else if (isObjectMethodsBootstrapBSM(bsmType)) {
+                } else if (bsmType == OBJECT_METHODS_MT) {
                     MethodHandle[] mhs = Arrays.copyOfRange(argv, 2, argv.length, MethodHandle[].class);
                     result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>)argv[0], (String)argv[1], mhs);
+                } else if (bsmType == PROXY_GET_METHOD_MT) {
+                    result = (Method)bootstrapMethod.invokeExact(caller, name, (Class<?>)type, (Class<?>)argv[0], (String)argv[1], (MethodType)argv[2]);
+                } else if (bsmType == CONDY_GET_STATIC_FINAL_MT) {
+                    result = bootstrapMethod.invokeExact(caller, name, (Class<?>)type);
+                } else if (bsmType == CONDY_GET_STATIC_FINAL_CLASS_MT) {
+                    result = bootstrapMethod.invokeExact(caller, name, (Class<?>)type, (Class<?>)argv[0]);
                 } else {
                     maybeReBoxElements(argv);
                     if (type instanceof Class<?> c) {
@@ -243,65 +254,54 @@ final class BootstrapMethodInvoker {
         }
     }
 
+
+    /**
+     * Exact type used by the {@link java.lang.invoke.LambdaMetafactory#metafactory(
+     * MethodHandles.Lookup,String,MethodType,MethodType,MethodHandle,MethodType)} bootstrap method.
+     */
     private static final MethodType LMF_INDY_MT = MethodType.methodType(CallSite.class,
             Lookup.class, String.class, MethodType.class, MethodType.class, MethodHandle.class, MethodType.class);
 
+    /**
+     * Exact type used by the {@link java.lang.invoke.LambdaMetafactory#altMetafactory(
+     * MethodHandles.Lookup,String,MethodType,Object[])} bootstrap method.
+     */
     private static final MethodType LMF_ALT_MT = MethodType.methodType(CallSite.class,
             Lookup.class, String.class, MethodType.class, Object[].class);
 
+    /**
+     * Exact type used for the {@link java.lang.runtime.ObjectMethods#bootstrap(
+     * MethodHandles.Lookup,String,TypeDescriptor,Class,String,MethodHandle[])} bootstrap method.
+     */
     private static final MethodType OBJECT_METHODS_MT = MethodType.methodType(Object.class,
             Lookup.class, String.class, TypeDescriptor.class, Class.class, String.class, MethodHandle[].class);
 
-    private static final MethodType LMF_CONDY_MT = MethodType.methodType(Object.class,
-            Lookup.class, String.class, Class.class, MethodType.class, MethodHandle.class, MethodType.class);
+    /**
+     * Exact type of the bootstrap methods generated for {@link java.lang.reflect.Proxy} classes.
+     */
+    private static final MethodType PROXY_GET_METHOD_MT = MethodType.methodType(Method.class,
+            Lookup.class, String.class, Class.class, Class.class, String.class, MethodType.class);
 
+    /**
+     * Exact type used of the {@link java.lang.invoke.ConstantBootstraps#getStaticFinal(Lookup, String, Class)}
+     * bootstrap method.
+     */
+    private static final MethodType CONDY_GET_STATIC_FINAL_MT = MethodType.methodType(Object.class,
+            Lookup.class, String.class, Class.class);
+
+    /**
+     * Exact type of the {@link java.lang.invoke.ConstantBootstraps#getStaticFinal(Lookup, String, Class, Class)}
+     * bootstrap method.
+     */
+    private static final MethodType CONDY_GET_STATIC_FINAL_CLASS_MT = MethodType.methodType(Object.class,
+            Lookup.class, String.class, Class.class, Class.class);
+
+    /**
+     * Exact type of the {@link java.lang.invoke.StringConcatFactory#makeConcatWithConstants(MethodHandles.Lookup,
+     * String,MethodType,String,Object...))} bootstrap method.
+     */
     private static final MethodType SCF_MT = MethodType.methodType(CallSite.class,
             Lookup.class, String.class, MethodType.class, String.class, Object[].class);
-
-    /**
-     * @return true iff the BSM method type exactly matches
-     *         {@link java.lang.invoke.StringConcatFactory#makeConcatWithConstants(MethodHandles.Lookup,
-     *                 String,MethodType,String,Object...))}
-     */
-    private static boolean isStringConcatFactoryBSM(MethodType bsmType) {
-        return bsmType == SCF_MT;
-    }
-
-    /**
-     * @return true iff the BSM method type exactly matches
-     *         {@link java.lang.invoke.LambdaMetafactory#metafactory(
-     *          MethodHandles.Lookup,String,Class,MethodType,MethodHandle,MethodType)}
-     */
-    private static boolean isLambdaMetafactoryCondyBSM(MethodType bsmType) {
-        return bsmType == LMF_CONDY_MT;
-    }
-
-    /**
-     * @return true iff the BSM method type exactly matches
-     *         {@link java.lang.invoke.LambdaMetafactory#metafactory(
-     *          MethodHandles.Lookup,String,MethodType,MethodType,MethodHandle,MethodType)}
-     */
-    private static boolean isLambdaMetafactoryIndyBSM(MethodType bsmType) {
-        return bsmType == LMF_INDY_MT;
-    }
-
-    /**
-     * @return true iff the BSM method type exactly matches
-     *         {@link java.lang.invoke.LambdaMetafactory#altMetafactory(
-     *          MethodHandles.Lookup,String,MethodType,Object[])}
-     */
-    private static boolean isLambdaMetafactoryAltMetafactoryBSM(MethodType bsmType) {
-        return bsmType == LMF_ALT_MT;
-    }
-
-    /**
-     * @return true iff the BSM method type exactly matches
-     *         {@link java.lang.runtime.ObjectMethods#bootstrap(
-     *          MethodHandles.Lookup,String,TypeDescriptor,Class,String,MethodHandle[])}
-     */
-    private static boolean isObjectMethodsBootstrapBSM(MethodType bsmType) {
-        return bsmType == OBJECT_METHODS_MT;
-    }
 
     /** The JVM produces java.lang.Integer values to box
      *  CONSTANT_Integer boxes but does not intern them.

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -50,7 +50,7 @@ public class ProxyGenBench {
     static final IHandler HANDLER = new IHandler();
 
     @Benchmark
-    public int generate100Proxies() {
+    public int generateAndProxy100() {
         int hash = 0;
         for (int i = 0; i < 100; i++) {
             hash += Proxy.newProxyInstance(new ClsLoader(), INTF, HANDLER).hashCode();
@@ -88,6 +88,6 @@ public class ProxyGenBench {
     }
 
     public static void main(String[] args) {
-        new ProxyGenBench().generate100Proxies();
+        new ProxyGenBench().generateAndProxy100();
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -50,10 +50,12 @@ public class ProxyGenBench {
     static final IHandler HANDLER = new IHandler();
 
     @Benchmark
-    public void generate100Proxies() {
+    public int generate100Proxies() {
+        int hash = 0;
         for (int i = 0; i < 100; i++) {
-            Proxy.newProxyInstance(new ClsLoader(), INTF, HANDLER);
+            hash += Proxy.newProxyInstance(new ClsLoader(), INTF, HANDLER).hashCode();
         }
+        return hash;
     }
 
     public interface Interfaze {

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -68,13 +68,13 @@ public class ProxyGenBench {
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
             if (method.getName().equals("hashCode")) {
-                return proxy.hashCode();
+                return 17;
             }
             if (method.getName().equals("equals")) {
-                return proxy.equals(args[0]);
+                return false;
             }
             if (method.getName().equals("toString")) {
-                return proxy.toString();
+                return "proxy";
             }
             return null;
         }

--- a/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/ProxyGenBench.java
@@ -67,7 +67,16 @@ public class ProxyGenBench {
     static class IHandler implements InvocationHandler {
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-            throw new UnsupportedOperationException();
+            if (method.getName().equals("hashCode")) {
+                return proxy.hashCode();
+            }
+            if (method.getName().equals("equals")) {
+                return proxy.equals(args[0]);
+            }
+            if (method.getName().equals("toString")) {
+                return proxy.toString();
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
This PR refactors type matching in BootstrapMethodInvoker and adds a few types, seeking to improve bootstrap overheads of some ConstantBootstraps and in particular the ProxyGenerator condys generated for e.g. annotation proxies since [JDK-8332457](https://bugs.openjdk.org/browse/JDK-8332457)

I've adjusted the micro-benchmark added by JDK-8332457 to not only generate a proxy but also call into one of the proxied methodt (`Object::hashCode`). 

Running org.openjdk.bench.java.lang.reflect.ProxyGenBench as a one-off startup benchmark sees significant improvement (-9% instructions, -6% cycles):
```
Name             Cnt           Base          Error            Test          Error         Unit  Change
Perfstartup-JMH   20        154,000 ±        8,165         148,000 ±       23,164        ms/op   1,04x (p = 0,352 )
  :.cycles            925335973,200 ± 47147600,262   842221278,800 ± 46836254,964       cycles   0,91x (p = 0,000*)
  :.instructions     2101588857,600 ± 81105850,361  1966307798,400 ± 22011043,908 instructions   0,94x (p = 0,000*)
  :.taskclock               291,500 ±       16,494         262,000 ±       15,328           ms   0,90x (p = 0,000*)
  * = significant
```
Number of classes loaded drops from 1096 to 1092

Running the micro regularly shows no significant difference:
```
Name                              Cnt   Base   Error    Test   Error  Unit  Change
ProxyGenBench.generateAndProxy100  10 26,827 ± 8,954  26,855 ± 7,531 ms/op   1,00x (p = 0,991 )
  * = significant
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333793](https://bugs.openjdk.org/browse/JDK-8333793): Improve BootstrapMethodInvoker for ConstantBootstraps and ProxyGenerator (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) 🔄 Re-review required (review applies to [532966a4](https://git.openjdk.org/jdk/pull/19598/files/532966a4c6eac2e3b61eb54ffc41740b0608cc47))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19598/head:pull/19598` \
`$ git checkout pull/19598`

Update a local copy of the PR: \
`$ git checkout pull/19598` \
`$ git pull https://git.openjdk.org/jdk.git pull/19598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19598`

View PR using the GUI difftool: \
`$ git pr show -t 19598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19598.diff">https://git.openjdk.org/jdk/pull/19598.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19598#issuecomment-2154718275)