### PR TITLE
8333716: Shenandoah: Check for disarmed method before taking the nmethod lock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahBarrierSetNMethod.cpp
@@ -36,13 +36,19 @@
 #include "runtime/threadWXSetters.inline.hpp"
 
 bool ShenandoahBarrierSetNMethod::nmethod_entry_barrier(nmethod* nm) {
+  if (!is_armed(nm)) {
+    // Some other thread got here first and healed the oops
+    // and disarmed the nmethod. No need to continue.
+    return true;
+  }
+
   ShenandoahReentrantLock* lock = ShenandoahNMethod::lock_for_nmethod(nm);
   assert(lock != nullptr, "Must be");
   ShenandoahReentrantLocker locker(lock);
 
   if (!is_armed(nm)) {
-    // Some other thread got here first and healed the oops
-    // and disarmed the nmethod.
+    // Some other thread managed to complete while we were
+    // waiting for lock. No need to continue.
     return true;
   }
 


### PR DESCRIPTION
This pull request contains a backport of commit [18e7d7b5](https://github.com/openjdk/jdk/commit/18e7d7b5e710b24e49b995777906a197e35795e6) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333716](https://bugs.openjdk.org/browse/JDK-8333716): Shenandoah: Check for disarmed method before taking the nmethod lock (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19888/head:pull/19888` \
`$ git checkout pull/19888`

Update a local copy of the PR: \
`$ git checkout pull/19888` \
`$ git pull https://git.openjdk.org/jdk.git pull/19888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19888`

View PR using the GUI difftool: \
`$ git pr show -t 19888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19888.diff">https://git.openjdk.org/jdk/pull/19888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19888#issuecomment-2189449877)