### PR TITLE
8335110: Fix instruction name and API spec inconsistencies in CodeBuilder

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -857,9 +857,9 @@ public sealed interface CodeBuilder
     }
 
     /**
-     * Generate an instruction to load a reference from a local variable.
+     * Generate an instruction to load a reference from a local variable
      *
-     * <p>This factory may also generate {@code aload_<N>} and
+     * <p>This may also generate {@code aload_<N>} and
      * {@code wide aload} instructions.
      *
      * @param slot the local variable slot
@@ -907,7 +907,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to store a reference into a local variable
      *
-     * <p>This factory may also generate {@code astore_<N>} and
+     * <p>This may also generate {@code astore_<N>} and
      * {@code wide astore} instructions.
      *
      * @param slot the local variable slot
@@ -1076,7 +1076,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to load a double from a local variable
      *
-     * <p>This factory may also generate {@code dload_<N>} and
+     * <p>This may also generate {@code dload_<N>} and
      * {@code wide dload} instructions.
      *
      * @param slot the local variable slot
@@ -1121,7 +1121,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to store a double into a local variable
      *
-     * <p>This factory may also generate {@code dstore_<N>} and
+     * <p>This may also generate {@code dstore_<N>} and
      * {@code wide dstore} instructions.
      *
      * @param slot the local variable slot
@@ -1288,7 +1288,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to load a float from a local variable
      *
-     * <p>This factory may also generate {@code fload_<N>} and
+     * <p>This may also generate {@code fload_<N>} and
      * {@code wide fload} instructions.
      *
      * @param slot the local variable slot
@@ -1333,7 +1333,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to store a float into a local variable
      *
-     * <p>This factory may also generate {@code fstore_<N>} and
+     * <p>This may also generate {@code fstore_<N>} and
      * {@code wide fstore} instructions.
      *
      * @param slot the local variable slot
@@ -1396,8 +1396,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to branch always
      *
-     * <p>This factory may also generate {@code goto_w} instructions if the offset
-     * to target cannot be encoded in a signed 2-byte integer, if the {@link
+     * <p>This may also generate {@code goto_w} instructions if the {@link
      * ClassFile.ShortJumpsOption#FIX_SHORT_JUMPS FIX_SHORT_JUMPS} option
      * is set.
      *
@@ -1722,7 +1721,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to load an int from a local variable
      *
-     * <p>This factory may also generate {@code iload_<N>} and
+     * <p>This may also generate {@code iload_<N>} and
      * {@code wide iload} instructions.
      *
      * @param slot the local variable slot
@@ -1980,7 +1979,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to store an int into a local variable
      *
-     * <p>This factory may also generate {@code istore_<N>} and
+     * <p>This may also generate {@code istore_<N>} and
      * {@code wide istore} instructions.
      *
      * @param slot the local variable slot
@@ -2107,7 +2106,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction pushing an item from the run-time constant pool onto the operand stack
      *
-     * <p>This factory may also generate {@code ldc_w} and {@code ldc2_w} instructions.
+     * <p>This may also generate {@code ldc_w} and {@code ldc2_w} instructions.
      *
      * @apiNote {@link #loadConstant(ConstantDesc) loadConstant} generates more optimal instructions
      * and should be used for general constants if an {@code ldc} instruction is not strictly required.
@@ -2122,7 +2121,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction pushing an item from the run-time constant pool onto the operand stack
      *
-     * <p>This factory may also generate {@code ldc_w} and {@code ldc2_w} instructions.
+     * <p>This may also generate {@code ldc_w} and {@code ldc2_w} instructions.
      *
      * @param entry the constant value
      * @return this builder
@@ -2145,7 +2144,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to load a long from a local variable
      *
-     * <p>This factory may also generate {@code lload_<N>} and
+     * <p>This may also generate {@code lload_<N>} and
      * {@code wide lload} instructions.
      *
      * @param slot the local variable slot
@@ -2214,7 +2213,7 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction to store a long into a local variable
      *
-     * <p>This factory may also generate {@code lstore_<N>} and
+     * <p>This may also generate {@code lstore_<N>} and
      * {@code wide lstore} instructions.
      *
      * @param slot the local variable slot

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -114,8 +114,8 @@ import jdk.internal.javac.PreviewFeature;
  * instanceOf}, {@link #new_ new_}, and {@link #return_() return_} respectively,
  * due to clashes with keywords in the Java programming language.
  * <li>Factories are not provided for instructions {@code jsr}, {@code jsr_w},
- * and {@code ret}, which cannot appear in class files with major version
- * {@value ClassFile#JAVA_7_VERSION} or higher. (JVMS {@jvms 4.9.1})
+ * {@code ret}, and {@code wide ret}, which cannot appear in class files with
+ * major version {@value ClassFile#JAVA_7_VERSION} or higher. (JVMS {@jvms 4.9.1})
  * </ul>
  *
  * @see CodeTransform
@@ -857,7 +857,11 @@ public sealed interface CodeBuilder
     }
 
     /**
-     * Generate an instruction to load a reference from a local variable
+     * Generate an instruction to load a reference from a local variable.
+     *
+     * <p>This factory may also generate {@code aload_<N>} and
+     * {@code wide aload} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -902,6 +906,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to store a reference into a local variable
+     *
+     * <p>This factory may also generate {@code astore_<N>} and
+     * {@code wide astore} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1067,6 +1075,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to load a double from a local variable
+     *
+     * <p>This factory may also generate {@code dload_<N>} and
+     * {@code wide dload} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1108,6 +1120,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to store a double into a local variable
+     *
+     * <p>This factory may also generate {@code dstore_<N>} and
+     * {@code wide dstore} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1271,6 +1287,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to load a float from a local variable
+     *
+     * <p>This factory may also generate {@code fload_<N>} and
+     * {@code wide fload} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1312,6 +1332,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to store a float into a local variable
+     *
+     * <p>This factory may also generate {@code fstore_<N>} and
+     * {@code wide fstore} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1371,6 +1395,11 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to branch always
+     *
+     * <p>This factory may also generate {@code goto_w} instructions if the offset
+     * to target cannot be encoded in a signed 2-byte integer, if the {@link
+     * ClassFile.ShortJumpsOption#FIX_SHORT_JUMPS FIX_SHORT_JUMPS} option
+     * is set.
      *
      * @apiNote The instruction's name is {@code goto}, which coincides with a
      * reserved keyword of the Java programming language, thus this method is
@@ -1692,6 +1721,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to load an int from a local variable
+     *
+     * <p>This factory may also generate {@code iload_<N>} and
+     * {@code wide iload} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -1946,6 +1979,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to store an int into a local variable
+     *
+     * <p>This factory may also generate {@code istore_<N>} and
+     * {@code wide istore} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -2070,6 +2107,8 @@ public sealed interface CodeBuilder
     /**
      * Generate an instruction pushing an item from the run-time constant pool onto the operand stack
      *
+     * <p>This factory may also generate {@code ldc_w} and {@code ldc2_w} instructions.
+     *
      * @apiNote {@link #loadConstant(ConstantDesc) loadConstant} generates more optimal instructions
      * and should be used for general constants if an {@code ldc} instruction is not strictly required.
      *
@@ -2082,6 +2121,9 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction pushing an item from the run-time constant pool onto the operand stack
+     *
+     * <p>This factory may also generate {@code ldc_w} and {@code ldc2_w} instructions.
+     *
      * @param entry the constant value
      * @return this builder
      */
