### PR TITLE
8334162: Gatherer.defaultCombiner has an erronous @see-link

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -293,7 +293,7 @@ public interface Gatherer<T, A, R> {
      *
      * @implSpec This method always returns the same instance.
      *
-     * @see Gatherer#finisher()
+     * @see Gatherer#combiner()
      * @return the instance of the default combiner
      * @param <A> the type of the state of the returned combiner
      */


### PR DESCRIPTION
Erronous Javadoc reference addressed. This should be backported to 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334162](https://bugs.openjdk.org/browse/JDK-8334162): Gatherer.defaultCombiner has an erronous @<!---->see-link (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [0218c212](https://git.openjdk.org/jdk/pull/19682/files/0218c2125bbedb19b0332a2b6937138282bb328c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19682/head:pull/19682` \
`$ git checkout pull/19682`

Update a local copy of the PR: \
`$ git checkout pull/19682` \
`$ git pull https://git.openjdk.org/jdk.git pull/19682/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19682`

View PR using the GUI difftool: \
`$ git pr show -t 19682`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19682.diff">https://git.openjdk.org/jdk/pull/19682.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19682#issuecomment-2163895324)