### PR TITLE
8333887: ubsan: unsafe.cpp:247:13: runtime error: store to null pointer of type 'volatile int'

### DIFF
--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -242,6 +242,11 @@ public:
     return normalize_for_read(*addr());
   }
 
+  // we use this method at some places for writing to 0 e.g. to cause a crash;
+  // ubsan does not know that this is the desired behavior
+#if defined(__clang__) || defined(__GNUC__)
+__attribute__((no_sanitize("undefined")))
+#endif
   void put(T x) {
     GuardUnsafeAccess guard(_thread);
     *addr() = normalize_for_write(x);


### PR DESCRIPTION
When running with ubsan enabled binaries, in a number of tests like
jdk/jfr/event/runtime/TestShutdownEvent.jtr
jdk/jfr/jvm/TestDumpOnCrash.jtr
we get those ubsan-errors :

src/hotspot/share/prims/unsafe.cpp:247:13: runtime error: store to null pointer of type 'volatile int'
    #0 0x7f0be9a3e10d in MemoryAccess<int>::put(int) src/hotspot/share/prims/unsafe.cpp:247
    #1 0x7f0be9a3e10d in Unsafe_PutInt src/hotspot/share/prims/unsafe.cpp:315
    #2 0x7f0bd0502e7b (<unknown module>)
    #3 0x7f0bd04fe01f (<unknown module>)
    #4 0x7f0bd04fe01f (<unknown module>)
    #5 0x7f0bd04fe525 (<unknown module>)
    #6 0x7f0bd04f6c85 (<unknown module>)
    #7 0x7f0be80a2972 in JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*) src/hotspot/share/runtime/javaCalls.cpp:415
    #8 0x7f0be83160d8 in jni_invoke_static src/hotspot/share/prims/jni.cpp:888
    #9 0x7f0be831d875 in jni_CallStaticVoidMethod src/hotspot/share/prims/jni.cpp:1717
    #10 0x7f0beed32cf8 in invokeStaticMainWithArgs src/java.base/share/native/libjli/java.c:418
    #11 0x7f0beed35894 in JavaMain src/java.base/share/native/libjli/java.c:623
    #12 0x7f0beed3cf68 in ThreadJavaMain src/java.base/unix/native/libjli/java_md.c:653
    #13 0x7f0beeceb6e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)

Looks like we use unsafe to put/write to 0 e.g. to cause a crash. Probably we could add an attribute to the function so that ubsan stops complaining (the put to 0 is done for a reason but ubsan cannot know this).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333887](https://bugs.openjdk.org/browse/JDK-8333887): ubsan: unsafe.cpp:247:13: runtime error: store to null pointer of type 'volatile int' (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19630/head:pull/19630` \
`$ git checkout pull/19630`

Update a local copy of the PR: \
`$ git checkout pull/19630` \
`$ git pull https://git.openjdk.org/jdk.git pull/19630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19630`

View PR using the GUI difftool: \
`$ git pr show -t 19630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19630.diff">https://git.openjdk.org/jdk/pull/19630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19630#issuecomment-2158451977)