### PR TITLE
8335142: compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
+++ b/test/hotspot/jtreg/compiler/c1/TestTraceLinearScanLevel.java
@@ -26,8 +26,8 @@
  * @bug 8251093
  * @summary Sanity check the flag TraceLinearScanLevel with the highest level in a silent HelloWorld program.
  *
- * @requires vm.debug == true & vm.compiler1.enabled
- * @run main/othervm -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
+ * @requires vm.debug == true & vm.compiler1.enabled & vm.compMode != "Xcomp"
+ * @run main/othervm -Xbatch -XX:TraceLinearScanLevel=4 compiler.c1.TestTraceLinearScanLevel
  */
 package compiler.c1;
 


### PR DESCRIPTION
The test`compiler/c1/TestTraceLinearScanLevel.java` is occasionally timing out on macosx-x64 when running with `-Xcomp`. The test's purpose is to sanity check the `TraceLinearScanLevel` flag with a hello world like test. It runs with the highest level which prints quite a lot of data which takes time. It becomes even worse when running with `-Xcomp`. Since we only want to sanity check the flag, there is not that much benefit in additionally running this test with `-Xcomp`. This only unnecessarily increases the time to run this test.

I therefore exclude the test from running with `-Xcomp`. As a trade-off, I added `-Xbatch` to at least cover all the C1 compiled methods from start-up.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335142](https://bugs.openjdk.org/browse/JDK-8335142): compiler/c1/TestTraceLinearScanLevel.java occasionally times out with -Xcomp (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19923/head:pull/19923` \
`$ git checkout pull/19923`

Update a local copy of the PR: \
`$ git checkout pull/19923` \
`$ git pull https://git.openjdk.org/jdk.git pull/19923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19923`

View PR using the GUI difftool: \
`$ git pr show -t 19923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19923.diff">https://git.openjdk.org/jdk/pull/19923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19923#issuecomment-2194118157)