### PR TITLE
8297191 : [macos] printing page range "page 2 to 2" or "page 2 to 4" on macOS leads to not print 

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -201,7 +201,7 @@ public final class CPrinterJob extends RasterPrinterJob {
             SunPageSelection rangeSelect = (SunPageSelection)attributes.get(SunPageSelection.class);
             // If rangeSelect is not null, we are using AWT's print dialog that has
             // All, Selection, and Range radio buttons
-            if (rangeSelect == null || rangeSelect == SunPageSelection.RANGE) {
+            if (rangeSelect == SunPageSelection.RANGE) {
                 int[][] range = pageRangesAttr.getMembers();
                 // setPageRange will set firstPage and lastPage as called in getFirstPage
                 // and getLastPage
@@ -222,7 +222,6 @@ public final class CPrinterJob extends RasterPrinterJob {
             // 1 less than pageRanges attribute
             if (isRangeSet) {
                 attributes.add(new PageRanges(from+1, to+1));
-                attributes.add(SunPageSelection.RANGE);
                 setPageRange(from, to);
             } else {
                 attributes.add(SunPageSelection.ALL);


### PR DESCRIPTION
Hi Reviewers,

This fix will resolve page range not printing proper pages if the rage begin from 2 or above on Mac machines. 
I have verified the manual range related tests like PageRanges.java, ClippedImages.java and test.java and confirmed its fixing the issue.

Please review and let me know your suggestions if any.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297191](https://bugs.openjdk.org/browse/JDK-8297191): [macos] printing page range "page 2 to 2" or "page 2 to 4" on macOS leads to not print (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19740/head:pull/19740` \
`$ git checkout pull/19740`

Update a local copy of the PR: \
`$ git checkout pull/19740` \
`$ git pull https://git.openjdk.org/jdk.git pull/19740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19740`

View PR using the GUI difftool: \
`$ git pr show -t 19740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19740.diff">https://git.openjdk.org/jdk/pull/19740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19740#issuecomment-2172353654)