### PR TITLE
8331675: gtest CollectorPolicy.young_min_ergo_vm fails after 8272364

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -213,18 +213,6 @@ class TestGenCollectorPolicy {
 // verify that there are some basic rules for NewSize honored by the policies.
 
 // If NewSize has been ergonomically set, the collector policy
-// should use it for min
-// This test doesn't work with 64k pages. See JDK-8331675.
-#if !defined(PPC)
-TEST_VM(CollectorPolicy, young_min_ergo) {
-  TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
-  TestGenCollectorPolicy::CheckYoungMin checker(20 * M);
-
-  TestGenCollectorPolicy::TestWrapper::test(&setter, &checker);
-}
-#endif
-
-// If NewSize has been ergonomically set, the collector policy
 // should use it for min but calculate the initial young size
 // using NewRatio.
 TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {


### PR DESCRIPTION
Remove a gtest test case around `NewSize`.

The gtest `young_min_ergo` essentially checks NewSize 20M set ergonomically will be preserved and MinNewSize will be <= 20M. However, the GCArguments::initialize_heap_sizes can overwrite the 20M value, in the process of respecting `InitialHeapSize` and `NewRatio`.

A more correct assert would be `ASSERT_LE(MinNewSize, NewSize);` in `CheckYoungMin` so that the up-to-date `NewSize` is picked up. The `MinNewSize <= NewSize` invariant is already checked in `GenArguments::assert_size_info`, so this gtest offers little benefit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8331675: gtest CollectorPolicy.young_min_ergo_vm fails after 8272364`

### Issue
 * [JDK-8331675](https://bugs.openjdk.org/browse/JDK-8331675): gtest CollectorPolicy.young_min_ergo_vm fails after 8272364 (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19621/head:pull/19621` \
`$ git checkout pull/19621`

Update a local copy of the PR: \
`$ git checkout pull/19621` \
`$ git pull https://git.openjdk.org/jdk.git pull/19621/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19621`

View PR using the GUI difftool: \
`$ git pr show -t 19621`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19621.diff">https://git.openjdk.org/jdk/pull/19621.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19621#issuecomment-2157898151)