### PR TITLE
8333891: Method excluded with directive is not compiled after removal of directive

### DIFF
--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1350,6 +1350,18 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   return nm;
 }
 
+static void clear_is_not_compilable_by(const methodHandle& method, AbstractCompiler* comp) {
+  if (comp == nullptr) {
+    return;
+  }
+
+  if (comp->is_c1()) {
+    method->clear_is_not_c1_compilable();
+  } else if (comp->is_c2()) {
+    method->clear_is_not_c2_compilable();
+  }
+}
+
 nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
                                          int comp_level,
                                          const methodHandle& hot_method, int hot_count,
@@ -1367,6 +1379,11 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   // lock, make sure that the compilation
   // isn't prohibited in a straightforward way.
   AbstractCompiler* comp = CompileBroker::compiler(comp_level);
+
+  // Compilation of a method not being compilable can be requested.
+  // We clear its not compilable status. The status will be updated
+  // as a result of the compilation.
+  clear_is_not_compilable_by(method, comp);
   if (comp == nullptr || compilation_is_prohibited(method, osr_bci, comp_level, directive->ExcludeOption)) {
     return nullptr;
   }

--- a/src/hotspot/share/compiler/compileBroker.cpp
+++ b/src/hotspot/share/compiler/compileBroker.cpp
@@ -1145,7 +1145,6 @@ void CompileBroker::compile_method_base(const methodHandle& method,
                                         const methodHandle& hot_method,
                                         int hot_count,
                                         CompileTask::CompileReason compile_reason,
-                                        bool blocking,
                                         Thread* thread) {
   guarantee(!method->is_abstract(), "cannot compile abstract methods");
   assert(method->method_holder()->is_instance_klass(),
@@ -1209,6 +1208,7 @@ void CompileBroker::compile_method_base(const methodHandle& method,
   // Outputs from the following MutexLocker block:
   CompileTask* task     = nullptr;
   CompileQueue* queue  = compile_queue(comp_level);
+  bool blocking = false;
 
   // Acquire our lock.
   {
@@ -1236,6 +1236,10 @@ void CompileBroker::compile_method_base(const methodHandle& method,
       // The compilation falls outside the allowed range.
       return;
     }
+
+    // This directive will be owned by a compile task.
+    DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, compiler(comp_level));
+    blocking = !directive->BackgroundCompilationOption || ReplayCompiles;
 
 #if INCLUDE_JVMCI
     if (UseJVMCICompiler && blocking) {
@@ -1315,11 +1319,54 @@ void CompileBroker::compile_method_base(const methodHandle& method,
                                compile_id, method,
                                osr_bci, comp_level,
                                hot_method, hot_count, compile_reason,
-                               blocking);
+                               directive, blocking);
   }
 
   if (blocking) {
     wait_for_completion(task);
+  }
+}
+
+static void apply_directive_exclude_option(const methodHandle& method, int comp_level) {
+  if (method->is_always_compilable()) {
+    return;
+  }
+
+  // Compiler directives can be updated.
+  // We need to guarantee that the directive is not changed while we are using it.
+  MutexLocker locker(DirectivesStack_lock, Mutex::_no_safepoint_check_flag);
+
+  if (method->is_not_compilable(comp_level) && !method->is_excluded_from_compilation(comp_level)) {
+    // The method is already not compilable, no need to exclude it.
+    return;
+  }
+
+  assert(method->is_not_compilable(comp_level) == method->is_excluded_from_compilation(comp_level),
+         "Excluded status must be aligned with compilable status");
+
+  AbstractCompiler *comp = CompileBroker::compiler(comp_level);
+  assert(comp != nullptr, "Ensure we have a compiler");
+
+  DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, comp);
+  const bool excluded_new_value = directive->ExcludeOption;
+  DirectivesStack::release(directive);
+  const bool not_compilable = method->is_not_compilable(comp_level);
+  const bool excluded_old_value = method->is_excluded_from_compilation(comp_level);
+  if (excluded_new_value == excluded_old_value) {
+    return;
+  }
+
+  if (comp->is_c1()) {
+    method->set_is_c1_excluded(excluded_new_value);
+    method->set_is_not_c1_compilable(excluded_new_value);
+  } else if (comp->is_c2()) {
+    method->set_is_c2_excluded(excluded_new_value);
+    method->set_is_not_c2_compilable(excluded_new_value);
+  }
+  if (excluded_new_value) {
+    method->print_made_not_compilable(comp_level, /*is_osr*/ false, /*report*/ true, "excluded by CompilerDirective");
+  } else {
+    method->print_made_compilable(comp_level, "included by CompilerDirective");
   }
 }
 
