### PR TITLE
8334162: Gatherer.defaultCombiner has an erronous @see-link

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ public interface Gatherer<T, A, R> {
      *
      * @implSpec This method always returns the same instance.
      *
-     * @see Gatherer#finisher()
+     * @see Gatherer#combiner()
      * @return the instance of the default combiner
      * @param <A> the type of the state of the returned combiner
      */


### PR DESCRIPTION
Making sure that the Javadoc is correct for Gatherer

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334162](https://bugs.openjdk.org/browse/JDK-8334162): Gatherer.defaultCombiner has an erronous @<!---->see-link (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19704/head:pull/19704` \
`$ git checkout pull/19704`

Update a local copy of the PR: \
`$ git checkout pull/19704` \
`$ git pull https://git.openjdk.org/jdk.git pull/19704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19704`

View PR using the GUI difftool: \
`$ git pr show -t 19704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19704.diff">https://git.openjdk.org/jdk/pull/19704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19704#issuecomment-2166237703)