### PR TITLE
5021949: JSplitPane setEnabled(false) shouldn't be partially functional

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import javax.accessibility.AccessibleState;
 import javax.accessibility.AccessibleStateSet;
 import javax.accessibility.AccessibleValue;
 import javax.swing.plaf.SplitPaneUI;
+import javax.swing.plaf.basic.BasicSplitPaneUI;
 
 /**
  * <code>JSplitPane</code> is used to divide two (and only two)
@@ -361,6 +362,15 @@ public class JSplitPane extends JComponent implements Accessible
 
     }
 
+    /**
+     * {@inheritDoc}
+     * @param enabled {@inheritDoc}
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        ((BasicSplitPaneUI)(this.getUI())).getDivider().setEnabled(enabled);
+    }
 
     /**
      * Sets the L&amp;F object that renders this component.
@@ -574,7 +584,6 @@ public class JSplitPane extends JComponent implements Accessible
         firePropertyChange(ONE_TOUCH_EXPANDABLE_PROPERTY, oldValue, newValue);
         repaint();
     }
-
 
     /**
      * Gets the <code>oneTouchExpandable</code> property.

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -361,7 +361,6 @@ public class JSplitPane extends JComponent implements Accessible
         updateUI();
 
     }
-
 
     /**
      * {@inheritDoc}

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -362,6 +362,7 @@ public class JSplitPane extends JComponent implements Accessible
 
     }
 
+
     /**
      * {@inheritDoc}
      * @param enabled {@inheritDoc}
@@ -369,7 +370,9 @@ public class JSplitPane extends JComponent implements Accessible
     @Override
     public void setEnabled(boolean enabled) {
         super.setEnabled(enabled);
-        ((BasicSplitPaneUI)(this.getUI())).getDivider().setEnabled(enabled);
+        if (this.getUI() instanceof BasicSplitPaneUI) {
+            ((BasicSplitPaneUI)(this.getUI())).getDivider().setEnabled(enabled);
+        }
     }
 
     /**
@@ -584,6 +587,7 @@ public class JSplitPane extends JComponent implements Accessible
         firePropertyChange(ONE_TOUCH_EXPANDABLE_PROPERTY, oldValue, newValue);
         repaint();
     }
+
 
     /**
      * Gets the <code>oneTouchExpandable</code> property.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -360,6 +360,20 @@ public class BasicSplitPaneDivider extends Container
         }
     }
 
+    /**
+     * {@inheritDoc}
+     * @param enabled {@inheritDoc}
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (splitPane.isOneTouchExpandable() &&
+                rightButton != null &&
+                leftButton != null) {
+
+            rightButton.setEnabled(enabled);
+            leftButton.setEnabled(enabled);
+        }
+    }
 
     /**
      * Paints the divider.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -486,6 +486,7 @@ public class BasicSplitPaneDivider extends Container
         b.setFocusPainted(false);
         b.setBorderPainted(false);
         b.setRequestFocusEnabled(false);
+        b.setEnabled(splitPane.isEnabled());
         return b;
     }
 
@@ -543,6 +544,7 @@ public class BasicSplitPaneDivider extends Container
         b.setFocusPainted(false);
         b.setBorderPainted(false);
         b.setRequestFocusEnabled(false);
+        b.setEnabled(splitPane.isEnabled());
         return b;
     }
 

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 5021949
+ * @key headful
+ * @summary  Verifies JSplitPane setEnabled(false) disables one touch expandable clicks
+ * @run main TestSplitPaneEnableTest
+ */
+
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.InputEvent;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JSplitPane;
+import javax.swing.plaf.basic.BasicSplitPaneDivider;
+import javax.swing.plaf.basic.BasicSplitPaneUI;
+import javax.swing.SwingUtilities;
+
+public class TestSplitPaneEnableTest {
+    private static JButton leftOneTouchButton;
+    private static JButton rightOneTouchButton;
+    private static JFrame frame;
+    private static JSplitPane jsp;
+    private static volatile Point loc;
+    private static volatile int prevDivLoc;
+    private static volatile int curDivLoc;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            Robot robot = new Robot();
+            SwingUtilities.invokeAndWait(() -> {
+                frame = new JFrame();
+                jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                                     new JButton("Left"),
+                                     new JButton("Right"));
+
+                frame.getContentPane().add(jsp);
+                jsp.setUI(new TestSplitPaneUI());
+                jsp.setOneTouchExpandable(true);
+
+                jsp.setEnabled(false);
+
+                frame.setSize(400, 200);
+                frame.setLocationRelativeTo(null);
+                frame.setVisible(true);
+            });
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                loc = leftOneTouchButton.getLocationOnScreen();
+                prevDivLoc = jsp.getDividerLocation();
+            });
+            robot.mouseMove(loc.x, loc.y);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            SwingUtilities.invokeAndWait(() -> {
+                curDivLoc = jsp.getDividerLocation();
+            });
+            System.out.println("current Divider location " + curDivLoc);
+            if (curDivLoc != prevDivLoc) {
+                throw new RuntimeException("Divider position changed on disabled oneTouchExpandable arrow click");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    static class TestSplitPaneUI extends BasicSplitPaneUI {
+
+        public TestSplitPaneUI() {
+            super();
+        }
+
+        public BasicSplitPaneDivider createDefaultDivider() {
+            return new TestSplitPaneDivider(this);
+        }
+    }
+
+    static class TestSplitPaneDivider extends BasicSplitPaneDivider {
+
+        public TestSplitPaneDivider(BasicSplitPaneUI ui) {
+            super(ui);
+        }
+
+        protected JButton createLeftOneTouchButton() {
+            leftOneTouchButton = super.createLeftOneTouchButton();
+            return leftOneTouchButton;
+        }
+
+        protected JButton createRightOneTouchButton() {
+            rightOneTouchButton = super.createRightOneTouchButton();
+            return rightOneTouchButton;
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
@@ -64,6 +64,9 @@ public class TestSplitPaneEnableTest {
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            if (laf.getClassName().toLowerCase().contains("gtk")) {
+                continue;
+            }
             System.out.println("Testing LAF : " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
@@ -74,7 +77,7 @@ public class TestSplitPaneEnableTest {
                                          new JButton("Left"),
                                          new JButton("Right"));
 
-                    frame.getContentPane().add(jsp);
+                    frame.add(jsp);
                     jsp.setUI(new TestSplitPaneUI());
                     jsp.setOneTouchExpandable(true);
 

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
@@ -30,10 +30,8 @@
  */
 
 import java.awt.Point;
-import java.awt.Robot;
 import java.awt.event.InputEvent;
 import javax.swing.JButton;
-import javax.swing.JFrame;
 import javax.swing.JSplitPane;
 import javax.swing.plaf.basic.BasicSplitPaneDivider;
 import javax.swing.plaf.basic.BasicSplitPaneUI;
@@ -44,7 +42,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 public class TestSplitPaneEnableTest {
     private static JButton leftOneTouchButton;
     private static JButton rightOneTouchButton;
-    private static JFrame frame;
     private static JSplitPane jsp;
     private static volatile boolean btnEnabled;
 
@@ -60,7 +57,6 @@ public class TestSplitPaneEnableTest {
     }
 
     public static void main(String[] args) throws Exception {
-        Robot robot = new Robot();
         for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
             if (laf.getClassName().toLowerCase().contains("gtk")) {
                 continue;
@@ -68,38 +64,20 @@ public class TestSplitPaneEnableTest {
             System.out.println("Testing LAF : " + laf.getClassName());
             SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
-            try {
-                SwingUtilities.invokeAndWait(() -> {
-                    frame = new JFrame("SplitPaneTest");
-                    jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
-                                         new JButton("Left"),
-                                         new JButton("Right"));
-
-                    frame.add(jsp);
-                    jsp.setUI(new TestSplitPaneUI());
-                    jsp.setOneTouchExpandable(true);
-
-                    jsp.setEnabled(false);
-
-                });
-
-                robot.waitForIdle();
-                robot.delay(500);
-
-                SwingUtilities.invokeAndWait(() -> {
-                    btnEnabled = leftOneTouchButton.isEnabled();
-                });
-                System.out.println("leftOneTouchButton.isEnabled " + btnEnabled);
-                if (btnEnabled) {
-                    throw new RuntimeException("Arrow buttons still enabled for disabled splitpane");
+            SwingUtilities.invokeAndWait(() -> {
+                JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                                                new JButton("Left"), new JButton("Right"));
+                jsp.setUI(new TestSplitPaneUI());
+                jsp.setOneTouchExpandable(true);
+                jsp.setEnabled(false);
+                if (leftOneTouchButton.isEnabled()) {
+                    throw new RuntimeException("leftButton is enabled for disabled JSplitPane");
                 }
-            } finally {
-                SwingUtilities.invokeAndWait(() -> {
-                    if (frame != null) {
-                        frame.dispose();
-                    }
-                });
-            }
+                if (rightOneTouchButton.isEnabled()) {
+                    throw new RuntimeException("rightButton is enabled for disabled JSplitPane");
+                }
+
+            });
         }
     }
 

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
@@ -46,9 +46,7 @@ public class TestSplitPaneEnableTest {
     private static JButton rightOneTouchButton;
     private static JFrame frame;
     private static JSplitPane jsp;
-    private static volatile Point loc;
-    private static volatile int prevDivLoc;
-    private static volatile int curDivLoc;
+    private static volatile boolean btnEnabled;
 
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
@@ -83,31 +81,17 @@ public class TestSplitPaneEnableTest {
 
                     jsp.setEnabled(false);
 
-                    frame.setSize(400, 200);
-                    frame.setLocationRelativeTo(null);
-                    frame.setVisible(true);
                 });
 
                 robot.waitForIdle();
-                robot.delay(1000);
+                robot.delay(500);
 
                 SwingUtilities.invokeAndWait(() -> {
-                    loc = leftOneTouchButton.getLocationOnScreen();
-                    prevDivLoc = jsp.getDividerLocation();
+                    btnEnabled = leftOneTouchButton.isEnabled();
                 });
-                robot.mouseMove(loc.x, loc.y);
-                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-
-                robot.waitForIdle();
-                robot.delay(1000);
-
-                SwingUtilities.invokeAndWait(() -> {
-                    curDivLoc = jsp.getDividerLocation();
-                });
-                System.out.println("current Divider location " + curDivLoc);
-                if (curDivLoc != prevDivLoc) {
-                    throw new RuntimeException("Divider position changed on disabled oneTouchExpandable arrow click");
+                System.out.println("leftOneTouchButton.isEnabled " + btnEnabled);
+                if (btnEnabled) {
+                    throw new RuntimeException("Arrow buttons still enabled for disabled splitpane");
                 }
             } finally {
                 SwingUtilities.invokeAndWait(() -> {

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneEnableTest.java
@@ -24,7 +24,6 @@
 /*
  * @test
  * @bug 5021949
- * @key headful
  * @summary  Verifies JSplitPane setEnabled(false) disables one touch expandable clicks
  * @run main TestSplitPaneEnableTest
  */
@@ -42,8 +41,6 @@ import javax.swing.UnsupportedLookAndFeelException;
 public class TestSplitPaneEnableTest {
     private static JButton leftOneTouchButton;
     private static JButton rightOneTouchButton;
-    private static JSplitPane jsp;
-    private static volatile boolean btnEnabled;
 
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
@@ -62,9 +59,9 @@ public class TestSplitPaneEnableTest {
                 continue;
             }
             System.out.println("Testing LAF : " + laf.getClassName());
-            SwingUtilities.invokeAndWait(() -> setLookAndFeel(laf));
 
             SwingUtilities.invokeAndWait(() -> {
+                setLookAndFeel(laf);
                 JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
                                                 new JButton("Left"), new JButton("Right"));
                 jsp.setUI(new TestSplitPaneUI());


### PR DESCRIPTION
Issue is seen in that if we call setEnabled(false) over JSplitPane than it can't be dragged via its divider, But if SplitPane have one touch expandable true than user can click those buttons and change the divider position. 
So, if splitpane is disabled, then both dragging in divider and one-touch-expandable click should be disabled.
Fix is made to override setEnabled and disable one-touch-expandable buttons actions..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-5021949](https://bugs.openjdk.org/browse/JDK-5021949): JSplitPane setEnabled(false) shouldn't be partially functional (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) ⚠️ Review applies to [7aadfcc2](https://git.openjdk.org/jdk/pull/19695/files/7aadfcc25225ea267ec5138dcd93a7090b57808f)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer) ⚠️ Review applies to [7aadfcc2](https://git.openjdk.org/jdk/pull/19695/files/7aadfcc25225ea267ec5138dcd93a7090b57808f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19695/head:pull/19695` \
`$ git checkout pull/19695`

Update a local copy of the PR: \
`$ git checkout pull/19695` \
`$ git pull https://git.openjdk.org/jdk.git pull/19695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19695`

View PR using the GUI difftool: \
`$ git pr show -t 19695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19695.diff">https://git.openjdk.org/jdk/pull/19695.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19695#issuecomment-2165600362)