### PR TITLE
8334779: Test compiler/c1/CanonicalizeArrayLength.java is timing out

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5142,7 +5142,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
     ss.print("verify_oop: %s: %s (%s:%d)", reg->name(), s, file, line);
     b = code_string(ss.as_string());
   }
-  ExternalAddress buffer((address) b);
+  AddressLiteral buffer((address) b, relocInfo::none);
   pushptr(buffer.addr(), rscratch1);
 
   // call indirectly to solve generation ordering problem
@@ -5212,7 +5212,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
     ss.print("verify_oop_addr: %s (%s:%d)", s, file, line);
     b = code_string(ss.as_string());
   }
-  ExternalAddress buffer((address) b);
+  AddressLiteral buffer((address) b, relocInfo::none);
   pushptr(buffer.addr(), rscratch1);
 
   // call indirectly to solve generation ordering problem

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5142,7 +5142,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
     ss.print("verify_oop: %s: %s (%s:%d)", reg->name(), s, file, line);
     b = code_string(ss.as_string());
   }
-  AddressLiteral buffer((address) b, relocInfo::none);
+  AddressLiteral buffer((address) b, external_word_Relocation::spec_for_immediate());
   pushptr(buffer.addr(), rscratch1);
 
   // call indirectly to solve generation ordering problem
@@ -5212,7 +5212,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
     ss.print("verify_oop_addr: %s (%s:%d)", s, file, line);
     b = code_string(ss.as_string());
   }
-  AddressLiteral buffer((address) b, relocInfo::none);
+  AddressLiteral buffer((address) b, external_word_Relocation::spec_for_immediate());
   pushptr(buffer.addr(), rscratch1);
 
   // call indirectly to solve generation ordering problem


### PR DESCRIPTION
The timeout is cause by running the test with `-Xcomp -XX:+VerifyOops -XX:+PatchALot`.
The test continuously deoptimize and recompile `java.lang.Throwable::<init>` method.
`-XX:+VerifyOops ` adds a lot of external addresses because it use ExternallAddress for error messages.
These messages are unique for each call to `verify_oop()` because they are constructed locally.
I reduced number of loop iteration by 10 to get reasonable execution time (2 mins instead of 20 mins) and got next data:
```
Without VerifyOops:
  External addresses table: 38 entries

With VerifyOops:
  External addresses table: 125922 entries
```
Looks like most of the time VM is spending to grow/reallocate big growable array added by [JDK-8333819](https://bugs.openjdk.org/browse/JDK-8333819).
Before that change these addresses were recorded locally in nmethod's relocation info. When nmethod was deoptimized, its relocation info was discarded together with nmethod.

Only on x86 we declared message address as ExternalAddress. Aarch64 uses movptr() to store address as simple pointer. ARM uses own InlineAddress with RelocInfo::none type of relocation. I verified other platforms: none is using ExternalAddress.

I suggest to use AddressLiteral with RelocInfo::none for x86. With that the global table is small even with -XX:+VerifyOops:
```
  External addresses table: 42 entries
```

Tested tier1,  run test with corresponding flags to verify that time is similar to before [JDK-8333819](https://bugs.openjdk.org/browse/JDK-8333819)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334779](https://bugs.openjdk.org/browse/JDK-8334779): Test compiler/c1/CanonicalizeArrayLength.java is timing out (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19871/head:pull/19871` \
`$ git checkout pull/19871`

Update a local copy of the PR: \
`$ git checkout pull/19871` \
`$ git pull https://git.openjdk.org/jdk.git pull/19871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19871`

View PR using the GUI difftool: \
`$ git pr show -t 19871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19871.diff">https://git.openjdk.org/jdk/pull/19871.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19871#issuecomment-2187641955)