### PR TITLE
8334123: log the opening of Type 1 fonts

### DIFF
--- a/src/java.desktop/share/classes/sun/font/Type1Font.java
+++ b/src/java.desktop/share/classes/sun/font/Type1Font.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,9 @@ public class Type1Font extends FileFont {
     private synchronized ByteBuffer getBuffer() throws FontFormatException {
         ByteBuffer bbuf = bufferRef.get();
         if (bbuf == null) {
-          //System.out.println("open T1 " + platName);
+            if (FontUtilities.isLogging()) {
+                FontUtilities.logInfo("open Type 1 font: " + platName);
+            }
             try {
                 @SuppressWarnings("removal")
                 RandomAccessFile raf = (RandomAccessFile)
@@ -229,6 +231,9 @@ public class Type1Font extends FileFont {
     void readFile(ByteBuffer buffer) {
         RandomAccessFile raf = null;
         FileChannel fc;
+        if (FontUtilities.isLogging()) {
+            FontUtilities.logInfo("open Type 1 font: " + platName);
+        }
         try {
             raf = (RandomAccessFile)
                 java.security.AccessController.doPrivileged(


### PR DESCRIPTION
When font logging is enabled (e.g. by setting -Dsun.java2d.debugfonts=true ), currently the open operations for ttf fonts are logged, but not for Type1 fonts.
The logging would be more clear and consistent with added logging for Type 1 fonts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8334123: log the opening of Type 1 fonts`

### Issue
 * [JDK-8334123](https://bugs.openjdk.org/browse/JDK-8334123): log the opening of Type 1 fonts (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19676/head:pull/19676` \
`$ git checkout pull/19676`

Update a local copy of the PR: \
`$ git checkout pull/19676` \
`$ git pull https://git.openjdk.org/jdk.git pull/19676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19676`

View PR using the GUI difftool: \
`$ git pr show -t 19676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19676.diff">https://git.openjdk.org/jdk/pull/19676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19676#issuecomment-2162873871)