### PR TITLE
8334650: Add debug information about whether an Assertion Predicate is for the init or last value

### DIFF
--- a/src/hotspot/share/opto/cfgnode.hpp
+++ b/src/hotspot/share/opto/cfgnode.hpp
@@ -57,6 +57,7 @@ class     JProjNode;
 class       JumpProjNode;
 class     SCMemProjNode;
 class PhaseIdealLoop;
+enum class AssertionPredicateType;
 
 // The success projection of a Parse Predicate is always an IfTrueNode and the uncommon projection an IfFalseNode
 typedef IfTrueNode ParsePredicateSuccessProj;
@@ -318,11 +319,23 @@ public:
 //------------------------------IfNode-----------------------------------------
 // Output selected Control, based on a boolean test
 class IfNode : public MultiBranchNode {
+ public:
+  float _prob;                           // Probability of true path being taken.
+  float _fcnt;                           // Frequency counter
+
+ private:
+  NOT_PRODUCT(AssertionPredicateType _assertion_predicate_type;)
+
+  void init_node(Node* control, Node* bol) {
+    init_class_id(Class_If);
+    init_req(0, control);
+    init_req(1, bol);
+  }
+
   // Size is bigger to hold the probability field.  However, _prob does not
   // change the semantics so it does not appear in the hash & cmp functions.
   virtual uint size_of() const { return sizeof(*this); }
 
-private:
   // Helper methods for fold_compares
   bool cmpi_folds(PhaseIterGVN* igvn, bool fold_ne = false);
   bool is_ctrl_folds(Node* ctrl, PhaseIterGVN* igvn);
@@ -413,14 +426,8 @@ public:
   // Magic manifest probabilities such as 0.83, 0.7, ... can be found in
   // gen_subtype_check() and catch_inline_exceptions().
 
-  float _prob;                  // Probability of true path being taken.
-  float _fcnt;                  // Frequency counter
-  IfNode( Node *control, Node *b, float p, float fcnt )
-    : MultiBranchNode(2), _prob(p), _fcnt(fcnt) {
-    init_class_id(Class_If);
-    init_req(0,control);
-    init_req(1,b);
-  }
+  IfNode(Node* control, Node* bol, float p, float fcnt);
+  NOT_PRODUCT(IfNode(Node* control, Node* bol, float p, float fcnt, AssertionPredicateType assertion_predicate_type);)
 
   static IfNode* make_with_same_profile(IfNode* if_node_profile, Node* ctrl, BoolNode* bol);
 
@@ -450,13 +457,19 @@ public:
 
 class RangeCheckNode : public IfNode {
 private:
-  int is_range_check(Node* &range, Node* &index, jint &offset);
+  int is_range_check(Node*& range, Node*& index, jint& offset);
 
 public:
-  RangeCheckNode(Node* control, Node *b, float p, float fcnt)
-    : IfNode(control, b, p, fcnt) {
+  RangeCheckNode(Node* control, Node* bol, float p, float fcnt) : IfNode(control, bol, p, fcnt) {
     init_class_id(Class_RangeCheck);
   }
+
+#ifndef PRODUCT
+  RangeCheckNode(Node* control, Node* bol, float p, float fcnt, AssertionPredicateType assertion_predicate_type)
+      : IfNode(control, bol, p, fcnt, assertion_predicate_type) {
+    init_class_id(Class_RangeCheck);
+  }
+#endif // NOT PRODUCT
 
   virtual int Opcode() const;
   virtual Node* Ideal(PhaseGVN *phase, bool can_reshape);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2769,10 +2769,9 @@ bool PhaseIdealLoop::is_scaled_iv_plus_extra_offset(Node* exp1, Node* offset3, N
 
 // Same as PhaseIdealLoop::duplicate_predicates() but for range checks
 // eliminated by iteration splitting.
-Node* PhaseIdealLoop::add_range_check_elimination_assertion_predicate(IdealLoopTree* loop, Node* ctrl,
-                                                                      const int scale_con, Node* offset, Node* limit,
-                                                                      jint stride_con, Node* value,
-                                                                      const bool is_template) {
+Node* PhaseIdealLoop::add_range_check_elimination_assertion_predicate(
+    IdealLoopTree* loop, Node* ctrl, const int scale_con, Node* offset, Node* limit, jint stride_con, Node* value,
+    const bool is_template NOT_PRODUCT(COMMA AssertionPredicateType assertion_predicate_type)) {
   bool overflow = false;
   BoolNode* bol = rc_predicate(ctrl, scale_con, offset, value, nullptr, stride_con,
                                limit, (stride_con > 0) != (scale_con > 0), overflow);
@@ -2993,8 +2992,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
 
           // Add two Template Assertion Predicates to create new Initialized Assertion Predicates from when either
           // unrolling or splitting this main-loop further.
-          loop_entry = add_range_check_elimination_assertion_predicate(loop, loop_entry, scale_con, int_offset,
-                                                                       int_limit, stride_con, opaque_init, true);
+          loop_entry = add_range_check_elimination_assertion_predicate(
+              loop, loop_entry, scale_con, int_offset, int_limit, stride_con, opaque_init, true
+              NOT_PRODUCT(COMMA AssertionPredicateType::Init_value));
           assert(assertion_predicate_has_loop_opaque_node(loop_entry->in(0)->as_If()), "unexpected");
 
           Node* opaque_stride = new OpaqueLoopStrideNode(C, cl->stride());
@@ -3006,8 +3006,9 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
           // init + (current stride - initial stride) is within the loop so narrow its type by leveraging the type of the iv Phi
           max_value = new CastIINode(max_value, loop->_head->as_CountedLoop()->phi()->bottom_type());
           register_new_node(max_value, loop_entry);
-          loop_entry = add_range_check_elimination_assertion_predicate(loop, loop_entry, scale_con, int_offset,
-                                                                       int_limit, stride_con, max_value, true);
+          loop_entry = add_range_check_elimination_assertion_predicate(
+              loop, loop_entry, scale_con, int_offset, int_limit, stride_con, max_value, true
+              NOT_PRODUCT(COMMA AssertionPredicateType::Last_value));
           assert(assertion_predicate_has_loop_opaque_node(loop_entry->in(0)->as_If()), "unexpected");
 
         } else {

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1339,9 +1339,10 @@ public:
                                       bool* p_short_scale, int depth);
 
   // Create a new if above the uncommon_trap_if_pattern for the predicate to be promoted
-  IfTrueNode* create_new_if_for_predicate(ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
-                                          Deoptimization::DeoptReason reason, int opcode,
-                                          bool rewire_uncommon_proj_phi_inputs = false);
+  IfTrueNode* create_new_if_for_predicate(
+      ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry, Deoptimization::DeoptReason reason, int opcode,
+      bool rewire_uncommon_proj_phi_inputs = false
+      NOT_PRODUCT (COMMA AssertionPredicateType assertion_predicate_type = AssertionPredicateType::None));
 
  private:
   // Helper functions for create_new_if_for_predicate()
@@ -1382,9 +1383,9 @@ public:
                                                IfProjNode* upper_bound_proj, int scale, Node* offset, Node* init, Node* limit,
                                                jint stride, Node* rng, bool& overflow, Deoptimization::DeoptReason reason);
   void eliminate_hoisted_range_check(IfTrueNode* hoisted_check_proj, IfTrueNode* template_assertion_predicate_proj);
-  Node* add_range_check_elimination_assertion_predicate(IdealLoopTree* loop, Node* predicate_proj, int scale_con,
-                                                        Node* offset, Node* limit, int stride_con, Node* value,
-                                                        bool is_template);
+  Node* add_range_check_elimination_assertion_predicate(
+      IdealLoopTree* loop, Node* predicate_proj, int scale_con, Node* offset, Node* limit, int stride_con, Node* value,
+      bool is_template NOT_PRODUCT(COMMA AssertionPredicateType assertion_predicate_type = AssertionPredicateType::None));
 
   // Helper function to collect predicate for eliminating the useless ones
   void eliminate_useless_predicates();

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -193,6 +193,15 @@
  * Main Loop Head
  */
 
+#ifndef PRODUCT
+// Assertion Predicates are either emitted to check the initial value of a range check in the first iteration or the last
+// value of a range check in the last iteration of a loop.
+enum class AssertionPredicateType {
+  None, // Not an Assertion Predicate
+  Init_value,
+  Last_value
+};
+#endif // NOT PRODUCT
 
 // Class to represent Assertion Predicates with a HaltNode instead of an UCT (i.e. either an Initialized Assertion
 // Predicate or a Template Assertion Predicate created after the initial one at Loop Predication).


### PR DESCRIPTION
It is sometimes hard to see if an Assertion Predicate is about the init or the last value of a range check. This patch therefore adds debugging information when dumping an Assertion Predicate node to tty or for IGV:

Template Assertion Predicate:
```
 292  Opaque4  === _ 291 25  [[ 295 ]]  !orig=[174]
 293  IfTrue  === 295  [[ 401 ]] #1 !orig=[176]
 294  IfFalse  === 295  [[ 297 ]] #0 !orig=[177]
 295  RangeCheck  === 273 292  [[ 293 294 ]] #Init Value Assertion Predicate  P=0.999999, C=-1.000000 !orig=[175]
...
 272  Opaque4  === _ 271 25  [[ 275 ]]  !orig=[184]
 273  IfTrue  === 275  [[ 295 ]] #1 !orig=[186]
 274  IfFalse  === 275  [[ 277 ]] #0 !orig=[187]
 275  RangeCheck  === 262 272  [[ 273 274 ]] #Last Value Assertion Predicate  P=0.999999, C=-1.000000 !orig=[185]
```
Initialized Assertion Predicate:
```
 398  OpaqueInitializedAssertionPredicate  === _ 396  [[ 401 ]] 
 399  IfTrue  === 401  [[ 413 ]] #1 !orig=293,[176]
 400  IfFalse  === 401  [[ 403 ]] #0 !orig=294,[177]
 401  RangeCheck  === 293 398  [[ 399 400 ]] #Init Value Assertion Predicate  P=0.999999, C=-1.000000 !orig=295,[175]
...
 410  OpaqueInitializedAssertionPredicate  === _ 408  [[ 413 ]] 
 411  IfTrue  === 413  [[ 149 ]] #1 !orig=273,[186]
 412  IfFalse  === 413  [[ 415 ]] #0 !orig=274,[187]
 413  RangeCheck  === 399 410  [[ 411 412 ]] #Last Value Assertion Predicate  P=0.999999, C=-1.000000 !orig=275,[185]
```

IGV:
![image](https://github.com/openjdk/jdk/assets/17833009/4d2725f7-ea8e-4304-8ad6-2c7bf76b072b)

I could have added an additional "initialized" or "template" to better distinguish them but I eventually plan to get rid of `If` nodes for templates and introduce a dedicated `TemplateAssertionPredicateNode`. I therefore use the same strings for templates and initialized versions for now. Moreover, one can easily look at the input nodes to see if it is a template (with `Opaque4`) or an initialized version (with `OpaqueInitializedAssertionPredicate`).

Since this is only useful for debugging, I've guarded everything with `NOT_PRODUCT`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334650](https://bugs.openjdk.org/browse/JDK-8334650): Add debug information about whether an Assertion Predicate is for the init or last value (**Sub-task** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19856/head:pull/19856` \
`$ git checkout pull/19856`

Update a local copy of the PR: \
`$ git checkout pull/19856` \
`$ git pull https://git.openjdk.org/jdk.git pull/19856/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19856`

View PR using the GUI difftool: \
`$ git pr show -t 19856`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19856.diff">https://git.openjdk.org/jdk/pull/19856.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19856#issuecomment-2188074868)