### PR TITLE
8333344: JMX attaching of Subject does not work when security manager not allowed

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -165,6 +165,7 @@ module java.base {
         java.desktop,
         java.logging,
         java.management,
+        java.management.rmi,
         java.naming,
         java.rmi,
         jdk.charsets,

--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -343,10 +343,9 @@ public class ServerNotifForwarder {
     //----------------
     // PRIVATE METHODS
     //----------------
-
     @SuppressWarnings("removal")
     private Subject getSubject() {
-        return Subject.getSubject(AccessController.getContext());
+        return Subject.current();
     }
 
     private void checkState() throws IOException {

--- a/src/java.management/share/classes/javax/management/monitor/Monitor.java
+++ b/src/java.management/share/classes/javax/management/monitor/Monitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,8 @@ import javax.management.MBeanServerConnection;
 import javax.management.NotificationBroadcasterSupport;
 import javax.management.ObjectName;
 import javax.management.ReflectionException;
+import javax.security.auth.Subject;
+import jdk.internal.access.SharedSecrets;
 import static javax.management.monitor.MonitorNotification.*;
 
 /**
@@ -169,8 +171,9 @@ public abstract class Monitor
         new CopyOnWriteArrayList<>();
 
     /**
-     * AccessControlContext of the Monitor.start() caller.
+     * Subject and possibly AccessControlContext of the Monitor.start() caller.
      */
+    private volatile Subject subject;
     @SuppressWarnings("removal")
     private static final AccessControlContext noPermissionsACC =
             new AccessControlContext(
@@ -713,10 +716,14 @@ public abstract class Monitor
             //
             cleanupIsComplexTypeAttribute();
 
-            // Cache the AccessControlContext of the Monitor.start() caller.
+            // Cache the Subject or AccessControlContext of the Monitor.start() caller.
             // The monitor tasks will be executed within this context.
             //
-            acc = AccessController.getContext();
+            if (!SharedSecrets.getJavaLangAccess().allowSecurityManager()) {
+                subject = Subject.current();
+            } else {
+                acc = AccessController.getContext();
+            }
 
             // Start the scheduler.
             //
@@ -747,8 +754,9 @@ public abstract class Monitor
             //
             cleanupFutures();
 
-            // Reset the AccessControlContext.
+            // Reset the Subject and AccessControlContext.
             //
+            subject = null;
             acc = noPermissionsACC;
 
             // Reset the complex type attribute information
@@ -1512,9 +1520,11 @@ public abstract class Monitor
         @SuppressWarnings("removal")
         public void run() {
             final ScheduledFuture<?> sf;
+            final Subject s;
             final AccessControlContext ac;
             synchronized (Monitor.this) {
                 sf = Monitor.this.schedulerFuture;
+                s  = Monitor.this.subject;
                 ac = Monitor.this.acc;
             }
             PrivilegedAction<Void> action = new PrivilegedAction<>() {
@@ -1531,10 +1541,20 @@ public abstract class Monitor
                     return null;
                 }
             };
-            if (ac == null) {
-                throw new SecurityException("AccessControlContext cannot be null");
+            if (!SharedSecrets.getJavaLangAccess().allowSecurityManager()) {
+                // No SecurityManager permitted:
+                if (s == null) {
+                    action.run();
+                } else {
+                    Subject.doAs(s, action);
+                }
+            } else {
+                if (ac == null) {
+                    throw new SecurityException("AccessControlContext cannot be null");
+                }
+                // ACC means SM is permitted.
+                AccessController.doPrivileged(action, ac);
             }
-            AccessController.doPrivileged(action, ac);
             synchronized (Monitor.this) {
                 if (Monitor.this.isActive() &&
                     Monitor.this.schedulerFuture == sf) {

--- a/test/jdk/javax/management/monitor/StartStopTest.java
+++ b/test/jdk/javax/management/monitor/StartStopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,17 @@
  *
  * @run clean StartStopTest
  * @run build StartStopTest
+ *
  * @run main/othervm/timeout=300 StartStopTest 1
  * @run main/othervm/timeout=300 StartStopTest 2
  * @run main/othervm/timeout=300 StartStopTest 3
+ * @run main/othervm/timeout=300 -Djava.security.manager=allow StartStopTest 1
+ * @run main/othervm/timeout=300 -Djava.security.manager=allow StartStopTest 2
+ * @run main/othervm/timeout=300 -Djava.security.manager=allow StartStopTest 3
+ * @run main/othervm/timeout=300/policy=all.policy StartStopTest 1
+ * @run main/othervm/timeout=300/policy=all.policy StartStopTest 2
+ * @run main/othervm/timeout=300/policy=all.policy StartStopTest 3
+ *
  * @run main/othervm/timeout=300 -Djmx.x.monitor.maximum.pool.size=5 StartStopTest 1
  * @run main/othervm/timeout=300 -Djmx.x.monitor.maximum.pool.size=5 StartStopTest 2
  * @run main/othervm/timeout=300 -Djmx.x.monitor.maximum.pool.size=5 StartStopTest 3

--- a/test/jdk/javax/management/monitor/all.policy
+++ b/test/jdk/javax/management/monitor/all.policy
@@ -1,0 +1,3 @@
+grant {
+    permission java.security.AllPermission;
+};

--- a/test/jdk/javax/management/remote/mandatory/notif/NotificationAccessControllerTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotificationAccessControllerTest.java
@@ -30,6 +30,8 @@
  *          java.management/com.sun.jmx.remote.security
  * @run clean NotificationAccessControllerTest
  * @run build NotificationAccessControllerTest
+ *
+ * @run main/othervm NotificationAccessControllerTest
  * @run main/othervm -Djava.security.manager=allow NotificationAccessControllerTest
  */
 

--- a/test/jdk/javax/management/remote/mandatory/notif/NotificationEmissionTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotificationEmissionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,9 @@
  *
  * @run clean NotificationEmissionTest
  * @run build NotificationEmissionTest
+ *
  * @run main NotificationEmissionTest 1
+ * @run main/othervm -Djava.security.manager=allow NotificationEmissionTest 1
  * @run main/othervm -Djava.security.manager=allow NotificationEmissionTest 2
  * @run main/othervm -Djava.security.manager=allow NotificationEmissionTest 3
  * @run main/othervm -Djava.security.manager=allow NotificationEmissionTest 4

--- a/test/jdk/javax/management/remote/mandatory/passwordAccessFile/NonJMXPrincipalsTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAccessFile/NonJMXPrincipalsTest.java
@@ -30,6 +30,7 @@
  *
  * @run clean NonJMXPrincipalsTest SimpleStandard SimpleStandardMBean
  * @run build NonJMXPrincipalsTest SimpleStandard SimpleStandardMBean
+ * @run main/othervm NonJMXPrincipalsTest
  * @run main/othervm -Djava.security.manager=allow NonJMXPrincipalsTest
  */
 

--- a/test/jdk/javax/management/remote/mandatory/passwordAccessFile/PasswordAccessFileTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAccessFile/PasswordAccessFileTest.java
@@ -30,6 +30,8 @@
  *
  * @run clean PasswordAccessFileTest SimpleStandard SimpleStandardMBean
  * @run build PasswordAccessFileTest SimpleStandard SimpleStandardMBean
+ *
+ * @run main/othervm PasswordAccessFileTest
  * @run main/othervm -Djava.security.manager=allow PasswordAccessFileTest
  */
 

--- a/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIAltAuthTest.java
@@ -30,7 +30,10 @@
  *          java.management/com.sun.jmx.remote.security
  * @run clean RMIAltAuthTest
  * @run build RMIAltAuthTest SimpleStandard SimpleStandardMBean
+ *
+ * @run main/othervm RMIAltAuthTest
  * @run main/othervm -Djava.security.manager=allow RMIAltAuthTest
+ * @run main/othervm -Djava.security.manager=allow -DSimpleStandard.useGetSubjectACC=true RMIAltAuthTest
  */
 
 import java.io.File;

--- a/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/RMIPasswdAuthTest.java
@@ -30,7 +30,10 @@
  *          java.management/com.sun.jmx.remote.security
  * @run clean RMIPasswdAuthTest
  * @run build RMIPasswdAuthTest SimpleStandard SimpleStandardMBean
+ *
+ * @run main/othervm RMIPasswdAuthTest
  * @run main/othervm -Djava.security.manager=allow RMIPasswdAuthTest
+ * @run main/othervm -Djava.security.manager=allow -DSimpleStandard.useGetSubjectACC=true RMIPasswdAuthTest
  */
 
 import java.io.File;

--- a/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/SimpleStandard.java
+++ b/test/jdk/javax/management/remote/mandatory/passwordAuthenticator/SimpleStandard.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,8 +152,8 @@ public class SimpleStandard
      * type JMXPrincipal and refers to the "monitorRole" identity.
      */
     private void checkSubject() {
-        AccessControlContext acc = AccessController.getContext();
-        Subject subject = Subject.getSubject(acc);
+        Subject subject = Boolean.getBoolean("SimpleStandard.useGetSubjectACC") ?
+                          Subject.getSubject(AccessController.getContext()) : Subject.current();
         Set principals = subject.getPrincipals();
         Principal principal = (Principal) principals.iterator().next();
         if (!(principal instanceof JMXPrincipal))

--- a/test/jdk/javax/management/security/AuthorizationTest.java
+++ b/test/jdk/javax/management/security/AuthorizationTest.java
@@ -29,9 +29,15 @@
  * @modules java.management.rmi
  * @library /test/lib
  * @compile Simple.java
+ *
+ * @run main/othervm/timeout=300 -DDEBUG_STANDARD -Dusername=username1 -Dpassword=password1 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials
+ * @run main/othervm/timeout=300 -DDEBUG_STANDARD -Dusername=username2 -Dpassword=password2 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials -expectedCreateException -expectedSetException -expectedInvokeException
+ * @run main/othervm/timeout=300 -DDEBUG_STANDARD -Dusername=username6 -Dpassword=password6 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials -expectedCreateException -expectedGetException -expectedSetException -expectedInvokeException
+ *
  * @run main/othervm/timeout=300 -Djava.security.manager=allow -DDEBUG_STANDARD -Dusername=username1 -Dpassword=password1 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials
  * @run main/othervm/timeout=300 -Djava.security.manager=allow -DDEBUG_STANDARD -Dusername=username2 -Dpassword=password2 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials -expectedCreateException -expectedSetException -expectedInvokeException
  * @run main/othervm/timeout=300 -Djava.security.manager=allow -DDEBUG_STANDARD -Dusername=username6 -Dpassword=password6 AuthorizationTest -server -mapType x.access.file;x.password.file -populate -client -mapType credentials -expectedCreateException -expectedGetException -expectedSetException -expectedInvokeException
+ *
  * @run main/othervm/timeout=300/policy=java.policy.authorization -DDEBUG_STANDARD -Dusername=username1 -Dpassword=password1 AuthorizationTest -server -mapType x.password.file -populate -client -mapType credentials
  * @run main/othervm/timeout=300/policy=java.policy.authorization -DDEBUG_STANDARD -Dusername=username3 -Dpassword=password3 AuthorizationTest -server -mapType x.password.file -populate -client -mapType credentials -expectedGetException
  * @run main/othervm/timeout=300/policy=java.policy.authorization -DDEBUG_STANDARD -Dusername=username5 -Dpassword=password5 AuthorizationTest -server -mapType x.password.file -populate -client -mapType credentials -expectedCreateException -expectedGetException -expectedSetException -expectedInvokeException

--- a/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
+++ b/test/jdk/sun/management/jmxremote/bootstrap/RmiBootstrapTest.java
@@ -61,6 +61,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_test.*.in
  * @run main/othervm/timeout=300 -Djava.security.manager=allow RmiBootstrapTest .*_test.*.in
  * */
 
@@ -72,6 +73,7 @@ import java.util.Set;
  *
  * @library /test/lib
  *
+ * @run main/othervm/timeout=300 RmiBootstrapTest .*_ssltest.*.in
  * @run main/othervm/timeout=300 -Djava.security.manager=allow RmiBootstrapTest .*_ssltest.*.in
  * */
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333344](https://bugs.openjdk.org/browse/JDK-8333344): JMX attaching of Subject does not work when security manager not allowed (**Bug** - P2)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19810/head:pull/19810` \
`$ git checkout pull/19810`

Update a local copy of the PR: \
`$ git checkout pull/19810` \
`$ git pull https://git.openjdk.org/jdk.git pull/19810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19810`

View PR using the GUI difftool: \
`$ git pr show -t 19810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19810.diff">https://git.openjdk.org/jdk/pull/19810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19810#issuecomment-2181475569)