### PR TITLE
8299487: Test java/net/httpclient/whitebox/SSLTubeTestDriver.java timed out

### DIFF
--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
@@ -85,16 +85,17 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                               ExecutorService exec,
                               CountDownLatch allBytesReceived) throws IOException {
             SSLServerSocketFactory fac = ctx.getServerSocketFactory();
+            InetAddress loopback = InetAddress.getLoopbackAddress();
             SSLServerSocket serv = (SSLServerSocket) fac.createServerSocket();
             serv.setReuseAddress(false);
-            serv.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+            serv.bind(new InetSocketAddress(loopback, 0));
             SSLParameters params = serv.getSSLParameters();
             params.setApplicationProtocols(new String[]{"proto2"});
             serv.setSSLParameters(params);
 
 
             int serverPort = serv.getLocalPort();
-            clientSock = new Socket("localhost", serverPort);
+            clientSock = new Socket(loopback, serverPort);
             serverSock = (SSLSocket) serv.accept();
             this.buffer = new LinkedBlockingQueue<>();
             this.allBytesReceived = allBytesReceived;
@@ -107,6 +108,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
         }
 
         public void start() {
+            System.out.println("Starting: server listening at: " + serverSock.getLocalSocketAddress());
             thread1.start();
             thread2.start();
             thread3.start();
@@ -144,6 +146,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                     publisher.submit(List.of(bb));
                 }
             } catch (Throwable e) {
+                System.out.println("clientReader got exception: " + e);
                 e.printStackTrace();
                 Utils.close(clientSock);
             }
@@ -176,6 +179,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                     clientSubscription.request(1);
                 }
             } catch (Throwable e) {
+                System.out.println("clientWriter got exception: " + e);
                 e.printStackTrace();
             }
         }
@@ -212,6 +216,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                         is.close();
                         os.close();
                         serverSock.close();
+                        System.out.println("serverLooback exiting normally");
                         return;
                     }
                     os.write(bb, 0, n);
@@ -219,7 +224,10 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                     loopCount.addAndGet(n);
                 }
             } catch (Throwable e) {
+                System.out.println("serverLooback got exception: " + e);
                 e.printStackTrace();
+            } finally {
+                System.out.println("serverLoopback exiting at count: " + loopCount.get());
             }
         }
 

--- a/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
+++ b/test/jdk/java/net/httpclient/whitebox/java.net.http/jdk/internal/net/http/SSLTubeTest.java
@@ -216,7 +216,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                         is.close();
                         os.close();
                         serverSock.close();
-                        System.out.println("serverLooback exiting normally");
+                        System.out.println("serverLoopback exiting normally");
                         return;
                     }
                     os.write(bb, 0, n);
@@ -224,7 +224,7 @@ public class SSLTubeTest extends AbstractSSLTubeTest {
                     loopCount.addAndGet(n);
                 }
             } catch (Throwable e) {
-                System.out.println("serverLooback got exception: " + e);
+                System.out.println("serverLoopback got exception: " + e);
                 e.printStackTrace();
             } finally {
                 System.out.println("serverLoopback exiting at count: " + loopCount.get());


### PR DESCRIPTION
Here is a trivial change that might fix intermittent failures in the test java/net/httpclient/whitebox/SSLTubeTestDriver.java.
The change makes sure the client connects using the loopback address instead of "localhost".

In case that does not fix the issue, some additional logging has been added to try to understand what's going on.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299487](https://bugs.openjdk.org/browse/JDK-8299487): Test java/net/httpclient/whitebox/SSLTubeTestDriver.java timed out (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19663/head:pull/19663` \
`$ git checkout pull/19663`

Update a local copy of the PR: \
`$ git checkout pull/19663` \
`$ git pull https://git.openjdk.org/jdk.git pull/19663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19663`

View PR using the GUI difftool: \
`$ git pr show -t 19663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19663.diff">https://git.openjdk.org/jdk/pull/19663.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19663#issuecomment-2161248636)