### PR TITLE
8324841: PKCS11 tests still skip execution

### DIFF
--- a/test/jdk/sun/security/pkcs11/PKCS11Test.java
+++ b/test/jdk/sun/security/pkcs11/PKCS11Test.java
@@ -791,8 +791,8 @@ public abstract class PKCS11Test {
                 (tp, attr) -> tp.getFileName().equals(libraryName))) {
 
             return files.findAny()
-                        .orElseThrow(() -> new SkippedException(
-                        "NSS library \"" + libraryName + "\" was not found in " + path));
+                        .orElseThrow(() ->
+                            new RuntimeException("NSS library \"" + libraryName + "\" was not found in " + path));
         }
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324841](https://bugs.openjdk.org/browse/JDK-8324841): PKCS11 tests still skip execution (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19857/head:pull/19857` \
`$ git checkout pull/19857`

Update a local copy of the PR: \
`$ git checkout pull/19857` \
`$ git pull https://git.openjdk.org/jdk.git pull/19857/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19857`

View PR using the GUI difftool: \
`$ git pr show -t 19857`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19857.diff">https://git.openjdk.org/jdk/pull/19857.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19857#issuecomment-2186479889)