### PR TITLE
8334765: JFR: Log chunk waste

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/consumer/filter/ChunkWriter.java
@@ -231,8 +231,6 @@ public final class ChunkWriter implements Closeable {
         }
         if (Logger.shouldLog(LogTag.JFR_SYSTEM_PARSER, LogLevel.DEBUG)) {
             for (CheckpointPool pool : event.getPools()) {
-                output.writeLong(pool.getTypeId());
-                output.writeLong(pool.getTouchedCount());
                 for (PoolEntry pe : pool.getEntries()) {
                     if (!pe.isTouched()) {
                         String name = pe.getType().getName();

--- a/test/jdk/jdk/jfr/jvm/TestWaste.java
+++ b/test/jdk/jdk/jfr/jvm/TestWaste.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ import jdk.jfr.Configuration;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.jvm.TestWaste
+ * @run main/othervm -Xlog:jfr+system+parser=debug -XX:TLABSize=2k jdk.jfr.jvm.TestWaste
  */
 public class TestWaste {
     static List<Object> list = new LinkedList<>();


### PR DESCRIPTION
Could I have a review of PR that adds logging of chunk waste.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334765](https://bugs.openjdk.org/browse/JDK-8334765): JFR: Log chunk waste (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19845/head:pull/19845` \
`$ git checkout pull/19845`

Update a local copy of the PR: \
`$ git checkout pull/19845` \
`$ git pull https://git.openjdk.org/jdk.git pull/19845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19845`

View PR using the GUI difftool: \
`$ git pr show -t 19845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19845.diff">https://git.openjdk.org/jdk/pull/19845.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19845#issuecomment-2184849642)