### PR TITLE
8334040: jdk/classfile/CorpusTest.java timed out

### DIFF
--- a/test/jdk/jdk/classfile/CorpusTest.java
+++ b/test/jdk/jdk/classfile/CorpusTest.java
@@ -117,7 +117,7 @@ class CorpusTest {
     static Path[] corpus() throws IOException, URISyntaxException {
         splitTableAttributes("testdata/Pattern2.class", "testdata/Pattern2-split.class");
         return Stream.of(
-                Files.walk(JRT.getPath("modules/java.base/java")),
+                Files.walk(JRT.getPath("modules/java.base/java/util")),
                 Files.walk(JRT.getPath("modules"), 2).filter(p -> p.endsWith("module-info.class")),
                 Files.walk(Paths.get(URI.create(CorpusTest.class.getResource("CorpusTest.class").toString())).getParent()))
                 .flatMap(p -> p)
@@ -140,6 +140,7 @@ class CorpusTest {
         for (Transforms.NoOpTransform m : Transforms.NoOpTransform.values()) {
             if (m == Transforms.NoOpTransform.ARRAYCOPY
                 || m == Transforms.NoOpTransform.SHARED_3_NO_STACKMAP
+                || m == Transforms.NoOpTransform.CLASS_REMAPPER
                 || m.name().startsWith("ASM"))
                 continue;
 
@@ -190,12 +191,8 @@ class CorpusTest {
                                  .collect(joining("\n"));
             fail(String.format("Errors in testNullAdapt: %s", msg));
         }
-    }
 
-    @ParameterizedTest
-    @MethodSource("corpus")
-    void testReadAndTransform(Path path) throws IOException {
-        byte[] bytes = Files.readAllBytes(path);
+        // test read and transform
         var cc = ClassFile.of();
         var classModel = cc.parse(bytes);
         assertEqualsDeep(ClassRecord.ofClassModel(classModel), ClassRecord.ofStreamingElements(classModel),


### PR DESCRIPTION
jdk/classfile/CorpusTest.java is timing out on some Windows systems.

This patch introduces several optimizations to the test:
 - scope of the test is reduced to java.util classes
 - class remapping transformation is excluded (it is covered by another test)
 - two-dimensional parametrized test has been joined to a single parameterized test (avoids repeated class reading and reduces JUnit test matrix preparation and results computation workload)

The test run time has been significantly reduced on my Mac, however I've never observed such extensive times.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334040](https://bugs.openjdk.org/browse/JDK-8334040): jdk/classfile/CorpusTest.java timed out (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19854/head:pull/19854` \
`$ git checkout pull/19854`

Update a local copy of the PR: \
`$ git checkout pull/19854` \
`$ git pull https://git.openjdk.org/jdk.git pull/19854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19854`

View PR using the GUI difftool: \
`$ git pr show -t 19854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19854.diff">https://git.openjdk.org/jdk/pull/19854.diff</a>

</details>
