### PR TITLE
8334365: Problemlist CAInterop.java#microsoftecc2017

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,6 +620,7 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
+security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#microsoftecc2017     8328990 generic-all
 security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
 
 ############################################################################


### PR DESCRIPTION
Exclude CAInterop.java#microsoftecc2017 because it generates lots of noice in CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334365](https://bugs.openjdk.org/browse/JDK-8334365): Problemlist CAInterop.java#microsoftecc2017 (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19741/head:pull/19741` \
`$ git checkout pull/19741`

Update a local copy of the PR: \
`$ git checkout pull/19741` \
`$ git pull https://git.openjdk.org/jdk.git pull/19741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19741`

View PR using the GUI difftool: \
`$ git pr show -t 19741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19741.diff">https://git.openjdk.org/jdk/pull/19741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19741#issuecomment-2172578928)