### PR TITLE
8211854: [aix] java/net/ServerSocket/AcceptInheritHandle.java fails: read times out

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -552,8 +552,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/ServerSocket/AcceptInheritHandle.java                  8211854 aix-ppc64
-
 java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8211854](https://bugs.openjdk.org/browse/JDK-8211854), commit [9d8439c1](https://github.com/openjdk/jdk/commit/9d8439c10780c3a0169c2675955a0506518f44fb) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Christoph Langer on 13 Jun 2024 and was reviewed by Daniel Fuchs and Jaikiran Pai.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211854](https://bugs.openjdk.org/browse/JDK-8211854): [aix] java/net/ServerSocket/AcceptInheritHandle.java fails: read times out (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19743/head:pull/19743` \
`$ git checkout pull/19743`

Update a local copy of the PR: \
`$ git checkout pull/19743` \
`$ git pull https://git.openjdk.org/jdk.git pull/19743/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19743`

View PR using the GUI difftool: \
`$ git pr show -t 19743`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19743.diff">https://git.openjdk.org/jdk/pull/19743.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19743#issuecomment-2172689873)