### PR TITLE
8334843: RISC-V: Fix wraparound checking for r_array_index in lookup_secondary_supers_table_slow_path

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3799,7 +3799,7 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
 
     // Check for wraparound.
     Label skip;
-    bge(r_array_length, r_array_index, skip);
+    blt(r_array_index, r_array_length, skip);
     mv(r_array_index, zr);
     bind(skip);
 


### PR DESCRIPTION
Branch condition for r_array_index wraparound checking in lookup_secondary_supers_table_slow_path is wrong.
```
    // Check for wraparound.
    Label skip;
    bge(r_array_length, r_array_index, skip);
    mv(r_array_index, zr);
    bind(skip);
```
As discussed at https://github.com/openjdk/jdk/pull/19320/files#r1650548279 . If length == index, then we must set index to 0. That is `blt(r_array_index,r_array_length,skip);`.

### Correctness testing:
- [x] Run tier1-3 tests on SOPHON SG2042 (release)

### JMH tested on Banana Pi BPI-F3 board (has Zbb) and Enable UseZbb
without this patch:
```
SecondarySupersLookup.testNegative00  avgt   15   13.275 ± 0.223  ns/op
SecondarySupersLookup.testNegative01  avgt   15   13.264 ± 0.201  ns/op
SecondarySupersLookup.testNegative02  avgt   15   13.261 ± 0.194  ns/op
SecondarySupersLookup.testNegative03  avgt   15   13.271 ± 0.210  ns/op
SecondarySupersLookup.testNegative04  avgt   15   13.265 ± 0.201  ns/op
SecondarySupersLookup.testNegative05  avgt   15   13.258 ± 0.191  ns/op
SecondarySupersLookup.testNegative06  avgt   15   13.280 ± 0.225  ns/op
SecondarySupersLookup.testNegative07  avgt   15   13.268 ± 0.201  ns/op
SecondarySupersLookup.testNegative08  avgt   15   13.266 ± 0.202  ns/op
SecondarySupersLookup.testNegative09  avgt   15   13.261 ± 0.196  ns/op
SecondarySupersLookup.testNegative10  avgt   15   13.268 ± 0.198  ns/op
SecondarySupersLookup.testNegative16  avgt   15   13.268 ± 0.205  ns/op
SecondarySupersLookup.testNegative20  avgt   15   13.284 ± 0.231  ns/op
SecondarySupersLookup.testNegative30  avgt   15   13.281 ± 0.226  ns/op
SecondarySupersLookup.testNegative32  avgt   15   13.273 ± 0.215  ns/op
SecondarySupersLookup.testNegative40  avgt   15   13.287 ± 0.233  ns/op
SecondarySupersLookup.testNegative50  avgt   15   13.292 ± 0.242  ns/op
SecondarySupersLookup.testNegative55  avgt   15   53.064 ± 0.757  ns/op
SecondarySupersLookup.testNegative56  avgt   15   53.052 ± 0.767  ns/op
SecondarySupersLookup.testNegative57  avgt   15   53.068 ± 0.803  ns/op
SecondarySupersLookup.testNegative58  avgt   15   53.076 ± 0.776  ns/op
SecondarySupersLookup.testNegative59  avgt   15   53.095 ± 0.846  ns/op
SecondarySupersLookup.testNegative60  avgt   15   75.106 ± 1.033  ns/op
SecondarySupersLookup.testNegative61  avgt   15   76.832 ± 4.047  ns/op
SecondarySupersLookup.testNegative62  avgt   15   75.085 ± 1.010  ns/op
SecondarySupersLookup.testNegative63  avgt   15  153.709 ± 0.893  ns/op
SecondarySupersLookup.testNegative64  avgt   15  155.623 ± 0.922  ns/op
SecondarySupersLookup.testPositive01  avgt   15   10.727 ± 0.145  ns/op
SecondarySupersLookup.testPositive02  avgt   15   10.734 ± 0.157  ns/op
SecondarySupersLookup.testPositive03  avgt   15   10.731 ± 0.151  ns/op
SecondarySupersLookup.testPositive04  avgt   15   10.733 ± 0.156  ns/op
SecondarySupersLookup.testPositive05  avgt   15   10.742 ± 0.168  ns/op
SecondarySupersLookup.testPositive06  avgt   15   10.729 ± 0.148  ns/op
SecondarySupersLookup.testPositive07  avgt   15   10.738 ± 0.163  ns/op
SecondarySupersLookup.testPositive08  avgt   15   10.736 ± 0.159  ns/op
SecondarySupersLookup.testPositive09  avgt   15   10.735 ± 0.158  ns/op
SecondarySupersLookup.testPositive10  avgt   15   10.730 ± 0.150  ns/op
SecondarySupersLookup.testPositive16  avgt   15   10.734 ± 0.157  ns/op
SecondarySupersLookup.testPositive20  avgt   15   10.731 ± 0.149  ns/op
SecondarySupersLookup.testPositive30  avgt   15   10.733 ± 0.156  ns/op
SecondarySupersLookup.testPositive32  avgt   15   10.729 ± 0.149  ns/op
SecondarySupersLookup.testPositive40  avgt   15   10.732 ± 0.154  ns/op
SecondarySupersLookup.testPositive50  avgt   15   10.735 ± 0.154  ns/op
SecondarySupersLookup.testPositive60  avgt   15   10.736 ± 0.157  ns/op
SecondarySupersLookup.testPositive63  avgt   15   10.733 ± 0.155  ns/op
SecondarySupersLookup.testPositive64  avgt   15   10.729 ± 0.149  ns/op
```

