### PR TITLE
8334230: Optimize C2 classes layout

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -102,22 +102,22 @@ public:
 class C2Access: public StackObj {
 protected:
   DecoratorSet      _decorators;
-  BasicType         _type;
   Node*             _base;
   C2AccessValuePtr& _addr;
   Node*             _raw_access;
+  BasicType         _type;
   uint8_t           _barrier_data;
 
   void fixup_decorators();
 
 public:
   C2Access(DecoratorSet decorators,
-           BasicType type, Node* base, C2AccessValuePtr& addr) :
+           Node* base, C2AccessValuePtr& addr, BasicType type) :
     _decorators(decorators),
-    _type(type),
     _base(base),
     _addr(addr),
     _raw_access(nullptr),
+    _type(type),
     _barrier_data(0)
   {}
 
@@ -153,7 +153,7 @@ protected:
 public:
   C2ParseAccess(GraphKit* kit, DecoratorSet decorators,
                 BasicType type, Node* base, C2AccessValuePtr& addr) :
-    C2Access(decorators, type, base, addr),
+    C2Access(decorators, base, addr, type),
     _kit(kit) {
     fixup_decorators();
   }
@@ -193,7 +193,7 @@ class C2OptAccess: public C2Access {
 public:
   C2OptAccess(PhaseGVN& gvn, Node* ctl, MergeMemNode* mem, DecoratorSet decorators,
               BasicType type, Node* base, C2AccessValuePtr& addr) :
-    C2Access(decorators, type, base, addr),
+    C2Access(decorators, base, addr, type),
     _gvn(gvn), _mem(mem), _ctl(ctl) {
     fixup_decorators();
   }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -112,7 +112,7 @@ protected:
 
 public:
   C2Access(DecoratorSet decorators,
-           Node* base, C2AccessValuePtr& addr, BasicType type) :
+           BasicType type, Node* base, C2AccessValuePtr& addr) :
     _decorators(decorators),
     _base(base),
     _addr(addr),
@@ -153,7 +153,7 @@ protected:
 public:
   C2ParseAccess(GraphKit* kit, DecoratorSet decorators,
                 BasicType type, Node* base, C2AccessValuePtr& addr) :
-    C2Access(decorators, base, addr, type),
+    C2Access(decorators, type, base, addr),
     _kit(kit) {
     fixup_decorators();
   }

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -193,7 +193,7 @@ class C2OptAccess: public C2Access {
 public:
   C2OptAccess(PhaseGVN& gvn, Node* ctl, MergeMemNode* mem, DecoratorSet decorators,
               BasicType type, Node* base, C2AccessValuePtr& addr) :
-    C2Access(decorators, base, addr, type),
+    C2Access(decorators, type, base, addr),
     _gvn(gvn), _mem(mem), _ctl(ctl) {
     fixup_decorators();
   }

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -42,9 +42,9 @@ private:
 
   // Used 32-bit words
   uint       _size;
-  uint32_t*  _data;
   // Allocated words
   uint       _data_size;
+  uint32_t*  _data;
   Arena*     _set_arena;
 
   void init(Arena* arena);

--- a/src/hotspot/share/opto/callnode.hpp
+++ b/src/hotspot/share/opto/callnode.hpp
@@ -754,18 +754,18 @@ protected:
   virtual bool cmp( const Node &n ) const;
   virtual uint size_of() const; // Size is bigger
 
+  ciMethod* _method;               // Method being direct called
   bool    _optimized_virtual;
   bool    _method_handle_invoke;
   bool    _override_symbolic_info; // Override symbolic call site info from bytecode
-  ciMethod* _method;               // Method being direct called
   bool    _arg_escape;             // ArgEscape in parameter list
 public:
   CallJavaNode(const TypeFunc* tf , address addr, ciMethod* method)
     : CallNode(tf, addr, TypePtr::BOTTOM),
+      _method(method),
       _optimized_virtual(false),
       _method_handle_invoke(false),
       _override_symbolic_info(false),
-      _method(method),
       _arg_escape(false)
   {
     init_class_id(Class_CallJava);

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2731,13 +2731,13 @@ private:
   const jint _int_offset_shift; // (optional) Shift value for int_offset
   const bool _is_valid;          // The parsing succeeded
 
-  ArrayPointer(const Node* pointer,
+  ArrayPointer(const bool is_valid,
+               const Node* pointer,
                const Node* base,
                const jlong constant_offset,
                const Node* int_offset,
-               const GrowableArray<Node*>* other_offsets,
                const jint int_offset_shift,
-               const bool is_valid) :
+               const GrowableArray<Node*>* other_offsets) :
       _pointer(pointer),
       _base(base),
       _constant_offset(constant_offset),
@@ -2752,7 +2752,7 @@ private:
   }
 
   static ArrayPointer make_invalid(const Node* pointer) {
-    return ArrayPointer(pointer, nullptr, 0, nullptr, nullptr, 0, false);
+    return ArrayPointer(false, pointer, nullptr, 0, nullptr, 0, nullptr);
   }
 
   static bool parse_int_offset(Node* offset, Node*& int_offset, jint& int_offset_shift) {
@@ -2826,7 +2826,7 @@ public:
       }
     }
 
