### PR TITLE
8334771: [TESTBUG] Run TestDockerMemoryMetrics.java with -Xcomp fails exitValue = 137

### DIFF
--- a/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
+++ b/test/jdk/jdk/internal/platform/docker/MetricsMemoryTester.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ public class MetricsMemoryTester {
             case "softlimit":
                 testMemorySoftLimit(args[1]);
                 break;
+            default:
+                throw new RuntimeException("unknown args: " + args[0] + " for MetricsMemoryTester");
         }
     }
 

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class TestDockerMemoryMetrics {
             }
             testOomKillFlag("100m", true);
 
-            testMemoryFailCount("64m");
+            testMemoryFailCount("128m");
 
             testMemorySoftLimit("500m","200m");
 


### PR DESCRIPTION
Hi all,
  After [JDK-8294960](https://bugs.openjdk.org/browse/JDK-8294960), the footprint memory usage increased significantly when run the testcase with -Xcomp jvm options, then cause the testcase was killed by docker by OOM.
  Maybe the footprint memory usage increased was inevitable, so I think we should increase the smallest memory limite for this testcase.
  Only change the testcase, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8334771](https://bugs.openjdk.org/browse/JDK-8334771): [TESTBUG] Run TestDockerMemoryMetrics.java with -Xcomp fails exitValue = 137 (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19864/head:pull/19864` \
`$ git checkout pull/19864`

Update a local copy of the PR: \
`$ git checkout pull/19864` \
`$ git pull https://git.openjdk.org/jdk.git pull/19864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19864`

View PR using the GUI difftool: \
`$ git pr show -t 19864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19864.diff">https://git.openjdk.org/jdk/pull/19864.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19864#issuecomment-2186953075)