### PR TITLE
8333804: java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures

### DIFF
--- a/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
+++ b/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
@@ -381,7 +381,7 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
     public void teardown() throws Exception {
         authClient = noAuthClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(1500);
         try {
             proxy.stop();
             authproxy.stop();


### PR DESCRIPTION
The test failed because the shared HttpClients were not garbage collected in the imparted time.
The timeout of 500ms to wait for the clients to clean up is sufficient most of the time but rather small, I suspect a bit more time was needed in that instance.

The fix raises the timeout to 1500ms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333804](https://bugs.openjdk.org/browse/JDK-8333804): java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19600/head:pull/19600` \
`$ git checkout pull/19600`

Update a local copy of the PR: \
`$ git checkout pull/19600` \
`$ git pull https://git.openjdk.org/jdk.git pull/19600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19600`

View PR using the GUI difftool: \
`$ git pr show -t 19600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19600.diff">https://git.openjdk.org/jdk/pull/19600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19600#issuecomment-2155067810)