### PR TITLE
8331675: gtest CollectorPolicy.young_min_ergo_vm fails after 8272364

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -213,18 +213,6 @@ class TestGenCollectorPolicy {
 // verify that there are some basic rules for NewSize honored by the policies.
 
 // If NewSize has been ergonomically set, the collector policy
-// should use it for min
-// This test doesn't work with 64k pages. See JDK-8331675.
-#if !defined(PPC)
-TEST_VM(CollectorPolicy, young_min_ergo) {
-  TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
-  TestGenCollectorPolicy::CheckYoungMin checker(20 * M);
-
-  TestGenCollectorPolicy::TestWrapper::test(&setter, &checker);
-}
-#endif
-
-// If NewSize has been ergonomically set, the collector policy
 // should use it for min but calculate the initial young size
 // using NewRatio.
 TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8331675](https://bugs.openjdk.org/browse/JDK-8331675), commit [badf1cb9](https://github.com/openjdk/jdk/commit/badf1cb9ce9dcae6cca92046f7cc1231067ca799) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Albert Mingkun Yang on 11 Jun 2024 and was reviewed by Thomas Schatzl, Zhengyu Gu and Guoxiong Li.

It removes a questionable test that was even failing on PowerPC.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8331675: gtest CollectorPolicy.young_min_ergo_vm fails after 8272364`

### Issue
 * [JDK-8331675](https://bugs.openjdk.org/browse/JDK-8331675): gtest CollectorPolicy.young_min_ergo_vm fails after 8272364 (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19759/head:pull/19759` \
`$ git checkout pull/19759`

Update a local copy of the PR: \
`$ git checkout pull/19759` \
`$ git pull https://git.openjdk.org/jdk.git pull/19759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19759`

View PR using the GUI difftool: \
`$ git pr show -t 19759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19759.diff">https://git.openjdk.org/jdk/pull/19759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19759#issuecomment-2175391112)