### PR TITLE
8334032: javax.print: Missing @since tag in new class OutputBin

### DIFF
--- a/src/java.desktop/share/classes/javax/print/attribute/standard/OutputBin.java
+++ b/src/java.desktop/share/classes/javax/print/attribute/standard/OutputBin.java
@@ -49,6 +49,8 @@ import sun.print.CustomOutputBin;
  * IPP attribute name. The enumeration's integer value is the IPP enum value.
  * The {@code toString()} method returns the IPP string representation of the
  * attribute value.
+ *
+ * @since 23
  */
 public sealed class OutputBin extends EnumSyntax implements PrintRequestAttribute, PrintJobAttribute permits CustomOutputBin {
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334032](https://bugs.openjdk.org/browse/JDK-8334032): javax.print: Missing @<!---->since tag in new class OutputBin (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19711/head:pull/19711` \
`$ git checkout pull/19711`

Update a local copy of the PR: \
`$ git checkout pull/19711` \
`$ git pull https://git.openjdk.org/jdk.git pull/19711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19711`

View PR using the GUI difftool: \
`$ git pr show -t 19711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19711.diff">https://git.openjdk.org/jdk/pull/19711.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19711#issuecomment-2166683515)