### PR TITLE
8335217: Fix memory ordering in ClassLoaderData::ChunkedHandleList

### DIFF
--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -181,7 +181,7 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool has_class_mirror_ho
 }
 
 ClassLoaderData::ChunkedHandleList::~ChunkedHandleList() {
-  Chunk* c = Atomic::load_acquire(&_head);
+  Chunk* c = _head;
   while (c != nullptr) {
     Chunk* next = c->_next;
     delete c;

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -181,7 +181,7 @@ ClassLoaderData::ClassLoaderData(Handle h_class_loader, bool has_class_mirror_ho
 }
 
 ClassLoaderData::ChunkedHandleList::~ChunkedHandleList() {
-  Chunk* c = _head;
+  Chunk* c = Atomic::load_acquire(&_head);
   while (c != nullptr) {
     Chunk* next = c->_next;
     delete c;
@@ -202,7 +202,7 @@ OopHandle ClassLoaderData::ChunkedHandleList::add(oop o) {
 
 int ClassLoaderData::ChunkedHandleList::count() const {
   int count = 0;
-  Chunk* chunk = _head;
+  Chunk* chunk = Atomic::load_acquire(&_head);
   while (chunk != nullptr) {
     count += chunk->_size;
     chunk = chunk->_next;
@@ -258,7 +258,7 @@ bool ClassLoaderData::ChunkedHandleList::contains(oop p) {
 
 #ifndef PRODUCT
 bool ClassLoaderData::ChunkedHandleList::owner_of(oop* oop_handle) {
-  Chunk* chunk = _head;
+  Chunk* chunk = Atomic::load_acquire(&_head);
   while (chunk != nullptr) {
     if (&(chunk->_data[0]) <= oop_handle && oop_handle < &(chunk->_data[chunk->_size])) {
       return true;

--- a/src/hotspot/share/classfile/classLoaderData.cpp
+++ b/src/hotspot/share/classfile/classLoaderData.cpp
@@ -260,7 +260,7 @@ bool ClassLoaderData::ChunkedHandleList::contains(oop p) {
 bool ClassLoaderData::ChunkedHandleList::owner_of(oop* oop_handle) {
   Chunk* chunk = Atomic::load_acquire(&_head);
   while (chunk != nullptr) {
-    if (&(chunk->_data[0]) <= oop_handle && oop_handle < &(chunk->_data[chunk->_size])) {
+    if (&(chunk->_data[0]) <= oop_handle && oop_handle < &(chunk->_data[Atomic::load(&chunk->_size)])) {
       return true;
     }
     chunk = chunk->_next;


### PR DESCRIPTION
ClassLoaderData::ChunkedHandleList's head is installed via Atomic::release_store(). Therefore, readers need Atomic::Atomic::load_acquire() barrier to access its members safely.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335217](https://bugs.openjdk.org/browse/JDK-8335217): Fix memory ordering in ClassLoaderData::ChunkedHandleList (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) ⚠️ Review applies to [84a7d1cf](https://git.openjdk.org/jdk/pull/19919/files/84a7d1cf92a3dda68273b6a9fc089ec85c01664a)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) ⚠️ Review applies to [86bb359b](https://git.openjdk.org/jdk/pull/19919/files/86bb359b9f7c53ffe2e85fee5adaa91840b1e0d5)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19919/head:pull/19919` \
`$ git checkout pull/19919`

Update a local copy of the PR: \
`$ git checkout pull/19919` \
`$ git pull https://git.openjdk.org/jdk.git pull/19919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19919`

View PR using the GUI difftool: \
`$ git pr show -t 19919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19919.diff">https://git.openjdk.org/jdk/pull/19919.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19919#issuecomment-2192963734)