### PR TITLE
8333819: Move embedded external addresses from relocation info into separate global table

### DIFF
--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3984,6 +3984,7 @@ void nmethod::print_statistics() {
   DebugInformationRecorder::print_statistics();
   pc_nmethod_stats.print_pc_stats();
   Dependencies::print_statistics();
+  ExternalsRecorder::print_statistics();
   if (xtty != nullptr)  xtty->tail("statistics");
 }
 

--- a/src/hotspot/share/code/nmethod.hpp
+++ b/src/hotspot/share/code/nmethod.hpp
@@ -705,6 +705,7 @@ public:
 
   void copy_values(GrowableArray<jobject>* oops);
   void copy_values(GrowableArray<Metadata*>* metadata);
+  void copy_values(GrowableArray<address>* metadata) {} // Nothing to do
 
   // Relocation support
 private:

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -226,6 +226,7 @@ void ExternalsRecorder_init() {
 
 void ExternalsRecorder::initialize() {
   // After Mutex and before CodeCache are initialized
+  assert(_recorder == nullptr, "should initialize only once");
   _recorder = new ExternalsRecorder();
 }
 

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
 #include "memory/allocation.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "utilities/copy.hpp"
 
 #ifdef ASSERT
@@ -211,3 +212,45 @@ OopRecorder::OopRecorder(Arena* arena, bool deduplicate): _oops(arena), _metadat
     _object_lookup = nullptr;
   }
 }
+
+// Explicitly instantiate
+template class ValueRecorder<address>;
+
+ExternalsRecorder* ExternalsRecorder::_recorder = nullptr;
+
+ExternalsRecorder::ExternalsRecorder(): _arena(mtCode), _externals(&_arena) {}
+
+void ExternalsRecorder_init() {
+  ExternalsRecorder::initialize();
+}
+
+void ExternalsRecorder::initialize() {
+  // After Mutex and before CodeCache are initialized
+  _recorder = new ExternalsRecorder();
+}
+
+int ExternalsRecorder::find_index(address adr) {
+  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
+  assert(_recorder != nullptr, "sanity");
+  return _recorder->_externals.find_index(adr);
+}
+
+address ExternalsRecorder::at(int index) {
+  // find_index() may resize array by reallocating it and freeing old,
+  // we need loock here to make sure we not accessing to old freed array.
+  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
+  assert(_recorder != nullptr, "sanity");
+  return _recorder->_externals.at(index);
+}
+
+int ExternalsRecorder::count() {
+  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
+  assert(_recorder != nullptr, "sanity");
+  return _recorder->_externals.count();
+}
+
+#ifndef PRODUCT
+void ExternalsRecorder::print_statistics() {
+  tty->print_cr("External addresses table: %d entries", count());
+}
+#endif

