### PR TITLE
8334564: VM startup: fatal error: FLAG_SET_ERGO cannot be used to set an invalid value for NonNMethodCodeHeapSize

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -231,7 +231,7 @@ void CodeCache::initialize_heaps() {
     // aligned down to the next lower multiple of min_size. For large page
     // sizes, this may result in (non_nmethod.size == 0) which is not acceptable.
     // Therefore, force non_nmethod.size to at least min_size.
-    non_nmethod.size  = MAX2(non_nmethod.size, min_size);
+    non_nmethod.size = MAX2(non_nmethod.size, min_size);
   }
 
   if (!profiled.set && !non_profiled.set) {

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -227,6 +227,11 @@ void CodeCache::initialize_heaps() {
 
   if (!non_nmethod.set) {
     non_nmethod.size += compiler_buffer_size;
+    // Further down, just before FLAG_SET_ERGO(), all segment sizes are
+    // aligned down to the next lower multiple of min_size. For large page
+    // sizes, this may result in (non_nmethod.size == 0) which is not acceptable.
+    // Therefore, force non_nmethod.size to at least min_size.
+    non_nmethod.size  = MAX2(non_nmethod.size, min_size);
   }
 
   if (!profiled.set && !non_profiled.set) {


### PR DESCRIPTION
CodeHeap segment sizes are aligned to page size multiples. This can result in the non-nmethod segment receiving size 0 (zero). Range checking during FLAG_SET_ERGO processing detects that and raises an error, preventing the vm from starting.

This fix increases the minimum size of the non-nmethod segment to page size, preventing it from being rounded down to zero.

Verified by manual testing. Nightly tests (mainly to discover unexpected side effects) pending.

Nightly tests did not reveal anything suspicious.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334564](https://bugs.openjdk.org/browse/JDK-8334564): VM startup: fatal error: FLAG_SET_ERGO cannot be used to set an invalid value for NonNMethodCodeHeapSize (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) ⚠️ Review applies to [53f32a14](https://git.openjdk.org/jdk/pull/19812/files/53f32a1486ccf605199e4e3a293c5c9fd924d9d0)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to [53f32a14](https://git.openjdk.org/jdk/pull/19812/files/53f32a1486ccf605199e4e3a293c5c9fd924d9d0)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19812/head:pull/19812` \
`$ git checkout pull/19812`

Update a local copy of the PR: \
`$ git checkout pull/19812` \
`$ git pull https://git.openjdk.org/jdk.git pull/19812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19812`

View PR using the GUI difftool: \
`$ git pr show -t 19812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19812.diff">https://git.openjdk.org/jdk/pull/19812.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19812#issuecomment-2181044159)