### PR TITLE
8335150: Test LogGeneratedClassesTest.java fails on rpmbuild mock enviroment

### DIFF
--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -225,7 +225,7 @@ public class LogGeneratedClassesTest {
         }
         if (!fs.supportsFileAttributeView(PosixFileAttributeView.class)) {
             // No easy way to setup readonly directory without POSIX
-            // Same as above, return instead of SkipException("Posix not supported")
+            // Same as above, return instead of throw SkipException("Posix not supported")
             System.out.println("WARNING: POSIX is not supported. Skipping testDumpDirNotWritable test.");
             return;
         }

--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8023524 8304846 8335150
+ * @bug 8023524 8304846
  * @requires vm.flagless
  * @library /test/lib/
  * @library /java/nio/file
@@ -48,6 +48,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.SkipException;
 
 import static java.nio.file.attribute.PosixFilePermissions.*;
 import static jdk.test.lib.process.ProcessTools.*;
@@ -212,22 +213,12 @@ public class LogGeneratedClassesTest {
         try {
             fs = Files.getFileStore(Paths.get("."));
         } catch (IOException e) {
-            if (e.getMessage().contains("Mount point not found")) {
-                // We would like to skip the test with a cause with
-                //      throw new SkipException("Mount point not found");
-                // but jtreg will report failure so we just pass the test
-                // which we can look at if jtreg changed its behavior
-                System.out.println("Mount point not found. Skipping testDumpDirNotWritable test.");
-                return;
-            } else {
-                throw e;
-            }
+            e.printStackTrace();
+            throw new SkipException("WARNING: IOException occur. Skipping testDumpDirNotWritable test.");
         }
         if (!fs.supportsFileAttributeView(PosixFileAttributeView.class)) {
             // No easy way to setup readonly directory without POSIX
-            // Same as above, return instead of throw SkipException("Posix not supported")
-            System.out.println("WARNING: POSIX is not supported. Skipping testDumpDirNotWritable test.");
-            return;
+            throw new SkipException("WARNING: POSIX is not supported. Skipping testDumpDirNotWritable test.");
         }
 
         Path testDir = Path.of("readOnly");
@@ -239,8 +230,7 @@ public class LogGeneratedClassesTest {
             if (isWriteableDirectory(dumpDir)) {
                 // Skipping the test: it's allowed to write into read-only directory
                 // (e.g. current user is super user).
-                System.out.println("WARNING: The dump directory is writeable. Skipping testDumpDirNotWritable test.");
-                return;
+                throw new SkipException("WARNING: The dump directory is writeable. Skipping testDumpDirNotWritable test.");
             }
 
             ProcessBuilder pb = createLimitedTestJavaProcessBuilder(

--- a/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
+++ b/test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java
@@ -213,8 +213,7 @@ public class LogGeneratedClassesTest {
         try {
             fs = Files.getFileStore(Paths.get("."));
         } catch (IOException e) {
-            e.printStackTrace();
-            throw new SkipException("WARNING: IOException occur. Skipping testDumpDirNotWritable test.");
+            throw new SkipException("WARNING: IOException occurred: " + e + ", Skipping testDumpDirNotWritable test.");
         }
         if (!fs.supportsFileAttributeView(PosixFileAttributeView.class)) {
             // No easy way to setup readonly directory without POSIX


### PR DESCRIPTION
Hi all,
Test `test/jdk/java/lang/invoke/lambda/LogGeneratedClassesTest.java` fails on rpm build mock environment. The `df -h` command return fail `df: cannot read table of mounted file systems: No such file or directory` on the rpm build mock environment also. I think it's a environmental issue, and the environmental issue should not cause the test fails, it should skip the test.

The rpmbuild mock enviroment is like a sandbox, which created by `chroot` shell command, in the rpmbuild mock enviroment, `df -h` report `cannot read table of mounted file systems`, and java Files.getFileStore also throw `IOException`. We want to build and test the jdk in this `sandbox`, and the default jtreg work directory is `JTWork` in current directory, so this testcase will report fails.

Only change the testcase, the change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335150](https://bugs.openjdk.org/browse/JDK-8335150): Test LogGeneratedClassesTest.java fails on rpmbuild mock enviroment (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19905/head:pull/19905` \
`$ git checkout pull/19905`

Update a local copy of the PR: \
`$ git checkout pull/19905` \
`$ git pull https://git.openjdk.org/jdk.git pull/19905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19905`

View PR using the GUI difftool: \
`$ git pr show -t 19905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19905.diff">https://git.openjdk.org/jdk/pull/19905.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19905#issuecomment-2191551347)