### PR TITLE
8334371: [AIX] Beginning with AIX 7.3 TL1 mmap() supports 64K memory pages

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -67,9 +67,9 @@
 #include "services/attachListener.hpp"
 #include "services/runtimeService.hpp"
 #include "signals_posix.hpp"
-#include "utilities/debug.hpp"
 #include "utilities/align.hpp"
 #include "utilities/checkedCast.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/decoder.hpp"
 #include "utilities/defaultStream.hpp"
 #include "utilities/events.hpp"
@@ -99,7 +99,7 @@
 #include <sys/mman.h>
 // sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
 #ifndef MAP_ANON_64K
-  #define MAP_ANON_64K  0x400
+  #define MAP_ANON_64K 0x400
 #else
   STATIC_ASSERT(MAP_ANON_64K == 0x400);
 #endif
@@ -2743,6 +2743,10 @@ void os::Aix::initialize_libperfstat() {
   } else {
     trcVerbose("libperfstat initialized.");
   }
+}
+
+bool os::Aix::supports_64K_mmap_pages() {
+  return g_multipage_support.can_use_64K_mmap_pages;
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/src/hotspot/os/aix/os_aix.hpp
+++ b/src/hotspot/os/aix/os_aix.hpp
@@ -76,6 +76,7 @@ class os::Aix {
  public:
   static void init_thread_fpu_state();
   static pthread_t main_thread(void)                                { return _main_thread; }
+  static bool supports_64K_mmap_pages();
 
   // Given an address, returns the size of the page backing that address
   static size_t query_pagesize(void* p);

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -380,7 +380,7 @@ void ReservedHeapSpace::establish_noaccess_prefix() {
   if (base() && base() + _size > (char *)OopEncodingHeapMax) {
     if (true
         WIN64_ONLY(&& !UseLargePages)
-        AIX_ONLY(&& os::vm_page_size() != 64*K)) {
+        AIX_ONLY(&& (os::Aix::supports_64K_mmap_pages() || os::vm_page_size() == 4*K))) {
       // Protect memory at the base of the allocated region.
       // If special, the page was committed (only matters on windows)
       if (!os::protect_memory(_base, _noaccess_prefix, os::MEM_PROT_NONE, _special)) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1924,7 +1924,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
   const size_t system_allocation_granularity =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : 256*M)
+    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : os::Aix::supports_64K_mmap_pages() ? 64*K : 256*M)
     NOT_AIX(os::vm_allocation_granularity());
 
   const size_t alignment_adjusted = MAX2(alignment, system_allocation_granularity);

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1924,8 +1924,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
   // This is not reflected by os_allocation_granularity().
   // The logic here is dual to the one in pd_reserve_memory in os_aix.cpp
   const size_t system_allocation_granularity =
-    AIX_ONLY(os::vm_page_size() == 4*K ? 4*K : os::Aix::supports_64K_mmap_pages() ? 64*K : 256*M)
-    NOT_AIX(os::vm_allocation_granularity());
+    AIX_ONLY((!os::Aix::supports_64K_mmap_pages() && os::vm_page_size() == 64*K) ? 256*M : ) os::vm_allocation_granularity();
 
   const size_t alignment_adjusted = MAX2(alignment, system_allocation_granularity);
 

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -38,6 +38,13 @@
 #ifdef _WIN32
 #include "os_windows.hpp"
 #endif
+#ifdef AIX
+# include <sys/mman.h>
+// sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
+# ifndef MAP_ANON_64K
+# define MAP_ANON_64K  0x400
+# endif
+#endif
 
 using testing::HasSubstr;
 
@@ -955,9 +962,18 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
 }
 
 #ifdef AIX
-// On Aix, we should fail attach attempts not aligned to segment boundaries (256m)
+// On Aix, when using shmget() in os::attempt_reserve_memory_at() we should fail with attach
+// attempts not aligned to shmget() segment boundaries (256m)
+// But shmget() is only used in cases we want to have 64K pages and mmap() does not provide it.
 TEST_VM(os, aix_reserve_at_non_shmlba_aligned_address) {
-  if (Use64KPages) {
+  // Can we use mmap with 64K pages? (Should be available with AIX 7.3 TL1)
+  void* p = mmap(NULL, 1000000, PROT_READ | PROT_WRITE, MAP_ANON_64K | MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+  guarantee(p != (void*) -1, "mmap returned invalid ptr."); // Should always work.
+  bool can_use_64K_mmap_pages = (64*K == os::Aix::query_pagesize(p));
+  munmap(p, 1000000);
+
+  if (os::vm_page_size() != 4*K && !can_use_64K_mmap_pages) {
+    // With this condition true shmget() is used inside
     char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
     ASSERT_EQ(p, nullptr); // should have failed
     p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);

--- a/test/hotspot/gtest/runtime/test_os.cpp
+++ b/test/hotspot/gtest/runtime/test_os.cpp
@@ -38,13 +38,6 @@
 #ifdef _WIN32
 #include "os_windows.hpp"
 #endif
-#ifdef AIX
-# include <sys/mman.h>
-// sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
-# ifndef MAP_ANON_64K
-# define MAP_ANON_64K  0x400
-# endif
-#endif
 
 using testing::HasSubstr;
 
@@ -960,27 +953,6 @@ TEST_VM(os, reserve_at_wish_address_shall_not_replace_mappings_largepages) {
     tty->print_cr("Skipped.");
   }
 }
-
-#ifdef AIX
-// On Aix, when using shmget() in os::attempt_reserve_memory_at() we should fail with attach
-// attempts not aligned to shmget() segment boundaries (256m)
-// But shmget() is only used in cases we want to have 64K pages and mmap() does not provide it.
-TEST_VM(os, aix_reserve_at_non_shmlba_aligned_address) {
-  // Can we use mmap with 64K pages? (Should be available with AIX 7.3 TL1)
-  void* p = mmap(NULL, 1000000, PROT_READ | PROT_WRITE, MAP_ANON_64K | MAP_ANONYMOUS | MAP_SHARED, -1, 0);
-  guarantee(p != (void*) -1, "mmap returned invalid ptr."); // Should always work.
-  bool can_use_64K_mmap_pages = (64*K == os::Aix::query_pagesize(p));
-  munmap(p, 1000000);
-
-  if (os::vm_page_size() != 4*K && !can_use_64K_mmap_pages) {
-    // With this condition true shmget() is used inside
-    char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
-    ASSERT_EQ(p, nullptr); // should have failed
-    p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);
-    ASSERT_EQ(p, nullptr); // should have failed
-  }
-}
-#endif // AIX
 
 TEST_VM(os, vm_min_address) {
   size_t s = os::vm_min_address();

--- a/test/hotspot/gtest/runtime/test_os_aix.cpp
+++ b/test/hotspot/gtest/runtime/test_os_aix.cpp
@@ -29,25 +29,12 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
-#include <sys/mman.h>
-// sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
-#ifndef MAP_ANON_64K
-  #define MAP_ANON_64K  0x400
-#else
-  STATIC_ASSERT(MAP_ANON_64K == 0x400);
-#endif
 
 // On Aix, when using shmget() in os::attempt_reserve_memory_at() we should fail with attach
 // attempts not aligned to shmget() segment boundaries (256m)
 // But shmget() is only used in cases we want to have 64K pages and mmap() does not provide it.
 TEST_VM(os_aix, aix_reserve_at_non_shmlba_aligned_address) {
-  // Can we use mmap with 64K pages? (Should be available with AIX 7.3 TL1)
-  void* p = mmap(NULL, 1000000, PROT_READ | PROT_WRITE, MAP_ANON_64K | MAP_ANONYMOUS | MAP_SHARED, -1, 0);
-  guarantee(p != (void*) -1, "mmap returned invalid ptr."); // Should always work.
-  bool can_use_64K_mmap_pages = (64*K == os::Aix::query_pagesize(p));
-  munmap(p, 1000000);
-
-  if (os::vm_page_size() != 4*K && !can_use_64K_mmap_pages) {
+  if (os::vm_page_size() != 4*K && !os::Aix::supports_64K_mmap_pages()) {
     // With this condition true shmget() is used inside
     char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
     ASSERT_EQ(p, nullptr); // should have failed

--- a/test/hotspot/gtest/runtime/test_os_aix.cpp
+++ b/test/hotspot/gtest/runtime/test_os_aix.cpp
@@ -29,11 +29,13 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "unittest.hpp"
-# include <sys/mman.h>
+#include <sys/mman.h>
 // sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
-# ifndef MAP_ANON_64K
-# define MAP_ANON_64K  0x400
-# endif
+#ifndef MAP_ANON_64K
+  #define MAP_ANON_64K  0x400
+#else
+  STATIC_ASSERT(MAP_ANON_64K == 0x400);
+#endif
 
 // On Aix, when using shmget() in os::attempt_reserve_memory_at() we should fail with attach
 // attempts not aligned to shmget() segment boundaries (256m)

--- a/test/hotspot/gtest/runtime/test_os_aix.cpp
+++ b/test/hotspot/gtest/runtime/test_os_aix.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+
+#ifdef AIX
+
+#include "memory/allocation.hpp"
+#include "memory/resourceArea.hpp"
+#include "nmt/memTracker.hpp"
+#include "runtime/frame.inline.hpp"
+#include "runtime/globals.hpp"
+#include "runtime/os.inline.hpp"
+#include "runtime/thread.hpp"
+#include "runtime/threads.hpp"
+#include "utilities/align.hpp"
+#include "utilities/globalDefinitions.hpp"
+#include "utilities/macros.hpp"
+#include "utilities/ostream.hpp"
+#include "unittest.hpp"
+# include <sys/mman.h>
+// sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1
+# ifndef MAP_ANON_64K
+# define MAP_ANON_64K  0x400
+# endif
+
+// On Aix, when using shmget() in os::attempt_reserve_memory_at() we should fail with attach
+// attempts not aligned to shmget() segment boundaries (256m)
+// But shmget() is only used in cases we want to have 64K pages and mmap() does not provide it.
+TEST_VM(os_aix, aix_reserve_at_non_shmlba_aligned_address) {
+  // Can we use mmap with 64K pages? (Should be available with AIX 7.3 TL1)
+  void* p = mmap(NULL, 1000000, PROT_READ | PROT_WRITE, MAP_ANON_64K | MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+  guarantee(p != (void*) -1, "mmap returned invalid ptr."); // Should always work.
+  bool can_use_64K_mmap_pages = (64*K == os::Aix::query_pagesize(p));
+  munmap(p, 1000000);
+
+  if (os::vm_page_size() != 4*K && !can_use_64K_mmap_pages) {
+    // With this condition true shmget() is used inside
+    char* p = os::attempt_reserve_memory_at((char*)0x1f00000, M);
+    ASSERT_EQ(p, nullptr); // should have failed
+    p = os::attempt_reserve_memory_at((char*)((64 * G) + M), M);
+    ASSERT_EQ(p, nullptr); // should have failed
+  }
+}
+
+#endif // AIX

--- a/test/hotspot/gtest/runtime/test_os_aix.cpp
+++ b/test/hotspot/gtest/runtime/test_os_aix.cpp
@@ -25,18 +25,9 @@
 
 #ifdef AIX
 
-#include "memory/allocation.hpp"
-#include "memory/resourceArea.hpp"
-#include "nmt/memTracker.hpp"
-#include "runtime/frame.inline.hpp"
-#include "runtime/globals.hpp"
 #include "runtime/os.inline.hpp"
-#include "runtime/thread.hpp"
-#include "runtime/threads.hpp"
-#include "utilities/align.hpp"
+#include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
-#include "utilities/macros.hpp"
-#include "utilities/ostream.hpp"
 #include "unittest.hpp"
 # include <sys/mman.h>
 // sys/mman.h defines MAP_ANON_64K beginning with AIX7.3 TL1


### PR DESCRIPTION
Beginning with AIX 7.3 TL1 mmap() supports 64K memory pages. As an enhancement, during the initialization of the VM the availability of this new feature is examined. If the 64K pages are supported the VM will use mmap() with 64K pages instead of shmget()/shmat() with 64K pages due to the bad 256M alignment of shmget()/shmat().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334371](https://bugs.openjdk.org/browse/JDK-8334371): [AIX] Beginning with AIX 7.3 TL1 mmap() supports 64K memory pages (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) 🔄 Re-review required (review applies to [cd15f133](https://git.openjdk.org/jdk/pull/19771/files/cd15f13396d6a927149a030d5d36f82f7d9b7e37))
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19771/head:pull/19771` \
`$ git checkout pull/19771`

Update a local copy of the PR: \
`$ git checkout pull/19771` \
`$ git pull https://git.openjdk.org/jdk.git pull/19771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19771`

View PR using the GUI difftool: \
`$ git pr show -t 19771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19771.diff">https://git.openjdk.org/jdk/pull/19771.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19771#issuecomment-2176165072)