### PR TITLE
8209092: Remove outdated wording from RC5ParameterSpec

### DIFF
--- a/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
+++ b/src/java.base/share/classes/javax/crypto/spec/RC5ParameterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,9 +37,7 @@ import java.util.Arrays;
  * size, and optionally an initialization vector (IV) (only in feedback mode).
  *
  * <p> This class can be used to initialize a {@code Cipher} object that
- * implements the <i>RC5</i> algorithm as supplied by
- * <a href="http://www.rsa.com">RSA Security LLC</a>,
- * or any parties authorized by RSA Security.
+ * implements the <i>RC5</i> algorithm.
  *
  * @author Jan Luehe
  *


### PR DESCRIPTION
The RC5ParameterSpec class description contains the following sentence: "This class can be used to initialize a Cipher object that implements the RC5 algorithm as supplied by RSA Security LLC, or any parties authorized by RSA Security." 

The part "as supplied by RSA Security LLC, or any parties authorized by RSA Security." should be removed. We don't generally include information about 3rd-party JCA providers in the standard javadocs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8209092](https://bugs.openjdk.org/browse/JDK-8209092): Remove outdated wording from RC5ParameterSpec (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19680/head:pull/19680` \
`$ git checkout pull/19680`

Update a local copy of the PR: \
`$ git checkout pull/19680` \
`$ git pull https://git.openjdk.org/jdk.git pull/19680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19680`

View PR using the GUI difftool: \
`$ git pr show -t 19680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19680.diff">https://git.openjdk.org/jdk/pull/19680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19680#issuecomment-2163449399)