### PR TITLE
8334598: Default classlist in JDK is not deterministic after JDK-8293980

### DIFF
--- a/make/GenerateLinkOptData.gmk
+++ b/make/GenerateLinkOptData.gmk
@@ -62,14 +62,14 @@ ifeq ($(EXTERNAL_BUILDJDK), true)
   INTERIM_IMAGE_DIR := $(BUILD_JDK)
 endif
 
-# These are needed for deterministic classlist:
+# To make the classlist deterministic:
 # - The classlist can be influenced by locale. Always set it to en/US.
-# - Run with -Xint, as the compiler can speculatively resolve constant pool entries.
-# - ForkJoinPool parallelism can cause constant pool resolution to be non-deterministic.
+# - Concurrency in the core libraries can cause constant pool resolution
+#   to be non-deterministic. Since the benefits of resolved CP references in the
+#   default classlist is minimal, let's filter out the '@cp' lines until we can
+#   find a proper solution.
 CLASSLIST_FILE_VM_OPTS = \
-    -Duser.language=en -Duser.country=US \
-    -Xint \
-    -Djava.util.concurrent.ForkJoinPool.common.parallelism=0
+    -Duser.language=en -Duser.country=US
 
 # Save the stderr output of the command and print it along with stdout in case
 # something goes wrong.
@@ -101,9 +101,10 @@ $(CLASSLIST_FILE): $(INTERIM_IMAGE_DIR)/bin/java$(EXECUTABLE_SUFFIX) $(CLASSLIST
 	        exit $$exitcode \
 	    )
 	$(GREP) -v HelloClasslist $@.raw.2 > $@.raw.3
+	$(GREP) -v @cp $@.raw.3 > $@.raw.4
 	$(FIXPATH) $(INTERIM_IMAGE_DIR)/bin/java \
 	    -cp $(SUPPORT_OUTPUTDIR)/classlist.jar \
-	    build.tools.classlist.SortClasslist $@.raw.3 > $@
+	    build.tools.classlist.SortClasslist $@.raw.4 > $@
 
 # The jli trace is created by the same recipe as classlist. By declaring these
 # dependencies, make will correctly rebuild both jli trace and classlist


### PR DESCRIPTION
More filtering is needed when building the default archive in the JDK: constant pool resolution when running the `build.tools.classlist.HelloClasslist` program is not deterministic (due to concurrency in core library classes). This could cause different values in the `@cp` lines in the classlist file. The benefit of pre-resolved constant pool entries is more visible for custom archives and not so much for the default archive in the JDK, so we disable this optimization for the default CDS archive, until we can find a way to make it deterministic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334598](https://bugs.openjdk.org/browse/JDK-8334598): Default classlist in JDK is not deterministic after JDK-8293980 (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19868/head:pull/19868` \
`$ git checkout pull/19868`

Update a local copy of the PR: \
`$ git checkout pull/19868` \
`$ git pull https://git.openjdk.org/jdk.git pull/19868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19868`

View PR using the GUI difftool: \
`$ git pr show -t 19868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19868.diff">https://git.openjdk.org/jdk/pull/19868.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19868#issuecomment-2187435460)