### PR TITLE
JDK-8335007: Inline OopMapCache table

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.cpp
+++ b/src/hotspot/share/interpreter/oopMapCache.cpp
@@ -445,17 +445,13 @@ inline unsigned int OopMapCache::hash_value_for(const methodHandle& method, int 
 OopMapCacheEntry* volatile OopMapCache::_old_entries = nullptr;
 
 OopMapCache::OopMapCache() {
-  _array  = NEW_C_HEAP_ARRAY(OopMapCacheEntry*, _size, mtClass);
   for(int i = 0; i < _size; i++) _array[i] = nullptr;
 }
 
 
 OopMapCache::~OopMapCache() {
-  assert(_array != nullptr, "sanity check");
   // Deallocate oop maps that are allocated out-of-line
   flush();
-  // Deallocate array
-  FREE_C_HEAP_ARRAY(OopMapCacheEntry*, _array);
 }
 
 OopMapCacheEntry* OopMapCache::entry_at(int i) const {

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -156,7 +156,7 @@ class OopMapCache : public CHeapObj<mtClass> {
          _probe_depth = 3       // probe depth in case of collisions
   };
 
-  OopMapCacheEntry* volatile * _array;
+  OopMapCacheEntry* volatile _array[_size];
 
   unsigned int hash_value_for(const methodHandle& method, int bci) const;
   OopMapCacheEntry* entry_at(int i) const;


### PR DESCRIPTION
OopMapCache uses a (closed hashing) table. The table is C-heap allocated. OopMapCache itself is also C-heap allocated. Since table size is fixed, we can just inline the table to OopMapCache and save one unnecessary pointer-hop on lookup. 