### PR TITLE
8333583: Crypto-XDH.generateSecret regression after JDK-8329538

### DIFF
--- a/make/jdk/src/classes/build/tools/intpoly/FieldGen.java
+++ b/make/jdk/src/classes/build/tools/intpoly/FieldGen.java
@@ -778,7 +778,7 @@ public class FieldGen {
         result.appendLine("}");
 
         result.appendLine("@Override");
-        result.appendLine("protected int mult(long[] a, long[] b, long[] r) {");
+        result.appendLine("protected void mult(long[] a, long[] b, long[] r) {");
         result.incrIndent();
         for (int i = 0; i < 2 * params.getNumLimbs() - 1; i++) {
             result.appendIndent();
@@ -804,9 +804,6 @@ public class FieldGen {
             }
         }
         result.append(");\n");
-        result.appendIndent();
-        result.append("return 0;");
-        result.appendLine();
         result.decrIndent();
         result.appendLine("}");
 
@@ -836,7 +833,7 @@ public class FieldGen {
         //      }
         //  }
         result.appendLine("@Override");
-        result.appendLine("protected int square(long[] a, long[] r) {");
+        result.appendLine("protected void square(long[] a, long[] r) {");
         result.incrIndent();
         for (int i = 0; i < 2 * params.getNumLimbs() - 1; i++) {
             result.appendIndent();
@@ -877,9 +874,6 @@ public class FieldGen {
             }
         }
         result.append(");\n");
-        result.appendIndent();
-        result.append("return 0;");
-        result.appendLine();
         result.decrIndent();
         result.appendLine("}");
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_poly_mont.cpp
@@ -249,7 +249,6 @@ address StubGenerator::generate_intpoly_montgomeryMult_P256() {
   const Register tmp     = r9;
 
   montgomeryMultiply(aLimbs, bLimbs, rLimbs, tmp, _masm);
-  __ mov64(rax, 0x1); // Return 1 (Fig. 5, Step 6 [1] skipped in montgomeryMultiply)
 
   __ leave();
   __ ret(0);

--- a/src/hotspot/share/classfile/vmIntrinsics.hpp
+++ b/src/hotspot/share/classfile/vmIntrinsics.hpp
@@ -529,8 +529,8 @@ class methodHandle;
   /* support for sun.security.util.math.intpoly.MontgomeryIntegerPolynomialP256 */                                      \
   do_class(sun_security_util_math_intpoly_MontgomeryIntegerPolynomialP256, "sun/security/util/math/intpoly/MontgomeryIntegerPolynomialP256")  \
   do_intrinsic(_intpoly_montgomeryMult_P256, sun_security_util_math_intpoly_MontgomeryIntegerPolynomialP256, intPolyMult_name, intPolyMult_signature, F_R) \
-  do_name(intPolyMult_name, "mult")                                                                                     \
-  do_signature(intPolyMult_signature, "([J[J[J)I")                                                                      \
+  do_name(intPolyMult_name, "multImpl")                                                                                     \
+  do_signature(intPolyMult_signature, "([J[J[J)V")                                                                      \
                                                                                                                         \
   do_class(sun_security_util_math_intpoly_IntegerPolynomial, "sun/security/util/math/intpoly/IntegerPolynomial")        \
   do_intrinsic(_intpoly_assign, sun_security_util_math_intpoly_IntegerPolynomial, intPolyAssign_name, intPolyAssign_signature, F_S) \

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -7554,8 +7554,6 @@ bool LibraryCallKit::inline_intpoly_montgomeryMult_P256() {
                                  OptoRuntime::intpoly_montgomeryMult_P256_Type(),
                                  stubAddr, stubName, TypePtr::BOTTOM,
                                  a_start, b_start, r_start);
-  Node* result = _gvn.transform(new ProjNode(call, TypeFunc::Parms));
-  set_result(result);
   return true;
 }
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1414,8 +1414,8 @@ const TypeFunc* OptoRuntime::intpoly_montgomeryMult_P256_Type() {
 
   // result type needed
   fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms + 0] = TypeInt::INT; // carry bits in output
-  const TypeTuple* range = TypeTuple::make(TypeFunc::Parms+1, fields);
+  fields[TypeFunc::Parms + 0] = NULL;
+  const TypeTuple* range = TypeTuple::make(TypeFunc::Parms, fields);
   return TypeFunc::make(domain, range);
 }
 

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -1414,7 +1414,7 @@ const TypeFunc* OptoRuntime::intpoly_montgomeryMult_P256_Type() {
 
   // result type needed
   fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms + 0] = NULL;
+  fields[TypeFunc::Parms + 0] = nullptr; // void
   const TypeTuple* range = TypeTuple::make(TypeFunc::Parms, fields);
   return TypeFunc::make(domain, range);
 }
