### PR TITLE
8322882: Null pointer error when compiling Static initializer in a local class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1653,6 +1653,13 @@ public class Lower extends TreeTranslator {
     }
 //where
         JCExpression loadFreevar(DiagnosticPosition pos, VarSymbol v) {
+
+            // Verify we are not trying to access a proxy field from a static method
+            Symbol proxy = proxies.get(v);
+            if (proxy != null && proxy.owner == currentClass && currentMethodSym.isStatic())
+                log.error(pos, Errors.NonStaticCantBeRef(Kinds.kindName(v), v));
+
+            // Access symbol
             return access(v, make.at(pos).Ident(v), null, false);
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -2858,7 +2858,7 @@ compiler.err.abstract.cant.be.accessed.directly=\
     abstract {0} {1} in {2} cannot be accessed directly
 
 ## The first argument ({0}) is a "kindname".
-# 0: symbol kind, 1: symbol
+# 0: kind name, 1: symbol
 compiler.err.non-static.cant.be.ref=\
     non-static {0} {1} cannot be referenced from a static context
 

--- a/test/langtools/tools/javac/LocalFreeVarStaticInstantiate.java
+++ b/test/langtools/tools/javac/LocalFreeVarStaticInstantiate.java
@@ -1,0 +1,20 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8322882
+ * @summary Disallow attempts to access a free variable proxy field from a static method
+ * @compile/fail/ref=LocalFreeVarStaticInstantiate.out -XDrawDiagnostics LocalFreeVarStaticInstantiate.java
+ */
+
+class LocalFreeVarStaticInstantiate {
+
+    static void foo(Object there) {
+        class Local {
+            {
+                there.hashCode();
+            }
+            static {
+                new Local();    // can't get there from here
+            }
+        }
+    }
+}

--- a/test/langtools/tools/javac/LocalFreeVarStaticInstantiate.out
+++ b/test/langtools/tools/javac/LocalFreeVarStaticInstantiate.out
@@ -1,0 +1,2 @@
+LocalFreeVarStaticInstantiate.java:16:17: compiler.err.non-static.cant.be.ref: kindname.variable, there
+1 error


### PR DESCRIPTION
A local class can capture a free variable from its enclosing scope. The variable's value is passed to the local class constructor via a synthetic constructor parameter, and then stored in a synthetic proxy field in the local class. Therefore, at any point at which such a local class is instantiated, it must also be possible to access the captured free variable's value so it can be passed to the constructor.

The compiler was incorrectly assuming that within the local class itself, this would always be the case, because of the existence of the synthetic proxy field. Prior to JDK 16, local classes were not allowed to have static methods, so this was a safe assumption. However, that assumption is no longer safe, and violating results in a `NullPointerException`, for example with this class:

```java
class LocalFreeVarStaticInstantiate {
    static void foo(Object there) {
        class Local {
            {
                there.hashCode();
            }
            static {
                new Local();    // can't get there from here
            }
        }
    }
}
```

This patch adds the missing check for the situation where access to a proxy variable instance field is required for a synthetic constructor parameter, but the instantiation is occurring within a static method of the class containing the field and so the field can't be accessed.

**Note:** With this change, the following test fails to compile until Maurizio's refactoring relating to lambda's and outer instances (see "javac-pre-capture" Jira bug label) has been applied:

* `test/langtools/tools/javac/lambda/T8209407/VerifierErrorInnerPlusLambda.java`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322882](https://bugs.openjdk.org/browse/JDK-8322882): Null pointer error when compiling Static initializer in a local class (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19754/head:pull/19754` \
`$ git checkout pull/19754`

Update a local copy of the PR: \
`$ git checkout pull/19754` \
`$ git pull https://git.openjdk.org/jdk.git pull/19754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19754`

View PR using the GUI difftool: \
`$ git pr show -t 19754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19754.diff">https://git.openjdk.org/jdk/pull/19754.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19754#issuecomment-2173953613)