### PR TITLE
8334179: VMATreeTest.TestConsistencyWithSimpleTracker_vm runs 50+ seconds

### DIFF
--- a/test/hotspot/gtest/nmt/test_vmatree.cpp
+++ b/test/hotspot/gtest/nmt/test_vmatree.cpp
@@ -358,7 +358,7 @@ struct SimpleVMATracker : public CHeapObj<mtTest> {
     }
   };
   // Page (4KiB) granular array
-  static constexpr const size_t num_pages = 1024 * 512;
+  static constexpr const size_t num_pages = 1024 * 4;
   Info pages[num_pages];
 
   SimpleVMATracker()
@@ -434,8 +434,6 @@ TEST_VM_F(VMATreeTest, TestConsistencyWithSimpleTracker) {
   const MEMFLAGS candidate_flags[candidates_len_flags] = {
     mtNMT,
     mtTest,
-    mtGC,
-    mtCompiler
   };
 
   const int operation_count = 100000; // One hundred thousand


### PR DESCRIPTION
Trivial fix:

- reduce area size, and hence, granularity. This is actually beneficial since it slightly increases the chance of testing corner cases  where addresses coincide

I also reduce number of tested combinations to 8 (2 flags 2 states 2 stacks). This will exercise merging better.

Changes reduce time to ~400ms on my Mac M1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334179](https://bugs.openjdk.org/browse/JDK-8334179): VMATreeTest.TestConsistencyWithSimpleTracker_vm runs 50+ seconds (**Bug** - P3)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19687/head:pull/19687` \
`$ git checkout pull/19687`

Update a local copy of the PR: \
`$ git checkout pull/19687` \
`$ git pull https://git.openjdk.org/jdk.git pull/19687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19687`

View PR using the GUI difftool: \
`$ git pr show -t 19687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19687.diff">https://git.openjdk.org/jdk/pull/19687.diff</a>

</details>
