### PR TITLE
8334031: Generated JfrNativeSettings seems off

### DIFF
--- a/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
+++ b/make/src/classes/build/tools/jfr/GenerateJfrFiles.java
@@ -668,7 +668,7 @@ public class GenerateJfrFiles {
             out.write("  // add named struct members also.");
             out.write("  struct {");
             out.write("    jfrNativeEventSetting pad[NUMBER_OF_RESERVED_EVENTS];");
-            for (TypeElement t : metadata.getEventsAndStructs()) {
+            for (TypeElement t : metadata.getEvents()) {
                 out.write("    jfrNativeEventSetting " + t.name + ";");
             }
             out.write("  } ev;");


### PR DESCRIPTION
This PR changes GenerateJfrFiles.java so that the generated `JfrNativeSettings` union does not include JFR structs.`JfrNativeSettings` is meant to hold the settings for JFR events, but previously also included JFR structs such as MetaspaceSizes, StackFrame, CopyFailed, G1EvacuationStatistics, ObjectSpace, VirtualSpace. These are not events, but instead are JFR `Type`s, and so do not have settings such as stacktraces or thresholds.

The inclusion of JFR structs in `JfrNativeSettings` was problematic because it could cause a displacement between event ID and`JfrNativeSettings` array index (each index is meant to correspond with a specific event ID).

Testing:
- jdk/jdk/jfr
- tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334031](https://bugs.openjdk.org/browse/JDK-8334031): Generated JfrNativeSettings seems off (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19891/head:pull/19891` \
`$ git checkout pull/19891`

Update a local copy of the PR: \
`$ git checkout pull/19891` \
`$ git pull https://git.openjdk.org/jdk.git pull/19891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19891`

View PR using the GUI difftool: \
`$ git pr show -t 19891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19891.diff">https://git.openjdk.org/jdk/pull/19891.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19891#issuecomment-2189988479)