### PR TITLE
8334706: [JVMCI] APX registers incorrectly exposed on AMD64

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -83,6 +83,7 @@ public class AMD64 extends Architecture {
     public static final Register r30 = new Register(30, 30, "r30", CPU);
     public static final Register r31 = new Register(31, 31, "r31", CPU);
 
+    // The set of common CPU registers available on all x64 platforms.
     public static final Register[] cpuRegisters = {
         rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi,
         r8, r9, r10, r11, r12, r13, r14, r15

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/amd64/AMD64.java
@@ -85,9 +85,7 @@ public class AMD64 extends Architecture {
 
     public static final Register[] cpuRegisters = {
         rax, rcx, rdx, rbx, rsp, rbp, rsi, rdi,
-        r8, r9, r10, r11, r12, r13, r14, r15,
-        r16, r17, r18, r19, r20, r21, r22, r23,
-        r24, r25, r26, r27, r28, r29, r30, r31
+        r8, r9, r10, r11, r12, r13, r14, r15
     };
 
     public static final RegisterCategory XMM = new RegisterCategory("XMM");
@@ -162,8 +160,6 @@ public class AMD64 extends Architecture {
     public static final RegisterArray valueRegistersAVX512 = new RegisterArray(
         rax,  rcx,  rdx,   rbx,   rsp,   rbp,   rsi,   rdi,
         r8,   r9,   r10,   r11,   r12,   r13,   r14,   r15,
-        r16,  r17,  r18,   r19,   r20,   r21,   r22,   r23,
-        r24,  r25,  r26,   r27,   r28,   r29,   r30,   r31,
         xmm0, xmm1, xmm2,  xmm3,  xmm4,  xmm5,  xmm6,  xmm7,
         xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15,
         xmm16, xmm17, xmm18, xmm19, xmm20, xmm21, xmm22, xmm23,
@@ -179,6 +175,8 @@ public class AMD64 extends Architecture {
     public static final RegisterArray allRegisters = new RegisterArray(
         rax,  rcx,  rdx,   rbx,   rsp,   rbp,   rsi,   rdi,
         r8,   r9,   r10,   r11,   r12,   r13,   r14,   r15,
+        r16,  r17,  r18,   r19,   r20,   r21,   r22,   r23,
+        r24,  r25,  r26,   r27,   r28,   r29,   r30,   r31,
         xmm0, xmm1, xmm2,  xmm3,  xmm4,  xmm5,  xmm6,  xmm7,
         xmm8, xmm9, xmm10, xmm11, xmm12, xmm13, xmm14, xmm15,
         xmm16, xmm17, xmm18, xmm19, xmm20, xmm21, xmm22, xmm23,

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/Architecture.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/Architecture.java
@@ -26,6 +26,7 @@ import java.nio.ByteOrder;
 import java.util.Set;
 
 import jdk.vm.ci.code.Register.RegisterCategory;
+import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.PlatformKind;
 
@@ -81,6 +82,13 @@ public abstract class Architecture {
     protected Architecture(String name, PlatformKind wordKind, ByteOrder byteOrder, boolean unalignedMemoryAccess, RegisterArray registers, int implicitMemoryBarriers,
                     int nativeCallDisplacementOffset,
                     int returnAddressSize) {
+        // registers is expected to mention all registers in order of their encoding.
+        for (int i = 0; i < registers.size(); ++i) {
+            if (registers.get(i).number != i) {
+                Register reg = registers.get(i);
+                throw new JVMCIError("%s: %d != %d", reg, reg.number, i);
+            }
+        }
         this.name = name;
         this.registers = registers;
         this.wordKind = wordKind;


### PR DESCRIPTION
This PR fixes a bug introduced by [JDK-8329032](https://bugs.openjdk.org/browse/JDK-8329032) which added the APX registers to `AMD64.java`.
It broke [this invariant](https://github.com/openjdk/jdk/blob/d2bebffb1fd26fae4526afd33a818ee776b7102e/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/Architecture.java#L48-L52):
```
    /**
     * List of all available registers on this architecture. The index of each register in this list
     * is equal to its {@linkplain Register#number number}.
     */
    private final RegisterArray registers;
```
That invariant is relied upon by the Graal register allocator.
This PR now tests the invariant and fixes the definitions in `AMD64.java` that were violating it.

This fix was developed by @tkrodriguez.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334706](https://bugs.openjdk.org/browse/JDK-8334706): [JVMCI] APX registers incorrectly exposed on AMD64 (**Bug** - P2)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer) ⚠️ Review applies to [f8028db1](https://git.openjdk.org/jdk/pull/19824/files/f8028db188505224142221a96796e2f74eedac0e)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19824/head:pull/19824` \
`$ git checkout pull/19824`

Update a local copy of the PR: \
`$ git checkout pull/19824` \
`$ git pull https://git.openjdk.org/jdk.git pull/19824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19824`

View PR using the GUI difftool: \
`$ git pr show -t 19824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19824.diff">https://git.openjdk.org/jdk/pull/19824.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19824#issuecomment-2182444826)