### PR TITLE
8334043: VerifyError when inner class is accessed in prologue

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -3861,7 +3861,20 @@ public class Resolve {
 
         // Get the symbol's qualifier, if any
         JCExpression lhs = TreeInfo.skipParens(assign.lhs);
-        JCExpression base = lhs instanceof JCFieldAccess select ? select.selected : null;
+        JCExpression base;
+        switch (lhs.getTag()) {
+        case IDENT:
+            base = null;
+            break;
+        case SELECT:
+            JCFieldAccess select = (JCFieldAccess)lhs;
+            base = select.selected;
+            if (!TreeInfo.isExplicitThisReference(types, (ClassType)env.enclClass.type, base))
+                return false;
+            break;
+        default:
+            return false;
+        }
 
         // If an early reference, the field must not be declared in a superclass
         if (isEarlyReference(env, base, v) && v.owner != env.enclClass.sym)

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignments.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignments.java
@@ -158,4 +158,15 @@ public class EarlyAssignments {
             super();
         }
     }
+
+    public static class Inner8 {
+        class Inner8a {
+            int x;
+        }
+
+        public Inner8() {
+            this.new Inner8a().x = 1;           // FAIL - illegal early access
+            super();
+        }
+    }
 }

--- a/test/langtools/tools/javac/SuperInit/EarlyAssignments.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyAssignments.out
@@ -23,6 +23,7 @@ EarlyAssignments.java:134:17: compiler.err.cant.ref.before.ctor.called: super
 EarlyAssignments.java:139:23: compiler.err.cant.ref.before.ctor.called: this
 EarlyAssignments.java:148:13: compiler.err.cant.assign.initialized.before.ctor.called: x
 EarlyAssignments.java:157:13: compiler.err.cant.assign.val.to.var: final, x
+EarlyAssignments.java:168:13: compiler.err.cant.ref.before.ctor.called: this
 - compiler.note.preview.filename: EarlyAssignments.java, DEFAULT
 - compiler.note.preview.recompile
-25 errors
+26 errors


### PR DESCRIPTION
clean backport of JDK-8334043

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334043](https://bugs.openjdk.org/browse/JDK-8334043): VerifyError when inner class is accessed in prologue (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19783/head:pull/19783` \
`$ git checkout pull/19783`

Update a local copy of the PR: \
`$ git checkout pull/19783` \
`$ git pull https://git.openjdk.org/jdk.git pull/19783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19783`

View PR using the GUI difftool: \
`$ git pr show -t 19783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19783.diff">https://git.openjdk.org/jdk/pull/19783.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19783#issuecomment-2177474029)