### PR TITLE
8312412: Uninitialized klassVtable::_verify_count field

### DIFF
--- a/src/hotspot/share/oops/klassVtable.hpp
+++ b/src/hotspot/share/oops/klassVtable.hpp
@@ -54,6 +54,9 @@ class klassVtable {
   klassVtable(Klass* klass, void* base, int length) : _klass(klass) {
     _tableOffset = int((address)base - (address)klass);
     _length = length;
+#ifndef PRODUCT
+    _verify_count = 0;
+#endif
   }
 
   // accessors


### PR DESCRIPTION
[JDK-8312412](https://bugs.openjdk.org/browse/JDK-8312412)

Initilizating Uninitialized klassVtable::_verify_count field, without proper initialization, it could lead to incorrect verification logic or misleading debug information.  
Tested locally

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8312412](https://bugs.openjdk.org/browse/JDK-8312412): Uninitialized klassVtable::_verify_count field (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19602/head:pull/19602` \
`$ git checkout pull/19602`

Update a local copy of the PR: \
`$ git checkout pull/19602` \
`$ git pull https://git.openjdk.org/jdk.git pull/19602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19602`

View PR using the GUI difftool: \
`$ git pr show -t 19602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19602.diff">https://git.openjdk.org/jdk/pull/19602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19602#issuecomment-2155269827)