### PR TITLE
8333722: Fix CompilerDirectives for non-compiler JVM variants

### DIFF
--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -761,7 +761,7 @@ DirectiveSet* DirectivesStack::getMatchingDirective(const methodHandle& method, 
       if (dir->is_default_directive() || dir->match(method)) {
         match = dir->get_for(comp);
         assert(match != nullptr, "Consistency");
-        if (match->EnableOption) {
+        if (match->EnableOption || dir->is_default_directive()) {
           // The directiveSet for this compile is also enabled -> success
           dir->inc_refcount();
           break;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit 5f9d3e3a from the openjdk/jdk repository.

The commit being backported was authored by Volker Simonis on 10 Jun 2024 and was reviewed by Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333722](https://bugs.openjdk.org/browse/JDK-8333722): Fix CompilerDirectives for non-compiler JVM variants (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19622/head:pull/19622` \
`$ git checkout pull/19622`

Update a local copy of the PR: \
`$ git checkout pull/19622` \
`$ git pull https://git.openjdk.org/jdk.git pull/19622/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19622`

View PR using the GUI difftool: \
`$ git pr show -t 19622`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19622.diff">https://git.openjdk.org/jdk/pull/19622.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19622#issuecomment-2157946818)