### PR TITLE
8334726: Remove accidentally exposed individual methods from Class-File API

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/ModuleAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,7 +153,7 @@ public sealed interface ModuleAttribute
                               Consumer<ModuleAttributeBuilder> attrHandler) {
         var mb = new ModuleAttributeBuilderImpl(moduleName);
         attrHandler.accept(mb);
-        return  mb.build();
+        return mb.build();
     }
 
     /**
@@ -166,7 +166,7 @@ public sealed interface ModuleAttribute
                               Consumer<ModuleAttributeBuilder> attrHandler) {
         var mb = new ModuleAttributeBuilderImpl(moduleName);
         attrHandler.accept(mb);
-        return  mb.build();
+        return mb.build();
     }
 
     /**
@@ -319,11 +319,5 @@ public sealed interface ModuleAttribute
          * @return this builder
          */
         ModuleAttributeBuilder provides(ModuleProvideInfo provides);
-
-        /**
-         * Builds module attribute.
-         * @return the module attribute
-         */
-        ModuleAttribute build();
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeRelabeler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,12 +74,4 @@ public sealed interface CodeRelabeler extends CodeTransform permits CodeRelabele
     static CodeRelabeler of(BiFunction<Label, CodeBuilder, Label> mapFunction) {
         return new CodeRelabelerImpl(mapFunction);
     }
-
-    /**
-     * Access method to internal re-labeling function.
-     * @param label source label
-     * @param codeBuilder builder to create new labels
-     * @return target label
-     */
-    Label relabel(Label label, CodeBuilder codeBuilder);
 }

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,14 +91,6 @@ public sealed interface ConstantPoolBuilder
      * @param constantPool the other constant pool
      */
     boolean canWriteDirect(ConstantPool constantPool);
-
-    /**
-     * Writes associated bootstrap method entries to the specified writer
-     *
-     * @param buf the writer
-     * @return false when no bootstrap method entry has been written
-     */
-    boolean writeBootstrapMethods(BufWriter buf);
 
     /**
      * {@return A {@link Utf8Entry} describing the provided {@linkplain String}}

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeRelabelerImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeRelabelerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,6 @@ import java.util.function.BiFunction;
 
 public record CodeRelabelerImpl(BiFunction<Label, CodeBuilder, Label> mapFunction) implements CodeRelabeler {
 
-    @Override
     public Label relabel(Label label, CodeBuilder cob) {
         return mapFunction.apply(label, cob);
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ModuleAttributeBuilderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ModuleAttributeBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ public final class ModuleAttributeBuilderImpl
         this(TemporaryConstantPool.INSTANCE.moduleEntry(TemporaryConstantPool.INSTANCE.utf8Entry(moduleName.name())));
     }
 
-    @Override
     public ModuleAttribute build() {
         return new UnboundAttribute.UnboundModuleAttribute(moduleEntry, moduleFlags, moduleVersion,
                                                             requires, exports, opens, uses, provides);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -135,7 +135,6 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         return this == other || parent == other;
     }
 
-    @Override
     public boolean writeBootstrapMethods(BufWriter buf) {
         if (bsmSize == 0)
             return false;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TemporaryConstantPool.java
@@ -191,11 +191,6 @@ public final class TemporaryConstantPool implements ConstantPoolBuilder {
     }
 
     @Override
-    public boolean writeBootstrapMethods(BufWriter buf) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void writeTo(BufWriter buf) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
In preparation of Class-File API exiting review, we are housekeeping our API surface. These 3 method removals are the most obvious and simple ones.

This is separated from more throughout and (possibly controversial) changes for the future, to make reviews (both code and CSR) easier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8334728](https://bugs.openjdk.org/browse/JDK-8334728) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8334726](https://bugs.openjdk.org/browse/JDK-8334726): Remove accidentally exposed individual methods from Class-File API (**Bug** - P4)
 * [JDK-8334728](https://bugs.openjdk.org/browse/JDK-8334728): Remove accidentally exposed individual methods from Class-File API (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19832/head:pull/19832` \
`$ git checkout pull/19832`

Update a local copy of the PR: \
`$ git checkout pull/19832` \
`$ git pull https://git.openjdk.org/jdk.git pull/19832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19832`

View PR using the GUI difftool: \
`$ git pr show -t 19832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19832.diff">https://git.openjdk.org/jdk/pull/19832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19832#issuecomment-2182893698)