### PR TITLE
8333801: Typos in @code references of BufferedImage and JTableHeader

### DIFF
--- a/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
+++ b/src/java.desktop/share/classes/java/awt/image/BufferedImage.java
@@ -899,7 +899,7 @@ public class BufferedImage extends java.awt.Image
      *
      * <p>
      *
-     * An {@code ArrayOutOfBoundsException} may be thrown
+     * An {@code ArrayIndexOutOfBoundsException} may be thrown
      * if the coordinates are not in bounds.
      * However, explicit bounds checking is not guaranteed.
      *
@@ -933,7 +933,7 @@ public class BufferedImage extends java.awt.Image
      *
      * <p>
      *
-     * An {@code ArrayOutOfBoundsException} may be thrown
+     * An {@code ArrayIndexOutOfBoundsException} may be thrown
      * if the region is not in bounds.
      * However, explicit bounds checking is not guaranteed.
      *
@@ -1003,7 +1003,7 @@ public class BufferedImage extends java.awt.Image
      *
      * <p>
      *
-     * An {@code ArrayOutOfBoundsException} may be thrown
+     * An {@code ArrayIndexOutOfBoundsException} may be thrown
      * if the coordinates are not in bounds.
      * However, explicit bounds checking is not guaranteed.
      *
@@ -1033,7 +1033,7 @@ public class BufferedImage extends java.awt.Image
      *
      * <p>
      *
-     * An {@code ArrayOutOfBoundsException} may be thrown
+     * An {@code ArrayIndexOutOfBoundsException} may be thrown
      * if the region is not in bounds.
      * However, explicit bounds checking is not guaranteed.
      *

--- a/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
+++ b/src/java.desktop/share/classes/javax/swing/table/JTableHeader.java
@@ -951,7 +951,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             private AccessibleContext getCurrentAccessibleContext() {
                 TableColumnModel tcm = table.getColumnModel();
                 if (tcm != null) {
-                    // Fixes 4772355 - ArrayOutOfBoundsException in
+                    // Fixes 4772355 - ArrayIndexOutOfBoundsException in
                     // JTableHeader
                     if (column < 0 || column >= tcm.getColumnCount()) {
                         return null;
@@ -979,7 +979,7 @@ public class JTableHeader extends JComponent implements TableColumnModelListener
             private Component getCurrentComponent() {
                 TableColumnModel tcm = table.getColumnModel();
                 if (tcm != null) {
-                    // Fixes 4772355 - ArrayOutOfBoundsException in
+                    // Fixes 4772355 - ArrayIndexOutOfBoundsException in
                     // JTableHeader
                     if (column < 0 || column >= tcm.getColumnCount()) {
                         return null;

--- a/test/jdk/javax/swing/JTabbedPane/4361477/bug4361477.java
+++ b/test/jdk/javax/swing/JTabbedPane/4361477/bug4361477.java
@@ -30,7 +30,7 @@ import javax.swing.event.*;
  * @test
  * @key headful
  * @bug 4361477
- * @summary JTabbedPane throws ArrayOutOfBoundsException
+ * @summary JTabbedPane throws ArrayIndexOutOfBoundsException
  * @author Oleg Mokhovikov
  * @run main bug4361477
  */

--- a/test/jdk/javax/swing/JTabbedPane/4361477/bug4361477.java
+++ b/test/jdk/javax/swing/JTabbedPane/4361477/bug4361477.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import javax.swing.event.*;
  * @key headful
  * @bug 4361477
  * @summary JTabbedPane throws ArrayIndexOutOfBoundsException
- * @author Oleg Mokhovikov
  * @run main bug4361477
  */
 public class bug4361477 {


### PR DESCRIPTION
Resolved typos related to ArrayIndexOutOfBoundsException in BufferedImage and JTableHeader.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333801](https://bugs.openjdk.org/browse/JDK-8333801): Typos in @<!---->code references of BufferedImage and JTableHeader (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [a383eb14](https://git.openjdk.org/jdk/pull/19654/files/a383eb1484d96a8bb129cb4dc61ce278767e59ce)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [a383eb14](https://git.openjdk.org/jdk/pull/19654/files/a383eb1484d96a8bb129cb4dc61ce278767e59ce)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19654/head:pull/19654` \
`$ git checkout pull/19654`

Update a local copy of the PR: \
`$ git checkout pull/19654` \
`$ git pull https://git.openjdk.org/jdk.git pull/19654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19654`

View PR using the GUI difftool: \
`$ git pr show -t 19654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19654.diff">https://git.openjdk.org/jdk/pull/19654.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19654#issuecomment-2160634952)