### PR TITLE
8334594: Generational ZGC: Deadlock after OopMap rewrites in 8331572

### DIFF
--- a/src/hotspot/share/gc/shared/gcVMOperations.cpp
+++ b/src/hotspot/share/gc/shared/gcVMOperations.cpp
@@ -132,7 +132,7 @@ bool VM_GC_Operation::doit_prologue() {
 void VM_GC_Operation::doit_epilogue() {
   // GC thread root traversal likely used OopMapCache a lot, which
   // might have created lots of old entries. Trigger the cleanup now.
-  OopMapCache::trigger_cleanup();
+  OopMapCache::try_trigger_cleanup();
   if (Universe::has_reference_pending_list()) {
     Heap_lock->notify_all();
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVMOperations.cpp
@@ -44,7 +44,7 @@ void VM_ShenandoahOperation::doit_epilogue() {
   assert(!ShenandoahHeap::heap()->has_gc_state_changed(), "GC State was not synchronized to java threads.");
   // GC thread root traversal likely used OopMapCache a lot, which
   // might have created lots of old entries. Trigger the cleanup now.
-  OopMapCache::trigger_cleanup();
+  OopMapCache::try_trigger_cleanup();
 }
 
 bool VM_ShenandoahReferenceOperation::doit_prologue() {

--- a/src/hotspot/share/gc/x/xDriver.cpp
+++ b/src/hotspot/share/gc/x/xDriver.cpp
@@ -134,7 +134,7 @@ public:
 
     // GC thread root traversal likely used OopMapCache a lot, which
     // might have created lots of old entries. Trigger the cleanup now.
-    OopMapCache::trigger_cleanup();
+    OopMapCache::try_trigger_cleanup();
   }
 
   bool gc_locked() const {

--- a/src/hotspot/share/gc/z/zGeneration.cpp
+++ b/src/hotspot/share/gc/z/zGeneration.cpp
@@ -456,7 +456,7 @@ public:
 
     // GC thread root traversal likely used OopMapCache a lot, which
     // might have created lots of old entries. Trigger the cleanup now.
-    OopMapCache::trigger_cleanup();
+    OopMapCache::try_trigger_cleanup();
   }
 
   bool success() const {

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -183,8 +183,8 @@ class OopMapCache : public CHeapObj<mtClass> {
   // Check if we need to clean up old entries
   static bool has_cleanup_work();
 
-  // Request cleanup if work is needed
-  static void trigger_cleanup();
+  // Request cleanup if work is needed and notification is currently possible
+  static void try_trigger_cleanup();
 
   // Clean up the old entries
   static void cleanup();


### PR DESCRIPTION
As shown in the bug, there are cases when acquiring the `ServiceLock` for opportunistic notification leads to deadlock. We can untie the deadlock by checking if `ServiceLock` can be acquired on triggering path, and never blocking otherwise.

Additional testing:
 - [x] Linux x86_64 service fastdebug, `all`
 - [x] Linux AArch64 service fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334594](https://bugs.openjdk.org/browse/JDK-8334594): Generational ZGC: Deadlock after OopMap rewrites in 8331572 (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19800/head:pull/19800` \
`$ git checkout pull/19800`

Update a local copy of the PR: \
`$ git checkout pull/19800` \
`$ git pull https://git.openjdk.org/jdk.git pull/19800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19800`

View PR using the GUI difftool: \
`$ git pr show -t 19800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19800.diff">https://git.openjdk.org/jdk/pull/19800.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19800#issuecomment-2180207325)