### PR TITLE
8145948: C2: Initializing volatile fields to default values should be optimized

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/ConstructorDefaultInitBarriers.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/ConstructorDefaultInitBarriers.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8145948
+ * @summary Test default value initializations in constructors
+ * @library /test/lib /
+ * @requires os.arch=="aarch64" | os.arch=="riscv64" | os.arch=="x86_64" | os.arch=="amd64"
+ * @run driver compiler.c2.irTests.ConstructorDefaultInitBarriers
+ */
+public class ConstructorDefaultInitBarriers {
+    public static void main(String[] args) {
+        TestFramework.run();
+     }
+
+    public static class PlainInit {
+        int x;
+        public PlainInit(int x) {
+            this.x = x;
+        }
+    }
+
+    public static class VolatileInit {
+        volatile int x;
+        public VolatileInit(int x) {
+            this.x = x;
+        }
+    }
+
+    @DontInline
+    public void consume(Object o) {}
+
+    @Test
+    @IR(counts = {IRNode.MEMBAR_STORESTORE, "1"})
+    public Object plain_init_0() {
+        return new PlainInit(0);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MEMBAR_STORESTORE, "1"})
+    public Object plain_init_42() {
+        return new PlainInit(42);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MEMBAR_STORESTORE, "1"})
+    @IR(failOn = IRNode.MEMBAR_VOLATILE)
+    public Object volatile_init_0() {
+        return new VolatileInit(0);
+    }
+
+    @Test
+    @IR(counts = {IRNode.MEMBAR_STORESTORE, "1"})
+    @IR(counts = {IRNode.MEMBAR_VOLATILE, "1"})
+    public Object volatile_init_42() {
+        return new VolatileInit(42);
+    }
+
+}

--- a/test/micro/org/openjdk/bench/vm/compiler/ConstructorDefaultInitBarriers.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ConstructorDefaultInitBarriers.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, jvmArgsAppend = {"-Xms512m", "-Xmx512m", "-XX:+AlwaysPreTouch", "-XX:+UseParallelGC"})
+public class ConstructorDefaultInitBarriers {
+
+    public static class PlainInit {
+        int x;
+        public PlainInit(int x) {
+            this.x = x;
+        }
+    }
+
+    public static class VolatileInit {
+        volatile int x;
+        public VolatileInit(int x) {
+            this.x = x;
+        }
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public Object plain_init_0() {
+        return new PlainInit(0);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public Object plain_init_42() {
+        return new PlainInit(42);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public Object volatile_init_0() {
+        return new VolatileInit(0);
+    }
+
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public Object volatile_init_42() {
+        return new VolatileInit(42);
+    }
+
+}
+


### PR DESCRIPTION
WIP.

Additional testing:
 - [x] New IR tests pass
 - [ ] Linux x86_64 server fastdebug, `all`
 - [ ] Linux AArch64 server fastdebug, `all`

```
Benchmark                                        Mode  Cnt   Score   Error  Units

# Baseline
ConstructorDefaultInitBarriers.plain_init_0      avgt    3   5.815 ± 0.187  ns/op
ConstructorDefaultInitBarriers.plain_init_42     avgt    3   5.511 ± 0.053  ns/op
ConstructorDefaultInitBarriers.volatile_init_0   avgt    3   5.737 ± 0.079  ns/op
ConstructorDefaultInitBarriers.volatile_init_42  avgt    3  11.885 ± 0.950  ns/op

# Patched
ConstructorDefaultInitBarriers.plain_init_0      avgt    3   5.820 ± 0.161  ns/op
ConstructorDefaultInitBarriers.plain_init_42     avgt    3   5.504 ± 0.108  ns/op
ConstructorDefaultInitBarriers.volatile_init_0   avgt    3  11.969 ± 0.223  ns/op  ; <----
ConstructorDefaultInitBarriers.volatile_init_42  avgt    3  12.028 ± 1.671  ns/op
```