### PR TITLE
8334106: Problemlist CAInterop.java#quovadisrootca1g3 due to JDK-8334105

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/FollowReferences/FieldIndices/libFieldIndicesTest.cpp
@@ -273,7 +273,9 @@ void Klass::explore_interfaces(JNIEnv* env) {
   if (super_klass != nullptr) {
     // Add all interfaces implemented by super_klass first.
     interface_count = super_klass->interface_count;
-    memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    if (super_klass->interfaces != nullptr) {
+      memcpy(interfaces, super_klass->interfaces, sizeof(Klass*) * super_klass->interface_count);
+    }
   }
 
   // Interfaces implemented by the klass.

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,8 +623,8 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1 8333640 generic-all
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#quovadisrootca1g3 8334105 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#quovadisrootca1g3    8334105 generic-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,7 +623,8 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1 8333640 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#quovadisrootca1g3 8334105 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
Hi all, 
  Test `security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#quovadisrootca1g3` report failure as `failed to validate`, before the validate issue has been fixed, should we problem list the testcase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334106](https://bugs.openjdk.org/browse/JDK-8334106): Problemlist CAInterop.java#quovadisrootca1g3 due to JDK-8334105 (**Sub-task** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19685/head:pull/19685` \
`$ git checkout pull/19685`

Update a local copy of the PR: \
`$ git checkout pull/19685` \
`$ git pull https://git.openjdk.org/jdk.git pull/19685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19685`

View PR using the GUI difftool: \
`$ git pr show -t 19685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19685.diff">https://git.openjdk.org/jdk/pull/19685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19685#issuecomment-2164202057)