### PR TITLE
8326820: Metadata artificially kept alive

### DIFF
--- a/src/hotspot/share/classfile/classLoaderDataGraph.cpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.cpp
@@ -241,9 +241,14 @@ LockedClassesDo::~LockedClassesDo() {
 
 
 // Iterating over the CLDG needs to be locked because
-// unloading can remove entries concurrently soon.
-template <bool keep_alive = true>
-class ClassLoaderDataGraphIteratorBase : public StackObj {
+// unloading can remove entries concurrently.
+// This iterator does not keep the CLD alive.
+// Any CLD OopHandles (modules, mirrors, resolved refs)
+// resolved must be treated as no keepalive. And requires
+// that its CLD's holder is kept alive if they escape the
+// caller's safepoint or ClassLoaderDataGraph_lock
+// critical section.
+class ClassLoaderDataGraph::ClassLoaderDataGraphIterator : public StackObj {
   ClassLoaderData* _next;
   Thread*          _thread;
   HandleMark       _hm;  // clean up handles when this is done.
@@ -251,12 +256,8 @@ class ClassLoaderDataGraphIteratorBase : public StackObj {
                             // unless verifying at a safepoint.
 
 public:
-  ClassLoaderDataGraphIteratorBase() : _next(ClassLoaderDataGraph::_head), _thread(Thread::current()), _hm(_thread) {
-    if (keep_alive) {
-      assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
-    } else {
-      assert_at_safepoint();
-    }
+  ClassLoaderDataGraphIterator() : _next(ClassLoaderDataGraph::_head), _thread(Thread::current()), _hm(_thread) {
+    assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
   }
 
   ClassLoaderData* get_next() {
@@ -266,10 +267,6 @@ public:
       cld = cld->next();
     }
     if (cld != nullptr) {
-      if (keep_alive) {
-        // Keep cld that is being returned alive.
-        Handle(_thread, cld->holder());
-      }
       _next = cld->next();
     } else {
       _next = nullptr;
@@ -278,18 +275,8 @@ public:
   }
 };
 
-using ClassLoaderDataGraphIterator = ClassLoaderDataGraphIteratorBase<true /* keep_alive */>;
-using ClassLoaderDataGraphIteratorNoKeepAlive = ClassLoaderDataGraphIteratorBase<false /* keep_alive */>;
-
 void ClassLoaderDataGraph::loaded_cld_do(CLDClosure* cl) {
   ClassLoaderDataGraphIterator iter;
-  while (ClassLoaderData* cld = iter.get_next()) {
-    cl->do_cld(cld);
-  }
-}
-
-void ClassLoaderDataGraph::loaded_cld_do_no_keepalive(CLDClosure* cl) {
-  ClassLoaderDataGraphIteratorNoKeepAlive iter;
   while (ClassLoaderData* cld = iter.get_next()) {
     cl->do_cld(cld);
   }
@@ -318,6 +305,16 @@ void ClassLoaderDataGraph::methods_do(void f(Method*)) {
   }
 }
 
+void ClassLoaderDataGraph::modules_do_keepalive(void f(ModuleEntry*)) {
+  assert_locked_or_safepoint(Module_lock);
+  ClassLoaderDataGraphIterator iter;
+  while (ClassLoaderData* cld = iter.get_next()) {
+    // Keep the holder alive.
+    (void)cld->holder();
+    cld->modules_do(f);
+  }
+}
+
 void ClassLoaderDataGraph::modules_do(void f(ModuleEntry*)) {
   assert_locked_or_safepoint(Module_lock);
   ClassLoaderDataGraphIterator iter;
@@ -334,9 +331,11 @@ void ClassLoaderDataGraph::packages_do(void f(PackageEntry*)) {
   }
 }
 
-void ClassLoaderDataGraph::loaded_classes_do(KlassClosure* klass_closure) {
+void ClassLoaderDataGraph::loaded_classes_do_keepalive(KlassClosure* klass_closure) {
   ClassLoaderDataGraphIterator iter;
   while (ClassLoaderData* cld = iter.get_next()) {
+    // Keep the holder alive.
+    (void)cld->holder();
     cld->loaded_classes_do(klass_closure);
   }
 }
@@ -346,7 +345,7 @@ void ClassLoaderDataGraph::classes_unloading_do(void f(Klass* const)) {
 }
 
 void ClassLoaderDataGraph::verify_dictionary() {
-  ClassLoaderDataGraphIteratorNoKeepAlive iter;
+  ClassLoaderDataGraphIterator iter;
   while (ClassLoaderData* cld = iter.get_next()) {
     if (cld->dictionary() != nullptr) {
       cld->dictionary()->verify();
@@ -354,26 +353,28 @@ void ClassLoaderDataGraph::verify_dictionary() {
   }
 }
 
-#define FOR_ALL_DICTIONARY(X)   ClassLoaderDataGraphIterator iter; \
-                                while (ClassLoaderData* X = iter.get_next()) \
-                                  if (X->dictionary() != nullptr)
-
 void ClassLoaderDataGraph::print_dictionary(outputStream* st) {
-  FOR_ALL_DICTIONARY(cld) {
-    st->print("Dictionary for ");
-    cld->print_value_on(st);
-    st->cr();
-    cld->dictionary()->print_on(st);
-    st->cr();
+  ClassLoaderDataGraphIterator iter;
+  while (ClassLoaderData *cld = iter.get_next()) {
+    if (cld->dictionary() != nullptr) {
+      st->print("Dictionary for ");
+      cld->print_value_on(st);
+      st->cr();
+      cld->dictionary()->print_on(st);
+      st->cr();
+    }
   }
 }
 
 void ClassLoaderDataGraph::print_table_statistics(outputStream* st) {
-  FOR_ALL_DICTIONARY(cld) {
-    ResourceMark rm; // loader_name_and_id
-    stringStream tempst;
-    tempst.print("System Dictionary for %s class loader", cld->loader_name_and_id());
-    cld->dictionary()->print_table_statistics(st, tempst.freeze());
+  ClassLoaderDataGraphIterator iter;
+  while (ClassLoaderData *cld = iter.get_next()) {
+    if (cld->dictionary() != nullptr) {
+      ResourceMark rm; // loader_name_and_id
+      stringStream tempst;
+      tempst.print("System Dictionary for %s class loader", cld->loader_name_and_id());
+      cld->dictionary()->print_table_statistics(st, tempst.freeze());
+    }
   }
 }
 
@@ -550,7 +551,7 @@ Klass* ClassLoaderDataGraphKlassIteratorAtomic::next_klass() {
 }
 
 void ClassLoaderDataGraph::verify() {
-  ClassLoaderDataGraphIteratorNoKeepAlive iter;
+  ClassLoaderDataGraphIterator iter;
   while (ClassLoaderData* cld = iter.get_next()) {
     cld->verify();
   }

--- a/src/hotspot/share/classfile/classLoaderDataGraph.hpp
+++ b/src/hotspot/share/classfile/classLoaderDataGraph.hpp
@@ -37,10 +37,10 @@ class ClassLoaderDataGraph : public AllStatic {
   friend class ClassLoaderDataGraphMetaspaceIterator;
   friend class ClassLoaderDataGraphKlassIteratorAtomic;
   friend class ClassLoaderDataGraphKlassIteratorStatic;
-  template <bool keep_alive>
-  friend class ClassLoaderDataGraphIteratorBase;
   friend class VMStructs;
  private:
+  class ClassLoaderDataGraphIterator;
+
   // All CLDs (except unlinked CLDs) can be reached by walking _head->_next->...
   static ClassLoaderData* volatile _head;
 
@@ -71,8 +71,12 @@ class ClassLoaderDataGraph : public AllStatic {
   static void roots_cld_do(CLDClosure* strong, CLDClosure* weak);
   static void always_strong_cld_do(CLDClosure* cl);
   // Iteration through CLDG not by GC.
+  // All the do suffixed functions do not keep the CLD alive. Any CLD OopHandles
+  // (modules, mirrors, resolved refs) resolved must be treated as no keepalive.
+  // And requires that its CLD's holder is kept alive if they escape the
+  // caller's safepoint or ClassLoaderDataGraph_lock critical section.
+  // The do_keepalive suffixed functions will keep all CLDs alive.
   static void loaded_cld_do(CLDClosure* cl);
-  static void loaded_cld_do_no_keepalive(CLDClosure* cl);
   // klass do
   // Walking classes through the ClassLoaderDataGraph include array classes.  It also includes
   // classes that are allocated but not loaded, classes that have errors, and scratch classes
@@ -81,9 +85,10 @@ class ClassLoaderDataGraph : public AllStatic {
   static void classes_do(KlassClosure* klass_closure);
   static void classes_do(void f(Klass* const));
   static void methods_do(void f(Method*));
+  static void modules_do_keepalive(void f(ModuleEntry*));
   static void modules_do(void f(ModuleEntry*));
   static void packages_do(void f(PackageEntry*));
-  static void loaded_classes_do(KlassClosure* klass_closure);
+  static void loaded_classes_do_keepalive(KlassClosure* klass_closure);
   static void classes_unloading_do(void f(Klass* const));
   static bool do_unloading();
 

--- a/src/hotspot/share/classfile/classLoaderStats.cpp
+++ b/src/hotspot/share/classfile/classLoaderStats.cpp
@@ -165,7 +165,7 @@ void ClassLoaderStatsClosure::addEmptyParents(oop cl) {
 
 void ClassLoaderStatsVMOperation::doit() {
   ClassLoaderStatsClosure clsc (_out);
-  ClassLoaderDataGraph::loaded_cld_do_no_keepalive(&clsc);
+  ClassLoaderDataGraph::loaded_cld_do(&clsc);
   clsc.print();
 }
 

--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -177,7 +177,7 @@ class SystemDictionary : AllStatic {
 
   static void classes_do(MetaspaceClosure* it);
   // Iterate over all methods in all klasses
-
+  // Will not keep metadata alive. See ClassLoaderDataGraph::methods_do.
   static void methods_do(void f(Method*));
 
   // Garbage collection support

--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -2339,7 +2339,7 @@ JvmtiModuleClosure::get_all_modules(JvmtiEnv* env, jint* module_count_ptr, jobje
   }
 
   // Iterate over all the modules loaded to the system.
-  ClassLoaderDataGraph::modules_do(&do_module);
+  ClassLoaderDataGraph::modules_do_keepalive(&do_module);
 
   jint len = _tbl->length();
   guarantee(len > 0, "at least one module must be present");

--- a/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
+++ b/src/hotspot/share/prims/jvmtiGetLoadedClasses.cpp
@@ -105,7 +105,7 @@ JvmtiGetLoadedClasses::getLoadedClasses(JvmtiEnv *env, jint* classCountPtr, jcla
     // Iterate through all classes in ClassLoaderDataGraph
     // and collect them using the LoadedClassesClosure
     MutexLocker mcld(ClassLoaderDataGraph_lock);
-    ClassLoaderDataGraph::loaded_classes_do(&closure);
+    ClassLoaderDataGraph::loaded_classes_do_keepalive(&closure);
   }
 
   return closure.get_result(env, classCountPtr, classesPtr);


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [5909d541](https://github.com/openjdk/jdk/commit/5909d54147355dd7da5786ff39ead4c15816705c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Axel Boldt-Christmas on 27 Jun 2024 and was reviewed by Erik Österlund, Stefan Karlsson and Coleen Phillimore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326820](https://bugs.openjdk.org/browse/JDK-8326820): Metadata artificially kept alive (**Bug** - P2)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19929/head:pull/19929` \
`$ git checkout pull/19929`

Update a local copy of the PR: \
`$ git checkout pull/19929` \
`$ git pull https://git.openjdk.org/jdk.git pull/19929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19929`

View PR using the GUI difftool: \
`$ git pr show -t 19929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19929.diff">https://git.openjdk.org/jdk/pull/19929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19929#issuecomment-2194902765)