### PR TITLE
8334339: Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java fails on alinux3

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -72,6 +72,10 @@ public class CreationTime {
         view.setTimes(null, null, time);
     }
 
+    /**
+     * read the output of linux command `stat -c "%w" file`, if the output is "-",
+     * then the file system doesn't support birth time 
+     */
     public static boolean supportBirthTimeOnLinux(Path file) {
         try {
             String filePath = file.toAbsolutePath().toString();

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -30,7 +30,7 @@
  * @run main CreationTime
  */
 
- /* @test id=cwd
+/* @test id=cwd
  * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, test directory is JTwork/scratch. The JTwork/scratch

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -74,7 +74,7 @@ public class CreationTime {
 
     /**
      * read the output of linux command `stat -c "%w" file`, if the output is "-",
-     * then the file system doesn't support birth time 
+     * then the file system doesn't support birth time
      */
     public static boolean supportBirthTimeOnLinux(Path file) {
         try {

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -72,24 +72,6 @@ public class CreationTime {
         view.setTimes(null, null, time);
     }
 
-    /**
-     * read the output of linux command `stat -c "%w" file`, if the output is "-",
-     * then the file system doesn't support birth time
-     */
-    public static boolean supportBirthTimeOnLinux(Path file) {
-        try {
-            String filePath = file.toAbsolutePath().toString();
-            ProcessBuilder pb = new ProcessBuilder("stat", "-c", "%w", filePath);
-            pb.redirectErrorStream(true);
-            Process p = pb.start();
-            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
-            String l = b.readLine();
-            if (l != null && l.equals("-")) { return false; }
-        } catch(Exception e) {
-        }
-        return true;
-    }
-
     static void test(Path top) throws IOException {
         Path file = Files.createFile(top.resolve("foo"));
 
@@ -100,7 +82,8 @@ public class CreationTime {
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
             System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
-            if(0 == creationTime.toMillis() && Platform.isLinux() && !supportBirthTimeOnLinux(file) ) {
+            // If the file system doesn't support birth time, then skip this test
+            if (0 == creationTime.toMillis()) {
                 throw new SkippedException("birth time not support for: " + file);
             } else {
                 err.println("File creation time reported as: " + creationTime);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -81,7 +81,7 @@ public class CreationTime {
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
             System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
             // If the file system doesn't support birth time, then skip this test
-            if (0 == creationTime.toMillis()) {
+            if (creationTime.toMillis() == 0) {
                 throw new SkippedException("birth time not support for: " + file);
             } else {
                 err.println("File creation time reported as: " + creationTime);
@@ -145,7 +145,7 @@ public class CreationTime {
     public static void main(String[] args) throws IOException {
         // create temporary directory to run tests
         Path dir;
-        if(0 == args.length) {
+        if(args.length == 0) {
             dir = TestUtil.createTemporaryDirectory();
         } else {
             dir = TestUtil.createTemporaryDirectory(args[0]);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -31,7 +31,6 @@
  */
 
 /* @test id=cwd
- * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using the test scratch directory, the test
  *     scratch directory maybe at diff disk partition to /tmp on linux.

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -144,7 +144,7 @@ public class CreationTime {
     public static void main(String[] args) throws IOException {
         // create temporary directory to run tests
         Path dir;
-        if(args.length == 0) {
+        if (args.length == 0) {
             dir = TestUtil.createTemporaryDirectory();
         } else {
             dir = TestUtil.createTemporaryDirectory(args[0]);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -24,7 +24,7 @@
 /* @test id=tmp
  * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
- *     that support it, test directory is /tmp.
+ *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @run main CreationTime
@@ -33,8 +33,8 @@
 /* @test id=cwd
  * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
- *     that support it, test directory is JTwork/scratch. The JTwork/scratch
- *     directory maybe at diff disk partition to /tmp on linux
+ *     that support it, tests using the test scratch directory, the test
+ *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @run main CreationTime .

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -45,9 +45,7 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.attribute.*;
 import java.time.Instant;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import jdk.test.lib.Platform;
 import jtreg.SkippedException;


### PR DESCRIPTION
Hi all,
  The testcase `java/nio/file/attribute/BasicFileAttributeView/CreationTime.java` fails on alinux3(alibaba cloud linux version 3) after [JDK-8316304](https://bugs.openjdk.org/browse/JDK-8316304).
  The testcase use /tmp directory to create the file and get the createtime(birth time) of this file. But on alinux3(alibaba cloud linux version 3), the /tmp is mount as tmpfs, it's not a real physic disk paitition, it's mount from RAM, and the alinux3 doesn't support get the `birth time` on tmpfs.
  On ubuntu 22, when I create a file on /dev/shm(it's also a tmpfs type partition), stat also doesn't support `birth time`.
  According to the [Java API doc](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/nio/file/attribute/BasicFileAttributes.html#creationTime()), If the file system implementation does not support a time stamp to indicate the time when the file was created, the creationTime() API return the epoch (1970-01-01T00:00:00Z).

  So in this PR, if the test directory(on linux the test directory is /tmp) doesn't support `birth time`, the test throw a jtreg.SkippedException, rather than report a failure.
  And in this PR, I create a new test, change the test directory from /tmp to `pwd`, which the current work directory maybe at diffrent partition to /tmp, and the current work directory support `birth time` possibly.

 The change has been verified on below env:

- [x] alinux3 run test CreationTime.java
- [x] windows run test CreationTime.java

[windows-CreationTime.java.log](https://github.com/user-attachments/files/15857148/windows-CreationTime.java.log)
[alinux3-CreationTime.java.log](https://github.com/user-attachments/files/15857149/alinux3-CreationTime.java.log)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334339](https://bugs.openjdk.org/browse/JDK-8334339): Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java fails on alinux3 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [ea36354e](https://git.openjdk.org/jdk/pull/19737/files/ea36354eef761c2d6cf80427a91129fbd80cd070)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19737/head:pull/19737` \
`$ git checkout pull/19737`

Update a local copy of the PR: \
`$ git checkout pull/19737` \
`$ git pull https://git.openjdk.org/jdk.git pull/19737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19737`

View PR using the GUI difftool: \
`$ git pr show -t 19737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19737.diff">https://git.openjdk.org/jdk/pull/19737.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19737#issuecomment-2171216331)