### PR TITLE
8335135: HttpURLConnection#HttpInputStream does not throw IOException when response is truncated

### DIFF
--- a/src/java.base/share/classes/sun/net/www/MeteredStream.java
+++ b/src/java.base/share/classes/sun/net/www/MeteredStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,9 @@ public class MeteredStream extends FilterInputStream {
         assert isLockHeldByCurrentThread();
 
         if (n == -1) {
+            if (expected > count) {
+                throw new IOException("Premature EOF");
+            }
 
             /*
              * don't close automatically when mark is set and is valid;

--- a/test/jdk/java/net/Authenticator/BasicTest4.java
+++ b/test/jdk/java/net/Authenticator/BasicTest4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/Authenticator/BasicTest4.java
+++ b/test/jdk/java/net/Authenticator/BasicTest4.java
@@ -151,7 +151,7 @@ public class BasicTest4 {
                 System.out.println ("checkfor returned " + success);
                 readAll (s);
                 os = s.getOutputStream();
-                os.write (reply2.getBytes());
+                os.write ((reply2+"HelloAgain").getBytes());
                 s.close ();
 
                 if (success)

--- a/test/jdk/java/net/URLConnection/TruncatedFixedResponse.java
+++ b/test/jdk/java/net/URLConnection/TruncatedFixedResponse.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8335135
+ * @library /test/lib
+ * @summary Check that reading from inputStream throws an IOException
+ *          if the fixed response stream is closed before reading all bytes.
+ */
+
+import jdk.test.lib.net.URIBuilder;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+
+public class TruncatedFixedResponse implements Runnable {
+
+    ServerSocket ss;
+
+    /*
+     * Our "http" server to return a truncated fixed response
+     */
+    public void run() {
+        try {
+            Socket s = ss.accept();
+
+            BufferedReader in = new BufferedReader(
+                    new InputStreamReader(s.getInputStream()));
+            while (true) {
+                String req = in.readLine();
+                if (req.isEmpty()) {
+                    break;
+                }
+            }
+            PrintStream out = new PrintStream(
+                    new BufferedOutputStream(s.getOutputStream()));
+
+            /* send the header */
+            out.print("HTTP/1.1 200\r\n");
+            out.print("Content-Length: 100\r\n");
+            out.print("Content-Type: text/html\r\n");
+            out.print("\r\n");
+            out.print("Some content, but too short");
+            out.close();
+            s.close();
+            ss.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    TruncatedFixedResponse() throws Exception {
+        /* start the server */
+        ss = new ServerSocket();
+        ss.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+        new Thread(this).start();
+
+        /* establish http connection to server */
+        URL url = URIBuilder.newBuilder()
+                .scheme("http")
+                .loopback()
+                .port(ss.getLocalPort())
+                .path("/foo")
+                .toURL();
+        HttpURLConnection http = (HttpURLConnection) url.openConnection(Proxy.NO_PROXY);
+
+        try (InputStream in = http.getInputStream()) {
+            while (in.read() != -1) {
+                // discard response
+            }
+            throw new AssertionError("Expected IOException was not thrown");
+        } catch (IOException ex) {
+            System.out.println("Got expected exception: " + ex);
+        }
+    }
+
+    public static void main(String args[]) throws Exception {
+        new TruncatedFixedResponse();
+    }
+}

--- a/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java
+++ b/test/jdk/sun/net/www/http/KeepAliveStream/KeepAliveStreamCloseWithWrongContentLength.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public class KeepAliveStreamCloseWithWrongContentLength {
                     c=is.read();
                     System.out.println("client reads: "+c);
                 } catch (IOException ioe) {
-                    is.read ();
+                    System.out.println("client got expected exception: "+ioe);
                     break;
                 }
             }


### PR DESCRIPTION
Currently HttpUrlConnection accepts truncated responses: if the server sends a `Content-Length` header, and then closes the connection before transferring all promised bytes, the input stream reports a clean EOF.

In this PR I modify the MeteredStream class to throw an IOException when it detects EOF before receiving all promised response bytes. MeteredStream (or its subclass KeepAliveStream) is used when the response contains a content-length header.

The included test fails without the change, passes with it.
The same exception message and type is reported when a chunked response (`Transfer-Encoding: chunked`) is truncated.
Unknown length responses that are terminated by EOF continue to work.

2 tests depended on the old behavior and had to be adjusted. The remaining tier 1-3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335135](https://bugs.openjdk.org/browse/JDK-8335135): HttpURLConnection#HttpInputStream does not throw IOException when response is truncated (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19909/head:pull/19909` \
`$ git checkout pull/19909`

Update a local copy of the PR: \
`$ git checkout pull/19909` \
`$ git pull https://git.openjdk.org/jdk.git pull/19909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19909`

View PR using the GUI difftool: \
`$ git pr show -t 19909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19909.diff">https://git.openjdk.org/jdk/pull/19909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19909#issuecomment-2192230754)