### PR TITLE
8333748: javap crash - Fatal error: Unmatched bit position 0x2 for location CLASS

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ public class AttributeWriter extends BasicWriter {
                             indent(+1);
                             first = false;
                         }
-                        for (var flag : info.flags()) {
+                        for (var flag : ClassWriter.maskToAccessFlagsIgnoreUnknown(access_flags, AccessFlag.Location.INNER_CLASS)) {
                             if (flag.sourceModifier() && (flag != AccessFlag.ABSTRACT
                                     || !info.has(AccessFlag.INTERFACE))) {
                                 print(Modifier.toString(flag.mask()) + " ");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/AttributeWriter.java
@@ -208,7 +208,7 @@ public class AttributeWriter extends BasicWriter {
                             indent(+1);
                             first = false;
                         }
-                        for (var flag : ClassWriter.maskToAccessFlagsIgnoreUnknown(access_flags, AccessFlag.Location.INNER_CLASS)) {
+                        for (var flag : maskToAccessFlagsReportUnknown(access_flags, AccessFlag.Location.INNER_CLASS)) {
                             if (flag.sourceModifier() && (flag != AccessFlag.ABSTRACT
                                     || !info.has(AccessFlag.INTERFACE))) {
                                 print(Modifier.toString(flag.mask()) + " ");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/BasicWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/BasicWriter.java
@@ -81,7 +81,7 @@ public class BasicWriter {
             return AccessFlag.maskToAccessFlags(mask, location);
         } catch (IllegalArgumentException ex) {
             mask &= LOCATION_MASKS.get(location);
-            report(ex);
+            report("Access Flags: " + ex.getMessage());
             return AccessFlag.maskToAccessFlags(mask, location);
         }
     }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/BasicWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/BasicWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,12 @@
 package com.sun.tools.javap;
 
 import java.io.PrintWriter;
+import java.lang.classfile.AccessFlags;
+import java.lang.reflect.AccessFlag;
+import java.lang.reflect.Modifier;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /*
@@ -38,12 +44,46 @@ import java.util.function.Supplier;
  *  deletion without notice.</b>
  */
 public class BasicWriter {
+    private static final Map<AccessFlag.Location, Integer> LOCATION_MASKS;
+
+    static {
+        var map = new EnumMap<AccessFlag.Location, Integer>(AccessFlag.Location.class);
+        for (var loc : AccessFlag.Location.values()) {
+            map.put(loc, 0);
+        }
+
+        for (var flag : AccessFlag.values()) {
+            for (var loc : flag.locations()) {
+                map.compute(loc, (_, v) -> v | flag.mask());
+            }
+        }
+
+        // Peculiarities from AccessFlag.maskToAccessFlag
+        map.compute(AccessFlag.Location.METHOD, (_, v) -> v | Modifier.STRICT);
+
+        LOCATION_MASKS = map;
+    }
+
     protected BasicWriter(Context context) {
         lineWriter = LineWriter.instance(context);
         out = context.get(PrintWriter.class);
         messages = context.get(Messages.class);
         if (messages == null)
             throw new AssertionError();
+    }
+
+    protected Set<AccessFlag> flagsReportUnknown(AccessFlags flags) {
+        return maskToAccessFlagsReportUnknown(flags.flagsMask(), flags.location());
+    }
+
+    protected Set<AccessFlag> maskToAccessFlagsReportUnknown(int mask, AccessFlag.Location location) {
+        try {
+            return AccessFlag.maskToAccessFlags(mask, location);
+        } catch (IllegalArgumentException ex) {
+            mask &= LOCATION_MASKS.get(location);
+            report(ex);
+            return AccessFlag.maskToAccessFlags(mask, location);
+        }
     }
 
     protected void print(String s) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -858,7 +858,7 @@ public class ClassWriter extends BasicWriter {
         }
 
         // Peculiarities from AccessFlag.maskToAccessFlag
-        map.put(AccessFlag.Location.METHOD, Modifier.STRICT);
+        map.compute(AccessFlag.Location.METHOD, (_, v) -> v | Modifier.STRICT);
 
         LOCATION_MASKS = map;
     }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -856,6 +856,10 @@ public class ClassWriter extends BasicWriter {
                 map.compute(loc, (_, v) -> v | flag.mask());
             }
         }
+
+        // Peculiarities from AccessFlag.maskToAccessFlag
+        map.put(AccessFlag.Location.METHOD, Modifier.STRICT);
+
         LOCATION_MASKS = map;
     }
 

--- a/test/langtools/tools/javap/UndefinedAccessFlagTest.java
+++ b/test/langtools/tools/javap/UndefinedAccessFlagTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test 8333748
+ * @summary javap should not fail if reserved access flag bits are set to 1
+ * @library /tools/lib
+ * @modules jdk.jdeps/com.sun.tools.javap
+ * @enablePreview
+ * @run junit UndefinedAccessFlagTest
+ */
+
+import toolbox.JavapTask;
+import toolbox.ToolBox;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.classfile.AccessFlags;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.FieldModel;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.attribute.InnerClassInfo;
+import java.lang.classfile.attribute.InnerClassesAttribute;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.classfile.ClassFile.*;
+
+public class UndefinedAccessFlagTest {
+
+    final ToolBox toolBox = new ToolBox();
+
+    @Test
+    void test() throws Throwable {
+        var cf = of();
+        ClassModel cm;
+        try (var is = UndefinedAccessFlagTest.class.getResourceAsStream(
+            "/UndefinedAccessFlagTest$SampleInnerClass.class"
+        )) {
+            cm = cf.parse(is.readAllBytes());
+        }
+        var bytes = cf.transform(cm, (cb, ce) -> {
+            switch (ce) {
+                case AccessFlags flags -> cb.withFlags(flags.flagsMask() | ACC_PRIVATE);
+                case FieldModel f -> cb.transformField(f, (fb, fe) -> {
+                    if (fe instanceof AccessFlags flags) {
+                        fb.withFlags(flags.flagsMask() | ACC_SYNCHRONIZED);
+                    } else {
+                        fb.with(fe);
+                    }
+                });
+                case MethodModel m -> cb.transformMethod(m, (mb, me) -> {
+                    if (me instanceof AccessFlags flags) {
+                        mb.withFlags(flags.flagsMask() | ACC_INTERFACE);
+                    } else {
+                        mb.with(me);
+                    }
+                });
+                case InnerClassesAttribute attr -> {
+                    cb.with(InnerClassesAttribute.of(attr.classes().stream()
+                        .map(ic -> InnerClassInfo.of(ic.innerClass(), ic.outerClass(), ic.innerName(), ic.flagsMask() | 0x0020))
+                        .toList()));
+                }
+                default -> cb.with(ce);
+            }
+        });
+
+        Files.write(Path.of("transformed.class"), bytes);
+
+        new JavapTask(toolBox)
+            .classes("transformed.class")
+            .options("-c", "-p", "-v")
+            .run();
+    }
+
+    static class SampleInnerClass {
+        String field;
+        void method() {}
+    }
+}


### PR DESCRIPTION
Currently, javap crashes for class files that have set non-zero values for undefined access flag bits, as `java.lang.reflect.AccessFlag.maskToAccessFlag` and `java.lang.classfile.AccessFlags.flags` fail. In contrast, the JVMS, though asking for these bits to be set to 0, requires VM to proceed and ignore these bits. javap should emulate the VM behavior and proceed rendering, ignoring these undefined bits.

In addition, a few bytecode generation utilities in the JDK set unused bits, such as in `java.lang.invoke.MethodHandleImpl.BindCaller#generateInvokerTemplate` and `java.lang.invoke.GenerateJLIClassesHelper#generateCodeBytesForLFs`. Those can be updated in a later cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8334406](https://bugs.openjdk.org/browse/JDK-8334406) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8333748: javap crash - Fatal error: Unmatched bit position 0x2 for location CLASS`

### Issues
 * [JDK-8333748](https://bugs.openjdk.org/browse/JDK-8333748): javap crash - Fatal error: Unmatched bit position 0x2 for location CLASS (**Bug** - P2)
 * [JDK-8334406](https://bugs.openjdk.org/browse/JDK-8334406): javap crash - Fatal error: Unmatched bit position 0x2 for location CLASS (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19708/head:pull/19708` \
`$ git checkout pull/19708`

Update a local copy of the PR: \
`$ git checkout pull/19708` \
`$ git pull https://git.openjdk.org/jdk.git pull/19708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19708`

View PR using the GUI difftool: \
`$ git pr show -t 19708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19708.diff">https://git.openjdk.org/jdk/pull/19708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19708#issuecomment-2166447935)