### PR TITLE
8332524: Instead of printing "TLSv1.3," it is showing "TLS13"

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/ClientHello.java
+++ b/src/java.base/share/classes/sun/security/ssl/ClientHello.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -903,8 +903,8 @@ final class ClientHello {
             throw context.conContext.fatal(Alert.PROTOCOL_VERSION,
                 "The client supported protocol versions " + Arrays.toString(
                     ProtocolVersion.toStringArray(clientSupportedVersions)) +
-                " are not accepted by server preferences " +
-                context.activeProtocols);
+                " are not accepted by server preferences " + Arrays.toString(
+                ProtocolVersion.toStringArray(context.activeProtocols)));
         }
     }
 


### PR DESCRIPTION
While doing SSL/TLS connection, start the Client with protocol TLSv1.2 and Server with protocol TLSv1.3. During handshake process, the exception shows as "javax.net.ssl.SSLHandshakeException: The client supported protocol versions [TLSv1.2] are not accepted by server preferences [TLS13]", where printing as TLS13 and not formatted to TLSv1.3.

After the given change, the protocol version is correctly printing:
javax.net.ssl.SSLHandshakeException: (protocol_version) The client supported protocol versions [TLSv1.2] are not accepted by server preferences [TLSv1.3]

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332524](https://bugs.openjdk.org/browse/JDK-8332524): Instead of printing "TLSv1.3," it is showing "TLS13" (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19749/head:pull/19749` \
`$ git checkout pull/19749`

Update a local copy of the PR: \
`$ git checkout pull/19749` \
`$ git pull https://git.openjdk.org/jdk.git pull/19749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19749`

View PR using the GUI difftool: \
`$ git pr show -t 19749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19749.diff">https://git.openjdk.org/jdk/pull/19749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19749#issuecomment-2173573039)