### PR TITLE
8332903: ubsan: opto/output.cpp:1002:18: runtime error: load of value 171, which is not a valid value for type 'bool'

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3430,6 +3430,7 @@ encode %{
     call->_in_rms            = _in_rms;
     call->_nesting           = _nesting;
     call->_override_symbolic_info = _override_symbolic_info;
+    call->_arg_escape        = _arg_escape;
 
     // New call needs all inputs of old call.
     // Req...

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -937,7 +937,7 @@ public:
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _method_handle_invoke;   // Tells if the call has to preserve SP
   bool      _arg_escape;             // ArgEscape in parameter list
-  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false), _arg_escape(false) {
+  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false) {
     init_class_id(Class_MachCallJava);
   }
 

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -937,7 +937,7 @@ public:
   bool      _optimized_virtual;      // Tells if node is a static call or an optimized virtual
   bool      _method_handle_invoke;   // Tells if the call has to preserve SP
   bool      _arg_escape;             // ArgEscape in parameter list
-  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false) {
+  MachCallJavaNode() : MachCallNode(), _override_symbolic_info(false), _arg_escape(false) {
     init_class_id(Class_MachCallJava);
   }
 


### PR DESCRIPTION
When building with ubsan on linuxppc64le we run into the issue below; seems some initialization is missing.
 
/jdk/src/hotspot/share/opto/output.cpp:1002:18: runtime error: load of value 171, which is not a valid value for type 'bool'
    #0 0x7fff8f52b71c in PhaseOutput::Process_OopMap_Node(MachNode*, int) (/jdk/lib/server/libjvm.so+0x74cb71c)
    #1 0x7fff8f530ab4 in PhaseOutput::fill_buffer(C2_MacroAssembler*, unsigned int*) (/jdk/lib/server/libjvm.so+0x74d0ab4)
    #2 0x7fff8f53c740 in PhaseOutput::Output() (/jdk/lib/server/libjvm.so+0x74dc740)
    #3 0x7fff8d5b6350 in Compile::Code_Gen() (/jdk/lib/server/libjvm.so+0x5556350)
    #4 0x7fff8d5be730 in Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*) (/jdk/lib/server/libjvm.so+0x555e730)
    #5 0x7fff8cfe7434 in C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) (/jdk/lib/server/libjvm.so+0x4f87434)
    #6 0x7fff8d5e3bf4 in CompileBroker::invoke_compiler_on_method(CompileTask*) (/jdk/lib/server/libjvm.so+0x5583bf4)
    #7 0x7fff8d5e5a74 in CompileBroker::compiler_thread_loop() (/jdk/lib/server/libjvm.so+0x5585a74)
    #8 0x7fff8d6403c0 in CompilerThread::thread_entry(JavaThread*, JavaThread*) (/jdk/lib/server/libjvm.so+0x55e03c0)
    #9 0x7fff8e428810 in JavaThread::thread_main_inner() (/jdk/lib/server/libjvm.so+0x63c8810)
    #10 0x7fff900992e8 in Thread::call_run() (/jdk/lib/server/libjvm.so+0x80392e8)
    #11 0x7fff8f4a6a08 in thread_native_entry(Thread*) (/jdk/lib/server/libjvm.so+0x7446a08)
    #12 0x7fff95139714 in start_thread (/lib64/libpthread.so.0+0x9714)
    #13 0x7fff944eb774 in __GI___clone (/lib64/libc.so.6+0x13b774)
   ... (rest of output omitted)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332903](https://bugs.openjdk.org/browse/JDK-8332903): ubsan: opto/output.cpp:1002:18: runtime error: load of value 171, which is not a valid value for type 'bool' (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19677/head:pull/19677` \
`$ git checkout pull/19677`

Update a local copy of the PR: \
`$ git checkout pull/19677` \
`$ git pull https://git.openjdk.org/jdk.git pull/19677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19677`

View PR using the GUI difftool: \
`$ git pr show -t 19677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19677.diff">https://git.openjdk.org/jdk/pull/19677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19677#issuecomment-2163071334)