### PR TITLE
8333363: ubsan: instanceKlass.cpp: runtime error: member call on null pointer of type 'struct AnnotationArray'

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3560,9 +3560,7 @@ void InstanceKlass::print_on(outputStream* st) const {
       }
     }
   }
-  if (default_vtable_indices() != nullptr) {
-    st->print(BULLET"default vtable indices:   "); default_vtable_indices()->print_value_on(st);       st->cr();
-  }
+  print_on_maybe_null(st, BULLET"default vtable indices:   ", default_vtable_indices());
   st->print(BULLET"local interfaces:  "); local_interfaces()->print_value_on(st);      st->cr();
   st->print(BULLET"trans. interfaces: "); transitive_interfaces()->print_value_on(st); st->cr();
 
@@ -3589,41 +3587,18 @@ void InstanceKlass::print_on(outputStream* st) const {
     }
   }
   st->print(BULLET"constants:         "); constants()->print_value_on(st);         st->cr();
-  if (class_loader_data() != nullptr) {
-    st->print(BULLET"class loader data:  ");
-    class_loader_data()->print_value_on(st);
-    st->cr();
-  }
-  if (source_file_name() != nullptr) {
-    st->print(BULLET"source file:       ");
-    source_file_name()->print_value_on(st);
-    st->cr();
-  }
+
+  print_on_maybe_null(st, BULLET"class loader data:  ", class_loader_data());
+  print_on_maybe_null(st, BULLET"source file:       ", source_file_name());
   if (source_debug_extension() != nullptr) {
     st->print(BULLET"source debug extension:       ");
     st->print("%s", source_debug_extension());
     st->cr();
   }
