### PR TITLE
8333361: ubsan,test : libHeapMonitorTest.cpp:518:9: runtime error: null pointer passed as argument 2, which is declared to never be null

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp
@@ -515,7 +515,9 @@ static void event_storage_augment_storage(EventStorage* storage) {
   ObjectTrace** new_objects = reinterpret_cast<ObjectTrace**>(malloc(new_max * sizeof(*new_objects)));
 
   int current_count = storage->live_object_count;
-  memcpy(new_objects, storage->live_objects, current_count * sizeof(*new_objects));
+  if (storage->live_objects != nullptr) {
+    memcpy(new_objects, storage->live_objects, current_count * sizeof(*new_objects));
+  }
   free(storage->live_objects);
   storage->live_objects = new_objects;
   storage->live_object_size = new_max;


### PR DESCRIPTION
The following issue has been observed when running
serviceability/jvmti/HeapMonitor/MyPackage/HeapMonitorThreadTest  (and some other :tier1 tests)
on Linux with ubsan enabled binaries :

test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp:518:9: runtime error: null pointer passed as argument 2, which is declared to never be null
    #0 0xffff80388020 in event_storage_augment_storage test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp:518
    #1 0xffff80388020 in event_storage_add test/hotspot/jtreg/serviceability/jvmti/HeapMonitor/libHeapMonitorTest.cpp:557
    #2 0xffff85e695fc in JvmtiExport::post_sampled_object_alloc(JavaThread*, oopDesc*) src/hotspot/share/prims/jvmtiExport.cpp:2926
    #3 0xffff85e558b8 in JvmtiObjectAllocEventCollector::generate_call_for_allocated() src/hotspot/share/prims/jvmtiExport.cpp:3074
    #4 0xffff85e56c14 in JvmtiSampledObjectAllocEventCollector::~JvmtiSampledObjectAllocEventCollector() src/hotspot/share/prims/jvmtiExport.cpp:3171
    #5 0xffff85e56c14 in JvmtiSampledObjectAllocEventCollector::~JvmtiSampledObjectAllocEventCollector() src/hotspot/share/prims/jvmtiExport.cpp:3166
    #6 0xffff862ace34 in MemAllocator::Allocation::notify_allocation_jvmti_sampler() src/hotspot/share/gc/shared/memAllocator.cpp:196
    #7 0xffff862af7a4 in MemAllocator::Allocation::~Allocation() src/hotspot/share/gc/shared/memAllocator.cpp:87
    #8 0xffff862af7a4 in MemAllocator::allocate() const src/hotspot/share/gc/shared/memAllocator.cpp:356
    #9 0xffff86dca4dc in CollectedHeap::array_allocate(Klass*, unsigned long, int, bool, JavaThread*) src/hotspot/share/gc/shared/collectedHeap.inline.hpp:41
    #10 0xffff86dca4dc in TypeArrayKlass::allocate_common(int, bool, JavaThread*) src/hotspot/share/oops/typeArrayKlass.cpp:93
    #11 0xffff86dca4dc in TypeArrayKlass::allocate_common(int, bool, JavaThread*) src/hotspot/share/oops/typeArrayKlass.cpp:89
    #12 0xffff857f35c8 in InterpreterRuntime::newarray(JavaThread*, BasicType, int) src/hotspot/share/interpreter/interpreterRuntime.cpp:232
    #13 0xffff6b094cf4 (<unknown module>)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333361](https://bugs.openjdk.org/browse/JDK-8333361): ubsan,test : libHeapMonitorTest.cpp:518:9: runtime error: null pointer passed as argument 2, which is declared to never be null (**Bug** - P4)


### Reviewers
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19804/head:pull/19804` \
`$ git checkout pull/19804`

Update a local copy of the PR: \
`$ git checkout pull/19804` \
`$ git pull https://git.openjdk.org/jdk.git pull/19804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19804`

View PR using the GUI difftool: \
`$ git pr show -t 19804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19804.diff">https://git.openjdk.org/jdk/pull/19804.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19804#issuecomment-2180504671)