### PR TITLE
8334670: SSLSocketOutputRecord buffer miscalculation

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -168,13 +168,12 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
 
             for (int limit = (offset + length); offset < limit;) {
 
-                int remains = (limit - offset) + (count - position);
-                int fragLen = Math.min(fragLimit - count + position,
-                    limit - offset);
+                int remains = (limit - offset);
+                int fragLen = Math.min(fragLimit - count + position, remains);
 
                 // use the buf of ByteArrayOutputStream
                 write(source, offset, fragLen);
-                if (remains < fragLimit) {
+                if (remains < fragLen) {
                     return;
                 }
 

--- a/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLSocketOutputRecord.java
@@ -169,7 +169,8 @@ final class SSLSocketOutputRecord extends OutputRecord implements SSLRecord {
             for (int limit = (offset + length); offset < limit;) {
 
                 int remains = (limit - offset) + (count - position);
-                int fragLen = Math.min(fragLimit, remains);
+                int fragLen = Math.min(fragLimit - count + position,
+                    limit - offset);
 
                 // use the buf of ByteArrayOutputStream
                 write(source, offset, fragLen);


### PR DESCRIPTION
Hi,

I need a review to change the a fragment buffer size miscalculation error.   This appears when there are large handshake messages and hasn't been observed during application data.  This was found during testing of the NewSessionTicket change in [JDK-8328608](https://bugs.openjdk.org/browse/JDK-8328608).  There is no regression test as the failure hasn't shown to fail every time. 

thanks

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334670](https://bugs.openjdk.org/browse/JDK-8334670): SSLSocketOutputRecord buffer miscalculation (**Bug** - P3)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Sibabrata Sahoo](https://openjdk.org/census#ssahoo) (@sisahoo - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19862/head:pull/19862` \
`$ git checkout pull/19862`

Update a local copy of the PR: \
`$ git checkout pull/19862` \
`$ git pull https://git.openjdk.org/jdk.git pull/19862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19862`

View PR using the GUI difftool: \
`$ git pr show -t 19862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19862.diff">https://git.openjdk.org/jdk/pull/19862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19862#issuecomment-2186914298)