with this patch:
```
Benchmark                             Mode  Cnt    Score   Error  Units
SecondarySupersLookup.testNegative00  avgt   15   13.257 ± 0.181  ns/op
SecondarySupersLookup.testNegative01  avgt   15   13.267 ± 0.175  ns/op
SecondarySupersLookup.testNegative02  avgt   15   13.309 ± 0.209  ns/op
SecondarySupersLookup.testNegative03  avgt   15   13.288 ± 0.181  ns/op
SecondarySupersLookup.testNegative04  avgt   15   13.321 ± 0.201  ns/op
SecondarySupersLookup.testNegative05  avgt   15   13.278 ± 0.177  ns/op
SecondarySupersLookup.testNegative06  avgt   15   13.315 ± 0.218  ns/op
SecondarySupersLookup.testNegative07  avgt   15   13.327 ± 0.217  ns/op
SecondarySupersLookup.testNegative08  avgt   15   13.253 ± 0.175  ns/op
SecondarySupersLookup.testNegative09  avgt   15   13.271 ± 0.181  ns/op
SecondarySupersLookup.testNegative10  avgt   15   13.284 ± 0.187  ns/op
SecondarySupersLookup.testNegative16  avgt   15   13.266 ± 0.195  ns/op
SecondarySupersLookup.testNegative20  avgt   15   13.376 ± 0.226  ns/op
SecondarySupersLookup.testNegative30  avgt   15   13.311 ± 0.233  ns/op
SecondarySupersLookup.testNegative32  avgt   15   13.284 ± 0.210  ns/op
SecondarySupersLookup.testNegative40  avgt   15   13.311 ± 0.221  ns/op
SecondarySupersLookup.testNegative50  avgt   15   13.281 ± 0.218  ns/op
SecondarySupersLookup.testNegative55  avgt   15   52.172 ± 0.810  ns/op
SecondarySupersLookup.testNegative56  avgt   15   52.492 ± 0.714  ns/op
SecondarySupersLookup.testNegative57  avgt   15   52.470 ± 0.950  ns/op
SecondarySupersLookup.testNegative58  avgt   15   52.249 ± 0.919  ns/op
SecondarySupersLookup.testNegative59  avgt   15   52.374 ± 1.004  ns/op
SecondarySupersLookup.testNegative60  avgt   15   73.985 ± 1.451  ns/op
SecondarySupersLookup.testNegative61  avgt   15   74.515 ± 1.291  ns/op
SecondarySupersLookup.testNegative62  avgt   15   73.915 ± 0.938  ns/op
SecondarySupersLookup.testNegative63  avgt   15  154.865 ± 1.025  ns/op
SecondarySupersLookup.testNegative64  avgt   15  156.899 ± 0.965  ns/op
SecondarySupersLookup.testPositive01  avgt   15   10.724 ± 0.136  ns/op
SecondarySupersLookup.testPositive02  avgt   15   10.756 ± 0.155  ns/op
SecondarySupersLookup.testPositive03  avgt   15   10.761 ± 0.145  ns/op
SecondarySupersLookup.testPositive04  avgt   15   10.728 ± 0.142  ns/op
SecondarySupersLookup.testPositive05  avgt   15   10.726 ± 0.135  ns/op
SecondarySupersLookup.testPositive06  avgt   15   10.735 ± 0.145  ns/op
SecondarySupersLookup.testPositive07  avgt   15   10.739 ± 0.146  ns/op
SecondarySupersLookup.testPositive08  avgt   15   10.729 ± 0.140  ns/op
SecondarySupersLookup.testPositive09  avgt   15   10.730 ± 0.141  ns/op
SecondarySupersLookup.testPositive10  avgt   15   10.727 ± 0.137  ns/op
SecondarySupersLookup.testPositive16  avgt   15   10.736 ± 0.157  ns/op
SecondarySupersLookup.testPositive20  avgt   15   10.726 ± 0.138  ns/op
SecondarySupersLookup.testPositive30  avgt   15   10.724 ± 0.135  ns/op
SecondarySupersLookup.testPositive32  avgt   15   10.742 ± 0.152  ns/op
SecondarySupersLookup.testPositive40  avgt   15   10.739 ± 0.143  ns/op
SecondarySupersLookup.testPositive50  avgt   15   10.744 ± 0.146  ns/op
SecondarySupersLookup.testPositive60  avgt   15   10.739 ± 0.147  ns/op
SecondarySupersLookup.testPositive63  avgt   15   10.760 ± 0.168  ns/op
SecondarySupersLookup.testPositive64  avgt   15   10.729 ± 0.143  ns/op
Finished running test 'micro:vm.lang.SecondarySupersLookup'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334843](https://bugs.openjdk.org/browse/JDK-8334843): RISC-V: Fix wraparound checking for r_array_index in lookup_secondary_supers_table_slow_path (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19852/head:pull/19852` \
`$ git checkout pull/19852`

Update a local copy of the PR: \
`$ git checkout pull/19852` \
`$ git pull https://git.openjdk.org/jdk.git pull/19852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19852`

View PR using the GUI difftool: \
`$ git pr show -t 19852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19852.diff">https://git.openjdk.org/jdk/pull/19852.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19852#issuecomment-2186699822)