### PR TITLE
8277949: (dc) java/nio/channels/DatagramChannel/AdaptorBasic.java failed in timeout

### DIFF
--- a/test/jdk/java/nio/channels/DatagramChannel/AdaptorBasic.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/AdaptorBasic.java
@@ -36,6 +36,8 @@ import java.nio.channels.*;
 import java.util.*;
 import java.lang.reflect.Field;
 
+import jdk.test.lib.Platform;
+
 
 public class AdaptorBasic {
 
@@ -118,7 +120,13 @@ public class AdaptorBasic {
             while (true) {
                 DatagramChannel dc = DatagramChannel.open();
                 ds = dc.socket();
-                ds.bind(new InetSocketAddress(0));
+                if (Platform.isOSX() && dst.getAddress().isLoopbackAddress()) {
+                    // avoid binding to the wildcard on macOS if possible, in order to limit
+                    // potential port conflict issues
+                    ds.bind(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
+                } else {
+                    ds.bind(new InetSocketAddress(0));
+                }
                 // on some systems it may be possible to bind two sockets
                 // to the same port if one of them is bound to the wildcard,
                 // if that happens, try again...

--- a/test/jdk/java/nio/channels/DatagramChannel/AdaptorBasic.java
+++ b/test/jdk/java/nio/channels/DatagramChannel/AdaptorBasic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,6 +69,8 @@ public class AdaptorBasic {
         for (;;) {
             try {
                 ds.receive(ip);
+                // weed off stray datagrams
+                if (ip.getPort() != dst.getPort()) continue;
             } catch (SocketTimeoutException x) {
                 if (shouldTimeout) {
                     out.println("Receive timed out, as expected");
@@ -111,12 +113,30 @@ public class AdaptorBasic {
             // Original
             ds = new DatagramSocket();
         } else {
-            DatagramChannel dc = DatagramChannel.open();
-            ds = dc.socket();
-            ds.bind(new InetSocketAddress(0));
+            int attempts = 0;
+            DatagramChannel toclose = null;
+            while (true) {
+                DatagramChannel dc = DatagramChannel.open();
+                ds = dc.socket();
+                ds.bind(new InetSocketAddress(0));
+                // on some systems it may be possible to bind two sockets
+                // to the same port if one of them is bound to the wildcard,
+                // if that happens, try again...
+                if (ds.getLocalPort() == dst.getPort()) {
+                    if (toclose != null) toclose.close();
+                    toclose = dc;
+                    if (++attempts == 10) {
+                        throw new AssertionError("Couldn't allocate port for client socket");
+                    }
+                    continue;
+                }
+                if (toclose != null) toclose.close();
+                break;
+            }
         }
 
-        out.println("socket: " + ds);
+        out.println("socket: " + ds + " bound to src: "
+                + ds.getLocalSocketAddress() + ", dst: " + dst);
         if (connect) {
             ds.connect(dst);
             out.println("connect: " + ds);
@@ -141,7 +161,7 @@ public class AdaptorBasic {
     public static void main(String[] args) throws Exception {
         // need an UDP echo server
         try (TestServers.UdpEchoServer echoServer
-                = TestServers.UdpEchoServer.startNewServer(100)) {
+                = TestServers.UdpEchoServer.startNewServer(100, InetAddress.getLoopbackAddress())) {
             final InetSocketAddress address
                 = new InetSocketAddress(echoServer.getAddress(),
                                         echoServer.getPort());

--- a/test/jdk/java/nio/channels/TestServers.java
+++ b/test/jdk/java/nio/channels/TestServers.java
@@ -497,6 +497,7 @@ public class TestServers {
             implements Runnable, Closeable {
 
         protected final long linger; // #of ms to wait before responding
+        protected final InetAddress bindAddress; //local address to bind to; can be null.
         private Thread acceptThread; // thread waiting for packets
         private DatagramSocket serverSocket; // the server socket
         private boolean started = false; // whether the server is started
@@ -509,7 +510,19 @@ public class TestServers {
          * responding to requests.
          */
         protected AbstractUdpServer(long linger) {
+            this(linger, null);
+        }
+
+        /**
+         *
+         * @param linger the amount of time the server should wait before
+         *          responding to requests.
+         * @param bindAddress the address to bind to. If {@code null}, will
+         *                    bind to InetAddress.getLocalHost();
+         */
+        protected AbstractUdpServer(long linger, InetAddress bindAddress) {
             this.linger = linger;
+            this.bindAddress = bindAddress;
         }
 
         /**
@@ -574,8 +587,9 @@ public class TestServers {
             if (started) {
                 return;
             }
+            InetAddress lh = bindAddress == null ? InetAddress.getLocalHost() : bindAddress;
             final DatagramSocket socket =
-                    newDatagramSocket(0, InetAddress.getLocalHost());
+                    newDatagramSocket(0, lh);
             serverSocket = socket;
             acceptThread = new Thread(this);
             acceptThread.setDaemon(true);
@@ -759,7 +773,11 @@ public class TestServers {
         }
 
         public UdpEchoServer(long linger) {
-            super(linger);
+            this(linger, null);
+        }
+
+        public UdpEchoServer(long linger, InetAddress bindAddress) {
+            super(linger, bindAddress);
         }
 
         @Override
@@ -795,7 +813,11 @@ public class TestServers {
         }
 
         public static UdpEchoServer startNewServer(long linger) throws IOException {
-            final UdpEchoServer echoServer = new UdpEchoServer(linger);
+            return startNewServer(0, InetAddress.getLocalHost());
+        }
+
+        public static UdpEchoServer startNewServer(long linger, InetAddress bindAddress) throws IOException {
+            final UdpEchoServer echoServer = new UdpEchoServer(linger, bindAddress);
             echoServer.start();
             return echoServer;
         }

--- a/test/jdk/java/nio/channels/TestServers.java
+++ b/test/jdk/java/nio/channels/TestServers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,6 +514,7 @@ public class TestServers {
         }
 
         /**
+         * Creates a new abstract UDP server.
          *
          * @param linger the amount of time the server should wait before
          *          responding to requests.


### PR DESCRIPTION
On macOS, when binding a datagram socket to the wildcard address with port 0, or when connecting an unbound socket (which ends up binding the socket to the wildacrd with port 0 first), the system may assign a port which is already used by another socket for a different local address. When that happens, a datagram may get misrouted which explains the intermittent failures where the test is blocked in receive().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277949](https://bugs.openjdk.org/browse/JDK-8277949): (dc) java/nio/channels/DatagramChannel/AdaptorBasic.java failed in timeout (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19922/head:pull/19922` \
`$ git checkout pull/19922`

Update a local copy of the PR: \
`$ git checkout pull/19922` \
`$ git pull https://git.openjdk.org/jdk.git pull/19922/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19922`

View PR using the GUI difftool: \
`$ git pr show -t 19922`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19922.diff">https://git.openjdk.org/jdk/pull/19922.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19922#issuecomment-2193928179)