-    return ArrayPointer(pointer, base, constant_offset, int_offset, other_offsets, int_offset_shift, true);
+    return ArrayPointer(true, pointer, base, constant_offset, int_offset, int_offset_shift, other_offsets);
   }
 
   bool is_adjacent_to_and_before(const ArrayPointer& other, const jlong data_size) const {


### PR DESCRIPTION
**Notes**

Rearrange C2 class fields to optimize footprint.


**Verification**

1. Ran tier2_compiler, hotspot_compiler, tier 1 & tier 2 tests.
2. Ran pahole on 64 bit machine post re-ordering and verified that there are no holes / reduction in total bytes.

| Class | Size | Cachelines | Sum Members | Holes | Sum holes | Last Cacheline | Padding |
| ----- | ----- | ---------- | --------------- | ----- | ---------- | --------------- | -------- |
| ArrayPointer | 56 -> 48 | 1 -> 1 | 45 -> 0 | 2 ->  0 | 11 -> 0  | 56 bytes -> 48 | 0 -> 3 |
| CallJavaNode | 152 -> 144 | 3 -> 3 | 12 -> 0 | 1 ->  0 | 5 -> 0  | 24 bytes -> 16 | 7 -> 4 |
| C2Access | 56 -> 48 | 1-> 1 | 42 -> 0 | 1 ->  0 | 7 -> 0  | 56 bytes -> 48 | 7 -> 6 |
| VectorSet| 32 -> 24 | 1-> 1 | 24 -> 0 | 1 ->  0 | 8 -> 0  | 32 bytes -> 24 | 1 -> 1 |
```
class ArrayPointer {
	const class Node  *        _pointer;             /*     0     8 */
	const class Node  *        _base;                /*     8     8 */
	const jlong                _constant_offset;     /*    16     8 */
	const class Node  *        _int_offset;          /*    24     8 */
	const class GrowableArray<Node*>  * _other_offsets; /*    32     8 */
	const jint                 _int_offset_shift;    /*    40     4 */
	const bool                 _is_valid;            /*    44     1 */
public:


	/* size: 48, cachelines: 1, members: 7 */
	/* padding: 3 */
	/* last cacheline: 48 bytes */
};
```

```
class CallJavaNode : public CallNode {
public:

	/* class CallNode            <ancestor>; */      /*     0   128 */
protected:

	/* --- cacheline 2 boundary (128 bytes) --- */
	class ciMethod *           _method;              /*   128     8 */
	bool                       _optimized_virtual;   /*   136     1 */
	bool                       _method_handle_invoke; /*   137     1 */
	bool                       _override_symbolic_info; /*   138     1 */
	bool                       _arg_escape;          /*   139     1 */
public:

protected:

public:


	/* size: 144, cachelines: 3, members: 6 */
	/* padding: 4 */
	/* last cacheline: 16 bytes */

	/* BRAIN FART ALERT! 144 bytes != 12 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 1024 bits */
};
```

```
class C2Access : public StackObj {
public:

	/* class StackObj            <ancestor>; */      /*     0     0 */

	/* XXX last struct has 1 byte of padding */

	int ()(void) * *           _vptr.C2Access;       /*     0     8 */
protected:

	DecoratorSet               _decorators;          /*     8     8 */
	class Node *               _base;                /*    16     8 */
	class C2AccessValuePtr &   _addr;                /*    24     8 */
	class Node *               _raw_access;          /*    32     8 */
	enum BasicType             _type;                /*    40     1 */
	uint8_t                    _barrier_data;        /*    41     1 */
public:

protected:

public:


	/* size: 48, cachelines: 1, members: 8 */
	/* padding: 6 */
	/* paddings: 1, sum paddings: 1 */
	/* last cacheline: 48 bytes */
};
```

```
class VectorSet : public AnyObj {
public:

	/* class AnyObj              <ancestor>; */      /*     0     0 */

	/* XXX last struct has 1 byte of padding */

	static const uint                 word_bits;     /*     0     0 */
	static const uint                 bit_mask;      /*     0     0 */
	uint                       _size;                /*     0     4 */
	uint                       _data_size;           /*     4     4 */
	uint32_t *                 _data;                /*     8     8 */
	class Arena *              _set_arena;           /*    16     8 */

	/* size: 24, cachelines: 1, members: 5, static members: 2 */
	/* paddings: 1, sum paddings: 1 */
	/* last cacheline: 24 bytes */
};
```
I wrote simple program that just assigns integer value to a variable and observed the following - 
Number of ArrayPointer instances = 58. 
Number of C2Access instances = 1390.
Number of CallJavaNode instances = 1626.
58 * 8 byte + 1390 * 8 + 1626 * 8 = 24KB
24 KB space saving at the very least and significant memory footprint savings for much complex programs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334230](https://bugs.openjdk.org/browse/JDK-8334230): Optimize C2 classes layout (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [f5309ce4](https://git.openjdk.org/jdk/pull/19861/files/f5309ce4d9597ae1fb0141b435ba54bae8d69afb))
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) 🔄 Re-review required (review applies to [f5309ce4](https://git.openjdk.org/jdk/pull/19861/files/f5309ce4d9597ae1fb0141b435ba54bae8d69afb))
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19861/head:pull/19861` \
`$ git checkout pull/19861`

Update a local copy of the PR: \
`$ git checkout pull/19861` \
`$ git pull https://git.openjdk.org/jdk.git pull/19861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19861`

View PR using the GUI difftool: \
`$ git pr show -t 19861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19861.diff">https://git.openjdk.org/jdk/pull/19861.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19861#issuecomment-2211030538)