### PR TITLE
8335274: SwitchBootstraps.ResolvedEnumLabels.resolvedEnum should be final

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -358,7 +358,7 @@ public class SwitchBootstraps {
         private final MethodHandles.Lookup lookup;
         private final EnumDesc<?>[] enumDescs;
         @Stable
-        private Object[] resolvedEnum;
+        private final Object[] resolvedEnum;
 
         public ResolvedEnumLabels(MethodHandles.Lookup lookup, EnumDesc<?>[] enumDescs) {
             this.lookup = lookup;


### PR DESCRIPTION
I was auditing the current uses of `@Stable` before relaxing its barriers ([JDK-8333791](https://bugs.openjdk.org/browse/JDK-8333791)), and this is an easy spot. 

`resolvedEnum` is not `final`. So technically publishing the object via data race can show `resolvedEnum` as `null`, which would break `test()` that does not expect it. Currently not a practical problem since its safety is covered by adjacent `final` fields, but should be more precise.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335274](https://bugs.openjdk.org/browse/JDK-8335274): SwitchBootstraps.ResolvedEnumLabels.resolvedEnum should be final (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19933/head:pull/19933` \
`$ git checkout pull/19933`

Update a local copy of the PR: \
`$ git checkout pull/19933` \
`$ git pull https://git.openjdk.org/jdk.git pull/19933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19933`

View PR using the GUI difftool: \
`$ git pr show -t 19933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19933.diff">https://git.openjdk.org/jdk/pull/19933.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19933#issuecomment-2195526851)