### PR TITLE
8334777: Test javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java failed with NullPointerException

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
  * @bug 6199899
  * @summary Tests reconnection done by a fetching notif thread.
  * @author Shanliang JIANG
+ * @requires vm.compMode != "Xcomp"
  *
  * @run clean NotifReconnectDeadlockTest
  * @run build NotifReconnectDeadlockTest

--- a/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java
@@ -27,6 +27,8 @@
  * @summary Tests reconnection done by a fetching notif thread.
  * @author Shanliang JIANG
  * @requires vm.compMode != "Xcomp"
+ * @comment Running with -Xcomp is likely to cause a timeout from ServerCommunicatorAdmin
+ *          before addNotificationListener can complete.
  *
  * @run clean NotifReconnectDeadlockTest
  * @run build NotifReconnectDeadlockTest


### PR DESCRIPTION
Disable running this test with -Xcomp.

The NPE seen in this test is due to a timeout establishing the connection.  ServerCommunicatorAdmin hits its timeout, during an addNotificationListener call on a new connection.

-Xcomp causes this slowdown and the failure is reproducible.  There is no need to test this test with -Xcomp, we should exclude it as we do for various other tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334777](https://bugs.openjdk.org/browse/JDK-8334777): Test javax/management/remote/mandatory/notif/NotifReconnectDeadlockTest.java failed with NullPointerException (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19930/head:pull/19930` \
`$ git checkout pull/19930`

Update a local copy of the PR: \
`$ git checkout pull/19930` \
`$ git pull https://git.openjdk.org/jdk.git pull/19930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19930`

View PR using the GUI difftool: \
`$ git pr show -t 19930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19930.diff">https://git.openjdk.org/jdk/pull/19930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19930#issuecomment-2195091535)