### PR TITLE
8334215: serviceability/dcmd/thread/PrintMountedVirtualThread.java failing with JTREG_TEST_THREAD_FACTORY=Virtual

### DIFF
--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1332,8 +1332,8 @@ void Threads::print_on(outputStream* st, bool print_stacks,
           if (p->is_vthread_mounted()) {
             const oop vt = p->vthread();
             assert(vt != nullptr, "vthread should not be null when vthread is mounted");
+            // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
             if (vt != thread_oop) {
-              // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
               st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(vt), (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1331,8 +1331,9 @@ void Threads::print_on(outputStream* st, bool print_stacks,
         if (thread_oop != nullptr) {
           if (p->is_vthread_mounted()) {
             const oop vt = p->vthread();
+            assert(vt != nullptr, "vthread should not be null when vthread is mounted");
             if (vt != thread_oop) {
-              assert(vt != nullptr, "vthread should not be null when vthread is mounted");
+              // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
               st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(vt), (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1331,9 +1331,11 @@ void Threads::print_on(outputStream* st, bool print_stacks,
         if (thread_oop != nullptr) {
           if (p->is_vthread_mounted()) {
             const oop vt = p->vthread();
-            assert(vt != nullptr, "vthread should not be null when vthread is mounted");
-            st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(vt), (int64_t)java_lang_Thread::thread_id(vt));
-            p->print_vthread_stack_on(st);
+            if (vt != thread_oop) {
+              assert(vt != nullptr, "vthread should not be null when vthread is mounted");
+              st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(vt), (int64_t)java_lang_Thread::thread_id(vt));
+              p->print_vthread_stack_on(st);
+            }
           }
         }
       }

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -1334,7 +1334,7 @@ void Threads::print_on(outputStream* st, bool print_stacks,
             assert(vt != nullptr, "vthread should not be null when vthread is mounted");
             // JavaThread._vthread can refer to the carrier thread. Print only if _vthread refers to a virtual thread.
             if (vt != thread_oop) {
-              st->print_cr("   Mounted virtual thread \"%s\" #" INT64_FORMAT, JavaThread::name_for(vt), (int64_t)java_lang_Thread::thread_id(vt));
+              st->print_cr("   Mounted virtual thread #" INT64_FORMAT, (int64_t)java_lang_Thread::thread_id(vt));
               p->print_vthread_stack_on(st);
             }
           }

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintMountedVirtualThread.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintMountedVirtualThread.java
@@ -26,7 +26,6 @@ import jdk.test.lib.dcmd.JMXExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
@@ -41,11 +40,13 @@ public class PrintMountedVirtualThread {
 
     public void run(CommandExecutor executor) throws InterruptedException {
         var shouldFinish = new AtomicBoolean(false);
-        var started = new CountDownLatch(1);
+        var started = new AtomicBoolean();
         final Runnable runnable = new DummyRunnable(shouldFinish, started);
         try {
             Thread vthread = Thread.ofVirtual().name("Dummy Vthread").start(runnable);
-            started.await();
+            while (!started.get()) {
+                Thread.sleep(10);
+            }
             /* Execute */
             OutputAnalyzer output = executor.execute("Thread.print");
             output.shouldMatch(".*at " + Pattern.quote(DummyRunnable.class.getName()) + "\\.run.*");
@@ -63,11 +64,10 @@ public class PrintMountedVirtualThread {
     }
 
     static class DummyRunnable implements Runnable {
-
         private final AtomicBoolean shouldFinish;
-        private final CountDownLatch started;
+        private final AtomicBoolean started;
 
-        public DummyRunnable(AtomicBoolean shouldFinish, CountDownLatch started) {
+        public DummyRunnable(AtomicBoolean shouldFinish, AtomicBoolean started) {
            this.shouldFinish = shouldFinish;
            this.started = started;
         }
@@ -77,12 +77,11 @@ public class PrintMountedVirtualThread {
         }
 
         void compute() {
-            started.countDown();
+            started.set(true);
             while (!shouldFinish.get()) {
                 Thread.onSpinWait();
             }
         }
     }
-
 
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/thread/PrintMountedVirtualThread.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/thread/PrintMountedVirtualThread.java
@@ -51,7 +51,7 @@ public class PrintMountedVirtualThread {
             OutputAnalyzer output = executor.execute("Thread.print");
             output.shouldMatch(".*at " + Pattern.quote(DummyRunnable.class.getName()) + "\\.run.*");
             output.shouldMatch(".*at " + Pattern.quote(DummyRunnable.class.getName()) + "\\.compute.*");
-            output.shouldMatch("Mounted virtual thread " + "\"Dummy Vthread\"" + " #" + vthread.threadId());
+            output.shouldMatch("Mounted virtual thread " + "#" + vthread.threadId());
 
         } finally {
             shouldFinish.set(true);


### PR DESCRIPTION
Follow up to https://github.com/openjdk/jdk/pull/19482 that was causing issues when the PrintMountedVirtualTest.java was
running with `JTREG_TEST_THREAD_FACTORY=Virtual` in the loom repo. 

- Fixes issues where the test observes the thread during transitions.
- Fixes a potential issue in the test where CountDownLatch.countDown unparks the main (virtual) thread and the main thread observes the dummy thread is transition .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334215](https://bugs.openjdk.org/browse/JDK-8334215): serviceability/dcmd/thread/PrintMountedVirtualThread.java failing with JTREG_TEST_THREAD_FACTORY=Virtual (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19744/head:pull/19744` \
`$ git checkout pull/19744`

Update a local copy of the PR: \
`$ git checkout pull/19744` \
`$ git pull https://git.openjdk.org/jdk.git pull/19744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19744`

View PR using the GUI difftool: \
`$ git pr show -t 19744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19744.diff">https://git.openjdk.org/jdk/pull/19744.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19744#issuecomment-2172839937)