### PR TITLE
8334488: Improve error for illegal early access from nested class

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -950,7 +950,6 @@ public class Attr extends JCTree.Visitor {
                 Optional.ofNullable(env.info.attributionMode.isSpeculative ?
                         argumentAttr.withLocalCacheContext() : null);
         boolean ctorProloguePrev = env.info.ctorPrologue;
-        env.info.ctorPrologue = false;
         try {
             // Local and anonymous classes have not been entered yet, so we need to
             // do it now.
@@ -995,7 +994,7 @@ public class Attr extends JCTree.Visitor {
         Lint lint = env.info.lint.augment(m);
         Lint prevLint = chk.setLint(lint);
         boolean ctorProloguePrev = env.info.ctorPrologue;
-        env.info.ctorPrologue = false;
+        Assert.check(!env.info.ctorPrologue);
         MethodSymbol prevMethod = chk.setMethod(m);
         try {
             deferredLintHandler.flush(tree.pos(), lint);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Enter.java
@@ -209,6 +209,7 @@ public class Enter extends JCTree.Visitor {
         localEnv.info.lint = null; // leave this to be filled in by Attr,
                                    // when annotations have been processed
         localEnv.info.isAnonymousDiamond = TreeInfo.isDiamond(env.tree);
+        localEnv.info.ctorPrologue = false;
         return localEnv;
     }
 

--- a/test/langtools/tools/javac/AnonymousClass/AnonymousInSuperCallNegTest.out
+++ b/test/langtools/tools/javac/AnonymousClass/AnonymousInSuperCallNegTest.out
@@ -1,2 +1,2 @@
-AnonymousInSuperCallNegTest.java:23:49: compiler.err.no.encl.instance.of.type.in.scope: AnonymousInSuperCallNegTest.JavacBug
+AnonymousInSuperCallNegTest.java:23:49: compiler.err.cant.ref.before.ctor.called: x
 1 error

--- a/test/langtools/tools/javac/LocalClassCtorPrologue.out
+++ b/test/langtools/tools/javac/LocalClassCtorPrologue.out
@@ -1,4 +1,4 @@
-LocalClassCtorPrologue.java:16:17: compiler.err.no.encl.instance.of.type.in.scope: LocalClassCtorPrologue
+LocalClassCtorPrologue.java:16:17: compiler.err.cant.ref.before.ctor.called: x
 - compiler.note.preview.filename: LocalClassCtorPrologue.java, DEFAULT
 - compiler.note.preview.recompile
 1 error

--- a/test/langtools/tools/javac/SuperInit/EarlyInnerAccessErrorMessageTest.java
+++ b/test/langtools/tools/javac/SuperInit/EarlyInnerAccessErrorMessageTest.java
@@ -1,0 +1,16 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334488
+ * @summary Verify the error message generated for early access from inner class
+ * @compile/fail/ref=EarlyInnerAccessErrorMessageTest.out -XDrawDiagnostics EarlyInnerAccessErrorMessageTest.java
+ * @enablePreview
+ */
+public class EarlyInnerAccessErrorMessageTest {
+    int x;
+    EarlyInnerAccessErrorMessageTest() {
+        class Inner {
+            { System.out.println(x); }
+        }
+        super();
+    }
+}

--- a/test/langtools/tools/javac/SuperInit/EarlyInnerAccessErrorMessageTest.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyInnerAccessErrorMessageTest.out
@@ -1,0 +1,4 @@
+EarlyInnerAccessErrorMessageTest.java:12:34: compiler.err.cant.ref.before.ctor.called: x
+- compiler.note.preview.filename: EarlyInnerAccessErrorMessageTest.java, DEFAULT
+- compiler.note.preview.recompile
+1 error

--- a/test/langtools/tools/javac/SuperInit/EarlyLocalClass.out
+++ b/test/langtools/tools/javac/SuperInit/EarlyLocalClass.out
@@ -1,4 +1,4 @@
-EarlyLocalClass.java:12:32: compiler.err.no.encl.instance.of.type.in.scope: EarlyLocalClass
+EarlyLocalClass.java:12:32: compiler.err.cant.ref.before.ctor.called: this
 - compiler.note.preview.filename: EarlyLocalClass.java, DEFAULT
 - compiler.note.preview.recompile
 1 error


### PR DESCRIPTION
clean backport of: JDK-8334488

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334488](https://bugs.openjdk.org/browse/JDK-8334488): Improve error for illegal early access from nested class (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19797/head:pull/19797` \
`$ git checkout pull/19797`

Update a local copy of the PR: \
`$ git checkout pull/19797` \
`$ git pull https://git.openjdk.org/jdk.git pull/19797/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19797`

View PR using the GUI difftool: \
`$ git pr show -t 19797`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19797.diff">https://git.openjdk.org/jdk/pull/19797.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19797#issuecomment-2179355605)