### PR TITLE
8334505: RISC-V: Several tests fail when MaxVectorSize does not match VM_Version::_initial_vector_length

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -328,7 +328,8 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
   } else {
     if (!FLAG_IS_DEFAULT(MaxVectorSize) && MaxVectorSize != _initial_vector_length) {
-      warning("Current system does not support RVV vector length for MaxVectorSize %d. Set MaxVectorSize to %d", (int)MaxVectorSize, _initial_vector_length);
+      warning("Current system does not support RVV vector length for MaxVectorSize %d.
+               Set MaxVectorSize to %d", (int)MaxVectorSize, _initial_vector_length);
     }
     MaxVectorSize = _initial_vector_length;
     if (MaxVectorSize < 16) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -328,7 +328,7 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
   } else {
     if (!FLAG_IS_DEFAULT(MaxVectorSize) && MaxVectorSize != _initial_vector_length) {
-      warning("MaxVectorSize is set to %i on this platform", _initial_vector_length);
+      warning("Current system does not support RVV vector length for MaxVectorSize %d. Set MaxVectorSize to %d", (int)MaxVectorSize, _initial_vector_length);
     }
     MaxVectorSize = _initial_vector_length;
     if (MaxVectorSize < 16) {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -327,15 +327,10 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(MaxVectorSize, 0);
     FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
   } else {
-    if (FLAG_IS_DEFAULT(MaxVectorSize)) {
-      MaxVectorSize = _initial_vector_length;
-    } else if (!is_power_of_2(MaxVectorSize)) {
-      vm_exit_during_initialization(err_msg("Unsupported MaxVectorSize: %d, must be a power of 2", (int)MaxVectorSize));
-    } else if (MaxVectorSize > _initial_vector_length) {
-      warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",
-              _initial_vector_length, _initial_vector_length);
-      MaxVectorSize = _initial_vector_length;
+    if (!FLAG_IS_DEFAULT(MaxVectorSize) && MaxVectorSize != _initial_vector_length) {
+      warning("MaxVectorSize is set to %i on this platform", _initial_vector_length);
     }
+    MaxVectorSize = _initial_vector_length;
     if (MaxVectorSize < 16) {
       warning("RVV does not support vector length less than 16 bytes. Disabling RVV.");
       UseRVV = false;

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -328,8 +328,8 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
   } else {
     if (!FLAG_IS_DEFAULT(MaxVectorSize) && MaxVectorSize != _initial_vector_length) {
-      warning("Current system does not support RVV vector length for MaxVectorSize %d.
-               Set MaxVectorSize to %d", (int)MaxVectorSize, _initial_vector_length);
+      warning("Current system does not support RVV vector length for MaxVectorSize %d. Set MaxVectorSize to %d",
+               (int)MaxVectorSize, _initial_vector_length);
     }
     MaxVectorSize = _initial_vector_length;
     if (MaxVectorSize < 16) {


### PR DESCRIPTION
HI, It's possible to specify a MaxVectorSize which is not equal to VM_Version::_initial_vector_length on RISC-V. For example, it could happen on Banana-Pi that MaxVectorSize equals 16, while VM_Version::_initial_vector_length is 32. This may lead to several jtreg test failures, see jbs issue for exception information.

The reason for this problem is that when spill vector registers into memory, the whole width of the register is used incorrectly, and MaxVectorSize should be used to handle the number of elements spill.

https://github.com/openjdk/jdk/blob/326dbb1b139dd1ec1b8605339b91697cdf49da9a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp#L133-L136

PR propose to simply set MaxVectorSize to VM_Version::_initial_vector_length for the following reasons:
1. The CSR_VLENB register of RISC-V is read-only, we can't change it to MaxVectorSize like like aarch64.
2. It does not make sense to me to set MaxVectorSize to a value smaller than VM_Version::_initial_vector_length in the real world, which might bring negative impact on performance.
3. If MaxVectorSize equals to VM_Version::_initial_vector_length, then we can make use of vs1r_v/vl1r_v when saving and restoring vector registers, which avoids the need to control the number of elements with vsetvli.

After this patch, MaxVectorSize always equal to VM_Version::_initial_vector_length:
```
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$ ./java -XX:MaxVectorSize=16 -XX:+PrintFlagsFinal -version |grep MaxVectorSize
OpenJDK 64-Bit Server VM warning: MaxVectorSize is set to 32 on this platform
     intx MaxVectorSize                            = 32                                     {C2 product} {command line}
openjdk version "24-internal" 2025-03-18
OpenJDK Runtime Environment (fastdebug build 24-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 24-internal-adhoc.zifeihan.jdk, mixed mode)
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$ ./java -XX:MaxVectorSize=32 -XX:+PrintFlagsFinal -version |grep MaxVectorSize
     intx MaxVectorSize                            = 32                                     {C2 product} {command line}
openjdk version "24-internal" 2025-03-18
OpenJDK Runtime Environment (fastdebug build 24-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 24-internal-adhoc.zifeihan.jdk, mixed mode)
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$ ./java -XX:MaxVectorSize=64 -XX:+PrintFlagsFinal -version |grep MaxVectorSize
OpenJDK 64-Bit Server VM warning: MaxVectorSize is set to 32 on this platform
     intx MaxVectorSize                            = 32                                     {C2 product} {command line}
openjdk version "24-internal" 2025-03-18
OpenJDK Runtime Environment (fastdebug build 24-internal-adhoc.zifeihan.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 24-internal-adhoc.zifeihan.jdk, mixed mode)
zifeihan@plct-c8:~/jdk/build/linux-riscv64-server-fastdebug/jdk/bin$
```

### Testing
- [x] test/jdk/jdk/incubator/vector on Banana Pi BPI-F3 board (with RVV1.0)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334505](https://bugs.openjdk.org/browse/JDK-8334505): RISC-V: Several tests fail when MaxVectorSize does not match VM_Version::_initial_vector_length (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19785/head:pull/19785` \
`$ git checkout pull/19785`

Update a local copy of the PR: \
`$ git checkout pull/19785` \
`$ git pull https://git.openjdk.org/jdk.git pull/19785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19785`

View PR using the GUI difftool: \
`$ git pr show -t 19785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19785.diff">https://git.openjdk.org/jdk/pull/19785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19785#issuecomment-2177747303)