-  if (class_annotations() != nullptr) {
-    st->print(BULLET"class annotations:       ");
-    class_annotations()->print_value_on(st);
-    st->cr();
-  }
-  if (class_type_annotations() != nullptr) {
-    st->print(BULLET"class type annotations:  ");
-    class_type_annotations()->print_value_on(st);
-    st->cr();
-  }
-  if (fields_annotations() != nullptr) {
-    st->print(BULLET"field annotations:       ");
-    fields_annotations()->print_value_on(st);
-    st->cr();
-  }
-  if (fields_type_annotations() != nullptr) {
-    st->print(BULLET"field type annotations:  ");
-    fields_type_annotations()->print_value_on(st);
-    st->cr();
-  }
+  print_on_maybe_null(st, BULLET"class annotations:       ", class_annotations());
+  print_on_maybe_null(st, BULLET"class type annotations:  ", class_type_annotations());
+  print_on_maybe_null(st, BULLET"field annotations:  ", fields_annotations());
+  print_on_maybe_null(st, BULLET"field type annotations:  ", fields_type_annotations());
   {
     bool have_pv = false;
     // previous versions are linked together through the InstanceKlass
@@ -3638,16 +3613,10 @@ void InstanceKlass::print_on(outputStream* st) const {
     if (have_pv) st->cr();
   }
 
-  if (generic_signature() != nullptr) {
-    st->print(BULLET"generic signature: ");
-    generic_signature()->print_value_on(st);
-    st->cr();
-  }
+  print_on_maybe_null(st, BULLET"generic signature: ", generic_signature());
   st->print(BULLET"inner classes:     "); inner_classes()->print_value_on(st);     st->cr();
   st->print(BULLET"nest members:     "); nest_members()->print_value_on(st);     st->cr();
-  if (record_components() != nullptr) {
-    st->print(BULLET"record components:     "); record_components()->print_value_on(st);     st->cr();
-  }
+  print_on_maybe_null(st, BULLET"record components:     ", record_components());
   st->print(BULLET"permitted subclasses:     "); permitted_subclasses()->print_value_on(st);     st->cr();
   if (java_mirror() != nullptr) {
     st->print(BULLET"java mirror:       ");

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3597,7 +3597,7 @@ void InstanceKlass::print_on(outputStream* st) const {
   }
   print_on_maybe_null(st, BULLET"class annotations:       ", class_annotations());
   print_on_maybe_null(st, BULLET"class type annotations:  ", class_type_annotations());
-  print_on_maybe_null(st, BULLET"field annotations:  ", fields_annotations());
+  print_on_maybe_null(st, BULLET"field annotations:       ", fields_annotations());
   print_on_maybe_null(st, BULLET"field type annotations:  ", fields_type_annotations());
   {
     bool have_pv = false;

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -3604,10 +3604,26 @@ void InstanceKlass::print_on(outputStream* st) const {
     st->print("%s", source_debug_extension());
     st->cr();
   }
-  st->print(BULLET"class annotations:       "); class_annotations()->print_value_on(st); st->cr();
-  st->print(BULLET"class type annotations:  "); class_type_annotations()->print_value_on(st); st->cr();
-  st->print(BULLET"field annotations:       "); fields_annotations()->print_value_on(st); st->cr();
-  st->print(BULLET"field type annotations:  "); fields_type_annotations()->print_value_on(st); st->cr();
+  if (class_annotations() != nullptr) {
+    st->print(BULLET"class annotations:       ");
+    class_annotations()->print_value_on(st);
+    st->cr();
+  }
+  if (class_type_annotations() != nullptr) {
+    st->print(BULLET"class type annotations:  ");
+    class_type_annotations()->print_value_on(st);
+    st->cr();
+  }
+  if (fields_annotations() != nullptr) {
+    st->print(BULLET"field annotations:       ");
+    fields_annotations()->print_value_on(st);
+    st->cr();
+  }
+  if (fields_type_annotations() != nullptr) {
+    st->print(BULLET"field type annotations:  ");
+    fields_type_annotations()->print_value_on(st);
+    st->cr();
+  }
   {
     bool have_pv = false;
     // previous versions are linked together through the InstanceKlass

--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -76,4 +76,13 @@ class Metadata : public MetaspaceObj {
   static void mark_on_stack(Metadata* m) { m->set_on_stack(true); }
 };
 
+template <typename M>
+static void print_on_maybe_null(outputStream* st, const char* str, const M* m) {
+  if (nullptr != m) {
+    st->print_raw(str);
+    m->print_value_on(st);
+    st->cr();
+  }
+}
+
 #endif // SHARE_OOPS_METADATA_HPP


### PR DESCRIPTION
With ubsan enabled binaries we run on Linux aarch64 and Linux x86_64 into this issue :

runtime/CommandLine/PrintClasses_id0.jtr

src/hotspot/share/oops/instanceKlass.cpp:3603:84: runtime error: member call on null pointer of type 'struct AnnotationArray'
    #0 0xfffface09b40 in InstanceKlass::print_on(outputStream*) const src/hotspot/share/oops/instanceKlass.cpp:3603
    #1 0xffffacdcd088 in PrintClassClosure::do_klass(Klass*) src/hotspot/share/oops/instanceKlass.cpp:2228
    #2 0xffffac464200 in ClassLoaderData::classes_do(KlassClosure*) src/hotspot/share/classfile/classLoaderData.cpp:387
    #3 0xffffac475c4c in ClassLoaderDataGraph::classes_do(KlassClosure*) src/hotspot/share/classfile/classLoaderDataGraph.cpp:303
    #4 0xffffac7bc4f4 in VM_PrintClasses::doit() src/hotspot/share/services/diagnosticCommand.cpp:989
    #5 0xffffae599c88 in VM_Operation::evaluate() src/hotspot/share/runtime/vmOperations.cpp:75
    #6 0xffffae5a5a14 in VMThread::evaluate_operation(VM_Operation*) src/hotspot/share/runtime/vmThread.cpp:283
    #7 0xffffae5a779c in VMThread::inner_execute(VM_Operation*) src/hotspot/share/runtime/vmThread.cpp:427
    #8 0xffffae5a7fd8 in VMThread::loop() src/hotspot/share/runtime/vmThread.cpp:493
    #9 0xffffae5a80bc in VMThread::run() src/hotspot/share/runtime/vmThread.cpp:177
    #10 0xffffae396958 in Thread::call_run() src/hotspot/share/runtime/thread.cpp:225
    #11 0xffffadba1b0c in thread_native_entry src/hotspot/os/linux/os_linux.cpp:846
    #12 0xffffb1a9d5c4 (/lib/aarch64-linux-gnu/libc.so.6+0x7d5c4)
    #13 0xffffb1b05ed8 (/lib/aarch64-linux-gnu/libc.so.6+0xe5ed8)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333363](https://bugs.openjdk.org/browse/JDK-8333363): ubsan: instanceKlass.cpp: runtime error: member call on null pointer of type 'struct AnnotationArray' (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19885/head:pull/19885` \
`$ git checkout pull/19885`

Update a local copy of the PR: \
`$ git checkout pull/19885` \
`$ git pull https://git.openjdk.org/jdk.git pull/19885/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19885`

View PR using the GUI difftool: \
`$ git pr show -t 19885`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19885.diff">https://git.openjdk.org/jdk/pull/19885.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19885#issuecomment-2189206072)