### PR TITLE
8334763: --enable-asan: assert(_thread->is_in_live_stack((address)this)) failed: not on stack?

### DIFF
--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -453,6 +453,8 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           # MSVC produces a warning if you pass -fsanitize=address to the linker. It also complains
           $ if -DEBUG is not passed to the linker when building with ASan.
           ASAN_LDFLAGS="-debug"
+          # -fsanitize-address-use-after-return is off by default in MS Visual Studio 22 (19.37.32824).
+          # cl : Command line warning D9002 : ignoring unknown option '-fno-sanitize-address-use-after-return'
         fi
         JVM_CFLAGS="$JVM_CFLAGS $ASAN_CFLAGS"
         JVM_LDFLAGS="$JVM_LDFLAGS $ASAN_LDFLAGS"

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -438,14 +438,6 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           # It's harmless to be suppressed in clang as well.
           ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -fno-common -DADDRESS_SANITIZER"
           ASAN_LDFLAGS="-fsanitize=address"
-          # detect_stack_use_after_return is using a fake stack and thus JDK would crashe:
-          # assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
-          if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
-            ASAN_CFLAGS="$ASAN_CFLAGS --param asan-use-after-return=0"
-          fi
-          if test "x$TOOLCHAIN_TYPE" = "xclang"; then
-            ASAN_CFLAGS="$ASAN_CFLAGS -fsanitize-address-use-after-return=never"
-          fi
         elif test "x$TOOLCHAIN_TYPE" = "xmicrosoft"; then
           # -Oy- is equivalent to -fno-omit-frame-pointer in GCC/Clang.
           ASAN_CFLAGS="-fsanitize=address -Oy- -DADDRESS_SANITIZER"

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -438,6 +438,14 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           # It's harmless to be suppressed in clang as well.
           ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -fno-common -DADDRESS_SANITIZER"
           ASAN_LDFLAGS="-fsanitize=address"
+          # detect_stack_use_after_return is using a fake stack and thus JDK would crashe:
+          # assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
+          if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
+            ASAN_CFLAGS="$ASAN_CFLAGS --param asan-use-after-return=0"
+          fi
+          if test "x$TOOLCHAIN_TYPE" = "xclang"; then
+            ASAN_CFLAGS="$ASAN_CFLAGS -fsanitize-address-use-after-return=never"
+          fi
         elif test "x$TOOLCHAIN_TYPE" = "xmicrosoft"; then
           # -Oy- is equivalent to -fno-omit-frame-pointer in GCC/Clang.
           ASAN_CFLAGS="-fsanitize=address -Oy- -DADDRESS_SANITIZER"

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -438,8 +438,9 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           # It's harmless to be suppressed in clang as well.
           ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -fno-common -DADDRESS_SANITIZER"
           ASAN_LDFLAGS="-fsanitize=address"
-          # detect_stack_use_after_return is using a fake stack and thus JDK would crash:
-          # assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
+          # detect_stack_use_after_return causes ASAN to offload stack-local
+          # variables to c-heap and therefore breaks assumptions in hotspot
+          # that rely on data (e.g. Marks) living in thread stacks.
           if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
             ASAN_CFLAGS="$ASAN_CFLAGS --param asan-use-after-return=0"
           fi

--- a/make/autoconf/jdk-options.m4
+++ b/make/autoconf/jdk-options.m4
@@ -438,7 +438,7 @@ AC_DEFUN_ONCE([JDKOPT_SETUP_ADDRESS_SANITIZER],
           # It's harmless to be suppressed in clang as well.
           ASAN_CFLAGS="-fsanitize=address -Wno-stringop-truncation -fno-omit-frame-pointer -fno-common -DADDRESS_SANITIZER"
           ASAN_LDFLAGS="-fsanitize=address"
-          # detect_stack_use_after_return is using a fake stack and thus JDK would crashe:
+          # detect_stack_use_after_return is using a fake stack and thus JDK would crash:
           # assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
           if test "x$TOOLCHAIN_TYPE" = "xgcc"; then
             ASAN_CFLAGS="$ASAN_CFLAGS --param asan-use-after-return=0"

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -42,9 +42,6 @@
 #if INCLUDE_JFR
 #include "jfr/support/jfrThreadExtension.hpp"
 #endif
-#ifdef ADDRESS_SANITIZER
-#include <sanitizer/asan_interface.h>
-#endif
 
 class CompilerThread;
 class HandleArea;
@@ -469,23 +466,11 @@ class Thread: public ThreadShadow {
   void metadata_handles_do(void f(Metadata*));
 
  private:
-  bool is_in_asan_fake_stack(address adr) const {
-#ifdef ADDRESS_SANITIZER
-    if (__asan_addr_is_in_fake_stack(__asan_get_current_fake_stack(), adr, nullptr/*beg*/, nullptr/*end*/)) {
-      return true;
-    }
-#endif
-    return false;
-  }
-
   // Check if address is within the given range of this thread's
   // stack:  stack_base() > adr >/>= limit
   // The check is inclusive of limit if passed true, else exclusive.
   bool is_in_stack_range(address adr, address limit, bool inclusive) const {
     assert(stack_base() > limit && limit >= stack_end(), "limit is outside of stack");
-    if (is_in_asan_fake_stack(adr)) {
-      return true;
-    }
     return stack_base() > adr && (inclusive ? adr >= limit : adr > limit);
   }
 
@@ -512,9 +497,6 @@ class Thread: public ThreadShadow {
   // Like is_in_full_stack_checked but without the assertions as this
   // may be called in a thread before _stack_base is initialized.
   bool is_in_full_stack(address adr) const {
-    if (is_in_asan_fake_stack(adr)) {
-      return true;
-    }
     address stack_end = _stack_base - _stack_size;
     return _stack_base > adr && adr >= stack_end;
   }


### PR DESCRIPTION
fastdebug:

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/home/azul/azul/openjdk-git/src/hotspot/share/runtime/handles.inline.hpp:77), pid=878152, tid=878158
#  assert(_thread->is_in_live_stack((address)this)) failed: not on stack?
#
# JRE version:  (24.0) (fastdebug build )
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 24-internal-adhoc.azul.openjdk-git, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-amd64)
# Problematic frame:
# V  [libjvm.so+0x1d20658]  constantPoolHandle::constantPoolHandle(Thread*, ConstantPool*)+0x268
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334763](https://bugs.openjdk.org/browse/JDK-8334763): --enable-asan: assert(_thread-&gt;is_in_live_stack((address)this)) failed: not on stack? (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) ⚠️ Review applies to [1ec6942a](https://git.openjdk.org/jdk/pull/19843/files/1ec6942a90fd8a88684bbb7e08117642dc30986d)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19843/head:pull/19843` \
`$ git checkout pull/19843`

Update a local copy of the PR: \
`$ git checkout pull/19843` \
`$ git pull https://git.openjdk.org/jdk.git pull/19843/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19843`

View PR using the GUI difftool: \
`$ git pr show -t 19843`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19843.diff">https://git.openjdk.org/jdk/pull/19843.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19843#issuecomment-2184046354)