### PR TITLE
8334166: Enable binary check

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -5,7 +5,7 @@ version=24
 
 [checks]
 error=author,committer,reviewers,merge,issues,executable,symlink,message,hg-tag,whitespace,problemlists
-warning=issuestitle
+warning=issuestitle,binary
 
 [repository]
 tags=(?:jdk-(?:[1-9]([0-9]*)(?:\.(?:0|[1-9][0-9]*)){0,4})(?:\+(?:(?:[0-9]+))|(?:-ga)))|(?:jdk[4-9](?:u\d{1,3})?-(?:(?:b\d{2,3})|(?:ga)))|(?:hs\d\d(?:\.\d{1,2})?-b\d\d)


### PR DESCRIPTION
@kevinrushforth said in [SKARA-2289](https://bugs.openjdk.org/browse/SKARA-2289), 'In general, our repositories contain source code and not binary files. There are exceptions to this for images and other similar resources, but otherwise the policy for most repos is to avoid binary files'. Skara is able to identify binary files when executing jcheck, but this check is not enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334166](https://bugs.openjdk.org/browse/JDK-8334166): Enable binary check (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19683/head:pull/19683` \
`$ git checkout pull/19683`

Update a local copy of the PR: \
`$ git checkout pull/19683` \
`$ git pull https://git.openjdk.org/jdk.git pull/19683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19683`

View PR using the GUI difftool: \
`$ git pr show -t 19683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19683.diff">https://git.openjdk.org/jdk/pull/19683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19683#issuecomment-2164019212)