### PR TITLE
8335137: Disable the SUSPEND_NONE mode of BreakpointOnClassPrepare.java

### DIFF
--- a/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
+++ b/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
@@ -23,15 +23,22 @@
 
 /**
  * @test
- * @bug 8333542
+ * @bug 8333542 8335134
  * @summary Missed breakpoint due to JVM not blocking other threads while
  *          delivering a ClassPrepareEvent.
  *
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g BreakpointOnClassPrepare.java
- * @run driver BreakpointOnClassPrepare SUSPEND_NONE
  * @run driver BreakpointOnClassPrepare SUSPEND_EVENT_THREAD
  * @run driver BreakpointOnClassPrepare SUSPEND_ALL
+ */
+
+/**
+ * @test id=SUSPEND_NONE
+ * @summary Disable SUSPEND_NONE mode util the JDK-8335134 has been fixed.
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g BreakpointOnClassPrepare.java
+ * @run main/othervm/manual BreakpointOnClassPrepare SUSPEND_NONE
  */
 
 import com.sun.jdi.*;


### PR DESCRIPTION
Hi all,
The newly added test `com/sun/jdi/BreakpointOnClassPrepare.java` fails at `SUSPEND_NONE` mode.
To make this test less noisy, should we disable the SUSPEND_NONE mode for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335137](https://bugs.openjdk.org/browse/JDK-8335137): Disable the SUSPEND_NONE mode of BreakpointOnClassPrepare.java (**Sub-task** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19897/head:pull/19897` \
`$ git checkout pull/19897`

Update a local copy of the PR: \
`$ git checkout pull/19897` \
`$ git pull https://git.openjdk.org/jdk.git pull/19897/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19897`

View PR using the GUI difftool: \
`$ git pr show -t 19897`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19897.diff">https://git.openjdk.org/jdk/pull/19897.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19897#issuecomment-2190929090)