### PR TITLE
8334560: [PPC64]: postalloc_expand_java_dynamic_call_sched does not copy all fields

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -3429,6 +3429,7 @@ encode %{
     call->_oop_map           = _oop_map;
     call->_jvms              = _jvms;
     call->_jvmadj            = _jvmadj;
+    call->_has_ea_local_in_scope = _has_ea_local_in_scope;
     call->_in_rms            = _in_rms;
     call->_nesting           = _nesting;
     call->_override_symbolic_info = _override_symbolic_info;

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -289,6 +289,7 @@ class EATestsTarget {
         // Relocking test cases
         new EARelockingSimpleTarget()                                                       .run();
         new EARelockingSimpleWithAccessInOtherThreadTarget()                                .run();
+        new EARelockingSimpleWithAccessInOtherThread_02_DynamicCall_Target()                .run();
         new EARelockingRecursiveTarget()                                                    .run();
         new EARelockingNestedInflatedTarget()                                               .run();
         new EARelockingNestedInflated_02Target()                                            .run();
@@ -413,6 +414,7 @@ public class EATests extends TestScaffold {
         // Relocking test cases
         new EARelockingSimple()                                                       .run(this);
         new EARelockingSimpleWithAccessInOtherThread()                                .run(this);
+        new EARelockingSimpleWithAccessInOtherThread_02_DynamicCall()                 .run(this);
         new EARelockingRecursive()                                                    .run(this);
         new EARelockingNestedInflated()                                               .run(this);
         new EARelockingNestedInflated_02()                                            .run(this);
@@ -1840,6 +1842,95 @@ class EARelockingSimpleWithAccessInOtherThreadTarget extends EATestCaseBaseTarge
             dontinline_brkpt();  // Debugger publishes l1 to sharedCounter.
             iResult = l1.inc();  // Changes by the 2nd thread will be observed if l1
                                  // was not relocked before passing it to the debugger.
+        }
+    }
+
+    @Override
+    public int getExpectedIResult() {
+        return 1;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+// The debugger reads and publishes an object with eliminated locking to an instance field.
+// A 2nd thread in the debuggee finds it there and changes its state using a synchronized method.
+// Without eager relocking the accesses are unsynchronized which can be observed.
+// This is a variant of EARelockingSimpleWithAccessInOtherThread with a dynamic call (not devirtualized).
+class EARelockingSimpleWithAccessInOtherThread_02_DynamicCall extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        String l1ClassName = EARelockingSimpleWithAccessInOtherThread_02_DynamicCall_Target.SyncCounter.class.getName();
+        ObjectReference ctr = getLocalRef(bpe.thread().frame(2), l1ClassName, "l1");
+        setField(testCase, "sharedCounter", ctr);
+        terminateEndlessLoop();
+    }
+}
+
+class EARelockingSimpleWithAccessInOtherThread_02_DynamicCall_Target extends EATestCaseBaseTarget {
+
+    public static final BrkPtDispatchA[] disp =
+        {new BrkPtDispatchA(), new BrkPtDispatchB(), new BrkPtDispatchC(), new BrkPtDispatchD()};
+
+    public static class BrkPtDispatchA {
+        public EATestCaseBaseTarget testCase;
+        public void dontinline_brkpt() { testCase.dontinline_brkpt(); }
+    }
+
+    public static class BrkPtDispatchB extends BrkPtDispatchA {
+        @Override
+        public void dontinline_brkpt() { testCase.dontinline_brkpt(); }
+    }
+
+    public static class BrkPtDispatchC extends BrkPtDispatchA {
+        @Override
+        public void dontinline_brkpt() { testCase.dontinline_brkpt(); }
+    }
+
+    public static class BrkPtDispatchD extends BrkPtDispatchA {
+        @Override
+        public void dontinline_brkpt() {
+            testCase.dontinline_brkpt();
+        }
+    }
+
+    public static class SyncCounter {
+        private int val;
+        public synchronized int inc() { return val++; }
+    }
+
+    public volatile SyncCounter sharedCounter;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        testMethodDepth = 2;
+        for (BrkPtDispatchA d : disp) {
+            d.testCase = this;
+        }
+        doLoop = true;
+        new Thread(() -> {
+                while (doLoop) {
+                    SyncCounter ctr = sharedCounter;
+                    if (ctr != null) {
+                        ctr.inc();
+                    }
+                }
+            }).start();
+    }
+
+    public int dispCount;
+    public void dontinline_testMethod() {
+        SyncCounter l1 = new SyncCounter();
+        synchronized (l1) {      // Eliminated locking
+            l1.inc();
+            // Use different types for the subsequent call to prevent devirtualization.
+            BrkPtDispatchA d = disp[(dispCount++) & 3];
+            d.dontinline_brkpt();  // Dynamic call. Debugger publishes l1 to sharedCounter.
+            iResult = l1.inc();    // Changes by the 2nd thread will be observed if l1
+                                   // was not relocked before passing it to the debugger.
         }
     }
 


### PR DESCRIPTION
On PPC64 we use a special feature where C2 Mach nodes get expanded after register allocation.
This pr adds copying the field `MachSafePointNode::_has_ea_local_in_scope` when expanding `MachCallDynamicJavaNode`s in `postalloc_expand_java_dynamic_call_sched`.

It adds also a test case that fails without the fix.

The fix passed our CI testing: JTReg tests: tier1-4 of hotspot and jdk. All of Langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done with fastdebug and release builds on the main platforms and also on Linux/PPC64le and AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334560](https://bugs.openjdk.org/browse/JDK-8334560): [PPC64]: postalloc_expand_java_dynamic_call_sched does not copy all fields (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19789/head:pull/19789` \
`$ git checkout pull/19789`

Update a local copy of the PR: \
`$ git checkout pull/19789` \
`$ git pull https://git.openjdk.org/jdk.git pull/19789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19789`

View PR using the GUI difftool: \
`$ git pr show -t 19789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19789.diff">https://git.openjdk.org/jdk/pull/19789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19789#issuecomment-2182366311)