### PR TITLE
8331090: Run Ideal_minmax before de-canonicalizing CMoves

### DIFF
--- a/src/hotspot/share/opto/movenode.cpp
+++ b/src/hotspot/share/opto/movenode.cpp
@@ -91,15 +91,18 @@ Node *CMoveNode::Ideal(PhaseGVN *phase, bool can_reshape) {
       phase->type(in(IfTrue))    == Type::TOP) {
     return nullptr;
   }
+
+  // Check for Min/Max patterns. This is called before constants are pushed to the right input, as that transform can
+  // make BoolTests non-canonical.
+  Node* minmax = Ideal_minmax(phase, this);
+  if (minmax != nullptr) {
+    return minmax;
+  }
+
   // Canonicalize the node by moving constants to the right input.
   if (in(Condition)->is_Bool() && phase->type(in(IfFalse))->singleton() && !phase->type(in(IfTrue))->singleton()) {
     BoolNode* b = in(Condition)->as_Bool()->negate(phase);
     return make(in(Control), phase->transform(b), in(IfTrue), in(IfFalse), _type);
-  }
-
-  Node* minmax = Ideal_minmax(phase, this);
-  if (minmax != nullptr) {
-    return minmax;
   }
 
   return nullptr;

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIfMinMax.java
@@ -30,7 +30,7 @@ import jdk.test.lib.Utils;
 
 /*
  * @test
- * @bug 8324655 8329797
+ * @bug 8324655 8329797 8331090
  * @key randomness
  * @summary Test that if expressions are properly folded into min/max nodes
  * @requires os.arch != "riscv64"
@@ -505,7 +505,27 @@ public class TestIfMinMax {
         }
     }
 
-    @Run(test = { "testMinI1", "testMinI2", "testMaxI1", "testMaxI2", "testMinI1E", "testMinI2E", "testMaxI1E", "testMaxI2E" })
+    @Test
+    @IR(failOn = { IRNode.IF }, counts = { IRNode.MIN_I, "1" })
+    public int testMinIConst(int a) {
+        if (a > 65535) {
+            a = 65535;
+        }
+
+        return a;
+    }
+
+    @Test
+    @IR(phase = { CompilePhase.BEFORE_MACRO_EXPANSION }, failOn = { IRNode.IF }, counts = { IRNode.MIN_L, "1" })
+    public long testMinLConst(long a) {
+        if (a > 65535) {
+            a = 65535;
+        }
+
+        return a;
+    }
+
+    @Run(test = { "testMinI1", "testMinI2", "testMaxI1", "testMaxI2", "testMinI1E", "testMinI2E", "testMaxI1E", "testMaxI2E", "testMinIConst" })
     public void runTestIntegers() {
         testIntegers(10, 20);
         testIntegers(20, 10);
@@ -526,9 +546,12 @@ public class TestIfMinMax {
         Asserts.assertEQ(a >= b ? b : a, testMinI2E(a, b));
         Asserts.assertEQ(a >= b ? a : b, testMaxI1E(a, b));
         Asserts.assertEQ(a <= b ? b : a, testMaxI2E(a, b));
+
+        Asserts.assertEQ(a > 65535 ? 65535 : a, testMinIConst(a));
+        Asserts.assertEQ(b > 65535 ? 65535 : b, testMinIConst(b));
     }
 
-    @Run(test = { "testMinL1", "testMinL2", "testMaxL1", "testMaxL2", "testMinL1E", "testMinL2E", "testMaxL1E", "testMaxL2E" })
+    @Run(test = { "testMinL1", "testMinL2", "testMaxL1", "testMaxL2", "testMinL1E", "testMinL2E", "testMaxL1E", "testMaxL2E", "testMinLConst" })
     public void runTestLongs() {
         testLongs(10, 20);
         testLongs(20, 10);
@@ -551,5 +574,8 @@ public class TestIfMinMax {
         Asserts.assertEQ(a >= b ? b : a, testMinL2E(a, b));
         Asserts.assertEQ(a >= b ? a : b, testMaxL1E(a, b));
         Asserts.assertEQ(a <= b ? b : a, testMaxL2E(a, b));
+
+        Asserts.assertEQ(a > 65535L ? 65535L : a, testMinLConst(a));
+        Asserts.assertEQ(b > 65535L ? 65535L : b, testMinLConst(b));
     }
 }


### PR DESCRIPTION
Hi all,
This patch aims to solve some CMove min/max patterns not being recognized due to the BoolNode comparison being non-canonical, as was reported in [#18824](https://github.com/openjdk/jdk/pull/18824). This can occur due to other Ideal transforms done by CMoves, such as in [here](https://github.com/openjdk/jdk/blob/efb905e57ab7a5299952419fa9961316541056c2/src/hotspot/share/opto/movenode.cpp#L95-L97) and [here](https://github.com/openjdk/jdk/blob/efb905e57ab7a5299952419fa9961316541056c2/src/hotspot/share/opto/movenode.cpp#L274-L278). These transforms move constants and zero-types to the right hand side of the CMove by flipping the comparison, potentially de-canonicalizing it. These invariants are used later on in the [ad files](https://github.com/openjdk/jdk/blob/efb905e57ab7a5299952419fa9961316541056c2/src/hotspot/cpu/x86/x86_64.ad#L6127-L6130) to emit more optimized assembly for these patterns. Since these existing patterns are useful to have, I think the best way to solve this would be to move `Ideal_minmax` before the branches are swapped and the BoolNode is negated. This should increase the set of inputs that the idealization is able to transform.

Tier 1-3 testing passes on my machine. Reviews and comments would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331090](https://bugs.openjdk.org/browse/JDK-8331090): Run Ideal_minmax before de-canonicalizing CMoves (**Enhancement** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19914/head:pull/19914` \
`$ git checkout pull/19914`

Update a local copy of the PR: \
`$ git checkout pull/19914` \
`$ git pull https://git.openjdk.org/jdk.git pull/19914/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19914`

View PR using the GUI difftool: \
`$ git pr show -t 19914`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19914.diff">https://git.openjdk.org/jdk/pull/19914.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19914#issuecomment-2192399054)