### PR TITLE
8334396: RISC-V: verify perf of ReverseBytesI/L

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1914,6 +1914,8 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_PopCountL:
       return UsePopCountInstruction;
 
+    case Op_ReverseBytesI:
+    case Op_ReverseBytesL:
     case Op_RotateRight:
     case Op_RotateLeft:
     case Op_CountLeadingZerosI:
@@ -1921,6 +1923,7 @@ bool Matcher::match_rule_supported(int opcode) {
     case Op_CountTrailingZerosI:
     case Op_CountTrailingZerosL:
       return UseZbb;
+
     case Op_FmaF:
     case Op_FmaD:
     case Op_FmaVF:
@@ -7855,34 +7858,6 @@ instruct xorL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
 
 // ============================================================================
 // BSWAP Instructions
-
-instruct bytes_reverse_int(iRegINoSp dst, iRegIorL2I src, rFlagsReg cr) %{
-  match(Set dst (ReverseBytesI src));
-  effect(KILL cr);
-
-  ins_cost(ALU_COST * 13);
-  format %{ "revb_w_w  $dst, $src\t#@bytes_reverse_int" %}
-
-  ins_encode %{
-    __ revb_w_w(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(pipe_class_default);
-%}
-
-instruct bytes_reverse_long(iRegLNoSp dst, iRegL src, rFlagsReg cr) %{
-  match(Set dst (ReverseBytesL src));
-  effect(KILL cr);
-
-  ins_cost(ALU_COST * 29);
-  format %{ "revb  $dst, $src\t#@bytes_reverse_long" %}
-
-  ins_encode %{
-    __ revb(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(pipe_class_default);
-%}
 
 instruct bytes_reverse_unsigned_short(iRegINoSp dst, iRegIorL2I src) %{
   match(Set dst (ReverseBytesUS src));

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -178,13 +178,13 @@ instruct convI2UL_reg_reg_b(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
 
 // BSWAP instructions
 instruct bytes_reverse_int_b(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseZbb);
   match(Set dst (ReverseBytesI src));
 
   ins_cost(ALU_COST * 2);
   format %{ "revb_w_w  $dst, $src\t#@bytes_reverse_int_b" %}
 
   ins_encode %{
+    assert(UseZbb, "must be");
     __ revb_w_w(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
@@ -192,13 +192,13 @@ instruct bytes_reverse_int_b(iRegINoSp dst, iRegIorL2I src) %{
 %}
 
 instruct bytes_reverse_long_b(iRegLNoSp dst, iRegL src) %{
-  predicate(UseZbb);
   match(Set dst (ReverseBytesL src));
 
   ins_cost(ALU_COST);
   format %{ "rev8  $dst, $src\t#@bytes_reverse_long_b" %}
 
   ins_encode %{
+    assert(UseZbb, "must be");
     __ rev8(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 


### PR DESCRIPTION
Hi,
Can you help to review the patch?

The test data below shows that, if zbb is not supported on current hardware, then intrinsic brings perf regression rather than benefit.
So, ReverseBytesI/L should only be enabled when zbb is supported.

## Test data
existing benchmark:
test/micro/org/openjdk/bench/java/lang/Longs.java, reverseBytes()
test/micro/org/openjdk/bench/java/lang/Integers.java, reverseBytes()

all tests running below with rvv disabled.
tested on K230-CanMV

1. -XX:-UseZbb, intrinsic enabled by default
o.o.b.j.lang.Integers.reverseBytes N/A 500 avgt 6128.125 ns/op
o.o.b.j.lang.Longs.reverseBytes N/A 500 avgt 10807.930 ns/op

2. -XX:+UseZbb, intrinsic enabled by default
o.o.b.j.lang.Integers.reverseBytes N/A 500 avgt 1788.990 ns/op
o.o.b.j.lang.Longs.reverseBytes N/A 500 avgt 1113.734 ns/op

3. -XX:-UseZbb, and disable ReverseBytesI/L instrinsic
o.o.b.j.lang.Integers.reverseBytes N/A 500 avgt 3552.902 ns/op
o.o.b.j.lang.Longs.reverseBytes N/A 500 avgt 4586.980 ns/op

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334396](https://bugs.openjdk.org/browse/JDK-8334396): RISC-V: verify perf of ReverseBytesI/L (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19750/head:pull/19750` \
`$ git checkout pull/19750`

Update a local copy of the PR: \
`$ git checkout pull/19750` \
`$ git pull https://git.openjdk.org/jdk.git pull/19750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19750`

View PR using the GUI difftool: \
`$ git pr show -t 19750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19750.diff">https://git.openjdk.org/jdk/pull/19750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19750#issuecomment-2173607463)