### PR TITLE
8334761: Source launcher fails with "Module reads more than one module named" error

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1542,7 +1542,7 @@ ParseArguments(int *pargc, char ***pargv,
     }
 
     if (mode == LM_SOURCE) {
-        AddOption("--add-modules=ALL-DEFAULT", NULL);
+        AddOption("--add-modules=ALL-DEFAULT,ALL-MODULE-PATH", NULL);
         *pwhat = SOURCE_LAUNCHER_MAIN_ENTRY;
         // adjust (argc, argv) so that the name of the source file
         // is included in the args passed to the source launcher

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
@@ -204,11 +204,15 @@ final class MemoryContext {
         var parentLayer = bootLayer;
         var parentLoader = parent;
 
-        // Optionally create module layer for all modules on the module path.
+        // Optionally create module layer with all missing modules from the module path.
         var modulePathFinder = createModuleFinderFromModulePath();
-        var modulePathModules = modulePathFinder.findAll().stream().map(ModuleReference::descriptor).map(ModuleDescriptor::name).toList();
+        var modulePathModules = modulePathFinder.findAll().stream()
+                .map(ModuleReference::descriptor)
+                .map(ModuleDescriptor::name)
+                .filter(name -> bootLayer.findModule(name).isEmpty())
+                .toList();
         if (!modulePathModules.isEmpty()) {
-            var modulePathConfiguration = bootLayer.configuration().resolveAndBind(modulePathFinder, ModuleFinder.of(), Set.copyOf(modulePathModules));
+            var modulePathConfiguration = bootLayer.configuration().resolve(modulePathFinder, ModuleFinder.of(), Set.copyOf(modulePathModules));
             var modulePathLayer = ModuleLayer.defineModulesWithOneLoader(modulePathConfiguration, List.of(bootLayer), parent).layer();
             parentLayer = modulePathLayer;
             parentLoader = modulePathLayer.findLoader(modulePathModules.getFirst());


### PR DESCRIPTION
Please review this change to fix the setup of the optional module layer for user-supplied modules.

This fix is composed of two parts:
- modules already resolved in the boot layer are no longer part of the parent layer
- the parent layer configuration does no longer bind services

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334761](https://bugs.openjdk.org/browse/JDK-8334761): Source launcher fails with "Module reads more than one module named" error (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19842/head:pull/19842` \
`$ git checkout pull/19842`

Update a local copy of the PR: \
`$ git checkout pull/19842` \
`$ git pull https://git.openjdk.org/jdk.git pull/19842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19842`

View PR using the GUI difftool: \
`$ git pr show -t 19842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19842.diff">https://git.openjdk.org/jdk/pull/19842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19842#issuecomment-2218078688)