### PR TITLE
8333813: Seviceability tests fail due to stderr containing Temporarily processing option UseNotificationThread

### DIFF
--- a/test/lib/jdk/test/lib/process/OutputAnalyzer.java
+++ b/test/lib/jdk/test/lib/process/OutputAnalyzer.java
@@ -42,6 +42,8 @@ public final class OutputAnalyzer {
 
     private static final String deprecatedmsg = ".* VM warning:.* deprecated.*";
 
+    private static final String obsoletedmsg  = ".* VM warning:.* scheduled for removal.*";
+
     private static final String FATAL_ERROR_PAT = "# A fatal error has been detected.*";
 
     private final OutputBuffer buffer;
@@ -176,13 +178,15 @@ public final class OutputAnalyzer {
 
     /**
      * Verify that the stderr contents of output buffer is empty,
-     * after filtering out the Hotspot deprecation warning messages
+     * after filtering out the Hotspot deprecation warning messages,
+     * and warning messages about removal.
      *
      * @throws RuntimeException
      *             If stderr was not empty
      */
     public OutputAnalyzer stderrShouldBeEmptyIgnoreDeprecatedWarnings() {
-        if (!getStderr().replaceAll(deprecatedmsg + "\\R", "").isEmpty()) {
+        if (!getStderr().replaceAll(deprecatedmsg + "\\R", "")
+                        .replaceAll(obsoletedmsg + "\\R", "").isEmpty()) {
             reportDiagnosticSummary();
             throw new RuntimeException("stderr was not empty");
         }


### PR DESCRIPTION
Allow warning messages such as the following to appear in stderr:

Java HotSpot(TM) 64-Bit Server VM warning: Temporarily processing option UseNotificationThread; support is scheduled for removal in 24.0

Tested by running CI tier5, which reproduced the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8333813](https://bugs.openjdk.org/browse/JDK-8333813)

### Issue
 * [JDK-8333813](https://bugs.openjdk.org/browse/JDK-8333813): Serviceability tests fail due to stderr containing Temporarily processing option UseNotificationThread (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19606/head:pull/19606` \
`$ git checkout pull/19606`

Update a local copy of the PR: \
`$ git checkout pull/19606` \
`$ git pull https://git.openjdk.org/jdk.git pull/19606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19606`

View PR using the GUI difftool: \
`$ git pr show -t 19606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19606.diff">https://git.openjdk.org/jdk/pull/19606.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19606#issuecomment-2155522292)