### PR TITLE
8335006: C2 SuperWord: add JMH benchmark VectorLoadToStoreForwarding.java

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
@@ -47,7 +47,7 @@ public abstract class VectorLoadToStoreForwarding {
     @Setup
     public void init() {
         aI = new int[SIZE];
-        
+
         for (int i = 0; i < SIZE; i++) {
             aI[i] = r.nextInt();
         }

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1)
+public abstract class VectorLoadToStoreForwarding {
+    @Param({"2048"})
+    public int SIZE;
+
+    private int[] aI;
+
+    @Param("0")
+    private int seed;
+    private Random r = new Random(seed);
+
+    @Setup
+    public void init() {
+        aI = new int[SIZE];
+        
+        for (int i = 0; i < SIZE; i++) {
+            aI[i] = r.nextInt();
+        }
+    }
+
+    @Benchmark
+    public void benchmark_00() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 0] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_01() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 1] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_02() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 2] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_03() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 3] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_04() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 4] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_05() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 5] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_06() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 6] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_07() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 7] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_08() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 8] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_09() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 9] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_10() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 10] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_11() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 11] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_12() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 12] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_13() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 13] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_14() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 14] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_15() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 15] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_16() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 16] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_17() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 17] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_18() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 18] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_19() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 19] + 1;
+        }
+    }
+
+    @Benchmark
+    public void benchmark_20() {
+        for (int i = 20; i < SIZE; i++) {
+            aI[i] = aI[i - 20] + 1;
+        }
+    }
+
+    @Fork(value = 1, jvmArgsPrepend = {
+        "-XX:+UseSuperWord"
+    })
+    public static class VectorLoadToStoreForwardingSuperWord extends VectorLoadToStoreForwarding {}
+
+    @Fork(value = 1, jvmArgsPrepend = {
+        "-XX:-UseSuperWord"
+    })
+    public static class VectorLoadToStoreForwardingNoSuperWord extends VectorLoadToStoreForwarding {}
+}


### PR DESCRIPTION
I'm committing the benchmark mentioned in my blog article:
https://eme64.github.io/blog/2024/06/24/Auto-Vectorization-and-Store-to-Load-Forwarding.html

These are the numbers I got on my machine. Read the blog for a full analysis.
![image](https://github.com/openjdk/jdk/assets/32593061/28ba310d-1f7e-4c5c-ae0e-1f38e6214603)

**Quick summary:**
We see that vectorization is only beneficial for `OFFSET = 0, 1, 2, 4, 8, 16`, at least with the current SuperWord implementation. The regression for `OFFSET = 3 `is especially stark.

The effect that explains the slowdown of vectorization for the other cases is failed store-to-load-forwarding.

I ran it like this on my machine:
`make test TEST="micro:vm.compiler.VectorLoadToStoreForwarding" CONF=linux-x64`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335006](https://bugs.openjdk.org/browse/JDK-8335006): C2 SuperWord: add JMH benchmark VectorLoadToStoreForwarding.java (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19880/head:pull/19880` \
`$ git checkout pull/19880`

Update a local copy of the PR: \
`$ git checkout pull/19880` \
`$ git pull https://git.openjdk.org/jdk.git pull/19880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19880`

View PR using the GUI difftool: \
`$ git pr show -t 19880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19880.diff">https://git.openjdk.org/jdk/pull/19880.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19880#issuecomment-2188893412)