### PR TITLE
8334026: Provide a diagnostic PrintMemoryMapAtExit switch on Linux

### DIFF
--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -94,7 +94,9 @@
   product(bool, UseMadvPopulateWrite, true, DIAGNOSTIC,                 \
           "Use MADV_POPULATE_WRITE in os::pd_pretouch_memory.")         \
                                                                         \
-
+  product(bool, PrintMemoryMapAtExit, false, DIAGNOSTIC,                \
+	        "Print an annotated memory map at exit")                      \
+	                                                                      \
 // end of RUNTIME_OS_FLAGS
 
 //

--- a/src/hotspot/os/linux/globals_linux.hpp
+++ b/src/hotspot/os/linux/globals_linux.hpp
@@ -95,8 +95,8 @@
           "Use MADV_POPULATE_WRITE in os::pd_pretouch_memory.")         \
                                                                         \
   product(bool, PrintMemoryMapAtExit, false, DIAGNOSTIC,                \
-	        "Print an annotated memory map at exit")                      \
-	                                                                      \
+          "Print an annotated memory map at exit")                      \
+                                                                        \
 // end of RUNTIME_OS_FLAGS
 
 //

--- a/src/hotspot/share/nmt/memMapPrinter.cpp
+++ b/src/hotspot/share/nmt/memMapPrinter.cpp
@@ -30,16 +30,17 @@
 #include "logging/logAsyncWriter.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "memory/universe.hpp"
+#include "memory/resourceArea.hpp"
 #include "nmt/memflags.hpp"
+#include "nmt/memFlagBitmap.hpp"
+#include "nmt/memMapPrinter.hpp"
+#include "nmt/memTracker.hpp"
+#include "nmt/virtualMemoryTracker.hpp"
 #include "runtime/nonJavaThread.hpp"
 #include "runtime/osThread.hpp"
 #include "runtime/thread.hpp"
 #include "runtime/threadSMR.hpp"
 #include "runtime/vmThread.hpp"
-#include "nmt/memFlagBitmap.hpp"
-#include "nmt/memMapPrinter.hpp"
-#include "nmt/memTracker.hpp"
-#include "nmt/virtualMemoryTracker.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
@@ -202,6 +203,8 @@ static void print_thread_details(uintx thread_id, const char* name, outputStream
 
 // Given a region [from, to), if it intersects a known thread stack, print detail infos about that thread.
 static void print_thread_details_for_supposed_stack_address(const void* from, const void* to, outputStream* st) {
+
+  ResourceMark rm;
 
 #define HANDLE_THREAD(T)                                                        \
   if (T != nullptr && vma_touches_thread_stack(from, to, T)) {                  \

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -46,6 +46,7 @@
 #include "memory/oopFactory.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "nmt/memMapPrinter.hpp"
 #include "nmt/memTracker.hpp"
 #include "oops/constantPool.hpp"
 #include "oops/generateOopMap.hpp"
@@ -477,6 +478,9 @@ void before_exit(JavaThread* thread, bool halt) {
 #ifdef LINUX
   if (DumpPerfMapAtExit) {
     CodeCache::write_perf_map();
+  }
+  if (PrintMemoryMapAtExit) {
+    MemMapPrinter::print_all_mappings(tty, false);
   }
 #endif
 

--- a/test/hotspot/jtreg/runtime/NMT/PrintMemoryMapAtExitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/PrintMemoryMapAtExitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Verify PrintMemoryMapAtExit on normal JVM exit for summary tracking level
+ * @requires os.family == "linux"
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @run driver PrintMemoryMapAtExitTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class PrintMemoryMapAtExitTest {
+
+    public static void main(String args[]) throws Exception {
+
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+      "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintMemoryMapAtExit",
+                "-XX:NativeMemoryTracking=summary", "-version");
+
+        OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldContain("Memory mappings");
+        output.shouldContain("JAVAHEAP");
+        output.shouldHaveExitValue(0);
+    }
+}

--- a/test/hotspot/jtreg/runtime/NMT/PrintMemoryMapAtExitTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/PrintMemoryMapAtExitTest.java
@@ -39,10 +39,11 @@ public class PrintMemoryMapAtExitTest {
     public static void main(String args[]) throws Exception {
 
         ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-      "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintMemoryMapAtExit",
+                "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintMemoryMapAtExit",
                 "-XX:NativeMemoryTracking=summary", "-version");
 
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
+        output.shouldHaveExitValue(0);
         output.shouldContain("Memory mappings");
         output.shouldContain("JAVAHEAP");
         output.shouldHaveExitValue(0);


### PR DESCRIPTION
To investigate footprint problems of processes with a short lifespan (e.g. startup footprint problems), we found it very useful to be able to get an annotated memory map at exit - the same map printed by jcmd System.map.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334026](https://bugs.openjdk.org/browse/JDK-8334026): Provide a diagnostic PrintMemoryMapAtExit switch on Linux (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19660/head:pull/19660` \
`$ git checkout pull/19660`

Update a local copy of the PR: \
`$ git checkout pull/19660` \
`$ git pull https://git.openjdk.org/jdk.git pull/19660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19660`

View PR using the GUI difftool: \
`$ git pr show -t 19660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19660.diff">https://git.openjdk.org/jdk/pull/19660.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19660#issuecomment-2162278928)