### PR TITLE
8332113: Update nsk.share.Log to be always verbose

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -74,15 +74,15 @@ public class Log {
 
     /**
      * Is log-mode verbose?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean verbose = false;
+    private final boolean verbose = true;
 
     /**
      * Should log messages prefixed with timestamps?
-     * Default value is <code>false</code>.
+     * Always enabled.
      */
-    private boolean timestamp = false;
+    private final boolean timestamp = true;
 
     /**
      * Names for trace levels
@@ -127,7 +127,7 @@ public class Log {
      * Threshold value for printing trace messages for debugging purpose.
      * Default value is <code>0</code> a.k.a. <code>TraceLevel.INFO</code>;
      */
-    private int traceLevel = TraceLevel.DEFAULT;
+    private final int traceLevel = TraceLevel.TRACE_DEBUG + 1;
 
     /**
      * This <code>errosBuffer</code> will keep all messages printed via
@@ -193,7 +193,6 @@ public class Log {
      */
     public Log(PrintStream stream, boolean verbose) {
         this(stream);
-        this.verbose = verbose;
     }
 
     /**
@@ -203,8 +202,6 @@ public class Log {
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
         this(stream, argsParser.verbose());
-        traceLevel = argsParser.getTraceLevel();
-        timestamp = argsParser.isTimestamp();
     }
 
     /////////////////////////////////////////////////////////////////
@@ -223,19 +220,10 @@ public class Log {
         if (!verbose) {
             flushLogBuffer();
         }
-        verbose = enable;
     }
 
     public int getTraceLevel() {
         return traceLevel;
-    }
-
-    /**
-     * Set threshold for printing trace messages.
-     * Warning: trace level changes may NOT be observed by other threads immediately.
-     */
-    public void setTraceLevel(int level) {
-        traceLevel = level;
     }
 
     /**
@@ -422,7 +410,6 @@ public class Log {
             out.flush();
         }
         out = stream;
-        verbose = true;
     }
 
     /////////////////////////////////////////////////////////////////

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -221,9 +221,6 @@ public class Log {
         if (!enable) {
             throw new RuntimeException("The non-verbose logging is not supported.");
         }
-        if (!verbose) {
-            flushLogBuffer();
-        }
     }
 
     public int getTraceLevel() {

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -217,6 +217,9 @@ public class Log {
      * Enable or disable verbose mode for printing messages.
      */
     public void enableVerbose(boolean enable) {
+        if (!enable) {
+            throw new RuntimeException("The non-verbose logging is not supported.");
+        }
         if (!verbose) {
             flushLogBuffer();
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -127,7 +127,7 @@ public class Log {
      * Threshold value for printing trace messages for debugging purpose.
      * Default value is <code>0</code> a.k.a. <code>TraceLevel.INFO</code>;
      */
-    private final int traceLevel = TraceLevel.TRACE_DEBUG + 1;
+    private int traceLevel = TraceLevel.DEFAULT;
 
     /**
      * This <code>errosBuffer</code> will keep all messages printed via
@@ -202,6 +202,7 @@ public class Log {
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
         this(stream, argsParser.verbose());
+        traceLevel = argsParser.getTraceLevel();
     }
 
     /////////////////////////////////////////////////////////////////
@@ -227,6 +228,14 @@ public class Log {
 
     public int getTraceLevel() {
         return traceLevel;
+    }
+
+    /**
+     * Set threshold for printing trace messages.
+     * Warning: trace level changes may NOT be observed by other threads immediately.
+     */
+    public void setTraceLevel(int level) {
+        traceLevel = level;
     }
 
     /**


### PR DESCRIPTION
The nsk.share.Log  has 3 parameters that might be configured by tests or using command-line:
 - verbose, traceLevel and timestamp 

The main purpose of these modes was to minimize output and use command-line arguments to enable them during bug reproducing/debugging for vmTestbase when it was compiled separately.  

However, such an approach has several disadvantages:
 -- For intermittent issues, there is no all data in the logs 
 -- The enabling log might affect test behavior 
 -- No easy way to set these command-line options for jtreg tests
 -- When verbose mode is disabled the messages are saved in some buffer and printed only test complains. The mode causes issues if the test fails without complaining (exception, crash, etc). The messages are just never printed.
  -- the solution is over-complicated.

The fix enabled verbose mode and printing time stamps always, setting the debugging log level.

The plan is to remove all these options and simplify logging as much as possible in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332113](https://bugs.openjdk.org/browse/JDK-8332113): Update nsk.share.Log to be always verbose (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [0434e815](https://git.openjdk.org/jdk/pull/19613/files/0434e815703cfd6757415726f52ff6f4cf7f1c23)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19613/head:pull/19613` \
`$ git checkout pull/19613`

Update a local copy of the PR: \
`$ git checkout pull/19613` \
`$ git pull https://git.openjdk.org/jdk.git pull/19613/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19613`

View PR using the GUI difftool: \
`$ git pr show -t 19613`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19613.diff">https://git.openjdk.org/jdk/pull/19613.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19613#issuecomment-2159542025)