### PR TITLE
8334293: G1: Refactor G1ConcurrentMark::update_top_at_rebuild_start

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -214,17 +214,14 @@ inline HeapWord* G1ConcurrentMark::top_at_rebuild_start(G1HeapRegion* r) const {
 }
 
 inline void G1ConcurrentMark::update_top_at_rebuild_start(G1HeapRegion* r) {
+  assert(r->is_old() || r->is_humongous(), "precondition");
+
   uint const region = r->hrm_index();
   assert(region < _g1h->max_reserved_regions(), "Tried to access TARS for region %u out of bounds", region);
   assert(_top_at_rebuild_starts[region] == nullptr,
          "TARS for region %u has already been set to " PTR_FORMAT " should be null",
          region, p2i(_top_at_rebuild_starts[region]));
-  G1RemSetTrackingPolicy* tracker = _g1h->policy()->remset_tracker();
-  if (tracker->needs_scan_for_rebuild(r)) {
-    _top_at_rebuild_starts[region] = r->top();
-  } else {
-    // Leave TARS at null.
-  }
+  _top_at_rebuild_starts[region] = r->top();
 }
 
 inline void G1CMTask::update_liveness(oop const obj, const size_t obj_size) {

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.cpp
@@ -30,14 +30,6 @@
 #include "gc/g1/g1RemSetTrackingPolicy.hpp"
 #include "runtime/safepoint.hpp"
 
-bool G1RemSetTrackingPolicy::needs_scan_for_rebuild(G1HeapRegion* r) const {
-  // All non-free and non-young regions need to be scanned for references;
-  // At every gc we gather references to other regions in young.
-  // Free regions trivially do not need scanning because they do not contain live
-  // objects.
-  return !(r->is_young() || r->is_free());
-}
-
 void G1RemSetTrackingPolicy::update_at_allocate(G1HeapRegion* r) {
   assert(r->is_young() || r->is_humongous() || r->is_old(),
         "Region %u with unexpected heap region type %s", r->hrm_index(), r->get_type_str());

--- a/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.hpp
+++ b/src/hotspot/share/gc/g1/g1RemSetTrackingPolicy.hpp
@@ -34,9 +34,6 @@
 // set is complete.
 class G1RemSetTrackingPolicy : public CHeapObj<mtGC> {
 public:
-  // Do we need to scan the given region to get all outgoing references for remembered
-  // set rebuild?
-  bool needs_scan_for_rebuild(G1HeapRegion* r) const;
   // Update remembered set tracking state at allocation of the region. May be
   // called at any time. The caller makes sure that the changes to the remembered
   // set state are visible to other threads.


### PR DESCRIPTION
Simple removing an always true condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334293](https://bugs.openjdk.org/browse/JDK-8334293): G1: Refactor G1ConcurrentMark::update_top_at_rebuild_start (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19718/head:pull/19718` \
`$ git checkout pull/19718`

Update a local copy of the PR: \
`$ git checkout pull/19718` \
`$ git pull https://git.openjdk.org/jdk.git pull/19718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19718`

View PR using the GUI difftool: \
`$ git pr show -t 19718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19718.diff">https://git.openjdk.org/jdk/pull/19718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19718#issuecomment-2167740162)