### PR TITLE
8334254: Cleanup CGroups initialization code

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -94,29 +94,23 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
    *
    */
   assert(is_cgroup_v1(&cg_type_flags), "Cgroup v1 expected");
-  for (int i = 0; i < CG_INFO_LENGTH; i++) {
-    CgroupInfo& info = cg_infos[i];
-    if (info._data_complete) { // pids controller might have incomplete data
-      if (strcmp(info._name, "memory") == 0) {
-        memory = new CgroupV1MemoryController(info._root_mount_path, info._mount_path);
-        memory->set_subsystem_path(info._cgroup_path);
-      } else if (strcmp(info._name, "cpuset") == 0) {
-        cpuset = new CgroupV1Controller(info._root_mount_path, info._mount_path);
-        cpuset->set_subsystem_path(info._cgroup_path);
-      } else if (strcmp(info._name, "cpu") == 0) {
-        cpu = new CgroupV1Controller(info._root_mount_path, info._mount_path);
-        cpu->set_subsystem_path(info._cgroup_path);
-      } else if (strcmp(info._name, "cpuacct") == 0) {
-        cpuacct = new CgroupV1Controller(info._root_mount_path, info._mount_path);
-        cpuacct->set_subsystem_path(info._cgroup_path);
-      } else if (strcmp(info._name, "pids") == 0) {
-        pids = new CgroupV1Controller(info._root_mount_path, info._mount_path);
-        pids->set_subsystem_path(info._cgroup_path);
-      }
-    } else {
-      log_debug(os, container)("CgroupInfo for %s not complete", cg_controller_name[i]);
-    }
+  memory = new CgroupV1MemoryController(cg_infos[MEMORY_IDX]._root_mount_path, cg_infos[MEMORY_IDX]._mount_path);
+  memory->set_subsystem_path(cg_infos[MEMORY_IDX]._cgroup_path);
+  
+  cpuset = new CgroupV1Controller(cg_infos[CPUSET_IDX]._root_mount_path, cg_infos[CPUSET_IDX]._mount_path);
+  cpuset->set_subsystem_path(cg_infos[CPUSET_IDX]._cgroup_path);
+  cpu = new CgroupV1Controller(cg_infos[CPU_IDX]._root_mount_path, cg_infos[CPU_IDX]._mount_path);
+  cpu->set_subsystem_path(cg_infos[CPU_IDX]._cgroup_path);
+  cpuacct = new CgroupV1Controller(cg_infos[CPUACCT_IDX]._root_mount_path, cg_infos[CPUACCT_IDX]._mount_path);
+  cpuacct->set_subsystem_path(cg_infos[CPUACCT_IDX]._cgroup_path);
+
+  if (cg_infos[PIDS_IDX]._data_complete) {
+    pids = new CgroupV1Controller(cg_infos[PIDS_IDX]._root_mount_path, cg_infos[PIDS_IDX]._mount_path);
+    pids->set_subsystem_path(cg_infos[PIDS_IDX]._cgroup_path);
+  } else {
+    log_debug(os, container)("CgroupInfo for %s not complete", cg_controller_name[PIDS_IDX]);
   }
+
   return new CgroupV1Subsystem(cpuset, cpu, cpuacct, pids, memory);
 }
 

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -343,26 +343,22 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
         continue;
       }
       while ((token = strsep(&cptr, ",")) != nullptr) {
+        CG_INFO index = CG_INFO_INVALID;
         if (strcmp(token, "memory") == 0) {
-          any_cgroup_mounts_found = true;
-          set_controller_paths(cg_infos, MEMORY_IDX, token, tmpmount, tmproot);
-          cg_infos[MEMORY_IDX]._data_complete = true;
+          index = MEMORY_IDX;
         } else if (strcmp(token, "cpuset") == 0) {
-          any_cgroup_mounts_found = true;
-          set_controller_paths(cg_infos, CPUSET_IDX, token, tmpmount, tmproot);
-          cg_infos[CPUSET_IDX]._data_complete = true;
+          index = CPUSET_IDX;
         } else if (strcmp(token, "cpu") == 0) {
-          any_cgroup_mounts_found = true;
-          set_controller_paths(cg_infos, CPU_IDX, token, tmpmount, tmproot);
-          cg_infos[CPU_IDX]._data_complete = true;
+          index = CPU_IDX;
         } else if (strcmp(token, "cpuacct") == 0) {
-          any_cgroup_mounts_found = true;
-          set_controller_paths(cg_infos, CPUACCT_IDX, token, tmpmount, tmproot);
-          cg_infos[CPUACCT_IDX]._data_complete = true;
+          index = CPUACCT_IDX;
         } else if (strcmp(token, "pids") == 0) {
+          index = PIDS_IDX;
+        }
+        if (index != CG_INFO_INVALID) {
           any_cgroup_mounts_found = true;
-          set_controller_paths(cg_infos, PIDS_IDX, token, tmpmount, tmproot);
-          cg_infos[PIDS_IDX]._data_complete = true;
+          set_controller_paths(cg_infos, index, token, tmpmount, tmproot);
+          cg_infos[index]._data_complete = true;
         }
       }
     }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -22,6 +22,7 @@
  *
  */
 
