### PR TITLE
8334899: Test runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java failed after JDK-8306580

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
@@ -69,7 +69,7 @@ public class ExceptionDuringDumpAtObjectsInitPhase {
                         "-Dtest.with.exception=true",
                         gcLog).shouldNotHaveExitValue(0)
                               .shouldContain("Preload Warning: Cannot find jdk/internal/math/FDBigInteger")
-                              .shouldContain("VM exits due to exception, use -Xlog:cds,exceptions=trace for detail");
+                              .shouldContain("Unexpected exception, use -Xlog:cds,exceptions=trace for detail");
 
         // 2. Test with OOM
         System.out.println("2. OOM during dump");


### PR DESCRIPTION
JDK-8306580 changed the text of an error message to better fit the changes introduced by the patch. The test `ExceptionDuringDumpAtObjectsInitPhase.java` expects the old message and thus fails after the change. This patch alters the expected output what is now being generated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334899](https://bugs.openjdk.org/browse/JDK-8334899): Test runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java failed after JDK-8306580 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19873/head:pull/19873` \
`$ git checkout pull/19873`

Update a local copy of the PR: \
`$ git checkout pull/19873` \
`$ git pull https://git.openjdk.org/jdk.git pull/19873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19873`

View PR using the GUI difftool: \
`$ git pr show -t 19873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19873.diff">https://git.openjdk.org/jdk/pull/19873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19873#issuecomment-2187947369)