### PR TITLE
8333940: Ensure javax/swing/TestUngrab.java run on all platforms

### DIFF
--- a/test/jdk/javax/swing/JMenu/TestUngrab.java
+++ b/test/jdk/javax/swing/JMenu/TestUngrab.java
@@ -27,7 +27,6 @@
  * @test
  * @bug 8267374
  * @key headful
- * @requires (os.family == "mac")
  * @summary Verifies menu closes when main window is resized
  * @run main TestUngrab
  */


### PR DESCRIPTION
TestUngrab.java was added for [JDK-8267374](https://bugs.openjdk.org/browse/JDK-8267374) macos fix but the test can be run for all platforms as the behaviour is common for all
CI run job link in JBS..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333940](https://bugs.openjdk.org/browse/JDK-8333940): Ensure javax/swing/TestUngrab.java run on all platforms (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19644/head:pull/19644` \
`$ git checkout pull/19644`

Update a local copy of the PR: \
`$ git checkout pull/19644` \
`$ git pull https://git.openjdk.org/jdk.git pull/19644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19644`

View PR using the GUI difftool: \
`$ git pr show -t 19644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19644.diff">https://git.openjdk.org/jdk/pull/19644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19644#issuecomment-2159872124)