### PR TITLE
8334509: Cancelling PageDialog does not return the same PageFormat object

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -578,7 +578,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
          */
         if ((setup.hDevMode == NULL) && (setup.hDevNames == NULL)) {
             CLEANUP_SHOW;
-            return JNI_FALSE;
+            return doIt;
         }
     } else {
         int measure = PSD_INTHOUSANDTHSOFINCHES;
@@ -606,7 +606,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
     pageFormatToSetup(env, self, page, &setup, AwtPrintControl::getPrintDC(env, self));
     if (env->ExceptionCheck()) {
         CLEANUP_SHOW;
-        return JNI_FALSE;
+        return doIt;
     }
 
     setup.lpfnPageSetupHook = reinterpret_cast<LPPAGESETUPHOOK>(pageDlgHook);
@@ -620,7 +620,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
         jobject paper = getPaper(env, page);
         if (paper == NULL) {
             CLEANUP_SHOW;
-            return JNI_FALSE;
+            return doIt;
         }
         int units = setup.Flags & PSD_INTHOUSANDTHSOFINCHES ?
                                                 MM_HIENGLISH :
@@ -662,7 +662,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
         setPaperValues(env, paper, &paperSize, &margins, units);
         if (env->ExceptionCheck()) {
             CLEANUP_SHOW;
-            return JNI_FALSE;
+            return doIt;
          }
         /*
          * Put the updated Paper instance and the orientation into
@@ -671,7 +671,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
         setPaper(env, page, paper);
         if (env->ExceptionCheck()) {
             CLEANUP_SHOW;
-            return JNI_FALSE;
+            return doIt;
         }
         setPageFormatOrientation(env, page, orientation);
         if (env->ExceptionCheck()) {
@@ -685,7 +685,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
                     jboolean err = setPrintPaperSize(env, self, devmode->dmPaperSize);
                     if (err) {
                         CLEANUP_SHOW;
-                        return JNI_FALSE;
+                        return doIt;
                     }
                 }
             }

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintJob.cpp
@@ -522,6 +522,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
     AwtComponent *awtParent = (parent != NULL) ? (AwtComponent *)JNI_GET_PDATA(parent) : NULL;
     HWND hwndOwner = awtParent ? awtParent->GetHWnd() : NULL;
 
+    jboolean doIt = JNI_FALSE;
     PAGESETUPDLG setup;
     memset(&setup, 0, sizeof(setup));
 
@@ -690,6 +691,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
             }
             ::GlobalUnlock(setup.hDevMode);
         }
+        doIt = JNI_TRUE;
     }
 
     AwtDialog::CheckUninstallModalHook();
@@ -708,7 +710,7 @@ Java_sun_awt_windows_WPageDialogPeer__1show(JNIEnv *env, jobject peer)
 
     CLEANUP_SHOW;
 
-    return JNI_TRUE;
+    return doIt;
 
     CATCH_BAD_ALLOC_RET(0);
 }

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
@@ -44,16 +44,9 @@ public class PageDialogCancelTest {
         Robot robot = new Robot();
         Thread t1 = new Thread(() -> {
             robot.delay(2000);
-            for (int i = 0; i < 8; i++) {
-                robot.keyPress(KeyEvent.VK_TAB);
-                robot.keyRelease(KeyEvent.VK_TAB);
-                robot.waitForIdle();
-                robot.delay(500);
-            }
-            robot.keyPress(KeyEvent.VK_ENTER);
-            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
             robot.waitForIdle();
-            robot.delay(500);
         });
         t1.start();
         PageFormat newFormat = pj.pageDialog(oldFormat);

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8334366
  * @key printer
- * @summary Verifies oriignal pageobject is returned unmodified
+ * @summary Verifies original pageobject is returned unmodified
  *          on cancelling pagedialog
  * @requires (os.family == "windows")
  * @run main PageDialogCancelTest
@@ -57,10 +57,7 @@ public class PageDialogCancelTest {
         });
         t1.start();
         PageFormat newFormat = pj.pageDialog(oldFormat);
-        boolean result = newFormat.equals(oldFormat);
-        if (result) {
-            System.out.println("Test Passed");
-        } else {
+        if (!newFormat.equals(oldFormat)) {
             throw new RuntimeException("Original PageFormat not returned on cancelling PageDialog");
         }
     }

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8334366
- * @key printer
+ * @key headful printer
  * @summary Verifies original pageobject is returned unmodified
  *          on cancelling pagedialog
  * @requires (os.family == "windows")

--- a/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8334366
+ * @key printer
+ * @summary Verifies oriignal pageobject is returned unmodified
+ *          on cancelling pagedialog
+ * @requires (os.family == "windows")
+ * @run main PageDialogCancelTest
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.print.PageFormat;
+import java.awt.print.PrinterJob;
+
+public class PageDialogCancelTest {
+
+    public static void main(String[] args) throws Exception {
+        PrinterJob pj = PrinterJob.getPrinterJob();
+        PageFormat oldFormat = new PageFormat();
+        Robot robot = new Robot();
+        Thread t1 = new Thread(() -> {
+            robot.delay(2000);
+            for (int i = 0; i < 8; i++) {
+                robot.keyPress(KeyEvent.VK_TAB);
+                robot.keyRelease(KeyEvent.VK_TAB);
+                robot.waitForIdle();
+                robot.delay(500);
+            }
+            robot.keyPress(KeyEvent.VK_ENTER);
+            robot.keyRelease(KeyEvent.VK_ENTER);
+            robot.waitForIdle();
+            robot.delay(500);
+        });
+        t1.start();
+        PageFormat newFormat = pj.pageDialog(oldFormat);
+        boolean result = newFormat.equals(oldFormat);
+        if (result) {
+            System.out.println("Test Passed");
+        } else {
+            throw new RuntimeException("Original PageFormat not returned on cancelling PageDialog");
+        }
+    }
+}
+


### PR DESCRIPTION
On cancelling PageDialog, same PageFormat object should be returned which stopped working after [JDK-8307160](https://bugs.openjdk.org/browse/JDK-8307160).
Fix is made to reinstate "doIt" flag removed in JDK-8307160 so that correct value is returned from PageDialog.show action..
An automated printing testcase is created since the issue was caught by manual test and so having another manual test run the risk of not being executed during CI testing..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334509](https://bugs.openjdk.org/browse/JDK-8334509): Cancelling PageDialog does not return the same PageFormat object (**Bug** - P2)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) ⚠️ Review applies to [2b298f89](https://git.openjdk.org/jdk/pull/19786/files/2b298f899df95ba81fde62d66536e6a7014877c3)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19786/head:pull/19786` \
`$ git checkout pull/19786`

Update a local copy of the PR: \
`$ git checkout pull/19786` \
`$ git pull https://git.openjdk.org/jdk.git pull/19786/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19786`

View PR using the GUI difftool: \
`$ git pr show -t 19786`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19786.diff">https://git.openjdk.org/jdk/pull/19786.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19786#issuecomment-2177789841)