### PR TITLE
8334509: Cancelling PageDialog does not return the same PageFormat object

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PageDialogCancelTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8334366
+ * @key headful printer
+ * @summary Verifies original pageobject is returned unmodified
+ *          on cancelling pagedialog
+ * @requires (os.family == "windows")
+ * @run main PageDialogCancelTest
+ */
+
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.awt.print.PageFormat;
+import java.awt.print.PrinterJob;
+
+public class PageDialogCancelTest {
+
+    public static void main(String[] args) throws Exception {
+        PrinterJob pj = PrinterJob.getPrinterJob();
+        PageFormat oldFormat = new PageFormat();
+        Robot robot = new Robot();
+        Thread t1 = new Thread(() -> {
+            robot.delay(2000);
+            robot.keyPress(KeyEvent.VK_ESCAPE);
+            robot.keyRelease(KeyEvent.VK_ESCAPE);
+            robot.waitForIdle();
+        });
+        t1.start();
+        PageFormat newFormat = pj.pageDialog(oldFormat);
+        if (!newFormat.equals(oldFormat)) {
+            throw new RuntimeException("Original PageFormat not returned on cancelling PageDialog");
+        }
+    }
+}
+


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334509](https://bugs.openjdk.org/browse/JDK-8334509): Cancelling PageDialog does not return the same PageFormat object (**Bug** - P2)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19865/head:pull/19865` \
`$ git checkout pull/19865`

Update a local copy of the PR: \
`$ git checkout pull/19865` \
`$ git pull https://git.openjdk.org/jdk.git pull/19865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19865`

View PR using the GUI difftool: \
`$ git pr show -t 19865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19865.diff">https://git.openjdk.org/jdk/pull/19865.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19865#issuecomment-2186982637)