### PR TITLE
8332699: ubsan: jfrEventSetting.inline.hpp:31:43: runtime error: index 163 out of bounds for type 'jfrNativeEventSetting [162]'

### DIFF
--- a/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
+++ b/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -663,7 +663,7 @@ public class GenerateJfrFiles {
             out.write("");
             out.write("union JfrNativeSettings {");
             out.write("  // Array version.");
-            out.write("  jfrNativeEventSetting bits[NUMBER_OF_EVENTS];");
+            out.write("  jfrNativeEventSetting bits[NUMBER_OF_EVENTS + NUMBER_OF_RESERVED_EVENTS];");
             out.write("  // Then, to make it easy to debug,");
             out.write("  // add named struct members also.");
             out.write("  struct {");


### PR DESCRIPTION
When running hs :tier1 tests or jdk/jfr tests, with ubsan enabled (configure flag --enable-ubsan), in a lot of jfr related tests like
compiler/intrinsics/klass/CastNullCheckDroppingsTest.jtr
serviceability/jvmti/RedefineClasses/RedefineSharedClassJFR.jtr
this oob error can be seen :

/jdk/src/hotspot/share/jfr/recorder/jfrEventSetting.inline.hpp:31:43: runtime error: index 163 out of bounds for type 'jfrNativeEventSetting [162]'
    #0 0x7f6b75a8634b in JfrEventSetting::setting(JfrEventId) /jdk/src/hotspot/share/jfr/recorder/jfrEventSetting.inline.hpp:31
    #1 0x7f6b75a8634b in JfrEventSetting::set_stacktrace(long, bool) /jdk/src/hotspot/share/jfr/recorder/jfrEventSetting.cpp:47

Looks like the array in generated code is too small.
With
`jfrNativeEventSetting bits[NUMBER_OF_EVENTS];`
and
```
static const int NUMBER_OF_EVENTS = 162;
static const int NUMBER_OF_RESERVED_EVENTS = 2;
```

Access at index 163 cannot work.
But it looks like there is always enough memory after the array so we do not crash and it was not noticed before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332699](https://bugs.openjdk.org/browse/JDK-8332699): ubsan: jfrEventSetting.inline.hpp:31:43: runtime error: index 163 out of bounds for type 'jfrNativeEventSetting [162]' (**Bug** - P4)


### Reviewers
 * [Johannes Bechberger](https://openjdk.org/census#jbechberger) (@parttimenerd - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19628/head:pull/19628` \
`$ git checkout pull/19628`

Update a local copy of the PR: \
`$ git checkout pull/19628` \
`$ git pull https://git.openjdk.org/jdk.git pull/19628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19628`

View PR using the GUI difftool: \
`$ git pr show -t 19628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19628.diff">https://git.openjdk.org/jdk/pull/19628.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19628#issuecomment-2158229750)