### PR TITLE
8334332: TestIOException.java fails if run by root

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -53,7 +53,7 @@ public class TestIOException extends JavadocTester {
 
     public static void main(String... args) throws Exception {
         var tester = new TestIOException();
-        if(Platform.isRoot() && ! tester.isWindows()) {
+        if(Platform.isRoot() && !tester.isWindows()) {
             throw new SkippedException("root user has privileged will make this test fail.");
         }
         tester.runTests();

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,10 @@
  * @test
  * @bug 8164130
  * @summary test IOException handling
- * @library ../../lib
+ * @library ../../lib /test/lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build javadoc.tester.*
+ * @build jdk.test.lib.Platform
  * @run main TestIOException
  */
 
@@ -39,6 +40,8 @@ import java.util.Locale;
 import java.util.Map;
 
 import javadoc.tester.JavadocTester;
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 /**
  * Tests IO Exception handling.
@@ -50,6 +53,9 @@ public class TestIOException extends JavadocTester {
 
     public static void main(String... args) throws Exception {
         var tester = new TestIOException();
+        if(Platform.isRoot() && ! tester.isWindows()) {
+            throw new SkippedException("root user has privileged will make this test fail.");
+        }
         tester.runTests();
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8164130
+ * @bug 8164130 8334332
  * @summary test IOException handling
  * @library ../../lib /test/lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool

--- a/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
+++ b/test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java
@@ -28,7 +28,6 @@
  * @library ../../lib /test/lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
  * @build javadoc.tester.*
- * @build jdk.test.lib.Platform
  * @run main TestIOException
  */
 
@@ -40,7 +39,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import javadoc.tester.JavadocTester;
-import jdk.test.lib.Platform;
 import jtreg.SkippedException;
 
 /**
@@ -53,9 +51,6 @@ public class TestIOException extends JavadocTester {
 
     public static void main(String... args) throws Exception {
         var tester = new TestIOException();
-        if(Platform.isRoot() && !tester.isWindows()) {
-            throw new SkippedException("root user has privileged will make this test fail.");
-        }
         tester.runTests();
     }
 
@@ -67,16 +62,13 @@ public class TestIOException extends JavadocTester {
     public void testReadOnlyDirectory() {
         File outDir = new File("out1");
         if (!outDir.mkdir()) {
-            throw error(outDir, "Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         if (!outDir.setReadOnly()) {
-            if (skip(outDir)) {
-                return;
-            }
-            throw error(outDir, "could not set directory read-only");
+            throw skip(outDir, "could not set directory read-only");
         }
         if (outDir.canWrite()) {
-            throw error(outDir, "directory is writable");
+            throw skip(outDir, "directory is writable");
         }
 
         try {
@@ -99,15 +91,15 @@ public class TestIOException extends JavadocTester {
     public void testReadOnlyFile() throws Exception {
         File outDir = new File("out2");
         if (!outDir.mkdir()) {
-            throw error(outDir, "Cannot create directory");
+            throw skip(outDir, "Cannot create directory");
         }
         File index = new File(outDir, "index.html");
         try (FileWriter fw = new FileWriter(index)) { }
         if (!index.setReadOnly()) {
-            throw error(index, "could not set index read-only");
+            throw skip(index, "could not set index read-only");
         }
         if (index.canWrite()) {
-            throw error(index, "index is writable");
+            throw skip(index, "index is writable");
         }
 
         try {
@@ -145,16 +137,13 @@ public class TestIOException extends JavadocTester {
         File outDir = new File("out3");
         File pkgOutDir = new File(outDir, "p");
         if (!pkgOutDir.mkdirs()) {
-            throw error(pkgOutDir, "Cannot create directory");
+            throw skip(pkgOutDir, "Cannot create directory");
         }
         if (!pkgOutDir.setReadOnly()) {
-            if (skip(pkgOutDir)) {
-                return;
-            }
-            throw error(pkgOutDir, "could not set directory read-only");
+            throw skip(pkgOutDir, "could not set directory read-only");
         }
         if (pkgOutDir.canWrite()) {
-            throw error(pkgOutDir, "directory is writable");
+            throw skip(pkgOutDir, "directory is writable");
         }
 
         // run javadoc and check results
@@ -198,16 +187,13 @@ public class TestIOException extends JavadocTester {
         File pkgOutDir = new File(outDir, "p");
         File docFilesOutDir = new File(pkgOutDir, "doc-files");
         if (!docFilesOutDir.mkdirs()) {
-            throw error(docFilesOutDir, "Cannot create directory");
+            throw skip(docFilesOutDir, "Cannot create directory");
         }
         if (!docFilesOutDir.setReadOnly()) {
-            if (skip(docFilesOutDir)) {
-                return;
-            }
-            throw error(docFilesOutDir, "could not set directory read-only");
+            throw skip(docFilesOutDir, "could not set directory read-only");
         }
         if (docFilesOutDir.canWrite()) {
-            throw error(docFilesOutDir, "directory is writable");
+            throw skip(docFilesOutDir, "directory is writable");
         }
 
         try {
@@ -225,10 +211,11 @@ public class TestIOException extends JavadocTester {
         }
     }
 
-    private Error error(File f, String message) {
+    private Error skip(File f, String message) {
+        out.print(System.getProperty("user.name"));
         out.println(f + ": " + message);
         showAllAttributes(f.toPath());
-        throw new Error(f + ": " + message);
+        throw new SkippedException(f + ": " + message);
     }
 
     private void showAllAttributes(Path p) {
@@ -247,21 +234,6 @@ public class TestIOException extends JavadocTester {
         } catch (Throwable t) {
             out.println("Error accessing attributes " + attributes + ": " + t);
         }
-    }
-
-    private boolean skip(File dir) {
-        if (isWindows()) {
-            showAllAttributes(dir.toPath());
-            out.println("Windows: cannot set directory read only:" + dir);
-            out.println("TEST CASE SKIPPED");
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    private boolean isWindows() {
-        return System.getProperty("os.name").toLowerCase(Locale.US).startsWith("windows");
     }
 }
 


### PR DESCRIPTION
Hi all,
  Test `test/langtools/jdk/javadoc/doclet/testIOException/TestIOException.java` run fails with root user privileged. I think it's necessary to skip this testcase when user is root.
  Why run the jtreg test by root user? It's because during rpmbuild process for linux distribution of JDK, root user is the default user to build the openjdk, also is the default user to run the `make test-tier1`, this PR make this testcase more robustness.
  The change has been verified, only change the testcase, no risk.

The change verified on:

- [x] linux
- [x] windows

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334332](https://bugs.openjdk.org/browse/JDK-8334332): TestIOException.java fails if run by root (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19731/head:pull/19731` \
`$ git checkout pull/19731`

Update a local copy of the PR: \
`$ git checkout pull/19731` \
`$ git pull https://git.openjdk.org/jdk.git pull/19731/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19731`

View PR using the GUI difftool: \
`$ git pr show -t 19731`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19731.diff">https://git.openjdk.org/jdk/pull/19731.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19731#issuecomment-2169234537)