### PR TITLE
8334562: Automate com/sun/security/auth/callback/TextCallbackHandler/Default.java test

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -609,7 +609,6 @@ sun/security/smartcardio/TestMultiplePresent.java               8039280 generic-
 sun/security/smartcardio/TestPresent.java                       8039280 generic-all
 sun/security/smartcardio/TestTransmit.java                      8039280 generic-all
 com/sun/crypto/provider/Cipher/DES/PerformanceTest.java         8039280 generic-all
-com/sun/security/auth/callback/TextCallbackHandler/Default.java 8039280 generic-all
 com/sun/security/auth/callback/TextCallbackHandler/Password.java 8039280 generic-all
 com/sun/security/sasl/gsskerb/AuthOnly.java                     8039280 generic-all
 com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-all

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -621,7 +621,6 @@ jdk_security_manual_no_input = \
     com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementDirect4.java \
-    com/sun/security/auth/callback/TextCallbackHandler/Default.java \
     com/sun/security/auth/callback/TextCallbackHandler/Password.java \
     com/sun/security/sasl/gsskerb/AuthOnly.java \
     com/sun/security/sasl/gsskerb/ConfSecurityLayer.java \

--- a/test/jdk/java/security/testlibrary/HumanInputStream.java
+++ b/test/jdk/java/security/testlibrary/HumanInputStream.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * HumanInputStream tries to act like a human sitting in front of a computer
+ * terminal typing on the keyboard while a program is running.
+ * <p>
+ * The program may call InputStream.read() and BufferedReader.readLine() in
+ * various places. a call to B.readLine() will try to buffer as much input as
+ * possible. Thus, a trivial InputStream will find it impossible to feed
+ * anything to I.read() after a B.readLine() call.
+ * <p>
+ * This is why HumanInputStream was created, which will only send a single line
+ * to B.readLine(), no more, no less, and the next I.read() can have a chance
+ * to read the exact character right after "\n".
+ *
+ */
+
+public class HumanInputStream extends InputStream {
+    byte[] src;
+    int pos;
+    int length;
+    boolean inLine;
+    int stopIt;
+
+    public HumanInputStream(String input) {
+        src = input.getBytes();
+        pos = 0;
+        length = src.length;
+        stopIt = 0;
+        inLine = false;
+    }
+
+    // the trick: when called through read(byte[], int, int),
+    // return -1 twice after "\n"
+
+    @Override public int read() throws IOException {
+        int re;
+        if(pos < length) {
+            re = src[pos];
+            if(inLine) {
+                if(stopIt > 0) {
+                    stopIt--;
+                    re = -1;
+                } else {
+                    if(re == '\n') {
+                        stopIt = 2;
+                    }
+                    pos++;
+                }
+            } else {
+                pos++;
+            }
+        } else {
+            re = -1; //throws new IOException("NO MORE TO READ");
+        }
+        return re;
+    }
+    @Override public int read(byte[] buffer, int offset, int len) {
+        inLine = true;
+        try {
+            return super.read(buffer, offset, len);
+        } catch(Exception e) {
+            throw new RuntimeException("HumanInputStream error");
+        } finally {
+            inLine = false;
+        }
+    }
+    @Override public int available() {
+        if (pos < length) return 1;
+        return 0;
+    }
+
+    // test part
+    static void assertTrue(boolean bool) {
+        if (!bool)
+            throw new RuntimeException();
+    }
+
+    public static void test() throws Exception {
+        class Tester {
+            HumanInputStream is;
+            BufferedReader reader;
+            Tester(String s) {
+                is = new HumanInputStream(s);
+                reader = new BufferedReader(new InputStreamReader(is));
+            }
+
+            // three kinds of test method
+            // 1. read byte by byte from InputStream
+            void testStreamReadOnce(int expection) throws Exception {
+                assertTrue(is.read() == expection);
+            }
+            void testStreamReadMany(String expectation) throws Exception {
+                char[] keys = expectation.toCharArray();
+                for (char key : keys) {
+                    assertTrue(is.read() == key);
+                }
+            }
+            // 2. read a line with a newly created Reader
+            void testReaderReadline(String expectation) throws Exception {
+                String s = new BufferedReader(new InputStreamReader(is)).readLine();
+                if(s == null) assertTrue(expectation == null);
+                else assertTrue(s.equals(expectation));
+            }
+            // 3. read a line with the old Reader
+            void testReaderReadline2(String expectation) throws Exception  {
+                String s = reader.readLine();
+                if(s == null) assertTrue(expectation == null);
+                else assertTrue(s.equals(expectation));
+            }
+        }
+
+        Tester test;
+
+        test = new Tester("111\n222\n\n444\n\n");
+        test.testReaderReadline("111");
+        test.testReaderReadline("222");
+        test.testReaderReadline("");
+        test.testReaderReadline("444");
+        test.testReaderReadline("");
+        test.testReaderReadline(null);
+
+        test = new Tester("111\n222\n\n444\n\n");
+        test.testReaderReadline2("111");
+        test.testReaderReadline2("222");
+        test.testReaderReadline2("");
+        test.testReaderReadline2("444");
+        test.testReaderReadline2("");
+        test.testReaderReadline2(null);
+
+        test = new Tester("111\n222\n\n444\n\n");
+        test.testReaderReadline2("111");
+        test.testReaderReadline("222");
+        test.testReaderReadline2("");
+        test.testReaderReadline2("444");
+        test.testReaderReadline("");
+        test.testReaderReadline2(null);
+
+        test = new Tester("1\n2");
+        test.testStreamReadMany("1\n2");
+        test.testStreamReadOnce(-1);
+
+        test = new Tester("12\n234");
+        test.testStreamReadOnce('1');
+        test.testReaderReadline("2");
+        test.testStreamReadOnce('2');
+        test.testReaderReadline2("34");
+        test.testReaderReadline2(null);
+
+        test = new Tester("changeit\n");
+        test.testStreamReadMany("changeit\n");
+        test.testReaderReadline(null);
+
+        test = new Tester("changeit\nName\nCountry\nYes\n");
+        test.testStreamReadMany("changeit\n");
+        test.testReaderReadline("Name");
+        test.testReaderReadline("Country");
+        test.testReaderReadline("Yes");
+        test.testReaderReadline(null);
+
+        test = new Tester("Me\nHere\n");
+        test.testReaderReadline2("Me");
+        test.testReaderReadline2("Here");
+    }
+}


### PR DESCRIPTION
The following test: **com/sun/security/auth/callback/TextCallbackHandler/Default.java** is currently marked to be run manually because user inputs are required in the console, but instead it can be automated by providing a custom inputStream to System.in in the actual test to simulate sequential user input.

In addition, this patch is removing the test from the problemList as it passes, and from manual test list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334562](https://bugs.openjdk.org/browse/JDK-8334562): Automate com/sun/security/auth/callback/TextCallbackHandler/Default.java test (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19790/head:pull/19790` \
`$ git checkout pull/19790`

Update a local copy of the PR: \
`$ git checkout pull/19790` \
`$ git pull https://git.openjdk.org/jdk.git pull/19790/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19790`

View PR using the GUI difftool: \
`$ git pr show -t 19790`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19790.diff">https://git.openjdk.org/jdk/pull/19790.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19790#issuecomment-2179015045)