### PR TITLE
8334078: RISC-V: TestIntVect.java fails after JDK-8332153 when running without RVV

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -131,7 +131,12 @@ void VM_Version::setup_cpu_available_features() {
       if (_feature_list[i]->feature_string()) {
         const char* tmp = _feature_list[i]->pretty();
         if (strlen(tmp) == 1) {
+          // Feature string is expected to be in multi-character form
+          // like rvc, rvv, etc so that it will be easier to specify
+          // target feature string in tests.
           strcat(buf, " ");
+          strcat(buf, "r");
+          strcat(buf, "v");
           strcat(buf, tmp);
         } else {
           // Feature string is expected to be lower case.

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -134,9 +134,7 @@ void VM_Version::setup_cpu_available_features() {
           // Feature string is expected to be in multi-character form
           // like rvc, rvv, etc so that it will be easier to specify
           // target feature string in tests.
-          strcat(buf, " ");
-          strcat(buf, "r");
-          strcat(buf, "v");
+          strcat(buf, " rv");
           strcat(buf, tmp);
         } else {
           // Feature string is expected to be lower case.

--- a/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java
@@ -480,10 +480,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_mulc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*VALUE);
@@ -492,10 +489,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.SUB_VI, "> 0", IRNode.LSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_mulc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]*(-VALUE));
@@ -527,15 +521,7 @@ public class TestIntVect {
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
-        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true"})
-    @IR(counts = { IRNode.ADD_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
-                   IRNode.RSHIFT_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
-                   IRNode.SUB_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true", "rvv", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -555,15 +541,7 @@ public class TestIntVect {
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
                    IRNode.SUB_VI,
                    IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
-        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true"})
-    @IR(counts = { IRNode.ADD_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
-                   IRNode.RSHIFT_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0",
-                   IRNode.SUB_VI,
-                   IRNode.VECTOR_SIZE + "min(max_int, max_long)", "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"avx2", "true", "sve", "true", "rvv", "true"})
     // Not vectorized: On aarch64, vectorization for this example results in
     // MulVL nodes, which asimd does not support.
     @IR(counts = { IRNode.LOAD_VECTOR_I, "= 0",
@@ -683,10 +661,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_sllc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<VALUE);
@@ -695,10 +670,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_sllc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-VALUE));
@@ -710,12 +682,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_sllc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<SHIFT);
@@ -727,12 +694,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.LSHIFT_VI,     "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_sllc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<(-SHIFT));
@@ -741,10 +703,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.LSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_sllv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]<<b);
@@ -753,10 +712,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srlc(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>VALUE);
@@ -765,10 +721,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srlc_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-VALUE));
@@ -780,12 +733,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srlc_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>SHIFT);
@@ -797,12 +745,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.URSHIFT_VI,    "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srlc_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>(-SHIFT));
@@ -811,10 +754,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.URSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srlv(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>>b);
@@ -823,10 +763,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srac(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>VALUE);
@@ -835,10 +772,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srac_n(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-VALUE));
@@ -850,12 +784,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srac_o(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>SHIFT);
@@ -867,12 +796,7 @@ public class TestIntVect {
     @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
                    IRNode.LOAD_VECTOR_I, "> 0",
                    IRNode.STORE_VECTOR,  "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.RSHIFT_VI,     "= 0",
-                   IRNode.LOAD_VECTOR_I, "> 0",
-                   IRNode.STORE_VECTOR,  "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srac_on(int[] a0, int[] a1) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>(-SHIFT));
@@ -881,10 +805,7 @@ public class TestIntVect {
 
     @Test
     @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
-    @IR(counts = { IRNode.RSHIFT_VI, "> 0" },
-        applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"})
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true", "rvv", "true"})
     void test_srav(int[] a0, int[] a1, int b) {
         for (int i = 0; i < a0.length; i+=1) {
             a0[i] = (int)(a1[i]>>b);

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizeURShiftSubword.java
@@ -35,7 +35,7 @@ import jdk.test.lib.Utils;
  * @key randomness
  * @summary Auto-vectorization enhancement for unsigned shift right on signed subword types
  * @requires ((os.arch=="amd64" | os.arch=="x86_64") & (vm.opt.UseSSE == "null" | vm.opt.UseSSE > 3)) | os.arch=="aarch64" |
- *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.c2.irTests.TestVectorizeURShiftSubword
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/TestBitShuffleOpers.java
@@ -31,7 +31,7 @@
  *            (vm.cpu.features ~= ".*bmi2.*" & vm.cpu.features ~= ".*bmi1.*" &
  *             vm.cpu.features ~= ".*sse2.*")) |
  *            (os.arch=="aarch64" & vm.cpu.features ~= ".*svebitperm.*") |
- *            (os.arch=="riscv64" & vm.cpu.features ~= ".*v,.*"))
+ *            (os.arch=="riscv64" & vm.cpu.features ~= ".*rvv.*"))
  * @library /test/lib /
  * @run driver compiler.intrinsics.TestBitShuffleOpers
  */

--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -38,7 +38,7 @@ import jdk.test.whitebox.cpuinfo.CPUInfo;
  * @library /test/lib
  * @requires (vm.cpu.features ~= ".*avx512.*" | vm.cpu.features ~= ".*avx2.*" | vm.cpu.features ~= ".*avx.*") |
  *           (os.arch=="aarch64" & vm.cpu.features ~= ".*simd.*") |
- *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @build   compiler.intrinsics.chacha.ExerciseChaCha20
  *          jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -60,13 +60,9 @@ public class TestChaCha20 {
         return n;
     }
 
-    private static boolean containsFuzzy(List<String> list, String sub, Boolean matchExactly) {
+    private static boolean containsFuzzy(List<String> list, String sub) {
         for (String s : list) {
-            if (matchExactly) {
-                if (s.equals(sub)) return true;
-            } else {
-                if (s.contains(sub)) return true;
-            }
+            if (s.contains(sub)) return true;
         }
         return false;
     }
@@ -86,27 +82,27 @@ public class TestChaCha20 {
             }
 
             // Otherwise, select the tests that make sense on current platform.
-            if (containsFuzzy(cpuFeatures, "avx512", false)) {
+            if (containsFuzzy(cpuFeatures, "avx512")) {
                 System.out.println("Setting up AVX512 worker");
                 configs.add(List.of("-XX:UseAVX=3"));
             }
-            if (containsFuzzy(cpuFeatures, "avx2", false)) {
+            if (containsFuzzy(cpuFeatures, "avx2")) {
                 System.out.println("Setting up AVX2 worker");
                 configs.add(List.of("-XX:UseAVX=2"));
             }
-            if (containsFuzzy(cpuFeatures, "avx", false)) {
+            if (containsFuzzy(cpuFeatures, "avx")) {
                 System.out.println("Setting up AVX worker");
                 configs.add(List.of("-XX:UseAVX=1"));
             }
         } else if (Platform.isAArch64()) {
             // AArch64 intrinsics require the advanced simd instructions
-            if (containsFuzzy(cpuFeatures, "simd", false)) {
+            if (containsFuzzy(cpuFeatures, "simd")) {
                 System.out.println("Setting up ASIMD worker");
                 configs.add(new ArrayList());
             }
         } else if (Platform.isRISCV64()) {
             // Riscv64 intrinsics require the vector instructions
-            if (containsFuzzy(cpuFeatures, "v", true)) {
+            if (containsFuzzy(cpuFeatures, "rvv")) {
                 System.out.println("Setting up vector worker");
                 configs.add(List.of("-XX:+UseRVV"));
             }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/test/IREncodingPrinter.java
@@ -108,7 +108,7 @@ public class IREncodingPrinter {
         "asimd",
         "sve",
         // Riscv64
-        "v",
+        "rvv",
         "zvbb"
     ));
 

--- a/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastRVV.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/reshape/TestVectorCastRVV.java
@@ -34,7 +34,7 @@ import compiler.vectorapi.reshape.utils.VectorReshapeHelper;
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.misc
  * @summary Test that vector cast intrinsics work as intended on riscv (rvv).
- * @requires os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*"
+ * @requires os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*"
  * @library /test/lib /
  * @run main/timeout=300 compiler.vectorapi.reshape.TestVectorCastRVV
  */

--- a/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestSignumVector.java
@@ -28,7 +28,7 @@
  *          and riscv64 (vector)
  * @requires vm.compiler2.enabled
  * @requires (os.simpleArch == "x64" & vm.cpu.features ~= ".*avx.*") | os.arch == "aarch64" |
- *           (os.arch == "riscv64" & vm.cpu.features ~= ".*v,.*")
+ *           (os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
  * @library /test/lib /
  * @run driver compiler.vectorization.TestSignumVector
  */

--- a/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/ArrayShiftOpTest.java
@@ -153,10 +153,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
 
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VI, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistConstant() {
         int[] res = new int[SIZE];
@@ -167,10 +164,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VI, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] intShiftLargeDistInvariant() {
         int[] res = new int[SIZE];
@@ -181,10 +175,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistConstant() {
         short[] res = new short[SIZE];
@@ -195,10 +186,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] shortShiftLargeDistInvariant() {
         short[] res = new short[SIZE];
@@ -209,10 +197,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_VL, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] longShiftLargeDistConstant() {
         long[] res = new long[SIZE];
@@ -223,10 +208,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_VL, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] longShiftLargeDistInvariant() {
         long[] res = new long[SIZE];
@@ -259,10 +241,7 @@ public class ArrayShiftOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicByteOpTest.java
@@ -189,10 +189,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.LSHIFT_VB, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VB, ">0"})
     public byte[] vectorShiftLeft() {
         byte[] res = new byte[SIZE];
@@ -203,10 +200,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.RSHIFT_VB, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorSignedShiftRight() {
         byte[] res = new byte[SIZE];
@@ -217,10 +211,7 @@ public class BasicByteOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true"},
-        counts = {IRNode.RSHIFT_VB, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse4.1", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VB, ">0"})
     public byte[] vectorUnsignedShiftRight() {
         byte[] res = new byte[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicCharOpTest.java
@@ -191,10 +191,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_VC, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VC, ">0"})
     public char[] vectorShiftLeft() {
         char[] res = new char[SIZE];
@@ -205,10 +202,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_VC, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorSignedShiftRight() {
         char[] res = new char[SIZE];
@@ -219,10 +213,7 @@ public class BasicCharOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_VC, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.URSHIFT_VC, ">0"})
     public char[] vectorUnsignedShiftRight() {
         char[] res = new char[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicIntOpTest.java
@@ -198,10 +198,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_VI, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VI, ">0"})
     public int[] vectorShiftLeft() {
         int[] res = new int[SIZE];
@@ -212,10 +209,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VI, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VI, ">0"})
     public int[] vectorSignedShiftRight() {
         int[] res = new int[SIZE];
@@ -226,10 +220,7 @@ public class BasicIntOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_VI, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.URSHIFT_VI, ">0"})
     public int[] vectorUnsignedShiftRight() {
         int[] res = new int[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicLongOpTest.java
@@ -190,10 +190,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_VL, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VL, ">0"})
     public long[] vectorShiftLeft() {
         long[] res = new long[SIZE];
@@ -204,10 +201,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VL, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VL, ">0"})
     public long[] vectorSignedShiftRight() {
         long[] res = new long[SIZE];
@@ -218,10 +212,7 @@ public class BasicLongOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.URSHIFT_VL, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.URSHIFT_VL, ">0"})
     public long[] vectorUnsignedShiftRight() {
         long[] res = new long[SIZE];

--- a/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
+++ b/test/hotspot/jtreg/compiler/vectorization/runner/BasicShortOpTest.java
@@ -189,10 +189,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
 
     // ---------------- Shift ----------------
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.LSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.LSHIFT_VS, ">0"})
     public short[] vectorShiftLeft() {
         short[] res = new short[SIZE];
@@ -203,10 +200,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorSignedShiftRight() {
         short[] res = new short[SIZE];
@@ -242,10 +236,7 @@ public class BasicShortOpTest extends VectorizationTestRunner {
     }
 
     @Test
-    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true"},
-        counts = {IRNode.RSHIFT_VS, ">0"})
-    @IR(applyIfPlatform = {"riscv64", "true"},
-        applyIfCPUFeature = {"v", "true"},
+    @IR(applyIfCPUFeatureOr = {"asimd", "true", "sse2", "true", "rvv", "true"},
         counts = {IRNode.RSHIFT_VS, ">0"})
     public short[] vectorUnsignedShiftRight() {
         short[] res = new short[SIZE];


### PR DESCRIPTION
Hi, test/hotspot/jtreg/compiler/c2/cr7200264/TestIntVect.java fails without RVV after [JDK-8332153](https://bugs.openjdk.org/browse/JDK-8332153) in fastdebug mode.  see jbs issue for exception information.

As discussed on jbs, we prefixed the single letter cpu features with rv so that there would be no problem. And to synchronize the test cases.

After this patch, we can get cpu feature string like this:
```
----------System.out:(4/168)----------
WB.getCPUFeatures(): "rv64 rvi rvm rva rvf rvd rvc rvv"
CPUInfo.getAdditionalCPUInfo(): ""
CPUInfo.getFeatures(): [rv64, rvi, rvm, rva, rvf, rvd, rvc, rvv]
TEST PASSED
```

### Testing
- [x] All Tests related to all changes in this patch on Banana Pi BPI-F3 board (with RVV1.0) (fastdebug)
- [x] All Tests related to all changes in this patch on SOPHON SG2042 (fastdebug)
- [ ] Run tier1-3 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334078](https://bugs.openjdk.org/browse/JDK-8334078): RISC-V: TestIntVect.java fails after JDK-8332153 when running without RVV (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19686/head:pull/19686` \
`$ git checkout pull/19686`

Update a local copy of the PR: \
`$ git checkout pull/19686` \
`$ git pull https://git.openjdk.org/jdk.git pull/19686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19686`

View PR using the GUI difftool: \
`$ git pr show -t 19686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19686.diff">https://git.openjdk.org/jdk/pull/19686.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19686#issuecomment-2164388615)