### PR TITLE
8334570: Problem list gc/TestAlwaysPreTouchBehavior.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,13 +82,13 @@ gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
-gc/TestAlwaysPreTouchBehavior.java#ParallelCollector 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#SerialCollector 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#Shenandoah 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#G1 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#ZGenerational 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#ZSinglegen 8334513 macosx-aarch64,linux-ppc64le
-gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#ParallelCollector 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#SerialCollector 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#Shenandoah 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#G1 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#ZGenerational 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#ZSinglegen 8334513 generic-all
+gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 generic-all
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 
 #############################################################################

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -82,6 +82,13 @@ gc/TestAllocHumongousFragment.java#aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#iu-aggressive 8298781 generic-all
 gc/TestAllocHumongousFragment.java#g1 8298781 generic-all
 gc/TestAllocHumongousFragment.java#static 8298781 generic-all
+gc/TestAlwaysPreTouchBehavior.java#ParallelCollector 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#SerialCollector 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#Shenandoah 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#G1 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#ZGenerational 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#ZSinglegen 8334513 macosx-aarch64,linux-ppc64le
+gc/TestAlwaysPreTouchBehavior.java#Epsilon 8334513 macosx-aarch64,linux-ppc64le
 gc/stress/gclocker/TestExcessGCLockerCollections.java 8229120 generic-all
 
 #############################################################################


### PR DESCRIPTION
Hi all, 

This PR addresses [8334570](https://bugs.openjdk.org/browse/JDK-8334570) problem listing `gc/TestAlwaysPreTouchBehavior.java` until the underlying issues are resolved. 

Note that despite failures only showing up for some collectors (G1 on linux-ppc64le, ZSingleGen and the parallel collector on macos-aarch64), I am problem listing all collectors in case it has to do with underprovisioned machines leading to the errors trickling down to the other test cases. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334570](https://bugs.openjdk.org/browse/JDK-8334570): Problem list gc/TestAlwaysPreTouchBehavior.java (**Sub-task** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19794/head:pull/19794` \
`$ git checkout pull/19794`

Update a local copy of the PR: \
`$ git checkout pull/19794` \
`$ git pull https://git.openjdk.org/jdk.git pull/19794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19794`

View PR using the GUI difftool: \
`$ git pr show -t 19794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19794.diff">https://git.openjdk.org/jdk/pull/19794.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19794#issuecomment-2178949023)