--- a/src/hotspot/share/code/oopRecorder.hpp
+++ b/src/hotspot/share/code/oopRecorder.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,10 +133,10 @@ template <class T> class ValueRecorder : public StackObj {
   enum { null_index = 0, first_index = 1, index_cache_threshold = 20 };
 
   GrowableArray<T>*        _handles;  // ordered list (first is always nullptr)
-  GrowableArray<int>*       _no_finds; // all unfindable indexes; usually empty
+  GrowableArray<int>*      _no_finds; // all unfindable indexes; usually empty
   IndexCache<T>*           _indexes;  // map: handle -> its probable index
-  Arena*                    _arena;
-  bool                      _complete;
+  Arena*                   _arena;
+  bool                     _complete;
 
 #ifdef ASSERT
   static int _find_index_calls, _hit_indexes, _missed_indexes;
@@ -186,7 +186,7 @@ class OopRecorder : public ResourceObj {
   int allocate_oop_index(jobject h) {
     return _oops.allocate_index(h);
   }
-  virtual int find_index(jobject h) {
+  int find_index(jobject h) {
     return _object_lookup != nullptr ? _object_lookup->find_index(h, this) : _oops.find_index(h);
   }
   jobject oop_at(int index) {
@@ -203,7 +203,7 @@ class OopRecorder : public ResourceObj {
   int allocate_metadata_index(Metadata* oop) {
     return _metadata.allocate_index(oop);
   }
-  virtual int find_index(Metadata* h) {
+  int find_index(Metadata* h) {
     return _metadata.find_index(h);
   }
   Metadata* metadata_at(int index) {
@@ -243,5 +243,20 @@ class OopRecorder : public ResourceObj {
 #endif
 };
 
+// Class is used to record and retrive external addresses
+// for Relocation info in compiled code and stubs.
+class ExternalsRecorder : public CHeapObj<mtCode> {
+ private:
+  Arena  _arena;
+  ValueRecorder<address> _externals;
+  static ExternalsRecorder* _recorder;
+ public:
+  ExternalsRecorder();
+  static void initialize();
+  static int find_index(address adr);
+  static address at(int index);
+  static int count();
+  static void print_statistics() PRODUCT_RETURN;
+};
 
 #endif // SHARE_CODE_OOPRECORDER_HPP

--- a/src/hotspot/share/code/oopRecorder.hpp
+++ b/src/hotspot/share/code/oopRecorder.hpp
@@ -250,8 +250,8 @@ class ExternalsRecorder : public CHeapObj<mtCode> {
   Arena  _arena;
   ValueRecorder<address> _externals;
   static ExternalsRecorder* _recorder;
- public:
   ExternalsRecorder();
+ public:
   static void initialize();
   static int find_index(address adr);
   static address at(int index);

--- a/src/hotspot/share/code/relocInfo.cpp
+++ b/src/hotspot/share/code/relocInfo.cpp
@@ -454,27 +454,15 @@ void trampoline_stub_Relocation::unpack_data() {
 
 void external_word_Relocation::pack_data_to(CodeSection* dest) {
   short* p = (short*) dest->locs_end();
-#ifndef _LP64
-  p = pack_1_int_to(p, (int32_t) (intptr_t)_target);
-#else
-  jlong t = (jlong) _target;
-  int32_t lo = low(t);
-  int32_t hi = high(t);
-  p = pack_2_ints_to(p, lo, hi);
-#endif /* _LP64 */
+  int index = ExternalsRecorder::find_index(_target);
+  p = pack_1_int_to(p, index);
   dest->set_locs_end((relocInfo*) p);
 }
 
 
 void external_word_Relocation::unpack_data() {
-#ifndef _LP64
-  _target = (address) (intptr_t)unpack_1_int();
-#else
-  jint lo, hi;
-  unpack_2_ints(lo, hi);
-  jlong t = jlong_from(hi, lo);;
-  _target = (address) t;
-#endif /* _LP64 */
+  int index = unpack_1_int();
+  _target = ExternalsRecorder::at(index);
 }
 
 

--- a/src/hotspot/share/runtime/init.cpp
+++ b/src/hotspot/share/runtime/init.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ void mutex_init();
 void universe_oopstorage_init();
 void perfMemory_init();
 void SuspendibleThreadSet_init();
+void ExternalsRecorder_init(); // After mutex_init() and before CodeCache_init
 
 // Initialization done by Java thread in init_globals()
 void management_init();
@@ -107,6 +108,7 @@ void vm_init_globals() {
   universe_oopstorage_init();
   perfMemory_init();
   SuspendibleThreadSet_init();
+  ExternalsRecorder_init(); // After mutex_init() and before CodeCache_init
 }
 
 

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -123,6 +123,8 @@ Monitor* JfrThreadSampler_lock        = nullptr;
 
 Mutex*   CodeHeapStateAnalytics_lock  = nullptr;
 
+Mutex*   ExternalsRecorder_lock       = nullptr;
+
 Monitor* ContinuationRelativize_lock  = nullptr;
 
 Mutex*   Metaspace_lock               = nullptr;
@@ -327,6 +329,9 @@ void mutex_init() {
   MUTEX_DEFL(VtableStubs_lock               , PaddedMutex  , CompiledIC_lock);  // Also holds DumpTimeTable_lock
   MUTEX_DEFL(CodeCache_lock                 , PaddedMonitor, VtableStubs_lock);
   MUTEX_DEFL(NMethodState_lock              , PaddedMutex  , CodeCache_lock);
+
+  // tty_lock is held when printing nmethod and its relocations which use this lock.
+  MUTEX_DEFL(ExternalsRecorder_lock         , PaddedMutex  , tty_lock);
 
   MUTEX_DEFL(Threads_lock                   , PaddedMonitor, CompileThread_lock, true);
   MUTEX_DEFL(Compile_lock                   , PaddedMutex  , MethodCompileQueue_lock);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -142,6 +142,8 @@ extern Mutex*   ClassLoaderDataGraph_lock;       // protects CLDG list, needed f
 extern Mutex*   CodeHeapStateAnalytics_lock;     // lock print functions against concurrent analyze functions.
                                                  // Only used locally in PrintCodeCacheLayout processing.
 
+extern Mutex*   ExternalsRecorder_lock;          // used to guard access to the external addresses table
+
 extern Monitor* ContinuationRelativize_lock;
 
 #if INCLUDE_JVMCI


### PR DESCRIPTION
Currently we have oops and metadata in nmethod's local data sections which are referenced by index from relocation info.
On other hand external addresses (declared with `ExternalAddress` in assembler code) are embedded into relocation info data because they don't need to be patched during normal execution.

But based on my experiments we usually use the same external addresses in generated code.  JavacBanch runs with product VM show about 4000 C1 and C2 compiled nmethods reference only 11 external addresses during execution. Which means these addresses are duplicated in a lot of relocation info data.

There is also issue with embedded addresses in relocation info in Leyden project. Because these VM external addresses can change between runs we have to update/patch them when we load cached code and its relocation info.  But because addresses are packed (compressed) the number of bytes used for it in relocation info may be not enough to pack new address. So we have to throw out such cached code.

I suggest to move external addresses from  relocation info into separate global table and use indexes to access it.
It is similar to what we do for oops and metadata addresses so I used similar to OopRecorder but simplified mechanism.
The results show that relocation info is reduced by 10% in product VM and by 32% in debug vm (which shared 145 external addresses). Which is few % reduction in nmethod size - more compact CodeCache.

This should not affect generated code performance but only slightly compilation time (I need to use lock to access table) because we only modify how `external_data_relocation` is processed.

Tested tier1-5,stress,xcomp
Performance testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333819](https://bugs.openjdk.org/browse/JDK-8333819): Move embedded external addresses from relocation info into separate global table (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19703/head:pull/19703` \
`$ git checkout pull/19703`

Update a local copy of the PR: \
`$ git checkout pull/19703` \
`$ git pull https://git.openjdk.org/jdk.git pull/19703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19703`

View PR using the GUI difftool: \
`$ git pr show -t 19703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19703.diff">https://git.openjdk.org/jdk/pull/19703.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19703#issuecomment-2166021825)