### PR TITLE
8334201: Exclude CAInterop.java#certignarootca

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -624,6 +624,7 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
 security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#certignarootca       8331883 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
The test is failing currently and the JBS issue could not be resolved since about a month, so let's exclude the test for now.
