### PR TITLE
8335134: Test com/sun/jdi/BreakpointOnClassPrepare.java timeout

### DIFF
--- a/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
+++ b/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
@@ -104,7 +104,15 @@ public class BreakpointOnClassPrepare extends TestScaffold {
 
     public void breakpointReached(BreakpointEvent event) {
         bkptCount++;
-        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + event.thread());
+        String threadInfo;
+        try {
+            threadInfo = event.thread().toString();
+        } catch (ObjectCollectedException e) {
+            // It's possible the Thread already terminated and was collected
+            // if the SUSPEND_NONE policy was used.
+            threadInfo = "(thread collected)";
+        }
+        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + threadInfo);
     }
 
     public void vmDisconnected(VMDisconnectEvent event) {


### PR DESCRIPTION
Allow ObjectCollectedException during ThreadReference.toString() call. This can happen when using SUSPEND_NONE since the thread continues to run after hitting the breakpoint.

So far I've just run the test locally. I'll run the full suite of debugger tests before committing. Note I don't know how to reproduce the filed issue. We have not seen this turn up in our CI yet, but theoretically the ObjectCollectedException can happen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335134](https://bugs.openjdk.org/browse/JDK-8335134): Test com/sun/jdi/BreakpointOnClassPrepare.java timeout (**Bug** - P3)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19910/head:pull/19910` \
`$ git checkout pull/19910`

Update a local copy of the PR: \
`$ git checkout pull/19910` \
`$ git pull https://git.openjdk.org/jdk.git pull/19910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19910`

View PR using the GUI difftool: \
`$ git pr show -t 19910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19910.diff">https://git.openjdk.org/jdk/pull/19910.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19910#issuecomment-2192271079)