### PR TITLE
8334339: Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java fails on alinux3

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,13 +21,22 @@
  * questions.
  */
 
-/* @test
- * @bug 8011536 8151430 8316304
+/* @test id=tmp
+ * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
- *     that support it.
+ *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @run main CreationTime
+ */
+
+/* @test id=cwd
+ * @summary Basic test for creationTime attribute on platforms/file systems
+ *     that support it, tests using the test scratch directory, the test
+ *     scratch directory maybe at diff disk partition to /tmp on linux.
+ * @library  ../.. /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main CreationTime .
  */
 
 import java.lang.foreign.Linker;
@@ -38,6 +47,7 @@ import java.time.Instant;
 import java.io.IOException;
 
 import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class CreationTime {
 
@@ -68,8 +78,14 @@ public class CreationTime {
         FileTime creationTime = creationTime(file);
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
-            err.println("File creation time reported as: " + creationTime);
-            throw new RuntimeException("Expected to be close to: " + now);
+            System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
+            // If the file system doesn't support birth time, then skip this test
+            if (creationTime.toMillis() == 0) {
+                throw new SkippedException("birth time not support for: " + file);
+            } else {
+                err.println("File creation time reported as: " + creationTime);
+                throw new RuntimeException("Expected to be close to: " + now);
+            }
         }
 
         /**
@@ -95,7 +111,7 @@ public class CreationTime {
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }
-        System.out.println("supportsCreationTimeRead == " + supportsCreationTimeRead);
+        System.out.println(top + " supportsCreationTimeRead == " + supportsCreationTimeRead);
 
         /**
          * If the creation-time attribute is supported then change the file's
@@ -127,7 +143,12 @@ public class CreationTime {
 
     public static void main(String[] args) throws IOException {
         // create temporary directory to run tests
-        Path dir = TestUtil.createTemporaryDirectory();
+        Path dir;
+        if (args.length == 0) {
+            dir = TestUtil.createTemporaryDirectory();
+        } else {
+            dir = TestUtil.createTemporaryDirectory(args[0]);
+        }
         try {
             test(dir);
         } finally {


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [7baddc20](https://github.com/openjdk/jdk/commit/7baddc202a9ab2b85401aa05f827678b514ebf55) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by SendaoYan on 23 Jun 2024 and was reviewed by Alan Bateman.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334339](https://bugs.openjdk.org/browse/JDK-8334339): Test java/nio/file/attribute/BasicFileAttributeView/CreationTime.java fails on alinux3 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19848/head:pull/19848` \
`$ git checkout pull/19848`

Update a local copy of the PR: \
`$ git checkout pull/19848` \
`$ git pull https://git.openjdk.org/jdk.git pull/19848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19848`

View PR using the GUI difftool: \
`$ git pr show -t 19848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19848.diff">https://git.openjdk.org/jdk/pull/19848.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19848#issuecomment-2185505242)