### PR TITLE
8291472: [macos] jawt 1.4 lock/unlock not supported

### DIFF
--- a/src/java.desktop/macosx/native/libjawt/jawt.m
+++ b/src/java.desktop/macosx/native/libjawt/jawt.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libjawt/jawt.m
+++ b/src/java.desktop/macosx/native/libjawt/jawt.m
@@ -55,15 +55,14 @@ _JNI_IMPORT_OR_EXPORT_ jboolean JNICALL JAWT_GetAWT
 
     awt->GetDrawingSurface = awt_GetDrawingSurface;
     awt->FreeDrawingSurface = awt_FreeDrawingSurface;
-    if (awt->version >= JAWT_VERSION_1_4) {
-        awt->Lock = awt_Lock;
-        awt->Unlock = awt_Unlock;
-        awt->GetComponent = awt_GetComponent;
-        if (awt->version >= JAWT_VERSION_9) {
-            awt->CreateEmbeddedFrame = awt_CreateEmbeddedFrame;
-            awt->SetBounds = awt_SetBounds;
-            awt->SynthesizeWindowActivation = awt_SynthesizeWindowActivation;
-        }
+
+    awt->Lock = awt_Lock;
+    awt->Unlock = awt_Unlock;
+    awt->GetComponent = awt_GetComponent;
+    if (awt->version >= JAWT_VERSION_9) {
+        awt->CreateEmbeddedFrame = awt_CreateEmbeddedFrame;
+        awt->SetBounds = awt_SetBounds;
+        awt->SynthesizeWindowActivation = awt_SynthesizeWindowActivation;
     }
 
     return JNI_TRUE;


### PR DESCRIPTION
Removing if check for unsupported jawt versions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291472](https://bugs.openjdk.org/browse/JDK-8291472): [macos] jawt 1.4 lock/unlock not supported (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19639/head:pull/19639` \
`$ git checkout pull/19639`

Update a local copy of the PR: \
`$ git checkout pull/19639` \
`$ git pull https://git.openjdk.org/jdk.git pull/19639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19639`

View PR using the GUI difftool: \
`$ git pr show -t 19639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19639.diff">https://git.openjdk.org/jdk/pull/19639.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19639#issuecomment-2159295427)