### PR TITLE
8334287: Man page update for jstatd deprecation

### DIFF
--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -43,10 +43,9 @@ jstatd - monitor the creation and termination of instrumented Java
 HotSpot VMs
 .SH SYNOPSIS
 .PP
-\f[B]WARNING:\f[R] This command is deprecated and will be removed in a
-future release.
-.PP
-\f[B]Note:\f[R] This command is experimental and unsupported.
+\f[B]WARNING:\f[R] This command is experimental, unsupported, and
+deprecated.
+It will be removed in a future release.
 .PP
 \f[V]jstatd\f[R] [\f[I]options\f[R]]
 .TP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,9 @@
 jstatd - monitor the creation and termination of instrumented Java
 HotSpot VMs
 .SH SYNOPSIS
+.PP
+\f[B]WARNING:\f[R] This command is deprecated and will be removed in a
+future release.
 .PP
 \f[B]Note:\f[R] This command is experimental and unsupported.
 .PP


### PR DESCRIPTION
Man page update for JDK-8327793 which marked jstatd as deprecated for removal in JDK 24.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334287](https://bugs.openjdk.org/browse/JDK-8334287): Man page update for jstatd deprecation (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19829/head:pull/19829` \
`$ git checkout pull/19829`

Update a local copy of the PR: \
`$ git checkout pull/19829` \
`$ git pull https://git.openjdk.org/jdk.git pull/19829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19829`

View PR using the GUI difftool: \
`$ git pr show -t 19829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19829.diff">https://git.openjdk.org/jdk/pull/19829.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19829#issuecomment-2182835351)