### PR TITLE
8333833: Remove the use of ByteArrayLittleEndian from UUID::toString

### DIFF
--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -31,7 +31,6 @@ import java.security.*;
 
 import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.util.ByteArrayLittleEndian;
 import jdk.internal.util.HexDigits;
 
 /**
@@ -467,38 +466,24 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
      */
     @Override
     public String toString() {
-        long lsb = leastSigBits;
-        long msb = mostSigBits;
-        byte[] buf = new byte[36];
-        ByteArrayLittleEndian.setLong(
-                buf,
-                0,
-                HexDigits.packDigits((int) (msb >> 56), (int) (msb >> 48), (int) (msb >> 40), (int) (msb >> 32)));
-        buf[8] = '-';
-        ByteArrayLittleEndian.setInt(
-                buf,
-                9,
-                HexDigits.packDigits(((int) msb) >> 24, ((int) msb) >> 16));
-        buf[13] = '-';
-        ByteArrayLittleEndian.setInt(
-                buf,
-                14,
-                HexDigits.packDigits(((int) msb) >> 8, (int) msb));
-        buf[18] = '-';
-        ByteArrayLittleEndian.setInt(
-                buf,
-                19,
-                HexDigits.packDigits((int) (lsb >> 56), (int) (lsb >> 48)));
-        buf[23] = '-';
-        ByteArrayLittleEndian.setLong(
-                buf,
-                24,
-                HexDigits.packDigits((int) (lsb >> 40), (int) (lsb >> 32), ((int) lsb) >> 24, ((int) lsb) >> 16));
-        ByteArrayLittleEndian.setInt(
-                buf,
-                32,
-                HexDigits.packDigits(((int) lsb) >> 8, (int) lsb));
+        int i0 = (int) (mostSigBits >> 32);
+        int i1 = (int) mostSigBits;
+        int i2 = (int) (leastSigBits >> 32);
+        int i3 = (int) leastSigBits;
 
+        byte[] buf = new byte[36];
+        HexDigits.putHex(buf, 0, i0 >> 16);
+        HexDigits.putHex(buf, 4, i0);
+        buf[8] = '-';
+        HexDigits.putHex(buf, 9, i1 >> 16);
+        buf[13] = '-';
+        HexDigits.putHex(buf, 14, i1);
+        buf[18] = '-';
+        HexDigits.putHex(buf, 19, i2 >> 16);
+        buf[23] = '-';
+        HexDigits.putHex(buf, 24, i2);
+        HexDigits.putHex(buf, 28, i3 >> 16);
+        HexDigits.putHex(buf, 32, i3);
         try {
             return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -472,18 +472,18 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
         int i3 = (int) leastSigBits;
 
         byte[] buf = new byte[36];
-        HexDigits.putHex(buf, 0, i0 >> 16);
-        HexDigits.putHex(buf, 4, i0);
+        HexDigits.putHex4(buf, 0, i0 >> 16);
+        HexDigits.putHex4(buf, 4, i0);
         buf[8] = '-';
-        HexDigits.putHex(buf, 9, i1 >> 16);
+        HexDigits.putHex4(buf, 9, i1 >> 16);
         buf[13] = '-';
-        HexDigits.putHex(buf, 14, i1);
+        HexDigits.putHex4(buf, 14, i1);
         buf[18] = '-';
-        HexDigits.putHex(buf, 19, i2 >> 16);
+        HexDigits.putHex4(buf, 19, i2 >> 16);
         buf[23] = '-';
-        HexDigits.putHex(buf, 24, i2);
-        HexDigits.putHex(buf, 28, i3 >> 16);
-        HexDigits.putHex(buf, 32, i3);
+        HexDigits.putHex4(buf, 24, i2);
+        HexDigits.putHex4(buf, 28, i3 >> 16);
+        HexDigits.putHex4(buf, 32, i3);
         try {
             return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {

--- a/src/java.base/share/classes/java/util/UUID.java
+++ b/src/java.base/share/classes/java/util/UUID.java
@@ -472,18 +472,18 @@ public final class UUID implements java.io.Serializable, Comparable<UUID> {
         int i3 = (int) leastSigBits;
 
         byte[] buf = new byte[36];
-        HexDigits.putHex4(buf, 0, i0 >> 16);
-        HexDigits.putHex4(buf, 4, i0);
+        HexDigits.put4(buf, 0, i0 >> 16);
+        HexDigits.put4(buf, 4, i0);
         buf[8] = '-';
-        HexDigits.putHex4(buf, 9, i1 >> 16);
+        HexDigits.put4(buf, 9, i1 >> 16);
         buf[13] = '-';
-        HexDigits.putHex4(buf, 14, i1);
+        HexDigits.put4(buf, 14, i1);
         buf[18] = '-';
-        HexDigits.putHex4(buf, 19, i2 >> 16);
+        HexDigits.put4(buf, 19, i2 >> 16);
         buf[23] = '-';
-        HexDigits.putHex4(buf, 24, i2);
-        HexDigits.putHex4(buf, 28, i3 >> 16);
-        HexDigits.putHex4(buf, 32, i3);
+        HexDigits.put4(buf, 24, i2);
+        HexDigits.put4(buf, 28, i3 >> 16);
+        HexDigits.put4(buf, 32, i3);
         try {
             return jla.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
         } catch (CharacterCodingException cce) {

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -120,7 +120,7 @@ public final class HexDigits {
      * @param off insert point
      * @param i to convert
      */
-    public static void putHex4(byte[] buffer, int off, int i) {
+    public static void put4(byte[] buffer, int off, int i) {
         // Prepare an int value so C2 generates a 4-byte write instead of two 2-byte writes
         int v = (DIGITS[i & 0xff] << 16) | DIGITS[(i >> 8) & 0xff];
         buffer[off]     = (byte)  v;

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -120,6 +120,7 @@ public final class HexDigits {
      * @param value to convert
      */
     public static void putHex(byte[] buffer, int off, int i) {
+        // Prepare an int value so C2 generates a 4-byte write instead of two 2-byte writes
         int v = (DIGITS[i & 0xff] << 16) | DIGITS[(i >> 8) & 0xff];
         buffer[off]     = (byte)  v;
         buffer[off + 1] = (byte) (v >> 8);

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -117,16 +117,16 @@ public final class HexDigits {
      * Insert the unsigned 2-byte integer into the buffer as 4 hexadecimal digit ASCII bytes,
      * only least significant 16 bits of {@code i} are used.
      * @param buffer byte buffer to copy into
-     * @param off insert point
-     * @param i to convert
+     * @param index insert point
+     * @param value to convert
      */
-    public static void put4(byte[] buffer, int off, int i) {
+    public static void put4(byte[] buffer, int index, int value) {
         // Prepare an int value so C2 generates a 4-byte write instead of two 2-byte writes
-        int v = (DIGITS[i & 0xff] << 16) | DIGITS[(i >> 8) & 0xff];
-        buffer[off]     = (byte)  v;
-        buffer[off + 1] = (byte) (v >> 8);
-        buffer[off + 2] = (byte) (v >> 16);
-        buffer[off + 3] = (byte) (v >> 24);
+        int v = (DIGITS[value & 0xff] << 16) | DIGITS[(value >> 8) & 0xff];
+        buffer[index]     = (byte)  v;
+        buffer[index + 1] = (byte) (v >> 8);
+        buffer[index + 2] = (byte) (v >> 16);
+        buffer[index + 3] = (byte) (v >> 24);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -115,7 +115,7 @@ public final class HexDigits {
 
     /**
      * Insert the unsigned 2-byte integer into the buffer as 4 hexadecimal digit ASCII bytes,
-     * {@code i} only least significant 16 bits are used.
+     * only least significant 16 bits of {@code i} are used.
      * @param buffer byte buffer to copy into
      * @param off insert point
      * @param i to convert

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -115,7 +115,7 @@ public final class HexDigits {
 
     /**
      * Insert the unsigned 2-byte integer into the buffer as 4 hexadecimal digit ASCII bytes,
-     * only least significant 16 bits of {@code i} are used.
+     * only least significant 16 bits of {@code value} are used.
      * @param buffer byte buffer to copy into
      * @param index insert point
      * @param value to convert

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -114,12 +114,13 @@ public final class HexDigits {
     }
 
     /**
-     * Insert the int into the buffer as 4 hexadecimal digits
+     * Insert the unsigned 2-byte integer into the buffer as 4 hexadecimal digit ASCII bytes,
+     * {@code i} only least significant 16 bits are used.
      * @param buffer byte buffer to copy into
      * @param off insert point
-     * @param value to convert
+     * @param i to convert
      */
-    public static void putHex(byte[] buffer, int off, int i) {
+    public static void putHex4(byte[] buffer, int off, int i) {
         // Prepare an int value so C2 generates a 4-byte write instead of two 2-byte writes
         int v = (DIGITS[i & 0xff] << 16) | DIGITS[(i >> 8) & 0xff];
         buffer[off]     = (byte)  v;

--- a/src/java.base/share/classes/jdk/internal/util/HexDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/HexDigits.java
@@ -114,24 +114,17 @@ public final class HexDigits {
     }
 
     /**
-     * Return a little-endian packed integer for the 4 ASCII bytes for an input unsigned 2-byte integer.
-     * {@code b0} is the most significant byte and {@code b1} is the least significant byte.
-     * The integer is passed byte-wise to allow reordering of execution.
+     * Insert the int into the buffer as 4 hexadecimal digits
+     * @param buffer byte buffer to copy into
+     * @param off insert point
+     * @param value to convert
      */
-    public static int packDigits(int b0, int b1) {
-        return DIGITS[b0 & 0xff] | (DIGITS[b1 & 0xff] << 16);
-    }
-
-    /**
-     * Return a little-endian packed long for the 8 ASCII bytes for an input unsigned 4-byte integer.
-     * {@code b0} is the most significant byte and {@code b3} is the least significant byte.
-     * The integer is passed byte-wise to allow reordering of execution.
-     */
-    public static long packDigits(int b0, int b1, int b2, int b3) {
-        return DIGITS[b0 & 0xff]
-                | (DIGITS[b1 & 0xff] << 16)
-                | (((long) DIGITS[b2 & 0xff]) << 32)
-                | (((long) DIGITS[b3 & 0xff]) << 48);
+    public static void putHex(byte[] buffer, int off, int i) {
+        int v = (DIGITS[i & 0xff] << 16) | DIGITS[(i >> 8) & 0xff];
+        buffer[off]     = (byte)  v;
+        buffer[off + 1] = (byte) (v >> 8);
+        buffer[off + 2] = (byte) (v >> 16);
+        buffer[off + 3] = (byte) (v >> 24);
     }
 
     /**


### PR DESCRIPTION
After PR #16245, C2 optimizes stores into primitive arrays by combining values ​​into larger stores. In the UUID.toString method, ByteArrayLittleEndian can be removed, making the code more elegant and faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333833](https://bugs.openjdk.org/browse/JDK-8333833): Remove the use of ByteArrayLittleEndian from UUID::toString (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Author) ⚠️ Review applies to [035a07ab](https://git.openjdk.org/jdk/pull/19610/files/035a07ab7d4f679c914e5dd9089f769637d562be)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) ⚠️ Review applies to [5696288f](https://git.openjdk.org/jdk/pull/19610/files/5696288f9ccd41c3d57b86a4fd6599fc27f9c117)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19610/head:pull/19610` \
`$ git checkout pull/19610`

Update a local copy of the PR: \
`$ git checkout pull/19610` \
`$ git pull https://git.openjdk.org/jdk.git pull/19610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19610`

View PR using the GUI difftool: \
`$ git pr show -t 19610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19610.diff">https://git.openjdk.org/jdk/pull/19610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19610#issuecomment-2155776858)