### PR TITLE
8319933: Disable tests for JDK-8280481 on Graal

### DIFF
--- a/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
+++ b/test/hotspot/jtreg/compiler/sharedstubs/SharedStubToInterpTest.java
@@ -36,6 +36,7 @@
  * @requires vm.opt.TieredStopAtLevel == null & vm.opt.TieredCompilation == null
  * @requires vm.simpleArch == "x86" | vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @requires vm.debug
+ * @requires !vm.graal.enabled
  * @run driver compiler.sharedstubs.SharedStubToInterpTest -XX:-TieredCompilation
  *
  */


### PR DESCRIPTION
This test should be ignored when Graal is selected as the JIT until such time that Graal implements the same optimization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319933](https://bugs.openjdk.org/browse/JDK-8319933): Disable tests for JDK-8280481 on Graal (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19672/head:pull/19672` \
`$ git checkout pull/19672`

Update a local copy of the PR: \
`$ git checkout pull/19672` \
`$ git pull https://git.openjdk.org/jdk.git pull/19672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19672`

View PR using the GUI difftool: \
`$ git pr show -t 19672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19672.diff">https://git.openjdk.org/jdk/pull/19672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19672#issuecomment-2162349816)