### PR TITLE
8334402: ProblemList test/hotspot/jtreg/compiler/c2/TestMergeStores.java on big endian platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -64,6 +64,8 @@ compiler/rtm/locking/TestUseRTMXendForLockBusy.java 8183263 generic-x64,generic-
 compiler/rtm/print/TestPrintPreciseRTMLockingStatistics.java 8183263 generic-x64,generic-i586
 
 compiler/c2/Test8004741.java 8235801 generic-all
+compiler/c2/TestMergeStores.java#id0 8331311 generic-ppc64,linux-s390x
+compiler/c2/TestMergeStores.java#id1 8331311 generic-ppc64,linux-s390x
 compiler/c2/irTests/TestDuplicateBackedge.java 8318904 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all


### PR DESCRIPTION
This PR excludes the test test/hotspot/jtreg/compiler/c2/TestMergeStores.java in jdk 23 on big endian platforms.

It fails because [JDK-8318446](https://bugs.openjdk.org/browse/JDK-8318446) is only implemented for little endian platforms in jdk 23.

[JDK-8331311](https://bugs.openjdk.org/browse/JDK-8331311) is the big endian port. It will likely not be backported to jdk 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334402](https://bugs.openjdk.org/browse/JDK-8334402): ProblemList test/hotspot/jtreg/compiler/c2/TestMergeStores.java on big endian platforms (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19761/head:pull/19761` \
`$ git checkout pull/19761`

Update a local copy of the PR: \
`$ git checkout pull/19761` \
`$ git pull https://git.openjdk.org/jdk.git pull/19761/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19761`

View PR using the GUI difftool: \
`$ git pr show -t 19761`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19761.diff">https://git.openjdk.org/jdk/pull/19761.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19761#issuecomment-2175545812)