@@ -1434,7 +1434,7 @@ const TypeFunc* OptoRuntime::intpoly_assign_Type() {
 
   // result type needed
   fields = TypeTuple::fields(1);
-  fields[TypeFunc::Parms + 0] = NULL; // void
+  fields[TypeFunc::Parms + 0] = nullptr; // void
   const TypeTuple* range = TypeTuple::make(TypeFunc::Parms, fields);
   return TypeFunc::make(domain, range);
 }

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
-import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 /**
@@ -90,12 +89,11 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
      * store the result in an IntegerPolynomial representation in a. Requires
      * that a.length == numLimbs.
      */
-    protected int multByInt(long[] a, long b) {
+    protected void multByInt(long[] a, long b) {
         for (int i = 0; i < a.length; i++) {
             a[i] *= b;
         }
         reduce(a);
-        return 0;
     }
 
     /**
@@ -104,7 +102,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
      * a.length == b.length == r.length == numLimbs. It is allowed for a and r
      * to be the same array.
      */
-    protected abstract int mult(long[] a, long[] b, long[] r);
+    protected abstract void mult(long[] a, long[] b, long[] r);
 
     /**
      * Multiply an IntegerPolynomial representation (a) with itself and store
@@ -112,7 +110,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
      * a.length == r.length == numLimbs. It is allowed for a and r
      * to be the same array.
      */
-    protected abstract int square(long[] a, long[] r);
+    protected abstract void square(long[] a, long[] r);
 
     IntegerPolynomial(int bitsPerLimb,
                       int numLimbs,
@@ -456,7 +454,6 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
      * will be unchanged. If set==1, then the values of b will be assigned to a.
      * The behavior is undefined if swap has any value other than 0 or 1.
      */
-    @ForceInline
     @IntrinsicCandidate
     protected static void conditionalAssign(int set, long[] a, long[] b) {
         int maskValue = -set;
@@ -622,8 +619,8 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
             }
 
             long[] newLimbs = new long[limbs.length];
-            int numAdds = mult(limbs, b.limbs, newLimbs);
-            return new ImmutableElement(newLimbs, numAdds);
+            mult(limbs, b.limbs, newLimbs);
+            return new ImmutableElement(newLimbs, 0);
         }
 
         @Override
@@ -635,8 +632,8 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
             }
 
             long[] newLimbs = new long[limbs.length];
-            int numAdds = IntegerPolynomial.this.square(limbs, newLimbs);
-            return new ImmutableElement(newLimbs, numAdds);
+            IntegerPolynomial.this.square(limbs, newLimbs);
+            return new ImmutableElement(newLimbs, 0);
         }
 
         public void addModPowerTwo(IntegerModuloP arg, byte[] result) {
@@ -751,7 +748,8 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
                 b.numAdds = 0;
             }
 
-            numAdds = mult(limbs, b.limbs, limbs);
+            mult(limbs, b.limbs, limbs);
+            numAdds = 0;
             return this;
         }
 
@@ -764,7 +762,8 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
             }
 
             int value = ((Limb)v).value;
-            numAdds += multByInt(limbs, value);
+            multByInt(limbs, value);
+            numAdds = 0;
             return this;
         }
 
@@ -824,7 +823,8 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
                 numAdds = 0;
             }
 
-            numAdds = IntegerPolynomial.this.square(limbs, limbs);
+            IntegerPolynomial.this.square(limbs, limbs);
+            numAdds = 0; 
             return this;
         }
 

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -824,7 +824,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
             }
 
             IntegerPolynomial.this.square(limbs, limbs);
