### PR TITLE
8334886: jdk/jfr/api/recording/time/TestTimeMultiple.java failed with RuntimeException: getStopTime() > afterStop

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
@@ -47,8 +47,6 @@ jlong JfrChunk::nanos_now() {
   const jlong now = seconds * 1000000000 + nanos;
   if (now > last) {
     last = now;
-  } else {
-    ++last;
   }
   return last;
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMSupport.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVMSupport.java
@@ -103,7 +103,6 @@ public final class JVMSupport {
 
     static long getChunkStartNanos() {
         long nanos = JVM.getChunkStartNanos();
-        // JVM::getChunkStartNanos() may return a bumped timestamp, +1 ns or +2 ns.
         // Spin here to give Instant.now() a chance to catch up.
         awaitUniqueTimestamp();
         return nanos;


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334886](https://bugs.openjdk.org/browse/JDK-8334886): jdk/jfr/api/recording/time/TestTimeMultiple.java failed with RuntimeException: getStopTime() &gt; afterStop (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19932/head:pull/19932` \
`$ git checkout pull/19932`

Update a local copy of the PR: \
`$ git checkout pull/19932` \
`$ git pull https://git.openjdk.org/jdk.git pull/19932/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19932`

View PR using the GUI difftool: \
`$ git pr show -t 19932`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19932.diff">https://git.openjdk.org/jdk/pull/19932.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19932#issuecomment-2195192784)