### PR TITLE
8211854: [aix] java/net/ServerSocket/AcceptInheritHandle.java fails: read times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -552,8 +552,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
-
 java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
The issue seems to be not reproducable. We've run the test now for a while in SAP's nightlies but it didn't reoccur. So let's remove the exclusion.
