### PR TITLE
8334810: Redo: Un-ProblemList LocaleProvidersRun and CalendarDataRegression

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -717,9 +717,6 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 
-java/util/Locale/LocaleProvidersRun.java                        8268379 macosx-x64
-sun/util/locale/provider/CalendarDataRegression.java            8268379 macosx-x64
-
 ############################################################################
 
 # jdk_instrument


### PR DESCRIPTION
[JDK-8318107](https://bugs.openjdk.org/browse/JDK-8318107) Un-ProblemListed LocaleProvidersRun and CalendarDataRegression, and [JDK-8288899](https://bugs.openjdk.org/browse/JDK-8288899) added them back. I'm guessing it's a mistake in resolving merge conflict.