### PR TITLE
8334544: C2: wrong control assigned in PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops()

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -373,7 +373,7 @@ IfProjNode* PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops(IfNod
                                                                            ParsePredicateSuccessProj* parse_predicate_proj) {
   TemplateAssertionPredicateExpression template_assertion_predicate_expression(
       template_assertion_predicate->in(1)->as_Opaque4());
-  Opaque4Node* cloned_opaque4_node = template_assertion_predicate_expression.clone(parse_predicate_proj, this);
+  Opaque4Node* cloned_opaque4_node = template_assertion_predicate_expression.clone(parse_predicate_proj->in(0)->in(0), this);
   IfProjNode* if_proj = create_new_if_for_predicate(parse_predicate_proj, nullptr, reason, template_assertion_predicate->Opcode(), false);
   _igvn.replace_input_of(if_proj->in(0), 1, cloned_opaque4_node);
   _igvn.replace_input_of(parse_predicate_proj->in(0), 0, if_proj);


### PR DESCRIPTION
There's a minor (and harmless AFAICT) bug in
`PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops()`. Control
for the new predicate expression is set to `parse_predicate_proj` but
the `If` for the new predicate is created to be above
`parse_predicate_proj`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334544](https://bugs.openjdk.org/browse/JDK-8334544): C2: wrong control assigned in PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops() (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19787/head:pull/19787` \
`$ git checkout pull/19787`

Update a local copy of the PR: \
`$ git checkout pull/19787` \
`$ git pull https://git.openjdk.org/jdk.git pull/19787/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19787`

View PR using the GUI difftool: \
`$ git pr show -t 19787`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19787.diff">https://git.openjdk.org/jdk/pull/19787.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19787#issuecomment-2178083331)