### PR TITLE
8334907: Test ExceptionDuringDumpAtObjectsInitPhase.java fail to initialize archive heap

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class ExceptionDuringDumpAtObjectsInitPhase {
                         "-Dtest.with.exception=true",
                         gcLog).shouldNotHaveExitValue(0)
                               .shouldContain("Preload Warning: Cannot find jdk/internal/math/FDBigInteger")
-                              .shouldContain("VM exits due to exception, use -Xlog:cds,exceptions=trace for detail");
+                              .shouldContain("Unexpected exception, use -Xlog:cds,exceptions=trace for detail");
 
         // 2. Test with OOM
         System.out.println("2. OOM during dump");


### PR DESCRIPTION
Hi all,
Test runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java fails after [JDK-8306580](https://bugs.openjdk.org/browse/JDK-8306580). The PR in [JDK-8306580](https://bugs.openjdk.org/browse/JDK-8306580) change behavior from `exits the VM` to `MetaspaceShared::writing_error() to report errors without exiting the VM`. So we need to change this testcase to adopt the behavior change.
Only change the testcase, the change has been verified locally, no risk.