### PR TITLE
8335154: jcmd VM.classes -verbose=false does not set verbose to false

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -992,7 +992,7 @@ public:
 };
 
 void ClassesDCmd::execute(DCmdSource source, TRAPS) {
-  VM_PrintClasses vmop(output(), _verbose.is_set());
+  VM_PrintClasses vmop(output(), _verbose.value());
   VMThread::execute(&vmop);
 }
 


### PR DESCRIPTION
VM.classes uses:

995    VM_PrintClasses vmop(output(), _verbose.is_set());

_verbose.is_set() is wrong: it could be set, but set to false.

_verbose.value() should be used (see other examples such as StringtableDCmd::execute).

With this change -verbose=false will turn off verbose mode like all other DCmds which accept -verbose

bash-4.2$ jcmd 20193 VM.classes -verbose=false | wc -l
2490
bash-4.2$ jcmd 20193 VM.classes -verbose=true | wc -l
90258
