### PR TITLE
8333886: Explicitly specify that asSlice and reinterpret return a memory segment backed by the same region of memory.

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -631,8 +631,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, newSize, 1);
      * }
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @see #asSlice(long, long, long)
      *
@@ -650,8 +650,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * alignment constraint. The returned segment's address is the address of this
      * segment plus the given offset; its size is specified by the given argument.
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @param offset The new segment base offset (relative to the address of this segment),
      *               specified in bytes
@@ -677,8 +677,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, layout.byteSize(), layout.byteAlignment());
      * }
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @see #asSlice(long, long, long)
      *
@@ -703,8 +703,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, byteSize() - offset);
      * }
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @see #asSlice(long, long)
      *
@@ -719,8 +719,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Returns a new memory segment that has the same address and scope as this segment,
      * but with the provided size.
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @param newSize the size of the returned segment
      * @return a new memory segment that has the same address and scope as
@@ -757,8 +757,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@link #byteSize()}.
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @apiNote The cleanup action (if present) should take care not to leak the received
      *          segment to external clients that might access the segment after its
@@ -805,8 +805,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@code newSize}.
      * <p>
-     * The returned memory segment is backed by a subset of the region of memory
-     * that backs this memory segment.
+     * The returned memory segment shares a region of backing memory with this segment.
+     * Hence, no memory will be allocated or freed by this method.
      *
      * @apiNote The cleanup action (if present) should take care not to leak the received
      *          segment to external clients that might access the segment after its

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -630,6 +630,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * {@snippet lang=java :
      * asSlice(offset, newSize, 1);
      * }
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @see #asSlice(long, long, long)
      *
@@ -646,6 +649,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Returns a slice of this memory segment, at the given offset, with the provided
      * alignment constraint. The returned segment's address is the address of this
      * segment plus the given offset; its size is specified by the given argument.
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @param offset The new segment base offset (relative to the address of this segment),
      *               specified in bytes
@@ -670,6 +676,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * {@snippet lang=java :
      * asSlice(offset, layout.byteSize(), layout.byteAlignment());
      * }
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @see #asSlice(long, long, long)
      *
@@ -693,6 +702,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * {@snippet lang=java :
      * asSlice(offset, byteSize() - offset);
      * }
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @see #asSlice(long, long)
      *
@@ -706,6 +718,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * Returns a new memory segment that has the same address and scope as this segment,
      * but with the provided size.
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @param newSize the size of the returned segment
      * @return a new memory segment that has the same address and scope as
@@ -741,6 +756,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * That is, the cleanup action receives a segment that is associated with the global
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@link #byteSize()}.
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @apiNote The cleanup action (if present) should take care not to leak the received
      *          segment to external clients that might access the segment after its
@@ -786,6 +804,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * That is, the cleanup action receives a segment that is associated with the global
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@code newSize}.
+     * <p>
+     * The returned memory segment is backed by a subset of the region of memory
+     * that backs this memory segment.
      *
      * @apiNote The cleanup action (if present) should take care not to leak the received
      *          segment to external clients that might access the segment after its


### PR DESCRIPTION
This PR proposes to explicitly state that returned segments form the `asSlice` and `reinterpret` method share memory regions with `this` memory segment.

Note: The term "subset"  means a true subset or the same set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8333886: Explicitly specify that asSlice and reinterpret return a memory segment backed by the same region of memory.`

### Issue
 * [JDK-8333886](https://bugs.openjdk.org/browse/JDK-8333886): Explicitly specify that asSlice and reinterpret return a memory segment backed by the same region of memory. (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19633/head:pull/19633` \
`$ git checkout pull/19633`

Update a local copy of the PR: \
`$ git checkout pull/19633` \
`$ git pull https://git.openjdk.org/jdk.git pull/19633/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19633`

View PR using the GUI difftool: \
`$ git pr show -t 19633`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19633.diff">https://git.openjdk.org/jdk/pull/19633.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19633#issuecomment-2158722267)