### PR TITLE
8334222: exclude containers/cgroup/PlainRead.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -106,6 +106,7 @@ runtime/Thread/TestAlwaysPreTouchStacks.java 8324781 linux-all
 
 applications/jcstress/copy.java 8229852 linux-all
 
+containers/cgroup/PlainRead.java 8333967,8261242 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 containers/docker/TestJFREvents.java 8327723 linux-x64


### PR DESCRIPTION
The test PlainRead.java started to fail recently on some of our Linux systems.
Issue might be resolved by [JDK-8261242](https://bugs.openjdk.org/browse/JDK-8261242) ; there is also some discussion about it here JDK-8333967 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8334222: exclude containers/cgroup/PlainRead.java`

### Issue
 * [JDK-8334222](https://bugs.openjdk.org/browse/JDK-8334222): exclude containers/cgroup/PlainRead.java (**Sub-task** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19700/head:pull/19700` \
`$ git checkout pull/19700`

Update a local copy of the PR: \
`$ git checkout pull/19700` \
`$ git pull https://git.openjdk.org/jdk.git pull/19700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19700`

View PR using the GUI difftool: \
`$ git pr show -t 19700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19700.diff">https://git.openjdk.org/jdk/pull/19700.diff</a>

</details>
