### PR TITLE
8333841: Add more logging into setfldw001 tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -28,8 +28,6 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
-vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,3 +48,10 @@
  * @run main/othervm/native -agentlib:setfldw001 nsk.jvmti.SetFieldAccessWatch.setfldw001
  */
 
+/*
+ * @test id=logging
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @run main/othervm/native -agentlib:setfldw001 -XX:TraceJVMTI=ec+,+ioe,+s -Xlog:jvmti=trace:file=vm.%p.log nsk.jvmti.SetFieldAccessWatch.setfldw001
+ */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/setfldw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/setfldw001.cpp
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include "jvmti.h"
 #include "agent_common.hpp"
+#include "jvmti_common.hpp"
 #include "JVMTITools.hpp"
 
 extern "C" {
@@ -114,6 +115,14 @@ void JNICALL FieldAccess(jvmtiEnv *jvmti_env, JNIEnv *env,
     }
     fld_ind = (int)(fld_name[len - 1] - '0'); /* last digit is index in the array */
     fields[fld_ind].thrown_fid = field;
+
+    if (field == nullptr) {
+      fatal(env, "null field ID in FieldModification event.");
+    }
+
+    LOG("Event: (Field %d) field ID expected: 0x%p, got: 0x%p\n",
+        fld_ind, fields[fld_ind].fid, field);
+
     jvmti_env->Deallocate((unsigned char*) fld_name);
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,3 +48,10 @@
  * @run main/othervm/native -agentlib:setfmodw001 nsk.jvmti.SetFieldModificationWatch.setfmodw001
  */
 
+/*
+ * @test id=logging
+ *
+ * @library /vmTestbase
+ *          /test/lib
+ * @run main/othervm/native -agentlib:setfmodw001 -XX:TraceJVMTI=ec+,+ioe,+s -Xlog:jvmti=trace:file=vm.%p.log nsk.jvmti.SetFieldModificationWatch.setfmodw001
+ */

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/setfmodw001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/setfmodw001.cpp
@@ -26,6 +26,7 @@
 #include <ctype.h>
 #include "jvmti.h"
 #include "agent_common.hpp"
+#include "jvmti_common.hpp"
 #include "JVMTITools.hpp"
 
 extern "C" {
@@ -108,6 +109,13 @@ void JNICALL FieldModification(jvmtiEnv *jvmti_env, JNIEnv *env,
     }
     fld_ind = (int)(fld_name[len - 1] - '0'); /* last digit is index in the array */
     fields[fld_ind].thrown_fid = field;
+
+    if (field == nullptr) {
+      fatal(env, "null field ID in FieldModification event.");
+    }
+    LOG("Event: (Field %d) field ID expected: 0x%p, got: 0x%p\n",
+        fld_ind, fields[fld_ind].fid, field);
+
     jvmti_env->Deallocate((unsigned char*) fld_name);
 }
 


### PR DESCRIPTION
Tests
SetFieldAccessWatch/setfldw001
SetFieldModificationWatch/setfmodw001
intermittently fail with Xcomp. I was unable to reproduce the problem.
The fix adds more checks and variants with jvmti logging.

The goal is to understand why the test fails.
1. Confirm that the event is not sent. Currently, the test doesn't differ between sending "NULL" event and not sending an event at all. 
2. Check if the interpreter-only mode is switched too late in Thread-1. The jvmti logging shows when field events are enabled and when each thread actually switches to interpreter-only and enables event handling. 

The plan is to try to reproduce the failure and remove '@test id=logging'  after https://bugs.openjdk.org/browse/JDK-8205957 is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333841](https://bugs.openjdk.org/browse/JDK-8333841): Add more logging into setfldw001 tests (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19612/head:pull/19612` \
`$ git checkout pull/19612`

Update a local copy of the PR: \
`$ git checkout pull/19612` \
`$ git pull https://git.openjdk.org/jdk.git pull/19612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19612`

View PR using the GUI difftool: \
`$ git pr show -t 19612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19612.diff">https://git.openjdk.org/jdk/pull/19612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19612#issuecomment-2156105478)