### PR TITLE
8311110: multichar warning in WinAccessBridge.cpp

### DIFF
--- a/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
+++ b/src/jdk.accessibility/windows/native/libwindowsaccessbridge/WinAccessBridge.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2773,7 +2773,7 @@ WinAccessBridge::getAccessibleTextItems(long vmID,
     if (destABWindow != (HWND) 0) {
         if (sendMemoryPackage(buffer, sizeof(buffer), destABWindow) == TRUE) {
             memcpy(textItems, &(pkg->rTextItemsInfo), sizeof(AccessibleTextItemsInfo));
-            if (pkg->rTextItemsInfo.letter != '/0') {
+            if (pkg->rTextItemsInfo.letter != '\0') {
                 return TRUE;
             }
         }


### PR DESCRIPTION
Looks like there was a typo for null character. It should be `'\0'` instead of `'/0'`.
Build with clang toolchain with the help of [this PR](https://github.com/openjdk/jdk/pull/17019) and after the changes there is no warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8311110: multichar warning in WinAccessBridge.cpp`

### Issue
 * [JDK-8311110](https://bugs.openjdk.org/browse/JDK-8311110): multichar warning in WinAccessBridge.cpp (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19670/head:pull/19670` \
`$ git checkout pull/19670`

Update a local copy of the PR: \
`$ git checkout pull/19670` \
`$ git pull https://git.openjdk.org/jdk.git pull/19670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19670`

View PR using the GUI difftool: \
`$ git pr show -t 19670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19670.diff">https://git.openjdk.org/jdk/pull/19670.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19670#issuecomment-2162112320)