### PR TITLE
8299813: java/nio/channels/DatagramChannel/Disconnect.java fails with jtreg test timeout due to lost datagram

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -35,6 +35,7 @@ import java.nio.*;
 import java.nio.channels.*;
 import java.io.IOException;
 
+import jdk.test.lib.Platform;
 import jdk.test.lib.net.IPSupport;
 
 public class Disconnect {
@@ -43,23 +44,29 @@ public class Disconnect {
 
         // test with default protocol family
         try (DatagramChannel dc = DatagramChannel.open()) {
-            test(dc, InetAddress.getLoopbackAddress());
-            test(dc, InetAddress.getLoopbackAddress());
+            InetAddress lo = InetAddress.getLoopbackAddress();
+            System.out.println("Testing with default family and " + lo);
+            test(dc, lo);
+            test(dc, lo);
         }
 
         if (IPSupport.hasIPv4()) {
             // test with IPv4 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-                test(dc, InetAddress.ofLiteral("127.0.0.1"));
-                test(dc, InetAddress.ofLiteral("127.0.0.1"));
+                InetAddress lo4 = InetAddress.ofLiteral("127.0.0.1");
+                System.out.println("Testing with INET family and " + lo4);
+                test(dc, lo4);
+                test(dc, lo4);
             }
         }
 
         if (IPSupport.hasIPv6()) {
             // test with IPv6 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
-                test(dc, InetAddress.ofLiteral("::1"));
-                test(dc, InetAddress.ofLiteral("::1"));
+                InetAddress lo6 = InetAddress.ofLiteral("::1");
+                System.out.println("Testing with INET6 family and " + lo6);
+                test(dc, lo6);
+                test(dc, lo6);
             }
         }
     }
@@ -74,6 +81,8 @@ public class Disconnect {
             server.bind(new InetSocketAddress(l0, 0));
 
             dc.connect(new InetSocketAddress(l0, server.socket().getLocalPort()));
+            System.out.println("dc connected from " +
+                    dc.getLocalAddress() + " to " + dc.getRemoteAddress());
 
             dc.write(ByteBuffer.wrap("hello".getBytes()));
 

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import java.net.*;
 import java.nio.*;
 import java.nio.channels.*;
 import java.io.IOException;
+
 import jdk.test.lib.net.IPSupport;
 
 public class Disconnect {
@@ -42,23 +43,23 @@ public class Disconnect {
 
         // test with default protocol family
         try (DatagramChannel dc = DatagramChannel.open()) {
-            test(dc);
-            test(dc);
+            test(dc, InetAddress.getLoopbackAddress());
+            test(dc, InetAddress.getLoopbackAddress());
         }
 
         if (IPSupport.hasIPv4()) {
             // test with IPv4 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET)) {
-                test(dc);
-                test(dc);
+                test(dc, InetAddress.ofLiteral("127.0.0.1"));
+                test(dc, InetAddress.ofLiteral("127.0.0.1"));
             }
         }
 
         if (IPSupport.hasIPv6()) {
             // test with IPv6 only
             try (DatagramChannel dc = DatagramChannel.open(StandardProtocolFamily.INET6)) {
-                test(dc);
-                test(dc);
+                test(dc, InetAddress.ofLiteral("::1"));
+                test(dc, InetAddress.ofLiteral("::1"));
             }
         }
     }
@@ -68,12 +69,11 @@ public class Disconnect {
      * a second or subsequent time with the same DatagramChannel instance to check
      * that disconnect works as expected.
      */
-    static void test(DatagramChannel dc) throws IOException {
+    static void test(DatagramChannel dc, InetAddress l0) throws IOException {
         try (DatagramChannel server = DatagramChannel.open()) {
-            server.bind(new InetSocketAddress(0));
+            server.bind(new InetSocketAddress(l0, 0));
 
-            InetAddress lh = InetAddress.getLocalHost();
-            dc.connect(new InetSocketAddress(lh, server.socket().getLocalPort()));
+            dc.connect(new InetSocketAddress(l0, server.socket().getLocalPort()));
 
             dc.write(ByteBuffer.wrap("hello".getBytes()));
 

--- a/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/Disconnect.java
@@ -90,7 +90,7 @@ public class Disconnect {
 
             dc.write(ByteBuffer.wrap("hello".getBytes()));
 
-            if (getLocalPort(dc) == getLocalPort(server)) {
+            if (getLocalPort(dc) != getLocalPort(server)) {
                 ByteBuffer bb = ByteBuffer.allocate(100);
                 server.receive(bb);
             } else {


### PR DESCRIPTION
Please find here a simple fix to solve an intermittent failure in  java/nio/channels/DatagramChannel/Disconnect.java

On some platform, the underlying system may allow two datagram sockets to bind to the same port, if one of them uses the wildcard address and the other doesn't.

What happens here is that during DC:connect, if the socket is unbound, it will get bound to the wildcard.
From time to time, this results into binding to the same port that the `server` is using in the test.
When that happens, datagram sent to the connected server may get misrouted and may not get delivered, and the call server::receive may block forever.

This change does two things: 
  1. explicitly  bind the server to the loopback address instead of InetAddress.getLocalHost()
  2. skip the receive part of the test if the client local address obtained after connecting uses the same port than the server. 
  
This is rare, and skipping the receive part in that case does not invalidate the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299813](https://bugs.openjdk.org/browse/JDK-8299813): java/nio/channels/DatagramChannel/Disconnect.java fails with jtreg test timeout due to lost datagram (**Bug** - P4)


### Reviewers
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19908/head:pull/19908` \
`$ git checkout pull/19908`

Update a local copy of the PR: \
`$ git checkout pull/19908` \
`$ git pull https://git.openjdk.org/jdk.git pull/19908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19908`

View PR using the GUI difftool: \
`$ git pr show -t 19908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19908.diff">https://git.openjdk.org/jdk/pull/19908.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19908#issuecomment-2191838757)