### PR TITLE
8334222: exclude containers/cgroup/PlainRead.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -125,6 +125,7 @@ applications/jcstress/coherence.java 8325984 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 
+containers/cgroup/PlainRead.java 8333967,8261242 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 containers/docker/TestJFREvents.java 8327723 linux-x64


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8334222](https://bugs.openjdk.org/browse/JDK-8334222), commit [5e09397b](https://github.com/openjdk/jdk/commit/5e09397bf6244c98204180f53a2891604d2843d1) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Matthias Baesken on 17 Jun 2024 and was reviewed by Lutz Schmidt.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8334222: exclude containers/cgroup/PlainRead.java`

### Issue
 * [JDK-8334222](https://bugs.openjdk.org/browse/JDK-8334222): exclude containers/cgroup/PlainRead.java (**Sub-task** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19747/head:pull/19747` \
`$ git checkout pull/19747`

Update a local copy of the PR: \
`$ git checkout pull/19747` \
`$ git pull https://git.openjdk.org/jdk.git pull/19747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19747`

View PR using the GUI difftool: \
`$ git pr show -t 19747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19747.diff">https://git.openjdk.org/jdk/pull/19747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19747#issuecomment-2172960911)