### PR TITLE
8334258: Compiler erronousely allows access to instance variable in argument expression of a constructor invocation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,7 @@ public class Resolve {
     DeferredAttr deferredAttr;
     Check chk;
     Infer infer;
+    Preview preview;
     ClassFinder finder;
     ModuleFinder moduleFinder;
     Types types;
@@ -135,7 +136,7 @@ public class Resolve {
         moduleFinder = ModuleFinder.instance(context);
         types = Types.instance(context);
         diags = JCDiagnostic.Factory.instance(context);
-        Preview preview = Preview.instance(context);
+        preview = Preview.instance(context);
         Source source = Source.instance(context);
         Options options = Options.instance(context);
         compactMethodDiags = options.isSet(Option.XDIAGS, "compact") ||
@@ -1480,10 +1481,11 @@ public class Resolve {
 
     /** Find unqualified variable or field with given name.
      *  Synthetic fields always skipped.
+     *  @param pos       The position to use for error reporting.
      *  @param env     The current environment.
      *  @param name    The name of the variable or field.
      */
-    Symbol findVar(Env<AttrContext> env, Name name) {
+    Symbol findVar(DiagnosticPosition pos, Env<AttrContext> env, Name name) {
         Symbol bestSoFar = varNotFound;
         Env<AttrContext> env1 = env;
         boolean staticOnly = false;
@@ -1508,7 +1510,7 @@ public class Resolve {
                         (sym.flags() & STATIC) == 0) {
                     if (staticOnly)
                         return new StaticError(sym);
-                    if (env1.info.ctorPrologue && !isAllowedEarlyReference(env1, (VarSymbol)sym))
+                    if (env1.info.ctorPrologue && !isAllowedEarlyReference(pos, env1, (VarSymbol)sym))
                         return new RefBeforeCtorCalledError(sym);
                 }
                 return sym;
@@ -2421,15 +2423,15 @@ public class Resolve {
      *                   (a subset of VAL, TYP, PCK).
      */
     Symbol findIdent(DiagnosticPosition pos, Env<AttrContext> env, Name name, KindSelector kind) {
-        return checkNonExistentType(checkRestrictedType(pos, findIdentInternal(env, name, kind), name));
+        return checkNonExistentType(checkRestrictedType(pos, findIdentInternal(pos, env, name, kind), name));
     }
 
-    Symbol findIdentInternal(Env<AttrContext> env, Name name, KindSelector kind) {
+    Symbol findIdentInternal(DiagnosticPosition pos, Env<AttrContext> env, Name name, KindSelector kind) {
         Symbol bestSoFar = typeNotFound;
         Symbol sym;
 
         if (kind.contains(KindSelector.VAL)) {
-            sym = findVar(env, name);
+            sym = findVar(pos, env, name);
             if (sym.exists()) return sym;
             else bestSoFar = bestOf(bestSoFar, sym);
         }
@@ -3776,7 +3778,7 @@ public class Resolve {
                 if (sym != null) {
                     if (staticOnly)
                         sym = new StaticError(sym);
-                    else if (env1.info.ctorPrologue && !isAllowedEarlyReference(env1, (VarSymbol)sym))
+                    else if (env1.info.ctorPrologue && !isAllowedEarlyReference(pos, env1, (VarSymbol)sym))
                         sym = new RefBeforeCtorCalledError(sym);
                     return accessBase(sym, pos, env.enclClass.sym.type,
                                   name, true);
@@ -3845,11 +3847,14 @@ public class Resolve {
      * We also don't verify that the field has no initializer, which is required.
      * To catch those cases, we rely on similar logic in Attr.checkAssignable().
      */
-    private boolean isAllowedEarlyReference(Env<AttrContext> env, VarSymbol v) {
+    private boolean isAllowedEarlyReference(DiagnosticPosition pos, Env<AttrContext> env, VarSymbol v) {
 
         // Check assumptions
         Assert.check(env.info.ctorPrologue);
         Assert.check((v.flags_field & STATIC) == 0);
+
+        // The flexible constructors feature must be enabled
+        preview.checkSourceLevel(pos, Feature.FLEXIBLE_CONSTRUCTORS);
 
         // The symbol must appear in the LHS of an assignment statement
         if (!(env.tree instanceof JCAssign assign))

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3853,9 +3853,6 @@ public class Resolve {
         Assert.check(env.info.ctorPrologue);
         Assert.check((v.flags_field & STATIC) == 0);
 
-        // The flexible constructors feature must be enabled
-        preview.checkSourceLevel(pos, Feature.FLEXIBLE_CONSTRUCTORS);
-
         // The symbol must appear in the LHS of an assignment statement
         if (!(env.tree instanceof JCAssign assign))
             return false;
@@ -3871,6 +3868,9 @@ public class Resolve {
         // If an early reference, the field must not be declared in a superclass
         if (isEarlyReference(env, base, v) && v.owner != env.enclClass.sym)
             return false;
+
+        // The flexible constructors feature must be enabled
+        preview.checkSourceLevel(pos, Feature.FLEXIBLE_CONSTRUCTORS);
 
         // OK
         return true;

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview1.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview1.java
@@ -1,0 +1,21 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334258
+ * @summary Disallow early assignment if FLEXIBLE_CONSTRUCTORS preview feature is not enabled
+ * @compile/fail/ref=EarlyAssignmentNoPreview1.out -XDrawDiagnostics EarlyAssignmentNoPreview1.java
+ */
+public class EarlyAssignmentNoPreview1 {
+
+    Runnable r;
+
+    public EarlyAssignmentNoPreview1() {
+        this(r = () -> System.out.println("hello"));
+    }
+
+    public EarlyAssignmentNoPreview1(Runnable r) {
+    }
+
+    public static void main(String[] args) {
+        new EarlyAssignmentNoPreview1();
+    }
+}

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview1.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview1.out
@@ -1,0 +1,2 @@
+EarlyAssignmentNoPreview1.java:12:14: compiler.err.preview.feature.disabled: (compiler.misc.feature.flexible.constructors)
+1 error

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview2.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview2.java
@@ -1,0 +1,21 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334258
+ * @summary Disallow early assignment if FLEXIBLE_CONSTRUCTORS preview feature is not enabled
+ * @compile/fail/ref=EarlyAssignmentNoPreview2.out -XDrawDiagnostics EarlyAssignmentNoPreview2.java
+ */
+public class EarlyAssignmentNoPreview2 {
+
+    Runnable r;
+
+    public EarlyAssignmentNoPreview2() {
+        this(this.r = () -> System.out.println("hello"));
+    }
+
+    public EarlyAssignmentNoPreview2(Runnable r) {
+    }
+
+    public static void main(String[] args) {
+        new EarlyAssignmentNoPreview2();
+    }
+}

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview2.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview2.out
@@ -1,0 +1,2 @@
+EarlyAssignmentNoPreview2.java:12:14: compiler.err.preview.feature.disabled: (compiler.misc.feature.flexible.constructors)
+1 error

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.java
@@ -1,0 +1,21 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334258
+ * @summary Disallow early assignment if FLEXIBLE_CONSTRUCTORS preview feature is not enabled
+ * @compile/fail/ref=EarlyAssignmentNoPreview3.out -XDrawDiagnostics EarlyAssignmentNoPreview3.java
+ */
+public class EarlyAssignmentNoPreview3 {
+
+    Runnable r;
+
+    public EarlyAssignmentNoPreview3() {
+        this(EarlyAssignmentNoPreview3.this.r = () -> System.out.println("hello"));
+    }
+
+    public EarlyAssignmentNoPreview3(Runnable r) {
+    }
+
+    public static void main(String[] args) {
+        new EarlyAssignmentNoPreview3();
+    }
+}

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.out
@@ -1,0 +1,2 @@
+EarlyAssignmentNoPreview3.java:12:14: compiler.err.preview.feature.disabled: (compiler.misc.feature.flexible.constructors)
+1 error

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignmentNoPreview3.out
@@ -1,2 +1,2 @@
-EarlyAssignmentNoPreview3.java:12:14: compiler.err.preview.feature.disabled: (compiler.misc.feature.flexible.constructors)
+EarlyAssignmentNoPreview3.java:12:39: compiler.err.preview.feature.disabled: (compiler.misc.feature.flexible.constructors)
 1 error


### PR DESCRIPTION
For the "flexible constructors" JEP 482 feature, the compiler allows assignments to instance fields in early construction contexts. However, when it creates this exception it is failing to check that the feature is enabled. This patch adds that check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334258](https://bugs.openjdk.org/browse/JDK-8334258): Compiler erronousely allows access to instance variable in argument expression of a constructor invocation (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) ⚠️ Review applies to [7abe6171](https://git.openjdk.org/jdk/pull/19712/files/7abe6171e4e62df660185de8856f200498385a12)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19712/head:pull/19712` \
`$ git checkout pull/19712`

Update a local copy of the PR: \
`$ git checkout pull/19712` \
`$ git pull https://git.openjdk.org/jdk.git pull/19712/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19712`

View PR using the GUI difftool: \
`$ git pr show -t 19712`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19712.diff">https://git.openjdk.org/jdk/pull/19712.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19712#issuecomment-2166794695)