### PR TITLE
8335221: Some C2 intrinsics incorrectly assume that type argument is compile-time constant

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5491,7 +5491,7 @@ void LibraryCallKit::create_new_uncommon_trap(CallStaticJavaNode* uncommon_trap_
 
 // Common checks for array sorting intrinsics arguments.
 // Returns `true` if checks passed.
-bool LibraryCallKit::check_array_sort_arguments(Node* elementType, Node* obj, BasicType* bt) {
+bool LibraryCallKit::check_array_sort_arguments(Node* elementType, Node* obj, BasicType& bt) {
   // check address of the class
   if (elementType == nullptr || elementType->is_top()) {
     return false;  // dead path
@@ -5505,9 +5505,9 @@ bool LibraryCallKit::check_array_sort_arguments(Node* elementType, Node* obj, Ba
   if (elem_type == nullptr) {
     return false;
   }
-  BasicType ebt = elem_type->basic_type();
+  bt = elem_type->basic_type();
   // Disable the intrinsic if the CPU does not support SIMD sort
-  if (!Matcher::supports_simd_sort(ebt)) {
+  if (!Matcher::supports_simd_sort(bt)) {
     return false;
   }
   // check address of the array
@@ -5518,7 +5518,6 @@ bool LibraryCallKit::check_array_sort_arguments(Node* elementType, Node* obj, Ba
   if (obj_t == nullptr || obj_t->elem() == Type::BOTTOM) {
     return false; // failed input validation
   }
-  *bt = ebt;
   return true;
 }
 
@@ -5543,7 +5542,7 @@ bool LibraryCallKit::inline_array_partition() {
   Node* pivotIndices = nullptr;
   BasicType bt = T_ILLEGAL;
 
-  if (!check_array_sort_arguments(elementType, obj, &bt)) {
+  if (!check_array_sort_arguments(elementType, obj, bt)) {
     return false;
   }
   null_check(obj);
@@ -5604,7 +5603,7 @@ bool LibraryCallKit::inline_array_sort() {
 
   BasicType bt = T_ILLEGAL;
 
-  if (!check_array_sort_arguments(elementType, obj, &bt)) {
+  if (!check_array_sort_arguments(elementType, obj, bt)) {
     return false;
   }
   null_check(obj);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -5489,52 +5489,68 @@ void LibraryCallKit::create_new_uncommon_trap(CallStaticJavaNode* uncommon_trap_
   uncommon_trap_call->set_req(0, top()); // not used anymore, kill it
 }
 
-//------------------------------inline_array_partition-----------------------
-bool LibraryCallKit::inline_array_partition() {
-
-  Node* elementType     = argument(0);
-  Node* obj             = argument(1);
-  Node* offset          = argument(2);
-  Node* fromIndex       = argument(4);
-  Node* toIndex         = argument(5);
-  Node* indexPivot1     = argument(6);
-  Node* indexPivot2     = argument(7);
-
-  Node* pivotIndices = nullptr;
-
-  const TypeInstPtr* elem_klass = gvn().type(elementType)->isa_instptr();
-  if (elem_klass == nullptr) {
-    return false;  // dead path (elementType->is_top()).
-  }
-  if (obj == nullptr || obj->is_top()) {
+// Common checks for array sorting intrinsics arguments.
+// Returns `true` if checks passed.
+bool LibraryCallKit::check_array_sort_arguments(Node* elementType, Node* obj, BasicType* bt) {
+  // check address of the class
+  if (elementType == nullptr || elementType->is_top()) {
     return false;  // dead path
   }
-  // java_mirror_type() returns non-null for compile-time Class constants only.
+  const TypeInstPtr* elem_klass = gvn().type(elementType)->isa_instptr();
+  if (elem_klass == nullptr) {
+    return false;  // dead path
+  }
+  // java_mirror_type() returns non-null for compile-time Class constants only
   ciType* elem_type = elem_klass->java_mirror_type();
   if (elem_type == nullptr) {
     return false;
   }
-  BasicType bt = elem_type->basic_type();
+  BasicType ebt = elem_type->basic_type();
   // Disable the intrinsic if the CPU does not support SIMD sort
-  if (!Matcher::supports_simd_sort(bt)) {
+  if (!Matcher::supports_simd_sort(ebt)) {
     return false;
   }
-  address stubAddr = nullptr;
-  stubAddr = StubRoutines::select_array_partition_function();
-  // stub not loaded
-  if (stubAddr == nullptr) {
-    return false;
+  // check address of the array
+  if (obj == nullptr || obj->is_top()) {
+    return false;  // dead path
   }
-  // get the address of the array
   const TypeAryPtr* obj_t = _gvn.type(obj)->isa_aryptr();
-  if (obj_t == nullptr || obj_t->elem() == Type::BOTTOM ) {
+  if (obj_t == nullptr || obj_t->elem() == Type::BOTTOM) {
     return false; // failed input validation
   }
+  *bt = ebt;
+  return true;
+}
 
+//------------------------------inline_array_partition-----------------------
+bool LibraryCallKit::inline_array_partition() {
+  address stubAddr = StubRoutines::select_array_partition_function();
+  if (stubAddr == nullptr) {
+    return false; // Intrinsic's stub is not implemented on this platform
+  }
+  assert(callee()->signature()->size() == 9, "arrayPartition has 8 parameters (one long)");
+
+  // no receiver because it is a static method
+  Node* elementType     = argument(0);
+  Node* obj             = argument(1);
+  Node* offset          = argument(2); // long
+  Node* fromIndex       = argument(4);
+  Node* toIndex         = argument(5);
+  Node* indexPivot1     = argument(6);
+  Node* indexPivot2     = argument(7);
+  // PartitionOperation:  argument(8) is ignored
+
+  Node* pivotIndices = nullptr;
+  BasicType bt = T_ILLEGAL;
+
+  if (!check_array_sort_arguments(elementType, obj, &bt)) {
+    return false;
+  }
   null_check(obj);
   // If obj is dead, only null-path is taken.
-  if (stopped())  return true;
-
+  if (stopped()) {
+    return true;
+  }
   // Set the original stack and the reexecute bit for the interpreter to reexecute
   // the bytecode that invokes DualPivotQuicksort.partition() if deoptimization happens.
   { PreserveReexecuteState preexecs(this);
@@ -5572,47 +5588,30 @@ bool LibraryCallKit::inline_array_partition() {
 
 //------------------------------inline_array_sort-----------------------
 bool LibraryCallKit::inline_array_sort() {
+  address stubAddr = StubRoutines::select_arraysort_function();
+  if (stubAddr == nullptr) {
+    return false; // Intrinsic's stub is not implemented on this platform
+  }
+  assert(callee()->signature()->size() == 7, "arraySort has 6 parameters (one long)");
 
+  // no receiver because it is a static method
   Node* elementType     = argument(0);
   Node* obj             = argument(1);
-  Node* offset          = argument(2);
+  Node* offset          = argument(2); // long
   Node* fromIndex       = argument(4);
   Node* toIndex         = argument(5);
+  // SortOperation:       argument(6) is ignored
 
-  const TypeInstPtr* elem_klass = gvn().type(elementType)->isa_instptr();
-  if (elem_klass == nullptr) {
-    return false;  // dead path (elementType->is_top()).
-  }
-  if (obj == nullptr || obj->is_top()) {
-    return false;  // dead path
-  }
-  // java_mirror_type() returns non-null for compile-time Class constants only.
-  ciType* elem_type = elem_klass->java_mirror_type();
-  if (elem_type == nullptr) {
+  BasicType bt = T_ILLEGAL;
+
+  if (!check_array_sort_arguments(elementType, obj, &bt)) {
     return false;
   }
-  BasicType bt = elem_type->basic_type();
-  // Disable the intrinsic if the CPU does not support SIMD sort
-  if (!Matcher::supports_simd_sort(bt)) {
-    return false;
-  }
-  address stubAddr = nullptr;
-  stubAddr = StubRoutines::select_arraysort_function();
-  //stub not loaded
-  if (stubAddr == nullptr) {
-    return false;
-  }
-
-  // get address of the array
-  const TypeAryPtr* obj_t = _gvn.type(obj)->isa_aryptr();
-  if (obj_t == nullptr || obj_t->elem() == Type::BOTTOM ) {
-    return false; // failed input validation
-  }
-
   null_check(obj);
   // If obj is dead, only null-path is taken.
-  if (stopped())  return true;
-
+  if (stopped()) {
+    return true;
+  }
   Node* obj_adr = make_unsafe_address(obj, offset);
 
   // pass the basic type enum to the stub

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -279,6 +279,7 @@ class LibraryCallKit : public GraphKit {
   JVMState* arraycopy_restore_alloc_state(AllocateArrayNode* alloc, int& saved_reexecute_sp);
   void arraycopy_move_allocation_here(AllocateArrayNode* alloc, Node* dest, JVMState* saved_jvms_before_guards, int saved_reexecute_sp,
                                       uint new_idx);
+  bool check_array_sort_arguments(Node* elementType, Node* obj, BasicType* bt);
   bool inline_array_sort();
   bool inline_array_partition();
   typedef enum { LS_get_add, LS_get_set, LS_cmp_swap, LS_cmp_swap_weak, LS_cmp_exchange } LoadStoreKind;

--- a/src/hotspot/share/opto/library_call.hpp
+++ b/src/hotspot/share/opto/library_call.hpp
@@ -279,7 +279,7 @@ class LibraryCallKit : public GraphKit {
   JVMState* arraycopy_restore_alloc_state(AllocateArrayNode* alloc, int& saved_reexecute_sp);
   void arraycopy_move_allocation_here(AllocateArrayNode* alloc, Node* dest, JVMState* saved_jvms_before_guards, int saved_reexecute_sp,
                                       uint new_idx);
-  bool check_array_sort_arguments(Node* elementType, Node* obj, BasicType* bt);
+  bool check_array_sort_arguments(Node* elementType, Node* obj, BasicType& bt);
   bool inline_array_sort();
   bool inline_array_partition();
   typedef enum { LS_get_add, LS_get_set, LS_cmp_swap, LS_cmp_swap_weak, LS_cmp_exchange } LoadStoreKind;


### PR DESCRIPTION
Problems were found in some C2 intrinsics while testing Leyden Early Release.

[`inline_array_partition()`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/library_call.cpp#L5493) and [`inline_array_sort()`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/library_call.cpp#L5559) intrinsics incorrectly assume that `elementType` argument is always compile-time constant. Which is not true for Leyden (and in general) when constant folding optimization is switched off (or did not executed for particular type).

Note, other intrinsics are very careful about that. For example, see [`inline_Class_cast()`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/library_call.cpp#L3963) intrinsic.

Add similar checks to `inline_array_partition()` and `inline_array_sort()`.

An other problem is that `null_check()` (which adds new control nodes to graph) was executed in these intrinsics before bailouts from intrinsic generation. We hit next assert if bailout happens:
```
  assert(ctrl == kit.control(), "Control flow was added although the intrinsic bailed out");
```

I moved `null_check()` after bailouts.

An other issue with `null_check()` is it checks for `null` first argument which is `Class`. It can't be `null` because corresponding Java methods are `private` and each call site passed `<primitive_type>.class` as first argument.
For example: [DualPivotQuicksort.java#L260](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/DualPivotQuicksort.java#L260)
On other hand there is no null check for passed array (second argument). I changed `null_check()` for array.

These 2 intrinsics were added by [JDK-8309130](https://bugs.openjdk.org/browse/JDK-8309130) in JDK 22.

Testing tier1-6, hs-stress, hs-xcomp

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335221](https://bugs.openjdk.org/browse/JDK-8335221): Some C2 intrinsics incorrectly assume that type argument is compile-time constant (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) ⚠️ Review applies to [c370b07a](https://git.openjdk.org/jdk/pull/19918/files/c370b07ab4d3cdeca9c91dbfa4ce0fda6973c0b0)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**) ⚠️ Review applies to [8ab7034a](https://git.openjdk.org/jdk/pull/19918/files/8ab7034a335db2f80cc0bdc4fa3c3cdc3b56fccd)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19918/head:pull/19918` \
`$ git checkout pull/19918`

Update a local copy of the PR: \
`$ git checkout pull/19918` \
`$ git pull https://git.openjdk.org/jdk.git pull/19918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19918`

View PR using the GUI difftool: \
`$ git pr show -t 19918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19918.diff">https://git.openjdk.org/jdk/pull/19918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19918#issuecomment-2192927692)