### PR TITLE
8333926: Shenandoah: Lower default immediate garbage threshold

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoah_globals.hpp
@@ -114,7 +114,7 @@
           "to learn application and GC performance.")                       \
           range(0,100)                                                      \
                                                                             \
-  product(uintx, ShenandoahImmediateThreshold, 90, EXPERIMENTAL,            \
+  product(uintx, ShenandoahImmediateThreshold, 70, EXPERIMENTAL,            \
           "The cycle may shortcut when enough garbage can be reclaimed "    \
           "from the immediate garbage (completely garbage regions). "       \
           "In percents of total garbage found. Setting this threshold "     \


### PR DESCRIPTION
After marking, when Shenandoah finds a certain percentage threshold of garbage within regions that contain no live objects it will skip the evacuation phase. This threshold is currently 90%, but we (Amazon) have found that many internal workloads benefit significantly by reducing this threshold to 70%. We have also seen improvements on dacapo/sunflow and specjbb2015. We have also not seen any performance degradation caused by lowering this threshold.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333926](https://bugs.openjdk.org/browse/JDK-8333926): Shenandoah: Lower default immediate garbage threshold (**Task** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - no project role)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19641/head:pull/19641` \
`$ git checkout pull/19641`

Update a local copy of the PR: \
`$ git checkout pull/19641` \
`$ git pull https://git.openjdk.org/jdk.git pull/19641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19641`

View PR using the GUI difftool: \
`$ git pr show -t 19641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19641.diff">https://git.openjdk.org/jdk/pull/19641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19641#issuecomment-2159446063)