### PR TITLE
8326705: Test CertMsgCheck.java fails to find alert certificate_required

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -616,7 +616,6 @@ com/sun/security/sasl/gsskerb/ConfSecurityLayer.java            8039280 generic-
 com/sun/security/sasl/gsskerb/NoSecurityLayer.java              8039280 generic-all
 sun/security/provider/PolicyFile/GrantAllPermToExtWhenNoPolicy.java 8039280 generic-all
 sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-all
-javax/net/ssl/SSLSession/CertMsgCheck.java                      8326705 generic-all
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183,8333317 generic-all
 

--- a/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
+++ b/test/jdk/javax/net/ssl/SSLSession/CertMsgCheck.java
@@ -40,20 +40,25 @@ public class CertMsgCheck {
 
         // Initial client session
         TLSBase.Client client1 = new TLSBase.Client(true, false);
-        if (server.getSession(client1).getSessionContext() == null) {
-            for (Exception e : server.getExceptionList()) {
-                System.out.println("Looking at " + e.getClass() + " " +
-                    e.getMessage());
-                if (e.getMessage().contains(args[0])) {
-                    System.out.println("Found correct exception: " + args[0] +
-                    " in " + e.getMessage());
-                    return;
-                } else {
-                    System.out.println("No \"" + args[0] + "\" found.");
-                }
-            }
 
-            throw new Exception("Failed to find expected alert: " + args[0]);
+        server.getSession(client1).getSessionContext();
+        server.done();
+
+        var eList = server.getExceptionList();
+        System.out.println("Exception list size is " + eList.size());
+
+        for (Exception e : eList) {
+            System.out.println("Looking at " + e.getClass() + " " +
+                e.getMessage());
+            if (e.getMessage().contains(args[0])) {
+                System.out.println("Found correct exception: " + args[0] +
+                    " in " + e.getMessage());
+                return;
+            } else {
+                System.out.println("No \"" + args[0] + "\" found.");
+            }
         }
+
+        throw new Exception("Failed to find expected alert: " + args[0]);
     }
 }

--- a/test/jdk/javax/net/ssl/templates/TLSBase.java
+++ b/test/jdk/javax/net/ssl/templates/TLSBase.java
@@ -97,8 +97,8 @@ abstract public class TLSBase {
     private static KeyManager[] getKeyManager(boolean empty) throws Exception {
         FileInputStream fis = null;
         if (!empty) {
-            fis = new FileInputStream(System.getProperty("test.src", "./") + "/" + pathToStores +
-                "/" + keyStoreFile);
+            fis = new FileInputStream(System.getProperty("test.src", "./") +
+                "/" + pathToStores + "/" + keyStoreFile);
         }
         // Load the keystore
         char[] pwd = passwd.toCharArray();
@@ -113,8 +113,8 @@ abstract public class TLSBase {
     private static TrustManager[] getTrustManager(boolean empty) throws Exception {
         FileInputStream fis = null;
         if (!empty) {
-            fis = new FileInputStream(System.getProperty("test.src", "./") + "/" + pathToStores +
-                "/" + trustStoreFile);
+            fis = new FileInputStream(System.getProperty("test.src", "./") +
+                "/" + pathToStores + "/" + trustStoreFile);
         }
         // Load the keystore
         KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());
@@ -148,7 +148,6 @@ abstract public class TLSBase {
         // Clients sockets are kept in a hash table with the port as the key.
         ConcurrentHashMap<Integer, SSLSocket> clientMap =
                 new ConcurrentHashMap<>();
-        boolean exit = false;
         Thread t;
         List<Exception> exceptionList = new ArrayList<>();
 
@@ -157,13 +156,14 @@ abstract public class TLSBase {
             name = "server";
             try {
                 sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(TLSBase.getKeyManager(builder.km), TLSBase.getTrustManager(builder.tm), null);
+                sslContext.init(TLSBase.getKeyManager(builder.km),
+                    TLSBase.getTrustManager(builder.tm), null);
                 fac = sslContext.getServerSocketFactory();
                 ssock = (SSLServerSocket) fac.createServerSocket(0);
                 ssock.setNeedClientAuth(builder.clientauth);
                 serverPort = ssock.getLocalPort();
             } catch (Exception e) {
-                System.err.println(e.getMessage());
+                System.err.println("Failure during server initialization");
                 e.printStackTrace();
             }
 
@@ -178,6 +178,7 @@ abstract public class TLSBase {
                         try {
                             write(c, read(c));
                         } catch (Exception e) {
+                            System.out.println("Caught " + e.getMessage());
                             e.printStackTrace();
                             exceptionList.add(e);
                         }
@@ -203,13 +204,14 @@ abstract public class TLSBase {
             name = "server";
             try {
                 sslContext = SSLContext.getInstance("TLS");
-                sslContext.init(TLSBase.getKeyManager(km), TLSBase.getTrustManager(tm), null);
+                sslContext.init(TLSBase.getKeyManager(km),
+                    TLSBase.getTrustManager(tm), null);
                 fac = sslContext.getServerSocketFactory();
                 ssock = (SSLServerSocket) fac.createServerSocket(0);
                 ssock.setNeedClientAuth(true);
                 serverPort = ssock.getLocalPort();
             } catch (Exception e) {
-                System.err.println(e.getMessage());
+                System.err.println("Failure during server initialization");
                 e.printStackTrace();
             }
 
@@ -224,7 +226,9 @@ abstract public class TLSBase {
                             try {
                                 write(c, read(c));
                             } catch (Exception e) {
+                                System.out.println("Caught " + e.getMessage());
                                 e.printStackTrace();
+                                exceptionList.add(e);
                             }
                         }
                     } catch (Exception ex) {
@@ -239,7 +243,7 @@ abstract public class TLSBase {
         // test or the test will never end.
         void done() {
             try {
-                t.interrupt();
+                t.join(5000);
                 ssock.close();
             } catch (Exception e) {
                 System.err.println(e.getMessage());


### PR DESCRIPTION
Hi,

I need a review of this clean backport of this test fix to jdk23.

Tony

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326705](https://bugs.openjdk.org/browse/JDK-8326705): Test CertMsgCheck.java fails to find alert certificate_required (**Bug** - P3)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19917/head:pull/19917` \
`$ git checkout pull/19917`

Update a local copy of the PR: \
`$ git checkout pull/19917` \
`$ git pull https://git.openjdk.org/jdk.git pull/19917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19917`

View PR using the GUI difftool: \
`$ git pr show -t 19917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19917.diff">https://git.openjdk.org/jdk/pull/19917.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19917#issuecomment-2192767973)