### PR TITLE
8334714: Class-File API leaves preview

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
+++ b/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
@@ -33,7 +33,7 @@ import java.lang.reflect.AccessFlag;
  * {@link ClassElement}, {@link FieldElement}, or {@link MethodElement}
  * when traversing the corresponding model type.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface AccessFlags
         extends ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
+++ b/src/java.base/share/classes/java/lang/classfile/AccessFlags.java
@@ -27,7 +27,6 @@ package java.lang.classfile;
 import java.util.Set;
 import jdk.internal.classfile.impl.AccessFlagsImpl;
 import java.lang.reflect.AccessFlag;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the access flags for a class, method, or field.  Delivered as a
@@ -36,7 +35,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AccessFlags
         extends ClassElement, MethodElement, FieldElement
         permits AccessFlagsImpl {

--- a/src/java.base/share/classes/java/lang/classfile/Annotation.java
+++ b/src/java.base/share/classes/java/lang/classfile/Annotation.java
@@ -46,7 +46,7 @@ import java.util.List;
  * @see RuntimeInvisibleParameterAnnotationsAttribute
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface Annotation
         extends WritableElement<Annotation>

--- a/src/java.base/share/classes/java/lang/classfile/Annotation.java
+++ b/src/java.base/share/classes/java/lang/classfile/Annotation.java
@@ -34,7 +34,6 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
 
 import java.lang.constant.ClassDesc;
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an annotation on a declaration.
@@ -49,7 +48,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Annotation
         extends WritableElement<Annotation>
         permits TypeAnnotation, AnnotationImpl {

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationElement.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
  * @see Annotation
  * @see AnnotationValue
  *
- * @since 22
+ * @since 24
  */
 public sealed interface AnnotationElement
         extends WritableElement<AnnotationElement>

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationElement.java
@@ -29,7 +29,6 @@ import java.lang.constant.ClassDesc;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AnnotationImpl;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a key-value pair of an annotation.
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AnnotationElement
         extends WritableElement<AnnotationElement>
         permits AnnotationImpl.AnnotationElementImpl {

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -45,7 +45,7 @@ import java.util.List;
  * @see AnnotationElement
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
         permits AnnotationValue.OfAnnotation, AnnotationValue.OfArray,
@@ -55,7 +55,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models an annotation-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfAnnotation extends AnnotationValue
             permits AnnotationImpl.OfAnnotationImpl {
@@ -66,7 +66,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models an array-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfArray extends AnnotationValue
             permits AnnotationImpl.OfArrayImpl {
@@ -78,7 +78,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * Models a constant-valued element
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     sealed interface OfConstant extends AnnotationValue
             permits AnnotationValue.OfString, AnnotationValue.OfDouble,
@@ -95,7 +95,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfString extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfStringImpl {
@@ -106,7 +106,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfDouble extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfDoubleImpl {
@@ -117,7 +117,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfFloat extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfFloatImpl {
@@ -128,7 +128,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfLong extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfLongImpl {
@@ -139,7 +139,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfInteger extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfIntegerImpl {
@@ -150,7 +150,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfShort extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfShortImpl {
@@ -161,7 +161,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfCharacter extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfCharacterImpl {
@@ -172,7 +172,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfByte extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfByteImpl {
@@ -183,7 +183,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a constant-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfBoolean extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfBooleanImpl {
@@ -194,7 +194,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models a class-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfClass extends AnnotationValue
             permits AnnotationImpl.OfClassImpl {
@@ -210,7 +210,7 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
     /**
      * Models an enum-valued element
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OfEnum extends AnnotationValue
             permits AnnotationImpl.OfEnumImpl {

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -37,7 +37,6 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 import java.util.ArrayList;
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the value of a key-value pair of an annotation.
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
         permits AnnotationValue.OfAnnotation, AnnotationValue.OfArray,
                 AnnotationValue.OfConstant, AnnotationValue.OfClass,
@@ -59,7 +57,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfAnnotation extends AnnotationValue
             permits AnnotationImpl.OfAnnotationImpl {
         /** {@return the annotation} */
@@ -71,7 +68,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfArray extends AnnotationValue
             permits AnnotationImpl.OfArrayImpl {
         /** {@return the values} */
@@ -84,7 +80,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfConstant extends AnnotationValue
             permits AnnotationValue.OfString, AnnotationValue.OfDouble,
                     AnnotationValue.OfFloat, AnnotationValue.OfLong,
@@ -102,7 +97,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfString extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfStringImpl {
         /** {@return the constant} */
@@ -114,7 +108,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfDouble extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfDoubleImpl {
         /** {@return the constant} */
@@ -126,7 +119,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfFloat extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfFloatImpl {
         /** {@return the constant} */
@@ -138,7 +130,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfLong extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfLongImpl {
         /** {@return the constant} */
@@ -150,7 +141,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfInteger extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfIntegerImpl {
         /** {@return the constant} */
@@ -162,7 +152,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfShort extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfShortImpl {
         /** {@return the constant} */
@@ -174,7 +163,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfCharacter extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfCharacterImpl {
         /** {@return the constant} */
@@ -186,7 +174,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfByte extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfByteImpl {
         /** {@return the constant} */
@@ -198,7 +185,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfBoolean extends AnnotationValue.OfConstant
             permits AnnotationImpl.OfBooleanImpl {
         /** {@return the constant} */
@@ -210,7 +196,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfClass extends AnnotationValue
             permits AnnotationImpl.OfClassImpl {
         /** {@return the class name} */
@@ -227,7 +212,6 @@ public sealed interface AnnotationValue extends WritableElement<AnnotationValue>
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OfEnum extends AnnotationValue
             permits AnnotationImpl.OfEnumImpl {
         /** {@return the enum class name} */

--- a/src/java.base/share/classes/java/lang/classfile/Attribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attribute.java
@@ -75,7 +75,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * @param <A> the attribute type
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface Attribute<A extends Attribute<A>>
         extends WritableElement<A>

--- a/src/java.base/share/classes/java/lang/classfile/Attribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attribute.java
@@ -63,7 +63,6 @@ import java.lang.classfile.attribute.SyntheticAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a classfile attribute {@jvms 4.7}.  Many, though not all, subtypes of
@@ -78,7 +77,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Attribute<A extends Attribute<A>>
         extends WritableElement<A>
         permits AnnotationDefaultAttribute, BootstrapMethodsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
@@ -35,14 +35,14 @@ package java.lang.classfile;
  * CustomAttribute}.
  * @param <A> the attribute type
  *
- * @since 22
+ * @since 24
  */
 public interface AttributeMapper<A> {
 
     /**
      * Attribute stability indicator
      *
-     * @since 22
+     * @since 24
      */
     enum AttributeStability {
 

--- a/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
@@ -24,8 +24,6 @@
  */
 package java.lang.classfile;
 
-import jdk.internal.javac.PreviewFeature;
-
 /**
  * Bidirectional mapper between the classfile representation of an attribute and
  * how that attribute is modeled in the API.  The attribute mapper is used
@@ -39,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public interface AttributeMapper<A> {
 
     /**
@@ -47,7 +44,6 @@ public interface AttributeMapper<A> {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum AttributeStability {
 
         /**

--- a/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 
 import java.lang.classfile.attribute.RecordComponentInfo;
 import jdk.internal.classfile.impl.AbstractUnboundModel;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A {@link ClassFileElement} describing an entity that has attributes, such
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AttributedElement extends ClassFileElement
         permits ClassModel, CodeModel, FieldModel, MethodModel,
                 RecordComponentInfo, AbstractUnboundModel {

--- a/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.AbstractUnboundModel;
  * as a class, field, method, code attribute, or record component.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface AttributedElement extends ClassFileElement
         permits ClassModel, CodeModel, FieldModel, MethodModel,

--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -87,7 +87,7 @@ import jdk.internal.classfile.impl.AbstractAttributeMapper.*;
  *
  * @see AttributeMapper
  *
- * @since 22
+ * @since 24
  */
 public final class Attributes {
 
@@ -204,7 +204,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code AnnotationDefault} attribute}
-     * @since 23
      */
     public static AttributeMapper<AnnotationDefaultAttribute> annotationDefault() {
         return AnnotationDefaultMapper.INSTANCE;
@@ -212,7 +211,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code BootstrapMethods} attribute}
-     * @since 23
      */
     public static AttributeMapper<BootstrapMethodsAttribute> bootstrapMethods() {
         return BootstrapMethodsMapper.INSTANCE;
@@ -221,7 +219,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code CharacterRangeTable} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<CharacterRangeTableAttribute> characterRangeTable() {
         return CharacterRangeTableMapper.INSTANCE;
@@ -229,7 +226,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code Code} attribute}
-     * @since 23
      */
     public static AttributeMapper<CodeAttribute> code() {
         return CodeMapper.INSTANCE;
@@ -237,7 +233,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code CompilationID} attribute}
-     * @since 23
      */
     public static AttributeMapper<CompilationIDAttribute> compilationId() {
         return CompilationIDMapper.INSTANCE;
@@ -245,7 +240,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ConstantValue} attribute}
-     * @since 23
      */
     public static AttributeMapper<ConstantValueAttribute> constantValue() {
         return ConstantValueMapper.INSTANCE;
@@ -254,7 +248,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code Deprecated} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<DeprecatedAttribute> deprecated() {
         return DeprecatedMapper.INSTANCE;
@@ -262,7 +255,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code EnclosingMethod} attribute}
-     * @since 23
      */
     public static AttributeMapper<EnclosingMethodAttribute> enclosingMethod() {
         return EnclosingMethodMapper.INSTANCE;
@@ -270,7 +262,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code Exceptions} attribute}
-     * @since 23
      */
     public static AttributeMapper<ExceptionsAttribute> exceptions() {
         return ExceptionsMapper.INSTANCE;
@@ -278,7 +269,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code InnerClasses} attribute}
-     * @since 23
      */
     public static AttributeMapper<InnerClassesAttribute> innerClasses() {
         return InnerClassesMapper.INSTANCE;
@@ -287,7 +277,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code LineNumberTable} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<LineNumberTableAttribute> lineNumberTable() {
         return LineNumberTableMapper.INSTANCE;
@@ -296,7 +285,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code LocalVariableTable} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<LocalVariableTableAttribute> localVariableTable() {
         return LocalVariableTableMapper.INSTANCE;
@@ -305,7 +293,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code LocalVariableTypeTable} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<LocalVariableTypeTableAttribute> localVariableTypeTable() {
         return LocalVariableTypeTableMapper.INSTANCE;
@@ -313,7 +300,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code MethodParameters} attribute}
-     * @since 23
      */
     public static AttributeMapper<MethodParametersAttribute> methodParameters() {
         return MethodParametersMapper.INSTANCE;
@@ -321,7 +307,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code Module} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModuleAttribute> module() {
         return ModuleMapper.INSTANCE;
@@ -329,7 +314,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ModuleHashes} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModuleHashesAttribute> moduleHashes() {
         return ModuleHashesMapper.INSTANCE;
@@ -337,7 +321,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ModuleMainClass} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModuleMainClassAttribute> moduleMainClass() {
         return ModuleMainClassMapper.INSTANCE;
@@ -345,7 +328,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ModulePackages} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModulePackagesAttribute> modulePackages() {
         return ModulePackagesMapper.INSTANCE;
@@ -353,7 +335,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ModuleResolution} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModuleResolutionAttribute> moduleResolution() {
         return ModuleResolutionMapper.INSTANCE;
@@ -361,7 +342,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code ModuleTarget} attribute}
-     * @since 23
      */
     public static AttributeMapper<ModuleTargetAttribute> moduleTarget() {
         return ModuleTargetMapper.INSTANCE;
@@ -369,7 +349,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code NestHost} attribute}
-     * @since 23
      */
     public static AttributeMapper<NestHostAttribute> nestHost() {
         return NestHostMapper.INSTANCE;
@@ -377,7 +356,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code NestMembers} attribute}
-     * @since 23
      */
     public static AttributeMapper<NestMembersAttribute> nestMembers() {
         return NestMembersMapper.INSTANCE;
@@ -385,7 +363,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code PermittedSubclasses} attribute}
-     * @since 23
      */
     public static AttributeMapper<PermittedSubclassesAttribute> permittedSubclasses() {
         return PermittedSubclassesMapper.INSTANCE;
@@ -393,7 +370,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code Record} attribute}
-     * @since 23
      */
     public static AttributeMapper<RecordAttribute> record() {
         return RecordMapper.INSTANCE;
@@ -401,7 +377,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeInvisibleAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeInvisibleAnnotationsAttribute> runtimeInvisibleAnnotations() {
         return RuntimeInvisibleAnnotationsMapper.INSTANCE;
@@ -409,7 +384,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeInvisibleParameterAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeInvisibleParameterAnnotationsAttribute> runtimeInvisibleParameterAnnotations() {
         return RuntimeInvisibleParameterAnnotationsMapper.INSTANCE;
@@ -417,7 +391,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeInvisibleTypeAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeInvisibleTypeAnnotationsAttribute> runtimeInvisibleTypeAnnotations() {
         return RuntimeInvisibleTypeAnnotationsMapper.INSTANCE;
@@ -425,7 +398,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeVisibleAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeVisibleAnnotationsAttribute> runtimeVisibleAnnotations() {
         return RuntimeVisibleAnnotationsMapper.INSTANCE;
@@ -433,7 +405,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeVisibleParameterAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeVisibleParameterAnnotationsAttribute> runtimeVisibleParameterAnnotations() {
         return RuntimeVisibleParameterAnnotationsMapper.INSTANCE;
@@ -441,7 +412,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code RuntimeVisibleTypeAnnotations} attribute}
-     * @since 23
      */
     public static AttributeMapper<RuntimeVisibleTypeAnnotationsAttribute> runtimeVisibleTypeAnnotations() {
         return RuntimeVisibleTypeAnnotationsMapper.INSTANCE;
@@ -449,7 +419,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code Signature} attribute}
-     * @since 23
      */
     public static AttributeMapper<SignatureAttribute> signature() {
         return SignatureMapper.INSTANCE;
@@ -457,7 +426,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code SourceDebugExtension} attribute}
-     * @since 23
      */
     public static AttributeMapper<SourceDebugExtensionAttribute> sourceDebugExtension() {
         return SourceDebugExtensionMapper.INSTANCE;
@@ -465,7 +433,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code SourceFile} attribute}
-     * @since 23
      */
     public static AttributeMapper<SourceFileAttribute> sourceFile() {
         return SourceFileMapper.INSTANCE;
@@ -473,7 +440,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code SourceID} attribute}
-     * @since 23
      */
     public static AttributeMapper<SourceIDAttribute> sourceId() {
         return SourceIDMapper.INSTANCE;
@@ -481,7 +447,6 @@ public final class Attributes {
 
     /**
      * {@return Attribute mapper for the {@code StackMapTable} attribute}
-     * @since 23
      */
     public static AttributeMapper<StackMapTableAttribute> stackMapTable() {
         return StackMapTableMapper.INSTANCE;
@@ -490,7 +455,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code Synthetic} attribute}
      * The mapper permits multiple instances in a given location.
-     * @since 23
      */
     public static AttributeMapper<SyntheticAttribute> synthetic() {
         return SyntheticMapper.INSTANCE;

--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -27,7 +27,6 @@ package java.lang.classfile;
 import java.lang.classfile.AttributeMapper.AttributeStability;
 import java.lang.classfile.attribute.*;
 import jdk.internal.classfile.impl.AbstractAttributeMapper.*;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Attribute mappers for standard classfile attributes.
@@ -90,7 +89,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public final class Attributes {
 
     /** AnnotationDefault */

--- a/src/java.base/share/classes/java/lang/classfile/BootstrapMethodEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/BootstrapMethodEntry.java
@@ -31,7 +31,6 @@ import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.LoadableConstantEntry;
 import java.lang.classfile.constantpool.MethodHandleEntry;
 import jdk.internal.classfile.impl.BootstrapMethodEntryImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an entry in the bootstrap method table.  The bootstrap method table
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface BootstrapMethodEntry
         extends WritableElement<BootstrapMethodEntry>
         permits BootstrapMethodEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/BootstrapMethodEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/BootstrapMethodEntry.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.BootstrapMethodEntryImpl;
  * the {@link ConstantPool}, since the bootstrap method table is logically
  * part of the constant pool.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface BootstrapMethodEntry
         extends WritableElement<BootstrapMethodEntry>

--- a/src/java.base/share/classes/java/lang/classfile/BufWriter.java
+++ b/src/java.base/share/classes/java/lang/classfile/BufWriter.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.BufWriterImpl;
  * are provided to write various standard entities (e.g., {@code u2}, {@code u4})
  * to the end of the buffer, as well as to create constant pool entries.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface BufWriter
         permits BufWriterImpl {

--- a/src/java.base/share/classes/java/lang/classfile/BufWriter.java
+++ b/src/java.base/share/classes/java/lang/classfile/BufWriter.java
@@ -30,7 +30,6 @@ import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.PoolEntry;
 import jdk.internal.classfile.impl.BufWriterImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Supports writing portions of a classfile to a growable buffer.   Methods
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface BufWriter
         permits BufWriterImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
@@ -40,7 +40,6 @@ import jdk.internal.classfile.impl.DirectClassBuilder;
 import jdk.internal.classfile.impl.Util;
 import java.lang.reflect.AccessFlag;
 import java.lang.classfile.attribute.CodeAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A builder for classfiles.  Builders are not created directly; they are passed
@@ -53,7 +52,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassBuilder
         extends ClassFileBuilder<ClassElement, ClassBuilder>
         permits ChainedClassBuilder, DirectClassBuilder {

--- a/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
@@ -50,7 +50,7 @@ import java.lang.classfile.attribute.CodeAttribute;
  *
  * @see ClassTransform
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassBuilder
         extends ClassFileBuilder<ClassElement, ClassBuilder>

--- a/src/java.base/share/classes/java/lang/classfile/ClassElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassElement.java
@@ -54,7 +54,7 @@ import java.lang.classfile.attribute.UnknownAttribute;
  * a {@link ClassModel} or be presented to a {@link ClassBuilder}.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ClassElement extends ClassFileElement
         permits AccessFlags, Superclass, Interfaces, ClassFileVersion,

--- a/src/java.base/share/classes/java/lang/classfile/ClassElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassElement.java
@@ -48,7 +48,6 @@ import java.lang.classfile.attribute.SourceFileAttribute;
 import java.lang.classfile.attribute.SourceIDAttribute;
 import java.lang.classfile.attribute.SyntheticAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A marker interface for elements that can appear when traversing
@@ -57,7 +56,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassElement extends ClassFileElement
         permits AccessFlags, Superclass, Interfaces, ClassFileVersion,
                 FieldModel, MethodModel,

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import java.lang.classfile.attribute.ModuleAttribute;
-import java.lang.classfile.attribute.UnknownAttribute;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.Utf8Entry;
@@ -46,7 +45,6 @@ import java.lang.classfile.instruction.ExceptionCatch;
 import java.util.List;
 import static java.util.Objects.requireNonNull;
 import static jdk.internal.constant.ConstantUtils.CD_module_info;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Represents a context for parsing, transforming, and generating classfiles.
@@ -55,7 +53,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassFile
         permits ClassFileImpl {
 
@@ -86,7 +83,6 @@ public sealed interface ClassFile
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface Option {
     }
 
@@ -96,7 +92,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface AttributeMapperOption extends Option
             permits ClassFileImpl.AttributeMapperOptionImpl {
 
@@ -121,7 +116,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface ClassHierarchyResolverOption extends Option
             permits ClassFileImpl.ClassHierarchyResolverOptionImpl {
 
@@ -152,7 +146,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum ConstantPoolSharingOption implements Option {
 
         /** Preserves the original constant pool when transforming classfile */
@@ -169,7 +162,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum DeadCodeOption implements Option {
 
         /** Patch unreachable code */
@@ -190,7 +182,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum DeadLabelsOption implements Option {
 
         /** Fail on unresolved labels */
@@ -209,7 +200,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum DebugElementsOption implements Option {
 
         /** Process debug elements */
@@ -227,7 +217,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum LineNumbersOption implements Option {
 
         /** Process line numbers */
@@ -245,7 +234,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum ShortJumpsOption implements Option {
 
         /** Automatically convert short jumps to long when necessary */
@@ -264,7 +252,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum StackMapsOption implements Option {
 
         /** Generate stack maps when required */
@@ -286,7 +273,6 @@ public sealed interface ClassFile
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     enum AttributesProcessingOption implements Option {
 
         /** Process all original attributes during transformation */

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -51,7 +51,7 @@ import static jdk.internal.constant.ConstantUtils.CD_module_info;
  * A {@code ClassFile} has a set of options that condition how parsing and
  * generation is done.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassFile
         permits ClassFileImpl {
@@ -81,7 +81,7 @@ public sealed interface ClassFile
      * An option that affects the parsing and writing of classfiles.
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     sealed interface Option {
     }
@@ -90,7 +90,7 @@ public sealed interface ClassFile
      * Option describing attribute mappers for custom attributes.
      * Default is only to process standard attributes.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface AttributeMapperOption extends Option
             permits ClassFileImpl.AttributeMapperOptionImpl {
@@ -114,7 +114,7 @@ public sealed interface ClassFile
      * Option describing the class hierarchy resolver to use when generating
      * stack maps.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface ClassHierarchyResolverOption extends Option
             permits ClassFileImpl.ClassHierarchyResolverOptionImpl {
@@ -144,7 +144,7 @@ public sealed interface ClassFile
      * Default is {@code SHARED_POOL} to preserve the original constant
      * pool.
      *
-     * @since 22
+     * @since 24
      */
     enum ConstantPoolSharingOption implements Option {
 
@@ -160,7 +160,7 @@ public sealed interface ClassFile
      * Default is {@code PATCH_DEAD_CODE} to automatically patch out unreachable
      * code with NOPs.
      *
-     * @since 22
+     * @since 24
      */
     enum DeadCodeOption implements Option {
 
@@ -180,7 +180,7 @@ public sealed interface ClassFile
      * Setting this option to {@code DROP_DEAD_LABELS} filters the above
      * elements instead.
      *
-     * @since 22
+     * @since 24
      */
     enum DeadLabelsOption implements Option {
 
@@ -198,7 +198,7 @@ public sealed interface ClassFile
      * reduce the overhead of parsing or transforming classfiles.
      * Default is {@code PASS_DEBUG} to process debug elements.
      *
-     * @since 22
+     * @since 24
      */
     enum DebugElementsOption implements Option {
 
@@ -215,7 +215,7 @@ public sealed interface ClassFile
      * classfiles.
      * Default is {@code PASS_LINE_NUMBERS} to process line numbers.
      *
-     * @since 22
+     * @since 24
      */
     enum LineNumbersOption implements Option {
 
@@ -232,7 +232,7 @@ public sealed interface ClassFile
      * Default is {@code FIX_SHORT_JUMPS} to automatically rewrite jump
      * instructions.
      *
-     * @since 22
+     * @since 24
      */
     enum ShortJumpsOption implements Option {
 
@@ -250,7 +250,7 @@ public sealed interface ClassFile
      * {@link #JAVA_6_VERSION} the stack maps may not be generated.
      * @jvms 4.10.1 Verification by Type Checking
      *
-     * @since 22
+     * @since 24
      */
     enum StackMapsOption implements Option {
 
@@ -271,7 +271,7 @@ public sealed interface ClassFile
      * Default is {@code PASS_ALL_ATTRIBUTES} to process all original attributes.
      * @see AttributeMapper.AttributeStability
      *
-     * @since 22
+     * @since 24
      */
     enum AttributesProcessingOption implements Option {
 
@@ -1462,16 +1462,10 @@ public sealed interface ClassFile
     /** The class major version of JAVA_22. */
     int JAVA_22_VERSION = 66;
 
-    /**
-     * The class major version of JAVA_23.
-     * @since 23
-     */
+    /** The class major version of JAVA_23. */
     int JAVA_23_VERSION = 67;
 
-    /**
-     * The class major version of JAVA_24.
-     * @since 24
-     */
+    /** The class major version of JAVA_24. */
     int JAVA_24_VERSION = 68;
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileBuilder.java
@@ -29,7 +29,6 @@ import java.util.function.Consumer;
 
 import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A builder for a classfile or portion of a classfile.  Builders are rarely
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassFileBuilder<E extends ClassFileElement, B extends ClassFileBuilder<E, B>>
         extends Consumer<E> permits ClassBuilder, FieldBuilder, MethodBuilder, CodeBuilder {
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileBuilder.java
@@ -43,7 +43,7 @@ import java.lang.classfile.constantpool.ConstantPoolBuilder;
  * @see ClassFileTransform
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ClassFileBuilder<E extends ClassFileElement, B extends ClassFileBuilder<E, B>>
         extends Consumer<E> permits ClassBuilder, FieldBuilder, MethodBuilder, CodeBuilder {

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
@@ -24,8 +24,6 @@
  */
 package java.lang.classfile;
 
-import jdk.internal.javac.PreviewFeature;
-
 /**
  * Immutable model for a portion of (or the entirety of) a classfile.  Elements
  * that model parts of the classfile that have attributes will implement {@link
@@ -37,7 +35,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassFileElement
         permits AttributedElement, CompoundElement, WritableElement,
                 ClassElement, CodeElement, FieldElement, MethodElement {

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileElement.java
@@ -33,7 +33,7 @@ package java.lang.classfile;
  * will implement {@link ClassElement}, {@link MethodElement}, etc.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ClassFileElement
         permits AttributedElement, CompoundElement, WritableElement,

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
@@ -73,7 +73,7 @@ import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
  * @param <B> the builder type
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ClassFileTransform<
         C extends ClassFileTransform<C, E, B>,
@@ -129,7 +129,7 @@ public sealed interface ClassFileTransform<
      *
      * @param <E> the element type
      *
-     * @since 22
+     * @since 24
      */
     interface ResolvedTransform<E extends ClassFileElement> {
         /**

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A transformation on streams of elements. Transforms are used during
@@ -76,7 +75,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassFileTransform<
         C extends ClassFileTransform<C, E, B>,
         E extends ClassFileElement,
@@ -133,7 +131,6 @@ public sealed interface ClassFileTransform<
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     interface ResolvedTransform<E extends ClassFileElement> {
         /**
          * {@return a {@link Consumer} to receive elements}

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
@@ -25,7 +25,6 @@
 package java.lang.classfile;
 
 import jdk.internal.classfile.impl.ClassFileVersionImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the classfile version information for a class.  Delivered as a {@link
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassFileVersion
         extends ClassElement
         permits ClassFileVersionImpl {

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileVersion.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.ClassFileVersionImpl;
  * java.lang.classfile.ClassElement} when traversing the elements of a {@link
  * ClassModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassFileVersion
         extends ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/ClassHierarchyResolver.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassHierarchyResolver.java
@@ -44,7 +44,7 @@ import static java.lang.constant.ConstantDescs.CD_Object;
  * Provides class hierarchy information for generating correct stack maps
  * during code building.
  *
- * @since 22
+ * @since 24
  */
 @FunctionalInterface
 public interface ClassHierarchyResolver {
@@ -68,7 +68,7 @@ public interface ClassHierarchyResolver {
     /**
      * Information about a resolved class.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface ClassHierarchyInfo permits ClassHierarchyImpl.ClassHierarchyInfoImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassHierarchyResolver.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassHierarchyResolver.java
@@ -39,7 +39,6 @@ import jdk.internal.classfile.impl.ClassHierarchyImpl.StaticClassHierarchyResolv
 import jdk.internal.classfile.impl.Util;
 
 import static java.lang.constant.ConstantDescs.CD_Object;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Provides class hierarchy information for generating correct stack maps
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 @FunctionalInterface
 public interface ClassHierarchyResolver {
 
@@ -72,7 +70,6 @@ public interface ClassHierarchyResolver {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface ClassHierarchyInfo permits ClassHierarchyImpl.ClassHierarchyInfoImpl {
 
         /**

--- a/src/java.base/share/classes/java/lang/classfile/ClassModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassModel.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.ClassImpl;
  * a streaming view (e.g., {@link #elements()}), or via random access (e.g.,
  * {@link #flags()}), or by freely mixing the two.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassModel
         extends CompoundElement<ClassElement>, AttributedElement

--- a/src/java.base/share/classes/java/lang/classfile/ClassModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassModel.java
@@ -27,13 +27,10 @@ package java.lang.classfile;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPool;
 import jdk.internal.classfile.impl.ClassImpl;
-import jdk.internal.classfile.impl.verifier.VerifierImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a classfile.  The contents of the classfile can be traversed via
@@ -42,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassModel
         extends CompoundElement<ClassElement>, AttributedElement
         permits ClassImpl {

--- a/src/java.base/share/classes/java/lang/classfile/ClassReader.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassReader.java
@@ -37,7 +37,6 @@ import jdk.internal.classfile.impl.ClassReaderImpl;
 
 import java.util.Optional;
 import java.util.function.Function;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Supports reading from a classfile.  Methods are provided to read data of
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassReader extends ConstantPool
         permits ClassReaderImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassReader.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassReader.java
@@ -45,7 +45,7 @@ import java.util.function.Function;
  * Encapsulates additional reading context such as mappers for custom attributes
  * and processing options.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassReader extends ConstantPool
         permits ClassReaderImpl {
@@ -124,7 +124,6 @@ public sealed interface ClassReader extends ConstantPool
      * @param cls the entry type
      * @throws ConstantPoolException if the index is out of range of the
      *         constant pool size, or zero, or the entry is not of the given type
-     * @since 23
      */
     <T extends PoolEntry> T readEntryOrNull(int offset, Class<T> cls);
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
@@ -31,7 +31,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Models the generic signature of a class file, as defined by {@jvms 4.7.9}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassSignature
         permits SignaturesImpl.ClassSignatureImpl {
@@ -52,7 +52,6 @@ public sealed interface ClassSignature
      * {@return a class signature}
      * @param superclassSignature the superclass
      * @param superinterfaceSignatures the interfaces
-     * @since 23
      */
     public static ClassSignature of(Signature.ClassTypeSig superclassSignature,
                                     Signature.ClassTypeSig... superinterfaceSignatures) {
@@ -64,7 +63,6 @@ public sealed interface ClassSignature
      * @param typeParameters the type parameters
      * @param superclassSignature the superclass
      * @param superinterfaceSignatures the interfaces
-     * @since 23
      */
     public static ClassSignature of(List<Signature.TypeParam> typeParameters,
                                     Signature.ClassTypeSig superclassSignature,

--- a/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
@@ -27,14 +27,12 @@ package java.lang.classfile;
 import java.util.List;
 import jdk.internal.classfile.impl.SignaturesImpl;
 import static java.util.Objects.requireNonNull;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the generic signature of a class file, as defined by {@jvms 4.7.9}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassSignature
         permits SignaturesImpl.ClassSignatureImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.TransformImpl;
  *
  * @see ClassFileTransform
  *
- * @since 22
+ * @since 24
  */
 @FunctionalInterface
 public non-sealed interface ClassTransform

--- a/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassTransform.java
@@ -30,7 +30,6 @@ import java.util.function.Supplier;
 
 import java.lang.classfile.attribute.CodeAttribute;
 import jdk.internal.classfile.impl.TransformImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A transformation on streams of {@link ClassElement}.
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 @FunctionalInterface
 public non-sealed interface ClassTransform
         extends ClassFileTransform<ClassTransform, ClassElement, ClassBuilder> {

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -98,7 +98,7 @@ import jdk.internal.classfile.impl.TransformingCodeBuilder;
  *
  * @see CodeTransform
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeBuilder
         extends ClassFileBuilder<CodeElement, CodeBuilder>
@@ -177,7 +177,7 @@ public sealed interface CodeBuilder
     /**
      * A builder for blocks of code.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface BlockCodeBuilder extends CodeBuilder
             permits BlockCodeBuilderImpl {
@@ -317,7 +317,7 @@ public sealed interface CodeBuilder
      *
      * @see #trying
      *
-     * @since 22
+     * @since 24
      */
     sealed interface CatchBuilder permits CatchBuilderImpl {
         /**
@@ -409,7 +409,6 @@ public sealed interface CodeBuilder
      * @param tk the load type
      * @param slot the local variable slot
      * @return this builder
-     * @since 23
      */
     default CodeBuilder loadLocal(TypeKind tk, int slot) {
         return with(LoadInstruction.of(tk, slot));
@@ -420,7 +419,6 @@ public sealed interface CodeBuilder
      * @param tk the store type
      * @param slot the local variable slot
      * @return this builder
-     * @since 23
      */
     default CodeBuilder storeLocal(TypeKind tk, int slot) {
         return with(StoreInstruction.of(tk, slot));
@@ -432,7 +430,6 @@ public sealed interface CodeBuilder
      * @param op the branch opcode
      * @param target the branch target
      * @return this builder
-     * @since 23
      */
     default CodeBuilder branch(Opcode op, Label target) {
         return with(BranchInstruction.of(op, target));
@@ -442,7 +439,6 @@ public sealed interface CodeBuilder
      * Generate return instruction
      * @param tk the return type
      * @return this builder
-     * @since 23
      */
     default CodeBuilder return_(TypeKind tk) {
         return with(ReturnInstruction.of(tk));
@@ -454,7 +450,6 @@ public sealed interface CodeBuilder
      * @param opcode the field access opcode
      * @param ref the field reference
      * @return this builder
-     * @since 23
      */
     default CodeBuilder fieldAccess(Opcode opcode, FieldRefEntry ref) {
         return with(FieldInstruction.of(opcode, ref));
@@ -468,7 +463,6 @@ public sealed interface CodeBuilder
      * @param name the field name
      * @param type the field type
      * @return this builder
-     * @since 23
      */
     default CodeBuilder fieldAccess(Opcode opcode, ClassDesc owner, String name, ClassDesc type) {
         return fieldAccess(opcode, constantPool().fieldRefEntry(owner, name, type));
@@ -480,7 +474,6 @@ public sealed interface CodeBuilder
      * @param opcode the invoke opcode
      * @param ref the interface method or method reference
      * @return this builder
-     * @since 23
      */
     default CodeBuilder invoke(Opcode opcode, MemberRefEntry ref) {
         return with(InvokeInstruction.of(opcode, ref));
@@ -495,7 +488,6 @@ public sealed interface CodeBuilder
      * @param desc the method type
      * @param isInterface the interface method invocation indication
      * @return this builder
-     * @since 23
      */
     default CodeBuilder invoke(Opcode opcode, ClassDesc owner, String name, MethodTypeDesc desc, boolean isInterface) {
         return invoke(opcode,
@@ -507,7 +499,6 @@ public sealed interface CodeBuilder
      * Generate an instruction to load from an array
      * @param tk the array element type
      * @return this builder
-     * @since 23
      */
     default CodeBuilder arrayLoad(TypeKind tk) {
         Opcode opcode = BytecodeHelpers.arrayLoadOpcode(tk);
@@ -518,7 +509,6 @@ public sealed interface CodeBuilder
      * Generate an instruction to store into an array
      * @param tk the array element type
      * @return this builder
-     * @since 23
      */
     default CodeBuilder arrayStore(TypeKind tk) {
         Opcode opcode = BytecodeHelpers.arrayStoreOpcode(tk);
@@ -531,7 +521,6 @@ public sealed interface CodeBuilder
      * @param toType the target type
      * @return this builder
      * @throws IllegalArgumentException for conversions of {@code VoidType} or {@code ReferenceType}
-     * @since 23
      */
     default CodeBuilder conversion(TypeKind fromType, TypeKind toType) {
         return switch (fromType) {
@@ -598,7 +587,6 @@ public sealed interface CodeBuilder
      * @param opcode the constant instruction opcode
      * @param value the constant value
      * @return this builder
-     * @since 23
      */
     default CodeBuilder loadConstant(Opcode opcode, ConstantDesc value) {
         BytecodeHelpers.validateValue(opcode, value);
@@ -613,7 +601,6 @@ public sealed interface CodeBuilder
      * Generate an instruction pushing a constant onto the operand stack
      * @param value the constant value
      * @return this builder
-     * @since 23
      */
     default CodeBuilder loadConstant(ConstantDesc value) {
         //avoid switch expressions here
@@ -1689,7 +1676,6 @@ public sealed interface CodeBuilder
      * Generate an instruction to determine if an object is of the given type
      * @param target the target type
      * @return this builder
-     * @since 23
      */
     default CodeBuilder instanceOf(ClassEntry target) {
         return with(TypeCheckInstruction.of(Opcode.INSTANCEOF, target));
@@ -1700,7 +1686,6 @@ public sealed interface CodeBuilder
      * @param target the target type
      * @return this builder
      * @throws IllegalArgumentException if {@code target} represents a primitive type
-     * @since 23
      */
     default CodeBuilder instanceOf(ClassDesc target) {
         return instanceOf(constantPool().classEntry(target));

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -87,7 +87,6 @@ import java.lang.classfile.instruction.TypeCheckInstruction;
 import static java.util.Objects.requireNonNull;
 import static jdk.internal.classfile.impl.BytecodeHelpers.handleDescToHandleInfo;
 import jdk.internal.classfile.impl.TransformingCodeBuilder;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A builder for code attributes (method bodies).  Builders are not created
@@ -101,7 +100,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeBuilder
         extends ClassFileBuilder<CodeElement, CodeBuilder>
         permits CodeBuilder.BlockCodeBuilder, ChainedCodeBuilder, TerminalCodeBuilder, NonterminalCodeBuilder {
@@ -181,7 +179,6 @@ public sealed interface CodeBuilder
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface BlockCodeBuilder extends CodeBuilder
             permits BlockCodeBuilderImpl {
         /**
@@ -322,7 +319,6 @@ public sealed interface CodeBuilder
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface CatchBuilder permits CatchBuilderImpl {
         /**
          * Adds a catch block that catches an exception of the given type.

--- a/src/java.base/share/classes/java/lang/classfile/CodeElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeElement.java
@@ -37,7 +37,7 @@ import java.lang.classfile.attribute.StackMapTableAttribute;
  * exception metadata, label target metadata, etc.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface CodeElement extends ClassFileElement
         permits Instruction, PseudoInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/CodeElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeElement.java
@@ -27,7 +27,6 @@ package java.lang.classfile;
 import java.lang.classfile.attribute.RuntimeInvisibleTypeAnnotationsAttribute;
 import java.lang.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import java.lang.classfile.attribute.StackMapTableAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A marker interface for elements that can appear when traversing
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeElement extends ClassFileElement
         permits Instruction, PseudoInstruction,
                 CustomAttribute, RuntimeVisibleTypeAnnotationsAttribute, RuntimeInvisibleTypeAnnotationsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/CodeModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeModel.java
@@ -38,7 +38,7 @@ import java.lang.classfile.instruction.ExceptionCatch;
  * of the method body are accessed via a streaming view (e.g., {@link
  * #elements()}).
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeModel
         extends CompoundElement<CodeElement>, AttributedElement, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/CodeModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeModel.java
@@ -32,7 +32,6 @@ import java.lang.classfile.attribute.CodeAttribute;
 import jdk.internal.classfile.impl.BufferedCodeBuilder;
 import jdk.internal.classfile.impl.CodeImpl;
 import java.lang.classfile.instruction.ExceptionCatch;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the body of a method (the {@code Code} attribute).  The instructions
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeModel
         extends CompoundElement<CodeElement>, AttributedElement, MethodElement
         permits CodeAttribute, BufferedCodeBuilder.Model, CodeImpl {

--- a/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import jdk.internal.classfile.impl.TransformImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A transformation on streams of {@link CodeElement}.
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 @FunctionalInterface
 public non-sealed interface CodeTransform
         extends ClassFileTransform<CodeTransform, CodeElement, CodeBuilder> {

--- a/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeTransform.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.TransformImpl;
  *
  * @see ClassFileTransform
  *
- * @since 22
+ * @since 24
  */
 @FunctionalInterface
 public non-sealed interface CodeTransform

--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -32,7 +32,6 @@ import java.util.Spliterators;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A {@link ClassFileElement} that has complex structure defined in terms of
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CompoundElement<E extends ClassFileElement>
         extends ClassFileElement, Iterable<E>
         permits ClassModel, CodeModel, FieldModel, MethodModel, jdk.internal.classfile.impl.AbstractUnboundModel {

--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -43,7 +43,7 @@ import java.util.stream.StreamSupport;
  * @param <E> the element type
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface CompoundElement<E extends ClassFileElement>
         extends ClassFileElement, Iterable<E>

--- a/src/java.base/share/classes/java/lang/classfile/CustomAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/CustomAttribute.java
@@ -24,8 +24,6 @@
  */
 package java.lang.classfile;
 
-import jdk.internal.javac.PreviewFeature;
-
 /**
  * Models a non-standard attribute of a classfile.  Clients should extend
  * this class to provide an implementation class for non-standard attributes,
@@ -35,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public abstract non-sealed class CustomAttribute<T extends CustomAttribute<T>>
         implements Attribute<T>, CodeElement, ClassElement, MethodElement, FieldElement {
 

--- a/src/java.base/share/classes/java/lang/classfile/CustomAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/CustomAttribute.java
@@ -31,7 +31,7 @@ package java.lang.classfile;
  * format and the {@linkplain CustomAttribute} representation.
  * @param <T> the custom attribute type
  *
- * @since 22
+ * @since 24
  */
 public abstract non-sealed class CustomAttribute<T extends CustomAttribute<T>>
         implements Attribute<T>, CodeElement, ClassElement, MethodElement, FieldElement {

--- a/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
@@ -32,7 +32,6 @@ import java.lang.reflect.AccessFlag;
 
 import java.util.Optional;
 import java.util.function.Consumer;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A builder for fields.  Builders are not created directly; they are passed
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FieldBuilder
         extends ClassFileBuilder<FieldElement, FieldBuilder>
         permits TerminalFieldBuilder, ChainedFieldBuilder {

--- a/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldBuilder.java
@@ -42,7 +42,7 @@ import java.util.function.Consumer;
  *
  * @see FieldTransform
  *
- * @since 22
+ * @since 24
  */
 public sealed interface FieldBuilder
         extends ClassFileBuilder<FieldElement, FieldBuilder>

--- a/src/java.base/share/classes/java/lang/classfile/FieldElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldElement.java
@@ -39,7 +39,7 @@ import java.lang.classfile.attribute.UnknownAttribute;
  * a {@link FieldModel} or be presented to a {@link FieldBuilder}.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface FieldElement extends ClassFileElement
         permits AccessFlags,

--- a/src/java.base/share/classes/java/lang/classfile/FieldElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldElement.java
@@ -33,7 +33,6 @@ import java.lang.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.classfile.attribute.SyntheticAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A marker interface for elements that can appear when traversing
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FieldElement extends ClassFileElement
         permits AccessFlags,
                 CustomAttribute, ConstantValueAttribute, DeprecatedAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/FieldModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldModel.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.FieldImpl;
  * a streaming view (e.g., {@link #elements()}), or via random access (e.g.,
  * {@link #flags()}), or by freely mixing the two.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface FieldModel
         extends WritableElement<FieldModel>, CompoundElement<FieldElement>, AttributedElement, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/FieldModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldModel.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BufferedFieldBuilder;
 import jdk.internal.classfile.impl.FieldImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a field.  The contents of the field can be traversed via
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FieldModel
         extends WritableElement<FieldModel>, CompoundElement<FieldElement>, AttributedElement, ClassElement
         permits BufferedFieldBuilder.Model, FieldImpl {

--- a/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.TransformImpl;
  *
  * @see ClassFileTransform
  *
- * @since 22
+ * @since 24
  */
 @FunctionalInterface
 public non-sealed interface FieldTransform

--- a/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldTransform.java
@@ -29,7 +29,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import jdk.internal.classfile.impl.TransformImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A transformation on streams of {@link FieldElement}.
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 @FunctionalInterface
 public non-sealed interface FieldTransform
         extends ClassFileTransform<FieldTransform, FieldElement, FieldBuilder> {

--- a/src/java.base/share/classes/java/lang/classfile/Instruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/Instruction.java
@@ -51,14 +51,12 @@ import java.lang.classfile.instruction.StoreInstruction;
 import java.lang.classfile.instruction.TableSwitchInstruction;
 import java.lang.classfile.instruction.ThrowInstruction;
 import java.lang.classfile.instruction.TypeCheckInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an executable instruction in a method body.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Instruction extends CodeElement
         permits ArrayLoadInstruction, ArrayStoreInstruction, BranchInstruction,
                 ConstantInstruction, ConvertInstruction, DiscontinuedInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/Instruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/Instruction.java
@@ -55,7 +55,7 @@ import java.lang.classfile.instruction.TypeCheckInstruction;
 /**
  * Models an executable instruction in a method body.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface Instruction extends CodeElement
         permits ArrayLoadInstruction, ArrayStoreInstruction, BranchInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/Interfaces.java
+++ b/src/java.base/share/classes/java/lang/classfile/Interfaces.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.Util;
  * Models the interfaces of a class.  Delivered as a {@link
  * java.lang.classfile.ClassElement} when traversing a {@link ClassModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface Interfaces
         extends ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/Interfaces.java
+++ b/src/java.base/share/classes/java/lang/classfile/Interfaces.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.InterfacesImpl;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the interfaces of a class.  Delivered as a {@link
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Interfaces
         extends ClassElement
         permits InterfacesImpl {

--- a/src/java.base/share/classes/java/lang/classfile/Label.java
+++ b/src/java.base/share/classes/java/lang/classfile/Label.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.LabelImpl;
  * can be bound to the current position within a {@linkplain CodeBuilder} via
  * {@link CodeBuilder#labelBinding(Label)} or {@link CodeBuilder#with(ClassFileElement)}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface Label
         permits LabelImpl {

--- a/src/java.base/share/classes/java/lang/classfile/Label.java
+++ b/src/java.base/share/classes/java/lang/classfile/Label.java
@@ -25,7 +25,6 @@
 package java.lang.classfile;
 
 import jdk.internal.classfile.impl.LabelImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A marker for a position within the instructions of a method body.  The
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Label
         permits LabelImpl {
 }

--- a/src/java.base/share/classes/java/lang/classfile/MethodBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodBuilder.java
@@ -42,7 +42,7 @@ import java.lang.reflect.AccessFlag;
  *
  * @see MethodTransform
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodBuilder
         extends ClassFileBuilder<MethodElement, MethodBuilder>

--- a/src/java.base/share/classes/java/lang/classfile/MethodBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodBuilder.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.ChainedMethodBuilder;
 import jdk.internal.classfile.impl.TerminalMethodBuilder;
 import java.lang.reflect.AccessFlag;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A builder for methods.  Builders are not created directly; they are passed
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodBuilder
         extends ClassFileBuilder<MethodElement, MethodBuilder>
         permits ChainedMethodBuilder, TerminalMethodBuilder {

--- a/src/java.base/share/classes/java/lang/classfile/MethodElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodElement.java
@@ -37,7 +37,6 @@ import java.lang.classfile.attribute.RuntimeVisibleTypeAnnotationsAttribute;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.classfile.attribute.SyntheticAttribute;
 import java.lang.classfile.attribute.UnknownAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A marker interface for elements that can appear when traversing
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodElement
         extends ClassFileElement
         permits AccessFlags, CodeModel, CustomAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/MethodElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodElement.java
@@ -43,7 +43,7 @@ import java.lang.classfile.attribute.UnknownAttribute;
  * a {@link MethodModel} or be presented to a {@link MethodBuilder}.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface MethodElement
         extends ClassFileElement

--- a/src/java.base/share/classes/java/lang/classfile/MethodModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodModel.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.MethodImpl;
  * a streaming view (e.g., {@link #elements()}), or via random access (e.g.,
  * {@link #flags()}), or by freely mixing the two.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodModel
         extends WritableElement<MethodModel>, CompoundElement<MethodElement>, AttributedElement, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/MethodModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodModel.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BufferedMethodBuilder;
 import jdk.internal.classfile.impl.MethodImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a method.  The contents of the method can be traversed via
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodModel
         extends WritableElement<MethodModel>, CompoundElement<MethodElement>, AttributedElement, ClassElement
         permits BufferedMethodBuilder.Model, MethodImpl {

--- a/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
@@ -29,14 +29,12 @@ import java.util.List;
 import jdk.internal.classfile.impl.SignaturesImpl;
 import static java.util.Objects.requireNonNull;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the generic signature of a method, as defined by {@jvms 4.7.9}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodSignature
         permits SignaturesImpl.MethodSignatureImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodSignature.java
@@ -33,7 +33,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models the generic signature of a method, as defined by {@jvms 4.7.9}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodSignature
         permits SignaturesImpl.MethodSignatureImpl {

--- a/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.TransformImpl;
  *
  * @see ClassFileTransform
  *
- * @since 22
+ * @since 24
  */
 @FunctionalInterface
 public non-sealed interface MethodTransform

--- a/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodTransform.java
@@ -29,7 +29,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import jdk.internal.classfile.impl.TransformImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A transformation on streams of {@link MethodElement}.
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 @FunctionalInterface
 public non-sealed interface MethodTransform
         extends ClassFileTransform<MethodTransform, MethodElement, MethodBuilder> {

--- a/src/java.base/share/classes/java/lang/classfile/Opcode.java
+++ b/src/java.base/share/classes/java/lang/classfile/Opcode.java
@@ -35,7 +35,7 @@ import java.lang.constant.ConstantDescs;
  * @see Instruction
  * @see PseudoInstruction
  *
- * @since 22
+ * @since 24
  */
 public enum Opcode {
 
@@ -696,7 +696,7 @@ public enum Opcode {
     /**
      * Kinds of opcodes.
      *
-     * @since 22
+     * @since 24
      */
     public static enum Kind {
 

--- a/src/java.base/share/classes/java/lang/classfile/Opcode.java
+++ b/src/java.base/share/classes/java/lang/classfile/Opcode.java
@@ -26,7 +26,6 @@ package java.lang.classfile;
 
 import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Describes the opcodes of the JVM instruction set, as described in {@jvms 6.5}.
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public enum Opcode {
 
     /** Do nothing */
@@ -700,7 +698,6 @@ public enum Opcode {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public static enum Kind {
 
         /**

--- a/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
@@ -32,7 +32,6 @@ import java.lang.classfile.instruction.LineNumber;
 import java.lang.classfile.instruction.LocalVariable;
 import java.lang.classfile.instruction.LocalVariableType;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models metadata about a {@link CodeAttribute}, such as entries in the
@@ -44,7 +43,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface PseudoInstruction
         extends CodeElement
         permits CharacterRange, ExceptionCatch, LabelTarget, LineNumber, LocalVariable, LocalVariableType, AbstractPseudoInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/PseudoInstruction.java
@@ -41,7 +41,7 @@ import jdk.internal.classfile.impl.AbstractPseudoInstruction;
  * pseudo-instructions can be disabled by modifying the value of classfile
  * options (e.g., {@link ClassFile.DebugElementsOption}).
  *
- * @since 22
+ * @since 24
  */
 public sealed interface PseudoInstruction
         extends CodeElement

--- a/src/java.base/share/classes/java/lang/classfile/Signature.java
+++ b/src/java.base/share/classes/java/lang/classfile/Signature.java
@@ -31,7 +31,6 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 import java.util.Optional;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models generic Java type signatures, as defined in {@jvms 4.7.9.1}.
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Signature {
 
     /** {@return the raw signature string} */
@@ -72,7 +70,6 @@ public sealed interface Signature {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface BaseTypeSig extends Signature
             permits SignaturesImpl.BaseTypeSigImpl {
 
@@ -109,7 +106,6 @@ public sealed interface Signature {
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface RefTypeSig
             extends Signature
             permits ArrayTypeSig, ClassTypeSig, TypeVarSig {
@@ -120,7 +116,6 @@ public sealed interface Signature {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ClassTypeSig
             extends RefTypeSig, ThrowableSig
             permits SignaturesImpl.ClassTypeSigImpl {
@@ -188,14 +183,12 @@ public sealed interface Signature {
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface TypeArg {
 
         /**
          * Models an unbounded type argument {@code *}.
          * @since 23
          */
-        @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
         public sealed interface Unbounded extends TypeArg permits SignaturesImpl.UnboundedTypeArgImpl {
         }
 
@@ -203,14 +196,12 @@ public sealed interface Signature {
          * Models a type argument with an explicit bound type.
          * @since 23
          */
-        @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
         public sealed interface Bounded extends TypeArg permits SignaturesImpl.TypeArgImpl {
 
             /**
              * Models a type argument's wildcard indicator.
              * @since 23
              */
-            @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
             public enum WildcardIndicator {
 
                 /**
@@ -295,7 +286,6 @@ public sealed interface Signature {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface TypeVarSig
             extends RefTypeSig, ThrowableSig
             permits SignaturesImpl.TypeVarSigImpl {
@@ -317,7 +307,6 @@ public sealed interface Signature {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ArrayTypeSig
             extends RefTypeSig
             permits SignaturesImpl.ArrayTypeSigImpl {
@@ -353,7 +342,6 @@ public sealed interface Signature {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface TypeParam
             permits SignaturesImpl.TypeParamImpl {
 
@@ -399,7 +387,6 @@ public sealed interface Signature {
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ThrowableSig extends Signature {
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/Signature.java
+++ b/src/java.base/share/classes/java/lang/classfile/Signature.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.Util;
  * Models generic Java type signatures, as defined in {@jvms 4.7.9.1}.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface Signature {
 
@@ -68,7 +68,7 @@ public sealed interface Signature {
     /**
      * Models the signature of a primitive type or void
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface BaseTypeSig extends Signature
             permits SignaturesImpl.BaseTypeSigImpl {
@@ -104,7 +104,7 @@ public sealed interface Signature {
      * type variable, or array type.
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     public sealed interface RefTypeSig
             extends Signature
@@ -114,7 +114,7 @@ public sealed interface Signature {
     /**
      * Models the signature of a possibly-parameterized class or interface type.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface ClassTypeSig
             extends RefTypeSig, ThrowableSig
@@ -181,26 +181,26 @@ public sealed interface Signature {
      * Models the type argument.
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     public sealed interface TypeArg {
 
         /**
          * Models an unbounded type argument {@code *}.
-         * @since 23
+         * @since 24
          */
         public sealed interface Unbounded extends TypeArg permits SignaturesImpl.UnboundedTypeArgImpl {
         }
 
         /**
          * Models a type argument with an explicit bound type.
-         * @since 23
+         * @since 24
          */
         public sealed interface Bounded extends TypeArg permits SignaturesImpl.TypeArgImpl {
 
             /**
              * Models a type argument's wildcard indicator.
-             * @since 23
+             * @since 24
              */
             public enum WildcardIndicator {
 
@@ -233,7 +233,6 @@ public sealed interface Signature {
         /**
          * {@return a bounded type arg}
          * @param boundType the bound
-         * @since 23
          */
         public static TypeArg.Bounded of(RefTypeSig boundType) {
             requireNonNull(boundType);
@@ -242,7 +241,6 @@ public sealed interface Signature {
 
         /**
          * {@return an unbounded type arg}
-         * @since 23
          */
         public static TypeArg.Unbounded unbounded() {
             return SignaturesImpl.UnboundedTypeArgImpl.INSTANCE;
@@ -251,7 +249,6 @@ public sealed interface Signature {
         /**
          * {@return an upper-bounded type arg}
          * @param boundType the upper bound
-         * @since 23
          */
         public static TypeArg.Bounded extendsOf(RefTypeSig boundType) {
             requireNonNull(boundType);
@@ -261,7 +258,6 @@ public sealed interface Signature {
         /**
          * {@return a lower-bounded type arg}
          * @param boundType the lower bound
-         * @since 23
          */
         public static TypeArg.Bounded superOf(RefTypeSig boundType) {
             requireNonNull(boundType);
@@ -272,7 +268,6 @@ public sealed interface Signature {
          * {@return a bounded type arg}
          * @param wildcard the wild card
          * @param boundType optional bound type
-         * @since 23
          */
         public static TypeArg.Bounded bounded(Bounded.WildcardIndicator wildcard, RefTypeSig boundType) {
             requireNonNull(wildcard);
@@ -284,7 +279,7 @@ public sealed interface Signature {
     /**
      * Models the signature of a type variable.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface TypeVarSig
             extends RefTypeSig, ThrowableSig
@@ -305,7 +300,7 @@ public sealed interface Signature {
     /**
      * Models the signature of an array type.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface ArrayTypeSig
             extends RefTypeSig
@@ -340,7 +335,7 @@ public sealed interface Signature {
     /**
      * Models a signature for a type parameter of a generic class or method.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface TypeParam
             permits SignaturesImpl.TypeParamImpl {
@@ -385,7 +380,7 @@ public sealed interface Signature {
      * Models a signature for a throwable type.
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     public sealed interface ThrowableSig extends Signature {
     }

--- a/src/java.base/share/classes/java/lang/classfile/Superclass.java
+++ b/src/java.base/share/classes/java/lang/classfile/Superclass.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.SuperclassImpl;
  * Models the superclass of a class.  Delivered as a {@link
  * java.lang.classfile.ClassElement} when traversing a {@link ClassModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface Superclass
         extends ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/Superclass.java
+++ b/src/java.base/share/classes/java/lang/classfile/Superclass.java
@@ -26,7 +26,6 @@ package java.lang.classfile;
 
 import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.SuperclassImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the superclass of a class.  Delivered as a {@link
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Superclass
         extends ClassElement
         permits SuperclassImpl {

--- a/src/java.base/share/classes/java/lang/classfile/TypeAnnotation.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeAnnotation.java
@@ -57,7 +57,6 @@ import static java.lang.classfile.ClassFile.TAT_NEW;
 import static java.lang.classfile.ClassFile.TAT_RESOURCE_VARIABLE;
 import static java.lang.classfile.ClassFile.TAT_THROWS;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an annotation on a type use, as defined in {@jvms 4.7.19} and {@jvms 4.7.20}.
@@ -67,7 +66,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface TypeAnnotation
         extends Annotation
         permits UnboundAttribute.UnboundTypeAnnotation {
@@ -77,7 +75,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public enum TargetType {
         /** For annotations on a class type parameter declaration. */
         CLASS_TYPE_PARAMETER(TAT_CLASS_TYPE_PARAMETER, 1),
@@ -239,7 +236,6 @@ public sealed interface TypeAnnotation
      * @sealedGraph
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface TargetInfo {
 
         /**
@@ -517,7 +513,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface TypeParameterTarget extends TargetInfo
             permits TargetInfoImpl.TypeParameterTargetImpl {
 
@@ -536,7 +531,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface SupertypeTarget extends TargetInfo
             permits TargetInfoImpl.SupertypeTargetImpl {
 
@@ -560,7 +554,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface TypeParameterBoundTarget extends TargetInfo
             permits TargetInfoImpl.TypeParameterBoundTargetImpl {
 
@@ -586,7 +579,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface EmptyTarget extends TargetInfo
             permits TargetInfoImpl.EmptyTargetImpl {
     }
@@ -597,7 +589,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface FormalParameterTarget extends TargetInfo
             permits TargetInfoImpl.FormalParameterTargetImpl {
 
@@ -616,7 +607,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface ThrowsTarget extends TargetInfo
             permits TargetInfoImpl.ThrowsTargetImpl {
 
@@ -636,7 +626,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface LocalVarTarget extends TargetInfo
             permits TargetInfoImpl.LocalVarTargetImpl {
 
@@ -653,7 +642,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface LocalVarTargetInfo
             permits TargetInfoImpl.LocalVarTargetInfoImpl {
 
@@ -700,7 +688,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface CatchTarget extends TargetInfo
             permits TargetInfoImpl.CatchTargetImpl {
 
@@ -719,7 +706,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface OffsetTarget extends TargetInfo
             permits TargetInfoImpl.OffsetTargetImpl {
 
@@ -741,7 +727,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface TypeArgumentTarget extends TargetInfo
             permits TargetInfoImpl.TypeArgumentTargetImpl {
 
@@ -777,7 +762,6 @@ public sealed interface TypeAnnotation
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface TypePathComponent
             permits UnboundAttribute.TypePathComponentImpl {
 
@@ -786,7 +770,6 @@ public sealed interface TypeAnnotation
          *
          * @since 22
          */
-        @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
         public enum Kind {
 
             /** Annotation is deeper in an array type */

--- a/src/java.base/share/classes/java/lang/classfile/TypeAnnotation.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeAnnotation.java
@@ -64,7 +64,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
  * @see RuntimeVisibleTypeAnnotationsAttribute
  * @see RuntimeInvisibleTypeAnnotationsAttribute
  *
- * @since 22
+ * @since 24
  */
 public sealed interface TypeAnnotation
         extends Annotation
@@ -73,7 +73,7 @@ public sealed interface TypeAnnotation
     /**
      * The kind of target on which the annotation appears, as defined in {@jvms 4.7.20.1}.
      *
-     * @since 22
+     * @since 24
      */
     public enum TargetType {
         /** For annotations on a class type parameter declaration. */
@@ -234,7 +234,7 @@ public sealed interface TypeAnnotation
      * Specifies which type in a declaration or expression is being annotated.
      *
      * @sealedGraph
-     * @since 22
+     * @since 24
      */
     sealed interface TargetInfo {
 
@@ -511,7 +511,7 @@ public sealed interface TypeAnnotation
      * parameter of a generic class, generic interface, generic method, or
      * generic constructor.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface TypeParameterTarget extends TargetInfo
             permits TargetInfoImpl.TypeParameterTargetImpl {
@@ -529,7 +529,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on a type in the extends or implements
      * clause of a class or interface declaration.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface SupertypeTarget extends TargetInfo
             permits TargetInfoImpl.SupertypeTargetImpl {
@@ -552,7 +552,7 @@ public sealed interface TypeAnnotation
      * type parameter declaration of a generic class, interface, method, or
      * constructor.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface TypeParameterBoundTarget extends TargetInfo
             permits TargetInfoImpl.TypeParameterBoundTargetImpl {
@@ -577,7 +577,7 @@ public sealed interface TypeAnnotation
      * declaration, the return type of a method, the type of a newly constructed
      * object, or the receiver type of a method or constructor.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface EmptyTarget extends TargetInfo
             permits TargetInfoImpl.EmptyTargetImpl {
@@ -587,7 +587,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on the type in a formal parameter
      * declaration of a method, constructor, or lambda expression.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface FormalParameterTarget extends TargetInfo
             permits TargetInfoImpl.FormalParameterTargetImpl {
@@ -605,7 +605,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on the i'th type in the throws
      * clause of a method or constructor declaration.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface ThrowsTarget extends TargetInfo
             permits TargetInfoImpl.ThrowsTargetImpl {
@@ -624,7 +624,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on the type in a local variable declaration,
      * including a variable declared as a resource in a try-with-resources statement.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface LocalVarTarget extends TargetInfo
             permits TargetInfoImpl.LocalVarTargetImpl {
@@ -640,7 +640,7 @@ public sealed interface TypeAnnotation
      * has a value, and the index into the local variable array of the current
      * frame at which that local variable can be found.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface LocalVarTargetInfo
             permits TargetInfoImpl.LocalVarTargetInfoImpl {
@@ -686,7 +686,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on the i'th type in an exception parameter
      * declaration.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface CatchTarget extends TargetInfo
             permits TargetInfoImpl.CatchTargetImpl {
@@ -704,7 +704,7 @@ public sealed interface TypeAnnotation
      * Indicates that an annotation appears on either the type in an instanceof expression
      * or a new expression, or the type before the :: in a method reference expression.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface OffsetTarget extends TargetInfo
             permits TargetInfoImpl.OffsetTargetImpl {
@@ -725,7 +725,7 @@ public sealed interface TypeAnnotation
      * expression, an explicit constructor invocation statement, a method invocation expression, or a method reference
      * expression.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface TypeArgumentTarget extends TargetInfo
             permits TargetInfoImpl.TypeArgumentTargetImpl {
@@ -760,7 +760,7 @@ public sealed interface TypeAnnotation
      * JVMS: Type_path structure identifies which part of the type is annotated,
      * as defined in {@jvms 4.7.20.2}
      *
-     * @since 22
+     * @since 24
      */
     sealed interface TypePathComponent
             permits UnboundAttribute.TypePathComponentImpl {
@@ -768,7 +768,7 @@ public sealed interface TypeAnnotation
         /**
          * Type path kind, as defined in {@jvms 4.7.20.2}
          *
-         * @since 22
+         * @since 24
          */
         public enum Kind {
 

--- a/src/java.base/share/classes/java/lang/classfile/TypeKind.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeKind.java
@@ -30,7 +30,7 @@ import java.lang.invoke.TypeDescriptor;
 /**
  * Describes the types that can be part of a field or method descriptor.
  *
- * @since 22
+ * @since 24
  */
 public enum TypeKind {
     /** the primitive type byte */
@@ -66,7 +66,6 @@ public enum TypeKind {
 
     /**
      * {@return the code used by the {@code newarray} opcode corresponding to this type}
-     * @since 23
      */
     public int newarrayCode() {
         return newarrayCode;
@@ -106,7 +105,6 @@ public enum TypeKind {
      * array code used as an operand to {@code newarray}}
      * @param newarrayCode the operand of the {@code newarray} instruction
      * @throws IllegalArgumentException if the code is invalid
-     * @since 23
      */
     public static TypeKind fromNewarrayCode(int newarrayCode) {
         return switch (newarrayCode) {

--- a/src/java.base/share/classes/java/lang/classfile/TypeKind.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeKind.java
@@ -26,14 +26,12 @@
 package java.lang.classfile;
 
 import java.lang.invoke.TypeDescriptor;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Describes the types that can be part of a field or method descriptor.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public enum TypeKind {
     /** the primitive type byte */
     ByteType("byte", "B", 8),

--- a/src/java.base/share/classes/java/lang/classfile/WritableElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/WritableElement.java
@@ -28,7 +28,6 @@ import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.PoolEntry;
 import jdk.internal.classfile.impl.DirectFieldBuilder;
 import jdk.internal.classfile.impl.DirectMethodBuilder;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A classfile element that can encode itself as a stream of bytes in the
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface WritableElement<T> extends ClassFileElement
         permits Annotation, AnnotationElement, AnnotationValue, Attribute,
                 PoolEntry, BootstrapMethodEntry, FieldModel, MethodModel,

--- a/src/java.base/share/classes/java/lang/classfile/WritableElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/WritableElement.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.DirectMethodBuilder;
  * @param <T> the type of the entity
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface WritableElement<T> extends ClassFileElement
         permits Annotation, AnnotationElement, AnnotationValue, Attribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/AnnotationDefaultAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/AnnotationDefaultAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.MethodElement;
 import java.lang.classfile.MethodModel;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code AnnotationDefault} attribute {@jvms 4.7.22}, which can
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AnnotationDefaultAttribute
         extends Attribute<AnnotationDefaultAttribute>, MethodElement
         permits BoundAttribute.BoundAnnotationDefaultAttr,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/AnnotationDefaultAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/AnnotationDefaultAttribute.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface AnnotationDefaultAttribute
         extends Attribute<AnnotationDefaultAttribute>, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/BootstrapMethodsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/BootstrapMethodsAttribute.java
@@ -32,7 +32,6 @@ import java.lang.classfile.BootstrapMethodEntry;
 import java.lang.classfile.constantpool.ConstantPool;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code BootstrapMethods} attribute {@jvms 4.7.23}, which serves as
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface BootstrapMethodsAttribute
         extends Attribute<BootstrapMethodsAttribute>
         permits BoundAttribute.BoundBootstrapMethodsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/BootstrapMethodsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/BootstrapMethodsAttribute.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 7.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface BootstrapMethodsAttribute
         extends Attribute<BootstrapMethodsAttribute>

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeInfo.java
@@ -29,7 +29,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models a single character range in the {@link CharacterRangeTableAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CharacterRangeInfo
         permits UnboundAttribute.UnboundCharacterRangeInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeInfo.java
@@ -25,14 +25,12 @@
 package java.lang.classfile.attribute;
 
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single character range in the {@link CharacterRangeTableAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CharacterRangeInfo
         permits UnboundAttribute.UnboundCharacterRangeInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.lang.classfile.Attribute;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * The CharacterRangeTable attribute is an optional variable-length attribute in
@@ -60,7 +59,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CharacterRangeTableAttribute
         extends Attribute<CharacterRangeTableAttribute>
         permits BoundAttribute.BoundCharacterRangeTableAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CharacterRangeTableAttribute.java
@@ -57,7 +57,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute permits multiple instances in a given location.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CharacterRangeTableAttribute
         extends Attribute<CharacterRangeTableAttribute>

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
@@ -29,7 +29,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Label;
 import jdk.internal.classfile.impl.BoundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Code} attribute {@jvms 4.7.3}, appears on non-native,
@@ -43,7 +42,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeAttribute extends Attribute<CodeAttribute>, CodeModel
         permits BoundAttribute.BoundCodeAttribute {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
@@ -40,7 +40,7 @@ import jdk.internal.classfile.impl.BoundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeAttribute extends Attribute<CodeAttribute>, CodeModel
         permits BoundAttribute.BoundCodeAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code CompilationID} attribute (@@@ need reference), which can
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CompilationIDAttribute
         extends Attribute<CompilationIDAttribute>, ClassElement
         permits BoundAttribute.BoundCompilationIDAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CompilationIDAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CompilationIDAttribute
         extends Attribute<CompilationIDAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ConstantValueAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ConstantValueAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantValueAttribute
         extends Attribute<ConstantValueAttribute>, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ConstantValueAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ConstantValueAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.constantpool.ConstantValueEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ConstantValue} attribute {@jvms 4.7.2}, which can appear on
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantValueAttribute
         extends Attribute<ConstantValueAttribute>, FieldElement
         permits BoundAttribute.BoundConstantValueAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
@@ -30,7 +30,6 @@ import java.lang.classfile.FieldElement;
 import java.lang.classfile.MethodElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Deprecated} attribute {@jvms 4.7.15}, which can appear on
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface DeprecatedAttribute
         extends Attribute<DeprecatedAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/DeprecatedAttribute.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute permits multiple instances in a given location.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface DeprecatedAttribute
         extends Attribute<DeprecatedAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/EnclosingMethodAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/EnclosingMethodAttribute.java
@@ -37,7 +37,6 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code EnclosingMethod} attribute {@jvms 4.7.7}, which can appear
@@ -53,7 +52,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface EnclosingMethodAttribute
         extends Attribute<EnclosingMethodAttribute>, ClassElement
         permits BoundAttribute.BoundEnclosingMethodAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/EnclosingMethodAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/EnclosingMethodAttribute.java
@@ -50,7 +50,7 @@ import jdk.internal.classfile.impl.Util;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface EnclosingMethodAttribute
         extends Attribute<EnclosingMethodAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ExceptionsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ExceptionsAttribute.java
@@ -45,7 +45,7 @@ import jdk.internal.classfile.impl.Util;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ExceptionsAttribute
         extends Attribute<ExceptionsAttribute>, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ExceptionsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ExceptionsAttribute.java
@@ -34,7 +34,6 @@ import java.lang.classfile.MethodElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Exceptions} attribute {@jvms 4.7.5}, which can appear on
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ExceptionsAttribute
         extends Attribute<ExceptionsAttribute>, MethodElement
         permits BoundAttribute.BoundExceptionsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
@@ -35,14 +35,12 @@ import java.lang.reflect.AccessFlag;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single inner class in the {@link InnerClassesAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InnerClassInfo
         permits UnboundAttribute.UnboundInnerClassInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassInfo.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single inner class in the {@link InnerClassesAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InnerClassInfo
         permits UnboundAttribute.UnboundInnerClassInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassesAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InnerClassesAttribute
         extends Attribute<InnerClassesAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/InnerClassesAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.ClassElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code InnerClasses} attribute {@jvms 4.7.6}, which can
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InnerClassesAttribute
         extends Attribute<InnerClassesAttribute>, ClassElement
         permits BoundAttribute.BoundInnerClassesAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberInfo.java
@@ -29,7 +29,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models a single line number in the {@link LineNumberTableAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LineNumberInfo
         permits UnboundAttribute.UnboundLineNumberInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberInfo.java
@@ -25,14 +25,12 @@
 package java.lang.classfile.attribute;
 
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single line number in the {@link LineNumberTableAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LineNumberInfo
         permits UnboundAttribute.UnboundLineNumberInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberTableAttribute.java
@@ -40,7 +40,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute permits multiple instances in a given location.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LineNumberTableAttribute
         extends Attribute<LineNumberTableAttribute>

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LineNumberTableAttribute.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.lang.classfile.Attribute;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code LineNumberTable} attribute {@jvms 4.7.12}, which can appear
@@ -43,7 +42,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LineNumberTableAttribute
         extends Attribute<LineNumberTableAttribute>
         permits BoundAttribute.BoundLineNumberTableAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models a single local variable in the {@link LocalVariableTableAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariableInfo
         permits UnboundAttribute.UnboundLocalVariableInfo, BoundLocalVariable {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
@@ -28,14 +28,12 @@ import java.lang.constant.ClassDesc;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundLocalVariable;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single local variable in the {@link LocalVariableTableAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariableInfo
         permits UnboundAttribute.UnboundLocalVariableInfo, BoundLocalVariable {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTableAttribute.java
@@ -40,7 +40,7 @@ import java.util.List;
  * <p>
  * The attribute permits multiple instances in a given location.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariableTableAttribute
         extends Attribute<LocalVariableTableAttribute>

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTableAttribute.java
@@ -29,7 +29,6 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code LocalVariableTable} attribute {@jvms 4.7.13}, which can appear
@@ -43,7 +42,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariableTableAttribute
         extends Attribute<LocalVariableTableAttribute>
         permits BoundAttribute.BoundLocalVariableTableAttribute, UnboundAttribute.UnboundLocalVariableTableAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeInfo.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models a single local variable in the {@link LocalVariableTypeTableAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariableTypeInfo
         permits UnboundAttribute.UnboundLocalVariableTypeInfo, BoundLocalVariableType {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeInfo.java
@@ -27,14 +27,12 @@ package java.lang.classfile.attribute;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundLocalVariableType;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single local variable in the {@link LocalVariableTypeTableAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariableTypeInfo
         permits UnboundAttribute.UnboundLocalVariableTypeInfo, BoundLocalVariableType {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeTableAttribute.java
@@ -30,7 +30,6 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code LocalVariableTypeTable} attribute {@jvms 4.7.14}, which can appear
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariableTypeTableAttribute
         extends Attribute<LocalVariableTypeTableAttribute>
         permits BoundAttribute.BoundLocalVariableTypeTableAttribute, UnboundAttribute.UnboundLocalVariableTypeTableAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableTypeTableAttribute.java
@@ -43,7 +43,7 @@ import java.util.List;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariableTypeTableAttribute
         extends Attribute<LocalVariableTypeTableAttribute>

--- a/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
@@ -33,14 +33,12 @@ import java.lang.classfile.ClassFile;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single method parameter in the {@link MethodParametersAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodParameterInfo
         permits UnboundAttribute.UnboundMethodParameterInfo {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/MethodParameterInfo.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single method parameter in the {@link MethodParametersAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodParameterInfo
         permits UnboundAttribute.UnboundMethodParameterInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/MethodParametersAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/MethodParametersAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.MethodElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code MethodParameters} attribute {@jvms 4.7.24}, which can
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodParametersAttribute
         extends Attribute<MethodParametersAttribute>, MethodElement
         permits BoundAttribute.BoundMethodParametersAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/MethodParametersAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/MethodParametersAttribute.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 8.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodParametersAttribute
         extends Attribute<MethodParametersAttribute>, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
@@ -43,7 +43,6 @@ import java.lang.constant.ModuleDesc;
 import java.lang.constant.PackageDesc;
 import jdk.internal.classfile.impl.ModuleAttributeBuilderImpl;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Module} attribute {@jvms 4.7.25}, which can
@@ -59,7 +58,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleAttribute
         extends Attribute<ModuleAttribute>, ClassElement
         permits BoundAttribute.BoundModuleAttribute, UnboundAttribute.UnboundModuleAttribute {
@@ -174,7 +172,6 @@ public sealed interface ModuleAttribute
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ModuleAttributeBuilder
             permits ModuleAttributeBuilderImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
@@ -56,7 +56,7 @@ import jdk.internal.classfile.impl.Util;
  * <p>
  * The attribute was introduced in the Java SE Platform version 9.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleAttribute
         extends Attribute<ModuleAttribute>, ClassElement
@@ -170,7 +170,7 @@ public sealed interface ModuleAttribute
     /**
      * A builder for module attributes.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface ModuleAttributeBuilder
             permits ModuleAttributeBuilderImpl {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
@@ -38,14 +38,12 @@ import java.lang.classfile.ClassFile;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single "exports" declaration in the {@link ModuleAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleExportInfo
         permits UnboundAttribute.UnboundModuleExportInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleExportInfo.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single "exports" declaration in the {@link ModuleAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleExportInfo
         permits UnboundAttribute.UnboundModuleExportInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashInfo.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models hash information for a single module in the {@link ModuleHashesAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleHashInfo
         permits UnboundAttribute.UnboundModuleHashInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashInfo.java
@@ -28,14 +28,12 @@ import java.lang.classfile.constantpool.ModuleEntry;
 import java.lang.constant.ModuleDesc;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models hash information for a single module in the {@link ModuleHashesAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleHashInfo
         permits UnboundAttribute.UnboundModuleHashInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
@@ -68,7 +68,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleHashesAttribute
         extends Attribute<ModuleHashesAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleHashesAttribute.java
@@ -34,7 +34,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ModuleHashes} attribute, which can
@@ -71,7 +70,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleHashesAttribute
         extends Attribute<ModuleHashesAttribute>, ClassElement
         permits BoundAttribute.BoundModuleHashesAttribute, UnboundAttribute.UnboundModuleHashesAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleMainClassAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleMainClassAttribute.java
@@ -45,7 +45,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 9.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleMainClassAttribute
         extends Attribute<ModuleMainClassAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleMainClassAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleMainClassAttribute.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ModuleMainClass} attribute {@jvms 4.7.27}, which can
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleMainClassAttribute
         extends Attribute<ModuleMainClassAttribute>, ClassElement
         permits BoundAttribute.BoundModuleMainClassAttribute, UnboundAttribute.UnboundModuleMainClassAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
@@ -41,7 +41,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single "opens" declaration in the {@link ModuleAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleOpenInfo
         permits UnboundAttribute.UnboundModuleOpenInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleOpenInfo.java
@@ -37,14 +37,12 @@ import java.lang.reflect.AccessFlag;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single "opens" declaration in the {@link ModuleAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleOpenInfo
         permits UnboundAttribute.UnboundModuleOpenInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModulePackagesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModulePackagesAttribute.java
@@ -35,7 +35,6 @@ import java.lang.classfile.constantpool.PackageEntry;
 import java.lang.constant.PackageDesc;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ModulePackages} attribute {@jvms 4.7.26}, which can
@@ -51,7 +50,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModulePackagesAttribute
         extends Attribute<ModulePackagesAttribute>, ClassElement
         permits BoundAttribute.BoundModulePackagesAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModulePackagesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModulePackagesAttribute.java
@@ -48,7 +48,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 9.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModulePackagesAttribute
         extends Attribute<ModulePackagesAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleProvideInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleProvideInfo.java
@@ -32,14 +32,12 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single "provides" declaration in the {@link ModuleAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleProvideInfo
         permits UnboundAttribute.UnboundModuleProvideInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleProvideInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleProvideInfo.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single "provides" declaration in the {@link ModuleAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleProvideInfo
         permits UnboundAttribute.UnboundModuleProvideInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
@@ -35,14 +35,12 @@ import java.lang.constant.ModuleDesc;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single "requires" declaration in the {@link ModuleAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleRequireInfo
         permits UnboundAttribute.UnboundModuleRequiresInfo {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleRequireInfo.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
 /**
  * Models a single "requires" declaration in the {@link ModuleAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleRequireInfo
         permits UnboundAttribute.UnboundModuleRequiresInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
@@ -29,7 +29,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.ClassElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ModuleResolution} attribute, which can
@@ -64,7 +63,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleResolutionAttribute
         extends Attribute<ModuleResolutionAttribute>, ClassElement
         permits BoundAttribute.BoundModuleResolutionAttribute, UnboundAttribute.UnboundModuleResolutionAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleResolutionAttribute.java
@@ -61,7 +61,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleResolutionAttribute
         extends Attribute<ModuleResolutionAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
@@ -56,7 +56,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleTargetAttribute
         extends Attribute<ModuleTargetAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleTargetAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code ModuleTarget} attribute, which can
@@ -59,7 +58,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleTargetAttribute
         extends Attribute<ModuleTargetAttribute>, ClassElement
         permits BoundAttribute.BoundModuleTargetAttribute, UnboundAttribute.UnboundModuleTargetAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/NestHostAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/NestHostAttribute.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code NestHost} attribute {@jvms 4.7.28}, which can
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NestHostAttribute extends Attribute<NestHostAttribute>, ClassElement
         permits BoundAttribute.BoundNestHostAttribute,
                 UnboundAttribute.UnboundNestHostAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/NestHostAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/NestHostAttribute.java
@@ -45,7 +45,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 11.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NestHostAttribute extends Attribute<NestHostAttribute>, ClassElement
         permits BoundAttribute.BoundNestHostAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/NestMembersAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/NestMembersAttribute.java
@@ -47,7 +47,7 @@ import jdk.internal.classfile.impl.Util;
  * <p>
  * The attribute was introduced in the Java SE Platform version 11.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NestMembersAttribute extends Attribute<NestMembersAttribute>, ClassElement
         permits BoundAttribute.BoundNestMembersAttribute, UnboundAttribute.UnboundNestMembersAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/NestMembersAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/NestMembersAttribute.java
@@ -34,7 +34,6 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code NestMembers} attribute {@jvms 4.7.29}, which can
@@ -50,7 +49,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NestMembersAttribute extends Attribute<NestMembersAttribute>, ClassElement
         permits BoundAttribute.BoundNestMembersAttribute, UnboundAttribute.UnboundNestMembersAttribute {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/PermittedSubclassesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/PermittedSubclassesAttribute.java
@@ -47,7 +47,7 @@ import jdk.internal.classfile.impl.Util;
  * <p>
  * The attribute was introduced in the Java SE Platform version 17.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface PermittedSubclassesAttribute
         extends Attribute<PermittedSubclassesAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/PermittedSubclassesAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/PermittedSubclassesAttribute.java
@@ -34,7 +34,6 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code PermittedSubclasses} attribute {@jvms 4.7.31}, which can
@@ -50,7 +49,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface PermittedSubclassesAttribute
         extends Attribute<PermittedSubclassesAttribute>, ClassElement
         permits BoundAttribute.BoundPermittedSubclassesAttribute, UnboundAttribute.UnboundPermittedSubclassesAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RecordAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RecordAttribute.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 16.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RecordAttribute extends Attribute<RecordAttribute>, ClassElement
         permits BoundAttribute.BoundRecordAttribute, UnboundAttribute.UnboundRecordAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RecordAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RecordAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.ClassElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Record} attribute {@jvms 4.7.30}, which can
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RecordAttribute extends Attribute<RecordAttribute>, ClassElement
         permits BoundAttribute.BoundRecordAttribute, UnboundAttribute.UnboundRecordAttribute {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
 /**
  * Models a single record component in the {@link java.lang.classfile.attribute.RecordAttribute}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RecordComponentInfo
         extends AttributedElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
@@ -33,14 +33,12 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundRecordComponentInfo;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single record component in the {@link java.lang.classfile.attribute.RecordAttribute}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RecordComponentInfo
         extends AttributedElement
         permits BoundRecordComponentInfo, UnboundAttribute.UnboundRecordComponentInfo {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleAnnotationsAttribute.java
@@ -43,7 +43,7 @@ import java.util.List;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeInvisibleAnnotationsAttribute
         extends Attribute<RuntimeInvisibleAnnotationsAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleAnnotationsAttribute.java
@@ -30,7 +30,6 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeInvisibleAnnotations} attribute {@jvms 4.7.17}, which
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeInvisibleAnnotationsAttribute
         extends Attribute<RuntimeInvisibleAnnotationsAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleParameterAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleParameterAnnotationsAttribute.java
@@ -33,7 +33,6 @@ import java.lang.classfile.MethodElement;
 import java.lang.classfile.MethodModel;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeInvisibleParameterAnnotations} attribute
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeInvisibleParameterAnnotationsAttribute
         extends Attribute<RuntimeInvisibleParameterAnnotationsAttribute>, MethodElement
         permits BoundAttribute.BoundRuntimeInvisibleParameterAnnotationsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleParameterAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleParameterAnnotationsAttribute.java
@@ -45,7 +45,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeInvisibleParameterAnnotationsAttribute
         extends Attribute<RuntimeInvisibleParameterAnnotationsAttribute>, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleTypeAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleTypeAnnotationsAttribute.java
@@ -35,7 +35,6 @@ import java.lang.classfile.MethodElement;
 import java.lang.classfile.TypeAnnotation;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeInvisibleTypeAnnotations} attribute {@jvms 4.7.21}, which
@@ -52,7 +51,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeInvisibleTypeAnnotationsAttribute
         extends Attribute<RuntimeInvisibleTypeAnnotationsAttribute>,
                 ClassElement, MethodElement, FieldElement, CodeElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleTypeAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeInvisibleTypeAnnotationsAttribute.java
@@ -49,7 +49,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 8.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeInvisibleTypeAnnotationsAttribute
         extends Attribute<RuntimeInvisibleTypeAnnotationsAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleAnnotationsAttribute.java
@@ -30,7 +30,6 @@ import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
 
 import java.util.List;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeVisibleAnnotations} attribute {@jvms 4.7.16}, which
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeVisibleAnnotationsAttribute
         extends Attribute<RuntimeVisibleAnnotationsAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleAnnotationsAttribute.java
@@ -43,7 +43,7 @@ import java.util.List;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeVisibleAnnotationsAttribute
         extends Attribute<RuntimeVisibleAnnotationsAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleParameterAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleParameterAnnotationsAttribute.java
@@ -45,7 +45,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeVisibleParameterAnnotationsAttribute
         extends Attribute<RuntimeVisibleParameterAnnotationsAttribute>, MethodElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleParameterAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleParameterAnnotationsAttribute.java
@@ -33,7 +33,6 @@ import java.lang.classfile.MethodElement;
 import java.lang.classfile.MethodModel;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeVisibleParameterAnnotations} attribute {@jvms 4.7.18}, which
@@ -48,7 +47,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeVisibleParameterAnnotationsAttribute
         extends Attribute<RuntimeVisibleParameterAnnotationsAttribute>, MethodElement
         permits BoundAttribute.BoundRuntimeVisibleParameterAnnotationsAttribute,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleTypeAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleTypeAnnotationsAttribute.java
@@ -49,7 +49,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 8.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface RuntimeVisibleTypeAnnotationsAttribute
         extends Attribute<RuntimeVisibleTypeAnnotationsAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleTypeAnnotationsAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RuntimeVisibleTypeAnnotationsAttribute.java
@@ -35,7 +35,6 @@ import java.lang.classfile.MethodElement;
 import java.lang.classfile.TypeAnnotation;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code RuntimeVisibleTypeAnnotations} attribute {@jvms 4.7.20}, which
@@ -52,7 +51,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface RuntimeVisibleTypeAnnotationsAttribute
         extends Attribute<RuntimeVisibleTypeAnnotationsAttribute>,
                 ClassElement, MethodElement, FieldElement, CodeElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SignatureAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SignatureAttribute.java
@@ -36,7 +36,6 @@ import java.lang.classfile.MethodSignature;
 import java.lang.classfile.Signature;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Signature} attribute {@jvms 4.7.9}, which
@@ -53,7 +52,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SignatureAttribute
         extends Attribute<SignatureAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SignatureAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SignatureAttribute.java
@@ -50,7 +50,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SignatureAttribute
         extends Attribute<SignatureAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceDebugExtensionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceDebugExtensionAttribute.java
@@ -29,7 +29,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.ClassElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code SourceDebugExtension} attribute.
@@ -44,7 +43,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SourceDebugExtensionAttribute
         extends Attribute<SourceDebugExtensionAttribute>, ClassElement
         permits BoundAttribute.BoundSourceDebugExtensionAttribute, UnboundAttribute.UnboundSourceDebugExtensionAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceDebugExtensionAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceDebugExtensionAttribute.java
@@ -41,7 +41,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 5.0.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SourceDebugExtensionAttribute
         extends Attribute<SourceDebugExtensionAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceFileAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceFileAttribute.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code SourceFile} attribute {@jvms 4.7.10}, which
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SourceFileAttribute
         extends Attribute<SourceFileAttribute>, ClassElement
         permits BoundAttribute.BoundSourceFileAttribute, UnboundAttribute.UnboundSourceFileAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceFileAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceFileAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SourceFileAttribute
         extends Attribute<SourceFileAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code SourceID} attribute, which can
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SourceIDAttribute
         extends Attribute<SourceIDAttribute>, ClassElement
         permits BoundAttribute.BoundSourceIDAttribute, UnboundAttribute.UnboundSourceIDAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SourceIDAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * Subsequent occurrence of the attribute takes precedence during the attributed
  * element build or transformation.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SourceIDAttribute
         extends Attribute<SourceIDAttribute>, ClassElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
@@ -37,7 +37,7 @@ import static java.lang.classfile.ClassFile.*;
 /**
  * Models stack map frame of {@code StackMapTable} attribute {@jvms 4.7.4}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface StackMapFrameInfo
             permits StackMapDecoder.StackMapFrameImpl {
@@ -78,7 +78,7 @@ public sealed interface StackMapFrameInfo
     /**
      * The type of a stack value.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface VerificationTypeInfo {
 
@@ -91,7 +91,7 @@ public sealed interface StackMapFrameInfo
     /**
      * A simple stack value.
      *
-     * @since 22
+     * @since 24
      */
     public enum SimpleVerificationTypeInfo implements VerificationTypeInfo {
 
@@ -132,7 +132,7 @@ public sealed interface StackMapFrameInfo
     /**
      * A stack value for an object type.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface ObjectVerificationTypeInfo extends VerificationTypeInfo
             permits StackMapDecoder.ObjectVerificationTypeInfoImpl {
@@ -170,7 +170,7 @@ public sealed interface StackMapFrameInfo
     /**
      * An uninitialized stack value.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface UninitializedVerificationTypeInfo extends VerificationTypeInfo
             permits StackMapDecoder.UninitializedVerificationTypeInfoImpl {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapFrameInfo.java
@@ -33,14 +33,12 @@ import java.lang.classfile.constantpool.ClassEntry;
 import jdk.internal.classfile.impl.StackMapDecoder;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import static java.lang.classfile.ClassFile.*;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models stack map frame of {@code StackMapTable} attribute {@jvms 4.7.4}.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface StackMapFrameInfo
             permits StackMapDecoder.StackMapFrameImpl {
 
@@ -82,7 +80,6 @@ public sealed interface StackMapFrameInfo
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface VerificationTypeInfo {
 
         /**
@@ -96,7 +93,6 @@ public sealed interface StackMapFrameInfo
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public enum SimpleVerificationTypeInfo implements VerificationTypeInfo {
 
         /** verification type top */
@@ -138,7 +134,6 @@ public sealed interface StackMapFrameInfo
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface ObjectVerificationTypeInfo extends VerificationTypeInfo
             permits StackMapDecoder.ObjectVerificationTypeInfoImpl {
 
@@ -177,7 +172,6 @@ public sealed interface StackMapFrameInfo
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface UninitializedVerificationTypeInfo extends VerificationTypeInfo
             permits StackMapDecoder.UninitializedVerificationTypeInfoImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapTableAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Attribute;
 import java.lang.classfile.CodeElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code StackMapTable} attribute {@jvms 4.7.4}, which can appear
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface StackMapTableAttribute
         extends Attribute<StackMapTableAttribute>, CodeElement
         permits BoundAttribute.BoundStackMapTableAttribute, UnboundAttribute.UnboundStackMapTableAttribute {

--- a/src/java.base/share/classes/java/lang/classfile/attribute/StackMapTableAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/StackMapTableAttribute.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute was introduced in the Java SE Platform version 6.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface StackMapTableAttribute
         extends Attribute<StackMapTableAttribute>, CodeElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SyntheticAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SyntheticAttribute.java
@@ -31,7 +31,6 @@ import java.lang.classfile.FieldElement;
 import java.lang.classfile.MethodElement;
 import jdk.internal.classfile.impl.BoundAttribute;
 import jdk.internal.classfile.impl.UnboundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models the {@code Synthetic} attribute {@jvms 4.7.8}, which can appear on
@@ -43,7 +42,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SyntheticAttribute
         extends Attribute<SyntheticAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/SyntheticAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/SyntheticAttribute.java
@@ -40,7 +40,7 @@ import jdk.internal.classfile.impl.UnboundAttribute;
  * <p>
  * The attribute permits multiple instances in a given location.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SyntheticAttribute
         extends Attribute<SyntheticAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/UnknownAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/UnknownAttribute.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.BoundAttribute;
 /**
  * Models an unknown attribute on a class, method, or field.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface UnknownAttribute
         extends Attribute<UnknownAttribute>,

--- a/src/java.base/share/classes/java/lang/classfile/attribute/UnknownAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/UnknownAttribute.java
@@ -30,14 +30,12 @@ import java.lang.classfile.ClassElement;
 import java.lang.classfile.FieldElement;
 import java.lang.classfile.MethodElement;
 import jdk.internal.classfile.impl.BoundAttribute;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an unknown attribute on a class, method, or field.
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface UnknownAttribute
         extends Attribute<UnknownAttribute>,
                 ClassElement, MethodElement, FieldElement

--- a/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
@@ -28,7 +28,7 @@
  *
  * The {@code java.lang.classfile.attribute} package contains interfaces describing classfile attributes.
  *
- * @since 22
+ * @since 24
  */
 package java.lang.classfile.attribute;
 

--- a/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/package-info.java
@@ -30,7 +30,5 @@
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile.attribute;
 
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
@@ -59,7 +59,7 @@ import jdk.internal.classfile.impl.ClassPrinterImpl;
  * Another use case for {@link ClassPrinter} is to simplify writing of automated tests:
  * {@snippet lang="java" class="PackageSnippets" region="printNodesInTest"}
  *
- * @since 22
+ * @since 24
  */
 public final class ClassPrinter {
 
@@ -69,7 +69,7 @@ public final class ClassPrinter {
     /**
      * Level of detail to print or export.
      *
-     * @since 22
+     * @since 24
      */
     public enum Verbosity {
 
@@ -103,7 +103,7 @@ public final class ClassPrinter {
     /**
      * Named, traversable, and printable node parent.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface Node {
 
@@ -147,7 +147,7 @@ public final class ClassPrinter {
     /**
      * A leaf node holding single printable value.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface LeafNode extends Node
             permits ClassPrinterImpl.LeafNodeImpl {
@@ -162,7 +162,7 @@ public final class ClassPrinter {
     /**
      * A tree node holding {@link List} of nested nodes.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface ListNode extends Node, List<Node>
             permits ClassPrinterImpl.ListNodeImpl {
@@ -173,7 +173,7 @@ public final class ClassPrinter {
      * <p>
      * Each {@link Map.Entry#getKey()} == {@link Map.Entry#getValue()}.{@link #name()}.
      *
-     * @since 22
+     * @since 24
      */
     public sealed interface MapNode extends Node, Map<ConstantDesc, Node>
             permits ClassPrinterImpl.MapNodeImpl {

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassPrinter.java
@@ -36,7 +36,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.CompoundElement;
 
 import jdk.internal.classfile.impl.ClassPrinterImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A printer of classfiles and its elements.
@@ -62,7 +61,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public final class ClassPrinter {
 
     private ClassPrinter() {
@@ -73,7 +71,6 @@ public final class ClassPrinter {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public enum Verbosity {
 
         /**
@@ -108,7 +105,6 @@ public final class ClassPrinter {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface Node {
 
         /**
@@ -153,7 +149,6 @@ public final class ClassPrinter {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface LeafNode extends Node
             permits ClassPrinterImpl.LeafNodeImpl {
 
@@ -169,7 +164,6 @@ public final class ClassPrinter {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface ListNode extends Node, List<Node>
             permits ClassPrinterImpl.ListNodeImpl {
     }
@@ -181,7 +175,6 @@ public final class ClassPrinter {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     public sealed interface MapNode extends Node, Map<ConstantDesc, Node>
             permits ClassPrinterImpl.MapNodeImpl {
     }

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
@@ -51,7 +51,7 @@ import jdk.internal.classfile.impl.ClassRemapperImpl;
  * Arrays of reference types are always decomposed, mapped as the base reference
  * types and composed back to arrays.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassRemapper extends ClassTransform permits ClassRemapperImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
@@ -34,7 +34,6 @@ import java.lang.classfile.CodeTransform;
 import java.lang.classfile.FieldTransform;
 import java.lang.classfile.MethodTransform;
 import jdk.internal.classfile.impl.ClassRemapperImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * {@code ClassRemapper} is a {@link ClassTransform}, {@link FieldTransform},
@@ -54,7 +53,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassRemapper extends ClassTransform permits ClassRemapperImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
@@ -30,7 +30,6 @@ import java.lang.classfile.AccessFlags;
 import java.lang.classfile.CodeTransform;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.CodeLocalsShifterImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * {@link CodeLocalsShifter} is a {@link CodeTransform} shifting locals to
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeLocalsShifter extends CodeTransform permits CodeLocalsShifterImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeLocalsShifter.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.CodeLocalsShifterImpl;
  * Locals pointing to the receiver or to method arguments slots are never shifted.
  * All locals pointing beyond the method arguments are re-indexed in order of appearance.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeLocalsShifter extends CodeTransform permits CodeLocalsShifterImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
@@ -42,7 +42,7 @@ import jdk.internal.classfile.impl.CodeRelabelerImpl;
  * Repeated injection of the same code block must be relabeled, so each instance of
  * {@link java.lang.classfile.Label} is bound in the target bytecode exactly once.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeRelabeler extends CodeTransform permits CodeRelabelerImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
@@ -31,7 +31,6 @@ import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.CodeTransform;
 import java.lang.classfile.Label;
 import jdk.internal.classfile.impl.CodeRelabelerImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A code relabeler is a {@link CodeTransform} replacing all occurrences
@@ -45,7 +44,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeRelabeler extends CodeTransform permits CodeRelabelerImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -30,7 +30,6 @@ import java.lang.classfile.CodeTransform;
 import java.lang.classfile.Label;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.CodeStackTrackerImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * {@link CodeStackTracker} is a {@link CodeTransform} tracking stack content
@@ -52,7 +51,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CodeStackTracker extends CodeTransform permits CodeStackTrackerImpl {
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -49,7 +49,7 @@ import jdk.internal.classfile.impl.CodeStackTrackerImpl;
  *     });
  * }
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CodeStackTracker extends CodeTransform permits CodeStackTrackerImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/components/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/package-info.java
@@ -111,7 +111,7 @@
  * instrumenting transformation:
  * {@snippet lang="java" class="PackageSnippets" region="classInstrumentation"}
  *
- * @since 22
+ * @since 24
  */
 package java.lang.classfile.components;
 

--- a/src/java.base/share/classes/java/lang/classfile/components/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/package-info.java
@@ -113,7 +113,5 @@
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile.components;
 
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/AnnotationConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/AnnotationConstantValueEntry.java
@@ -31,7 +31,7 @@ import java.lang.constant.ConstantDesc;
  * which includes the four kinds of primitive constants, and UTF8 constants.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface AnnotationConstantValueEntry extends PoolEntry
         permits DoubleEntry, FloatEntry, IntegerEntry, LongEntry, Utf8Entry {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/AnnotationConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/AnnotationConstantValueEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import java.lang.constant.ConstantDesc;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A constant pool entry that may be used as an annotation constant,
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface AnnotationConstantValueEntry extends PoolEntry
         permits DoubleEntry, FloatEntry, IntegerEntry, LongEntry, Utf8Entry {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ClassEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ClassEntry.java
@@ -33,7 +33,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.1 The CONSTANT_Class_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ClassEntry
         extends LoadableConstantEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ClassEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ClassEntry.java
@@ -27,7 +27,6 @@ package java.lang.classfile.constantpool;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDesc;
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Class_info} constant in the constant pool of a
@@ -36,7 +35,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ClassEntry
         extends LoadableConstantEntry
         permits AbstractPoolEntry.ClassEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
@@ -32,7 +32,6 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.DynamicConstantDesc;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Dynamic_info} constant in the constant pool of a
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantDynamicEntry
         extends DynamicConstantPoolEntry, LoadableConstantEntry
         permits AbstractPoolEntry.ConstantDynamicEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.10 The CONSTANT_Dynamic_info and CONSTANT_InvokeDynamic_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantDynamicEntry
         extends DynamicConstantPoolEntry, LoadableConstantEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
@@ -36,7 +36,7 @@ import java.lang.classfile.ClassReader;
  * @jvms 4.4 The Constant Pool
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantPool extends Iterable<PoolEntry>
         permits ClassReader, ConstantPoolBuilder {
@@ -67,7 +67,6 @@ public sealed interface ConstantPool extends Iterable<PoolEntry>
      * @param cls the entry type
      * @throws ConstantPoolException if the index is out of range of the
      *         constant pool, or the entry is not of the given type
-     * @since 23
      */
     <T extends PoolEntry> T entryByIndex(int index, Class<T> cls);
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPool.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.lang.classfile.BootstrapMethodEntry;
 import java.lang.classfile.ClassReader;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Provides read access to the constant pool and bootstrap method table of a
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantPool extends Iterable<PoolEntry>
         permits ClassReader, ConstantPoolBuilder {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -45,7 +45,6 @@ import jdk.internal.classfile.impl.AbstractPoolEntry.NameAndTypeEntryImpl;
 import jdk.internal.classfile.impl.SplitConstantPool;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -59,7 +58,6 @@ import static java.util.Objects.requireNonNull;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantPoolBuilder
         extends ConstantPool, WritableElement<ConstantPool>
         permits SplitConstantPool, TemporaryConstantPool {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -56,7 +56,7 @@ import static java.util.Objects.requireNonNull;
  * The {@linkplain ConstantPoolBuilder} also provides access to some of the
  * state of the {@linkplain ClassBuilder}, such as classfile processing options.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantPoolBuilder
         extends ConstantPool, WritableElement<ConstantPool>

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolException.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolException.java
@@ -24,7 +24,6 @@
  */
 package java.lang.classfile.constantpool;
 
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Thrown to indicate that requested entry cannot be obtained from the constant
@@ -32,7 +31,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public class ConstantPoolException extends IllegalArgumentException {
 
     @java.io.Serial

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolException.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolException.java
@@ -29,7 +29,7 @@ package java.lang.classfile.constantpool;
  * Thrown to indicate that requested entry cannot be obtained from the constant
  * pool.
  *
- * @since 22
+ * @since 24
  */
 public class ConstantPoolException extends IllegalArgumentException {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import java.lang.constant.ConstantDesc;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a constant pool entry that can be used as the constant in a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantValueEntry extends LoadableConstantEntry
         permits DoubleEntry, FloatEntry, IntegerEntry, LongEntry, StringEntry {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
@@ -32,7 +32,7 @@ import java.lang.constant.ConstantDesc;
  * types and {@linkplain String} constants.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantValueEntry extends LoadableConstantEntry
         permits DoubleEntry, FloatEntry, IntegerEntry, LongEntry, StringEntry {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/DoubleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/DoubleEntry.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.5 The CONSTANT_Long_info and CONSTANT_Double_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface DoubleEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/DoubleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/DoubleEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Double_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface DoubleEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry
         permits AbstractPoolEntry.DoubleEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/DynamicConstantPoolEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/DynamicConstantPoolEntry.java
@@ -32,7 +32,7 @@ import java.lang.classfile.BootstrapMethodEntry;
  * @jvms 4.4.10 The CONSTANT_Dynamic_info and CONSTANT_InvokeDynamic_info Structures
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface DynamicConstantPoolEntry extends PoolEntry
         permits ConstantDynamicEntry, InvokeDynamicEntry {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/DynamicConstantPoolEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/DynamicConstantPoolEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import java.lang.classfile.BootstrapMethodEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a dynamic constant pool entry, which is either {@link ConstantDynamicEntry}
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface DynamicConstantPoolEntry extends PoolEntry
         permits ConstantDynamicEntry, InvokeDynamicEntry {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 import java.lang.constant.ClassDesc;
 
 /**
@@ -36,7 +35,6 @@ import java.lang.constant.ClassDesc;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FieldRefEntry extends MemberRefEntry
         permits AbstractPoolEntry.FieldRefEntryImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
@@ -33,7 +33,7 @@ import java.lang.constant.ClassDesc;
  * classfile.
  * @jvms 4.4.2 The CONSTANT_Fieldref_info, CONSTANT_Methodref_info, and CONSTANT_InterfaceMethodref_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface FieldRefEntry extends MemberRefEntry
         permits AbstractPoolEntry.FieldRefEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/FloatEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/FloatEntry.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.4 The CONSTANT_Integer_info and CONSTANT_Float_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface FloatEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/FloatEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/FloatEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Float_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FloatEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry
         permits AbstractPoolEntry.FloatEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/IntegerEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/IntegerEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Integer_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface IntegerEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry
         permits AbstractPoolEntry.IntegerEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/IntegerEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/IntegerEntry.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.4 The CONSTANT_Integer_info and CONSTANT_Float_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface IntegerEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/InterfaceMethodRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/InterfaceMethodRefEntry.java
@@ -33,7 +33,7 @@ import java.lang.constant.MethodTypeDesc;
  * classfile.
  * @jvms 4.4.2 The CONSTANT_Fieldref_info, CONSTANT_Methodref_info, and CONSTANT_InterfaceMethodref_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InterfaceMethodRefEntry
         extends MemberRefEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/InterfaceMethodRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/InterfaceMethodRefEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 import java.lang.constant.MethodTypeDesc;
 
 /**
@@ -36,7 +35,6 @@ import java.lang.constant.MethodTypeDesc;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InterfaceMethodRefEntry
         extends MemberRefEntry
         permits AbstractPoolEntry.InterfaceMethodRefEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/InvokeDynamicEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/InvokeDynamicEntry.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.Util;
  * Models a constant pool entry for a dynamic call site.
  * @jvms 4.4.10 The CONSTANT_Dynamic_info and CONSTANT_InvokeDynamic_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InvokeDynamicEntry
         extends DynamicConstantPoolEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/InvokeDynamicEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/InvokeDynamicEntry.java
@@ -30,7 +30,6 @@ import java.lang.constant.MethodTypeDesc;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a constant pool entry for a dynamic call site.
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InvokeDynamicEntry
         extends DynamicConstantPoolEntry
         permits AbstractPoolEntry.InvokeDynamicEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/LoadableConstantEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/LoadableConstantEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import java.lang.constant.ConstantDesc;
 import java.lang.classfile.TypeKind;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Marker interface for constant pool entries suitable for loading via the
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LoadableConstantEntry extends PoolEntry
         permits ClassEntry, ConstantDynamicEntry, ConstantValueEntry, MethodHandleEntry, MethodTypeEntry {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/LoadableConstantEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/LoadableConstantEntry.java
@@ -32,7 +32,7 @@ import java.lang.classfile.TypeKind;
  * {@code LDC} instructions.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface LoadableConstantEntry extends PoolEntry
         permits ClassEntry, ConstantDynamicEntry, ConstantValueEntry, MethodHandleEntry, MethodTypeEntry {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/LongEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/LongEntry.java
@@ -32,7 +32,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.5 The CONSTANT_Long_info and CONSTANT_Double_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LongEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/LongEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/LongEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Long_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LongEntry
         extends AnnotationConstantValueEntry, ConstantValueEntry
         permits AbstractPoolEntry.LongEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MemberRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MemberRefEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a member reference constant in the constant pool of a classfile,
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MemberRefEntry extends PoolEntry
         permits FieldRefEntry, InterfaceMethodRefEntry, MethodRefEntry, AbstractPoolEntry.AbstractMemberRefEntry {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MemberRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MemberRefEntry.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * which includes references to fields, methods, and interface methods.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface MemberRefEntry extends PoolEntry
         permits FieldRefEntry, InterfaceMethodRefEntry, MethodRefEntry, AbstractPoolEntry.AbstractMemberRefEntry {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodHandleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodHandleEntry.java
@@ -28,7 +28,6 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.DirectMethodHandleDesc;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_MethodHandle_info} constant in the constant pool of a
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodHandleEntry
         extends LoadableConstantEntry
         permits AbstractPoolEntry.MethodHandleEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodHandleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodHandleEntry.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.8 The CONSTANT_MethodHandle_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodHandleEntry
         extends LoadableConstantEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodRefEntry.java
@@ -33,7 +33,7 @@ import java.lang.constant.MethodTypeDesc;
  * classfile.
  * @jvms 4.4.2 The CONSTANT_Fieldref_info, CONSTANT_Methodref_info, and CONSTANT_InterfaceMethodref_info Structures
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodRefEntry extends MemberRefEntry
         permits AbstractPoolEntry.MethodRefEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodRefEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 import java.lang.constant.MethodTypeDesc;
 
 /**
@@ -36,7 +35,6 @@ import java.lang.constant.MethodTypeDesc;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodRefEntry extends MemberRefEntry
         permits AbstractPoolEntry.MethodRefEntryImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodTypeEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodTypeEntry.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.9 The CONSTANT_MethodType_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MethodTypeEntry
         extends LoadableConstantEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/MethodTypeEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/MethodTypeEntry.java
@@ -28,7 +28,6 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.MethodTypeDesc;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_MethodType_info} constant in the constant pool of a
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MethodTypeEntry
         extends LoadableConstantEntry
         permits AbstractPoolEntry.MethodTypeEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ModuleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ModuleEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import java.lang.constant.ModuleDesc;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Module_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ModuleEntry extends PoolEntry
         permits AbstractPoolEntry.ModuleEntryImpl {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ModuleEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ModuleEntry.java
@@ -32,7 +32,7 @@ import java.lang.constant.ModuleDesc;
  * classfile.
  * @jvms 4.4.11 The CONSTANT_Module_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ModuleEntry extends PoolEntry
         permits AbstractPoolEntry.ModuleEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/NameAndTypeEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/NameAndTypeEntry.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.6 The CONSTANT_NameAndType_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NameAndTypeEntry extends PoolEntry
         permits AbstractPoolEntry.NameAndTypeEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/NameAndTypeEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/NameAndTypeEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_NameAndType_info} constant in the constant pool of a
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NameAndTypeEntry extends PoolEntry
         permits AbstractPoolEntry.NameAndTypeEntryImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/PackageEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/PackageEntry.java
@@ -26,7 +26,6 @@ package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
 import java.lang.constant.PackageDesc;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_Package_info} constant in the constant pool of a
@@ -35,7 +34,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface PackageEntry extends PoolEntry
         permits AbstractPoolEntry.PackageEntryImpl {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/PackageEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/PackageEntry.java
@@ -32,7 +32,7 @@ import java.lang.constant.PackageDesc;
  * classfile.
  * @jvms 4.4.12 The CONSTANT_Package_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface PackageEntry extends PoolEntry
         permits AbstractPoolEntry.PackageEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
@@ -30,7 +30,7 @@ import java.lang.classfile.WritableElement;
  * Models an entry in the constant pool of a classfile.
  *
  * @sealedGraph
- * @since 22
+ * @since 24
  */
 public sealed interface PoolEntry extends WritableElement<PoolEntry>
         permits AnnotationConstantValueEntry, DynamicConstantPoolEntry,

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/PoolEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import java.lang.classfile.WritableElement;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an entry in the constant pool of a classfile.
@@ -33,7 +32,6 @@ import jdk.internal.javac.PreviewFeature;
  * @sealedGraph
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface PoolEntry extends WritableElement<PoolEntry>
         permits AnnotationConstantValueEntry, DynamicConstantPoolEntry,
                 LoadableConstantEntry, MemberRefEntry, ModuleEntry, NameAndTypeEntry,

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/StringEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/StringEntry.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.3 The CONSTANT_String_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface StringEntry
         extends ConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/StringEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/StringEntry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_String_info} constant in the constant pool of a
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface StringEntry
         extends ConstantValueEntry
         permits AbstractPoolEntry.StringEntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/Utf8Entry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/Utf8Entry.java
@@ -31,7 +31,7 @@ import jdk.internal.classfile.impl.AbstractPoolEntry;
  * classfile.
  * @jvms 4.4.7 The CONSTANT_Utf8_info Structure
  *
- * @since 22
+ * @since 24
  */
 public sealed interface Utf8Entry
         extends CharSequence, AnnotationConstantValueEntry

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/Utf8Entry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/Utf8Entry.java
@@ -25,7 +25,6 @@
 package java.lang.classfile.constantpool;
 
 import jdk.internal.classfile.impl.AbstractPoolEntry;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code CONSTANT_UTF8_info} constant in the constant pool of a
@@ -34,7 +33,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface Utf8Entry
         extends CharSequence, AnnotationConstantValueEntry
         permits AbstractPoolEntry.Utf8EntryImpl {

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/package-info.java
@@ -30,7 +30,5 @@
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile.constantpool;
 
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/package-info.java
@@ -28,7 +28,7 @@
  *
  * The {@code java.lang.classfile.constantpool} package contains interfaces describing classfile constant pool entries.
  *
- * @since 22
+ * @since 24
  */
 package java.lang.classfile.constantpool;
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.Util;
  * Opcode.Kind#ARRAY_LOAD}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ArrayLoadInstruction extends Instruction
         permits AbstractInstruction.UnboundArrayLoadInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayLoadInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an array load instruction in the {@code code} array of a {@code Code}
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ArrayLoadInstruction extends Instruction
         permits AbstractInstruction.UnboundArrayLoadInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.Util;
  * Opcode.Kind#ARRAY_STORE}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ArrayStoreInstruction extends Instruction
         permits AbstractInstruction.UnboundArrayStoreInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ArrayStoreInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an array store instruction in the {@code code} array of a {@code Code}
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ArrayStoreInstruction extends Instruction
         permits AbstractInstruction.UnboundArrayStoreInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Label;
 import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a branching instruction (conditional or unconditional) in the {@code
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface BranchInstruction extends Instruction
         permits AbstractInstruction.BoundBranchInstruction,
                 AbstractInstruction.UnboundBranchInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/BranchInstruction.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.Util;
  * {@code kind} of {@link Opcode.Kind#BRANCH}.  Delivered as a {@link
  * CodeElement} when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface BranchInstruction extends Instruction
         permits AbstractInstruction.BoundBranchInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/CharacterRange.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/CharacterRange.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.BoundCharacterRange;
  * during traversal of the elements of a {@link CodeModel}, according to
  * the setting of the {@link ClassFile.DebugElementsOption} option.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface CharacterRange extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundCharacterRange, BoundCharacterRange {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/CharacterRange.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/CharacterRange.java
@@ -32,7 +32,6 @@ import java.lang.classfile.PseudoInstruction;
 import java.lang.classfile.attribute.CharacterRangeTableAttribute;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
 import jdk.internal.classfile.impl.BoundCharacterRange;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction which models a single entry in the
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface CharacterRange extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundCharacterRange, BoundCharacterRange {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
@@ -34,7 +34,6 @@ import java.lang.classfile.TypeKind;
 import java.lang.classfile.constantpool.LoadableConstantEntry;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a constant-load instruction in the {@code code} array of a {@code
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConstantInstruction extends Instruction {
 
     /**
@@ -65,7 +63,6 @@ public sealed interface ConstantInstruction extends Instruction {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface IntrinsicConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.UnboundIntrinsicConstantInstruction {
 
@@ -84,7 +81,6 @@ public sealed interface ConstantInstruction extends Instruction {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface ArgumentConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.BoundArgumentConstantInstruction,
                     AbstractInstruction.UnboundArgumentConstantInstruction {
@@ -107,7 +103,6 @@ public sealed interface ConstantInstruction extends Instruction {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface LoadConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.BoundLoadConstantInstruction,
                     AbstractInstruction.UnboundLoadConstantInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConstantInstruction.java
@@ -43,7 +43,7 @@ import jdk.internal.classfile.impl.Util;
  * a {@code kind} of {@link Opcode.Kind#CONSTANT}.  Delivered as a {@link
  * CodeElement} when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ConstantInstruction extends Instruction {
 
@@ -61,7 +61,7 @@ public sealed interface ConstantInstruction extends Instruction {
      * Models an "intrinsic constant" instruction (e.g., {@code
      * iconst_0}).
      *
-     * @since 22
+     * @since 24
      */
     sealed interface IntrinsicConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.UnboundIntrinsicConstantInstruction {
@@ -79,7 +79,7 @@ public sealed interface ConstantInstruction extends Instruction {
      * Models an "argument constant" instruction (e.g., {@code
      * bipush}).
      *
-     * @since 22
+     * @since 24
      */
     sealed interface ArgumentConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.BoundArgumentConstantInstruction,
@@ -101,7 +101,7 @@ public sealed interface ConstantInstruction extends Instruction {
      * Models a "load constant" instruction (e.g., {@code
      * ldc}).
      *
-     * @since 22
+     * @since 24
      */
     sealed interface LoadConstantInstruction extends ConstantInstruction
             permits AbstractInstruction.BoundLoadConstantInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
@@ -32,7 +32,6 @@ import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.BytecodeHelpers;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a primitive conversion instruction in the {@code code} array of a
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ConvertInstruction extends Instruction
         permits AbstractInstruction.UnboundConvertInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ConvertInstruction.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
  * a {@code kind} of {@link Opcode.Kind#CONVERT}.  Delivered as a {@link
  * CodeElement} when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ConvertInstruction extends Instruction
         permits AbstractInstruction.UnboundConvertInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Label;
 import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models instruction discontinued from the {@code code} array of a {@code Code}
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface DiscontinuedInstruction extends Instruction {
 
     /**
@@ -52,7 +50,6 @@ public sealed interface DiscontinuedInstruction extends Instruction {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface JsrInstruction extends DiscontinuedInstruction
             permits AbstractInstruction.BoundJsrInstruction,
                     AbstractInstruction.UnboundJsrInstruction {
@@ -95,7 +92,6 @@ public sealed interface DiscontinuedInstruction extends Instruction {
      *
      * @since 22
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
     sealed interface RetInstruction extends DiscontinuedInstruction
             permits AbstractInstruction.BoundRetInstruction,
                     AbstractInstruction.UnboundRetInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/DiscontinuedInstruction.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.Util;
  * attribute. Delivered as a {@link CodeElement} when traversing the elements of
  * a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface DiscontinuedInstruction extends Instruction {
 
@@ -48,7 +48,7 @@ public sealed interface DiscontinuedInstruction extends Instruction {
      * {@link Opcode.Kind#DISCONTINUED_JSR}.  Delivered as a {@link CodeElement}
      * when traversing the elements of a {@link CodeModel}.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface JsrInstruction extends DiscontinuedInstruction
             permits AbstractInstruction.BoundJsrInstruction,
@@ -90,7 +90,7 @@ public sealed interface DiscontinuedInstruction extends Instruction {
      * {@link Opcode.Kind#DISCONTINUED_RET}.  Delivered as a {@link CodeElement}
      * when traversing the elements of a {@link CodeModel}.
      *
-     * @since 22
+     * @since 24
      */
     sealed interface RetInstruction extends DiscontinuedInstruction
             permits AbstractInstruction.BoundRetInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
@@ -41,7 +41,7 @@ import jdk.internal.classfile.impl.AbstractPseudoInstruction;
  *
  * @see PseudoInstruction
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ExceptionCatch extends PseudoInstruction
         permits AbstractPseudoInstruction.ExceptionCatchImpl {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ExceptionCatch.java
@@ -32,7 +32,6 @@ import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.Label;
 import java.lang.classfile.PseudoInstruction;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction modeling an entry in the exception table of a code
@@ -44,7 +43,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ExceptionCatch extends PseudoInstruction
         permits AbstractPseudoInstruction.ExceptionCatchImpl {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.Util;
  * Opcode.Kind#FIELD_ACCESS}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface FieldInstruction extends Instruction
         permits AbstractInstruction.BoundFieldInstruction, AbstractInstruction.UnboundFieldInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/FieldInstruction.java
@@ -37,7 +37,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a field access instruction in the {@code code} array of a {@code Code}
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface FieldInstruction extends Instruction
         permits AbstractInstruction.BoundFieldInstruction, AbstractInstruction.UnboundFieldInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/IncrementInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/IncrementInstruction.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * {@link Opcode.Kind#INCREMENT}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface IncrementInstruction extends Instruction
         permits AbstractInstruction.BoundIncrementInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/IncrementInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/IncrementInstruction.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a local variable increment instruction in the {@code code} array of a
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface IncrementInstruction extends Instruction
         permits AbstractInstruction.BoundIncrementInstruction,
                 AbstractInstruction.UnboundIncrementInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/InvokeDynamicInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/InvokeDynamicInstruction.java
@@ -44,7 +44,7 @@ import jdk.internal.classfile.impl.Util;
  * {@code Code} attribute.  Delivered as a {@link CodeElement} when traversing
  * the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InvokeDynamicInstruction extends Instruction
         permits AbstractInstruction.BoundInvokeDynamicInstruction, AbstractInstruction.UnboundInvokeDynamicInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/InvokeDynamicInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/InvokeDynamicInstruction.java
@@ -38,7 +38,6 @@ import java.lang.classfile.constantpool.LoadableConstantEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an {@code invokedynamic} instruction in the {@code code} array of a
@@ -47,7 +46,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InvokeDynamicInstruction extends Instruction
         permits AbstractInstruction.BoundInvokeDynamicInstruction, AbstractInstruction.UnboundInvokeDynamicInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
@@ -39,7 +39,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a method invocation instruction in the {@code code} array of a {@code
@@ -49,7 +48,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface InvokeInstruction extends Instruction
         permits AbstractInstruction.BoundInvokeInterfaceInstruction, AbstractInstruction.BoundInvokeInstruction, AbstractInstruction.UnboundInvokeInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/InvokeInstruction.java
@@ -46,7 +46,7 @@ import jdk.internal.classfile.impl.Util;
  * will have a {@code kind} of {@link Opcode.Kind#INVOKE}.  Delivered as a
  * {@link CodeElement} when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface InvokeInstruction extends Instruction
         permits AbstractInstruction.BoundInvokeInterfaceInstruction, AbstractInstruction.BoundInvokeInstruction, AbstractInstruction.UnboundInvokeInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.LabelImpl;
  *
  * @see PseudoInstruction
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LabelTarget extends PseudoInstruction
         permits LabelImpl {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LabelTarget.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.Label;
 import java.lang.classfile.PseudoInstruction;
 import jdk.internal.classfile.impl.LabelImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction which indicates that the specified label corresponds to
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LabelTarget extends PseudoInstruction
         permits LabelImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LineNumber.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LineNumber.java
@@ -30,7 +30,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.PseudoInstruction;
 import java.lang.classfile.attribute.LineNumberTableAttribute;
 import jdk.internal.classfile.impl.LineNumberImpl;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction which models a single entry in the
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LineNumber extends PseudoInstruction
         permits LineNumberImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LineNumber.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LineNumber.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.LineNumberImpl;
  *
  * @see PseudoInstruction
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LineNumber extends PseudoInstruction
         permits LineNumberImpl {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
  * {@link Opcode.Kind#LOAD}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LoadInstruction extends Instruction
         permits AbstractInstruction.BoundLoadInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LoadInstruction.java
@@ -32,7 +32,6 @@ import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.BytecodeHelpers;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a local variable load instruction in the {@code code} array of a
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LoadInstruction extends Instruction
         permits AbstractInstruction.BoundLoadInstruction,
                 AbstractInstruction.UnboundLoadInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
@@ -46,7 +46,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
  *
  * @see PseudoInstruction
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariable extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundLocalVariable, BoundLocalVariable {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
@@ -37,7 +37,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
 import jdk.internal.classfile.impl.BoundLocalVariable;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction which models a single entry in the
@@ -49,7 +48,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariable extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundLocalVariable, BoundLocalVariable {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariableType.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariableType.java
@@ -43,7 +43,7 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
  * traversal of the elements of a {@link CodeModel}, according to the setting of
  * the {@link ClassFile.DebugElementsOption} option.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LocalVariableType extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundLocalVariableType, BoundLocalVariableType {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariableType.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariableType.java
@@ -36,7 +36,6 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
 import jdk.internal.classfile.impl.BoundLocalVariableType;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * A pseudo-instruction which models a single entry in the {@link
@@ -46,7 +45,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LocalVariableType extends PseudoInstruction
         permits AbstractPseudoInstruction.UnboundLocalVariableType, BoundLocalVariableType {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LookupSwitchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LookupSwitchInstruction.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * {@code Code} attribute.  Delivered as a {@link CodeElement} when traversing
  * the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface LookupSwitchInstruction extends Instruction
         permits AbstractInstruction.BoundLookupSwitchInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LookupSwitchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LookupSwitchInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.Label;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code lookupswitch} instruction in the {@code code} array of a
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface LookupSwitchInstruction extends Instruction
         permits AbstractInstruction.BoundLookupSwitchInstruction,
                 AbstractInstruction.UnboundLookupSwitchInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
@@ -30,7 +30,6 @@ import java.lang.classfile.Instruction;
 import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code monitorenter} or {@code monitorexit} instruction in the
@@ -39,7 +38,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface MonitorInstruction extends Instruction
         permits AbstractInstruction.UnboundMonitorInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/MonitorInstruction.java
@@ -36,7 +36,7 @@ import jdk.internal.classfile.impl.Util;
  * {@code code} array of a {@code Code} attribute.  Delivered as a {@link
  * CodeElement} when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface MonitorInstruction extends Instruction
         permits AbstractInstruction.UnboundMonitorInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewMultiArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewMultiArrayInstruction.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * array of a {@code Code} attribute.  Delivered as a {@link CodeElement}
  * when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NewMultiArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewMultidimensionalArrayInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewMultiArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewMultiArrayInstruction.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.Instruction;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code multianewarray} invocation instruction in the {@code code}
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NewMultiArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewMultidimensionalArrayInstruction,
                 AbstractInstruction.UnboundNewMultidimensionalArrayInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewObjectInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewObjectInstruction.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.Instruction;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code new} instruction in the {@code code} array of a {@code Code}
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NewObjectInstruction extends Instruction
         permits AbstractInstruction.BoundNewObjectInstruction, AbstractInstruction.UnboundNewObjectInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewObjectInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewObjectInstruction.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * attribute.  Delivered as a {@link CodeElement} when traversing the elements
  * of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NewObjectInstruction extends Instruction
         permits AbstractInstruction.BoundNewObjectInstruction, AbstractInstruction.UnboundNewObjectInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code newarray} invocation instruction in the {@code code}
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NewPrimitiveArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewPrimitiveArrayInstruction,
                 AbstractInstruction.UnboundNewPrimitiveArrayInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewPrimitiveArrayInstruction.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * array of a {@code Code} attribute.  Delivered as a {@link CodeElement}
  * when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NewPrimitiveArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewPrimitiveArrayInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewReferenceArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewReferenceArrayInstruction.java
@@ -29,7 +29,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.Instruction;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code anewarray} invocation instruction in the {@code code}
@@ -38,7 +37,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NewReferenceArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewReferenceArrayInstruction, AbstractInstruction.UnboundNewReferenceArrayInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NewReferenceArrayInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NewReferenceArrayInstruction.java
@@ -35,7 +35,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * array of a {@code Code} attribute.  Delivered as a {@link CodeElement}
  * when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NewReferenceArrayInstruction extends Instruction
         permits AbstractInstruction.BoundNewReferenceArrayInstruction, AbstractInstruction.UnboundNewReferenceArrayInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NopInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NopInstruction.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * array of a {@code Code} attribute.  Delivered as a {@link CodeElement}
  * when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface NopInstruction extends Instruction
         permits AbstractInstruction.UnboundNopInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/NopInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/NopInstruction.java
@@ -28,7 +28,6 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code nop} invocation instruction in the {@code code}
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface NopInstruction extends Instruction
         permits AbstractInstruction.UnboundNopInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
@@ -38,7 +38,7 @@ import jdk.internal.classfile.impl.Util;
  * {@link Opcode.Kind#OPERATOR}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface OperatorInstruction extends Instruction
         permits AbstractInstruction.UnboundOperatorInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/OperatorInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.Opcode;
 import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an arithmetic operator instruction in the {@code code} array of a
@@ -41,7 +40,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface OperatorInstruction extends Instruction
         permits AbstractInstruction.UnboundOperatorInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
  * {@link Opcode.Kind#RETURN}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ReturnInstruction extends Instruction
         permits AbstractInstruction.UnboundReturnInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ReturnInstruction.java
@@ -32,7 +32,6 @@ import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.BytecodeHelpers;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a return-from-method instruction in the {@code code} array of a
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ReturnInstruction extends Instruction
         permits AbstractInstruction.UnboundReturnInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.Util;
  * {@link Opcode.Kind#STACK}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface StackInstruction extends Instruction
         permits AbstractInstruction.UnboundStackInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StackInstruction.java
@@ -30,7 +30,6 @@ import java.lang.classfile.Instruction;
 import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a stack manipulation instruction in the {@code code} array of a
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface StackInstruction extends Instruction
         permits AbstractInstruction.UnboundStackInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
@@ -32,7 +32,6 @@ import java.lang.classfile.TypeKind;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.BytecodeHelpers;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a local variable store instruction in the {@code code} array of a
@@ -42,7 +41,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface StoreInstruction extends Instruction
         permits AbstractInstruction.BoundStoreInstruction, AbstractInstruction.UnboundStoreInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/StoreInstruction.java
@@ -39,7 +39,7 @@ import jdk.internal.classfile.impl.Util;
  * {@link Opcode.Kind#STORE}.  Delivered as a {@link CodeElement} when
  * traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface StoreInstruction extends Instruction
         permits AbstractInstruction.BoundStoreInstruction, AbstractInstruction.UnboundStoreInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/SwitchCase.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/SwitchCase.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * @see LookupSwitchInstruction
  * @see TableSwitchInstruction
  *
- * @since 22
+ * @since 24
  */
 public sealed interface SwitchCase
         permits AbstractInstruction.SwitchCaseImpl {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/SwitchCase.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/SwitchCase.java
@@ -26,7 +26,6 @@ package java.lang.classfile.instruction;
 
 import java.lang.classfile.Label;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a single case in a {@code lookupswitch} or {@code tableswitch}
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface SwitchCase
         permits AbstractInstruction.SwitchCaseImpl {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/TableSwitchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/TableSwitchInstruction.java
@@ -37,7 +37,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * {@code Code} attribute.  Delivered as a {@link CodeElement} when traversing
  * the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface TableSwitchInstruction extends Instruction
         permits AbstractInstruction.BoundTableSwitchInstruction, AbstractInstruction.UnboundTableSwitchInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/TableSwitchInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/TableSwitchInstruction.java
@@ -31,7 +31,6 @@ import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import java.lang.classfile.Label;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a {@code tableswitch} instruction in the {@code code} array of a
@@ -40,7 +39,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface TableSwitchInstruction extends Instruction
         permits AbstractInstruction.BoundTableSwitchInstruction, AbstractInstruction.UnboundTableSwitchInstruction {
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ThrowInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ThrowInstruction.java
@@ -34,7 +34,7 @@ import jdk.internal.classfile.impl.AbstractInstruction;
  * {@code Code} attribute.  Delivered as a {@link CodeElement} when traversing
  * the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface ThrowInstruction extends Instruction
         permits AbstractInstruction.UnboundThrowInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/ThrowInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/ThrowInstruction.java
@@ -28,7 +28,6 @@ import java.lang.classfile.CodeElement;
 import java.lang.classfile.CodeModel;
 import java.lang.classfile.Instruction;
 import jdk.internal.classfile.impl.AbstractInstruction;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an {@code athrow} instruction in the {@code code} array of a
@@ -37,7 +36,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface ThrowInstruction extends Instruction
         permits AbstractInstruction.UnboundThrowInstruction {
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
@@ -40,7 +40,7 @@ import jdk.internal.classfile.impl.Util;
  * code} array of a {@code Code} attribute.  Delivered as a {@link CodeElement}
  * when traversing the elements of a {@link CodeModel}.
  *
- * @since 22
+ * @since 24
  */
 public sealed interface TypeCheckInstruction extends Instruction
         permits AbstractInstruction.BoundTypeCheckInstruction,

--- a/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/TypeCheckInstruction.java
@@ -34,7 +34,6 @@ import java.lang.classfile.Opcode;
 import jdk.internal.classfile.impl.AbstractInstruction;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.Util;
-import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models an {@code instanceof} or {@code checkcast} instruction in the {@code
@@ -43,7 +42,6 @@ import jdk.internal.javac.PreviewFeature;
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 public sealed interface TypeCheckInstruction extends Instruction
         permits AbstractInstruction.BoundTypeCheckInstruction,
                 AbstractInstruction.UnboundTypeCheckInstruction {

--- a/src/java.base/share/classes/java/lang/classfile/instruction/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/package-info.java
@@ -28,7 +28,7 @@
  *
  * The {@code java.lang.classfile.attribute} package contains interfaces describing code instructions.
  *
- * @since 22
+ * @since 24
  */
 package java.lang.classfile.instruction;
 

--- a/src/java.base/share/classes/java/lang/classfile/instruction/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/package-info.java
@@ -30,7 +30,5 @@
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile.instruction;
 
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -546,6 +546,6 @@
  *     | CharacterRange(int rangeStart, int rangeEnd, int flags, Label startScope, Label endScope)
  * }
  *
- * @since 22
+ * @since 24
  */
 package java.lang.classfile;

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -548,7 +548,4 @@
  *
  * @since 22
  */
-@PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
 package java.lang.classfile;
-
-import jdk.internal.javac.PreviewFeature;

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -75,8 +75,6 @@ public @interface PreviewFeature {
         SCOPED_VALUES,
         @JEP(number=480, title="Structured Concurrency", status="Third Preview")
         STRUCTURED_CONCURRENCY,
-        @JEP(number=466, title="ClassFile API", status="Second Preview")
-        CLASSFILE_API,
         @JEP(number=473, title="Stream Gatherers", status="Second Preview")
         STREAM_GATHERERS,
         @JEP(number=476, title="Module Import Declarations", status="Preview")


### PR DESCRIPTION
Class-File API is leaving preview.
This is a removal of all `@PreviewFeature` annotations from Class-File API.
It also bumps all `@since` tags and removes `jdk.internal.javac.PreviewFeature.Feature.CLASSFILE_API`.

Please review.

Thanks,
Adam