@@ -2102,6 +2144,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to load a long from a local variable
+     *
+     * <p>This factory may also generate {@code lload_<N>} and
+     * {@code wide lload} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */
@@ -2167,6 +2213,10 @@ public sealed interface CodeBuilder
 
     /**
      * Generate an instruction to store a long into a local variable
+     *
+     * <p>This factory may also generate {@code lstore_<N>} and
+     * {@code wide lstore} instructions.
+     *
      * @param slot the local variable slot
      * @return this builder
      */

--- a/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/CodeAttribute.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,9 +58,9 @@ public sealed interface CodeAttribute extends Attribute<CodeAttribute>, CodeMode
     byte[] codeArray();
 
     /**
-     * {@return the position of the {@code Label} in the {@code codeArray}
-     * or -1 if the {@code Label} does not point to the {@code codeArray}}
+     * {@return the position of the {@code label} in the {@link #codeArray codeArray}}
      * @param label a marker for a position within this {@code CodeAttribute}
+     * @throws IllegalArgumentException if the {@code label} is not from this attribute
      */
     int labelToBci(Label label);
 }

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -422,7 +422,7 @@ public class SwitchBootstraps {
             cb.pop();
             cb.aload(SELECTOR_OBJ);
             Label nonNullLabel = cb.newLabel();
-            cb.if_nonnull(nonNullLabel);
+            cb.ifnonnull(nonNullLabel);
             cb.iconst_m1();
             cb.ireturn();
             cb.labelBinding(nonNullLabel);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/LabelImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/LabelImpl.java
@@ -51,7 +51,7 @@ public final class LabelImpl
     private final LabelContext labelContext;
     private int bci;
 
-        public LabelImpl(LabelContext labelContext, int bci) {
+    public LabelImpl(LabelContext labelContext, int bci) {
         this.labelContext = Objects.requireNonNull(labelContext);
         this.bci = bci;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -461,7 +461,7 @@ final class EventInstrumentation {
                     catchAllHandler.dup();
                     // stack: [ex] [EW] [EW]
                     Label rethrow = catchAllHandler.newLabel();
-                    catchAllHandler.if_null(rethrow);
+                    catchAllHandler.ifnull(rethrow);
                     // stack: [ex] [EW]
                     catchAllHandler.dup();
                     // stack: [ex] [EW] [EW]
@@ -486,7 +486,7 @@ final class EventInstrumentation {
             Label fail = codeBuilder.newLabel();
             if (guardEventConfiguration) {
                 getEventConfiguration(codeBuilder);
-                codeBuilder.if_null(fail);
+                codeBuilder.ifnull(fail);
             }
             // if (!eventConfiguration.shouldCommit(duration) goto fail;
             getEventConfiguration(codeBuilder);
@@ -525,7 +525,7 @@ final class EventInstrumentation {
                 if (guardEventConfiguration) {
                     // if (eventConfiguration == null) goto fail;
                     getEventConfiguration(codeBuilder);
-                    codeBuilder.if_null(fail);
+                    codeBuilder.ifnull(fail);
                 }
                 // return eventConfiguration.shouldCommit(duration);
                 getEventConfiguration(codeBuilder);
@@ -738,7 +738,7 @@ final class EventInstrumentation {
             Label nullLabel = codeBuilder.newLabel();
             if (guardEventConfiguration) {
                 getEventConfiguration(codeBuilder);
-                codeBuilder.if_null(nullLabel);
+                codeBuilder.ifnull(nullLabel);
             }
             getEventConfiguration(codeBuilder);
             invokevirtual(codeBuilder, TYPE_EVENT_CONFIGURATION, METHOD_IS_ENABLED);

--- a/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
+++ b/test/jdk/jdk/classfile/helpers/RebuildingTransformation.java
@@ -257,8 +257,8 @@ class RebuildingTransformation {
                         case IF_ICMPLE -> cob.if_icmple(target);
                         case IF_ICMPLT -> cob.if_icmplt(target);
                         case IF_ICMPNE -> cob.if_icmpne(target);
-                        case IFNONNULL -> cob.if_nonnull(target);
-                        case IFNULL -> cob.if_null(target);
+                        case IFNONNULL -> cob.ifnonnull(target);
+                        case IFNULL -> cob.ifnull(target);
                         case IFEQ -> cob.ifeq(target);
                         case IFGE -> cob.ifge(target);
                         case IFGT -> cob.ifgt(target);


### PR DESCRIPTION
This is a collection of fixes and improvements to CodeBuilder, plus 2 renames.

Fixes include:
1. `CodeBuilder::receiverSlot` typo
2. `CodeAttribute::labelToBci` update spec
3. `CodeBuilder::exceptionCatch` implementation
4. `CodeBuilder::if_nonnull`/`if_null` -> `ifnonnull`/`ifnull`
5. Docs for what instructions factories emit, and to explain why some factories have name mismatch; also a section in summary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8335111](https://bugs.openjdk.org/browse/JDK-8335111) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8335110](https://bugs.openjdk.org/browse/JDK-8335110): Fix instruction name and API spec inconsistencies in CodeBuilder (**Bug** - P4)
 * [JDK-8335111](https://bugs.openjdk.org/browse/JDK-8335111): Fix instruction name and API spec inconsistencies in CodeBuilder (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19889/head:pull/19889` \
`$ git checkout pull/19889`

Update a local copy of the PR: \
`$ git checkout pull/19889` \
`$ git pull https://git.openjdk.org/jdk.git pull/19889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19889`

View PR using the GUI difftool: \
`$ git pr show -t 19889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19889.diff">https://git.openjdk.org/jdk/pull/19889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19889#issuecomment-2189553397)