### PR TITLE
8334169: Long arguments of attach operation are silently truncated on Windows

### DIFF
--- a/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
@@ -54,7 +54,7 @@ typedef jint (WINAPI* EnqueueOperationFunc)
 static HANDLE
 doPrivilegedOpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId);
 
-/* Convert jstring to C string, returns JNI_FALSE if the string has been truncated. */
+/* Converts jstring to C string, returns JNI_FALSE if the string has been truncated. */
 static jboolean jstring_to_cstring(JNIEnv* env, jstring jstr, char* cstr, int len);
 
 
@@ -618,7 +618,7 @@ doPrivilegedOpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProc
     return hProcess;
 }
 
-/* Convert jstring to C string, returns JNI_FALSE if the string has been truncated. */
+/* Converts jstring to C string, returns JNI_FALSE if the string has been truncated. */
 static jboolean jstring_to_cstring(JNIEnv* env, jstring jstr, char* cstr, int len) {
     jboolean isCopy;
     const char* str;

--- a/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Tests that long arguments of attach operation are not truncated
+ * @bug 8334168
+ * @library /test/lib
+ * @modules jdk.attach/sun.tools.attach
+ * @run main LongArgTest
+ */
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.InputStream;
+import java.io.IOException;
+
+import com.sun.tools.attach.VirtualMachine;
+import sun.tools.attach.HotSpotVirtualMachine;
+
+import jdk.test.lib.apps.LingeredApp;
+
+public class LongArgTest {
+
+    public static void main(String[] args) throws Exception {
+        LingeredApp app = null;
+        try {
+            app = LingeredApp.startApp();
+
+            test(app).run();
+
+            test(app)
+                .withLongValue()
+                .run();
+
+            test(app)
+                .withSuperLongValue()
+                .run();
+
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+
+    }
+
+    // For simplicity, the test uses internal HotSpotVirtualMachine,
+    // sets/gets "HeapDumpPath" flag value (string flag, not validated by JVM).
+    private static class Test {
+        private LingeredApp app;
+        private String flagName = "HeapDumpPath";
+        private String flagValue = generateValue(5);
+
+        Test(LingeredApp app) {
+            this.app = app;
+        }
+
+        // Value length exceeds 1K.
+        Test withLongValue() {
+            flagValue = generateValue(1024 + 1);
+            return this;
+        }
+
+        // Value length exceeds 3K (1K * 3 args).
+        Test withSuperLongValue() {
+            flagValue = generateValue(3 * 1024 + 1);
+            return this;
+        }
+
+        void run() throws Exception {
+            System.out.println("======== Start ========");
+
+            HotSpotVirtualMachine vm = (HotSpotVirtualMachine)VirtualMachine.attach(String.valueOf(app.getPid()));
+
+            if (setFlag(vm)) {
+                String actualValue = getFlag(vm);
+
+                if (!flagValue.equals(actualValue)) {
+                    String msg = "Actual values is different: "
+                                + (actualValue == null
+                                    ? "null"
+                                    : ("size is " + actualValue.length() + " instead of " + flagValue.length()));
+                    System.out.println(msg);
+                    vm.detach();
+                    throw new RuntimeException(msg);
+                } else {
+                    System.out.println("Actual value matches: " + actualValue);
+                }
+            }
+
+            vm.detach();
+
+            System.out.println("======== End ========");
+            System.out.println();
+        }
+
+        // Sets the flag value, return true on success.
+        private boolean setFlag(HotSpotVirtualMachine vm) throws Exception {
+            BufferedReader replyReader = null;
+            try {
+                replyReader = new BufferedReader(new InputStreamReader(
+                    vm.setFlag(flagName, flagValue)));
+            } catch (IOException ex) {
+                System.out.println("OK: setFlag() thrown exception:");
+                ex.printStackTrace(System.out);
+                return false;
+            }
+
+            String line;
+            while ((line = replyReader.readLine()) != null) {
+                System.out.println("setFlag: " + line);
+            }
+            replyReader.close();
+            return true;
+        }
+
+        private String getFlag(HotSpotVirtualMachine vm) throws Exception {
+            // Then read and make sure we get back the same value.
+            BufferedReader replyReader = new BufferedReader(new InputStreamReader(vm.printFlag(flagName)));
+
+            String prefix = "-XX:" + flagName + "=";
+            String value = null;
+            String line;
+            while((line = replyReader.readLine()) != null) {
+                System.out.println("getFlag: " + line);
+                if (line.startsWith(prefix)) {
+                    value = line.substring(prefix.length());
+                }
+            }
+            return value;
+        }
+
+        private String generateValue(int len) {
+            return "X" + "A".repeat(len) + "X";
+        }
+    }
+
+    private static Test test(LingeredApp app) {
+        return new Test(app);
+    }
+
+}

--- a/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
@@ -95,10 +95,14 @@ public class LongArgTest {
                 String actualValue = getFlag(vm);
 
                 if (!flagValue.equals(actualValue)) {
-                    String msg = "Actual values is different: "
-                                + (actualValue == null
-                                    ? "null"
-                                    : ("size is " + actualValue.length() + " instead of " + flagValue.length()));
+                    String msg = "Actual value is different: ";
+                    if (actualValue == null) {
+                        msg += "null";
+                    } else if (flagValue.startsWith(actualValue)) {
+                        msg += "truncated from " + flagValue.length() + " to " + actualValue.length();
+                    } else {
+                        msg += actualValue + ", expected value: " + flagValue;
+                    }
                     System.out.println(msg);
                     vm.detach();
                     throw new RuntimeException(msg);


### PR DESCRIPTION
The change fixes a bug in Attach API implementation on Windows when argument(s) are longer than 1023 bytes

testing: test/hotspot/jtreg/serviceability/attach, test/jdk/com/sun/tools/attach on Oracle supported platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334169](https://bugs.openjdk.org/browse/JDK-8334169): Long arguments of attach operation are silently truncated on Windows (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19780/head:pull/19780` \
`$ git checkout pull/19780`

Update a local copy of the PR: \
`$ git checkout pull/19780` \
`$ git pull https://git.openjdk.org/jdk.git pull/19780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19780`

View PR using the GUI difftool: \
`$ git pr show -t 19780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19780.diff">https://git.openjdk.org/jdk/pull/19780.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19780#issuecomment-2177374431)