### PR TITLE
8334397: RISC-V: verify perf of ReverseBytesS/US

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1916,6 +1916,8 @@ bool Matcher::match_rule_supported(int opcode) {
 
     case Op_ReverseBytesI:
     case Op_ReverseBytesL:
+    case Op_ReverseBytesS:
+    case Op_ReverseBytesUS:
     case Op_RotateRight:
     case Op_RotateLeft:
     case Op_CountLeadingZerosI:
@@ -7864,35 +7866,6 @@ instruct xorL_reg_imm(iRegLNoSp dst, iRegL src1, immLAdd src2) %{
   %}
 
   ins_pipe(ialu_reg_imm);
-%}
-
-// ============================================================================
-// BSWAP Instructions
-
-instruct bytes_reverse_unsigned_short(iRegINoSp dst, iRegIorL2I src) %{
-  match(Set dst (ReverseBytesUS src));
-
-  ins_cost(ALU_COST * 5);
-  format %{ "revb_h_h_u  $dst, $src\t#@bytes_reverse_unsigned_short" %}
-
-  ins_encode %{
-    __ revb_h_h_u(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(pipe_class_default);
-%}
-
-instruct bytes_reverse_short(iRegINoSp dst, iRegIorL2I src) %{
-  match(Set dst (ReverseBytesS src));
-
-  ins_cost(ALU_COST * 5);
-  format %{ "revb_h_h  $dst, $src\t#@bytes_reverse_short" %}
-
-  ins_encode %{
-    __ revb_h_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(pipe_class_default);
 %}
 
 // ============================================================================

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -206,13 +206,13 @@ instruct bytes_reverse_long_b(iRegLNoSp dst, iRegL src) %{
 %}
 
 instruct bytes_reverse_unsigned_short_b(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseZbb);
   match(Set dst (ReverseBytesUS src));
 
   ins_cost(ALU_COST * 2);
   format %{ "revb_h_h_u  $dst, $src\t#@bytes_reverse_unsigned_short_b" %}
 
   ins_encode %{
+    assert(UseZbb, "must be");
     __ revb_h_h_u(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 
@@ -220,13 +220,13 @@ instruct bytes_reverse_unsigned_short_b(iRegINoSp dst, iRegIorL2I src) %{
 %}
 
 instruct bytes_reverse_short_b(iRegINoSp dst, iRegIorL2I src) %{
-  predicate(UseZbb);
   match(Set dst (ReverseBytesS src));
 
   ins_cost(ALU_COST * 2);
   format %{ "revb_h_h  $dst, $src\t#@bytes_reverse_short_b" %}
 
   ins_encode %{
+    assert(UseZbb, "must be");
     __ revb_h_h(as_Register($dst$$reg), as_Register($src$$reg));
   %}
 

--- a/test/micro/org/openjdk/bench/java/lang/Characters.java
+++ b/test/micro/org/openjdk/bench/java/lang/Characters.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -47,6 +48,29 @@ public class Characters {
 
     @Param({"9", "65", "97", "223", "430"})
     private int codePoint;
+
+    @Param("500")
+    private int size;
+
+    private char[] chars;
+    private char[] res;
+
+    @Setup
+    public void setup() {
+        Random r  = new Random(0);
+        chars     = new char[size];
+        res       = new char[size];
+        for (int i = 0; i < size; i++) {
+            chars[i] = (char)r.nextInt(Character.MAX_VALUE + 1);
+        }
+    }
+
+    @Benchmark
+    public void reverseBytes() {
+        for (int i = 0; i < size; i++) {
+            res[i] = Character.reverseBytes(chars[i]);
+        }
+    }
 
     @Benchmark
     public boolean isDigit() {

--- a/test/micro/org/openjdk/bench/java/lang/Shorts.java
+++ b/test/micro/org/openjdk/bench/java/lang/Shorts.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+public class Shorts {
+
+    @Param("500")
+    private int size;
+
+    private short[] shorts;
+    private short[] res;
+
+    @Setup
+    public void setup() {
+        Random r  = new Random(0);
+        shorts     = new short[size];
+        res       = new short[size];
+        for (int i = 0; i < size; i++) {
+            shorts[i] = (short)(r.nextInt(Character.MAX_VALUE + 1) + Short.MIN_VALUE);
+        }
+    }
+
+    @Benchmark
+    public void reverseBytes() {
+        for (int i = 0; i < size; i++) {
+            res[i] = Short.reverseBytes(shorts[i]);
+        }
+    }
+}


### PR DESCRIPTION
Hi,
Can you help to review this patch?
Thanks!

This is similar with previous JDK-8334396.
Added some tests.

### Test
<google-sheets-html-origin style="caret-color: rgb(0, 0, 0); color: rgb(0, 0, 0); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: auto; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: auto; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none;">
  | Tests | Scores | Errors | Unit
-- | -- | -- | -- | --
Intrinsic, +zbb, +rvv | Characters.reverseBytes | 1654.535 | 69.36 | ns/op
  | Shorts.reverseBytes | 1795.403 | 44.015 | ns/op
Intrinsic, +zbb, -rvv | Characters.reverseBytes | 1649.752 | 74.965 | ns/op
  | Shorts.reverseBytes | 1798.637 | 49.52 | ns/op
Intrinsic, -zbb, +rvv | Characters.reverseBytes | 2279.588 | 44.222 | ns/op
  | Shorts.reverseBytes | 2441.674 | 63.895 | ns/op
Intrinsic, -zbb, -rvv | Characters.reverseBytes | 2288.876 | 49.099 | ns/op
  | Shorts.reverseBytes | 2454.454 | 94.004 | ns/op
No intrinsic | Characters.reverseBytes | 1629.722 | 23.656 | ns/op
  | Shorts.reverseBytes | 2108.81 | 43.378 | ns/op

</google-sheets-html-origin>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334397](https://bugs.openjdk.org/browse/JDK-8334397): RISC-V: verify perf of ReverseBytesS/US (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19830/head:pull/19830` \
`$ git checkout pull/19830`

Update a local copy of the PR: \
`$ git checkout pull/19830` \
`$ git pull https://git.openjdk.org/jdk.git pull/19830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19830`

View PR using the GUI difftool: \
`$ git pr show -t 19830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19830.diff">https://git.openjdk.org/jdk/pull/19830.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19830#issuecomment-2182866211)