### PR TITLE
8334441: Mark tests in jdk_security_infra group as manual

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -620,8 +620,6 @@ javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 
-security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#teliasonerarootcav1  8333640 generic-all
-
 ############################################################################
 
 # jdk_sound

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -251,6 +251,8 @@ jdk_security = \
     :jdk_security3 \
     :jdk_security4
 
+# Tests in this group are manual as they depend on external infra
+# and may fail with external reasons, for instance - change in CA test portal.
 jdk_security_infra = \
     security/infra
 
@@ -618,6 +620,7 @@ jdk_core_manual_no_input = \
     javax/xml/jaxp/datatype/8033980/GregorianCalAndDurSerDataUtil.java
 
 jdk_security_manual_no_input = \
+    :jdk_security_infra \
     com/sun/crypto/provider/Cipher/DES/PerformanceTest.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementByte4.java \
     com/sun/crypto/provider/Cipher/AEAD/GCMIncrementDirect4.java \

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -27,12 +27,12 @@
  * @summary Interoperability tests with Actalis CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/timeout=180 -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual/timeout=180 -Djava.security.debug=certpath,ocsp
  *  -Dcom.sun.security.ocsp.useget=false
  *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/timeout=180 -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual/timeout=180 -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca CRL
  */
 
@@ -42,9 +42,9 @@
  * @summary Interoperability tests with Amazon's CA1
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca1 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca1 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop amazonrootca1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop amazonrootca1 CRL
  */
 
 /*
@@ -53,9 +53,9 @@
  * @summary Interoperability tests with Amazon's CA2
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca2 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca2 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca2 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop amazonrootca2 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca2 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop amazonrootca2 CRL
  */
 
 /*
@@ -64,9 +64,9 @@
  * @summary Interoperability tests with Amazon's CA3
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca3 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca3 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop amazonrootca3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop amazonrootca3 CRL
  */
 
 /*
@@ -75,9 +75,9 @@
  * @summary Interoperability tests with Amazon's CA4
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop amazonrootca4 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop amazonrootca4 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop amazonrootca4 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop amazonrootca4 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop amazonrootca4 CRL
  */
 
 /*
@@ -86,9 +86,9 @@
  * @summary Interoperability tests with Buypass Class 2 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop buypassclass2ca CRL
  */
 
 /*
@@ -97,9 +97,9 @@
  * @summary Interoperability tests with Buypass Class 3 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass3ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop buypassclass3ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop buypassclass3ca CRL
  */
 
 /*
@@ -108,9 +108,9 @@
  * @summary Interoperability tests with Comodo RSA CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop comodorsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodorsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop comodorsaca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop comodorsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodorsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop comodorsaca CRL
  */
 
 /*
@@ -119,9 +119,9 @@
  * @summary Interoperability tests with Comodo ECC CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop comodoeccca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodoeccca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop comodoeccca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop comodoeccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop comodoeccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop comodoeccca CRL
  */
 
 /*
@@ -130,9 +130,9 @@
  * @summary Interoperability tests with Comodo userTrust RSA CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop usertrustrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrustrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop usertrustrsaca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop usertrustrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrustrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop usertrustrsaca CRL
  */
 
 /*
@@ -141,9 +141,9 @@
  * @summary Interoperability tests with Comodo userTrust ECC CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop usertrusteccca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrusteccca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop usertrusteccca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop usertrusteccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop usertrusteccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop usertrusteccca CRL
  */
 
 /*
@@ -152,8 +152,8 @@
  * @summary Interoperability tests with Let's Encrypt ISRG Root X1 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx1 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx1 DEFAULT
  */
 
 /*
@@ -162,8 +162,8 @@
  * @summary Interoperability tests with Let's Encrypt ISRG Root X2 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx2 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx2 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop letsencryptisrgx2 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop letsencryptisrgx2 DEFAULT
  */
 
 /*
@@ -172,9 +172,9 @@
  * @summary Interoperability tests with GlobalSign R6 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsignrootcar6 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsignrootcar6 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop globalsignrootcar6 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop globalsignrootcar6 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsignrootcar6 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop globalsignrootcar6 CRL
  */
 
 /*
@@ -183,9 +183,9 @@
  * @summary Interoperability tests with Entrust CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop entrustrootcaec1 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcaec1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop entrustrootcaec1 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop entrustrootcaec1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcaec1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop entrustrootcaec1 CRL
  */
 
 /*
@@ -194,9 +194,9 @@
  * @summary Interoperability tests with Entrust CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop entrustrootcag4 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcag4 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop entrustrootcag4 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop entrustrootcag4 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop entrustrootcag4 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop entrustrootcag4 CRL
  */
 
 /*
@@ -205,9 +205,9 @@
  * @summary Interoperability tests with GoDaddy CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop godaddyrootg2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop godaddyrootg2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop godaddyrootg2ca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop godaddyrootg2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop godaddyrootg2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop godaddyrootg2ca CRL
  */
 
 /*
@@ -216,9 +216,9 @@
  * @summary Interoperability tests with Starfield CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop starfieldrootg2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop starfieldrootg2ca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop starfieldrootg2ca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop starfieldrootg2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop starfieldrootg2ca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop starfieldrootg2ca CRL
  */
 
 /*
@@ -227,8 +227,8 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsigneccrootcar4 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop globalsigneccrootcar4 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsigneccrootcar4 DEFAULT
  */
 
 /*
@@ -237,8 +237,8 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar1 DEFAULT
  */
 
 /*
@@ -247,8 +247,8 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar2 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop gtsrootcar2 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootcar2 DEFAULT
  */
 
 /*
@@ -257,8 +257,8 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar3 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar3 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar3 DEFAULT
  */
 
 /*
@@ -267,8 +267,8 @@
  * @summary Interoperability tests with Google's GlobalSign R4 and GTS Root certificates
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar4 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop gtsrootecccar4 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop gtsrootecccar4 DEFAULT
  */
 
 /*
@@ -277,9 +277,9 @@
  * @summary Interoperability tests with Microsoft TLS root CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop microsoftecc2017 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftecc2017 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop microsoftecc2017 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftecc2017 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftecc2017 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop microsoftecc2017 CRL
  */
 
 /*
@@ -288,9 +288,9 @@
  * @summary Interoperability tests with Microsoft TLS root CAs
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop microsoftrsa2017 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop microsoftrsa2017 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop microsoftrsa2017 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop microsoftrsa2017 CRL
  */
 
 /*
@@ -299,9 +299,9 @@
  * @summary Interoperability tests with QuoVadis Root CA1 G3 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca1g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca1g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca1g3 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca1g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca1g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop quovadisrootca1g3 CRL
  */
 
 /*
@@ -310,9 +310,9 @@
  * @summary Interoperability tests with QuoVadis Root CA2 G3 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca2g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca2g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca2g3 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca2g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca2g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop quovadisrootca2g3 CRL
  */
 
 /*
@@ -321,9 +321,9 @@
  * @summary Interoperability tests with QuoVadis Root CA3 G3 CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca3g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca3g3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop quovadisrootca3g3 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop quovadisrootca3g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop quovadisrootca3g3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop quovadisrootca3g3 CRL
  */
 
 /*
@@ -332,9 +332,9 @@
  * @summary Interoperability tests with DigiCert TLS ECC P384 Root G5
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop digicerttlseccrootg5 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlseccrootg5 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop digicerttlseccrootg5 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop digicerttlseccrootg5 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlseccrootg5 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop digicerttlseccrootg5 CRL
  */
 
 /*
@@ -343,9 +343,9 @@
  * @summary Interoperability tests with DigiCert TLS RSA4096 Root G5
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop digicerttlsrsarootg5 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlsrsarootg5 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop digicerttlsrsarootg5 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop digicerttlsrsarootg5 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop digicerttlsrsarootg5 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop digicerttlsrsarootg5 CRL
  */
 
 /*
@@ -354,9 +354,9 @@
  * @summary Interoperability tests with SSL.com's RSA CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrootrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop sslrootrsaca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop sslrootrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop sslrootrsaca CRL
  */
 
 /*
@@ -365,9 +365,9 @@
  * @summary Interoperability tests with SSL.com's EV RSA CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrootevrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootevrsaca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop sslrootevrsaca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop sslrootevrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrootevrsaca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop sslrootevrsaca CRL
  */
 
 /*
@@ -376,9 +376,9 @@
  * @summary Interoperability tests with SSL.com's ECC CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop sslrooteccca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrooteccca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop sslrooteccca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop sslrooteccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop sslrooteccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop sslrooteccca CRL
  */
 
 /*
@@ -387,9 +387,9 @@
  * @summary Interoperability tests with TeliaSonera Root CA v1
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop teliasonerarootcav1 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliasonerarootcav1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop teliasonerarootcav1 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop teliasonerarootcav1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliasonerarootcav1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop teliasonerarootcav1 CRL
  */
 
 /*
@@ -398,9 +398,9 @@
  * @summary Interoperability tests with TWCA Global Root CA from TAIWAN-CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop twcaglobalrootca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop twcaglobalrootca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop twcaglobalrootca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop twcaglobalrootca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop twcaglobalrootca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop twcaglobalrootca CRL
  */
 
 /*
@@ -409,9 +409,9 @@
  * @summary Interoperability tests with Certigna Root CAs from Dhimyotis
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certignarootca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certignarootca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop certignarootca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop certignarootca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certignarootca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop certignarootca CRL
  */
 
 /*
@@ -420,9 +420,9 @@
  * @summary Interoperability tests with AffirmTrust Commercial CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustcommercialca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustcommercialca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustcommercialca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop affirmtrustcommercialca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustcommercialca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop affirmtrustcommercialca CRL
  */
 
 /*
@@ -431,9 +431,9 @@
  * @summary Interoperability tests with AffirmTrust Networking CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustnetworkingca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustnetworkingca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustnetworkingca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop affirmtrustnetworkingca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustnetworkingca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop affirmtrustnetworkingca CRL
  */
 
 /*
@@ -442,9 +442,9 @@
  * @summary Interoperability tests with AffirmTrust Premium CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop affirmtrustpremiumca CRL
  */
 
 /*
@@ -453,9 +453,9 @@
  * @summary Interoperability tests with AffirmTrust Premium ECC CA
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumeccca OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumeccca OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop affirmtrustpremiumeccca CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop affirmtrustpremiumeccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop affirmtrustpremiumeccca OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop affirmtrustpremiumeccca CRL
  */
 
 /*
@@ -464,9 +464,9 @@
  * @summary Interoperability tests with Telia Root CA V2
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop teliarootcav2 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliarootcav2 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop teliarootcav2 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop teliarootcav2 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop teliarootcav2 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop teliarootcav2 CRL
  */
 
 /*
@@ -475,9 +475,9 @@
  * @summary Interoperability tests with eMudhra Root CA G1
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop emsignrootcag1 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsignrootcag1 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop emsignrootcag1 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop emsignrootcag1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsignrootcag1 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop emsignrootcag1 CRL
  */
 
 /*
@@ -486,9 +486,9 @@
  * @summary Interoperability tests with eMudhra ECC Root CA G3
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop emsigneccrootcag3 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsigneccrootcag3 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop emsigneccrootcag3 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop emsigneccrootcag3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop emsigneccrootcag3 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop emsigneccrootcag3 CRL
  */
 
 /*
@@ -497,8 +497,8 @@
  * @summary Interoperability tests with Certainly Root R1
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certainlyrootr1 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyrootr1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop certainlyrootr1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyrootr1 DEFAULT
  */
 
 /*
@@ -507,8 +507,8 @@
  * @summary Interoperability tests with Certainly Root E1
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop certainlyroote1 DEFAULT
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyroote1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop certainlyroote1 DEFAULT
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop certainlyroote1 DEFAULT
  */
 
 /*
@@ -517,9 +517,9 @@
  * @summary Interoperability tests with GlobalSign Root R46
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsignr46 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsignr46 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop globalsignr46 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop globalsignr46 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsignr46 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop globalsignr46 CRL
  */
 
 /*
@@ -528,13 +528,15 @@
  * @summary Interoperability tests with GlobalSign Root E46
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
- * @run main/othervm -Djava.security.debug=certpath,ocsp CAInterop globalsigne46 OCSP
- * @run main/othervm -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsigne46 OCSP
- * @run main/othervm -Djava.security.debug=certpath CAInterop globalsigne46 CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp CAInterop globalsigne46 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp -Dcom.sun.security.ocsp.useget=false CAInterop globalsigne46 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CAInterop globalsigne46 CRL
  */
 
 /**
- * Collection of certificate validation tests for interoperability with external CAs
+ * Collection of certificate validation tests for interoperability with external CAs.
+ * These tests are marked as manual as they depend on external infrastructure and may fail
+ * with external reasons, for instance - change in CA test portal.
  */
 public class CAInterop {
 

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CertignaCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CertignaCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8245654 8256895
  * @summary Interoperability tests with Certigna Root CAs from Dhimyotis
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=certpath CertignaCA OCSP
- * @run main/othervm -Djava.security.debug=certpath CertignaCA CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath CertignaCA OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath CertignaCA CRL
  */
 public class CertignaCA {
     // Owner: CN=Certigna Services CA, OID.2.5.4.97=NTRFR-48146308100036,

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/DTrustCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@
  * @summary Interoperability tests with "D-Trust Root Class 3 CA 2 2009" and
  *          "D-Trust Root Class 3 CA 2 EV 2009" CAs
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=certpath DTrustCA OCSP
- * @run main/othervm -Djava.security.debug=certpath DTrustCA CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath DTrustCA OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath DTrustCA CRL
  */
 public class DTrustCA {
 

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/DigicertCSRootG5.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/DigicertCSRootG5.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8318759
  * @summary Interoperability tests with Digicert CS Root G5 certificates
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=ocsp,certpath DigicertCSRootG5 OCSP
- * @run main/othervm -Djava.security.debug=certpath DigicertCSRootG5 CRL
+ * @run main/othervm/manual -Djava.security.debug=ocsp,certpath DigicertCSRootG5 OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath DigicertCSRootG5 CRL
  */
 
 public class DigicertCSRootG5 {

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/EmSignRootG2CA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/EmSignRootG2CA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8319187
  * @summary Interoperability tests with eMudhra emSign Root CA G2 CS root
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=certpath EmSignRootG2CA OCSP
- * @run main/othervm -Djava.security.debug=certpath EmSignRootG2CA CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath EmSignRootG2CA OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath EmSignRootG2CA CRL
  */
 
 public class EmSignRootG2CA {

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/HaricaCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8256421
  * @summary Interoperability tests with Harica CAs
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=certpath HaricaCA OCSP
- * @run main/othervm -Djava.security.debug=certpath HaricaCA CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath HaricaCA OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath HaricaCA CRL
  */
 
 /*

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/LuxTrustCA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
  * @bug 8232019 8256895
  * @summary Interoperability tests with LuxTrust Global Root 2 CA
  * @build ValidatePathWithParams
- * @run main/othervm -Djava.security.debug=certpath LuxTrustCA OCSP
- * @run main/othervm -Djava.security.debug=certpath LuxTrustCA CRL
+ * @run main/othervm/manual -Djava.security.debug=certpath LuxTrustCA OCSP
+ * @run main/othervm/manual -Djava.security.debug=certpath LuxTrustCA CRL
  */
 
 /*

--- a/test/jdk/security/infra/javax/net/ssl/HttpsURLConnectionTest.java
+++ b/test/jdk/security/infra/javax/net/ssl/HttpsURLConnectionTest.java
@@ -28,7 +28,7 @@
  *          KEYCHAINSTORE-ROOT trust store
  * @library /test/lib
  * @requires os.family == "mac"
- * @run main/othervm HttpsURLConnectionTest https://github.com KeychainStore-Root
+ * @run main/othervm/manual HttpsURLConnectionTest https://github.com KeychainStore-Root
  */
 import java.io.*;
 import java.net.*;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [8e1d2b09](https://github.com/openjdk/jdk/commit/8e1d2b091c9a311d98a0b886a803fb18d4405d8a) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Rajan Halade on 21 Jun 2024 and was reviewed by Christoph Langer and Sean Mullan.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334441](https://bugs.openjdk.org/browse/JDK-8334441): Mark tests in jdk_security_infra group as manual (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19841/head:pull/19841` \
`$ git checkout pull/19841`

Update a local copy of the PR: \
`$ git checkout pull/19841` \
`$ git pull https://git.openjdk.org/jdk.git pull/19841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19841`

View PR using the GUI difftool: \
`$ git pr show -t 19841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19841.diff">https://git.openjdk.org/jdk/pull/19841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19841#issuecomment-2183911978)