### PR TITLE
JDK-8334217 : [AIX] Misleading error messages after JDK-8320005

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1051,7 +1051,6 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   result = dll_load_library(filename, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  printf("Ebuf :%s\n",ebuf);
   if (strstr(ebuf, "No such file or directory") != nullptr && result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -113,7 +113,6 @@
 #error Hotspot on AIX must be compiled with -D_LARGE_FILES
 #endif
 
-#define ERROR_NO_SUCH_FILE "No such file or directory"
 // Missing prototypes for various system APIs.
 extern "C"
 int mread_real_time(timebasestruct_t *t, size_t size_of_timebasestruct_t);
@@ -989,7 +988,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
   return true;
 }
 
-static void* dll_load_library(const char *filename, int *errno, char *ebuf, int ebuflen) {
+static void* dll_load_library(const char *filename, int *eno, char *ebuf, int ebuflen) {
 
   log_info(os)("attempting shared library load of %s", filename);
   if (ebuf && ebuflen > 0) {
@@ -1017,7 +1016,7 @@ static void* dll_load_library(const char *filename, int *errno, char *ebuf, int 
   void* result;
   const char* error_report = nullptr;
   JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = Aix_dlopen(filename, errno, dflags, &error_report);
+  result = Aix_dlopen(filename, eno, dflags, &error_report);
   if (result != nullptr) {
     Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1051,7 +1051,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   result = dll_load_library(filename, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (strstr(ebuf, "No such file or directory") != nullptr && result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  if (result == nullptr && strstr(ebuf, "No such file or directory") != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1016,7 +1016,7 @@ static void* dll_load_library(const char *filename, int *eno, char *ebuf, int eb
   void* result;
   const char* error_report = nullptr;
   JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = Aix_dlopen(filename, eno, dflags, &error_report);
+  result = Aix_dlopen(filename, dlfags, eno, &error_report);
   if (result != nullptr) {
     Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1051,7 +1051,8 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   result = dll_load_library(filename, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  printf("Ebuf :%s\n",ebuf);
+  if (strstr(ebuf, "No such file or directory") != nullptr && result == nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -989,7 +989,7 @@ bool os::dll_address_to_library_name(address addr, char* buf,
   return true;
 }
 
-static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
+static void* dll_load_library(const char *filename, int *errno, char *ebuf, int ebuflen) {
 
   log_info(os)("attempting shared library load of %s", filename);
   if (ebuf && ebuflen > 0) {
@@ -1017,7 +1017,7 @@ static void* dll_load_library(const char *filename, char *ebuf, int ebuflen) {
   void* result;
   const char* error_report = nullptr;
   JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = Aix_dlopen(filename, dflags, &error_report);
+  result = Aix_dlopen(filename, errno, dflags, &error_report);
   if (result != nullptr) {
     Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.
@@ -1049,12 +1049,13 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   const char new_extension[] = ".a";
   STATIC_ASSERT(sizeof(old_extension) >= sizeof(new_extension));
   // First try to load the existing file.
-  result = dll_load_library(filename, ebuf, ebuflen);
+  int errno=0;
+  result = dll_load_library(filename, &errno, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (result == nullptr && strstr(ebuf, ERROR_NO_SUCH_FILE) != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  if (result == nullptr && err_no==ENOENT != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
-    result = dll_load_library(file_path, ebuf, ebuflen);
+    result = dll_load_library(file_path, &errno, ebuf, ebuflen);
   }
   FREE_C_HEAP_ARRAY(char, file_path);
   return result;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1054,7 +1054,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
   if (result == nullptr && eno == ENOENT && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
-    result = dll_load_library(file_path, &errno, ebuf, ebuflen);
+    result = dll_load_library(file_path, &eno, ebuf, ebuflen);
   }
   FREE_C_HEAP_ARRAY(char, file_path);
   return result;

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1049,11 +1049,11 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   const char new_extension[] = ".a";
   STATIC_ASSERT(sizeof(old_extension) >= sizeof(new_extension));
   // First try to load the existing file.
-  int errno=0;
-  result = dll_load_library(filename, &errno, ebuf, ebuflen);
+  int eno=0;
+  result = dll_load_library(filename, &eno, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (result == nullptr && err_no==ENOENT != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  if (result == nullptr && eno == ENOENT && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, &errno, ebuf, ebuflen);
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -113,6 +113,7 @@
 #error Hotspot on AIX must be compiled with -D_LARGE_FILES
 #endif
 
+#define ERROR_NO_SUCH_FILE "No such file or directory"
 // Missing prototypes for various system APIs.
 extern "C"
 int mread_real_time(timebasestruct_t *t, size_t size_of_timebasestruct_t);
@@ -1051,7 +1052,7 @@ void *os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   result = dll_load_library(filename, ebuf, ebuflen);
   // If the load fails,we try to reload by changing the extension to .a for .so files only.
   // Shared object in .so format dont have braces, hence they get removed for archives with members.
-  if (result == nullptr && strstr(ebuf, "No such file or directory") != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
+  if (result == nullptr && strstr(ebuf, ERROR_NO_SUCH_FILE) != nullptr && pointer_to_dot != nullptr && strcmp(pointer_to_dot, old_extension) == 0) {
     snprintf(pointer_to_dot, sizeof(old_extension), "%s", new_extension);
     result = dll_load_library(file_path, ebuf, ebuflen);
   }

--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1016,7 +1016,7 @@ static void* dll_load_library(const char *filename, int *eno, char *ebuf, int eb
   void* result;
   const char* error_report = nullptr;
   JFR_ONLY(NativeLibraryLoadEvent load_event(filename, &result);)
-  result = Aix_dlopen(filename, dlfags, eno, &error_report);
+  result = Aix_dlopen(filename, dflags, eno, &error_report);
   if (result != nullptr) {
     Events::log_dll_message(nullptr, "Loaded shared library %s", filename);
     // Reload dll cache. Don't do this in signal handling.

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1035,7 +1035,7 @@ static bool search_file_in_LIBPATH(const char* path, struct stat64x* stat) {
 // specific AIX versions for ::dlopen() and ::dlclose(), which handles the struct g_handletable
 // This way we mimic dl handle equality for a library
 // opened a second time, as it is implemented on other platforms.
-void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
+void* Aix_dlopen(const char* filename, int *errno, int Flags, const char** error_report) {
   assert(error_report != nullptr, "error_report is nullptr");
   void* result;
   struct stat64x libstat;
@@ -1047,6 +1047,7 @@ void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
     assert(result == nullptr, "dll_load: Could not stat() file %s, but dlopen() worked; Have to improve stat()", filename);
   #endif
     *error_report = "Could not load module .\nSystem error: No such file or directory";
+    *errno = ENOENT;
     return nullptr;
   }
   else {
@@ -1090,6 +1091,7 @@ void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
         p_handletable = new_tab;
       }
       // Library not yet loaded; load it, then store its handle in handle table
+      err_no = 0
       result = ::dlopen(filename, Flags);
       if (result != nullptr) {
         g_handletable_used++;
@@ -1101,6 +1103,7 @@ void* Aix_dlopen(const char* filename, int Flags, const char** error_report) {
       }
       else {
         // error analysis when dlopen fails
+        *errno = err_no;
         *error_report = ::dlerror();
         if (*error_report == nullptr) {
           *error_report = "dlerror returned no error description";

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1091,7 +1091,7 @@ void* Aix_dlopen(const char* filename, int *eno, int Flags, const char** error_r
         p_handletable = new_tab;
       }
       // Library not yet loaded; load it, then store its handle in handle table
-      errno = 0
+      errno = 0;
       result = ::dlopen(filename, Flags);
       if (result != nullptr) {
         g_handletable_used++;

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1035,7 +1035,7 @@ static bool search_file_in_LIBPATH(const char* path, struct stat64x* stat) {
 // specific AIX versions for ::dlopen() and ::dlclose(), which handles the struct g_handletable
 // This way we mimic dl handle equality for a library
 // opened a second time, as it is implemented on other platforms.
-void* Aix_dlopen(const char* filename, int *eno, int Flags, const char** error_report) {
+void* Aix_dlopen(const char* filename,int Flags, int *eno, const char** error_report) {
   assert(error_report != nullptr, "error_report is nullptr");
   void* result;
   struct stat64x libstat;

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1035,7 +1035,7 @@ static bool search_file_in_LIBPATH(const char* path, struct stat64x* stat) {
 // specific AIX versions for ::dlopen() and ::dlclose(), which handles the struct g_handletable
 // This way we mimic dl handle equality for a library
 // opened a second time, as it is implemented on other platforms.
-void* Aix_dlopen(const char* filename, int *errno, int Flags, const char** error_report) {
+void* Aix_dlopen(const char* filename, int *eno, int Flags, const char** error_report) {
   assert(error_report != nullptr, "error_report is nullptr");
   void* result;
   struct stat64x libstat;
@@ -1047,7 +1047,7 @@ void* Aix_dlopen(const char* filename, int *errno, int Flags, const char** error
     assert(result == nullptr, "dll_load: Could not stat() file %s, but dlopen() worked; Have to improve stat()", filename);
   #endif
     *error_report = "Could not load module .\nSystem error: No such file or directory";
-    *errno = ENOENT;
+    *eno = ENOENT;
     return nullptr;
   }
   else {
@@ -1091,7 +1091,7 @@ void* Aix_dlopen(const char* filename, int *errno, int Flags, const char** error
         p_handletable = new_tab;
       }
       // Library not yet loaded; load it, then store its handle in handle table
-      err_no = 0
+      errno = 0
       result = ::dlopen(filename, Flags);
       if (result != nullptr) {
         g_handletable_used++;
@@ -1103,7 +1103,7 @@ void* Aix_dlopen(const char* filename, int *errno, int Flags, const char** error
       }
       else {
         // error analysis when dlopen fails
-        *errno = err_no;
+        *eno = errno;
         *error_report = ::dlerror();
         if (*error_report == nullptr) {
           *error_report = "dlerror returned no error description";

--- a/src/hotspot/os/aix/porting_aix.cpp
+++ b/src/hotspot/os/aix/porting_aix.cpp
@@ -1035,7 +1035,7 @@ static bool search_file_in_LIBPATH(const char* path, struct stat64x* stat) {
 // specific AIX versions for ::dlopen() and ::dlclose(), which handles the struct g_handletable
 // This way we mimic dl handle equality for a library
 // opened a second time, as it is implemented on other platforms.
-void* Aix_dlopen(const char* filename,int Flags, int *eno, const char** error_report) {
+void* Aix_dlopen(const char* filename, int Flags, int *eno, const char** error_report) {
   assert(error_report != nullptr, "error_report is nullptr");
   void* result;
   struct stat64x libstat;

--- a/src/hotspot/os/aix/porting_aix.hpp
+++ b/src/hotspot/os/aix/porting_aix.hpp
@@ -115,6 +115,6 @@ class AixMisc {
 
 };
 
-void* Aix_dlopen(const char* filename, int *eno, int Flags, const char** error_report);
+void* Aix_dlopen(const char* filename, int Flags, int *eno, const char** error_report);
 
 #endif // OS_AIX_PORTING_AIX_HPP

--- a/src/hotspot/os/aix/porting_aix.hpp
+++ b/src/hotspot/os/aix/porting_aix.hpp
@@ -115,6 +115,6 @@ class AixMisc {
 
 };
 
-void* Aix_dlopen(const char* filename, int Flags, const char** error_report);
+void* Aix_dlopen(const char* filename, int *eno, int Flags, const char** error_report);
 
 #endif // OS_AIX_PORTING_AIX_HPP


### PR DESCRIPTION
dll_load_library() call fails is not analyzed (the ebuf content is ignored)
dll_load_library does not analyze the contents of ebuf which leads to misleading error message when library loading fails.

We now call  the second dll_load_library() only if the first returns with a 'No such file or directory' error message.
If the first dll_load_library() found the library is not able to load it by any reason, we do not try again with a .a extension.
[JDK-8334217](https://bugs.openjdk.org/browse/JDK-8334217)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334217](https://bugs.openjdk.org/browse/JDK-8334217): [AIX] Misleading error messages after JDK-8320005 (**Bug** - P4)


### Reviewers
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19887/head:pull/19887` \
`$ git checkout pull/19887`

Update a local copy of the PR: \
`$ git checkout pull/19887` \
`$ git pull https://git.openjdk.org/jdk.git pull/19887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19887`

View PR using the GUI difftool: \
`$ git pr show -t 19887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19887.diff">https://git.openjdk.org/jdk/pull/19887.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19887#issuecomment-2190970904)