### PR TITLE
8334252: Verifier error for lambda declared in early construction context

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1437,7 +1437,7 @@ public class LambdaToMethod extends TreeTranslator {
             List<ClassSymbol> prevTypesUnderConstruction = typesUnderConstruction;
             List<Frame> prevStack = frameStack;
             try {
-                if (TreeInfo.hasAnyConstructorCall(tree))   // start early construction context
+                if (TreeInfo.isConstructor(tree))       // start early construction context (Object() notwithstanding)
                     typesUnderConstruction = typesUnderConstruction.prepend(currentClass());
                 frameStack = frameStack.prepend(new Frame(tree));
                 super.visitMethodDef(tree);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1239,7 +1239,7 @@ public class LambdaToMethod extends TreeTranslator {
         private int lambdaCount = 0;
 
         /**
-         * List of types undergoing construction via explicit constructor chaining.
+         * List of types undergoing construction, i.e., in an early construction context.
          */
         private List<ClassSymbol> typesUnderConstruction;
 
@@ -1280,15 +1280,10 @@ public class LambdaToMethod extends TreeTranslator {
 
         @Override
         public void visitApply(JCMethodInvocation tree) {
-            List<ClassSymbol> previousNascentTypes = typesUnderConstruction;
-            try {
-                Name methName = TreeInfo.name(tree.meth);
-                if (methName == names._this || methName == names._super) {
-                    typesUnderConstruction = typesUnderConstruction.prepend(currentClass());
-                }
-                super.visitApply(tree);
-            } finally {
-                typesUnderConstruction = previousNascentTypes;
+            super.visitApply(tree);
+            if (TreeInfo.isConstructorCall(tree)) {
+                Assert.check(typesUnderConstruction.head == currentClass());
+                typesUnderConstruction = typesUnderConstruction.tail;   // end of early construction context
             }
         }
             // where
@@ -1439,13 +1434,16 @@ public class LambdaToMethod extends TreeTranslator {
 
         @Override
         public void visitMethodDef(JCMethodDecl tree) {
+            List<ClassSymbol> prevTypesUnderConstruction = typesUnderConstruction;
             List<Frame> prevStack = frameStack;
             try {
+                if (TreeInfo.hasAnyConstructorCall(tree))   // start early construction context
+                    typesUnderConstruction = typesUnderConstruction.prepend(currentClass());
                 frameStack = frameStack.prepend(new Frame(tree));
                 super.visitMethodDef(tree);
-            }
-            finally {
+            } finally {
                 frameStack = prevStack;
+                typesUnderConstruction = prevTypesUnderConstruction;
             }
         }
 

--- a/test/langtools/tools/javac/SuperInit/LambdaOuterCapture.java
+++ b/test/langtools/tools/javac/SuperInit/LambdaOuterCapture.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8194743
+ * @summary Test lambda declared in early construction context
+ * @enablePreview
+ */
+
+public class LambdaOuterCapture {
+
+    public class Inner {
+
+        public Inner() {
+            Runnable r = () -> System.out.println(LambdaOuterCapture.this);
+            this(r);
+        }
+
+        public Inner(Runnable r) {
+        }
+    }
+
+    public static void main(String[] args) {
+        new LambdaOuterCapture().new Inner();
+    }
+}


### PR DESCRIPTION
When a lambda is declared in an early construction context, any reference to an outer instance must be acquired through the synthetic constructor rather than the synthetic outer instance field, because 'this' is not available yet.

The code in `LambdaToMethod.java` has logic for this using the `typesUnderConstruction` field, but that logic assumes that the only early construction context that can exist is within a `super()` or `this()` parameter list. While this was true previously, with the "flexible constructors" JEP 482, this is no longer the case.

So the fix is to update the logic for managing `typesUnderConstruction` to also include any statements prior to `super()` or `this()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334252](https://bugs.openjdk.org/browse/JDK-8334252): Verifier error for lambda declared in early construction context (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19707/head:pull/19707` \
`$ git checkout pull/19707`

Update a local copy of the PR: \
`$ git checkout pull/19707` \
`$ git pull https://git.openjdk.org/jdk.git pull/19707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19707`

View PR using the GUI difftool: \
`$ git pr show -t 19707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19707.diff">https://git.openjdk.org/jdk/pull/19707.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19707#issuecomment-2166425638)