### PR TITLE
JDK-8333277: ubsan: mlib_ImageScanPoly.c:292:43: runtime error: division by zero

### DIFF
--- a/src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c
+++ b/src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -289,12 +289,14 @@ mlib_status mlib_AffineEdges(mlib_affine_param *param,
     mlib_d64 dX1 = coords[(topIdx - i) & 0x3][0];
     mlib_d64 dY2 = coords[(topIdx - i - 1) & 0x3][1];
     mlib_d64 dX2 = coords[(topIdx - i - 1) & 0x3][0];
-    mlib_d64 x = dX1, slope = (dX2 - dX1) / (dY2 - dY1);
+    mlib_d64 x = dX1, slope;
     mlib_s32 y1;
     mlib_s32 y2;
 
     if (dY1 == dY2)
       continue;
+
+    slope = (dX2 - dX1) / (dY2 - dY1);
 
     if (!(IS_FINITE(slope))) {
       continue;
@@ -330,12 +332,14 @@ mlib_status mlib_AffineEdges(mlib_affine_param *param,
     mlib_d64 dX1 = coords[(topIdx + i) & 0x3][0];
     mlib_d64 dY2 = coords[(topIdx + i + 1) & 0x3][1];
     mlib_d64 dX2 = coords[(topIdx + i + 1) & 0x3][0];
-    mlib_d64 x = dX1, slope = (dX2 - dX1) / (dY2 - dY1);
+    mlib_d64 x = dX1, slope;
     mlib_s32 y1;
     mlib_s32 y2;
 
     if (dY1 == dY2)
       continue;
+
+    slope = (dX2 - dX1) / (dY2 - dY1);
 
     if (!(IS_FINITE(slope))) {
       continue;


### PR DESCRIPTION
When running the jdk jtreg tests with ubsan enabled binaries on Linux x86_64, I get the warning below.
This shows up in a couple of tests, for example
java/awt/image/mlib/MlibOpsTest.jtr
java/awt/image/Raster/TestChildRasterOp.jtr

src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c:292:43: runtime error: division by zero
    #0 0x7fe6d958b862 in mlib_AffineEdges src/java.desktop/share/native/libmlib_image/mlib_ImageScanPoly.c:292
    #1 0x7fe6d958bb5d in mlib_ImageAffine_alltypes src/java.desktop/share/native/libmlib_image/mlib_ImageAffine.c:179
    #2 0x7fe6d9e9b398 in Java_sun_awt_image_ImagingLib_transformBI src/java.desktop/share/native/libawt/awt/medialib/awt_ImagingLib.c:922
    #3 0x7fe76f00ae7b (<unknown module>)

The issue has been discussed with Phil Race (see https://bugs.openjdk.org/browse/JDK-8333277) and the division by zero has been already handled in the coding.
However we can avoid it  (and make ubsan happy) and in this case also do a few operations less.