### PR TITLE
8334618: ubsan: support setting additional ubsan check options

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -496,11 +496,15 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_LEAK_SANITIZER],
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
-  UTIL_ARG_WITH(NAME: additional-ubsan-checks, TYPE: string, DEFAULT: [], DESC: [Custom ubsan checks], OPTIONAL: true)
+  UTIL_ARG_WITH(NAME: additional-ubsan-checks, TYPE: string,
+    DEFAULT: [],
+    DESC: [Custom ubsan checks],
+    OPTIONAL: true)
 
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.
-  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment $ADDITIONAL_UBSAN_CHECKS"
+  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment \
+      $ADDITIONAL_UBSAN_CHECKS"
   UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -496,12 +496,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_LEAK_SANITIZER],
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
-  AC_ARG_WITH(additional-ubsan-checks, [AS_HELP_STRING([--with-additional-ubsan-checks],
-      [customizes the ubsan checks])])
-  ADDITIONAL_UBSAN_CHECKS=
-  if test "x$with_additional_ubsan_checks" != "x" ; then
-    ADDITIONAL_UBSAN_CHECKS="$with_additional_ubsan_checks"
-  fi
+  UTIL_ARG_WITH(NAME: additional-ubsan-checks, TYPE: string, DEFAULT: [], DESC: [Custom ubsan checks], OPTIONAL: true)
 
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -497,9 +497,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_LEAK_SANITIZER],
 AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
   UTIL_ARG_WITH(NAME: additional-ubsan-checks, TYPE: string,
-    DEFAULT: [],
-    DESC: [Custom ubsan checks],
-    OPTIONAL: true)
+      DEFAULT: [],
+      DESC: [Customizes the ubsan checks],
+      OPTIONAL: true)
 
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -496,9 +496,16 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_LEAK_SANITIZER],
 #
 AC_DEFUN_ONCE([JDKOPT_SETUP_UNDEFINED_BEHAVIOR_SANITIZER],
 [
+  AC_ARG_WITH(additional-ubsan-checks, [AS_HELP_STRING([--with-additional-ubsan-checks],
+      [customizes the ubsan checks])])
+  ADDITIONAL_UBSAN_CHECKS=
+  if test "x$with_additional_ubsan_checks" != "x" ; then
+    ADDITIONAL_UBSAN_CHECKS="$with_additional_ubsan_checks"
+  fi
+
   # GCC reports lots of likely false positives for stringop-truncation and format-overflow.
   # Silence them for now.
-  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment"
+  UBSAN_CHECKS="-fsanitize=undefined -fsanitize=float-divide-by-zero -fno-sanitize=shift-base -fno-sanitize=alignment $ADDITIONAL_UBSAN_CHECKS"
   UBSAN_CFLAGS="$UBSAN_CHECKS -Wno-stringop-truncation -Wno-format-overflow -fno-omit-frame-pointer -DUNDEFINED_BEHAVIOR_SANITIZER"
   UBSAN_LDFLAGS="$UBSAN_CHECKS"
   UTIL_ARG_ENABLE(NAME: ubsan, DEFAULT: false, RESULT: UBSAN_ENABLED,


### PR DESCRIPTION
Sometimes it would be helpful to have configure-support for adding additional ubsan check options.
E.g. support new configure option '--with-additional-ubsan-checks=<check-settings>' .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334618](https://bugs.openjdk.org/browse/JDK-8334618): ubsan: support setting additional ubsan check options (**Bug** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [ad51358a](https://git.openjdk.org/jdk/pull/19802/files/ad51358ae56c6479211a150a74c77f914decab32)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19802/head:pull/19802` \
`$ git checkout pull/19802`

Update a local copy of the PR: \
`$ git checkout pull/19802` \
`$ git pull https://git.openjdk.org/jdk.git pull/19802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19802`

View PR using the GUI difftool: \
`$ git pr show -t 19802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19802.diff">https://git.openjdk.org/jdk/pull/19802.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19802#issuecomment-2180460889)