### PR TITLE
8335314: Problem list compiler/uncommontrap/DeoptReallocFailure.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,6 +70,8 @@ compiler/startup/StartupOutput.java 8326615 generic-x64
 
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
+compiler/uncommontrap/DeoptReallocFailure.java 8335308 windows-x64
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
A trivial problem-list of a test on windows-64. It consistently times out on tier3 for that platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335314](https://bugs.openjdk.org/browse/JDK-8335314): Problem list compiler/uncommontrap/DeoptReallocFailure.java (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19935/head:pull/19935` \
`$ git checkout pull/19935`

Update a local copy of the PR: \
`$ git checkout pull/19935` \
`$ git pull https://git.openjdk.org/jdk.git pull/19935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19935`

View PR using the GUI difftool: \
`$ git pr show -t 19935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19935.diff">https://git.openjdk.org/jdk/pull/19935.diff</a>

</details>
