### PR TITLE
8335124: com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed with CPU time out of expected range

### DIFF
--- a/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
+++ b/test/jdk/com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java
@@ -75,7 +75,6 @@ public class ThreadCpuTimeArray {
         // threads block after doing some computation
         waitUntilThreadBlocked();
 
-
         long times[] = mbean.getThreadCpuTime(ids);
         long userTimes[] = mbean.getThreadUserTime(ids);
 
@@ -222,6 +221,8 @@ public class ThreadCpuTimeArray {
                 }
             }
         }
+        // Account for threads using CPU for a few millis after their WAITING state is visible:
+        goSleep(500);
     }
 
     public static void doit() {


### PR DESCRIPTION
This test has had occasional failures for years, possibly forever.
A previous update made the test "othervm" which removed some interruptions, but a time accounting problem remains.

This change adds a simple sleep after observing that the test threads are all sleeping.

The idea is that threads may not have actually started sleeping when we observe their java.lang.Thread.State as WAITING, they may use some CPU time after that in order to actually get to sleep.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335124](https://bugs.openjdk.org/browse/JDK-8335124): com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed with CPU time out of expected range (**Bug** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19924/head:pull/19924` \
`$ git checkout pull/19924`

Update a local copy of the PR: \
`$ git checkout pull/19924` \
`$ git pull https://git.openjdk.org/jdk.git pull/19924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19924`

View PR using the GUI difftool: \
`$ git pr show -t 19924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19924.diff">https://git.openjdk.org/jdk/pull/19924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19924#issuecomment-2194221457)