+#include "precompiled.hpp"
 #include <string.h>
 #include <math.h>
 #include <errno.h>
@@ -29,9 +30,7 @@
 #include "cgroupV1Subsystem_linux.hpp"
 #include "cgroupV2Subsystem_linux.hpp"
 #include "logging/log.hpp"
-#include "memory/allocation.hpp"
 #include "os_linux.hpp"
-#include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -105,7 +105,6 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
 
   if (cg_infos[PIDS_IDX]._data_complete) {
     pids = new CgroupV1Controller(cg_infos[PIDS_IDX]._root_mount_path, cg_infos[PIDS_IDX]._mount_path, cg_infos[PIDS_IDX]._cgroup_path);
-    pids->set_subsystem_path(cg_infos[PIDS_IDX]._cgroup_path);
   } else {
     log_debug(os, container)("CgroupInfo for %s not complete", cg_controller_name[PIDS_IDX]);
   }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -38,11 +38,6 @@
 static const char* cg_controller_name[] = { "cpu", "cpuset", "cpuacct", "memory", "pids" };
 
 CgroupSubsystem* CgroupSubsystemFactory::create() {
-  CgroupV1MemoryController* memory = nullptr;
-  CgroupV1Controller* cpuset = nullptr;
-  CgroupV1Controller* cpu = nullptr;
-  CgroupV1Controller* cpuacct = nullptr;
-  CgroupV1Controller* pids = nullptr;
   CgroupInfo cg_infos[CG_INFO_LENGTH];
   u1 cg_type_flags = INVALID_CGROUPS_GENERIC;
   const char* proc_cgroups = "/proc/cgroups";
@@ -94,18 +89,22 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
    *
    */
   assert(is_cgroup_v1(&cg_type_flags), "Cgroup v1 expected");
-  memory = new CgroupV1MemoryController(cg_infos[MEMORY_IDX]._root_mount_path, cg_infos[MEMORY_IDX]._mount_path);
-  memory->set_subsystem_path(cg_infos[MEMORY_IDX]._cgroup_path);
-  
-  cpuset = new CgroupV1Controller(cg_infos[CPUSET_IDX]._root_mount_path, cg_infos[CPUSET_IDX]._mount_path);
-  cpuset->set_subsystem_path(cg_infos[CPUSET_IDX]._cgroup_path);
-  cpu = new CgroupV1Controller(cg_infos[CPU_IDX]._root_mount_path, cg_infos[CPU_IDX]._mount_path);
-  cpu->set_subsystem_path(cg_infos[CPU_IDX]._cgroup_path);
-  cpuacct = new CgroupV1Controller(cg_infos[CPUACCT_IDX]._root_mount_path, cg_infos[CPUACCT_IDX]._mount_path);
-  cpuacct->set_subsystem_path(cg_infos[CPUACCT_IDX]._cgroup_path);
+  CgroupV1MemoryController* memory = new CgroupV1MemoryController(cg_infos[MEMORY_IDX]._root_mount_path,
+                                                                  cg_infos[MEMORY_IDX]._mount_path,
+                                                                  cg_infos[MEMORY_IDX]._cgroup_path);
+  CgroupV1Controller* cpuset = new CgroupV1Controller(cg_infos[CPUSET_IDX]._root_mount_path,
+                                                      cg_infos[CPUSET_IDX]._mount_path,
+                                                      cg_infos[CPUSET_IDX]._cgroup_path);
+  CgroupV1Controller* cpu = new CgroupV1Controller(cg_infos[CPU_IDX]._root_mount_path,
+                                                   cg_infos[CPU_IDX]._mount_path,
+                                                   cg_infos[CPU_IDX]._cgroup_path);
+  CgroupV1Controller* cpuacct = new CgroupV1Controller(cg_infos[CPUACCT_IDX]._root_mount_path,
+                                                       cg_infos[CPUACCT_IDX]._mount_path,
+                                                       cg_infos[CPUACCT_IDX]._cgroup_path);
+  CgroupV1Controller* pids = nullptr;
 
   if (cg_infos[PIDS_IDX]._data_complete) {
-    pids = new CgroupV1Controller(cg_infos[PIDS_IDX]._root_mount_path, cg_infos[PIDS_IDX]._mount_path);
+    pids = new CgroupV1Controller(cg_infos[PIDS_IDX]._root_mount_path, cg_infos[PIDS_IDX]._mount_path, cg_infos[PIDS_IDX]._cgroup_path);
     pids->set_subsystem_path(cg_infos[PIDS_IDX]._cgroup_path);
   } else {
     log_debug(os, container)("CgroupInfo for %s not complete", cg_controller_name[PIDS_IDX]);

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -89,6 +89,7 @@ CgroupSubsystem* CgroupSubsystemFactory::create() {
    *
    */
   assert(is_cgroup_v1(&cg_type_flags), "Cgroup v1 expected");
+  // The following are required to exist, determine_type will fail and return false otherwise.
   CgroupV1MemoryController* memory = new CgroupV1MemoryController(cg_infos[MEMORY_IDX]._root_mount_path,
                                                                   cg_infos[MEMORY_IDX]._mount_path,
                                                                   cg_infos[MEMORY_IDX]._cgroup_path);
@@ -201,12 +202,9 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
 
   is_cgroupsV2 = true;
   all_required_controllers_enabled = true;
-  for (int i = 0; i < CG_INFO_LENGTH; i++) {
-    // pids controller is optional. All other controllers are required
-    if (i != PIDS_IDX) {
-      is_cgroupsV2 = is_cgroupsV2 && cg_infos[i]._hierarchy_id == 0;
-      all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;
-    }
+  for (int i = 0; i < CG_INFO_REQUIRED_END; i++) {
+    is_cgroupsV2 = is_cgroupsV2 && cg_infos[i]._hierarchy_id == 0;
+    all_required_controllers_enabled = all_required_controllers_enabled && cg_infos[i]._enabled;
     if (log_is_enabled(Debug, os, container) && !cg_infos[i]._enabled) {
       log_debug(os, container)("controller %s is not enabled\n", cg_controller_name[i]);
     }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -379,7 +379,8 @@ bool CgroupSubsystemFactory::determine_type(CgroupInfo* cg_infos,
 
   for (int i = CG_INFO_START; i < CG_INFO_REQUIRED_END; i++) {
     if (!cg_infos[i]._data_complete) {
-      log_debug(os, container)("Required cgroup v1 memory subsystem not found");
+      log_debug(os, container)("Required cgroup v1 subsystem controller %s not found",
+                               cg_controller_name[i]);
       *flags = INVALID_CGROUPS_V1;
       return false;
     }

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -69,7 +69,7 @@ enum CG_INFO {
   CPU_IDX,
   CPUACCT_IDX,
   MEMORY_IDX,
-  PIDS_IDX,
+  PIDS_IDX, // pids is not required
   CG_INFO_REQUIRED_END = PIDS_IDX,
   CG_INFO_LENGTH = PIDS_IDX+1
 };

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -254,6 +254,12 @@ class CgroupInfo : public StackObj {
       _mount_path = nullptr;
     }
 
+    ~CgroupInfo() {
+      os::free(_name);
+      os::free(_cgroup_path);
+      os::free(_root_mount_path);
+      os::free(_mount_path);
+    }
 };
 
 class CgroupSubsystemFactory: AllStatic {
@@ -287,7 +293,6 @@ class CgroupSubsystemFactory: AllStatic {
                                const char* proc_self_cgroup,
                                const char* proc_self_mountinfo,
                                u1* flags);
-    static void cleanup(CgroupInfo* cg_infos);
 };
 
 #endif // CGROUP_SUBSYSTEM_LINUX_HPP

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -62,12 +62,17 @@
 #define INVALID_CGROUPS_GENERIC  6
 
 // Five controllers: cpu, cpuset, cpuacct, memory, pids
-#define CG_INFO_LENGTH 5
-#define CPUSET_IDX     0
-#define CPU_IDX        1
-#define CPUACCT_IDX    2
-#define MEMORY_IDX     3
-#define PIDS_IDX       4
+enum CG_INFO {
+  CG_INFO_INVALID = -1,
+  CG_INFO_START = 0,
+  CPUSET_IDX = 0,
+  CPU_IDX,
+  CPUACCT_IDX,
+  MEMORY_IDX,
+  PIDS_IDX,
+  CG_INFO_REQUIRED_END = PIDS_IDX,
+  CG_INFO_LENGTH = PIDS_IDX+1
+};
 
 #define CONTAINER_READ_NUMBER_CHECKED(controller, filename, log_string, retval)       \
 {                                                                                     \
@@ -102,7 +107,7 @@
   log_trace(os, container)(log_string " is: %s", retval);                                 \
 }
 
-class CgroupController: public CHeapObj<mtInternal> {
+class CgroupController : public CHeapObj<mtInternal> {
   public:
     virtual char* subsystem_path() = 0;
 

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.hpp
@@ -71,7 +71,7 @@ enum CG_INFO {
   MEMORY_IDX,
   PIDS_IDX, // pids is not required
   CG_INFO_REQUIRED_END = PIDS_IDX,
-  CG_INFO_LENGTH = PIDS_IDX+1
+  CG_INFO_LENGTH = PIDS_IDX + 1
 };
 
 #define CONTAINER_READ_NUMBER_CHECKED(controller, filename, log_string, retval)       \

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -22,13 +22,11 @@
  *
  */
 
+#include "precompiled.hpp"
 #include <string.h>
-#include <math.h>
-#include <errno.h>
 #include "cgroupV1Subsystem_linux.hpp"
 #include "logging/log.hpp"
 #include "memory/allocation.hpp"
-#include "runtime/globals.hpp"
 #include "runtime/os.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "os_linux.hpp"

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -81,7 +81,6 @@ jlong CgroupV1MemoryController::uses_mem_hierarchy() {
 }
 
 void CgroupV1MemoryController::set_subsystem_path(char *cgroup_path) {
-  CgroupV1Controller::set_subsystem_path(cgroup_path);
   jlong hierarchy = uses_mem_hierarchy();
   if (hierarchy > 0) {
     set_hierarchical(true);

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -48,7 +48,7 @@ class CgroupV1Controller: public CgroupController {
       set_subsystem_path(cgroup_path);
     }
 
-    virtual void set_subsystem_path(char *cgroup_path);
+    void set_subsystem_path(char *cgroup_path);
     char *subsystem_path() { return _path; }
 };
 
@@ -67,9 +67,9 @@ class CgroupV1MemoryController: public CgroupV1Controller {
 
   public:
     CgroupV1MemoryController(char* root, char* mountpoint, char* cgroup_path)
-    : CgroupV1Controller(root, mountpoint),
+    : CgroupV1Controller(root, mountpoint, cgroup_path),
       _uses_mem_hierarchy(false) {
-      this->set_subsystem_path(cgroup_path);
+      set_subsystem_path(cgroup_path);
     }
 };
 

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -41,10 +41,11 @@ class CgroupV1Controller: public CgroupController {
     char *_path;
 
   public:
-    CgroupV1Controller(char *root, char *mountpoint) {
-      _root = os::strdup(root);
-      _mount_point = os::strdup(mountpoint);
-      _path = nullptr;
+  CgroupV1Controller(char* root, char* mountpoint, char* cgroup_path)
+    : _root(os::strdup(root)),
+      _mount_point(os::strdup(mountpoint)),
+      _path(nullptr) {
+      set_subsystem_path(cgroup_path);
     }
 
     virtual void set_subsystem_path(char *cgroup_path);
@@ -65,10 +66,11 @@ class CgroupV1MemoryController: public CgroupV1Controller {
     void set_hierarchical(bool value) { _uses_mem_hierarchy = value; }
 
   public:
-    CgroupV1MemoryController(char *root, char *mountpoint) : CgroupV1Controller(root, mountpoint) {
-      _uses_mem_hierarchy = false;
+    CgroupV1MemoryController(char* root, char* mountpoint, char* cgroup_path)
+    : CgroupV1Controller(root, mountpoint),
+      _uses_mem_hierarchy(false) {
+      this->set_subsystem_path(cgroup_path);
     }
-
 };
 
 class CgroupV1Subsystem: public CgroupSubsystem {

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -39,33 +39,29 @@ class CgroupV1Controller: public CgroupController {
 
     /* Constructed subsystem directory */
     char *_path;
+    void set_subsystem_path(char *cgroup_path);
 
   public:
-  CgroupV1Controller(char* root, char* mountpoint, char* cgroup_path)
-    : _root(os::strdup(root)),
-      _mount_point(os::strdup(mountpoint)),
-      _path(nullptr) {
-      set_subsystem_path(cgroup_path);
-    }
-
-    void set_subsystem_path(char *cgroup_path);
-    char *subsystem_path() { return _path; }
+    CgroupV1Controller(char* root, char* mountpoint, char* cgroup_path)
+      : _root(os::strdup(root)),
+        _mount_point(os::strdup(mountpoint)),
+        _path(nullptr) {
+        set_subsystem_path(cgroup_path);
+      }
+      char *subsystem_path() { return _path; }
 };
 
 class CgroupV1MemoryController: public CgroupV1Controller {
-
-  public:
-    bool is_hierarchical() { return _uses_mem_hierarchy; }
-    void set_subsystem_path(char *cgroup_path);
-  private:
     /* Some container runtimes set limits via cgroup
      * hierarchy. If set to true consider also memory.stat
      * file if everything else seems unlimited */
     bool _uses_mem_hierarchy;
     jlong uses_mem_hierarchy();
     void set_hierarchical(bool value) { _uses_mem_hierarchy = value; }
+    void set_subsystem_path(char *cgroup_path);
 
   public:
+    bool is_hierarchical() { return _uses_mem_hierarchy; }
     CgroupV1MemoryController(char* root, char* mountpoint, char* cgroup_path)
     : CgroupV1Controller(root, mountpoint, cgroup_path),
       _uses_mem_hierarchy(false) {

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.hpp
@@ -39,9 +39,10 @@ class CgroupV1Controller: public CgroupController {
 
     /* Constructed subsystem directory */
     char *_path;
-    void set_subsystem_path(char *cgroup_path);
 
   public:
+    void set_subsystem_path(char *cgroup_path);
+
     CgroupV1Controller(char* root, char* mountpoint, char* cgroup_path)
       : _root(os::strdup(root)),
         _mount_point(os::strdup(mountpoint)),

--- a/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_cgroupSubsystem_linux.cpp
@@ -436,8 +436,8 @@ TEST(cgroupTest, set_cgroupv1_subsystem_path) {
                             &container_engine };
   for (int i = 0; i < length; i++) {
     CgroupV1Controller* ctrl = new CgroupV1Controller( (char*)testCases[i]->root_path,
-                                                       (char*)testCases[i]->mount_path);
-    ctrl->set_subsystem_path((char*)testCases[i]->cgroup_path);
+                                                       (char*)testCases[i]->mount_path,
+                                                       (char*)testCases[i]->cgroup_path);
     ASSERT_STREQ(testCases[i]->expected_path, ctrl->subsystem_path());
   }
 }


### PR DESCRIPTION
Hi,

Please consider this patch which attempts to improve the code quality of some of the cgroups code, somewhat.

1. Get rid of `#define`s and upgrade to a `CG_INFO` enum, with some helpers
2. Make some of the code prettier by removing copy-pasted and edited code
3. Make `CgroupInfo` RAII, ridding us of the `cleanup` function
4. `set_subsystem_path` is **only** used at construction time, only call it at that time and make those functions private. Also remove `virtual`ness, as this is unnecessary now.

Testing:

1. cgroupTest group in gtest.

Thank you.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334254](https://bugs.openjdk.org/browse/JDK-8334254): Cleanup CGroups initialization code (**Enhancement** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19709/head:pull/19709` \
`$ git checkout pull/19709`

Update a local copy of the PR: \
`$ git checkout pull/19709` \
`$ git pull https://git.openjdk.org/jdk.git pull/19709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19709`

View PR using the GUI difftool: \
`$ git pr show -t 19709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19709.diff">https://git.openjdk.org/jdk/pull/19709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19709#issuecomment-2166614150)