### PR TITLE
8334241: Adjust API docs side bar dimensions

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -348,7 +348,7 @@ body.class-declaration-page .details h3 {
     flex-direction: row;
 }
 .main-grid main {
-    flex: 2.6 1 0;
+    flex: 3 1 0;
     min-width: 240px
 }
 .main-grid nav.toc {


### PR DESCRIPTION
Please review a change to slightly adjust the proportion between the side bar and the main content area in API documentation pages, making the side bar a bit slimmer and leaving more space for the main content area. The ratio between side bar and main content used to be 1 : 2.6, it is now 1 : 3. 

Updated API documentation[ can be viewed here](https://cr.openjdk.org/~hannesw/8334241/api.00/java.base/java/lang/Object.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334241](https://bugs.openjdk.org/browse/JDK-8334241): Adjust API docs side bar dimensions (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19726/head:pull/19726` \
`$ git checkout pull/19726`

Update a local copy of the PR: \
`$ git checkout pull/19726` \
`$ git pull https://git.openjdk.org/jdk.git pull/19726/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19726`

View PR using the GUI difftool: \
`$ git pr show -t 19726`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19726.diff">https://git.openjdk.org/jdk/pull/19726.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19726#issuecomment-2168396712)