### PR TITLE
8334299: Deprecate LockingMode option, along with LM_LEGACY and LM_MONITOR

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1814,6 +1814,15 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
+  if (UseHeavyMonitors) {
+    if (FLAG_IS_CMDLINE(LockingMode) && LockingMode != LM_MONITOR) {
+      jio_fprintf(defaultStream::error_stream(),
+                  "Conflicting -XX:+UseHeavyMonitors and -XX:LockingMode=%d flags\n", LockingMode);
+      return false;
+    }
+    FLAG_SET_CMDLINE(LockingMode, LM_MONITOR);
+  }
+
 #if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64) && !defined(S390)
   if (LockingMode == LM_MONITOR) {
     jio_fprintf(defaultStream::error_stream(),

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -506,6 +506,7 @@ static SpecialFlag const special_jvm_flags[] = {
   { "PreserveAllAnnotations",       JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseNotificationThread",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseEmptySlotsInSupers",        JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
+  { "LockingMode",                  JDK_Version::jdk(24), JDK_Version::jdk(26), JDK_Version::jdk(27) },
   // --- Deprecated alias flags (see also aliased_jvm_flags) - sorted by obsolete_in then expired_in:
   { "CreateMinidumpOnCrash",        JDK_Version::jdk(9),  JDK_Version::undefined(), JDK_Version::undefined() },
 

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1050,9 +1050,13 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
+  develop(bool, UseHeavyMonitors, false,                                    \
+          "(Deprecated) Use heavyweight instead of lightweight Java "       \
+          "monitors")                                                       \
+                                                                            \
   develop(bool, VerifyHeavyMonitors, false,                                 \
           "Checks that no stack locking happens when using "                \
-          "-XX:LockingMode=0 (LM_MONITOR)")                                 \
+          "+UseHeavyMonitors")                                              \
                                                                             \
   product(bool, PrintStringTableStatistics, false,                          \
           "print statistics about the StringTable and SymbolTable")         \

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -1050,9 +1050,8 @@ const int ObjectAlignmentInBytes = 8;
   product(bool, ErrorFileToStdout, false,                                   \
           "If true, error data is printed to stdout instead of a file")     \
                                                                             \
-  develop(bool, UseHeavyMonitors, false,                                    \
-          "(Deprecated) Use heavyweight instead of lightweight Java "       \
-          "monitors")                                                       \
+  product(bool, UseHeavyMonitors, false, DIAGNOSTIC,                        \
+          "Use heavyweight instead of lightweight Java monitors")           \
                                                                             \
   develop(bool, VerifyHeavyMonitors, false,                                 \
           "Checks that no stack locking happens when using "                \
@@ -1965,9 +1964,9 @@ const int ObjectAlignmentInBytes = 8;
              "fence. Add cleanliness checks.")                              \
                                                                             \
   product(int, LockingMode, LM_LIGHTWEIGHT,                                 \
-          "Select locking mode: "                                           \
-          "0: monitors only (LM_MONITOR), "                                 \
-          "1: monitors & legacy stack-locking (LM_LEGACY), "                \
+          "(Deprecated) Select locking mode: "                              \
+          "0: (Deprecated) monitors only (LM_MONITOR), "                    \
+          "1: (Deprecated) monitors & legacy stack-locking (LM_LEGACY), "   \
           "2: monitors & new lightweight locking (LM_LIGHTWEIGHT, default)") \
           range(0, 2)                                                       \
                                                                             \

--- a/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMDeprecatedOptions.java
@@ -58,6 +58,7 @@ public class VMDeprecatedOptions {
             // deprecated non-alias flags:
             {"AllowRedefinitionToAddDeleteMethods", "true"},
             {"ZGenerational", "false"},
+            {"LockingMode", "1"},
 
             // deprecated alias flags (see also aliased_jvm_flags):
             {"CreateMinidumpOnCrash", "false"}

--- a/test/hotspot/jtreg/runtime/Monitor/ConcurrentDeflation.java
+++ b/test/hotspot/jtreg/runtime/Monitor/ConcurrentDeflation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import java.lang.management.ThreadMXBean;
  * @bug 8318757
  * @summary Test concurrent monitor deflation by MonitorDeflationThread and thread dumping
  * @library /test/lib
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:GuaranteedAsyncDeflationInterval=2000 -XX:LockingMode=0 ConcurrentDeflation
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:GuaranteedAsyncDeflationInterval=2000 -XX:+UseHeavyMonitors ConcurrentDeflation
  */
 
 public class ConcurrentDeflation {

--- a/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
+++ b/test/jdk/java/lang/Thread/virtual/CarrierThreadWaits.java
@@ -34,7 +34,7 @@
  * @test
  * @requires vm.continuations & vm.debug
  * @modules java.base/java.lang:+open
- * @run junit/othervm -XX:LockingMode=0 CarrierThreadWaits
+ * @run junit/othervm -XX:+UseHeavyMonitors CarrierThreadWaits
  */
 
 import java.lang.management.LockInfo;

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
@@ -51,7 +51,7 @@
  * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64" | os.arch == "s390x"
  * @requires vm.debug
  * @library /test/lib
- * @run main/othervm/timeout=1600 -XX:LockingMode=0 -XX:+VerifyHeavyMonitors MapLoops
+ * @run main/othervm/timeout=1600 -XX:+UseHeavyMonitors -XX:+VerifyHeavyMonitors MapLoops
  */
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;


### PR DESCRIPTION
$ java -XX:LockingMode=2 -version
Java HotSpot(TM) 64-Bit Server VM warning: Option LockingMode was deprecated in version 24.0 and will likely be removed in a future release.
java version "24-internal" 2025-03-18
Java(TM) SE Runtime Environment (fastdebug build 24-internal-2024-06-14-1243167.cphillim...)
Java HotSpot(TM) 64-Bit Server VM (fastdebug build 24-internal-2024-06-14-1243167.cphillim..., mixed mode, sharing)

This patch also reintroduces the UseHeavyMonitors option as a DIAGNOSTIC option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8334496](https://bugs.openjdk.org/browse/JDK-8334496) to be approved

### Issues
 * [JDK-8334299](https://bugs.openjdk.org/browse/JDK-8334299): Deprecate LockingMode option, along with LM_LEGACY and LM_MONITOR (**Enhancement** - P4)
 * [JDK-8334496](https://bugs.openjdk.org/browse/JDK-8334496): Deprecate LockingMode option, along with LM_LEGACY and LM_MONITOR (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19779/head:pull/19779` \
`$ git checkout pull/19779`

Update a local copy of the PR: \
`$ git checkout pull/19779` \
`$ git pull https://git.openjdk.org/jdk.git pull/19779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19779`

View PR using the GUI difftool: \
`$ git pr show -t 19779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19779.diff">https://git.openjdk.org/jdk/pull/19779.diff</a>

</details>
