### PR TITLE
8334554: RISC-V: verify & fix perf of string comparison

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2326,12 +2326,13 @@ void C2_MacroAssembler::expand_bits_l_v(Register dst, Register src, Register mas
 }
 
 void C2_MacroAssembler::element_compare(Register a1, Register a2, Register result, Register cnt, Register tmp1, Register tmp2,
-                                        VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE) {
+                                        VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE,
+                                        bool is_m2) {
   Label loop;
   Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
 
   bind(loop);
-  vsetvli(tmp1, cnt, sew, Assembler::m2);
+  vsetvli(tmp1, cnt, sew, is_m2 ? Assembler::m2 : Assembler::m4);
   vlex_v(vr1, a1, sew);
   vlex_v(vr2, a2, sew);
   vmsne_vv(vrs, vr1, vr2);
@@ -2446,7 +2447,7 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
   bind(L);
 
   if (str1_isL == str2_isL) { // LL or UU
-    element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v2, v4, v2, encLL, DIFFERENCE);
+    element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v4, v8, v4, encLL, DIFFERENCE, false);
     j(DONE);
   } else { // LU or UL
     Register strL = encLU ? str1 : str2;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2327,12 +2327,12 @@ void C2_MacroAssembler::expand_bits_l_v(Register dst, Register src, Register mas
 
 void C2_MacroAssembler::element_compare(Register a1, Register a2, Register result, Register cnt, Register tmp1, Register tmp2,
                                         VectorRegister vr1, VectorRegister vr2, VectorRegister vrs, bool islatin, Label &DONE,
-                                        bool is_m2) {
+                                        Assembler::LMUL lmul) {
   Label loop;
   Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
 
   bind(loop);
-  vsetvli(tmp1, cnt, sew, is_m2 ? Assembler::m2 : Assembler::m4);
+  vsetvli(tmp1, cnt, sew, lmul);
   vlex_v(vr1, a1, sew);
   vlex_v(vr2, a2, sew);
   vmsne_vv(vrs, vr1, vr2);
@@ -2446,8 +2446,18 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
   mv(cnt2, cnt1);
   bind(L);
 
+  // We focus on the optimization of small sized string.
+  // Please check below document for string size distribution statistics.
+  // https://cr.openjdk.org/~shade/density/string-density-report.pdf
   if (str1_isL == str2_isL) { // LL or UU
-    element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v4, v8, v4, encLL, DIFFERENCE, false);
+    // Below construction of v regs and lmul is based on test on 2 different boards,
+    // vlen == 128 and vlen == 256 respectively.
+    if (!str1_isL && MaxVectorSize == 16) { // UU
+      element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v4, v8, v4, encLL, DIFFERENCE, Assembler::m4);
+    } else { // UU + MaxVectorSize or LL
+      element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v2, v4, v2, encLL, DIFFERENCE, Assembler::m2);
+    }
+
     j(DONE);
   } else { // LU or UL
     Register strL = encLU ? str1 : str2;

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2358,7 +2358,7 @@ void C2_MacroAssembler::string_equals_v(Register a1, Register a2, Register resul
 
   mv(result, false);
 
-  element_compare(a1, a2, result, cnt, tmp1, tmp2, v2, v4, v2, true, DONE);
+  element_compare(a1, a2, result, cnt, tmp1, tmp2, v2, v4, v2, true, DONE, Assembler::m2);
 
   bind(DONE);
   BLOCK_COMMENT("} string_equals_v");
@@ -2411,7 +2411,7 @@ void C2_MacroAssembler::arrays_equals_v(Register a1, Register a2, Register resul
   la(a1, Address(a1, base_offset));
   la(a2, Address(a2, base_offset));
 
-  element_compare(a1, a2, result, cnt1, tmp1, tmp2, v2, v4, v2, elem_size == 1, DONE);
+  element_compare(a1, a2, result, cnt1, tmp1, tmp2, v2, v4, v2, elem_size == 1, DONE, Assembler::m2);
 
   bind(DONE);
 
@@ -2452,7 +2452,7 @@ void C2_MacroAssembler::string_compare_v(Register str1, Register str2, Register 
   if (str1_isL == str2_isL) { // LL or UU
     // Below construction of v regs and lmul is based on test on 2 different boards,
     // vlen == 128 and vlen == 256 respectively.
-    if (!str1_isL && MaxVectorSize == 16) { // UU
+    if (!encLL && MaxVectorSize == 16) { // UU
       element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v4, v8, v4, encLL, DIFFERENCE, Assembler::m4);
     } else { // UU + MaxVectorSize or LL
       element_compare(str1, str2, zr, cnt2, tmp1, tmp2, v2, v4, v2, encLL, DIFFERENCE, Assembler::m2);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -37,7 +37,7 @@
                        Register tmp1, Register tmp2,
                        VectorRegister vr1, VectorRegister vr2,
                        VectorRegister vrs,
-                       bool is_latin, Label& DONE, bool is_m2 = true);
+                       bool is_latin, Label& DONE, Assembler::LMUL lmul = Assembler::m2);
 
   void compress_bits_v(Register dst, Register src, Register mask, bool is_long);
   void expand_bits_v(Register dst, Register src, Register mask, bool is_long);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -37,7 +37,7 @@
                        Register tmp1, Register tmp2,
                        VectorRegister vr1, VectorRegister vr2,
                        VectorRegister vrs,
-                       bool is_latin, Label& DONE, Assembler::LMUL lmul = Assembler::m2);
+                       bool is_latin, Label& DONE, Assembler::LMUL lmul);
 
   void compress_bits_v(Register dst, Register src, Register mask, bool is_long);
   void expand_bits_v(Register dst, Register src, Register mask, bool is_long);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -37,7 +37,7 @@
                        Register tmp1, Register tmp2,
                        VectorRegister vr1, VectorRegister vr2,
                        VectorRegister vrs,
-                       bool is_latin, Label& DONE);
+                       bool is_latin, Label& DONE, bool is_m2 = true);
 
   void compress_bits_v(Register dst, Register src, Register mask, bool is_long);
   void expand_bits_v(Register dst, Register src, Register mask, bool is_long);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3563,15 +3563,16 @@ instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
   ins_pipe(pipe_class_memory);
 %}
 
-instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+instruct vstring_compareUVlen16(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                           iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                          vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
+            MaxVectorSize == 16);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+        TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -3583,15 +3584,36 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
   %}
   ins_pipe(pipe_class_memory);
 %}
+
+instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegP_R28 tmp1, iRegL_R29 tmp2)
+%{
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
+            MaxVectorSize > 16);
+  match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
+  effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
+        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+
+  format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
+  ins_encode %{
+    // Count is in 8-bit bytes; non-Compact chars are 16 bits.
+    __ string_compare_v($str1$$Register, $str2$$Register,
+                        $cnt1$$Register, $cnt2$$Register, $result$$Register,
+                        $tmp1$$Register, $tmp2$$Register,
+                        StrIntrinsicNode::UU);
+  %}
+  ins_pipe(pipe_class_memory);
+%}
+
 instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareL" %}
   ins_encode %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3564,13 +3564,14 @@ instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
 %}
 
 instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
+                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-         TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -3583,13 +3584,14 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
   ins_pipe(pipe_class_memory);
 %}
 instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
+                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-         TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+          TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareL" %}
   ins_encode %{

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3563,7 +3563,7 @@ instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
   ins_pipe(pipe_class_memory);
 %}
 
-instruct vstring_compareUVlen16(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
+instruct vstring_compareU_128b(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                           iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)


### PR DESCRIPTION
Hi,
Can you help to review this patch?
Thanks!

As in compare-UL/LU, it already uses m4, so in this patch also use m4 for compare-UU/LL.

## Test
tested on K230-CanMV, vlen = 128.
warmup: 10 times
iteration: 10 times

### Before patch
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Benchmark | (size) | Score+rvv | Score-rvv | -rvv/+rvv
-- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 24 | 4242936.876 | 7227607.14 | 1.703444419
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 36 | 5738695.363 | 8157070.353 | 1.421415468
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 72 | 7163243.984 | 7209568.036 | 1.00646691
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 128 | 8627566.301 | 12720927.51 | 1.474451435
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 256 | 14632020.04 | 16291127.26 | 1.113388802
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 512 | 26539410.59 | 23612505.95 | 0.8897147833
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 24 | 4913490.894 | 10454585.94 | 2.127730807
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 36 | 7230036.286 | 13561865.48 | 1.875767277
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 72 | 9525418.104 | 21901656.51 | 2.299285582
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 128 | 12645301.4 | 37351484.04 | 2.953783611
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 256 | 21147886.68 | 64886475.43 | 3.068225039
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 512 | 39738017.94 | 125169103.6 | 3.149857745
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 24 | 5183884.427 | 11040441.7 | 2.129762314
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 36 | 7421224.1 | 13879329.16 | 1.870221
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 72 | 9739241.916 | 22346979.93 | 2.29452971
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 128 | 12115336.28 | 35576652.6 | 2.936497326
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 256 | 21473923.71 | 65486723.87 | 3.049592834
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 512 | 39885299.16 | 126584284.1 | 3.173707775
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 24 | 5869568.01 | 6264293.13 | 1.067249433
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 36 | 7426068.273 | 7166385.007 | 0.965030854
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 72 | 10526248.56 | 11169251.07 | 1.061085629
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 128 | 15267275.25 | 14296156.49 | 0.9363921363
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 256 | 27485452.58 | 21502833.49 | 0.7823350711
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 512 | 52373404.61 | 36336863.6 | 0.6938037325
org.openjdk.bench.java.lang.StringCompareToIgnoreCase.lower | N/A | 513.029 | 512.537 | 0.9990409899
org.openjdk.bench.java.lang.StringCompareToIgnoreCase.supLower | N/A | 1762.272 | 1809.632 | 1.026874399
org.openjdk.bench.java.lang.StringCompareToIgnoreCase.supUpperLower | N/A | 415.817 | 411.34 | 0.9892332444
org.openjdk.bench.java.lang.StringCompareToIgnoreCase.upperLower | N/A | 134.015 | 134.996 | 1.007320076

</google-sheets-html-origin>

### After patch
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
Benchmark | (size) | Score+rvv | Score-rvv | -rvv/+rvv
-- | -- | -- | -- | --
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 24 | 4941788.887 | 7235758.056 | 1.464198132
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 36 | 4858467.032 | 8251505.321 | 1.698376312
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 72 | 7005945.609 | 7249177.693 | 1.034717952
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 128 | 6978779.091 | 12739192.42 | 1.825418494
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 256 | 11415559.72 | 16327823.57 | 1.430313008
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLL | 512 | 19937616.04 | 23684883.47 | 1.187949624
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 24 | 4892286.111 | 10482882.2 | 2.142736945
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 36 | 7256276.588 | 13559492.21 | 1.868657023
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 72 | 9578807.302 | 21870959.39 | 2.28326541
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 128 | 12646740.63 | 37180505.2 | 2.939927867
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 256 | 21191170.83 | 65072376.34 | 3.070730582
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToLU | 512 | 39834754.39 | 124831609.3 | 3.133736136
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 24 | 5108362.647 | 11010578.08 | 2.15540259
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 36 | 7412159.529 | 13905404.14 | 1.87602602
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 72 | 9748728.771 | 22332596.73 | 2.290821425
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 128 | 12073341.2 | 35555290.53 | 2.944942079
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 256 | 21559366.55 | 65641886.44 | 3.044703855
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUL | 512 | 40341344 | 126752774.3 | 3.142006728
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 24 | 4976856.452 | 6356401.852 | 1.277192122
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 36 | 7181852.586 | 7170891.993 | 0.9984738488
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 72 | 9379572.647 | 11193184.19 | 1.193357588
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 128 | 11564753.39 | 14309848.99 | 1.237367413
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 256 | 20337803.69 | 21584269.25 | 1.06128811
com.arm.benchmarks.intrinsics.StringCompareToDifferentLength.compareToUU | 512 | 37906097.39 | 36445458.74 | 0.9614669209

</google-sheets-html-origin>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334554](https://bugs.openjdk.org/browse/JDK-8334554): RISC-V: verify &amp; fix perf of string comparison (**Sub-task** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19825/head:pull/19825` \
`$ git checkout pull/19825`

Update a local copy of the PR: \
`$ git checkout pull/19825` \
`$ git pull https://git.openjdk.org/jdk.git pull/19825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19825`

View PR using the GUI difftool: \
`$ git pr show -t 19825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19825.diff">https://git.openjdk.org/jdk/pull/19825.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19825#issuecomment-2182493273)