### PR TITLE
8335252: Reduce size of j.u.Formatter.Conversion#isValid

### DIFF
--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -63,7 +63,6 @@ import java.time.temporal.UnsupportedTemporalTypeException;
 
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFPDecimal;
-import jdk.internal.vm.annotation.ForceInline;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.ResourceBundleBasedAdapter;
 
@@ -4947,9 +4946,8 @@ public final class Formatter implements Closeable, Flushable {
         static final char LINE_SEPARATOR      = 'n';
         static final char PERCENT_SIGN        = '%';
 
-        // The switch here will generate bytecode with size > 325 bytes, so ForceInline is required.
-        @ForceInline
         static boolean isValid(char c) {
+            // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
             return switch (c) {
                 case BOOLEAN,
                      BOOLEAN_UPPER,
@@ -4970,9 +4968,8 @@ public final class Formatter implements Closeable, Flushable {
                      DECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT_UPPER,
-                     LINE_SEPARATOR,
-                     PERCENT_SIGN -> true;
-                default -> false;
+                     LINE_SEPARATOR -> true;
+                default -> c == PERCENT_SIGN;
             };
         }
 

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -4947,7 +4947,6 @@ public final class Formatter implements Closeable, Flushable {
         static final char PERCENT_SIGN        = '%';
 
         static boolean isValid(char c) {
-            // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
             return switch (c) {
                 case BOOLEAN,
                      BOOLEAN_UPPER,
@@ -4969,6 +4968,7 @@ public final class Formatter implements Closeable, Flushable {
                      HEXADECIMAL_FLOAT,
                      HEXADECIMAL_FLOAT_UPPER,
                      LINE_SEPARATOR -> true;
+                // Don't put PERCENT_SIGN inside switch, as that will make the method size exceed 325 and cannot be inlined.
                 default -> c == PERCENT_SIGN;
             };
         }

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -61,8 +61,11 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
+import java.util.function.IntPredicate;
+
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFPDecimal;
+import jdk.internal.util.ImmutableBitSetPredicate;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.ResourceBundleBasedAdapter;
 
@@ -4946,31 +4949,40 @@ public final class Formatter implements Closeable, Flushable {
         static final char LINE_SEPARATOR      = 'n';
         static final char PERCENT_SIGN        = '%';
 
-        static boolean isValid(char c) {
-            return switch (c) {
-                case BOOLEAN,
-                     BOOLEAN_UPPER,
-                     STRING,
-                     STRING_UPPER,
-                     HASHCODE,
-                     HASHCODE_UPPER,
-                     CHARACTER,
-                     CHARACTER_UPPER,
-                     DECIMAL_INTEGER,
-                     OCTAL_INTEGER,
-                     HEXADECIMAL_INTEGER,
-                     HEXADECIMAL_INTEGER_UPPER,
-                     SCIENTIFIC,
-                     SCIENTIFIC_UPPER,
-                     GENERAL,
-                     GENERAL_UPPER,
-                     DECIMAL_FLOAT,
-                     HEXADECIMAL_FLOAT,
-                     HEXADECIMAL_FLOAT_UPPER,
-                     LINE_SEPARATOR,
-                     PERCENT_SIGN -> true;
-                default -> false;
+        static final IntPredicate VALID;
+        static {
+            char[] chars = {
+                    BOOLEAN,
+                    BOOLEAN_UPPER,
+                    STRING,
+                    STRING_UPPER,
+                    HASHCODE,
+                    HASHCODE_UPPER,
+                    CHARACTER,
+                    CHARACTER_UPPER,
+                    DECIMAL_INTEGER,
+                    OCTAL_INTEGER,
+                    HEXADECIMAL_INTEGER,
+                    HEXADECIMAL_INTEGER_UPPER,
+                    SCIENTIFIC,
+                    SCIENTIFIC_UPPER,
+                    GENERAL,
+                    GENERAL_UPPER,
+                    DECIMAL_FLOAT,
+                    HEXADECIMAL_FLOAT,
+                    HEXADECIMAL_FLOAT_UPPER,
+                    LINE_SEPARATOR,
+                    PERCENT_SIGN
             };
+            var bitSet = new BitSet(128);
+            for (char ch : chars) {
+                bitSet.set(ch);
+            }
+            VALID = ImmutableBitSetPredicate.of(bitSet);
+        }
+
+        static boolean isValid(char c) {
+            return VALID.test(c);
         }
 
         // Returns true iff the Conversion is applicable to all objects.

--- a/src/java.base/share/classes/java/util/Formatter.java
+++ b/src/java.base/share/classes/java/util/Formatter.java
@@ -61,11 +61,9 @@ import java.time.temporal.TemporalAccessor;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.UnsupportedTemporalTypeException;
 
-import java.util.function.IntPredicate;
-
 import jdk.internal.math.DoubleConsts;
 import jdk.internal.math.FormattedFPDecimal;
-import jdk.internal.util.ImmutableBitSetPredicate;
+import jdk.internal.vm.annotation.ForceInline;
 import sun.util.locale.provider.LocaleProviderAdapter;
 import sun.util.locale.provider.ResourceBundleBasedAdapter;
 
@@ -4949,40 +4947,33 @@ public final class Formatter implements Closeable, Flushable {
         static final char LINE_SEPARATOR      = 'n';
         static final char PERCENT_SIGN        = '%';
 
-        static final IntPredicate VALID;
-        static {
-            char[] chars = {
-                    BOOLEAN,
-                    BOOLEAN_UPPER,
-                    STRING,
-                    STRING_UPPER,
-                    HASHCODE,
-                    HASHCODE_UPPER,
-                    CHARACTER,
-                    CHARACTER_UPPER,
-                    DECIMAL_INTEGER,
-                    OCTAL_INTEGER,
-                    HEXADECIMAL_INTEGER,
-                    HEXADECIMAL_INTEGER_UPPER,
-                    SCIENTIFIC,
-                    SCIENTIFIC_UPPER,
-                    GENERAL,
-                    GENERAL_UPPER,
-                    DECIMAL_FLOAT,
-                    HEXADECIMAL_FLOAT,
-                    HEXADECIMAL_FLOAT_UPPER,
-                    LINE_SEPARATOR,
-                    PERCENT_SIGN
-            };
-            var bitSet = new BitSet(128);
-            for (char ch : chars) {
-                bitSet.set(ch);
-            }
-            VALID = ImmutableBitSetPredicate.of(bitSet);
-        }
-
+        // The switch here will generate bytecode with size > 325 bytes, so ForceInline is required.
+        @ForceInline
         static boolean isValid(char c) {
-            return VALID.test(c);
+            return switch (c) {
+                case BOOLEAN,
+                     BOOLEAN_UPPER,
+                     STRING,
+                     STRING_UPPER,
+                     HASHCODE,
+                     HASHCODE_UPPER,
+                     CHARACTER,
+                     CHARACTER_UPPER,
+                     DECIMAL_INTEGER,
+                     OCTAL_INTEGER,
+                     HEXADECIMAL_INTEGER,
+                     HEXADECIMAL_INTEGER_UPPER,
+                     SCIENTIFIC,
+                     SCIENTIFIC_UPPER,
+                     GENERAL,
+                     GENERAL_UPPER,
+                     DECIMAL_FLOAT,
+                     HEXADECIMAL_FLOAT,
+                     HEXADECIMAL_FLOAT_UPPER,
+                     LINE_SEPARATOR,
+                     PERCENT_SIGN -> true;
+                default -> false;
+            };
         }
 
         // Returns true iff the Conversion is applicable to all objects.


### PR DESCRIPTION
Currently, the java.util.Formatter$Conversion::isValid method is implemented based on switch, which cannot be inlined because codeSize > 325. This problem can be avoided by implementing it with ImmutableBitSetPredicate.

use `-XX:+UnlockDiagnosticVMOptions -XX:+PrintInlining` to see the master branch:
```
@ 109   java.util.Formatter$Conversion::isValid (358 bytes)   failed to inline: hot method too big
```

current version
```
@ 109   java.util.Formatter$Conversion::isValid (10 bytes)   inline (hot)
  @ 4   jdk.internal.util.ImmutableBitSetPredicate$SmallImmutableBitSetPredicate::test (50 bytes)   inline (hot)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335252](https://bugs.openjdk.org/browse/JDK-8335252): Reduce size of j.u.Formatter.Conversion#isValid (**Enhancement** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19926/head:pull/19926` \
`$ git checkout pull/19926`

Update a local copy of the PR: \
`$ git checkout pull/19926` \
`$ git pull https://git.openjdk.org/jdk.git pull/19926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19926`

View PR using the GUI difftool: \
`$ git pr show -t 19926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19926.diff">https://git.openjdk.org/jdk/pull/19926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19926#issuecomment-2194509747)