### PR TITLE
8335108: Build error after JDK-8333658 due to class templates

### DIFF
--- a/src/hotspot/share/nmt/arrayWithFreeList.hpp
+++ b/src/hotspot/share/nmt/arrayWithFreeList.hpp
@@ -60,7 +60,7 @@ private:
   }
 
 public:
-  NONCOPYABLE(ArrayWithFreeList<E COMMA flag>);
+  NONCOPYABLE(ArrayWithFreeList);
 
   ArrayWithFreeList(int initial_capacity = 8)
     : _backing_storage(initial_capacity),


### PR DESCRIPTION
Hi all, 

This PR addresses [8335108](https://bugs.openjdk.org/browse/JDK-8335108). 

The error arises as template-id is not allowed for constructor/destructor in C++20. 

Testing: 
- [x] Compilation succeeds with g++ 14.1.1.

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335108](https://bugs.openjdk.org/browse/JDK-8335108): Build error after JDK-8333658 due to class templates (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19890/head:pull/19890` \
`$ git checkout pull/19890`

Update a local copy of the PR: \
`$ git checkout pull/19890` \
`$ git pull https://git.openjdk.org/jdk.git pull/19890/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19890`

View PR using the GUI difftool: \
`$ git pr show -t 19890`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19890.diff">https://git.openjdk.org/jdk/pull/19890.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19890#issuecomment-2192091037)