### PR TITLE
8334202: Exclude CAInterop.java#sslrooteccca,sslrootevrsaca

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -623,6 +623,8 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#sslrooteccca         8333788 generic-all
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#sslrootevrsaca       8333788 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
 
 ############################################################################


### PR DESCRIPTION
Let's exclude these CAInterop tests until the problem is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334202](https://bugs.openjdk.org/browse/JDK-8334202): Exclude CAInterop.java#sslrooteccca,sslrootevrsaca (**Sub-task** - P3)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19690/head:pull/19690` \
`$ git checkout pull/19690`

Update a local copy of the PR: \
`$ git checkout pull/19690` \
`$ git pull https://git.openjdk.org/jdk.git pull/19690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19690`

View PR using the GUI difftool: \
`$ git pr show -t 19690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19690.diff">https://git.openjdk.org/jdk/pull/19690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19690#issuecomment-2165128887)