### PR TITLE
8334392: Switch RNG in NMT's treap

### DIFF
--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -88,12 +88,9 @@ private:
   int _node_count;
 
   uint64_t prng_next() {
-    // Taken directly off of JFRPrng
-    static const constexpr uint64_t PrngMult = 0x5DEECE66DLL;
-    static const constexpr uint64_t PrngAdd = 0xB;
-    static const constexpr uint64_t PrngModPower = 48;
-    static const constexpr uint64_t PrngModMask = (static_cast<uint64_t>(1) << PrngModPower) - 1;
-    _prng_seed = (PrngMult * _prng_seed + PrngAdd) & PrngModMask;
+    uint32_t first_half = os::next_random(static_cast<uint32_t>(_prng_seed));
+    uint32_t second_half = os::next_random(static_cast<uint32_t>(_prng_seed >> 32));
+    _prng_seed = static_cast<uint64_t>(first_half) | (static_cast<uint64_t>(second_half) << 32);
     return _prng_seed;
   }
 
@@ -173,9 +170,9 @@ private:
 #ifdef ASSERT
   void verify_self() {
     // A balanced binary search tree should have a depth on the order of log(N).
-    // We take the ceiling of log_2(N + 1) * 2.5 as our maximum bound.
+    // We take the ceiling of log_2(N + 1) * 3 as our maximum bound.
     // For comparison, a RB-tree has a proven max depth of log_2(N + 1) * 2.
-    const int expected_maximum_depth = ceil((log(this->_node_count+1) / log(2)) * 2.5);
+    const int expected_maximum_depth = ceil((log(this->_node_count+1) / log(2)) * 3);
     // Find the maximum depth through DFS and ensure that the priority invariant holds.
     int maximum_depth_found = 0;
 

--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -25,13 +25,12 @@
 #ifndef SHARE_NMT_NMTTREAP_HPP
 #define SHARE_NMT_NMTTREAP_HPP
 
-#include "memory/allocation.hpp"
 #include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
-#include <stdint.h>
+#include "utilities/powerOfTwo.hpp"
 
 // A Treap is a self-balanced binary tree where each node is equipped with a
 // priority. It adds the invariant that the priority of a parent P is strictly larger
@@ -84,13 +83,15 @@ public:
 private:
   ALLOCATOR _allocator;
   TreapNode* _root;
+
+  static constexpr const uint64_t _initial_seed = 0x123456789ABCDEF;
   uint64_t _prng_seed;
   int _node_count;
 
   uint64_t prng_next() {
-    uint32_t first_half = os::next_random(static_cast<uint32_t>(_prng_seed));
-    uint32_t second_half = os::next_random(static_cast<uint32_t>(_prng_seed >> 32));
-    _prng_seed = static_cast<uint64_t>(first_half) | (static_cast<uint64_t>(second_half) << 32);
+    uint64_t first_half = os::next_random(_prng_seed);
+    uint64_t second_half = os::next_random(_prng_seed >> 32);
+    _prng_seed = first_half | (second_half << 32);
     return _prng_seed;
   }
 
@@ -172,7 +173,7 @@ private:
     // A balanced binary search tree should have a depth on the order of log(N).
     // We take the ceiling of log_2(N + 1) * 3 as our maximum bound.
     // For comparison, a RB-tree has a proven max depth of log_2(N + 1) * 2.
-    const int expected_maximum_depth = ceil((log(this->_node_count+1) / log(2)) * 3);
+    const int expected_maximum_depth = ceil(log2i(this->_node_count+1) * 3);
     // Find the maximum depth through DFS and ensure that the priority invariant holds.
     int maximum_depth_found = 0;
 
@@ -222,11 +223,10 @@ private:
 public:
   NONCOPYABLE(Treap);
 
-  Treap(uint64_t seed = static_cast<uint64_t>(os::random())
-                        | (static_cast<uint64_t>(os::random()) << 32))
+  Treap()
   : _allocator(),
     _root(nullptr),
-    _prng_seed(seed),
+    _prng_seed(_initial_seed),
     _node_count(0) {}
 
   ~Treap() {

--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -84,7 +84,8 @@ private:
   ALLOCATOR _allocator;
   TreapNode* _root;
 
-  static constexpr const uint64_t _initial_seed = 0x123456789ABCDEF;
+  // A random number
+  static constexpr const uint64_t _initial_seed = 0xC8DD2114AE0543A3;
   uint64_t _prng_seed;
   int _node_count;
 

--- a/test/hotspot/gtest/nmt/test_nmt_treap.cpp
+++ b/test/hotspot/gtest/nmt/test_nmt_treap.cpp
@@ -300,7 +300,9 @@ TEST_VM_F(TreapTest, VerifyItThroughStressTest) {
       } else {
         treap.remove(i);
       }
-      verify_it(treap);
+      if (i % 100 == 0) {
+        verify_it(treap);
+      }
     }
     for (int i = 0; i < ten_thousand; i++) {
       int r = os::random();
@@ -309,14 +311,16 @@ TEST_VM_F(TreapTest, VerifyItThroughStressTest) {
       } else {
         treap.remove(i);
       }
-      verify_it(treap);
+      if (i % 100 == 0) {
+        verify_it(treap);
+      }
     }
   }
   { // Make a very large treap and verify at the end
   struct Nothing {};
     TreapCHeap<int, Nothing, Cmp> treap;
-    constexpr const int five_million = 5000000;
-    for (int i = 0; i < five_million; i++) {
+    constexpr const int one_hundred_thousand = 100000;
+    for (int i = 0; i < one_hundred_thousand; i++) {
       treap.upsert(i, Nothing());
     }
     verify_it(treap);


### PR DESCRIPTION
Hi,

We've seen some behavior where the Treap's depth is slightly out of bounds (seen: 62 for 5 000 000 nodes) for what is expected. This PR does a couple of things to remedy that:

1. Nudge the factor upwards a bit to `3`, `log_2(N + 1)*2.5 + 3` may simply be too tight of a bound.
2. Remove the JFR prng and just do two `os::next_random` to fill out an unsigned 64-bit priority.

I ran the `5 000 000` node stress test 50 times, only seeing a maximum depth of 58. I also ran (only once) the test for some larger node amounts. These are my findings in a table:

```
5 000 000
58 (x50)
Factor: 2.606
10 000 000
61
Factor: 2.6232
20 000 000
68
Factor: 2.8037
50 000 000
69
Factor: 2.6979

Where "factor" is the factor necessary to multiply log_2(N + 1) with to hit that number.
```

Our Treap is currently implemented using two recursive methods: `split` and `merge.` They take up `80` and `48` bytes of stack space per frame, respectively. That means that a call depth of 69 would imply 5.4KiB of stack space for split and 3.3KiB of stack space for merge. Looking at our thread stack defaults, that is not a lot and leaves a lot of activity left on the stack for others :-).

All the best,
Johan

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334392](https://bugs.openjdk.org/browse/JDK-8334392): Switch RNG in NMT's treap (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Afshin Zafari](https://openjdk.org/census#azafari) (@afshin-zafari - Committer) ⚠️ Review applies to [56373240](https://git.openjdk.org/jdk/pull/19756/files/56373240937d350bf8ee83e83c77969ffb8a4fd1)
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19756/head:pull/19756` \
`$ git checkout pull/19756`

Update a local copy of the PR: \
`$ git checkout pull/19756` \
`$ git pull https://git.openjdk.org/jdk.git pull/19756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19756`

View PR using the GUI difftool: \
`$ git pr show -t 19756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19756.diff">https://git.openjdk.org/jdk/pull/19756.diff</a>

</details>
