### PR TITLE
8334097: Parallel: Obsolete HeapFirstMaximumCompactionCount

### DIFF
--- a/src/hotspot/share/gc/parallel/parallel_globals.hpp
+++ b/src/hotspot/share/gc/parallel/parallel_globals.hpp
@@ -36,10 +36,6 @@
           "any dead space)")                                                \
           range(0, max_uintx)                                               \
                                                                             \
-  product(uintx, HeapFirstMaximumCompactionCount, 3,                        \
-          "The collection count for the first maximum compaction")          \
-          range(0, max_uintx)                                               \
-                                                                            \
   product(bool, UseMaximumCompactionOnSystemGC, true,                       \
           "Use maximum compaction in the Parallel Old garbage collector "   \
           "for a system GC")                                                \

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -837,8 +837,7 @@ bool PSParallelCompact::reassess_maximum_compaction(bool maximum_compaction,
   const uint total_invocations = ParallelScavengeHeap::heap()->total_full_collections();
   assert(total_invocations >= _maximum_compaction_gc_num, "sanity");
   const size_t gcs_since_max = total_invocations - _maximum_compaction_gc_num;
-  const bool is_interval_ended = gcs_since_max > HeapMaximumCompactionInterval
-                              || total_invocations == HeapFirstMaximumCompactionCount;
+  const bool is_interval_ended = gcs_since_max > HeapMaximumCompactionInterval;
 
   // If all regions in old-gen are full
   const bool is_region_full =

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -519,6 +519,8 @@ static SpecialFlag const special_jvm_flags[] = {
   { "UseRTMDeopt",                  JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "RTMRetryCount",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #endif // X86
+
+  { "HeapFirstMaximumCompactionCount", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #ifdef ASSERT
   { "DummyObsoleteTestFlag",        JDK_Version::undefined(), JDK_Version::jdk(18), JDK_Version::undefined() },
 #endif


### PR DESCRIPTION
Simple obsoleting a Parallel GC product flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8334098](https://bugs.openjdk.org/browse/JDK-8334098) to be approved

### Issues
 * [JDK-8334097](https://bugs.openjdk.org/browse/JDK-8334097): Parallel: Obsolete HeapFirstMaximumCompactionCount (**Enhancement** - P4)
 * [JDK-8334098](https://bugs.openjdk.org/browse/JDK-8334098): Parallel: Obsolete HeapFirstMaximumCompactionCount (**CSR**)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19673/head:pull/19673` \
`$ git checkout pull/19673`

Update a local copy of the PR: \
`$ git checkout pull/19673` \
`$ git pull https://git.openjdk.org/jdk.git pull/19673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19673`

View PR using the GUI difftool: \
`$ git pr show -t 19673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19673.diff">https://git.openjdk.org/jdk/pull/19673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19673#issuecomment-2162354613)