### PR TITLE
8332602: [s390x] Improve itable_stub

### DIFF
--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -2867,8 +2867,8 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
 
   // Loop: Look for resolved_class record in itable
   //   while (true) {
-  //     temp_itbl_klass = *(scan_temp);
   //     scan_temp += itable_offset_entry_size
+  //     temp_itbl_klass = *(scan_temp);
   //     if (temp_itbl_klass == 0) {
   //       goto L_no_such_interface;
   //     }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -2900,6 +2900,7 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
 
   z_bru(L_loop_search_resolved);
 
+  // See if we already have a holder klass. If not, go and scan for it.
   bind(L_resolved_found);
   z_cghi(holder_offset, 0);
   z_bre(L_search_holder);

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -2847,11 +2847,11 @@ void MacroAssembler::lookup_interface_method_stub(Register recv_klass,
 
   // Loop: Look for holder_klass record in itable
   //   do {
+  //     scan_temp += itable_offset_entry_size
   //     temp_itbl_klass = *(scan_temp);
   //     if (temp_itbl_klass == holder_klass) {
   //       goto holder_found; // Found!
   //     }
-  //     scan_temp += itable_offset_entry_size
   //   } while (temp_itbl_klass != 0);
   //   goto no_such_interface // Not found.
   NearLabel L_search_holder;

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -670,6 +670,15 @@ class MacroAssembler: public Assembler {
                                Label&             no_such_interface,
                                bool               return_method = true);
 
+  void lookup_interface_method_stub(Register r_recv_klass,
+                                    Register r_holder_klass,
+                                    Register r_resolved_klass,
+                                    Register r_method_result,
+                                    Register r_temp,
+                                    Register r_temp2,
+                                    int      itable_index,
+                                    Label&   nl_no_such_interface);
+
   // virtual method calling
   void lookup_virtual_method(Register             recv_klass,
                              RegisterOrConstant   vtable_index,

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -677,7 +677,7 @@ class MacroAssembler: public Assembler {
                                     Register temp,
                                     Register temp2,
                                     int      itable_index,
-                                    Label&   nl_no_such_interface);
+                                    Label&   L_no_such_interface);
 
   // virtual method calling
   void lookup_virtual_method(Register             recv_klass,

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -670,12 +670,12 @@ class MacroAssembler: public Assembler {
                                Label&             no_such_interface,
                                bool               return_method = true);
 
-  void lookup_interface_method_stub(Register r_recv_klass,
-                                    Register r_holder_klass,
-                                    Register r_resolved_klass,
-                                    Register r_method_result,
-                                    Register r_temp,
-                                    Register r_temp2,
+  void lookup_interface_method_stub(Register recv_klass,
+                                    Register holder_klass,
+                                    Register resolved_klass,
+                                    Register method_result,
+                                    Register temp,
+                                    Register temp2,
                                     int      itable_index,
                                     Label&   nl_no_such_interface);
 

--- a/src/hotspot/cpu/s390/vtableStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/vtableStubs_s390.cpp
@@ -191,7 +191,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
   const Register recv_klass     = Z_tmp_1,
                  holder_klass   = Z_tmp_2, // declaring interface klass (DEFC)
                  resolved_klass = Z_tmp_3, // resolved interface klass (REFC)
-                 temp           = Z_R0_scratch, // not used as index, So should be fine
+                 temp           = Z_R1_scratch,
                  temp2          = Z_tmp_4;
 
 

--- a/src/hotspot/cpu/s390/vtableStubs_s390.cpp
+++ b/src/hotspot/cpu/s390/vtableStubs_s390.cpp
@@ -194,14 +194,12 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
                  temp           = Z_R1_scratch,
                  temp2          = Z_tmp_4;
 
-
-
   // Get receiver klass.
   // Must do an explicit check if offset too large or implicit checks are disabled.
   address npe_addr = __ pc(); // npe is short for null pointer exception
   __ load_klass(recv_klass, Z_ARG1);
 
-  __ z_lg(holder_klass, Address(Z_method, CompiledICData::itable_defc_klass_offset()));
+  __ z_lg(holder_klass,   Address(Z_method, CompiledICData::itable_defc_klass_offset()));
   __ z_lg(resolved_klass, Address(Z_method, CompiledICData::itable_refc_klass_offset()));
 
   __ lookup_interface_method_stub(recv_klass, holder_klass, resolved_klass, Z_method,
@@ -210,7 +208,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
 #ifndef PRODUCT
   if (DebugVtables) {
     __ z_ltgr(Z_method, Z_method);
-    __ asm_assert(Assembler::bcondNotEqual, "method is null", 103); // Z_method should be NE to 0
+    __ asm_assert(Assembler::bcondNotEqual, "method is null", 103); // Z_method shouldn't be 0
   }
 #endif
 


### PR DESCRIPTION
s390x Port similar to [JDK-8305959 (x86)](https://bugs.openjdk.org/browse/JDK-8305959) and [JDK-8307352(aarch64)](https://bugs.openjdk.org/browse/JDK-8307352)

Testing: I ran `tier1` test on fastdebug & release VM; I didn't see any regression there;

Benchmarking: 
```
Without Patch: 
Benchmark                        Mode  Cnt   Score    Error  Units
InterfaceCalls.test1stInt2Types  avgt   12   1.924 ±  0.001  ns/op
InterfaceCalls.test1stInt3Types  avgt   12  13.925 ±  0.014  ns/op
InterfaceCalls.test1stInt5Types  avgt   12  16.591 ±  0.045  ns/op
InterfaceCalls.test2ndInt2Types  avgt   12   2.028 ±  0.013  ns/op
InterfaceCalls.test2ndInt3Types  avgt   12   7.634 ±  0.049  ns/op
InterfaceCalls.test2ndInt5Types  avgt   12  16.231 ±  1.222  ns/op
InterfaceCalls.testIfaceCall     avgt   12  16.587 ±  0.058  ns/op
InterfaceCalls.testIfaceExtCall  avgt   12  17.532 ±  0.024  ns/op
InterfaceCalls.testMonomorphic   avgt   12   0.746 ±  0.001  ns/op
Finished running test 'micro:vm.compiler.InterfaceCalls'


With Patch: 

Benchmark                        Mode  Cnt   Score    Error  Units
InterfaceCalls.test1stInt2Types  avgt   12   1.929 ±  0.012  ns/op
InterfaceCalls.test1stInt3Types  avgt   12  13.280 ±  0.093  ns/op
InterfaceCalls.test1stInt5Types  avgt   12  16.169 ±  0.364  ns/op
InterfaceCalls.test2ndInt2Types  avgt   12   6.758 ±  4.473  ns/op
InterfaceCalls.test2ndInt3Types  avgt   12  11.772 ±  2.411  ns/op
InterfaceCalls.test2ndInt5Types  avgt   12  15.099 ±  0.081  ns/op
InterfaceCalls.testIfaceCall     avgt   12  15.972 ±  0.021  ns/op
InterfaceCalls.testIfaceExtCall  avgt   12  16.600 ±  0.322  ns/op
InterfaceCalls.testMonomorphic   avgt   12   0.746 ±  0.001  ns/op
Finished running test 'micro:vm.compiler.InterfaceCalls'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332602](https://bugs.openjdk.org/browse/JDK-8332602): [s390x] Improve itable_stub (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19698/head:pull/19698` \
`$ git checkout pull/19698`

Update a local copy of the PR: \
`$ git checkout pull/19698` \
`$ git pull https://git.openjdk.org/jdk.git pull/19698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19698`

View PR using the GUI difftool: \
`$ git pr show -t 19698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19698.diff">https://git.openjdk.org/jdk/pull/19698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19698#issuecomment-2165648765)