### PR TITLE
8324841: PKCS11 tests still skip execution

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -791,8 +791,8 @@ public abstract class PKCS11Test {
                 (tp, attr) -> tp.getFileName().equals(libraryName))) {
 
             return files.findAny()
-                        .orElseThrow(() -> new SkippedException(
-                        "NSS library \"" + libraryName + "\" was not found in " + path));
+                        .orElseThrow(() ->
+                            new RuntimeException("NSS library \"" + libraryName + "\" was not found in " + path));
         }
     }
 


### PR DESCRIPTION
In this PR, I updated PKCS11Test to throw a RuntimeException if the NSS binaries are not found in a directory specified with the property jdk.test.lib.artifacts.nsslib-<platform>.  If the property is not specified, the tests will throw a SkippedException.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324841](https://bugs.openjdk.org/browse/JDK-8324841): PKCS11 tests still skip execution (**Bug** - P4)(⚠️ The fixVersion in this issue is [23] but the fixVersion in .jcheck/conf is 24, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19767/head:pull/19767` \
`$ git checkout pull/19767`

Update a local copy of the PR: \
`$ git checkout pull/19767` \
`$ git pull https://git.openjdk.org/jdk.git pull/19767/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19767`

View PR using the GUI difftool: \
`$ git pr show -t 19767`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19767.diff">https://git.openjdk.org/jdk/pull/19767.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19767#issuecomment-2175963612)