### PR TITLE
8334135: RISC-V: check vector support in VM_Version::os_aux_features

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -158,17 +158,6 @@ void VM_Version::setup_cpu_available_features() {
 void VM_Version::os_aux_features() {
   uint64_t auxv = getauxval(AT_HWCAP);
   for (int i = 0; _feature_list[i] != nullptr; i++) {
-    if (_feature_list[i]->feature_bit() == HWCAP_ISA_V) {
-      // Special case for V: some dev boards only support RVV version 0.7, while
-      // the OpenJDK only supports RVV version 1.0. These two versions are not
-      // compatible with each other. Given the V bit is set through HWCAP on
-      // some custom kernels, regardless of the version, it can lead to
-      // generating V instructions on boards that don't support RVV version 1.0
-      // (ex: Sipeed LicheePi), leading to a SIGILL.
-      // That is an acceptable workaround as only Linux Kernel v6.5+ supports V,
-      // and that version already support hwprobe anyway
-      continue;
-    }
     if ((_feature_list[i]->feature_bit() & auxv) != 0) {
       _feature_list[i]->enable_feature();
     }


### PR DESCRIPTION
Hi,
Can you help to review this patch?

Previously, VM_Version::os_aux_features skips vector check, even if it knows vector is supported via HWCAP, because it can not tell if the rvv0.7 or rvv1.0 is supported, and jdk only supports rvv 1.0.
But this brings another issue in some situation where borad itself supports rvv1.0, but kernel does not support hw probe, then jdk can not enable UseRVV, but it should be.
The solution is to delete the skipping rvv check code, and does not care about if it supports 0.7 or 1.0. The result is, when rvv 1.0 is supported then user can get the feature from jdk; when rvv 0.7 is supported then user needs to pass "-XX:-UseRVV" to disable it explicitly.
Although the solution is not perfect, but I hope it will support both situations anyway.

And I suppose more and more board will support rvv 1.0 rather than 0.7.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334135](https://bugs.openjdk.org/browse/JDK-8334135): RISC-V: check vector support in VM_Version::os_aux_features (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19679/head:pull/19679` \
`$ git checkout pull/19679`

Update a local copy of the PR: \
`$ git checkout pull/19679` \
`$ git pull https://git.openjdk.org/jdk.git pull/19679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19679`

View PR using the GUI difftool: \
`$ git pr show -t 19679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19679.diff">https://git.openjdk.org/jdk/pull/19679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19679#issuecomment-2163241329)