### PR TITLE
8332717: ZGC: Division by zero in heuristics

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -524,6 +524,10 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 }
 
 static double calculate_young_to_old_worker_ratio(const ZDirectorStats& stats) {
+  if (!stats._old_stats._cycle._is_time_trustable) {
+    return 1.0;
+  }
+
   const double young_gc_time = gc_time(stats._young_stats);
   const double old_gc_time = gc_time(stats._old_stats);
   const size_t reclaimed_per_young_gc = stats._young_stats._stat_heap._reclaimed_avg;


### PR DESCRIPTION
Before we have run the first major collection, the "time to perform GC" is considered not stable. We missed once such check when computing how many old GC threads we should use compared to young GC threads, resulting in a division by zero when starting the first "warmup" major collection. This division by zero is detected by UBSan. I added a check for unstable times like we have in many other places, which I have verified removes the problem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332717](https://bugs.openjdk.org/browse/JDK-8332717): ZGC: Division by zero in heuristics (**Bug** - P3)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19768/head:pull/19768` \
`$ git checkout pull/19768`

Update a local copy of the PR: \
`$ git checkout pull/19768` \
`$ git pull https://git.openjdk.org/jdk.git pull/19768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19768`

View PR using the GUI difftool: \
`$ git pr show -t 19768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19768.diff">https://git.openjdk.org/jdk/pull/19768.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19768#issuecomment-2175967637)