### PR TITLE
8334028: HttpClient: NPE thrown from assert statement

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ResponseSubscribers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -356,6 +356,7 @@ public class ResponseSubscribers {
             // incoming buffers are allocated by http client internally,
             // and won't be used anywhere except this place.
             // So it's free simply to store them for further processing.
+            Objects.requireNonNull(items); // ensure NPE is thrown before assert
             assert Utils.hasRemaining(items);
             received.addAll(items);
         }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/common/Utils.java
@@ -746,6 +746,7 @@ public final class Utils {
     }
 
     public static long remaining(ByteBuffer[] bufs) {
+        if (bufs == null) return 0;
         long remain = 0;
         for (ByteBuffer buf : bufs) {
             remain += buf.remaining();
@@ -754,6 +755,7 @@ public final class Utils {
     }
 
     public static boolean hasRemaining(List<ByteBuffer> bufs) {
+        if (bufs == null) return false;
         for (ByteBuffer buf : bufs) {
             if (buf.hasRemaining())
                 return true;
@@ -762,6 +764,7 @@ public final class Utils {
     }
 
     public static boolean hasRemaining(ByteBuffer[] bufs) {
+        if (bufs == null) return false;
         for (ByteBuffer buf : bufs) {
             if (buf.hasRemaining())
                 return true;
@@ -770,6 +773,7 @@ public final class Utils {
     }
 
     public static long remaining(List<ByteBuffer> bufs) {
+        if (bufs == null) return 0L;
         long remain = 0;
         for (ByteBuffer buf : bufs) {
             remain += buf.remaining();
@@ -778,12 +782,14 @@ public final class Utils {
     }
 
     public static long synchronizedRemaining(List<ByteBuffer> bufs) {
+        if (bufs == null) return 0L;
         synchronized (bufs) {
             return remaining(bufs);
         }
     }
 
-    public static int remaining(List<ByteBuffer> bufs, int max) {
+    public static long remaining(List<ByteBuffer> bufs, long max) {
+        if (bufs == null) return 0;
         long remain = 0;
         for (ByteBuffer buf : bufs) {
             remain += buf.remaining();
@@ -794,7 +800,13 @@ public final class Utils {
         return (int) remain;
     }
 
-    public static int remaining(ByteBuffer[] refs, int max) {
+    public static int remaining(List<ByteBuffer> bufs, int max) {
+        // safe cast since max is an int
+        return (int) remaining(bufs, (long) max);
+    }
+
+    public static long remaining(ByteBuffer[] refs, long max) {
+        if (refs == null) return 0;
         long remain = 0;
         for (ByteBuffer b : refs) {
             remain += b.remaining();
@@ -803,6 +815,11 @@ public final class Utils {
             }
         }
         return (int) remain;
+    }
+
+    public static int remaining(ByteBuffer[] refs, int max) {
+        // safe cast since max is an int
+        return (int) remaining(refs, (long) max);
     }
 
     public static void close(Closeable... closeables) {

--- a/test/jdk/java/net/httpclient/BodySubscribersTest.java
+++ b/test/jdk/java/net/httpclient/BodySubscribersTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Basic test for the standard BodySubscribers default behavior
- * @bug 8225583
+ * @bug 8225583 8334028
  * @run testng BodySubscribersTest
  */
 


### PR DESCRIPTION
The `jdk.internal.http.common.Utils` class exposes methods that work on lists or arrays of byte buffers, and tell whether or how much remaining data is present in the buffers in the list/array. These methods currently throw `NullPointerException` if the given list/buffer is null.

This is not in itself an issue, except that these methods are often called in debug statements, or in assert statements, where `null` could be passed and `NullPointerException` are not expected and should not be thrown.

One such assert statement in `ResponseSubscribers` hid a bug where a `NullPointerException` that  should have been unconditionally thrown was in fact only thrown if asserts were enabled. The test that was supposed to verify that NPEs are thrown was passing because assert are always enabled by default when running tests.

The proposed change modifies these Utils methods to allow null parameter, returning false or 0 when a null list or array is given. It also fixes the code in ResponseSunscribers that was throwing from the assert to unconditionally check for nulls before the assertion.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334028](https://bugs.openjdk.org/browse/JDK-8334028): HttpClient: NPE thrown from assert statement (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19661/head:pull/19661` \
`$ git checkout pull/19661`

Update a local copy of the PR: \
`$ git checkout pull/19661` \
`$ git pull https://git.openjdk.org/jdk.git pull/19661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19661`

View PR using the GUI difftool: \
`$ git pr show -t 19661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19661.diff">https://git.openjdk.org/jdk/pull/19661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19661#issuecomment-2160949258)