### PR TITLE
8334121: Anonymous class capturing two enclosing instances fails to compile

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -370,53 +370,9 @@ public class Lower extends TreeTranslator {
                     if (v.getConstValue() == null) {
                         addFreeVar(v);
                     }
-                } else {
-                    if (outerThisStack.head != null &&
-                        outerThisStack.head != _sym)
-                        visitSymbol(outerThisStack.head);
                 }
             }
         }
-
-        /** If tree refers to a class instance creation expression
-         *  add all free variables of the freshly created class.
-         */
-        public void visitNewClass(JCNewClass tree) {
-            ClassSymbol c = (ClassSymbol)tree.constructor.owner;
-            if (tree.encl == null &&
-                c.hasOuterInstance() &&
-                outerThisStack.head != null)
-                visitSymbol(outerThisStack.head);
-            super.visitNewClass(tree);
-        }
-
-        /** If tree refers to a qualified this or super expression
-         *  for anything but the current class, add the outer this
-         *  stack as a free variable.
-         */
-        public void visitSelect(JCFieldAccess tree) {
-            if ((tree.name == names._this || tree.name == names._super) &&
-                tree.selected.type.tsym != clazz &&
-                outerThisStack.head != null)
-                visitSymbol(outerThisStack.head);
-            super.visitSelect(tree);
-        }
-
-        /** If tree refers to a superclass constructor call,
-         *  add all free variables of the superclass.
-         */
-        public void visitApply(JCMethodInvocation tree) {
-            if (TreeInfo.name(tree.meth) == names._super) {
-                Symbol constructor = TreeInfo.symbol(tree.meth);
-                ClassSymbol c = (ClassSymbol)constructor.owner;
-                if (c.hasOuterInstance() &&
-                    !tree.meth.hasTag(SELECT) &&
-                    outerThisStack.head != null)
-                    visitSymbol(outerThisStack.head);
-            }
-            super.visitApply(tree);
-        }
-
     }
 
     ClassSymbol ownerToCopyFreeVarsFrom(ClassSymbol c) {
@@ -1590,7 +1546,7 @@ public class Lower extends TreeTranslator {
     }
 
     private VarSymbol makeOuterThisVarSymbol(Symbol owner, long flags) {
-        Type target = types.erasure(owner.enclClass().type.getEnclosingType());
+        Type target = owner.innermostAccessibleEnclosingClass().erasure(types);
         // Set NOOUTERTHIS for all synthetic outer instance variables, and unset
         // it when the variable is accessed. If the variable is never accessed,
         // we skip creating an outer instance field and saving the constructor
@@ -3101,7 +3057,7 @@ public class Lower extends TreeTranslator {
                 thisArg.type = tree.encl.type;
             } else if (c.isDirectlyOrIndirectlyLocal()) {
                 // local class
-                thisArg = makeThis(tree.pos(), c.type.getEnclosingType().tsym);
+                thisArg = makeThis(tree.pos(), c.innermostAccessibleEnclosingClass());
             } else {
                 // nested class
                 thisArg = makeOwnerThis(tree.pos(), c, false);
@@ -3307,7 +3263,7 @@ public class Lower extends TreeTranslator {
                     ((JCIdent) tree.meth).name = methName;
                 } else if (c.isDirectlyOrIndirectlyLocal() || methName == names._this){
                     // local class or this() call
-                    thisArg = makeThis(tree.meth.pos(), c.type.getEnclosingType().tsym);
+                    thisArg = makeThis(tree.meth.pos(), c.innermostAccessibleEnclosingClass());
                 } else if (currentClass.isStatic()) {
                     // super() call from static nested class - invalid
                     log.error(tree.pos(),

--- a/test/langtools/tools/javac/MethodParameters/LocalClassTest.out
+++ b/test/langtools/tools/javac/MethodParameters/LocalClassTest.out
@@ -1,7 +1,7 @@
 class LocalClassTest$1 -- anon
 LocalClassTest$1.<init>(final this$0/*implicit*/, final j, final val$i/*synthetic*/)
 class LocalClassTest$1CapturingLocal$1 -- anon
-LocalClassTest$1CapturingLocal$1.<init>(final val$this$0/*synthetic*/, final val$val$i/*synthetic*/)
+LocalClassTest$1CapturingLocal$1.<init>(final this$0/*implicit*/, final val$val$i/*synthetic*/)
 LocalClassTest$1CapturingLocal$1.test()
 class LocalClassTest$1CapturingLocal -- inner
 LocalClassTest$1CapturingLocal.<init>(final this$0/*implicit*/, final j, final val$i/*synthetic*/)

--- a/test/langtools/tools/javac/SuperInit/MultiLevelOuterInstance.java
+++ b/test/langtools/tools/javac/SuperInit/MultiLevelOuterInstance.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8334121
+ * @summary Anonymous class capturing two enclosing instances fails to compile
+ * @enablePreview
+ */
+
+public class MultiLevelOuterInstance {
+
+    interface A {
+        void run();
+    }
+    interface B {
+        void run();
+    }
+
+    class Inner1 {
+        Inner1() {
+            this(new A() {
+                class Inner2 {
+                    Inner2() {
+                        this(new B() {
+                            public void run() {
+                                m();
+                                g();
+                            }
+                        });
+                    }
+
+                    Inner2(B o) {
+                        o.run();
+                    }
+                }
+
+                public void run() {
+                    new Inner2();
+                }
+
+                void m() { }
+            });
+        }
+
+        Inner1(A o) { }
+    }
+    void g() { }
+
+    public static void main(String[] args) {
+        new MultiLevelOuterInstance().new Inner1();
+    }
+}


### PR DESCRIPTION
This PR contains a fix for an issue when translating local/anon classes. Currently, javac assumes that a local/anon class C must have an enclosing instance whose type is the innermost enclosing class of C. But this is not always true - there are cases where the innermost enclosing instance is in early construction context, so we can't really refer to its members from the local class. Moreover, even if the innermost class _was_ accessible, there could be cases where the enclosing instance of that innermost enclosing class is _not_ accessible.

In other words, we cannot rely on the assumption that, given a local/anonymous class, there exist a chain of enclosing instances from the innermost to the outermost. Some chain exists, but it might not start from the innermost enclosing class, and it might have holes.

The core of the fix is the addition of a new function in `Symbol`, namely `Symbol::innermostAccessibleEnclosingClass`. As the name implies, the goal of this function is to return the class symbol corresponding to the innermost enclosing type **that is accessible** from the symbol's class. This is used by `Lower` to determine the type of `this$0`, which allows us to construct a chain of enclosing instances that skips over all the inaccessible types.

I've also updated the `Symbol::hasOuterInstance` method, so that it, too, will skip over inaccessible enclosing type (and only return `true` if some accessible enclosing type is found).

This cleanup brings a lot of simplifications to `Lower.FreeVarCollector`. That class is used to compute the set of captured variables inside a local/anon class. There is a workaround in this class so that if a local/anon class occurs in a pre-construction context (where the enclosing `this` is not accessible), we say that the local/anon class captures the enclosing constructor parameter of the place where the local/anon class occurs (e.g. the enclosing `'this`'s enclosing `this`). This adds complexity to the code, as now the set of captured variables depends on the state of `Lower`. With this PR, all that logic is now gone, and `FreeVarCollector` is effectively a stateless visitor.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334121](https://bugs.openjdk.org/browse/JDK-8334121): Anonymous class capturing two enclosing instances fails to compile (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19900/head:pull/19900` \
`$ git checkout pull/19900`

Update a local copy of the PR: \
`$ git checkout pull/19900` \
`$ git pull https://git.openjdk.org/jdk.git pull/19900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19900`

View PR using the GUI difftool: \
`$ git pr show -t 19900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19900.diff">https://git.openjdk.org/jdk/pull/19900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19900#issuecomment-2191341684)