### PR TITLE
8334580: Deprecate no-arg constructor BasicSliderUI() for removal

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,7 +150,8 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
-     * @deprecated This constructor will be removed in future release
+     * @deprecated This constructor was exposed erroneously and will be removed in next version.
+     *             Use {@link #BasicSliderUI(JSlider b)} instead.
      */
     @Deprecated(since = "23", forRemoval = true)
     public BasicSliderUI() {}

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,7 +150,6 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
-     * 
      */
     @Deprecated(since = "23")
     public BasicSliderUI() {}

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,8 +150,9 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
+     * @deprecated This constructor will be removed in future release
      */
-    @Deprecated(since = "23")
+    @Deprecated(since = "23", forRemoval = true)
     public BasicSliderUI() {}
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,7 +150,9 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
+     * 
      */
+    @Deprecated(since = "23")
     public BasicSliderUI() {}
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,8 +150,8 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
-     * @deprecated This constructor was exposed erroneously and will be removed in next version.
-     *             Use {@link #BasicSliderUI(JSlider b)} instead.
+     * @deprecated This constructor was exposed erroneously and will be removed in a future release.
+     *             Use {@link #BasicSliderUI(JSlider)} instead.
      */
     @Deprecated(since = "23", forRemoval = true)
     public BasicSliderUI() {}


### PR DESCRIPTION
The no-arg constructor BasicSliderUI() was added under [JDK-8250852](https://bugs.openjdk.org/browse/JDK-8250852) by mistake. This constructor should be deprecated for removal in future release

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8334677](https://bugs.openjdk.org/browse/JDK-8334677) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8334580](https://bugs.openjdk.org/browse/JDK-8334580): Deprecate no-arg constructor BasicSliderUI() for removal (**Bug** - P2)
 * [JDK-8334677](https://bugs.openjdk.org/browse/JDK-8334677): Deprecate no-arg constructor BasicSliderUI() for removal (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) ⚠️ Review applies to [9dd9697b](https://git.openjdk.org/jdk/pull/19819/files/9dd9697b7f0686f832cb90be95080e3b3dc6340a)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19819/head:pull/19819` \
`$ git checkout pull/19819`

Update a local copy of the PR: \
`$ git checkout pull/19819` \
`$ git pull https://git.openjdk.org/jdk.git pull/19819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19819`

View PR using the GUI difftool: \
`$ git pr show -t 19819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19819.diff">https://git.openjdk.org/jdk/pull/19819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19819#issuecomment-2181940827)