### PR TITLE
8333925: Shenandoah: Heuristics should have an option to ignore abbreviated cycles

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -125,8 +125,8 @@ void ShenandoahAdaptiveHeuristics::record_cycle_start() {
   _allocation_rate.allocation_counter_reset();
 }
 
-void ShenandoahAdaptiveHeuristics::record_success_concurrent() {
-  ShenandoahHeuristics::record_success_concurrent();
+void ShenandoahAdaptiveHeuristics::record_success_concurrent(bool abbreviated) {
+  ShenandoahHeuristics::record_success_concurrent(abbreviated);
 
   size_t available = _space_info->available();
 
@@ -240,7 +240,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
   allocation_headroom -= MIN2(allocation_headroom, spike_headroom);
   allocation_headroom -= MIN2(allocation_headroom, penalties);
 
-  double avg_cycle_time = _gc_time_history->davg() + (_margin_of_error_sd * _gc_time_history->dsd());
+  double avg_cycle_time = _gc_cycle_time_history->davg() + (_margin_of_error_sd * _gc_cycle_time_history->dsd());
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
   if (avg_cycle_time > allocation_headroom / avg_alloc_rate) {
     log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (margin of error = %.2f)",

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.hpp
@@ -73,7 +73,7 @@ public:
                                                      size_t actual_free);
 
   void record_cycle_start();
-  void record_success_concurrent();
+  void record_success_concurrent(bool abbreviated);
   void record_success_degenerated();
   void record_success_full();
 

--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahHeuristics.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018, 2020, Red Hat, Inc. All rights reserved.
- * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,7 +223,7 @@ void ShenandoahHeuristics::record_success_concurrent(bool abbreviated) {
 
   adjust_penalty(Concurrent_Adjust);
 
-  if (_gc_times_learned <= ShenandoahLearningSteps || !(abbreviated && ShenandoahAdaptiveIgnoreShortCycles)) {
+  if (_gc_times_learned <= ShenandoahLearningSteps || !(abbreviated && ShenandoahAdaptiveIgnoreAbbreviated)) {
     _gc_cycle_time_history->add(elapsed_cycle_time());
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -325,7 +325,7 @@ void ShenandoahControlThread::service_concurrent_normal_cycle(GCCause::Cause cau
   ShenandoahConcurrentGC gc;
   if (gc.collect(cause)) {
     // Cycle is complete
-    heap->heuristics()->record_success_concurrent();
+    heap->heuristics()->record_success_concurrent(gc.abbreviated());
     heap->shenandoah_policy()->record_success_concurrent(gc.abbreviated());
   } else {
     assert(heap->cancelled_gc(), "Must have been cancelled");

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -472,6 +472,7 @@ void ShenandoahHeap::initialize_mode() {
 void ShenandoahHeap::initialize_heuristics() {
   assert(_gc_mode != nullptr, "Must be initialized");
   _heuristics = _gc_mode->initialize_heuristics();
+  _heuristics->set_guaranteed_gc_interval(ShenandoahGuaranteedGCInterval);
 
   if (_heuristics->is_diagnostic() && !UnlockDiagnosticVMOptions) {
     vm_exit_during_initialization(

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -149,6 +149,16 @@
           "Larger values give more weight to recent values.")               \
           range(0,1.0)                                                      \
                                                                             \
+  product(bool, ShenandoahAdaptiveIgnoreShortCycles, true, EXPERIMENTAL,    \
+          "The adaptive heuristic tracks a moving average of cycle "        \
+          "times in order to start a gc before memory is exhausted. "       \
+          "In some cases, Shenandoah may skip the evacuation and update "   \
+          "reference phases, resulting in a shorter cycle. These may skew " \
+          "the average cycle time downward and may cause the heuristic "    \
+          "to wait too long to start a cycle. Disabling this will have "    \
+          "the gc run less often, which will reduce CPU utilization, but"   \
+          "increase the risk of degenerated cycles.")                       \
+                                                                            \
   product(uintx, ShenandoahGuaranteedGCInterval, 5*60*1000, EXPERIMENTAL,   \
           "Many heuristics would guarantee a concurrent GC cycle at "       \
           "least with this interval. This is useful when large idle "       \

--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -149,7 +149,7 @@
           "Larger values give more weight to recent values.")               \
           range(0,1.0)                                                      \
                                                                             \
-  product(bool, ShenandoahAdaptiveIgnoreShortCycles, true, EXPERIMENTAL,    \
+  product(bool, ShenandoahAdaptiveIgnoreAbbreviated, true, EXPERIMENTAL,    \
           "The adaptive heuristic tracks a moving average of cycle "        \
           "times in order to start a gc before memory is exhausted. "       \
           "In some cases, Shenandoah may skip the evacuation and update "   \


### PR DESCRIPTION
After concurrent marking is complete, Shenandoah will skip the evacuation phase if a sufficient amount of garbage is found in regions that contain _no live objects_. These abbreviated cycles are much shorter than a cycle that performs evacuation and update references and tend to lower the average cycle time used by the heuristic to predict cycle times. This may cause the heuristic to wait too long to initiate a cycle and may lead to degenerated cycles. This change has the heuristic ignore abbreviated cycle times by default, with an option to have the heuristic count them as it does now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333925](https://bugs.openjdk.org/browse/JDK-8333925): Shenandoah: Heuristics should have an option to ignore abbreviated cycles (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Author) ⚠️ Review applies to [d8036f31](https://git.openjdk.org/jdk/pull/19640/files/d8036f316a69bad162923707552527b64fa27c79)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) ⚠️ Review applies to [d8036f31](https://git.openjdk.org/jdk/pull/19640/files/d8036f316a69bad162923707552527b64fa27c79)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19640/head:pull/19640` \
`$ git checkout pull/19640`

Update a local copy of the PR: \
`$ git checkout pull/19640` \
`$ git pull https://git.openjdk.org/jdk.git pull/19640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19640`

View PR using the GUI difftool: \
`$ git pr show -t 19640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19640.diff">https://git.openjdk.org/jdk/pull/19640.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19640#issuecomment-2159427095)