### PR TITLE
8334580: Deprecate no-arg constructor BasicSliderUI() for removal

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSliderUI.java
@@ -150,7 +150,10 @@ public class BasicSliderUI extends SliderUI{
 
     /**
      * Constructs a {@code BasicSliderUI}.
+     * @deprecated This constructor was exposed erroneously and will be removed in a future release.
+     *             Use {@link #BasicSliderUI(JSlider)} instead.
      */
+    @Deprecated(since = "23", forRemoval = true)
     public BasicSliderUI() {}
 
     /**


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8334677](https://bugs.openjdk.org/browse/JDK-8334677) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8334580](https://bugs.openjdk.org/browse/JDK-8334580): Deprecate no-arg constructor BasicSliderUI() for removal (**Bug** - P2)
 * [JDK-8334677](https://bugs.openjdk.org/browse/JDK-8334677): Deprecate no-arg constructor BasicSliderUI() for removal (**CSR**)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19874/head:pull/19874` \
`$ git checkout pull/19874`

Update a local copy of the PR: \
`$ git checkout pull/19874` \
`$ git pull https://git.openjdk.org/jdk.git pull/19874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19874`

View PR using the GUI difftool: \
`$ git pr show -t 19874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19874.diff">https://git.openjdk.org/jdk/pull/19874.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19874#issuecomment-2187913796)