### PR TITLE
8334442: Temporarily disable return type assertion to reduce noise in testing

### DIFF
--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1057,16 +1057,6 @@ void Parse::do_exits() {
       // loading.  It could also be due to an error, so mark this method as not compilable because
       // otherwise this could lead to an infinite compile loop.
       // In any case, this code path is rarely (and never in my testing) reached.
-#ifdef ASSERT
-      tty->print_cr("# Can't determine return type.");
-      tty->print_cr("# exit control");
-      _exits.control()->dump(2);
-      tty->print_cr("# ret phi type");
-      _gvn.type(ret_phi)->dump();
-      tty->print_cr("# ret phi");
-      ret_phi->dump(2);
-#endif // ASSERT
-      assert(false, "Can't determine return type.");
       C->record_method_not_compilable("Can't determine return type.");
       return;
     }


### PR DESCRIPTION
This changeset disables the following assertion and its associated information dump temporarily, to reduce noise in the testing pipelines while the root cause of its failures is investigated in [JDK-8305185](https://bugs.openjdk.org/browse/JDK-8305185):

```
# Internal Error (src/hotspot/share/opto/parse1.cpp:1051)
# assert(false) failed: Can't determine return type.
```
Note that the unexpected condition catched by the assertion is harmless (other than potentially causing a performance degradation) because it always results in a compilation bailout.

**Testing:** tier1 (x64 and aaarch64; linux, windows, and macosx; release and debug mode)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334442](https://bugs.openjdk.org/browse/JDK-8334442): Temporarily disable return type assertion to reduce noise in testing (**Sub-task** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19762/head:pull/19762` \
`$ git checkout pull/19762`

Update a local copy of the PR: \
`$ git checkout pull/19762` \
`$ git pull https://git.openjdk.org/jdk.git pull/19762/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19762`

View PR using the GUI difftool: \
`$ git pr show -t 19762`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19762.diff">https://git.openjdk.org/jdk/pull/19762.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19762#issuecomment-2175563898)