### PR TITLE
optimize building node tree

### DIFF
--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1340,6 +1340,7 @@ class ZipFileSystem extends FileSystem {
 
     private void makeParentDirs(IndexNode node, IndexNode root) {
         IndexNode parent;
+        if(node.name.length<=1) continue;
         ParentLookup lookup = new ParentLookup();
         while (true) {
             int off = getParentOff(node.name);


### PR DESCRIPTION
While using JDK11 to decompress a certain jar package, I noticed that the operation gets stuck without showing any error messages. Upon debugging, it was discovered that an infinite loop occurs during the process of constructing the directory tree, with the root directory continuously piling up at the bottom of the stack. 
<img width="185" alt="D5E6FF6A-77AA-43A2-8F9C-74DA9845839C" src="https://github.com/openjdk/jdk/assets/119659920/fc114bed-43c3-405c-a18a-8338228e50b7">
<img width="367" alt="A77DEE15-43DA-43BD-A32F-DC7BE817D3CF" src="https://github.com/openjdk/jdk/assets/119659920/6f7ce06b-2524-48e0-8207-f9d61cd802e4">

The reason for this is that the jar package erroneously contained a root directory symbol "/", causing the child of the root node in the directory tree construction process to point to the root node itself (that root directory).

![EEDBDE9F-B9E6-4757-8CD9-CBE5D7B260C6](https://github.com/openjdk/jdk/assets/119659920/bc1b8d81-531d-4999-ab58-cafff9b700a1)

 Subsequently, in the process of traversing the directory tree, continuous recursion occurs, and the root directory keeps accumulating at the bottom of the stack, ultimately leading to an OutOfMemoryError. I believe that incorporating a prior check (whether the child is the root directory) during the construction of the directory tree would be more appropriate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19684/head:pull/19684` \
`$ git checkout pull/19684`

Update a local copy of the PR: \
`$ git checkout pull/19684` \
`$ git pull https://git.openjdk.org/jdk.git pull/19684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19684`

View PR using the GUI difftool: \
`$ git pr show -t 19684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19684.diff">https://git.openjdk.org/jdk/pull/19684.diff</a>

</details>
