### PR TITLE
8334679: Wrong bug number in regression test for JDK-8334252

### DIFF
--- a/test/langtools/tools/javac/SuperInit/LambdaOuterCapture.java
+++ b/test/langtools/tools/javac/SuperInit/LambdaOuterCapture.java
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 8194743
+ * @bug 8334252
  * @summary Test lambda declared in early construction context
  * @enablePreview
  */


### PR DESCRIPTION
Please review this trivial fix to correct the`@bug` number in the regression test for [JDK-8334252](https://bugs.openjdk.org/browse/JDK-8334252).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334679](https://bugs.openjdk.org/browse/JDK-8334679): Wrong bug number in regression test for JDK-8334252 (**Bug** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19816/head:pull/19816` \
`$ git checkout pull/19816`

Update a local copy of the PR: \
`$ git checkout pull/19816` \
`$ git pull https://git.openjdk.org/jdk.git pull/19816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19816`

View PR using the GUI difftool: \
`$ git pr show -t 19816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19816.diff">https://git.openjdk.org/jdk/pull/19816.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19816#issuecomment-2181621278)