### PR TITLE
8334545: runtime/ClassInitErrors/TestStackOverflowDuringInit.java fails after JDK-8294960

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -108,7 +108,6 @@ runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
-runtime/ClassInitErrors/TestStackOverflowDuringInit.java 8334545 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,15 @@
 
 /**
  * @test
- * @bug 8309034
+ * @bug 8309034 8334545
  * @summary Test that when saving a class initialization failure caused by
  *          a StackOverflowError, that we record the SOE as the underlying
  *          cause, even if we can't create the ExceptionInInitializerError
- * @requires os.simpleArch == "x64"
- * @comment The reproducer only fails in the desired way on x64.
- * @requires vm.flagless
  * @comment This test could easily be perturbed so don't allow flag settings.
- *
- * @run main/othervm -Xss160K -Xint TestStackOverflowDuringInit
+ * @requires vm.flagless
+ * @comment Run with the smallest stack possible to limit the execution time.
+ *          This is the smallest stack that is supported by all platforms.
+ * @run main/othervm -Xss240K -Xint TestStackOverflowDuringInit
  */
 
 import java.io.ByteArrayOutputStream;
@@ -51,11 +50,33 @@ public class TestStackOverflowDuringInit {
     // of another class, which is where we will fail to create the EIIE.
     // Even then this is non-trivial, only the use of Long.valueOf from
     // the original reproducer seems to trigger SOE in just the right places.
+    // Later changes to the JDK meant that LongCache was initialized before
+    // the test even started under jtreg so we define local versions.
+
+    static class LongCache {
+        // Must have a static initializer
+        static {
+            System.out.println("LongCache is initializing");
+        }
+        static java.lang.Long valueOf(long l) {
+            return Long.valueOf(l);
+        }
+    }
+
+    static class MyLong {
+        static java.lang.Long valueOf(long l) {
+            if (l > -128 && l < 127) {
+                return LongCache.valueOf(l);
+            } else {
+                return Long.valueOf(l);
+            }
+        }
+    }
 
     static void recurse() {
         try {
-            // This will initialize Long but not touch LongCache.
-            Long.valueOf(1024L);
+            // This will initialize MyLong but not touch LongCache.
+            MyLong.valueOf(1024L);
             recurse();
         } finally {
             // This will require initializing LongCache, which will
@@ -63,14 +84,20 @@ public class TestStackOverflowDuringInit {
             // will be marked erroneous. As we unwind and again execute this
             // we will throw NoClassDefFoundError due to the erroneous
             // state of LongCache.
-            Long.valueOf(0);
+            MyLong.valueOf(0);
         }
     }
 
     public static void main(String[] args) throws Exception {
-        String expected = "java.lang.NoClassDefFoundError: Could not initialize class java.lang.Long$LongCache";
+        String expected = "java.lang.NoClassDefFoundError: Could not initialize class TestStackOverflowDuringInit$LongCache";
         String cause = "Caused by: java.lang.StackOverflowError";
 
+        // Pre-load, but not initialize, LongCache, else we will
+        // hit SOE during class loading.
+        System.out.println("Pre-loading ...");
+        Class<?> c = Class.forName("TestStackOverflowDuringInit$LongCache",
+                                   false,
+                                   TestStackOverflowDuringInit.class.getClassLoader());
         try {
             recurse();
         } catch (Throwable ex) {


### PR DESCRIPTION
When the test is now run under jtreg, hundreds of other classes are initialized before we trigger the initial `StackOverflowError` - including the critical `java/lang/Long$LongCache` class. This evades the failure scenario that the test was so carefully setting up and so the test fails.

We can restore the failure scenario if we use custom classes to replace `Long` and `LongCache`. This has the added advantage that the test now seems to work reliably on all mainstream platforms.

The test runs with a small -Xss value based on the minimum value allowed on any of macos/linux/windows x64, and macos/linux aarch64. It is possible other platforms - PPC, S390 - may not support that value. I don't know of a way to programmatically find the minimum for the current platform at runtime.

Testing:
- test was run 10x on each mainline platform in release and debug builds.
- logging was used (`-Xlog:exceptions=info,class+init=info`  with vm.flagless removed) to check that the SOE was triggering where expected and the NCDFE is thrown.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334545](https://bugs.openjdk.org/browse/JDK-8334545): runtime/ClassInitErrors/TestStackOverflowDuringInit.java fails after JDK-8294960 (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19894/head:pull/19894` \
`$ git checkout pull/19894`

Update a local copy of the PR: \
`$ git checkout pull/19894` \
`$ git pull https://git.openjdk.org/jdk.git pull/19894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19894`

View PR using the GUI difftool: \
`$ git pr show -t 19894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19894.diff">https://git.openjdk.org/jdk/pull/19894.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19894#issuecomment-2190775136)