### PR TITLE
8329335: HttpsURLConnectionTest fails due to network firewall rules

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -626,6 +626,7 @@ jdk_security_manual_no_input = \
     com/sun/security/sasl/gsskerb/AuthOnly.java \
     com/sun/security/sasl/gsskerb/ConfSecurityLayer.java \
     com/sun/security/sasl/gsskerb/NoSecurityLayer.java \
+    security/infra/javax/net/ssl/HttpsURLConnectionTest.java \
     sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java \
     sun/security/provider/PolicyParser/PrincipalExpansionError.java \
     sun/security/smartcardio/TestChannel.java \

--- a/test/jdk/security/infra/javax/net/ssl/HttpsURLConnectionTest.java
+++ b/test/jdk/security/infra/javax/net/ssl/HttpsURLConnectionTest.java
@@ -28,7 +28,7 @@
  *          KEYCHAINSTORE-ROOT trust store
  * @library /test/lib
  * @requires os.family == "mac"
- * @run main/othervm HttpsURLConnectionTest https://github.com KeychainStore-Root
+ * @run main/othervm/manual HttpsURLConnectionTest https://github.com KeychainStore-Root
  */
 import java.io.*;
 import java.net.*;


### PR DESCRIPTION
Since HttpsURLConnectionTest attempts to reach external servers, it can fail if run on hosts without outbound traffic allowed. Therefore, it should not be executed in CI pipelines but rather manually on a host with no firewall rules preventing egress traffic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329335](https://bugs.openjdk.org/browse/JDK-8329335): HttpsURLConnectionTest fails due to network firewall rules (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19745/head:pull/19745` \
`$ git checkout pull/19745`

Update a local copy of the PR: \
`$ git checkout pull/19745` \
`$ git pull https://git.openjdk.org/jdk.git pull/19745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19745`

View PR using the GUI difftool: \
`$ git pr show -t 19745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19745.diff">https://git.openjdk.org/jdk/pull/19745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19745#issuecomment-2173541999)