### PR TITLE
8334333: MissingResourceCauseTestRun.java fails if run by root

### DIFF
--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
  * @build jdk.test.lib.JDKToolLauncher
  *        jdk.test.lib.Utils
  *        jdk.test.lib.process.ProcessTools
+ *        jdk.test.lib.Platform
  *        MissingResourceCauseTest
  *        NonResourceBundle
  *        PrivateConstructorRB
@@ -50,9 +51,14 @@ import java.nio.file.Paths;
 import jdk.test.lib.JDKToolLauncher;
 import jdk.test.lib.Utils;
 import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class MissingResourceCauseTestRun {
     public static void main(String[] args) throws Throwable {
+        if(Platform.isRoot() && !Platform.isWindows()) {
+            throw new SkippedException("root user has privileged will make this test fail.");
+        }
         Path path = Paths.get("UnreadableRB.properties");
         Files.deleteIfExists(path);
         try {

--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 4354216 8213127
+ * @bug 4354216 8213127 8334333
  * @summary Test for the cause support when throwing a
  *          MissingResourceBundle. (This test exists under
  *          ResourceBundle/Control because bad resource bundle data can be

--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -57,7 +57,7 @@ import jtreg.SkippedException;
 public class MissingResourceCauseTestRun {
     public static void main(String[] args) throws Throwable {
         if(Platform.isRoot() && !Platform.isWindows()) {
-            throw new SkippedException("root user has privileged will make this test fail.");
+            throw new SkippedException("Unable to create an unreadable properties file.");
         }
         Path path = Paths.get("UnreadableRB.properties");
         Files.deleteIfExists(path);

--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java
@@ -56,7 +56,7 @@ import jtreg.SkippedException;
 
 public class MissingResourceCauseTestRun {
     public static void main(String[] args) throws Throwable {
-        if(Platform.isRoot() && !Platform.isWindows()) {
+        if (Platform.isRoot() && !Platform.isWindows()) {
             throw new SkippedException("Unable to create an unreadable properties file.");
         }
         Path path = Paths.get("UnreadableRB.properties");
@@ -104,7 +104,7 @@ public class MissingResourceCauseTestRun {
     }
 
     private static void deleteFile(Path path) throws Throwable {
-        if(path.toFile().exists()) {
+        if (path.toFile().exists()) {
             ProcessTools.executeCommand("chmod", "666", path.toString())
                         .outputTo(System.out)
                         .errorTo(System.out)


### PR DESCRIPTION
Hi all,
Testcase `test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTestRun.java` run fails with root user privileged. I think it's necessary to skip this testcase when user is root.
Why run the jtreg test by root user? It's because during rpmbuild process for linux distribution of JDK, root user is the default user to build the openjdk, also is the default user to run the `make test-tier1`, this PR make this testcase more robustness.
The change has been verified, only change the testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334333](https://bugs.openjdk.org/browse/JDK-8334333): MissingResourceCauseTestRun.java fails if run by root (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19732/head:pull/19732` \
`$ git checkout pull/19732`

Update a local copy of the PR: \
`$ git checkout pull/19732` \
`$ git pull https://git.openjdk.org/jdk.git pull/19732/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19732`

View PR using the GUI difftool: \
`$ git pr show -t 19732`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19732.diff">https://git.openjdk.org/jdk/pull/19732.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19732#issuecomment-2169256271)