### PR TITLE
8333308: javap --system handling doesn't work on internal class names

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -867,7 +867,7 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             if (moduleLocation != null) {
                 fo = fileManager.getJavaFileForInput(moduleLocation, className, JavaFileObject.Kind.CLASS);
             } else {
-                if (className.indexOf('.') > 0) {
+                if (className.indexOf('.') > 0 || className.indexOf('/') > 0) {
                     //search for classes with a named package in the JDK modules specifed by --system option first
                     try {
                         for (Set<Location> locations: fileManager.listLocationsForModules(StandardLocation.SYSTEM_MODULES)) {


### PR DESCRIPTION
Hi all, 

This PR addresses [JDK-8333308](https://bugs.openjdk.org/browse/JDK-8333308) enabling `javap -system` to handle internal class names. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8333308: javap --system handling doesn't work on internal class names`

### Issue
 * [JDK-8333308](https://bugs.openjdk.org/browse/JDK-8333308): javap --system handling doesn't work on internal class names (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19883/head:pull/19883` \
`$ git checkout pull/19883`

Update a local copy of the PR: \
`$ git checkout pull/19883` \
`$ git pull https://git.openjdk.org/jdk.git pull/19883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19883`

View PR using the GUI difftool: \
`$ git pr show -t 19883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19883.diff">https://git.openjdk.org/jdk/pull/19883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19883#issuecomment-2189323985)