@@ -1333,7 +1380,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     return nullptr;
   }
 
-  AbstractCompiler *comp = CompileBroker::compiler(comp_level);
+  AbstractCompiler *comp = compiler(comp_level);
   assert(comp != nullptr, "Ensure we have a compiler");
 
 #if INCLUDE_JVMCI
@@ -1343,50 +1390,17 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
   }
 #endif
 
-  DirectiveSet* directive = DirectivesStack::getMatchingDirective(method, comp);
-  // CompileBroker::compile_method can trap and can have pending async exception.
-  nmethod* nm = CompileBroker::compile_method(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, directive, THREAD);
-  DirectivesStack::release(directive);
-  return nm;
-}
-
-static void clear_is_not_compilable_by(const methodHandle& method, AbstractCompiler* comp) {
-  if (comp == nullptr) {
-    return;
-  }
-
-  if (comp->is_c1()) {
-    method->clear_is_not_c1_compilable();
-  } else if (comp->is_c2()) {
-    method->clear_is_not_c2_compilable();
-  }
-}
-
-nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
-                                         int comp_level,
-                                         const methodHandle& hot_method, int hot_count,
-                                         CompileTask::CompileReason compile_reason,
-                                         DirectiveSet* directive,
-                                         TRAPS) {
-
   // make sure arguments make sense
   assert(method->method_holder()->is_instance_klass(), "not an instance method");
   assert(osr_bci == InvocationEntryBci || (0 <= osr_bci && osr_bci < method->code_size()), "bci out of range");
   assert(!method->is_abstract() && (osr_bci == InvocationEntryBci || !method->is_native()), "cannot compile abstract/native methods");
   assert(!method->method_holder()->is_not_initialized(), "method holder must be initialized");
-  // return quickly if possible
 
-  // lock, make sure that the compilation
-  // isn't prohibited in a straightforward way.
-  AbstractCompiler* comp = CompileBroker::compiler(comp_level);
-
-  // Compilation of a method not being compilable can be requested.
-  // We clear its not compilable status. The status will be updated
-  // as a result of the compilation.
-  clear_is_not_compilable_by(method, comp);
-  if (comp == nullptr || compilation_is_prohibited(method, osr_bci, comp_level, directive->ExcludeOption)) {
+  if (compilation_is_prohibited(method, osr_bci, comp_level)) {
     return nullptr;
   }
+
+  apply_directive_exclude_option(method, comp_level);
 
   if (osr_bci == InvocationEntryBci) {
     // standard compilation
@@ -1488,8 +1502,7 @@ nmethod* CompileBroker::compile_method(const methodHandle& method, int osr_bci,
     if (!should_compile_new_jobs()) {
       return nullptr;
     }
-    bool is_blocking = !directive->BackgroundCompilationOption || ReplayCompiles;
-    compile_method_base(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, is_blocking, THREAD);
+    compile_method_base(method, osr_bci, comp_level, hot_method, hot_count, compile_reason, THREAD);
   }
 
   // return requested nmethod
@@ -1546,25 +1559,26 @@ bool CompileBroker::compilation_is_in_queue(const methodHandle& method) {
 // CompileBroker::compilation_is_prohibited
 //
 // See if this compilation is not allowed.
-bool CompileBroker::compilation_is_prohibited(const methodHandle& method, int osr_bci, int comp_level, bool excluded) {
+bool CompileBroker::compilation_is_prohibited(const methodHandle& method, int osr_bci, int comp_level) {
+  assert(compiler(comp_level) != nullptr, "Ensure we have a compiler");
+
   bool is_native = method->is_native();
   // Some compilers may not support the compilation of natives.
-  AbstractCompiler *comp = compiler(comp_level);
-  if (is_native && (!CICompileNatives || comp == nullptr)) {
+  if (is_native && !CICompileNatives) {
     method->set_not_compilable_quietly("native methods not supported", comp_level);
     return true;
   }
 
   bool is_osr = (osr_bci != standard_entry_bci);
   // Some compilers may not support on stack replacement.
-  if (is_osr && (!CICompileOSR || comp == nullptr)) {
+  if (is_osr && !CICompileOSR) {
     method->set_not_osr_compilable("OSR not supported", comp_level);
     return true;
   }
 
   // The method may be explicitly excluded by the user.
   double scale;
-  if (excluded || (CompilerOracle::has_option_value(method, CompileCommandEnum::CompileThresholdScaling, scale) && scale == 0)) {
+  if (CompilerOracle::has_option_value(method, CompileCommandEnum::CompileThresholdScaling, scale) && scale == 0) {
     bool quietly = CompilerOracle::be_quiet();
     if (PrintCompilation && !quietly) {
       // This does not happen quietly...
@@ -1639,11 +1653,12 @@ CompileTask* CompileBroker::create_compile_task(CompileQueue*       queue,
                                                 const methodHandle& hot_method,
                                                 int                 hot_count,
                                                 CompileTask::CompileReason compile_reason,
+                                                DirectiveSet*       directive,
                                                 bool                blocking) {
   CompileTask* new_task = CompileTask::allocate();
   new_task->initialize(compile_id, method, osr_bci, comp_level,
                        hot_method, hot_count, compile_reason,
-                       blocking);
+                       directive, blocking);
   queue->add(new_task);
   return new_task;
 }

--- a/src/hotspot/share/compiler/compileBroker.hpp
+++ b/src/hotspot/share/compiler/compileBroker.hpp
@@ -244,7 +244,7 @@ class CompileBroker: AllStatic {
   static JavaThread* make_thread(ThreadType type, jobject thread_oop, CompileQueue* queue, AbstractCompiler* comp, JavaThread* THREAD);
   static void init_compiler_threads();
   static void possibly_add_compiler_threads(JavaThread* THREAD);
-  static bool compilation_is_prohibited(const methodHandle& method, int osr_bci, int comp_level, bool excluded);
+  static bool compilation_is_prohibited(const methodHandle& method, int osr_bci, int comp_level);
 
   static CompileTask* create_compile_task(CompileQueue*       queue,
                                           int                 compile_id,
@@ -254,6 +254,7 @@ class CompileBroker: AllStatic {
                                           const methodHandle& hot_method,
                                           int                 hot_count,
                                           CompileTask::CompileReason compile_reason,
+                                          DirectiveSet*       directive,
                                           bool                blocking);
   static void wait_for_completion(CompileTask* task);
 #if INCLUDE_JVMCI
@@ -275,7 +276,6 @@ class CompileBroker: AllStatic {
                                   const methodHandle& hot_method,
                                   int hot_count,
                                   CompileTask::CompileReason compile_reason,
-                                  bool blocking,
                                   Thread* thread);
 
   static CompileQueue* compile_queue(int comp_level);
@@ -313,17 +313,6 @@ public:
   static CompileQueue* c1_compile_queue();
   static CompileQueue* c2_compile_queue();
 
-private:
-  static nmethod* compile_method(const methodHandle& method,
-                                   int osr_bci,
-                                   int comp_level,
-                                   const methodHandle& hot_method,
-                                   int hot_count,
-                                   CompileTask::CompileReason compile_reason,
-                                   DirectiveSet* directive,
-                                   TRAPS);
-
-public:
   // Acquire any needed locks and assign a compile id
   static int assign_compile_id_unlocked(Thread* thread, const methodHandle& method, int osr_bci);
 

--- a/src/hotspot/share/compiler/compileTask.cpp
+++ b/src/hotspot/share/compiler/compileTask.cpp
@@ -93,6 +93,7 @@ void CompileTask::initialize(int compile_id,
                              const methodHandle& hot_method,
                              int hot_count,
                              CompileTask::CompileReason compile_reason,
+                             DirectiveSet* directive,
                              bool is_blocking) {
   assert(!_lock->is_locked(), "bad locking");
 
@@ -117,8 +118,7 @@ void CompileTask::initialize(int compile_id,
   _time_started = 0;
   _compile_reason = compile_reason;
   _nm_content_size = 0;
-  AbstractCompiler* comp = compiler();
-  _directive = DirectivesStack::getMatchingDirective(method, comp);
+  _directive = directive;
   _nm_insts_size = 0;
   _nm_total_size = 0;
   _failure_reason = nullptr;

--- a/src/hotspot/share/compiler/compileTask.hpp
+++ b/src/hotspot/share/compiler/compileTask.hpp
@@ -122,7 +122,7 @@ class CompileTask : public CHeapObj<mtCompiler> {
 
   void initialize(int compile_id, const methodHandle& method, int osr_bci, int comp_level,
                   const methodHandle& hot_method, int hot_count,
-                  CompileTask::CompileReason compile_reason, bool is_blocking);
+                  CompileTask::CompileReason compile_reason, DirectiveSet* directive, bool is_blocking);
 
   static CompileTask* allocate();
   static void         free(CompileTask* task);

--- a/src/hotspot/share/compiler/compilerDirectives.cpp
+++ b/src/hotspot/share/compiler/compilerDirectives.cpp
@@ -728,7 +728,7 @@ void DirectivesStack::print(outputStream* st) {
 
 void DirectivesStack::release(DirectiveSet* set) {
   assert(set != nullptr, "Never nullptr");
-  MutexLocker locker(DirectivesStack_lock, Mutex::_no_safepoint_check_flag);
+  ConditionalMutexLocker locker(DirectivesStack_lock, !DirectivesStack_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
   if (set->is_exclusive_copy()) {
     // Old CompilecCmmands forced us to create an exclusive copy
     delete set;
@@ -752,7 +752,7 @@ DirectiveSet* DirectivesStack::getMatchingDirective(const methodHandle& method, 
 
   DirectiveSet* match = nullptr;
   {
-    MutexLocker locker(DirectivesStack_lock, Mutex::_no_safepoint_check_flag);
+    ConditionalMutexLocker locker(DirectivesStack_lock, !DirectivesStack_lock->owned_by_self(), Mutex::_no_safepoint_check_flag);
 
     CompilerDirectives* dir = _top;
     assert(dir != nullptr, "Must be initialized");

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -1028,6 +1028,34 @@ void Method::print_made_not_compilable(int comp_level, bool is_osr, bool report,
   }
 }
 
+void Method::print_made_compilable(int comp_level, const char* reason) {
+  assert(reason != nullptr, "must provide a reason");
+  if (PrintCompilation) {
+    ttyLocker ttyl;
+    tty->print("made compilable on ");
+    if (comp_level == CompLevel_all) {
+      tty->print("all levels ");
+    } else {
+      tty->print("level %d ", comp_level);
+    }
+    this->print_short_name(tty);
+    int size = this->code_size();
+    if (size > 0) {
+      tty->print(" (%d bytes)", size);
+    }
+    tty->print_cr("   %s", reason);
+  }
+  if ((TraceDeoptimization || LogCompilation) && (xtty != nullptr)) {
+    ttyLocker ttyl;
+    xtty->begin_elem("make_compilable thread='" UINTX_FORMAT "' level='%d'",
+                     os::current_thread_id(), comp_level);
+    xtty->print(" reason=\'%s\'", reason);
+    xtty->method(this);
+    xtty->stamp();
+    xtty->end_elem();
+  }
+}
+
 bool Method::is_always_compilable() const {
   // Generated adapters must be compiled
   if (is_special_native_intrinsic() && is_synthetic()) {
@@ -1096,6 +1124,16 @@ void Method::set_not_osr_compilable(const char* reason, int comp_level, bool rep
       set_is_not_c2_osr_compilable();
   }
   assert(!CompilationPolicy::can_be_osr_compiled(methodHandle(Thread::current(), this), comp_level), "sanity check");
+}
+
+bool Method::is_excluded_from_compilation(int comp_level) const {
+  if (comp_level == CompLevel_any)
+    return is_c1_excluded() && is_c2_excluded();
+  if (is_c1_compile(comp_level))
+    return is_c1_excluded();
+  if (is_c2_compile(comp_level))
+    return is_c2_excluded();
+  return false;
 }
 
 // Revert to using the interpreter and clear out the nmethod

--- a/src/hotspot/share/oops/method.hpp
+++ b/src/hotspot/share/oops/method.hpp
@@ -801,11 +801,11 @@ public:
     set_not_osr_compilable(reason, comp_level, false);
   }
   bool is_always_compilable() const;
+  bool is_excluded_from_compilation(int comp_level) const;
 
- private:
   void print_made_not_compilable(int comp_level, bool is_osr, bool report, const char* reason);
+  void print_made_compilable(int comp_level, const char* reason);
 
- public:
   MethodCounters* get_method_counters(Thread* current) {
     if (_method_counters == nullptr) {
       build_method_counters(current, this);

--- a/src/hotspot/share/oops/methodFlags.hpp
+++ b/src/hotspot/share/oops/methodFlags.hpp
@@ -58,6 +58,8 @@ class MethodFlags {
    status(has_loops_flag              , 1 << 13) /* Method has loops */ \
    status(has_loops_flag_init         , 1 << 14) /* The loop flag has been initialized */ \
    status(on_stack_flag               , 1 << 15) /* RedefineClasses support to keep Metadata from being cleaned */ \
+   status(is_c1_excluded              , 1 << 16) /* Method is excluded from C1 compilation with a directive */ \
+   status(is_c2_excluded              , 1 << 17) /* Method is excluded from C2 compilation with a directive */ \
    /* end of list */
 
 #define M_STATUS_ENUM_NAME(name, value)    _misc_##name = value,

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/ClearDirectivesTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/ClearDirectivesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test ClearDirectivesTest
+ * @bug 8333891
+ * @summary Test Java methods with a directive disabling compilation can get
+ *          compilable if the directive is removed.
+ * @requires vm.compiler1.enabled & vm.compiler2.enabled
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   serviceability.dcmd.compiler.ClearDirectivesTest
+ */
+
+package serviceability.dcmd.compiler;
+
+import jdk.test.lib.dcmd.JMXExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.whitebox.WhiteBox;
+
+import java.lang.reflect.Method;
+
+import static jdk.test.lib.Asserts.assertEQ;
+
+import static compiler.whitebox.CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION;
+import static compiler.whitebox.CompilerWhiteBoxTest.COMP_LEVEL_NONE;
+import static compiler.whitebox.CompilerWhiteBoxTest.COMP_LEVEL_SIMPLE;
+
+public class ClearDirectivesTest {
+
+    static int calc(int v) {
+        int result = 0;
+        for (int i = 0; i < v; ++i) {
+          result += result * v + i;
+        }
+        return result;
+    }
+
+    public static void main(String[] args) throws Exception {
+        Method method = ClearDirectivesTest.class.getDeclaredMethod("calc", int.class);
+        String dirs = """
+        [{
+           match: "*::calc",
+           Exclude: true
+        }]""";
+        WhiteBox wb = WhiteBox.getWhiteBox();
+        wb.addCompilerDirective(dirs);
+        new JMXExecutor().execute("Compiler.directives_print");
+
+        wb.enqueueMethodForCompilation(method, COMP_LEVEL_FULL_OPTIMIZATION);
+        while (wb.isMethodQueuedForCompilation(method)) {
+            Thread.onSpinWait();
+        }
+        assertEQ(COMP_LEVEL_NONE, wb.getMethodCompilationLevel(method), "Compilation level");
+
+        wb.enqueueMethodForCompilation(method, COMP_LEVEL_SIMPLE);
+        while (wb.isMethodQueuedForCompilation(method)) {
+            Thread.onSpinWait();
+        }
+        assertEQ(COMP_LEVEL_NONE, wb.getMethodCompilationLevel(method), "Compilation level");
+
+        new JMXExecutor().execute("Compiler.directives_clear");
+        new JMXExecutor().execute("Compiler.directives_print");
+
+        wb.enqueueMethodForCompilation(method, COMP_LEVEL_FULL_OPTIMIZATION);
+        while (wb.isMethodQueuedForCompilation(method)) {
+            Thread.onSpinWait();
+        }
+        assertEQ(COMP_LEVEL_FULL_OPTIMIZATION, wb.getMethodCompilationLevel(method), "Compilation level");
+
+        wb.deoptimizeMethod(method);
+        assertEQ(COMP_LEVEL_NONE, wb.getMethodCompilationLevel(method), "Compilation level");
+
+        wb.enqueueMethodForCompilation(method, COMP_LEVEL_SIMPLE);
+        while (wb.isMethodQueuedForCompilation(method)) {
+            Thread.onSpinWait();
+        }
+        assertEQ(COMP_LEVEL_SIMPLE, wb.getMethodCompilationLevel(method), "Compilation level");
+    }
+}


### PR DESCRIPTION
A Java method can become non-compilable if there are issues with its compilation or if its compiled version causes problems. Additionally, a method can be marked as non-compilable using a compile command or a compiler directive. Since compiler directives can be updated, a directive that disables a method's compilation can be changed or removed.

Currently, when a Java method is marked as non-compilable, the reason for this status is unknown. If a change in a compiler directive makes the method compilable again, we cannot clear the non-compilable status because we don't know if the directive initially caused the method to become non-compilable.

To resolve the issue two method flags are introduced: `is_c1_exclude` and `is_c2_excluded`. They mean a Java method is excluded from compilation by a directive. With these flags we can find out a Java method has been excluded with a directive. If the directive changes and allows compilation of the method we can detect this and clear the non-compilable status.

As accesses to flags must be race free we have to remove getting a directive from `CompileBroker::compile_method`. We combine two `CompileBroker::compile_method` into one. We also move calculation whether compilation is blocking into `CompileBroker::compile_method_base`. The directive used for that calculation is passed to a compile task, so a compile task does not need to get it again.

A regression test is added.

Tested fastdebug build on Linux AArch64, Linux x86_64 and Windows Server 2019 x86_64:
- Tier1/2/3 passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333891](https://bugs.openjdk.org/browse/JDK-8333891): Method excluded with directive is not compiled after removal of directive (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19637/head:pull/19637` \
`$ git checkout pull/19637`

Update a local copy of the PR: \
`$ git checkout pull/19637` \
`$ git pull https://git.openjdk.org/jdk.git pull/19637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19637`

View PR using the GUI difftool: \
`$ git pr show -t 19637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19637.diff">https://git.openjdk.org/jdk/pull/19637.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19637#issuecomment-2159197970)