### PR TITLE
8334170: bug6492108.java test failed with exception Image comparison failed at (0, 0) for image 4

### DIFF
--- a/test/jdk/com/sun/java/swing/plaf/gtk/bug6492108.java
+++ b/test/jdk/com/sun/java/swing/plaf/gtk/bug6492108.java
@@ -109,6 +109,7 @@ public class bug6492108 extends SwingTestHelper {
         } catch (Throwable t) {
             fail("Problem creating text components");
         }
+        setDelay(50);
         return panel;
     }
 


### PR DESCRIPTION
Test failed intermittently on Ubuntu 20.04, Ubuntu 22.04 system. Added a delay to stable the test and multiple run in CI is Ok. Link is added in JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334170](https://bugs.openjdk.org/browse/JDK-8334170): bug6492108.java test failed with exception Image comparison failed at (0, 0) for image 4 (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19788/head:pull/19788` \
`$ git checkout pull/19788`

Update a local copy of the PR: \
`$ git checkout pull/19788` \
`$ git pull https://git.openjdk.org/jdk.git pull/19788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19788`

View PR using the GUI difftool: \
`$ git pr show -t 19788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19788.diff">https://git.openjdk.org/jdk/pull/19788.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19788#issuecomment-2178112083)