### PR TITLE
8334083: C2 SuperWord: TestCompatibleUseDefTypeSize.java fails with -XX:+AlignVector after JDK-8325155

### DIFF
--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestCompatibleUseDefTypeSize.java
@@ -359,6 +359,7 @@ public class TestCompatibleUseDefTypeSize {
                   IRNode.ADD_VI,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"AlignVector", "false"}, // a[i] and a[i+1] cannot both be aligned.
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     // Used to not vectorize because of "alignment boundaries".
     // Assume 64 byte vector width:
@@ -376,6 +377,7 @@ public class TestCompatibleUseDefTypeSize {
                   IRNode.ADD_VI,        "> 0",
                   IRNode.STORE_VECTOR,  "> 0"},
         applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"AlignVector", "false"}, // a[i] and a[i+1] cannot both be aligned.
         applyIfCPUFeatureOr = {"sse4.1", "true", "asimd", "true"})
     // same as test3, but hand-unrolled
     static Object[] test4(int[] a, int[] b) {


### PR DESCRIPTION
This is a small test-bug fix.

In https://bugs.openjdk.org/browse/JDK-8325155 / https://github.com/openjdk/jdk/pull/18822, I added a test, but never ran it with `-XX:+AlignVector` - since that is not a flag we use at Oracle, and therefore do not regularly test.

I had to adjust the IR rule accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334083](https://bugs.openjdk.org/browse/JDK-8334083): C2 SuperWord: TestCompatibleUseDefTypeSize.java fails with -XX:+AlignVector after JDK-8325155 (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19801/head:pull/19801` \
`$ git checkout pull/19801`

Update a local copy of the PR: \
`$ git checkout pull/19801` \
`$ git pull https://git.openjdk.org/jdk.git pull/19801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19801`

View PR using the GUI difftool: \
`$ git pr show -t 19801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19801.diff">https://git.openjdk.org/jdk/pull/19801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19801#issuecomment-2180388228)