### PR TITLE
8335294: Fix simple -Wzero-as-null-pointer-constant warnings in gc code

### DIFF
--- a/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/x/xPhysicalMemoryBacking_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,7 +389,7 @@ XErrno XPhysicalMemoryBacking::fallocate_compat_mmap_hugetlbfs(size_t offset, si
   // On hugetlbfs, mapping a file segment will fail immediately, without
   // the need to touch the mapped pages first, if there aren't enough huge
   // pages available to back the mapping.
-  void* const addr = mmap(0, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, offset);
+  void* const addr = mmap(nullptr, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, offset);
   if (addr == MAP_FAILED) {
     // Failed
     return errno;
@@ -439,7 +439,7 @@ static bool safe_touch_mapping(void* addr, size_t length, size_t page_size) {
 XErrno XPhysicalMemoryBacking::fallocate_compat_mmap_tmpfs(size_t offset, size_t length) const {
   // On tmpfs, we need to touch the mapped pages to figure out
   // if there are enough pages available to back the mapping.
-  void* const addr = mmap(0, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, offset);
+  void* const addr = mmap(nullptr, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, offset);
   if (addr == MAP_FAILED) {
     // Failed
     return errno;

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -391,7 +391,7 @@ ZErrno ZPhysicalMemoryBacking::fallocate_compat_mmap_hugetlbfs(zoffset offset, s
   // On hugetlbfs, mapping a file segment will fail immediately, without
   // the need to touch the mapped pages first, if there aren't enough huge
   // pages available to back the mapping.
-  void* const addr = mmap(0, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, untype(offset));
+  void* const addr = mmap(nullptr, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, untype(offset));
   if (addr == MAP_FAILED) {
     // Failed
     return errno;
@@ -441,7 +441,7 @@ static bool safe_touch_mapping(void* addr, size_t length, size_t page_size) {
 ZErrno ZPhysicalMemoryBacking::fallocate_compat_mmap_tmpfs(zoffset offset, size_t length) const {
   // On tmpfs, we need to touch the mapped pages to figure out
   // if there are enough pages available to back the mapping.
-  void* const addr = mmap(0, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, untype(offset));
+  void* const addr = mmap(nullptr, length, PROT_READ|PROT_WRITE, MAP_SHARED, _fd, untype(offset));
   if (addr == MAP_FAILED) {
     // Failed
     return errno;

--- a/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
+++ b/src/hotspot/share/gc/parallel/parMarkBitMap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ ParMarkBitMap::initialize(MemRegion covered_region)
     return true;
   }
 
-  _heap_start = 0;
+  _heap_start = nullptr;
   _heap_size = 0;
   if (_virtual_space != nullptr) {
     delete _virtual_space;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -661,7 +661,7 @@ HeapWord* ParallelScavengeHeap::block_start(const void* addr) const {
            "addr should be in allocated part of old gen");
     return old_gen()->start_array()->object_start((HeapWord*)addr);
   }
-  return 0;
+  return nullptr;
 }
 
 bool ParallelScavengeHeap::block_is_obj(const HeapWord* addr) const {

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -237,7 +237,7 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
   MemTracker::record_virtual_memory_type((address)rs.base(), mtGC);
 
   PSVirtualSpace* vspace = new PSVirtualSpace(rs, page_sz);
-  if (vspace != 0) {
+  if (vspace != nullptr) {
     if (vspace->expand_by(_reserved_byte_size)) {
       return vspace;
     }
@@ -246,7 +246,7 @@ ParallelCompactData::create_vspace(size_t count, size_t element_size)
     rs.release();
   }
 
-  return 0;
+  return nullptr;
 }
 
 bool ParallelCompactData::initialize_region_data(size_t heap_size)
@@ -255,7 +255,7 @@ bool ParallelCompactData::initialize_region_data(size_t heap_size)
 
   const size_t count = heap_size >> Log2RegionSize;
   _region_vspace = create_vspace(count, sizeof(RegionData));
-  if (_region_vspace != 0) {
+  if (_region_vspace != nullptr) {
     _region_data = (RegionData*)_region_vspace->reserved_low_addr();
     _region_count = count;
     return true;

--- a/src/hotspot/share/gc/z/zPage.inline.hpp
+++ b/src/hotspot/share/gc/z/zPage.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,6 @@ inline const char* ZPage::type_to_string() const {
 
   default:
     fatal("Unexpected page type");
-    return 0;
   }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC01/libnativeGC01.cpp
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC01/libnativeGC01.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ Java_gc_gctests_nativeGC01_nativeGC01_nativeMethod01
            */
         cls  = env->GetObjectClass(obj);
         mid = env->GetMethodID(cls, "callbackGC", "()V");
-        if (mid == 0) {
+        if (mid == nullptr) {
                 printf("couldnt locate method callbackGC()");
                 return -1;
         }
@@ -56,7 +56,7 @@ Java_gc_gctests_nativeGC01_nativeGC01_nativeMethod01
 
         clss = env->GetObjectClass(linked_list);
         mid2 = env->GetMethodID(clss, "getLength", "()I");
-        if (mid2 == 0) {
+        if (mid2 == nullptr) {
                 printf("couldnt locate method getLength()");
                 return -1;
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC02/libnativeGC02.cpp
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC02/libnativeGC02.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ Java_gc_gctests_nativeGC02_nativeGC02_nativeMethod02
 
         clss = env->GetObjectClass(obj);
         fid = env->GetFieldID(clss, "cl", "Lnsk/share/gc/CircularLinkedList;");
-        if (fid == 0) {
+        if (fid == nullptr) {
                 printf("could not locate field - cl\n");
                 return -1;
         }
@@ -53,7 +53,7 @@ Java_gc_gctests_nativeGC02_nativeGC02_nativeMethod02
 
         cls = env->GetObjectClass(obj);
         mid = env->GetMethodID(cls, "callbackGC", "()V");
-        if (mid == 0) {
+        if (mid == nullptr) {
                 printf("couldnt locate method callbackGC()\n");
                 return -1;
         }
@@ -66,7 +66,7 @@ Java_gc_gctests_nativeGC02_nativeGC02_nativeMethod02
 
         clss = env->GetObjectClass(linked_list);
         mid2 = env->GetMethodID(clss, "getLength", "(Lnsk/share/gc/CircularLinkedList;)I");
-        if (mid2 == 0) {
+        if (mid2 == nullptr) {
                 printf("couldnt locate method getLength(CircularLinkedList)\n");
                 return -1;
         }

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC03/libnativeGC03.cpp
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC03/libnativeGC03.cpp
@@ -46,7 +46,7 @@ Java_gc_gctests_nativeGC03_nativeGC03_nativeMethod03
 
                 clss = env->GetObjectClass(obj);
                 mid = env->GetMethodID(clss, "fillArray", "()V");
-                if (mid == 0) {
+                if (mid == nullptr) {
                         return;
                 }
                 env->CallVoidMethod(obj, mid);

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC05/libnativeGC05.cpp
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/nativeGC05/libnativeGC05.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,8 @@ extern "C" {
 JNIEXPORT void JNICALL
 Java_gc_gctests_nativeGC05_nativeGC05_kickOffRefillers
 (JNIEnv *env, jobject obj, jobject matrix, jobject stack) {
-        jclass matrixClass, stackClass, pairClass = 0;
-        jmethodID stack_pop_mid, stack_empty_mid, matrix_repopulate_mid, pair_geti_mid = 0, pair_getj_mid = 0;
+        jclass matrixClass, stackClass, pairClass = nullptr;
+        jmethodID stack_pop_mid, stack_empty_mid, matrix_repopulate_mid, pair_geti_mid = nullptr, pair_getj_mid = nullptr;
         jobject pair;
         jint i, j;
         jboolean b;
@@ -40,18 +40,18 @@ Java_gc_gctests_nativeGC05_nativeGC05_kickOffRefillers
 
         /* GetMethodID's for the pop() and Repopulate() methods */
         stack_pop_mid  = env->GetMethodID(stackClass, "pop", "()Ljava/lang/Object;");
-        if (stack_pop_mid == 0) {
+        if (stack_pop_mid == nullptr) {
                 printf("could not get a methodID for Stack::pop()\n");
                 return;
         }
         stack_empty_mid = env->GetMethodID(stackClass, "empty", "()Z");
-        if (stack_empty_mid == 0) {
+        if (stack_empty_mid == nullptr) {
                 printf("could not get a methodID for Stack::empty()\n");
                 return;
         }
 
         matrix_repopulate_mid = env->GetMethodID(matrixClass, "repopulate", "(II)V");
-        if (matrix_repopulate_mid == 0) {
+        if (matrix_repopulate_mid == nullptr) {
                 printf("could not get a methodID for Matrix::repopulate(int, int)\n");
                 return;
         }
@@ -62,15 +62,15 @@ Java_gc_gctests_nativeGC05_nativeGC05_kickOffRefillers
                 /** pair = stack.pop() */
                 pair = env->CallObjectMethod(stack, stack_pop_mid);
 
-                if (pairClass == 0) {
+                if (pairClass == nullptr) {
                         pairClass = env->GetObjectClass(pair);
                         pair_geti_mid = env->GetMethodID(pairClass, "getI", "()I");
-                        if (pair_geti_mid == 0) {
+                        if (pair_geti_mid == nullptr) {
                                 printf("could not get a methodID for IndexPair::getI()\n");
                                 return;
                         }
                         pair_getj_mid = env->GetMethodID(pairClass, "getJ", "()I");
-                        if (pair_getj_mid == 0) {
+                        if (pair_getj_mid == nullptr) {
                                 printf("could not get a methodID for IndexPair::getJ()\n");
                                 return;
                         }


### PR DESCRIPTION
Please review this change that replaces some uses of literal 0 as a null
pointer constant in gc code to instead use nullptr.

There is also one place where the use was eliminated entirely, because it was
dead code following a [[noreturn]] call.

Testing: mach5 tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335294](https://bugs.openjdk.org/browse/JDK-8335294): Fix simple -Wzero-as-null-pointer-constant warnings in gc code (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19934/head:pull/19934` \
`$ git checkout pull/19934`

Update a local copy of the PR: \
`$ git checkout pull/19934` \
`$ git pull https://git.openjdk.org/jdk.git pull/19934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19934`

View PR using the GUI difftool: \
`$ git pr show -t 19934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19934.diff">https://git.openjdk.org/jdk/pull/19934.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19934#issuecomment-2196083652)