### PR TITLE
8334164: The fix for JDK-8322811 should use _filename.is_set() rather than strcmp()

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1203,11 +1203,11 @@ SystemDumpMapDCmd::SystemDumpMapDCmd(outputStream* output, bool heap) :
 void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
   stringStream defaultname;
   const char* name = nullptr;
-  if (::strcmp(default_filename, _filename.value()) == 0) {
+  if (_filename.is_set()) {
+    name = _filename.value();
+  } else {
     defaultname.print("vm_memory_map_%d.txt", os::current_process_id());
     name = defaultname.base();
-  } else {
-    name = _filename.value();
   }
   fileStream fs(name);
   if (fs.is_open()) {


### PR DESCRIPTION
Hi all, 

This PR addresses [8334164](https://bugs.openjdk.org/browse/JDK-8334164). 

Testing: 
- [x] Verified specifying the literal `vm_memory_map_<pid>.txt` as the map name does not replace `<pid>`. 
- [x] Verified `<pid>` is still appropriately replaced if a file path is not specified. 

Thanks, 
Sonia 