### PR TITLE
8322708: Global HTML attributes are not allowed

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -690,7 +690,9 @@ public class Checker extends DocTreePathScanner<Void, Void> {
             }
             // for now, doclint allows all attribute names beginning with "on" as event handler names,
             // without checking the validity or applicability of the name
-            if (!name.toString().startsWith("on")) {
+            // custom "data-*" attributes are also accepted
+            var attrName = name.toString();
+            if (!attrName.startsWith("on") && !attrName.startsWith("data-")) {
                 AttrKind k = currTag.getAttrKind(name);
                 switch (k) {
                     case OK -> { }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -434,57 +434,76 @@ public enum HtmlTag {
 
     public enum Attr {
         ABBR,
+        ACCESSKEY(true),
         ALIGN,
         ALINK,
         ALT,
-        ARIA_ACTIVEDESCENDANT,
-        ARIA_CONTROLS,
-        ARIA_DESCRIBEDBY,
-        ARIA_EXPANDED,
-        ARIA_LABEL,
-        ARIA_LABELLEDBY,
-        ARIA_LEVEL,
-        ARIA_MULTISELECTABLE,
-        ARIA_OWNS,
-        ARIA_POSINSET,
-        ARIA_SETSIZE,
-        ARIA_READONLY,
-        ARIA_REQUIRED,
-        ARIA_SELECTED,
-        ARIA_SORT,
+        ARIA_ACTIVEDESCENDANT(true),
+        ARIA_CONTROLS(true),
+        ARIA_DESCRIBEDBY(true),
+        ARIA_EXPANDED(true),
+        ARIA_LABEL(true),
+        ARIA_LABELLEDBY(true),
+        ARIA_LEVEL(true),
+        ARIA_MULTISELECTABLE(true),
+        ARIA_OWNS(true),
+        ARIA_POSINSET(true),
+        ARIA_READONLY(true),
+        ARIA_REQUIRED(true),
+        ARIA_SELECTED(true),
+        ARIA_SETSIZE(true),
+        ARIA_SORT(true),
+        AUTOCAPITALIZE(true),
+        AUTOFOCUS(true),
         AXIS,
         BACKGROUND,
         BGCOLOR,
         BORDER,
-        CELLSPACING,
         CELLPADDING,
+        CELLSPACING,
         CHAR,
         CHAROFF,
         CHARSET,
         CITE,
+        CLASS(true),
         CLEAR,
-        CLASS,
         COLOR,
         COLSPAN,
         COMPACT,
+        CONTENTEDITABLE(true),
         COORDS,
         CROSSORIGIN,
         DATETIME,
+        DIR(true),
+        DRAGGABLE(true),
+        ENTERKEYHINT(true),
         FACE,
         FRAME,
         FRAMEBORDER,
         HEADERS,
         HEIGHT,
+        HIDDEN(true),
         HREF,
         HSPACE,
-        ID,
+        ID(true),
+        INERT(true),
+        INPUTMODE(true),
+        IS(true),
+        ITEMID(true),
+        ITEMPROP(true),
+        ITEMREF(true),
+        ITEMSCOPE(true),
+        ITEMTYPE(true),
+        LANG(true),
         LINK,
         LONGDESC,
         MARGINHEIGHT,
         MARGINWIDTH,
         NAME,
+        NONCE(true),
         NOSHADE,
         NOWRAP,
+        POPOVER(true),
         PROFILE,
         REV,
         REVERSED,
@@ -497,24 +516,39 @@ public enum HtmlTag {
         SHAPE,
         SIZE,
         SPACE,
+        SPELLCHECK(true),
         SRC,
         START,
-        STYLE,
+        STYLE(true),
         SUMMARY,
+        TABINDEX(true),
         TARGET,
         TEXT,
+        TITLE(true),
+        TRANSLATE(true),
         TYPE,
         VALIGN,
         VALUE,
         VERSION,
         VLINK,
         VSPACE,
-        WIDTH;
+        WIDTH,
+        WRITINGSUGGESTIONS(true);
 
         private final String name;
+        private final boolean isGlobal;
 
         Attr() {
+            this(false);
+        }
+
+        Attr(boolean flag) {
             name = StringUtils.toLowerCase(name().replace("_", "-"));
+            isGlobal = flag;
+        }
+
+        public boolean isGlobal() {
+            return isGlobal;
         }
 
         public String getText() {
@@ -632,8 +666,13 @@ public enum HtmlTag {
     }
 
     public AttrKind getAttrKind(Name attrName) {
-        AttrKind k = attrs.get(getAttr(attrName)); // null-safe
-        return (k == null) ? AttrKind.INVALID : k;
+        Attr attr = getAttr(attrName);
+        if (attr == null) {
+            return AttrKind.INVALID;
+        }
+        return attr.isGlobal() ?
+                AttrKind.OK :
+                attrs.getOrDefault(attr, AttrKind.INVALID);
     }
 
     private static AttrMap attrs(AttrKind k, Attr... attrs) {

--- a/test/langtools/jdk/javadoc/doclet/TestGlobalHtml/TestGlobalHtml.java
+++ b/test/langtools/jdk/javadoc/doclet/TestGlobalHtml/TestGlobalHtml.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8322708
+ * @summary  Test to make sure global tags work properly
+ * @library  /tools/lib ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestGlobalHtml
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+
+public class TestGlobalHtml extends JavadocTester {
+    ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestGlobalHtml();
+        tester.runTests();
+    }
+
+    @Test
+    public void testGlobalTags() {
+        javadoc("--allow-script-in-comments",
+                "-d",
+                "out-global",
+                "-sourcepath",
+                testSrc,
+                "pkg1");
+        checkExit(Exit.OK);
+    }
+
+    @Test
+    public void testNegative(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                package p;
+                /**
+                 * class comment
+                 * <a href="https://openjdk.org/">Hyperlink to the OpenJDK website</a>
+                 */
+                public class C {
+                    /**
+                     * <form>
+                     *   <label for="methodname">Method name:</label><br>
+                     *   <input type="text" id="methodname" name="methodname"><br>
+                     *   <label for="paramname">Method Parameter:</label><br>
+                     *   <input type="text" id="paramname" name="paramname">
+                     * </form>
+                     */
+                    public C() {
+                    }
+                }
+                """);
+
+        javadoc("--allow-script-in-comments",
+                "-d",
+                "out-negative",
+                "-sourcepath",
+                src.toString(),
+                "p");
+        checkExit(Exit.ERROR);
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/TestGlobalHtml/pkg1/C1.java
+++ b/test/langtools/jdk/javadoc/doclet/TestGlobalHtml/pkg1/C1.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+
+/**
+ * <div inert>
+ * <p> This content is inert and not interactable.</p>
+ * <a href="https://openjdk.org/" title="OpenJDK's Website" tabindex="0">
+ * Visit OpenJDK's Website!
+ * </a>
+ * </div>
+ *
+ * <div>
+ *   <p autocapitalize="on">This content is interactable.</p>
+ *   <a href="https://openjdk.org/" title="OpenJDK's Website" tabindex="0">
+ *     Visit OpenJDK's Website!
+ *   </a>
+ * </div>
+ *
+ *
+ * <div dir="ltr" lang="en">
+ *   <p itemprop="description">This is used in a jtreg test to check that global HTML tags are allowed</p>
+ *   <ul spellcheck="true">
+ *     <li>Class C</li>
+ *     <li>Has a default constructor</li>
+ *   </ul>
+ * </div>
+ *
+ * <p contenteditable="true" inputmode="text">Here is a description of the class and methods:</p>
+ *
+ * <ol draggable="true" tabindex="0">
+ *   <li><p accesskey="1" data-element-type="constructor" title="Class Details">Has a default constructor</p></li>
+ *   <li><p accesskey="2" data-element-type="toString" title="Methods Summary">Overrides toString method</p></li>
+ *   <li><p accesskey="3" data-element-type="other" title="Usage Example">Is used for testing</p></li>
+ * </ol>
+ *
+ * <div itemscope>
+ *   <p itemprop="name">C1</p>
+ *   <p itemprop="description">C1</p>
+ * </div>
+ */
+public class C1 {
+
+    /**
+     * <p lang="en" accesskey="D" autocapitalize="on" draggable="true" spellcheck="false">
+     * Default constructor for the {@code C1} class. (this content is draggable!) </p>
+     * <div lang="en" contenteditable="true">
+     *   <p itemprop="creator">Author: try editing this content!</p>
+     *   <p title="Creation Date">Created on: June 14 2024</p>
+     * </div>
+     */
+    public C1() {
+    }
+
+    /**
+     * A method in C1
+     *
+     * <p lang="en" inputmode="numeric">simple method.</p>
+     *
+     * <div itemprop="method" itemscope>
+     *   <p itemprop="name">method m</p>
+     *   <p itemprop="description">the method m does nothing</p>
+     * </div>
+     */
+    public void m() {
+    }
+
+    /**
+     * A toString Override.
+     *
+     * <p dir="ltr" spellcheck="true">returns a String Object.</p>
+     *
+     * <div itemprop="method" itemscope>
+     *   <p itemprop="name">toString</p>
+     * </div>
+     *
+     * @return a string.
+     */
+    @Override
+    public String toString() {
+        return "C1";
+    }
+}


### PR DESCRIPTION
This is a clean backport of #19652 and commit 5cad0b4df7f5ccb6d462dc948c2ea5ad5da6e2ed. Allowing the use of global HTML attributes in javadoc.

I used the `/backport` command but also manually created a backport of the issue in JBS, I hope that's fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322708](https://bugs.openjdk.org/browse/JDK-8322708): Global HTML attributes are not allowed (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19805/head:pull/19805` \
`$ git checkout pull/19805`

Update a local copy of the PR: \
`$ git checkout pull/19805` \
`$ git pull https://git.openjdk.org/jdk.git pull/19805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19805`

View PR using the GUI difftool: \
`$ git pr show -t 19805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19805.diff">https://git.openjdk.org/jdk/pull/19805.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19805#issuecomment-2180571874)