### PR TITLE
8333931: Problemlist serviceability/jvmti/vthread/CarrierThreadEventNotification

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -139,6 +139,7 @@ serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
 serviceability/jvmti/vthread/GetThreadStateMountedTest/GetThreadStateMountedTest.java 8318090,8318729 generic-all
 serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
+serviceability/jvmti/vthread/CarrierThreadEventNotification/CarrierThreadEventNotification.java 8333681 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 generic-all
 
 serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64


### PR DESCRIPTION
Please, review a jdk23 backport of the:
  [8333931](https://bugs.openjdk.org/browse/JDK-8333931): Problemlist serviceability/jvmti/vthread/CarrierThreadEventNotification
 
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333931](https://bugs.openjdk.org/browse/JDK-8333931): Problemlist serviceability/jvmti/vthread/CarrierThreadEventNotification (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19651/head:pull/19651` \
`$ git checkout pull/19651`

Update a local copy of the PR: \
`$ git checkout pull/19651` \
`$ git pull https://git.openjdk.org/jdk.git pull/19651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19651`

View PR using the GUI difftool: \
`$ git pr show -t 19651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19651.diff">https://git.openjdk.org/jdk/pull/19651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19651#issuecomment-2160700947)