### PR TITLE
8333828: Use value javadoc tag in java.lang.{Float, Double}

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -411,14 +411,14 @@ public final class Double extends Number
     public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
 
     /**
-     * The number of bits used to represent a {@code double} value, {@value #SIZE}.
+     * The number of bits used to represent a {@code double} value, {@value}.
      *
      * @since 1.5
      */
     public static final int SIZE = 64;
 
     /**
-     * The number of bits in the significand of a {@code double} value, {@value #PRECISION}.
+     * The number of bits in the significand of a {@code double} value, {@value}.
      * This is the parameter N in section {@jls 4.2.3} of
      * <cite>The Java Language Specification</cite>.
      *
@@ -427,7 +427,7 @@ public final class Double extends Number
     public static final int PRECISION = 53;
 
     /**
-     * Maximum exponent a finite {@code double} variable may have, {@value #MAX_EXPONENT}.
+     * Maximum exponent a finite {@code double} variable may have, {@value}.
      * It is equal to the value returned by
      * {@code Math.getExponent(Double.MAX_VALUE)}.
      *
@@ -437,7 +437,7 @@ public final class Double extends Number
 
     /**
      * Minimum exponent a normalized {@code double} variable may
-     * have, {@value #MIN_EXPONENT}.  It is equal to the value returned by
+     * have, {@value}.  It is equal to the value returned by
      * {@code Math.getExponent(Double.MIN_NORMAL)}.
      *
      * @since 1.6
@@ -445,7 +445,7 @@ public final class Double extends Number
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -1022
 
     /**
-     * The number of bytes used to represent a {@code double} value, {@value #BYTES}.
+     * The number of bytes used to represent a {@code double} value, {@value}.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -411,41 +411,43 @@ public final class Double extends Number
     public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
 
     /**
-     * The number of bits used to represent a {@code double} value, {@value}.
+     * The number of bits used to represent a {@code double} value,
+     * {@value}.
      *
      * @since 1.5
      */
     public static final int SIZE = 64;
 
     /**
-     * The number of bits in the significand of a {@code double} value, {@value}.
-     * This is the parameter N in section {@jls 4.2.3} of
-     * <cite>The Java Language Specification</cite>.
+     * The number of bits in the significand of a {@code double}
+     * value, {@value}.  This is the parameter N in section {@jls
+     * 4.2.3} of <cite>The Java Language Specification</cite>.
      *
      * @since 19
      */
     public static final int PRECISION = 53;
 
     /**
-     * Maximum exponent a finite {@code double} variable may have, {@value}.
-     * It is equal to the value returned by
-     * {@code Math.getExponent(Double.MAX_VALUE)}.
+     * Maximum exponent a finite {@code double} variable may have,
+     * {@value}.  It is equal to the value returned by {@code
+     * Math.getExponent(Double.MAX_VALUE)}.
      *
      * @since 1.6
      */
     public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 1023
 
     /**
-     * Minimum exponent a normalized {@code double} variable may
-     * have, {@value}.  It is equal to the value returned by
-     * {@code Math.getExponent(Double.MIN_NORMAL)}.
+     * Minimum exponent a normalized {@code double} variable may have,
+     * {@value}.  It is equal to the value returned by {@code
+     * Math.getExponent(Double.MIN_NORMAL)}.
      *
      * @since 1.6
      */
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -1022
 
     /**
-     * The number of bytes used to represent a {@code double} value, {@value}.
+     * The number of bytes used to represent a {@code double} value,
+     * {@value}.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -411,14 +411,14 @@ public final class Double extends Number
     public static final double MIN_VALUE = 0x0.0000000000001P-1022; // 4.9e-324
 
     /**
-     * The number of bits used to represent a {@code double} value.
+     * The number of bits used to represent a {@code double} value, {@value #SIZE}.
      *
      * @since 1.5
      */
     public static final int SIZE = 64;
 
     /**
-     * The number of bits in the significand of a {@code double} value.
+     * The number of bits in the significand of a {@code double} value, {@value #PRECISION}.
      * This is the parameter N in section {@jls 4.2.3} of
      * <cite>The Java Language Specification</cite>.
      *
@@ -427,7 +427,7 @@ public final class Double extends Number
     public static final int PRECISION = 53;
 
     /**
-     * Maximum exponent a finite {@code double} variable may have.
+     * Maximum exponent a finite {@code double} variable may have, {@value #MAX_EXPONENT}.
      * It is equal to the value returned by
      * {@code Math.getExponent(Double.MAX_VALUE)}.
      *
@@ -437,7 +437,7 @@ public final class Double extends Number
 
     /**
      * Minimum exponent a normalized {@code double} variable may
-     * have.  It is equal to the value returned by
+     * have, {@value #MIN_EXPONENT}.  It is equal to the value returned by
      * {@code Math.getExponent(Double.MIN_NORMAL)}.
      *
      * @since 1.6
@@ -445,7 +445,7 @@ public final class Double extends Number
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -1022
 
     /**
-     * The number of bytes used to represent a {@code double} value.
+     * The number of bytes used to represent a {@code double} value, {@value #BYTES}.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -127,14 +127,14 @@ public final class Float extends Number
     public static final float MIN_VALUE = 0x0.000002P-126f; // 1.4e-45f
 
     /**
-     * The number of bits used to represent a {@code float} value.
+     * The number of bits used to represent a {@code float} value, {@value #SIZE}.
      *
      * @since 1.5
      */
     public static final int SIZE = 32;
 
     /**
-     * The number of bits in the significand of a {@code float} value.
+     * The number of bits in the significand of a {@code float} value, {@value #PRECISION}.
      * This is the parameter N in section {@jls 4.2.3} of
      * <cite>The Java Language Specification</cite>.
      *
@@ -143,7 +143,7 @@ public final class Float extends Number
     public static final int PRECISION = 24;
 
     /**
-     * Maximum exponent a finite {@code float} variable may have.  It
+     * Maximum exponent a finite {@code float} variable may have, {@value #MAX_EXPONENT}.  It
      * is equal to the value returned by {@code
      * Math.getExponent(Float.MAX_VALUE)}.
      *
@@ -152,7 +152,7 @@ public final class Float extends Number
     public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 127
 
     /**
-     * Minimum exponent a normalized {@code float} variable may have.
+     * Minimum exponent a normalized {@code float} variable may have, {@value #MIN_EXPONENT}.
      * It is equal to the value returned by {@code
      * Math.getExponent(Float.MIN_NORMAL)}.
      *
@@ -161,7 +161,7 @@ public final class Float extends Number
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -126
 
     /**
-     * The number of bytes used to represent a {@code float} value.
+     * The number of bytes used to represent a {@code float} value, {@value #BYTES}.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -127,14 +127,14 @@ public final class Float extends Number
     public static final float MIN_VALUE = 0x0.000002P-126f; // 1.4e-45f
 
     /**
-     * The number of bits used to represent a {@code float} value, {@value #SIZE}.
+     * The number of bits used to represent a {@code float} value, {@value}.
      *
      * @since 1.5
      */
     public static final int SIZE = 32;
 
     /**
-     * The number of bits in the significand of a {@code float} value, {@value #PRECISION}.
+     * The number of bits in the significand of a {@code float} value, {@value}.
      * This is the parameter N in section {@jls 4.2.3} of
      * <cite>The Java Language Specification</cite>.
      *
@@ -143,7 +143,7 @@ public final class Float extends Number
     public static final int PRECISION = 24;
 
     /**
-     * Maximum exponent a finite {@code float} variable may have, {@value #MAX_EXPONENT}.  It
+     * Maximum exponent a finite {@code float} variable may have, {@value}.  It
      * is equal to the value returned by {@code
      * Math.getExponent(Float.MAX_VALUE)}.
      *
@@ -152,7 +152,7 @@ public final class Float extends Number
     public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 127
 
     /**
-     * Minimum exponent a normalized {@code float} variable may have, {@value #MIN_EXPONENT}.
+     * Minimum exponent a normalized {@code float} variable may have, {@value}.
      * It is equal to the value returned by {@code
      * Math.getExponent(Float.MIN_NORMAL)}.
      *
@@ -161,7 +161,7 @@ public final class Float extends Number
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -126
 
     /**
-     * The number of bytes used to represent a {@code float} value, {@value #BYTES}.
+     * The number of bytes used to represent a {@code float} value, {@value}.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -127,15 +127,16 @@ public final class Float extends Number
     public static final float MIN_VALUE = 0x0.000002P-126f; // 1.4e-45f
 
     /**
-     * The number of bits used to represent a {@code float} value, {@value}.
+     * The number of bits used to represent a {@code float} value,
+     * {@value}.
      *
      * @since 1.5
      */
     public static final int SIZE = 32;
 
     /**
-     * The number of bits in the significand of a {@code float} value, {@value}.
-     * This is the parameter N in section {@jls 4.2.3} of
+     * The number of bits in the significand of a {@code float} value,
+     * {@value}.  This is the parameter N in section {@jls 4.2.3} of
      * <cite>The Java Language Specification</cite>.
      *
      * @since 19
@@ -143,8 +144,8 @@ public final class Float extends Number
     public static final int PRECISION = 24;
 
     /**
-     * Maximum exponent a finite {@code float} variable may have, {@value}.  It
-     * is equal to the value returned by {@code
+     * Maximum exponent a finite {@code float} variable may have,
+     * {@value}.  It is equal to the value returned by {@code
      * Math.getExponent(Float.MAX_VALUE)}.
      *
      * @since 1.6
@@ -152,8 +153,8 @@ public final class Float extends Number
     public static final int MAX_EXPONENT = (1 << (SIZE - PRECISION - 1)) - 1; // 127
 
     /**
-     * Minimum exponent a normalized {@code float} variable may have, {@value}.
-     * It is equal to the value returned by {@code
+     * Minimum exponent a normalized {@code float} variable may have,
+     * {@value}.  It is equal to the value returned by {@code
      * Math.getExponent(Float.MIN_NORMAL)}.
      *
      * @since 1.6
@@ -161,7 +162,8 @@ public final class Float extends Number
     public static final int MIN_EXPONENT = 1 - MAX_EXPONENT; // -126
 
     /**
-     * The number of bytes used to represent a {@code float} value, {@value}.
+     * The number of bytes used to represent a {@code float} value,
+     * {@value}.
      *
      * @since 1.8
      */


### PR DESCRIPTION
Use the value tag to make the javadoc for various format-related constants more informative to readers. Currently the information is available by following the "Constant Field Values" link.

I'll reflow the paragraphs before a push.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333828](https://bugs.openjdk.org/browse/JDK-8333828): Use value javadoc tag in java.lang.{Float, Double} (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [ea23aaf0](https://git.openjdk.org/jdk/pull/19607/files/ea23aaf06c3ae8961e57d85f9e5095a7dff9784d)
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**) ⚠️ Review applies to [ea23aaf0](https://git.openjdk.org/jdk/pull/19607/files/ea23aaf06c3ae8961e57d85f9e5095a7dff9784d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19607/head:pull/19607` \
`$ git checkout pull/19607`

Update a local copy of the PR: \
`$ git checkout pull/19607` \
`$ git pull https://git.openjdk.org/jdk.git pull/19607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19607`

View PR using the GUI difftool: \
`$ git pr show -t 19607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19607.diff">https://git.openjdk.org/jdk/pull/19607.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19607#issuecomment-2155558024)