### PR TITLE
8334057: JLinkReproducibleTest.java support receive test.tool.vm.opts

### DIFF
--- a/test/jdk/tools/jlink/JLinkReproducibleTest.java
+++ b/test/jdk/tools/jlink/JLinkReproducibleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,9 @@ import jdk.test.lib.process.ProcessTools;
  * @run driver JLinkReproducibleTest
  */
 public class JLinkReproducibleTest {
+
+    static final String TOOL_VM_OPTIONS = System.getProperty("test.tool.vm.opts", "");
+
     private static void run(List<String> cmd) throws Exception {
         var pb = new ProcessBuilder(cmd.toArray(new String[0]));
         var res = ProcessTools.executeProcess(pb);
@@ -46,6 +49,9 @@ public class JLinkReproducibleTest {
     private static void jlink(Path image, boolean with_default_trace_file) throws Exception {
         var cmd = new ArrayList<String>();
         cmd.add(JDKToolFinder.getJDKTool("jlink"));
+        if (!TOOL_VM_OPTIONS.isEmpty()) {
+            cmd.addAll(Arrays.asList(TOOL_VM_OPTIONS.split("\\s+", -1)));
+        }
         cmd.addAll(List.of(
             "--module-path", JMODS_DIR.toString() + File.pathSeparator + CLASS_DIR.toString(),
             "--add-modules", "main",

--- a/test/jdk/tools/jlink/JLinkReproducibleTest.java
+++ b/test/jdk/tools/jlink/JLinkReproducibleTest.java
@@ -38,7 +38,7 @@ import jdk.test.lib.process.ProcessTools;
  */
 public class JLinkReproducibleTest {
 
-    static final String TOOL_VM_OPTIONS = System.getProperty("test.tool.vm.opts", "");
+    private static final String TOOL_VM_OPTIONS = System.getProperty("test.tool.vm.opts", "");
 
     private static void run(List<String> cmd) throws Exception {
         var pb = new ProcessBuilder(cmd.toArray(new String[0]));


### PR DESCRIPTION
Hi all,
Currently, the testcase `test/jdk/tools/jlink/JLinkReproducibleTest.java` doesn't receive jvm options from jtreg.
I think it's necessory to receive jvm options from jtreg.
Fix solution similar to [JDK-8157850](https://bugs.openjdk.org/browse/JDK-8157850), the change has been verified, only change the testacase, the risk is low.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334057](https://bugs.openjdk.org/browse/JDK-8334057): JLinkReproducibleTest.java support receive test.tool.vm.opts (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19669/head:pull/19669` \
`$ git checkout pull/19669`

Update a local copy of the PR: \
`$ git checkout pull/19669` \
`$ git pull https://git.openjdk.org/jdk.git pull/19669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19669`

View PR using the GUI difftool: \
`$ git pr show -t 19669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19669.diff">https://git.openjdk.org/jdk/pull/19669.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19669#issuecomment-2161962349)