### PR TITLE
8333962: Obsolete OldSize

### DIFF
--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -32,6 +32,7 @@
 #include "gc/shared/gcLocker.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTrace.hpp"
+#include "gc/shared/genArguments.hpp"
 #include "gc/shared/space.hpp"
 #include "gc/shared/spaceDecorator.hpp"
 #include "logging/log.hpp"

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -540,10 +540,6 @@
           "Soft limit for maximum heap size (in bytes)")                    \
           constraint(SoftMaxHeapSizeConstraintFunc,AfterMemoryInit)         \
                                                                             \
-  product(size_t, OldSize, ScaleForWordSize(4*M),                           \
-          "(Deprecated) Initial tenured generation size (in bytes)")        \
-          range(0, max_uintx)                                               \
-                                                                            \
   product(size_t, NewSize, ScaleForWordSize(1*M),                           \
           "Initial new generation size (in bytes)")                         \
           constraint(NewSizeConstraintFunc,AfterErgo)                       \

--- a/src/hotspot/share/gc/shared/genArguments.cpp
+++ b/src/hotspot/share/gc/shared/genArguments.cpp
@@ -37,6 +37,8 @@ size_t MinNewSize = 0;
 size_t MinOldSize = 0;
 size_t MaxOldSize = 0;
 
+size_t OldSize = 0;
+
 size_t GenAlignment = 0;
 
 size_t GenArguments::conservative_max_heap_alignment() { return (size_t)Generation::GenGrain; }
@@ -152,24 +154,7 @@ void GenArguments::initialize_heap_flags_and_sizes() {
     vm_exit_during_initialization("Invalid young gen ratio specified");
   }
 
-  if (OldSize < old_gen_size_lower_bound()) {
-    FLAG_SET_ERGO(OldSize, old_gen_size_lower_bound());
-  }
-  if (!is_aligned(OldSize, GenAlignment)) {
-    FLAG_SET_ERGO(OldSize, align_down(OldSize, GenAlignment));
-  }
-
-  if (FLAG_IS_CMDLINE(OldSize) && FLAG_IS_DEFAULT(MaxHeapSize)) {
-    // NewRatio will be used later to set the young generation size so we use
-    // it to calculate how big the heap should be based on the requested OldSize
-    // and NewRatio.
-    assert(NewRatio > 0, "NewRatio should have been set up earlier");
-    size_t calculated_heapsize = (OldSize / NewRatio) * (NewRatio + 1);
-
-    calculated_heapsize = align_up(calculated_heapsize, HeapAlignment);
-    FLAG_SET_ERGO(MaxHeapSize, calculated_heapsize);
-    FLAG_SET_ERGO(InitialHeapSize, calculated_heapsize);
-  }
+  OldSize = old_gen_size_lower_bound();
 
   // Adjust NewSize and OldSize or MaxHeapSize to match each other
   if (NewSize + OldSize > MaxHeapSize) {
@@ -185,20 +170,9 @@ void GenArguments::initialize_heap_flags_and_sizes() {
       // HeapAlignment, and we just made sure that NewSize is aligned to
       // GenAlignment. In initialize_flags() we verified that HeapAlignment
       // is a multiple of GenAlignment.
-      FLAG_SET_ERGO(OldSize, MaxHeapSize - NewSize);
+      OldSize = MaxHeapSize - NewSize;
     } else {
       FLAG_SET_ERGO(MaxHeapSize, align_up(NewSize + OldSize, HeapAlignment));
-    }
-  }
-
-  // Update NewSize, if possible, to avoid sizing the young gen too small when only
-  // OldSize is set on the command line.
-  if (FLAG_IS_CMDLINE(OldSize) && !FLAG_IS_CMDLINE(NewSize)) {
-    if (OldSize < InitialHeapSize) {
-      size_t new_size = InitialHeapSize - OldSize;
-      if (new_size >= MinNewSize && new_size <= MaxNewSize) {
-        FLAG_SET_ERGO(NewSize, new_size);
-      }
     }
   }
 
