### PR TITLE
8334734: Remove specialized readXxxEntry methods from ClassReader

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassReader.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassReader.java
@@ -27,10 +27,6 @@ package java.lang.classfile;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPool;
 import java.lang.classfile.constantpool.ConstantPoolException;
-import java.lang.classfile.constantpool.MethodHandleEntry;
-import java.lang.classfile.constantpool.ModuleEntry;
-import java.lang.classfile.constantpool.NameAndTypeEntry;
-import java.lang.classfile.constantpool.PackageEntry;
 import java.lang.classfile.constantpool.PoolEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.ClassReaderImpl;
@@ -129,77 +125,6 @@ public sealed interface ClassReader extends ConstantPool
      * @since 23
      */
     <T extends PoolEntry> T readEntryOrNull(int offset, Class<T> cls);
-
-    /**
-     * {@return the UTF8 entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a UTF8 entry
-     */
-    Utf8Entry readUtf8Entry(int offset);
-
-    /**
-     * {@return the UTF8 entry whose index is given at the specified
-     * offset within the classfile, or null if the index at the specified
-     * offset is zero}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or the index does not correspond to
-     *         a UTF8 entry
-     */
-    Utf8Entry readUtf8EntryOrNull(int offset);
-
-    /**
-     * {@return the module entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a module entry
-     */
-    ModuleEntry readModuleEntry(int offset);
-
-    /**
-     * {@return the package entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a package entry
-     */
-    PackageEntry readPackageEntry(int offset);
-
-    /**
-     * {@return the class entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a class entry
-     */
-    ClassEntry readClassEntry(int offset);
-
-    /**
-     * {@return the name-and-type entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a name-and-type entry
-     */
-    NameAndTypeEntry readNameAndTypeEntry(int offset);
-
-    /**
-     * {@return the method handle entry whose index is given at the specified
-     * offset within the classfile}
-     * @param offset the offset of the index within the classfile
-     * @throws ConstantPoolException if the index is out of range of the
-     *         constant pool size, or zero, or the index does not correspond to
-     *         a method handle entry
-     */
-    MethodHandleEntry readMethodHandleEntry(int offset);
 
     /**
      * {@return the unsigned byte at the specified offset within the classfile}

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractInstruction.java
@@ -529,7 +529,7 @@ public abstract sealed class AbstractInstruction
         @Override
         public ClassEntry className() {
             if (classEntry == null)
-                classEntry = code.classReader.readClassEntry(pos + 1);
+                classEntry = code.classReader.readEntry(pos + 1, ClassEntry.class);
             return classEntry;
         }
 
@@ -576,7 +576,7 @@ public abstract sealed class AbstractInstruction
 
         @Override
         public ClassEntry componentType() {
-            return code.classReader.readClassEntry(pos + 1);
+            return code.classReader.readEntry(pos + 1, ClassEntry.class);
         }
 
         @Override
@@ -607,7 +607,7 @@ public abstract sealed class AbstractInstruction
 
         @Override
         public ClassEntry arrayType() {
-            return code.classReader.readClassEntry(pos + 1);
+            return code.classReader.readEntry(pos + 1, ClassEntry.class);
         }
 
         @Override
@@ -636,7 +636,7 @@ public abstract sealed class AbstractInstruction
         @Override
         public ClassEntry type() {
             if (typeEntry == null)
-                typeEntry = code.classReader.readClassEntry(pos + 1);
+                typeEntry = code.classReader.readEntry(pos + 1, ClassEntry.class);
             return typeEntry;
         }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AnnotationReader.java
@@ -66,9 +66,10 @@ class AnnotationReader {
             case AEV_LONG -> new AnnotationImpl.OfLongImpl(classReader.readEntry(p, LongEntry.class));
             case AEV_SHORT -> new AnnotationImpl.OfShortImpl(classReader.readEntry(p, IntegerEntry.class));
             case AEV_BOOLEAN -> new AnnotationImpl.OfBooleanImpl(classReader.readEntry(p, IntegerEntry.class));
-            case AEV_STRING -> new AnnotationImpl.OfStringImpl(classReader.readUtf8Entry(p));
-            case AEV_ENUM -> new AnnotationImpl.OfEnumImpl(classReader.readUtf8Entry(p), classReader.readUtf8Entry(p + 2));
-            case AEV_CLASS -> new AnnotationImpl.OfClassImpl(classReader.readUtf8Entry(p));
+            case AEV_STRING -> new AnnotationImpl.OfStringImpl(classReader.readEntry(p, Utf8Entry.class));
+            case AEV_ENUM -> new AnnotationImpl.OfEnumImpl(classReader.readEntry(p, Utf8Entry.class),
+                    classReader.readEntry(p + 2, Utf8Entry.class));
+            case AEV_CLASS -> new AnnotationImpl.OfClassImpl(classReader.readEntry(p, Utf8Entry.class));
             case AEV_ANNOTATION -> new AnnotationImpl.OfAnnotationImpl(readAnnotation(classReader, p));
             case AEV_ARRAY -> {
                 int numValues = classReader.readU2(p);
@@ -127,7 +128,7 @@ class AnnotationReader {
     }
 
     private static Annotation readAnnotation(ClassReader classReader, int p) {
-        Utf8Entry annotationClass = classReader.entryByIndex(classReader.readU2(p), Utf8Entry.class);
+        Utf8Entry annotationClass = classReader.readEntry(p, Utf8Entry.class);
         p += 2;
         List<AnnotationElement> elems = readAnnotationElementValuePairs(classReader, p);
         return new AnnotationImpl(annotationClass, elems);
@@ -150,7 +151,7 @@ class AnnotationReader {
         p += 2;
         var annotationElements = new Object[numElementValuePairs];
         for (int i = 0; i < numElementValuePairs; ++i) {
-            Utf8Entry elementName = classReader.readUtf8Entry(p);
+            Utf8Entry elementName = classReader.readEntry(p, Utf8Entry.class);
             p += 2;
             AnnotationValue value = readElementValue(classReader, p);
             annotationElements[i] = new AnnotationImpl.AnnotationElementImpl(elementName, value);
@@ -239,7 +240,7 @@ class AnnotationReader {
             };
         }
         // the annotation info for this annotation
-        Utf8Entry type = classReader.readUtf8Entry(p);
+        Utf8Entry type = classReader.readEntry(p, Utf8Entry.class);
         p += 2;
         return TypeAnnotation.of(targetInfo, List.of(typePath), type,
                                  readAnnotationElementValuePairs(classReader, p));

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -25,7 +25,6 @@
 
 package jdk.internal.classfile.impl;
 
-import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -25,6 +25,7 @@
 
 package jdk.internal.classfile.impl;
 
+import java.lang.classfile.constantpool.MethodHandleEntry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -135,7 +136,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
         int cfLen = reader.classfileLength();
         var apo = ((ClassReaderImpl)reader).context().attributesProcessingOption();
         for (int i = 0; i < size; ++i) {
-            Utf8Entry name = reader.readUtf8Entry(p);
+            Utf8Entry name = reader.readEntry(p, Utf8Entry.class);
             int len = reader.readInt(p + 2);
             p += 6;
             if (len < 0 || len > cfLen - p) {
@@ -347,7 +348,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 int p = payloadStart + 1;
                 int pEnd = p + (cnt * 4);
                 for (int i = 0; p < pEnd; p += 4, i++) {
-                    Utf8Entry name = classReader.readUtf8EntryOrNull(p);
+                    Utf8Entry name = classReader.readEntryOrNull(p, Utf8Entry.class);
                     int accessFlags = classReader.readU2(p + 2);
                     elements[i] = MethodParameterInfo.of(Optional.ofNullable(name), accessFlags);
                 }
@@ -367,7 +368,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry algorithm() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
 
         @Override
@@ -378,7 +379,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 int p = payloadStart + 4;
                 //System.err.printf("%5d: ModuleHashesAttr alg = %s, cnt = %d%n", pos, algorithm(), cnt);
                 for (int i = 0; i < cnt; ++i) {
-                    ModuleEntry module = classReader.readModuleEntry(p);
+                    ModuleEntry module = classReader.readEntry(p, ModuleEntry.class);
                     int hashLength = classReader.readU2(p + 2);
                     //System.err.printf("%5d:     [%d] module = %s, hashLength = %d%n", p, i, module, hashLength);
                     p += 4;
@@ -430,7 +431,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry signature() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
     }
 
@@ -442,7 +443,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry sourceFile() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
 
     }
@@ -454,7 +455,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public ClassEntry mainClass() {
-            return classReader.readClassEntry(payloadStart);
+            return classReader.readEntry(payloadStart, ClassEntry.class);
         }
     }
 
@@ -466,7 +467,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public ClassEntry nestHost() {
-            return classReader.readClassEntry(payloadStart);
+            return classReader.readEntry(payloadStart, ClassEntry.class);
         }
     }
 
@@ -498,7 +499,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry targetPlatform() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
     }
 
@@ -510,7 +511,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry compilationId() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
     }
 
@@ -522,7 +523,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Utf8Entry sourceId() {
-            return classReader.readUtf8Entry(payloadStart);
+            return classReader.readEntry(payloadStart, Utf8Entry.class);
         }
     }
 
@@ -569,7 +570,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public ModuleEntry moduleName() {
-            return classReader.readModuleEntry(payloadStart);
+            return classReader.readEntry(payloadStart, ModuleEntry.class);
         }
 
         @Override
@@ -579,7 +580,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public Optional<Utf8Entry> moduleVersion() {
-            return Optional.ofNullable(classReader.readUtf8EntryOrNull(payloadStart + 4));
+            return Optional.ofNullable(classReader.readEntryOrNull(payloadStart + 4, Utf8Entry.class));
         }
 
         @Override
@@ -630,7 +631,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 ModuleRequireInfo[] elements = new ModuleRequireInfo[cnt];
                 int end = p + (cnt * 6);
                 for (int i = 0; p < end; p += 6, i++) {
-                    elements[i] = ModuleRequireInfo.of(classReader.readModuleEntry(p),
+                    elements[i] = ModuleRequireInfo.of(classReader.readEntry(p, ModuleEntry.class),
                             classReader.readU2(p + 2),
                             classReader.readEntryOrNull(p + 4, Utf8Entry.class));
                 }
@@ -642,7 +643,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 p += 2;
                 ModuleExportInfo[] elements = new ModuleExportInfo[cnt];
                 for (int i = 0; i < cnt; i++) {
-                    PackageEntry pe = classReader.readPackageEntry(p);
+                    PackageEntry pe = classReader.readEntry(p, PackageEntry.class);
                     int exportFlags = classReader.readU2(p + 2);
                     p += 4;
                     List<ModuleEntry> exportsTo = readEntryList(p);
@@ -657,7 +658,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 p += 2;
                 ModuleOpenInfo[] elements = new ModuleOpenInfo[cnt];
                 for (int i = 0; i < cnt; i++) {
-                    PackageEntry po = classReader.readPackageEntry(p);
+                    PackageEntry po = classReader.readEntry(p, PackageEntry.class);
                     int opensFlags = classReader.readU2(p + 2);
                     p += 4;
                     List<ModuleEntry> opensTo = readEntryList(p);
@@ -675,7 +676,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 ModuleProvideInfo[] elements = new ModuleProvideInfo[cnt];
                 provides = new ArrayList<>(cnt);
                 for (int i = 0; i < cnt; i++) {
-                    ClassEntry c = classReader.readClassEntry(p);
+                    ClassEntry c = classReader.readEntry(p, ClassEntry.class);
                     p += 2;
                     List<ClassEntry> providesWith = readEntryList(p);
                     p += 2 + providesWith.size() * 2;
@@ -743,8 +744,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 BootstrapMethodEntry[] bs = new BootstrapMethodEntry[size];
                 int p = payloadStart + 2;
                 for (int i = 0; i < size; ++i) {
-                    final AbstractPoolEntry.MethodHandleEntryImpl handle
-                            = (AbstractPoolEntry.MethodHandleEntryImpl) classReader.readMethodHandleEntry(p);
+                    final var handle = classReader.readEntry(p, AbstractPoolEntry.MethodHandleEntryImpl.class);
                     final List<LoadableConstantEntry> args = readEntryList(p + 2);
                     p += 4 + args.size() * 2;
                     int hash = BootstrapMethodEntryImpl.computeHashCode(handle, args);
@@ -771,7 +771,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 int p = payloadStart + 2;
                 InnerClassInfo[] elements = new InnerClassInfo[cnt];
                 for (int i = 0; i < cnt; i++) {
-                    ClassEntry innerClass = classReader.readClassEntry(p);
+                    ClassEntry innerClass = classReader.readEntry(p, ClassEntry.class);
                     var outerClass = classReader.readEntryOrNull(p + 2, ClassEntry.class);
                     var innerName = classReader.readEntryOrNull(p + 4, Utf8Entry.class);
                     int flags = classReader.readU2(p + 6);
@@ -792,7 +792,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         @Override
         public ClassEntry enclosingClass() {
-            return classReader.readClassEntry(payloadStart);
+            return classReader.readEntry(payloadStart, ClassEntry.class);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundRecordComponentInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundRecordComponentInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundRecordComponentInfo.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundRecordComponentInfo.java
@@ -46,12 +46,12 @@ public final class BoundRecordComponentInfo
 
     @Override
     public Utf8Entry name() {
-        return reader.readUtf8Entry(startPos);
+        return reader.readEntry(startPos, Utf8Entry.class);
     }
 
     @Override
     public Utf8Entry descriptor() {
-        return reader.readUtf8Entry(startPos + 2);
+        return reader.readEntry(startPos + 2, Utf8Entry.class);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassImpl.java
@@ -137,7 +137,7 @@ public final class ClassImpl
             pos += 2;
             var arr = new Object[cnt];
             for (int i = 0; i < cnt; ++i) {
-                arr[i] = reader.readClassEntry(pos);
+                arr[i] = reader.readEntry(pos, ClassEntry.class);
                 pos += 2;
             }
             this.interfaces = SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(arr);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -151,7 +151,7 @@ public final class ClassReaderImpl
     @Override
     public ClassEntry thisClassEntry() {
         if (thisClass == null) {
-            thisClass = readClassEntry(thisClassPos);
+            thisClass = readEntry(thisClassPos, ClassEntry.class);
         }
         return thisClass;
     }
@@ -395,23 +395,23 @@ public final class ClassReaderImpl
                 case TAG_FLOAT -> new AbstractPoolEntry.FloatEntryImpl(this, index, readFloat(q));
                 case TAG_LONG -> new AbstractPoolEntry.LongEntryImpl(this, index, readLong(q));
                 case TAG_DOUBLE -> new AbstractPoolEntry.DoubleEntryImpl(this, index, readDouble(q));
-                case TAG_CLASS -> new AbstractPoolEntry.ClassEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
-                case TAG_STRING -> new AbstractPoolEntry.StringEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
-                case TAG_FIELDREF -> new AbstractPoolEntry.FieldRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
-                                                                             (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
-                case TAG_METHODREF -> new AbstractPoolEntry.MethodRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
-                                                                               (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
-                case TAG_INTERFACEMETHODREF -> new AbstractPoolEntry.InterfaceMethodRefEntryImpl(this, index, (AbstractPoolEntry.ClassEntryImpl) readClassEntry(q),
-                                                                                                 (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
-                case TAG_NAMEANDTYPE -> new AbstractPoolEntry.NameAndTypeEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q),
-                                                                                   (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q + 2));
+                case TAG_CLASS -> new AbstractPoolEntry.ClassEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class));
+                case TAG_STRING -> new AbstractPoolEntry.StringEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class));
+                case TAG_FIELDREF -> new AbstractPoolEntry.FieldRefEntryImpl(this, index, readEntry(q, AbstractPoolEntry.ClassEntryImpl.class),
+                        readEntry(q + 2, AbstractPoolEntry.NameAndTypeEntryImpl.class));
+                case TAG_METHODREF -> new AbstractPoolEntry.MethodRefEntryImpl(this, index, readEntry(q, AbstractPoolEntry.ClassEntryImpl.class),
+                        readEntry(q + 2, AbstractPoolEntry.NameAndTypeEntryImpl.class));
+                case TAG_INTERFACEMETHODREF -> new AbstractPoolEntry.InterfaceMethodRefEntryImpl(this, index, readEntry(q, AbstractPoolEntry.ClassEntryImpl.class),
+                        readEntry(q + 2, AbstractPoolEntry.NameAndTypeEntryImpl.class));
+                case TAG_NAMEANDTYPE -> new AbstractPoolEntry.NameAndTypeEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class),
+                        readEntry(q + 2, AbstractPoolEntry.Utf8EntryImpl.class));
                 case TAG_METHODHANDLE -> new AbstractPoolEntry.MethodHandleEntryImpl(this, index, readU1(q),
                                                                                      readEntry(q + 1, AbstractPoolEntry.AbstractMemberRefEntry.class));
-                case TAG_METHODTYPE -> new AbstractPoolEntry.MethodTypeEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
-                case TAG_CONSTANTDYNAMIC -> new AbstractPoolEntry.ConstantDynamicEntryImpl(this, index, readU2(q), (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
-                case TAG_INVOKEDYNAMIC -> new AbstractPoolEntry.InvokeDynamicEntryImpl(this, index, readU2(q), (AbstractPoolEntry.NameAndTypeEntryImpl) readNameAndTypeEntry(q + 2));
-                case TAG_MODULE -> new AbstractPoolEntry.ModuleEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
-                case TAG_PACKAGE -> new AbstractPoolEntry.PackageEntryImpl(this, index, (AbstractPoolEntry.Utf8EntryImpl) readUtf8Entry(q));
+                case TAG_METHODTYPE -> new AbstractPoolEntry.MethodTypeEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class));
+                case TAG_CONSTANTDYNAMIC -> new AbstractPoolEntry.ConstantDynamicEntryImpl(this, index, readU2(q), readEntry(q + 2, AbstractPoolEntry.NameAndTypeEntryImpl.class));
+                case TAG_INVOKEDYNAMIC -> new AbstractPoolEntry.InvokeDynamicEntryImpl(this, index, readU2(q), readEntry(q + 2, AbstractPoolEntry.NameAndTypeEntryImpl.class));
+                case TAG_MODULE -> new AbstractPoolEntry.ModuleEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class));
+                case TAG_PACKAGE -> new AbstractPoolEntry.PackageEntryImpl(this, index, readEntry(q, AbstractPoolEntry.Utf8EntryImpl.class));
                 default -> throw new ConstantPoolException(
                         "Bad tag (" + tag + ") at index (" + index + ") position (" + offset + ")");
             };
@@ -428,7 +428,7 @@ public final class ClassReaderImpl
             int len = readInt(p + 2);
             p += 6;
             if (len < 0 || len > classfileLength - p) {
-                throw new IllegalArgumentException("attribute " + readUtf8Entry(p - 6).stringValue() + " too big to handle");
+                throw new IllegalArgumentException("attribute " + readEntry(p - 6, Utf8Entry.class).stringValue() + " too big to handle");
             }
             p += len;
         }
@@ -463,41 +463,6 @@ public final class ClassReaderImpl
             return null;
         }
         return entryByIndex(index, cls);
-    }
-
-    @Override
-    public Utf8Entry readUtf8Entry(int pos) {
-        return readEntry(pos, Utf8Entry.class);
-    }
-
-    @Override
-    public Utf8Entry readUtf8EntryOrNull(int pos) {
-        return readEntryOrNull(pos, Utf8Entry.class);
-    }
-
-    @Override
-    public ModuleEntry readModuleEntry(int pos) {
-        return readEntry(pos, ModuleEntry.class);
-    }
-
-    @Override
-    public PackageEntry readPackageEntry(int pos) {
-        return readEntry(pos, PackageEntry.class);
-    }
-
-    @Override
-    public ClassEntry readClassEntry(int pos) {
-        return readEntry(pos, ClassEntry.class);
-    }
-
-    @Override
-    public NameAndTypeEntry readNameAndTypeEntry(int pos) {
-        return readEntry(pos, NameAndTypeEntry.class);
-    }
-
-    @Override
-    public MethodHandleEntry readMethodHandleEntry(int pos) {
-        return readEntry(pos, MethodHandleEntry.class);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/FieldImpl.java
@@ -61,12 +61,12 @@ public final class FieldImpl
 
     @Override
     public Utf8Entry fieldName() {
-        return reader.readUtf8Entry(startPos + 2);
+        return reader.readEntry(startPos + 2, Utf8Entry.class);
     }
 
     @Override
     public Utf8Entry fieldType() {
-        return reader.readUtf8Entry(startPos + 4);
+        return reader.readEntry(startPos + 4, Utf8Entry.class);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
@@ -64,12 +64,12 @@ public final class MethodImpl
 
     @Override
     public Utf8Entry methodName() {
-        return reader.readUtf8Entry(startPos + 2);
+        return reader.readEntry(startPos + 2, Utf8Entry.class);
     }
 
     @Override
     public Utf8Entry methodType() {
-        return reader.readUtf8Entry(startPos + 4);
+        return reader.readEntry(startPos + 4, Utf8Entry.class);
     }
 
     @Override


### PR DESCRIPTION
`ClassReader.readXxxEntry` were added before we had generic, type-aware `readEntry` and `readEntryOrNull` APIs (#19330). We should remove these specialized versions in favor of the generic version to reduce API bloating.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8334735](https://bugs.openjdk.org/browse/JDK-8334735) to be approved

### Issues
 * [JDK-8334734](https://bugs.openjdk.org/browse/JDK-8334734): Remove specialized readXxxEntry methods from ClassReader (**Bug** - P4)
 * [JDK-8334735](https://bugs.openjdk.org/browse/JDK-8334735): Remove specialized readXxxEntry methods from ClassReader (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19833/head:pull/19833` \
`$ git checkout pull/19833`

Update a local copy of the PR: \
`$ git checkout pull/19833` \
`$ git pull https://git.openjdk.org/jdk.git pull/19833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19833`

View PR using the GUI difftool: \
`$ git pr show -t 19833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19833.diff">https://git.openjdk.org/jdk/pull/19833.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19833#issuecomment-2183020266)