-            numAdds = 0; 
+            numAdds = 0;
             return this;
         }
 

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial.java
@@ -32,6 +32,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
 
+import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 /**
@@ -454,6 +455,7 @@ public abstract sealed class IntegerPolynomial implements IntegerFieldModuloP
      * will be unchanged. If set==1, then the values of b will be assigned to a.
      * The behavior is undefined if swap has any value other than 0 or 1.
      */
+    @ForceInline
     @IntrinsicCandidate
     protected static void conditionalAssign(int set, long[] a, long[] b) {
         int maskValue = -set;

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial1305.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomial1305.java
@@ -50,7 +50,7 @@ public final class IntegerPolynomial1305 extends IntegerPolynomial {
         super(BITS_PER_LIMB, NUM_LIMBS, 1, MODULUS);
     }
 
-    protected int mult(long[] a, long[] b, long[] r) {
+    protected void mult(long[] a, long[] b, long[] r) {
 
         // Use grade-school multiplication into primitives to avoid the
         // temporary array allocation. This is equivalent to the following
@@ -73,7 +73,6 @@ public final class IntegerPolynomial1305 extends IntegerPolynomial {
         long c8 = (a[4] * b[4]);
 
         carryReduce(r, c0, c1, c2, c3, c4, c5, c6, c7, c8);
-        return 0;
     }
 
     private void carryReduce(long[] r, long c0, long c1, long c2, long c3,
@@ -100,7 +99,7 @@ public final class IntegerPolynomial1305 extends IntegerPolynomial {
     }
 
     @Override
-    protected int square(long[] a, long[] r) {
+    protected void square(long[] a, long[] r) {
         // Use grade-school multiplication with a simple squaring optimization.
         // Multiply into primitives to avoid the temporary array allocation.
         // This is equivalent to the following code:
@@ -123,7 +122,6 @@ public final class IntegerPolynomial1305 extends IntegerPolynomial {
         long c8 = (a[4] * a[4]);
 
         carryReduce(r, c0, c1, c2, c3, c4, c5, c6, c7, c8);
-        return 0;
     }
 
     @Override

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomialModBinP.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/IntegerPolynomialModBinP.java
@@ -131,12 +131,11 @@ public sealed class IntegerPolynomialModBinP extends IntegerPolynomial {
     }
 
     @Override
-    protected int mult(long[] a, long[] b, long[] r) {
+    protected void mult(long[] a, long[] b, long[] r) {
 
         long[] c = new long[2 * numLimbs];
         multOnly(a, b, c);
         carryReduce(c, r);
-        return 0;
     }
 
     private void modReduceInBits(long[] limbs, int index, int bits, long x) {
@@ -189,7 +188,7 @@ public sealed class IntegerPolynomialModBinP extends IntegerPolynomial {
     }
 
     @Override
-    protected int square(long[] a, long[] r) {
+    protected void square(long[] a, long[] r) {
 
         long[] c = new long[2 * numLimbs];
         for (int i = 0; i < numLimbs; i++) {
@@ -200,7 +199,6 @@ public sealed class IntegerPolynomialModBinP extends IntegerPolynomial {
         }
 
         carryReduce(c, r);
-        return 0;
     }
 
     /**

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/MontgomeryIntegerPolynomialP256.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/MontgomeryIntegerPolynomialP256.java
@@ -435,21 +435,16 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
         d4 += n4 & LIMB_MASK;
 
         c5 += d1 + dd0 + (d0 >>> BITS_PER_LIMB);
-        c6 += d2 + dd1 + (c5 >>> BITS_PER_LIMB);
-        c7 += d3 + dd2 + (c6 >>> BITS_PER_LIMB);
-        c8 += d4 + dd3 + (c7 >>> BITS_PER_LIMB);
-        c9 = dd4 + (c8 >>> BITS_PER_LIMB);
+        c6 += d2 + dd1;
+        c7 += d3 + dd2;
+        c8 += d4 + dd3;
+        c9 = dd4;
 
-        c5 &= LIMB_MASK;
-        c6 &= LIMB_MASK;
-        c7 &= LIMB_MASK;
-        c8 &= LIMB_MASK;
-
-        r[0] = c5 & LIMB_MASK;
-        r[1] = c6 & LIMB_MASK;
-        r[2] = c7 & LIMB_MASK;
-        r[3] = c8 & LIMB_MASK;
-        r[4] = c9 & LIMB_MASK;
+        r[0] = c5;
+        r[1] = c6;
+        r[2] = c7;
+        r[3] = c8;
+        r[4] = c9;
     }
 
     @Override

--- a/src/java.base/share/classes/sun/security/util/math/intpoly/MontgomeryIntegerPolynomialP256.java
+++ b/src/java.base/share/classes/sun/security/util/math/intpoly/MontgomeryIntegerPolynomialP256.java
@@ -103,8 +103,8 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
         setLimbsValuePositive(v, vLimbs);
 
         // Convert to Montgomery domain
-        int numAdds = mult(vLimbs, h, montLimbs);
-        return new ImmutableElement(montLimbs, numAdds);
+        mult(vLimbs, h, montLimbs);
+        return new ImmutableElement(montLimbs, 0);
     }
 
     @Override
@@ -124,12 +124,32 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
      * Will return an unreduced value
      */
     @Override
-    protected int multByInt(long[] a, long b) {
+    protected void multByInt(long[] a, long b) {
         assert (b < (1 << BITS_PER_LIMB));
-        for (int i = 0; i < a.length; i++) {
-            a[i] *= b;
+        if (b == 2) {
+            for (int i = 0; i < NUM_LIMBS; i++) {
+                a[i] <<= 1;
+            }
+            reducePositive(a);
+        } else if (b == 3) {
+            for (int i = 0; i < NUM_LIMBS; i++) {
+                a[i] *= 3;
+            }
+            reducePositive(a);
+            reducePositive(a);
+        } else if (b == 4) {
+            for (int i = 0; i < NUM_LIMBS; i++) {
+                a[i] <<= 2;
+            }
+            reducePositive(a);
+            reducePositive(a);
+            reducePositive(a);
+        } else {
+            for (int i = 0; i < NUM_LIMBS; i++) {
+                a[i] *= b;
+            }
+            reduce(a);
         }
-        return (int) (b - 1);
     }
 
     @Override
@@ -163,9 +183,10 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
     }
 
     @Override
-    protected int square(long[] a, long[] r) {
-        return mult(a, a, r);
+    protected void square(long[] a, long[] r) {
+        mult(a, a, r);
     }
+
 
     /**
      * Unrolled Word-by-Word Montgomery Multiplication r = a * b * 2^-260 (mod P)
@@ -174,8 +195,14 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
      * for a Montgomery Friendly modulus p". Note: Step 6. Skipped; Instead use
      * numAdds to reuse existing overflow logic.
      */
+    @Override
+    protected void mult(long[] a, long[] b, long[] r) {
+        multImpl(a, b, r);
+        reducePositive(r);
+    }
+
     @IntrinsicCandidate
-    protected int mult(long[] a, long[] b, long[] r) {
+    private void multImpl(long[] a, long[] b, long[] r) {
         long aa0 = a[0];
         long aa1 = a[1];
         long aa2 = a[2];
@@ -418,26 +445,11 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
         c7 &= LIMB_MASK;
         c8 &= LIMB_MASK;
 
-        // At this point, the result could overflow by one modulus.
-        c0 = c5 - modulus[0];
-        c1 = c6 - modulus[1] + (c0 >> BITS_PER_LIMB);
-        c0 &= LIMB_MASK;
-        c2 = c7 - modulus[2] + (c1 >> BITS_PER_LIMB);
-        c1 &= LIMB_MASK;
-        c3 = c8 - modulus[3] + (c2 >> BITS_PER_LIMB);
-        c2 &= LIMB_MASK;
-        c4 = c9 - modulus[4] + (c3 >> BITS_PER_LIMB);
-        c3 &= LIMB_MASK;
-
-        long mask = c4 >> BITS_PER_LIMB; // Signed shift!
-
-        r[0] = ((c5 & mask) | (c0 & ~mask));
-        r[1] = ((c6 & mask) | (c1 & ~mask));
-        r[2] = ((c7 & mask) | (c2 & ~mask));
-        r[3] = ((c8 & mask) | (c3 & ~mask));
-        r[4] = ((c9 & mask) | (c4 & ~mask));
-
-        return 0;
+        r[0] = c5 & LIMB_MASK;
+        r[1] = c6 & LIMB_MASK;
+        r[2] = c7 & LIMB_MASK;
+        r[3] = c8 & LIMB_MASK;
+        r[4] = c9 & LIMB_MASK;
     }
 
     @Override
@@ -516,8 +528,8 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
         super.encode(v, offset, length, highByte, vLimbs);
 
         // Convert to Montgomery domain
-        int numAdds = mult(vLimbs, h, montLimbs);
-        return new ImmutableElement(montLimbs, numAdds);
+        mult(vLimbs, h, montLimbs);
+        return new ImmutableElement(montLimbs, 0);
     }
 
     /*
@@ -555,5 +567,27 @@ public final class MontgomeryIntegerPolynomialP256 extends IntegerPolynomial
         // 2^(52i-4*52-48)
         limbs[i - 5] += (v << 4) & LIMB_MASK;
         limbs[i - 4] += v >> 48;
+    }
+
+    // Used when limbs a could overflow by one modulus.
+    protected void reducePositive(long[] a) {
+        long aa0 = a[0];
+        long aa1 = a[1] + (aa0>>BITS_PER_LIMB);
+        long aa2 = a[2] + (aa1>>BITS_PER_LIMB);
+        long aa3 = a[3] + (aa2>>BITS_PER_LIMB);
+        long aa4 = a[4] + (aa3>>BITS_PER_LIMB);
+
+        long c0 = a[0] - modulus[0];
+        long c1 = a[1] - modulus[1] + (c0 >> BITS_PER_LIMB);
+        long c2 = a[2] - modulus[2] + (c1 >> BITS_PER_LIMB);
+        long c3 = a[3] - modulus[3] + (c2 >> BITS_PER_LIMB);
+        long c4 = a[4] - modulus[4] + (c3 >> BITS_PER_LIMB);
+        long mask = c4 >> BITS_PER_LIMB; // Signed shift!
+
+        a[0] = ((aa0 & mask) | (c0 & ~mask)) & LIMB_MASK;
+        a[1] = ((aa1 & mask) | (c1 & ~mask)) & LIMB_MASK;
+        a[2] = ((aa2 & mask) | (c2 & ~mask)) & LIMB_MASK;
+        a[3] = ((aa3 & mask) | (c3 & ~mask)) & LIMB_MASK;
+        a[4] = ((aa4 & mask) | (c4 & ~mask));
     }
 }


### PR DESCRIPTION
This fix recovers XDH performance but removes some of the P256 gains (~-8-14%). Still faster, but not as much.

The fix is to undo 'int' return type on mult()/square(), which allowed to return partially reduced result (e.g. this avoids extra reductions when mult() result is fed into addition). This is the behaviour before the Montgomery ECC PR.

---
XDH.generateSecret performance 
before Montgomery PR:
```
Benchmark                             (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
KeyAgreementBench.XDH.generateSecret          XDH          255             XDH              thrpt    3  8435.277 ± 27.230  ops/s
```
after Montgomery PR:
```
Benchmark                             (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
KeyAgreementBench.XDH.generateSecret          XDH          255             XDH              thrpt    3  8309.028 ± 22.071  ops/s
```
with this PR:
```
Benchmark                             (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
KeyAgreementBench.XDH.generateSecret          XDH          255             XDH              thrpt    3  8491.268 ± 32.858  ops/s
```
---

P256 performance with/without mult intrinsic:

Performance before Montgomery PR:
```
Benchmark                        (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt     Score    Error  Units
SignatureBench.ECDSA.sign    SHA256withECDSA        1024          256              thrpt    3  6398.727 ±  7.400  ops/s
SignatureBench.ECDSA.sign    SHA256withECDSA       16384          256              thrpt    3  6129.739 ±  5.995  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA        1024          256              thrpt    3  1889.928 ± 54.660  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA       16384          256              thrpt    3  1866.339 ± 42.438  ops/s
Benchmark                                            (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyAgreementBench.EC.generateSecret          ECDH          256              EC              thrpt    3  1350.745 ± 28.514  ops/s
o.o.b.j.c.small.KeyAgreementBench.EC.generateSecret         ECDH          256              EC              thrpt    3  1349.393 ± 32.050  ops/s
```
Performance in master without mult() intrinsic
```
Benchmark                        (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt     Score     Error  Units
SignatureBench.ECDSA.sign    SHA256withECDSA        1024          256              thrpt    3  6539.589 ± 132.844  ops/s
SignatureBench.ECDSA.sign    SHA256withECDSA       16384          256              thrpt    3  6202.530 ± 124.496  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA        1024          256              thrpt    3  1967.038 ±  15.819  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA       16384          256              thrpt    3  1931.667 ±  22.901  ops/s
Benchmark                                            (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyAgreementBench.EC.generateSecret          ECDH          256              EC              thrpt    3  1354.143 ± 24.861  ops/s
o.o.b.j.c.small.KeyAgreementBench.EC.generateSecret         ECDH          256              EC              thrpt    3  1354.139 ± 21.904  ops/s
```

Performance in master with mult() intrinsic
```
Benchmark                        (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt      Score     Error  Units
SignatureBench.ECDSA.sign    SHA256withECDSA        1024          256              thrpt    3  10534.707 ±  20.690  ops/s
SignatureBench.ECDSA.sign    SHA256withECDSA       16384          256              thrpt    3   9729.246 ± 102.803  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA        1024          256              thrpt    3   3549.011 ±  77.343  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA       16384          256              thrpt    3   3458.107 ±  14.622  ops/s
Benchmark                                            (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyAgreementBench.EC.generateSecret          ECDH          256              EC              thrpt    3  2563.566 ± 94.381  ops/s
o.o.b.j.c.small.KeyAgreementBench.EC.generateSecret         ECDH          256              EC              thrpt    3  2569.143 ± 53.337  ops/s
```

THIS PR without mult intrinsic
```
Benchmark                        (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt     Score     Error  Units
SignatureBench.ECDSA.sign    SHA256withECDSA        1024          256              thrpt    3  6401.053 ± 125.123  ops/s
SignatureBench.ECDSA.sign    SHA256withECDSA       16384          256              thrpt    3  6152.548 ± 150.399  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA        1024          256              thrpt    3  1926.609 ±   8.420  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA       16384          256              thrpt    3  1898.697 ±  28.935  ops/s
Benchmark                                            (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyAgreementBench.EC.generateSecret          ECDH          256              EC              thrpt    3  1359.759 ± 24.033  ops/s
o.o.b.j.c.small.KeyAgreementBench.EC.generateSecret         ECDH          256              EC              thrpt    3  1361.320 ± 21.072  ops/s
```

THIS PR with mult intrinsic
```
Benchmark                        (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt     Score     Error  Units
SignatureBench.ECDSA.sign    SHA256withECDSA        1024          256              thrpt    3  9631.846 ±   9.796  ops/s
SignatureBench.ECDSA.sign    SHA256withECDSA       16384          256              thrpt    3  8984.315 ± 159.869  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA        1024          256              thrpt    3  3116.537 ±  31.496  ops/s
SignatureBench.ECDSA.verify  SHA256withECDSA       16384          256              thrpt    3  3034.870 ±  78.147  ops/s
Benchmark                                            (algorithm)  (keyLength)  (kpgAlgorithm)  (provider)   Mode  Cnt     Score    Error  Units
o.o.b.j.c.full.KeyAgreementBench.EC.generateSecret          ECDH          256              EC              thrpt    3  2244.094 ± 17.384  ops/s
o.o.b.j.c.small.KeyAgreementBench.EC.generateSecret         ECDH          256              EC              thrpt    3  2249.111 ± 54.525  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333583](https://bugs.openjdk.org/browse/JDK-8333583): Crypto-XDH.generateSecret regression after JDK-8329538 (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19728/head:pull/19728` \
`$ git checkout pull/19728`

Update a local copy of the PR: \
`$ git checkout pull/19728` \
`$ git pull https://git.openjdk.org/jdk.git pull/19728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19728`

View PR using the GUI difftool: \
`$ git pr show -t 19728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19728.diff">https://git.openjdk.org/jdk/pull/19728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19728#issuecomment-2168723658)