@@ -215,12 +189,6 @@ void GenArguments::initialize_heap_flags_and_sizes() {
 // In the absence of explicitly set command line flags, policies
 // such as the use of NewRatio are used to size the generation.
 
-// Minimum sizes of the generations may be different than
-// the initial sizes.  An inconsistency is permitted here
-// in the total size that can be specified explicitly by
-// command line specification of OldSize and NewSize and
-// also a command line specification of -Xms.  Issue a warning
-// but allow the values to pass.
 void GenArguments::initialize_size_info() {
   GCArguments::initialize_size_info();
 
@@ -286,37 +254,7 @@ void GenArguments::initialize_size_info() {
                     InitialHeapSize - initial_young_size,
                     MinHeapSize - MinNewSize);
 
-  size_t initial_old_size = OldSize;
-
-  // If no explicit command line flag has been set for the
-  // old generation size, use what is left.
-  if (!FLAG_IS_CMDLINE(OldSize)) {
-    // The user has not specified any value but the ergonomics
-    // may have chosen a value (which may or may not be consistent
-    // with the overall heap size).  In either case make
-    // the minimum, maximum and initial sizes consistent
-    // with the young sizes and the overall heap sizes.
-    initial_old_size = clamp(InitialHeapSize - initial_young_size, MinOldSize, MaxOldSize);
-    // MaxOldSize and MinOldSize have already been made consistent above.
-  } else {
-    // OldSize has been explicitly set on the command line. Use it
-    // for the initial size but make sure the minimum allow a young
-    // generation to fit as well.
-    // If the user has explicitly set an OldSize that is inconsistent
-    // with other command line flags, issue a warning.
-    // The generation minimums and the overall heap minimum should
-    // be within one generation alignment.
-    if (initial_old_size > MaxOldSize) {
-      log_warning(gc, ergo)("Inconsistency between maximum heap size and maximum "
-                            "generation sizes: using maximum heap = " SIZE_FORMAT
-                            ", -XX:OldSize flag is being ignored",
-                            MaxHeapSize);
-      initial_old_size = MaxOldSize;
-    } else if (initial_old_size < MinOldSize) {
-      log_warning(gc, ergo)("Inconsistency between initial old size and minimum old size");
-      MinOldSize = initial_old_size;
-    }
-  }
+  size_t initial_old_size = clamp(InitialHeapSize - initial_young_size, MinOldSize, MaxOldSize);;
 
   // The initial generation sizes should match the initial heap size,
   // if not issue a warning and resize the generations. This behavior
@@ -359,7 +297,7 @@ void GenArguments::initialize_size_info() {
   }
 
   if (OldSize != initial_old_size) {
-    FLAG_SET_ERGO(OldSize, initial_old_size);
+    OldSize = initial_old_size;
   }
 
   log_trace(gc, heap)("Minimum old " SIZE_FORMAT "  Initial old " SIZE_FORMAT "  Maximum old " SIZE_FORMAT,

--- a/src/hotspot/share/gc/shared/genArguments.hpp
+++ b/src/hotspot/share/gc/shared/genArguments.hpp
@@ -33,6 +33,8 @@ extern size_t MinNewSize;
 extern size_t MinOldSize;
 extern size_t MaxOldSize;
 
+extern size_t OldSize;
+
 extern size_t GenAlignment;
 
 class GenArguments : public GCArguments {

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -34,6 +34,7 @@
 #include "compiler/compilerDefinitions.hpp"
 #include "gc/shared/gcArguments.hpp"
 #include "gc/shared/gcConfig.hpp"
+#include "gc/shared/genArguments.hpp"
 #include "gc/shared/stringdedup/stringDedup.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "jvm.h"
@@ -502,7 +503,6 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RequireSharedSpaces",          JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "UseSharedSpaces",              JDK_Version::jdk(18), JDK_Version::jdk(19), JDK_Version::undefined() },
   { "DontYieldALot",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
-  { "OldSize",                      JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "PreserveAllAnnotations",       JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseNotificationThread",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseEmptySlotsInSupers",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
@@ -513,6 +513,7 @@ static SpecialFlag const special_jvm_flags[] = {
 
   { "MetaspaceReclaimPolicy",       JDK_Version::undefined(), JDK_Version::jdk(21), JDK_Version::undefined() },
 
+  { "OldSize",                      JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #if defined(X86)
   { "UseRTMLocking",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseRTMDeopt",                  JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/HeapSummary.java
@@ -80,7 +80,6 @@ public class HeapSummary extends Tool {
       printValMB("MaxHeapSize              = ", getFlagValue("MaxHeapSize", flagMap));
       printValMB("NewSize                  = ", getFlagValue("NewSize", flagMap));
       printValMB("MaxNewSize               = ", getFlagValue("MaxNewSize", flagMap));
-      printValMB("OldSize                  = ", getFlagValue("OldSize", flagMap));
       printValue("NewRatio                 = ", getFlagValue("NewRatio", flagMap));
       printValue("SurvivorRatio            = ", getFlagValue("SurvivorRatio", flagMap));
       printValMB("MetaspaceSize            = ", getFlagValue("MetaspaceSize", flagMap));

--- a/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxHeapSizeTools.java
@@ -59,15 +59,10 @@ class TestMaxHeapSizeTools {
   }
 
   public static void checkMinInitialErgonomics(String gcflag) throws Exception {
-    // heap sizing ergonomics use the value NewSize + OldSize as default values
-    // for ergonomics calculation. Retrieve these values.
-    long[] values = new long[2];
-    getNewOldSize(gcflag, values);
-
     // we check cases with values smaller and larger than this default value.
-    long newPlusOldSize = values[0] + values[1];
-    long smallValue = newPlusOldSize / 2;
-    long largeValue = newPlusOldSize * 2;
+    long initialHeapSize = getInitialHeapSize(gcflag);
+    long smallValue = initialHeapSize / 2;
+    long largeValue = initialHeapSize * 2;
     long maxHeapSize = largeValue + (2 * 1024 * 1024);
 
     // -Xms is not set
@@ -114,14 +109,13 @@ class TestMaxHeapSizeTools {
     return (value + alignmentMinusOne) & ~alignmentMinusOne;
   }
 
-  private static void getNewOldSize(String gcflag, long[] values) throws Exception {
+  private static long getInitialHeapSize(String gcflag) throws Exception {
     OutputAnalyzer output = GCArguments.executeTestJava(gcflag,
       "-XX:+PrintFlagsFinal", "-version");
     output.shouldHaveExitValue(0);
 
     String stdout = output.getStdout();
-    values[0] = getFlagValue(" NewSize", stdout);
-    values[1] = getFlagValue(" OldSize", stdout);
+    return getFlagValue(" InitialHeapSize", stdout);
   }
 
   public static void checkGenMaxHeapErgo(String gcflag) throws Exception {

--- a/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMaxNewSize.java
@@ -29,7 +29,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.Serial & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
+ * @requires vm.gc.Serial & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -44,7 +44,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.Parallel & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
+ * @requires vm.gc.Parallel & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -59,7 +59,7 @@ package gc.arguments;
  * @summary Make sure that MaxNewSize always has a useful value after argument
  * processing.
  * @key flag-sensitive
- * @requires vm.gc.G1 & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null & vm.opt.OldSize == null
+ * @requires vm.gc.G1 & vm.opt.MaxNewSize == null & vm.opt.NewRatio == null & vm.opt.NewSize == null
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc
@@ -116,7 +116,6 @@ public class TestMaxNewSize {
     checkMaxNewSize(new String[] { gcName, "-Xmx128M" }, 128 * M);
     checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:NewRatio=5" }, 128 * M);
     checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:NewSize=32M" }, 128 * M);
-    checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:OldSize=96M" }, 128 * M);
     checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:MaxNewSize=32M" }, 32 * M);
     checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:NewSize=32M", "-XX:MaxNewSize=32M" }, 32 * M);
     checkMaxNewSize(new String[] { gcName, "-Xmx128M", "-XX:NewRatio=6", "-XX:MaxNewSize=32M" }, 32 * M);

--- a/test/hotspot/jtreg/gc/g1/TestInvalidateArrayCopy.java
+++ b/test/hotspot/jtreg/gc/g1/TestInvalidateArrayCopy.java
@@ -29,7 +29,7 @@ package gc.g1;
  * @summary Check that benign (0-sized) out of heap bounds card table invalidations do not assert.
  * @requires vm.gc.G1
  * @requires vm.debug
- * @run main/othervm -XX:NewSize=1M -Xlog:gc -XX:MaxNewSize=1m -XX:-UseTLAB -XX:OldSize=63M -XX:MaxHeapSize=64M gc.g1.TestInvalidateArrayCopy
+ * @run main/othervm -XX:NewSize=1M -Xlog:gc -XX:MaxNewSize=1m -XX:-UseTLAB -XX:MaxHeapSize=64M gc.g1.TestInvalidateArrayCopy
  */
 
 // The test allocates zero-sized arrays of j.l.O and tries to arraycopy random data into it so

--- a/test/hotspot/jtreg/gc/g1/plab/lib/PLABUtils.java
+++ b/test/hotspot/jtreg/gc/g1/plab/lib/PLABUtils.java
@@ -40,7 +40,6 @@ public class PLABUtils {
     private final static String[] GC_TUNE_OPTIONS = {
         "-XX:+UseG1GC",
         "-XX:G1HeapRegionSize=1m",
-        "-XX:OldSize=64m",
         "-XX:-UseAdaptiveSizePolicy",
         "-XX:MaxTenuringThreshold=1",
         "-XX:-UseTLAB",

--- a/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/OptionsValidation/TestOptionsWithRanges.java
@@ -240,7 +240,6 @@ public class TestOptionsWithRanges {
         excludeTestMaxRange("MaxHeapSize");
         excludeTestMaxRange("MaxRAM");
         excludeTestMaxRange("NewSize");
-        excludeTestMaxRange("OldSize");
         excludeTestMaxRange("ParallelGCThreads");
         excludeTestMaxRange("TLABSize");
 

--- a/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/huge/quicklook/largeheap/MemOptions/MemOptionsTest.java
@@ -79,10 +79,6 @@ public class MemOptionsTest {
         // positive("Initial young generation size at 32-bit range", "-Xmx5G", "-XX:NewSize=4G");
         // positive("Initial young generation size outside 32-bit range", "-Xmx5G", "-XX:NewSize=4G");
 
-        // positive("Initial old generation size within 32-bit range", "-Xmx3G", "-XX:OldSize=2G");
-        // positive("Initial old generation size at 32-bit range", "-Xmx5G", "-XX:OldSize=4G");
-        // positive("Initial old generation size outside 32-bit range", "-Xmx5G", "-XX:OldSize=4G");
-
         if (!failed.isEmpty()) {
             throw new AssertionError(String.format("%d cases failed : %s", failed.size(), failed));
         }

--- a/test/jdk/jdk/jfr/event/runtime/TestSizeTFlags.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestSizeTFlags.java
@@ -40,13 +40,12 @@ import jdk.test.lib.jfr.Events;
  * @key jfr
  * @summary Test checks that flags of type size_t are being sent to the jfr
  * @library /test/lib
- * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -XX:+UseG1GC -XX:+UseTLAB -XX:MinTLABSize=3k -XX:OldSize=30m -XX:YoungPLABSize=3k -XX:MaxDirectMemorySize=5M  jdk.jfr.event.runtime.TestSizeTFlags
+ * @run main/othervm -XX:+UnlockExperimentalVMOptions -XX:-UseFastUnorderedTimeStamps -XX:+UseG1GC -XX:+UseTLAB -XX:MinTLABSize=3k -XX:YoungPLABSize=3k -XX:MaxDirectMemorySize=5M  jdk.jfr.event.runtime.TestSizeTFlags
  */
 public class TestSizeTFlags {
     private static final String EVENT_NAME = EventNames.UnsignedLongFlag;
-    private static final int NUMBER_OF_FLAGS_TO_CHECK = 4;
+    private static final int NUMBER_OF_FLAGS_TO_CHECK = 3;
     private static final long MIN_TLAB_SIZE_FLAG_VALUE = 3*1024L;
-    private static final long OLD_SIZE_FLAG_VALUE = 30*1024*1024L;
     private static final long YOUNG_PLAB_SIZE_FLAG_VALUE = 3*1024L;
     private static final long MAX_DIRECT_MEMORY_SIZE_FLAG_VALUE = 5*1024*1024L;
 
@@ -71,16 +70,12 @@ public class TestSizeTFlags {
                         flagsFoundWithExpectedValue[0] = MIN_TLAB_SIZE_FLAG_VALUE == value;
                         continue;
                     }
-                    case "OldSize": {
-                        flagsFoundWithExpectedValue[1] = OLD_SIZE_FLAG_VALUE == value;
-                        continue;
-                    }
                     case "YoungPLABSize": {
-                        flagsFoundWithExpectedValue[2] = YOUNG_PLAB_SIZE_FLAG_VALUE == value;
+                        flagsFoundWithExpectedValue[1] = YOUNG_PLAB_SIZE_FLAG_VALUE == value;
                         continue;
                     }
                     case "MaxDirectMemorySize": {
-                        flagsFoundWithExpectedValue[3] = MAX_DIRECT_MEMORY_SIZE_FLAG_VALUE == value;
+                        flagsFoundWithExpectedValue[2] = MAX_DIRECT_MEMORY_SIZE_FLAG_VALUE == value;
                         continue;
                     }
                     default: {

--- a/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
+++ b/test/jdk/sun/tools/jhsdb/heapconfig/JMapHeapConfigTest.java
@@ -54,7 +54,6 @@ public class JMapHeapConfigTest {
         "MaxHeapSize",
         "NewSize",
         "MaxNewSize",
-        "OldSize",
         "NewRatio",
         "SurvivorRatio",
         "MetaspaceSize",


### PR DESCRIPTION
Obsolete OldSize and related code. An internal variable `OldSize` is kept to capture the capacity of old-gen size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333962](https://bugs.openjdk.org/browse/JDK-8333962): Obsolete OldSize (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19647/head:pull/19647` \
`$ git checkout pull/19647`

Update a local copy of the PR: \
`$ git checkout pull/19647` \
`$ git pull https://git.openjdk.org/jdk.git pull/19647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19647`

View PR using the GUI difftool: \
`$ git pr show -t 19647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19647.diff">https://git.openjdk.org/jdk/pull/19647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19647#issuecomment-2160101271)