### PR TITLE
8334433: jshell.exe runs an executable test.exe on startup

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/utils/OSUtils.java
@@ -63,7 +63,7 @@ public class OSUtils {
         String sttyfopt = null;
         String infocmp = null;
         String test = null;
-        String path = System.getenv("PATH");
+        String path = "/usr/bin" + File.pathSeparator + "/bin";//was: System.getenv("PATH");
         if (path != null) {
             String[] paths = path.split(File.pathSeparator);
             for (String p : paths) {

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/ConsoleIOContext.java
@@ -155,7 +155,12 @@ class ConsoleIOContext extends IOContext {
             setupReader = setupReader.andThen(r -> r.option(Option.DISABLE_HIGHLIGHTER, !enableHighlighter));
             input.setInputStream(cmdin);
         } else {
-            terminal = TerminalBuilder.builder().inputStreamWrapper(in -> {
+            //on platforms which are known to be fully supported by
+            //the FFMTerminalProvider, do not permit the ExecTerminalProvider:
+            boolean allowExecTerminal = !OSUtils.IS_WINDOWS &&
+                                        !OSUtils.IS_LINUX &&
+                                        !OSUtils.IS_OSX;
+            terminal = TerminalBuilder.builder().exec(allowExecTerminal).inputStreamWrapper(in -> {
                 input.setInputStream(in);
                 return nonBlockingInput;
             }).nativeSignals(false).build();

--- a/test/langtools/jdk/jshell/TerminalNoExecTest.java
+++ b/test/langtools/jdk/jshell/TerminalNoExecTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8334433
+ * @summary Verify that when running JShell on platforms that support FFMTerminalProvider,
+ *          no new processes are spawned.
+ * @requires os.family == "windows" | os.family == "mac" | os.family == "linux"
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavaTask TerminalNoExecTest
+ * @run main TerminalNoExecTest
+ */
+
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import jdk.jfr.consumer.RecordingStream;
+import jdk.jshell.tool.JavaShellToolBuilder;
+
+import toolbox.ToolBox;
+
+public class TerminalNoExecTest {
+
+    public static void main(String... args) throws Exception {
+        if (args.length > 0) {
+            AtomicBoolean spawnedNewProcess = new AtomicBoolean();
+            try (var rs = new RecordingStream()) {
+                rs.enable("jdk.ProcessStart").withoutThreshold();
+                rs.onEvent(evt -> {
+                    System.err.println("evt: " + evt);
+                    spawnedNewProcess.set(true);
+                });
+                rs.startAsync();
+                JavaShellToolBuilder.builder().run("--execution=local", "--no-startup");
+                rs.stop();
+            }
+            if (spawnedNewProcess.get()) {
+                System.err.println("Spawned a new process!");
+                System.exit(1);
+            }
+            System.exit(0);
+        } else {
+            Path testScript = Paths.get("do-exit");
+            try (Writer w = Files.newBufferedWriter(testScript)) {
+                w.append("/exit\n");
+            }
+
+            ToolBox tb = new ToolBox();
+            Process target =
+                new ProcessBuilder(tb.getJDKTool("java").toString(),
+                                   "-classpath", System.getProperty("java.class.path"),
+                                   TerminalNoExecTest.class.getName(),
+                                   "run-test")
+                        .redirectError(ProcessBuilder.Redirect.INHERIT)
+                        .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+                        .redirectInput(testScript.toFile())
+                        .start();
+
+            target.waitFor();
+
+            int exitCode = target.exitValue();
+
+            if (exitCode != 0) {
+                throw new AssertionError("Incorrect exit value, expected 0, got: " + exitCode);
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [99d2bbf7](https://github.com/openjdk/jdk/commit/99d2bbf767ac33e1a021c90ba12d95ef37ea4816) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 28 Jun 2024 and was reviewed by Jaikiran Pai.

Thanks!

Original description:
JLine has multiple providers that can setup and work with the native terminals. As part of an upgrade to JLine 3.26.1 (https://github.com/openjdk/jdk/pull/18142), a first phase of checks in the terminal providers providers runs fairly soon, when the providers are gathered. There is also a provider which setups the terminals using command line utilities - the "exec" provider. And this provider currently runs the "test" command line utility during the gathering phase, which (I believe) was not the case in previous version. I.e. even if some other provider is used to work with the terminal, the "exec" terminal might run the "test" utility anyway.

We currently largely don't need the "exec" provider at all - we currently primarily use a semi-native provider based on FFM. The "exec" provider is, I believe, used on platforms for which the FFM provider is not implemented, which is probably primarily AIX.

The proposal herein is twofold:

 -    disable the "exec" terminal on platforms for the FFM provider should work (Windows, Linux, Mac)
 -    make the "exec" provider ignore the PATH environment variable, and use hardcoded value.

I tested this on Windows with cmd, Cygwin and MSYS, and on Linux and seemed to work fine.

@MBaesken, please let me know what you think of this change.

I would like to backport this to JDK 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334433](https://bugs.openjdk.org/browse/JDK-8334433): jshell.exe runs an executable test.exe on startup (**Bug** - P3)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19939/head:pull/19939` \
`$ git checkout pull/19939`

Update a local copy of the PR: \
`$ git checkout pull/19939` \
`$ git pull https://git.openjdk.org/jdk.git pull/19939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19939`

View PR using the GUI difftool: \
`$ git pr show -t 19939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19939.diff">https://git.openjdk.org/jdk/pull/19939.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19939#issuecomment-2196795214)