### PR TITLE
8333730: ubsan: FieldIndices/libFieldIndicesTest.cpp:276:11: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
@@ -273,7 +273,9 @@ void Klass::explore_interfaces(JNIEnv* env) {
   if (super_klass != nullptr) {
     // Add all interfaces implemented by super_klass first.
     interface_count = super_klass->interface_count;
-    memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    if (super_klass->interfaces != nullptr) {
+      memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    }
   }
 
   // Interfaces implemented by the klass.


### PR DESCRIPTION
When running HS :tier1 tests with ubsan-enabled binaries, the following issue is reported :
test
serviceability/jvmti/FollowReferences/FieldIndices/FieldIndicesTest.jtr

test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp:276:11: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0x7efea442e379 in Klass::explore_interfaces(JNIEnv_*) test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp:276
    #1 0x7efea443280d in Klass::explore(JNIEnv_*, _jclass*) test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp:322
    #2 0x7efea4433adf in Object::explore(JNIEnv_*, _jobject*) test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp:349
    #3 0x7efea443443b in Java_FieldIndicesTest_prepare test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp:489
    #4 0x7efe7f8d1e7b (<unknown module>)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333730](https://bugs.openjdk.org/browse/JDK-8333730): ubsan: FieldIndices/libFieldIndicesTest.cpp:276:11: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19657/head:pull/19657` \
`$ git checkout pull/19657`

Update a local copy of the PR: \
`$ git checkout pull/19657` \
`$ git pull https://git.openjdk.org/jdk.git pull/19657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19657`

View PR using the GUI difftool: \
`$ git pr show -t 19657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19657.diff">https://git.openjdk.org/jdk/pull/19657.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19657#issuecomment-2160718412)