### PR TITLE
8333589: [macos] Menu item actions do not work with Desktop.setDefaultMenuBar()

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Desktop.java
+++ b/src/java.desktop/share/classes/java/awt/Desktop.java
@@ -264,6 +264,7 @@ public class Desktop {
     }
 
     private DesktopPeer peer;
+    private JMenuBar customDefaultMenuBar;
 
     /**
      * Suppresses default constructor for noninstantiability.
@@ -979,14 +980,27 @@ public class Desktop {
         checkActionSupport(Action.APP_MENU_BAR);
 
         if (menuBar != null) {
+            customDefaultMenuBar = menuBar;
             Container parent = menuBar.getParent();
             if (parent != null) {
                 parent.remove(menuBar);
                 menuBar.updateUI();
             }
+        } else {
+            customDefaultMenuBar = null;
         }
 
         peer.setDefaultMenuBar(menuBar);
+    }
+
+    /**
+     * Returns a previously set DefaultMenuBar. Returns null if
+     * no previous DefaultMenuBar has been set.
+     *
+     * @return customDefaultMenuBar The DefaultMenuBar
+     */
+    public JMenuBar getCustomDefaultMenuBar() {
+        return customDefaultMenuBar;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/KeyboardManager.java
+++ b/src/java.desktop/share/classes/javax/swing/KeyboardManager.java
@@ -302,6 +302,23 @@ class KeyboardManager {
              }
          }
 
+         // also check if a customDefaultMenuBar wants the event
+        JMenuBar customDefaultMenuBar = Desktop.getDesktop().getCustomDefaultMenuBar();
+        if (customDefaultMenuBar != null) {
+            if (customDefaultMenuBar.isEnabled()) {
+                boolean extended = (ksE != null) && !ksE.equals(ks);
+                if (extended) {
+                    fireBinding(customDefaultMenuBar, ksE, e, pressed);
+                }
+                if (!extended || !e.isConsumed()) {
+                    fireBinding(customDefaultMenuBar, ks, e, pressed);
+                }
+                if (e.isConsumed()) {
+                    return true;
+                }
+            }
+        }
+
          return e.isConsumed();
     }
 

--- a/test/jdk/java/awt/MenuBar/SetDefaultMenuBarTest.java
+++ b/test/jdk/java/awt/MenuBar/SetDefaultMenuBarTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Desktop;
+import java.awt.Toolkit;
+import java.awt.event.ActionEvent;
+import java.awt.event.KeyEvent;
+import javax.swing.AbstractAction;
+import javax.swing.Action;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+
+/*
+ * @test
+ * @bug 8333589
+ * @key headful
+ * @summary Check menu item actions work with Desktop.setDefaultMenuBar()
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SetDefaultMenuBarTest
+ */
+
+public class SetDefaultMenuBarTest {
+    static JFrame frame;
+    static JTextArea text;
+    final static boolean useDefaultMenuBar = true;
+
+    public static void main(String[] args) throws Exception {
+        try {
+            String INSTRUCTIONS = """
+                    Press cmd + Backspace.
+                    If a "Delete pressed" message appears, pass the test.
+                    Otherwise, fail the test.""";
+
+            PassFailJFrame.builder()
+                    .title("SetDefaultMenuBarTest")
+                    .instructions(INSTRUCTIONS)
+                    .rows(5)
+                    .columns(35)
+                    .testUI(SetDefaultMenuBarTest::createAndShowGUI)
+                    .build()
+                    .awaitAndCheck();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static JFrame createAndShowGUI() {
+        frame = new JFrame("SetDefaultMenuBarTest");
+
+        if (!useDefaultMenuBar) {
+            System.setProperty("apple.laf.useScreenMenuBar", "true");
+        }
+
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setSize(300, 300);
+
+        JMenuBar menuBar = new JMenuBar();
+
+        if (!useDefaultMenuBar) {
+            Desktop.getDesktop().setDefaultMenuBar(menuBar);
+        } else {
+            frame.setJMenuBar(menuBar);
+        }
+
+        JMenu menu = new JMenu("Test");
+        menuBar.add(menu);
+
+        var action = new DeleteAction();
+        menu.add(action);
+
+        text = new JTextArea();
+        frame.add(text);
+
+        return frame;
+    }
+
+    static class DeleteAction extends AbstractAction {
+        public DeleteAction() {
+            putValue(Action.NAME, "Delete");
+            var keystroke = KeyStroke.getKeyStroke(
+                    KeyEvent.VK_BACK_SPACE,
+                    Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()
+            );
+            putValue(Action.ACCELERATOR_KEY, keystroke);
+        }
+
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            text.append("Delete pressed\n");
+        }
+    }
+}


### PR DESCRIPTION
Add a check and storage for a custom DefaultMenuBar in Desktop.java and adds key event handling for a custom DefaultMenuBar in KeyboardManager.java.
Also adds a manual test for checking that key event handling is correct for DefaultMenuBars.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333589](https://bugs.openjdk.org/browse/JDK-8333589): [macos] Menu item actions do not work with Desktop.setDefaultMenuBar() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19714/head:pull/19714` \
`$ git checkout pull/19714`

Update a local copy of the PR: \
`$ git checkout pull/19714` \
`$ git pull https://git.openjdk.org/jdk.git pull/19714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19714`

View PR using the GUI difftool: \
`$ git pr show -t 19714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19714.diff">https://git.openjdk.org/jdk/pull/19714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19714#issuecomment-2167161933)