### PR TITLE
8333954: Parallel: Remove unused arguments of type ParCompactionManager*

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2228,7 +2228,7 @@ void PSParallelCompact::fill_region(ParCompactionManager* cm, MoveAndUpdateClosu
     if (closure.is_full()) {
       decrement_destination_counts(cm, src_space_id, src_region_idx,
                                    closure.source());
-      closure.complete_region(cm, dest_addr, region_ptr);
+      closure.complete_region(dest_addr, region_ptr);
       return;
     }
 
@@ -2271,7 +2271,7 @@ void PSParallelCompact::fill_region(ParCompactionManager* cm, MoveAndUpdateClosu
     if (closure.is_full()) {
       decrement_destination_counts(cm, src_space_id, src_region_idx,
                                    closure.source());
-      closure.complete_region(cm, dest_addr, region_ptr);
+      closure.complete_region(dest_addr, region_ptr);
       return;
     }
 
@@ -2304,7 +2304,7 @@ void PSParallelCompact::fill_and_update_shadow_region(ParCompactionManager* cm, 
     region_ptr->shadow_to_normal();
     return fill_region(cm, cl, region_idx);
   } else {
-    MoveAndUpdateShadowClosure cl(mark_bitmap(), cm, region_idx, shadow_region);
+    MoveAndUpdateShadowClosure cl(mark_bitmap(), region_idx, shadow_region);
     return fill_region(cm, cl, region_idx);
   }
 }
@@ -2381,8 +2381,7 @@ void MoveAndUpdateClosure::copy_partial_obj(size_t partial_obj_size)
   update_state(words);
 }
 
-void MoveAndUpdateClosure::complete_region(ParCompactionManager *cm, HeapWord *dest_addr,
-                                           PSParallelCompact::RegionData *region_ptr) {
+void MoveAndUpdateClosure::complete_region(HeapWord* dest_addr, PSParallelCompact::RegionData* region_ptr) {
   assert(region_ptr->shadow_state() == ParallelCompactData::RegionData::NormalRegion, "Region should be finished");
   region_ptr->set_completed();
 }
@@ -2412,8 +2411,7 @@ void MoveAndUpdateClosure::do_addr(HeapWord* addr, size_t words) {
   update_state(words);
 }
 
-void MoveAndUpdateShadowClosure::complete_region(ParCompactionManager *cm, HeapWord *dest_addr,
-                                                 PSParallelCompact::RegionData *region_ptr) {
+void MoveAndUpdateShadowClosure::complete_region(HeapWord* dest_addr, PSParallelCompact::RegionData* region_ptr) {
   assert(region_ptr->shadow_state() == ParallelCompactData::RegionData::ShadowRegion, "Region should be shadow");
   // Record the shadow region index
   region_ptr->set_shadow_region(_shadow);

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -895,8 +895,7 @@ public:
   // updated.
   void copy_partial_obj(size_t partial_obj_size);
 
-  virtual void complete_region(ParCompactionManager* cm, HeapWord* dest_addr,
-                               PSParallelCompact::RegionData* region_ptr);
+  virtual void complete_region(HeapWord* dest_addr, PSParallelCompact::RegionData* region_ptr);
 };
 
 inline void MoveAndUpdateClosure::decrement_words_remaining(size_t words) {
@@ -932,11 +931,9 @@ inline void MoveAndUpdateClosure::update_state(size_t words)
 class MoveAndUpdateShadowClosure: public MoveAndUpdateClosure {
   inline size_t calculate_shadow_offset(size_t region_idx, size_t shadow_idx);
 public:
-  inline MoveAndUpdateShadowClosure(ParMarkBitMap* bitmap, ParCompactionManager* cm,
-                       size_t region, size_t shadow);
+  inline MoveAndUpdateShadowClosure(ParMarkBitMap* bitmap, size_t region, size_t shadow);
 
-  virtual void complete_region(ParCompactionManager* cm, HeapWord* dest_addr,
-                               PSParallelCompact::RegionData* region_ptr);
+  virtual void complete_region(HeapWord* dest_addr, PSParallelCompact::RegionData* region_ptr);
 
 private:
   size_t _shadow;
@@ -950,10 +947,7 @@ inline size_t MoveAndUpdateShadowClosure::calculate_shadow_offset(size_t region_
 }
 
 inline
-MoveAndUpdateShadowClosure::MoveAndUpdateShadowClosure(ParMarkBitMap *bitmap,
-                                                       ParCompactionManager *cm,
-                                                       size_t region,
-                                                       size_t shadow) :
+MoveAndUpdateShadowClosure::MoveAndUpdateShadowClosure(ParMarkBitMap* bitmap, size_t region, size_t shadow) :
   MoveAndUpdateClosure(bitmap, region),
   _shadow(shadow) {
   _offset = calculate_shadow_offset(region, shadow);


### PR DESCRIPTION
Trivial removing unused args.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333954](https://bugs.openjdk.org/browse/JDK-8333954): Parallel: Remove unused arguments of type ParCompactionManager* (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19645/head:pull/19645` \
`$ git checkout pull/19645`

Update a local copy of the PR: \
`$ git checkout pull/19645` \
`$ git pull https://git.openjdk.org/jdk.git pull/19645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19645`

View PR using the GUI difftool: \
`$ git pr show -t 19645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19645.diff">https://git.openjdk.org/jdk/pull/19645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19645#issuecomment-2159964351)