### PR TITLE
8333805: Replaying compilation with null static final fields results in a crash

### DIFF
--- a/src/hotspot/share/ci/ciInstanceKlass.cpp
+++ b/src/hotspot/share/ci/ciInstanceKlass.cpp
@@ -661,7 +661,8 @@ class StaticFinalFieldPrinter : public FieldClosure {
       ResourceMark rm;
       oop mirror = fd->field_holder()->java_mirror();
       _out->print("staticfield %s %s %s ", _holder, fd->name()->as_quoted_ascii(), fd->signature()->as_quoted_ascii());
-      switch (fd->field_type()) {
+      BasicType field_type = fd->field_type();
+      switch (field_type) {
         case T_BYTE:    _out->print_cr("%d", mirror->byte_field(fd->offset()));   break;
         case T_BOOLEAN: _out->print_cr("%d", mirror->bool_field(fd->offset()));   break;
         case T_SHORT:   _out->print_cr("%d", mirror->short_field(fd->offset()));  break;
@@ -682,9 +683,12 @@ class StaticFinalFieldPrinter : public FieldClosure {
         case T_OBJECT: {
           oop value =  mirror->obj_field_acquire(fd->offset());
           if (value == nullptr) {
-            _out->print_cr("null");
+            if (field_type == T_ARRAY) {
+              _out->print("%d", -1);
+            }
+            _out->cr();
           } else if (value->is_instance()) {
-            assert(fd->field_type() == T_OBJECT, "");
+            assert(field_type == T_OBJECT, "");
             if (value->is_a(vmClasses::String_klass())) {
               const char* ascii_value = java_lang_String::as_quoted_ascii(value);
               _out->print_cr("\"%s\"", (ascii_value != nullptr) ? ascii_value : "");

--- a/test/hotspot/jtreg/compiler/ciReplay/TestNullStaticField.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestNullStaticField.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8333805
+ * @library / /test/lib
+ * @summary Replaying compilation with null static final fields results in a crash
+ * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.compMode != "Xcomp" & vm.debug == true & vm.compiler2.enabled
+ * @modules java.base/jdk.internal.misc
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestNullStaticField
+ */
+
+package compiler.ciReplay;
+
+public class TestNullStaticField extends DumpReplayBase {
+
+    public static void main(String[] args) {
+        new TestNullStaticField().runTest(TIERED_DISABLED_VM_OPTION);
+    }
+
+    @Override
+    public void testAction() {
+        positiveTest(TIERED_DISABLED_VM_OPTION, "-XX:+ReplayIgnoreInitErrors");
+    }
+
+    @Override
+    public String getTestClass() {
+        return TestClassNullStaticField.class.getName();
+    }
+
+}
+
+class TestClassNullStaticField {
+
+    static final Object[] staticNullArrayField = null;
+    static final Object[][] staticNullMultiArrayField = null;
+    static final Object staticNullObjectField = null;
+    static final String staticNullStringField = null;
+    static final int[] staticNullIntArrayField = null;
+    static final Object[] staticNotNullArrayField = new A[10];
+    static final Object[][] staticNotNullMultiArrayField = new A[10][10];
+    static final Object staticNotNullObjectField = new A();
+    static final String staticNotNullStringField = "Not null";
+    static final int[] staticNotNullIntArrayField = new int[10];
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test();
+        }
+    }
+    public static void test() {
+
+    }
+
+    private static class A {
+    }
+}
+


### PR DESCRIPTION
When dumping a replay file, if a static field is null the "null"
string is appended to the line for the field. When replaying the
compilation, this breaks for:

- string fields: instead of null, the field is initialized with a
  "null" string
  
- object fields: the jvm crashes because it treats "null" as a class
  name.
  
- array fields: the jvm crashes because it expects an array length
  where the "null" string is.
  
This patch fixes it by:

- leaving out the "null" string when the field is null. When the
  compilation is replayed, the missing field value is taken as meaning
  the field is null.
  
- setting the length to -1 for a null array which on the replay side
  is used as an indication that the field is null.
  
I also noticed, for object arrays, that the actual type of the array
(for a non null field) is included in the replay file (given it can
differ from the field type) but not used when replaying. I changed
that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333805](https://bugs.openjdk.org/browse/JDK-8333805): Replaying compilation with null static final fields results in a crash (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19601/head:pull/19601` \
`$ git checkout pull/19601`

Update a local copy of the PR: \
`$ git checkout pull/19601` \
`$ git pull https://git.openjdk.org/jdk.git pull/19601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19601`

View PR using the GUI difftool: \
`$ git pr show -t 19601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19601.diff">https://git.openjdk.org/jdk/pull/19601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19601#issuecomment-2155073221)