### PR TITLE
8333639: ubsan: cppVtables.cpp:81:55: runtime error: index 14 out of bounds for type 'long int [1]'

### DIFF
--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -67,6 +67,7 @@
 class CppVtableInfo {
   intptr_t _vtable_size;
   intptr_t _cloned_vtable[1]; // Pseudo flexible array member.
+  static size_t cloned_vtable_offs() { return offset_of(CppVtableInfo, _cloned_vtable); }
 public:
   static int num_slots(int vtable_size) {
     return 1 + vtable_size; // Need to add the space occupied by _vtable_size;
@@ -74,12 +75,11 @@ public:
   int vtable_size()           { return int(uintx(_vtable_size)); }
   void set_vtable_size(int n) { _vtable_size = intptr_t(n); }
   // Using _cloned_vtable[i] for i > 0 causes undefined behavior. We use address calculation instead.
-  intptr_t* cloned_vtable()   { return (intptr_t*)((char*)this + offset_of(CppVtableInfo, _cloned_vtable)); }
+  intptr_t* cloned_vtable()   { return (intptr_t*)((char*)this + cloned_vtable_offs()); }
   void zero()                 { memset(cloned_vtable(), 0, sizeof(intptr_t) * vtable_size()); }
   // Returns the address of the next CppVtableInfo that can be placed immediately after this CppVtableInfo
   static size_t byte_size(int vtable_size) {
-    CppVtableInfo i;
-    return pointer_delta(&i.cloned_vtable()[vtable_size], &i, sizeof(u1));
+    return cloned_vtable_offs() + (sizeof(intptr_t) * vtable_size);
   }
 };
 

--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -67,19 +67,16 @@
 class CppVtableInfo {
   intptr_t _vtable_size;
   intptr_t _cloned_vtable[1]; // Pseudo flexible array member.
-  static size_t cloned_vtable_offs() { return offset_of(CppVtableInfo, _cloned_vtable); }
+  static size_t cloned_vtable_offset() { return offset_of(CppVtableInfo, _cloned_vtable); }
 public:
-  static int num_slots(int vtable_size) {
-    return 1 + vtable_size; // Need to add the space occupied by _vtable_size;
-  }
   int vtable_size()           { return int(uintx(_vtable_size)); }
   void set_vtable_size(int n) { _vtable_size = intptr_t(n); }
   // Using _cloned_vtable[i] for i > 0 causes undefined behavior. We use address calculation instead.
-  intptr_t* cloned_vtable()   { return (intptr_t*)((char*)this + cloned_vtable_offs()); }
+  intptr_t* cloned_vtable()   { return (intptr_t*)((char*)this + cloned_vtable_offset()); }
   void zero()                 { memset(cloned_vtable(), 0, sizeof(intptr_t) * vtable_size()); }
   // Returns the address of the next CppVtableInfo that can be placed immediately after this CppVtableInfo
   static size_t byte_size(int vtable_size) {
-    return cloned_vtable_offs() + (sizeof(intptr_t) * vtable_size);
+    return cloned_vtable_offset() + (sizeof(intptr_t) * vtable_size);
   }
 };
 

--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -66,7 +66,7 @@
 
 class CppVtableInfo {
   intptr_t _vtable_size;
-  intptr_t _cloned_vtable[1];
+  intptr_t _cloned_vtable[];
 public:
   static int num_slots(int vtable_size) {
     return 1 + vtable_size; // Need to add the space occupied by _vtable_size;

--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -66,15 +66,15 @@
 
 class CppVtableInfo {
   intptr_t _vtable_size;
-  // intptr_t _cloned_vtable[]; exists here, but flexible array members are C99, not C++.
-  // Therefore, it's used implicitly as the space following _vtable_size.
+  intptr_t _cloned_vtable[1]; // Pseudo flexible array member.
 public:
   static int num_slots(int vtable_size) {
     return 1 + vtable_size; // Need to add the space occupied by _vtable_size;
   }
   int vtable_size()           { return int(uintx(_vtable_size)); }
   void set_vtable_size(int n) { _vtable_size = intptr_t(n); }
-  intptr_t* cloned_vtable()   { return &_vtable_size + 1; }
+  // Using _cloned_vtable[i] for i > 0 causes undefined behavior. We use address calculation instead.
+  intptr_t* cloned_vtable()   { return (intptr_t*)((char*)this + offset_of(CppVtableInfo, _cloned_vtable)); }
   void zero()                 { memset(cloned_vtable(), 0, sizeof(intptr_t) * vtable_size()); }
   // Returns the address of the next CppVtableInfo that can be placed immediately after this CppVtableInfo
   static size_t byte_size(int vtable_size) {

--- a/src/hotspot/share/cds/cppVtables.cpp
+++ b/src/hotspot/share/cds/cppVtables.cpp
@@ -66,19 +66,20 @@
 
 class CppVtableInfo {
   intptr_t _vtable_size;
-  intptr_t _cloned_vtable[];
+  // intptr_t _cloned_vtable[]; exists here, but flexible array members are C99, not C++.
+  // Therefore, it's used implicitly as the space following _vtable_size.
 public:
   static int num_slots(int vtable_size) {
     return 1 + vtable_size; // Need to add the space occupied by _vtable_size;
   }
   int vtable_size()           { return int(uintx(_vtable_size)); }
   void set_vtable_size(int n) { _vtable_size = intptr_t(n); }
-  intptr_t* cloned_vtable()   { return &_cloned_vtable[0]; }
-  void zero()                 { memset(_cloned_vtable, 0, sizeof(intptr_t) * vtable_size()); }
+  intptr_t* cloned_vtable()   { return &_vtable_size + 1; }
+  void zero()                 { memset(cloned_vtable(), 0, sizeof(intptr_t) * vtable_size()); }
   // Returns the address of the next CppVtableInfo that can be placed immediately after this CppVtableInfo
   static size_t byte_size(int vtable_size) {
     CppVtableInfo i;
-    return pointer_delta(&i._cloned_vtable[vtable_size], &i, sizeof(u1));
+    return pointer_delta(&i.cloned_vtable()[vtable_size], &i, sizeof(u1));
   }
 };
 


### PR DESCRIPTION
We shouldn't specify a wrong array length which causes undefined behavior. Using a "flexible array member".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333639](https://bugs.openjdk.org/browse/JDK-8333639): ubsan: cppVtables.cpp:81:55: runtime error: index 14 out of bounds for type 'long int [1]' (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19623/head:pull/19623` \
`$ git checkout pull/19623`

Update a local copy of the PR: \
`$ git checkout pull/19623` \
`$ git pull https://git.openjdk.org/jdk.git pull/19623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19623`

View PR using the GUI difftool: \
`$ git pr show -t 19623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19623.diff">https://git.openjdk.org/jdk/pull/19623.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19623#issuecomment-2158050328)