### PR TITLE
8334077: Fix problem list entries for compiler tests

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -67,8 +67,6 @@ compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586
 
 compiler/startup/StartupOutput.java 8326615 generic-x64
 
-compiler/rangechecks/TestArrayAccessAboveRCAfterRCCastIIEliminated.java 8332369 generic-all
-
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 #############################################################################
@@ -169,7 +167,7 @@ vmTestbase/vm/mlvm/meth/stress/jdi/breakpointInCompiledCode/Test.java 8257761 ge
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_a/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_b/TestDescription.java 8013267 generic-all
 vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_b/TestDescription.java 8013267 generic-all
-vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java#id1 8325905 generic-all
+vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java#id1 8324756 generic-all
 
 vmTestbase/nsk/jdwp/ThreadReference/ForceEarlyReturn/forceEarlyReturn001/forceEarlyReturn001.java 7199837 generic-all
 


### PR DESCRIPTION
- TestArrayAccessAboveRCAfterRCCastIIEliminated.java should be re-enabled because [JDK-8332369](https://bugs.openjdk.org/browse/JDK-8332369) was closed as duplicate of the backout [JDK-8332829](https://bugs.openjdk.org/browse/JDK-8332829)
- Problem listing of vmTestbase/vm/mlvm/meth/stress/compiler/deoptimize/Test.java#id refers to the wrong bug

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334077](https://bugs.openjdk.org/browse/JDK-8334077): Fix problem list entries for compiler tests (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19671/head:pull/19671` \
`$ git checkout pull/19671`

Update a local copy of the PR: \
`$ git checkout pull/19671` \
`$ git pull https://git.openjdk.org/jdk.git pull/19671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19671`

View PR using the GUI difftool: \
`$ git pr show -t 19671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19671.diff">https://git.openjdk.org/jdk/pull/19671.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19671#issuecomment-2162278352)