### PR TITLE
8334297: (so) java/nio/channels/SocketChannel/OpenLeak.java should not depend on SecurityManager

### DIFF
--- a/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
+++ b/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
@@ -38,6 +38,7 @@ import java.nio.channels.UnresolvedAddressException;
 
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OpenLeak {
 
@@ -69,32 +70,32 @@ public class OpenLeak {
         //   where close should be called
         SocketAddress sa = InetSocketAddress.createUnresolved(isa.getHostString(), isa.getPort());
 
-        System.out.println("Expecting Connection Refused for " + isa);
-        System.out.println("Expecting UnresolvedAddressException for " + sa);
+        System.err.println("Expecting Connection Refused for " + isa);
+        System.err.println("Expecting UnresolvedAddressException for " + sa);
         int i = 0;
         try {
             for (i = 0; i < MAX_LOOP; i++) {
                 try {
                     SocketChannel.open(sa);
-                    throw new RuntimeException("This should not happen");
+                    fail("This should not happen");
                 } catch (UnresolvedAddressException x) {
                     if (i < 5 || i >= MAX_LOOP - 5) {
                         // print a message for the first five and last 5 exceptions
-                        System.out.println(x);
+                        System.err.println(x);
                     }
                 }
                 try {
                     SocketChannel.open(isa);
-                    throw new RuntimeException("This should not happen");
+                    fail("This should not happen");
                 } catch (ConnectException x) {
                     if (i < 5 || i >= MAX_LOOP - 5) {
                         // print a message for the first five and last 5 exceptions
-                        System.out.println(x);
+                        System.err.println(x);
                     }
                 }
             }
         } catch (Throwable t) {
-            System.out.println("Failed at " + i + " with " + t);
+            System.err.println("Failed at " + i + " with " + t);
             throw t;
         }
     }

--- a/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
+++ b/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -105,16 +104,15 @@ public class OpenLeak {
 
         final List<Object[]> cases = new ArrayList<>();
         cases.add(new Object[]{sa, UnresolvedAddressException.class});
-        cases.add(new Object[]{isa, ConnectException.class});
+        if (isa != null) {
+            cases.add(new Object[]{isa, ConnectException.class});
+        }
         return cases;
     }
 
     @ParameterizedTest
     @MethodSource("testCases")
     public void test(SocketAddress sa, Class<? extends Throwable> expectedException) throws Exception {
-        if (sa == null) {
-            Assumptions.abort("No suitable port could be found for " + expectedException);
-        }
         System.err.printf("%nExpecting %s for %s%n", expectedException, sa);
 
         int i = 0;

--- a/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
+++ b/test/jdk/java/nio/channels/SocketChannel/OpenLeak.java
@@ -25,73 +25,106 @@
  * @bug 6548464
  * @summary SocketChannel.open(SocketAddress) leaks file descriptor if
  *     connection cannot be established
+ * @requires vm.flagless
  * @build OpenLeak
  * @run junit/othervm OpenLeak
  */
 
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.UnresolvedAddressException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 
 public class OpenLeak {
 
+    static final String OS_NAME = System.getProperty("os.name").toLowerCase(Locale.ROOT);
+    static final boolean IS_WINDOWS_2016 = OS_NAME.contains("windows") && OS_NAME.contains("2016");
+
+    // On Windows Server 2016 trying to connect to port 47 consumes the
+    // whole connect timeout - which makes the test fail in timeout.
+    // We skip this part of the test on Windows Server 2016
+    static final boolean TEST_WITH_RESERVED_PORT = !IS_WINDOWS_2016;
+
     private static final int MAX_LOOP = 250000;
 
-    @Test
-    public void test() throws Exception {
-        InetAddress lo = InetAddress.getLoopbackAddress();
 
-        // Try to find a suitable port that will cause a
-        // Connection Rejected exception
-        // port 47 is reserved - there should be nothing there...
-        InetSocketAddress isa = new InetSocketAddress(lo, 47);
+    // Try to find a suitable port to provoke a "Connection Refused"
+    // error.
+    private static InetSocketAddress findSuitableRefusedAddress(InetSocketAddress isa)
+            throws IOException {
+        if (!TEST_WITH_RESERVED_PORT) return null;
+        var addr = isa.getAddress();
         try (SocketChannel sc1 = SocketChannel.open(isa)) {
             // If we manage to connect, let's try to use some other
             // port.
             // port 51 is reserved too - there should be nothing there...
-            isa = new InetSocketAddress(lo, 51);
-            try (SocketChannel sc2 = SocketChannel.open(isa)) {};
+            isa = new InetSocketAddress(addr, 51);
+            try (SocketChannel sc2 = SocketChannel.open(isa)) {
+            }
             // OK, last attempt...
             // port 61 is reserved too - there should be nothing there...
-            isa = new InetSocketAddress(lo, 61);
-            try (SocketChannel sc3 = SocketChannel.open(isa)) {};
-            Assumptions.abort("Could not find a suitable port");
-            return;
-        } catch (ConnectException x) { }
+            isa = new InetSocketAddress(addr, 61);
+            try (SocketChannel sc3 = SocketChannel.open(isa)) {
+            }
+            System.err.println("Could not find a suitable port");
+            return null;
+        } catch (ConnectException x) {
+        }
+        return isa;
+    }
 
-        // create an unresolved address to test another path
-        //   where close should be called
-        SocketAddress sa = InetSocketAddress.createUnresolved(isa.getHostString(), isa.getPort());
+    private static InetSocketAddress createUnresolved(InetSocketAddress isa, InetSocketAddress def) {
+       var sa = isa == null ? def : isa;
+       return InetSocketAddress.createUnresolved(sa.getHostString(), sa.getPort());
+    }
 
-        System.err.println("Expecting Connection Refused for " + isa);
-        System.err.println("Expecting UnresolvedAddressException for " + sa);
+
+    // Builds a list of test cases
+    static List<Object[]> testCases() throws Exception {
+        InetAddress lo = InetAddress.getLoopbackAddress();
+
+        // Try to find a suitable port that will cause a
+        // Connection Refused exception
+        // port 47 is reserved - there should be nothing there...
+        InetSocketAddress def = new InetSocketAddress(lo, 47);
+        InetSocketAddress isa = findSuitableRefusedAddress(def);
+        InetSocketAddress sa  = createUnresolved(isa, def);
+
+        final List<Object[]> cases = new ArrayList<>();
+        cases.add(new Object[]{sa, UnresolvedAddressException.class});
+        cases.add(new Object[]{isa, ConnectException.class});
+        return cases;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testCases")
+    public void test(SocketAddress sa, Class<? extends Throwable> expectedException) throws Exception {
+        if (sa == null) {
+            Assumptions.abort("No suitable port could be found for " + expectedException);
+        }
+        System.err.printf("%nExpecting %s for %s%n", expectedException, sa);
+
         int i = 0;
         try {
             for (i = 0; i < MAX_LOOP; i++) {
-                try {
-                    SocketChannel.open(sa);
-                    fail("This should not happen");
-                } catch (UnresolvedAddressException x) {
-                    if (i < 5 || i >= MAX_LOOP - 5) {
-                        // print a message for the first five and last 5 exceptions
-                        System.err.println(x);
-                    }
-                }
-                try {
-                    SocketChannel.open(isa);
-                    fail("This should not happen");
-                } catch (ConnectException x) {
-                    if (i < 5 || i >= MAX_LOOP - 5) {
-                        // print a message for the first five and last 5 exceptions
-                        System.err.println(x);
-                    }
+                Throwable x =
+                        assertThrows(expectedException, () -> SocketChannel.open(sa));
+                if (i < 5 || i >= MAX_LOOP - 5) {
+                    // print a message for the first five and last 5 exceptions
+                    System.err.println(x);
                 }
             }
         } catch (Throwable t) {


### PR DESCRIPTION
The test java/nio/channels/SocketChannel/OpenLeak.java depends on the SecurityManager to trigger an exception in SocketChannel::connect.

This change rewrites it to connect to a TCP reserved port instead, such as port 47, 51, or 61, in order to trigger a `ConnectException` instead of a `SecurityException`.

The original issue that this test tried to check for was:
https://bugs.openjdk.org/browse/JDK-6548464

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334297](https://bugs.openjdk.org/browse/JDK-8334297): (so) java/nio/channels/SocketChannel/OpenLeak.java should not depend on SecurityManager (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19723/head:pull/19723` \
`$ git checkout pull/19723`

Update a local copy of the PR: \
`$ git checkout pull/19723` \
`$ git pull https://git.openjdk.org/jdk.git pull/19723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19723`

View PR using the GUI difftool: \
`$ git pr show -t 19723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19723.diff">https://git.openjdk.org/jdk/pull/19723.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19723#issuecomment-2168166041)