### PR TITLE
8333358: java/io/IO/IO.java test fails intermittently

### DIFF
--- a/test/jdk/java/io/IO/input.exp
+++ b/test/jdk/java/io/IO/input.exp
@@ -23,6 +23,7 @@
 
 set prompt [lindex $argv $argc-1]
 set stty_init "rows 24 cols 80"
+set timeout -1
 
 spawn {*}$argv
 expect {
@@ -30,7 +31,8 @@ expect {
         send "hello\r"
     }
     timeout {
-        puts "timeout"; exit 1
+        puts "timeout"
+        exit 1
     }
 }
 expect eof

--- a/test/jdk/java/io/IO/output.exp
+++ b/test/jdk/java/io/IO/output.exp
@@ -21,12 +21,23 @@
 # questions.
 #
 
-################################################################################
-# This script does not expect/verify anything and is only used to simulate tty #
-################################################################################
+# This script doesn't verify any output strings, it's only used to simulate tty
 
-# Use `noecho` below, otherwise, expect will output the expanded "spawn ..."
+set stty_init "rows 24 cols 80"
+set timeout -1
+
+# Use `-noecho` below, otherwise, expect will output the expanded "spawn ..."
 # command, which will interfere with asserting output from the java test
+# counterpart
 
 spawn -noecho {*}$argv
-expect eof
+
+expect {
+    eof {
+        exit 0
+    }
+    timeout {
+        puts "timeout"
+        exit 1
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [1b1dba80](https://github.com/openjdk/jdk/commit/1b1dba8082969244effa86ac03c6053b3b0ddc43) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Pavel Rappo on 20 Jun 2024 and was reviewed by Naoto Sato.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333358](https://bugs.openjdk.org/browse/JDK-8333358): java/io/IO/IO.java test fails intermittently (**Bug** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19847/head:pull/19847` \
`$ git checkout pull/19847`

Update a local copy of the PR: \
`$ git checkout pull/19847` \
`$ git pull https://git.openjdk.org/jdk.git pull/19847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19847`

View PR using the GUI difftool: \
`$ git pr show -t 19847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19847.diff">https://git.openjdk.org/jdk/pull/19847.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19847#issuecomment-2185037439)