### PR TITLE
8335237: ubsan: vtableStubs.hpp  is_vtable_stub exclude from ubsan checks

### DIFF
--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@
 #include "asm/macroAssembler.hpp"
 #include "code/vmreg.hpp"
 #include "memory/allStatic.hpp"
+#include "sanitizers/ub.hpp"
 #include "utilities/checkedCast.hpp"
 
 // A VtableStub holds an individual code stub for a pair (vtable index, #args) for either itables or vtables
@@ -173,6 +174,7 @@ class VtableStub {
  public:
   // Query
   bool is_itable_stub()                          { return !_is_vtable_stub; }
+  ATTRIBUTE_NO_UBSAN
   bool is_vtable_stub()                          { return  _is_vtable_stub; }
   bool is_abstract_method_error(address epc)     { return epc == code_begin()+_ame_offset; }
   bool is_null_pointer_exception(address epc)    { return epc == code_begin()+_npe_offset; }

--- a/src/hotspot/share/code/vtableStubs.hpp
+++ b/src/hotspot/share/code/vtableStubs.hpp
@@ -174,6 +174,8 @@ class VtableStub {
  public:
   // Query
   bool is_itable_stub()                          { return !_is_vtable_stub; }
+  // We reinterpret arbitrary memory as VtableStub. This does not cause failures because the lookup/equality
+  // check will reject false objects. Disabling UBSan is a temporary workaround until JDK-8331725 is fixed.
   ATTRIBUTE_NO_UBSAN
   bool is_vtable_stub()                          { return  _is_vtable_stub; }
   bool is_abstract_method_error(address epc)     { return epc == code_begin()+_ame_offset; }


### PR DESCRIPTION
[JDK-8331725](https://bugs.openjdk.org/browse/JDK-8331725) shows an ubsan (undefined behavior) issue in vtableStubs.hpp is_vtable_stub() .

/open_jdk/jdk_test/jdk/src/hotspot/share/code/vtableStubs.hpp:176:60: runtime error: load of value 204, which is not a valid value for type 'bool'
    #0 0x110a6ad7e in VtableStubs::entry_point(unsigned char*) vtableStubs.cpp:280
    #1 0x10f4cc8e6 in CompiledIC::is_megamorphic() const compiledIC.cpp:293
    #2 0x10f4cc95d in CompiledIC::update(CallInfo*, Klass*) compiledIC.cpp:268
    #3 0x110592eed in SharedRuntime::resolve_helper(bool, bool, JavaThread*) sharedRuntime.cpp:1366
    #4 0x11058c0b3 in SharedRuntime::resolve_virtual_call_C(JavaThread*) sharedRuntime.cpp:1514
    #5 0x12cd2e55a (<unknown module>)
    #6 0x12580e03b (<unknown module>)
    #7 0x12cc1f321 (<unknown module>)
    #8 0x12cc1f321 (<unknown module>)

From the comments of the issue it seems while the coding could be improved, the problem is not very severe ('The reason bad bool values are seen is because there is no VtableStub object at that location. The reason this works is that we use the data at this location to generate a hash code, do a hash table lookup and then check the actual address for equality. Generating a bogus hash is harmless, ... ')
so as long as nothing better was found, we can exclude the method from ubsan checking.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335237](https://bugs.openjdk.org/browse/JDK-8335237): ubsan: vtableStubs.hpp  is_vtable_stub exclude from ubsan checks (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19925/head:pull/19925` \
`$ git checkout pull/19925`

Update a local copy of the PR: \
`$ git checkout pull/19925` \
`$ git pull https://git.openjdk.org/jdk.git pull/19925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19925`

View PR using the GUI difftool: \
`$ git pr show -t 19925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19925.diff">https://git.openjdk.org/jdk/pull/19925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19925#issuecomment-2194225004)