### PR TITLE
8211847: [aix] java/lang/ProcessHandle/InfoTest.java fails: "reported cputime less than expected"

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -486,7 +486,6 @@ java/beans/XMLEncoder/Test6570354.java 8015593 macosx-all
 
 # jdk_lang
 
-java/lang/ProcessHandle/InfoTest.java                           8211847 aix-ppc64
 java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-all
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847), commit [f5213671](https://github.com/openjdk/jdk/commit/f5213671f7b636b32bb93c78e43696a61cd69bae) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 13 Jun 2024 and was reviewed by Thomas Stuefe.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211847](https://bugs.openjdk.org/browse/JDK-8211847): [aix] java/lang/ProcessHandle/InfoTest.java fails: "reported cputime less than expected" (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19742/head:pull/19742` \
`$ git checkout pull/19742`

Update a local copy of the PR: \
`$ git checkout pull/19742` \
`$ git pull https://git.openjdk.org/jdk.git pull/19742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19742`

View PR using the GUI difftool: \
`$ git pr show -t 19742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19742.diff">https://git.openjdk.org/jdk/pull/19742.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19742#issuecomment-2172689623)