### PR TITLE
8333804: java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures

### DIFF
--- a/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
+++ b/test/jdk/java/net/httpclient/ForbiddenHeadTest.java
@@ -381,7 +381,7 @@ public class ForbiddenHeadTest implements HttpServerAdapters {
     public void teardown() throws Exception {
         authClient = noAuthClient = null;
         Thread.sleep(100);
-        AssertionError fail = TRACKER.check(500);
+        AssertionError fail = TRACKER.check(1500);
         try {
             proxy.stop();
             authproxy.stop();


### PR DESCRIPTION
This is a trivial one liner bug fix in a test class to improve test stability. The backport is a clean backport.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333804](https://bugs.openjdk.org/browse/JDK-8333804): java/net/httpclient/ForbiddenHeadTest.java threw an exception with 0 failures (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19751/head:pull/19751` \
`$ git checkout pull/19751`

Update a local copy of the PR: \
`$ git checkout pull/19751` \
`$ git pull https://git.openjdk.org/jdk.git pull/19751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19751`

View PR using the GUI difftool: \
`$ git pr show -t 19751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19751.diff">https://git.openjdk.org/jdk/pull/19751.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19751#issuecomment-2173638542)