### PR TITLE
8335308: compiler/uncommontrap/DeoptReallocFailure.java times out with SerialGC on Windows

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -70,8 +70,6 @@ compiler/startup/StartupOutput.java 8326615 generic-x64
 
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
-compiler/uncommontrap/DeoptReallocFailure.java 8335308 windows-x64
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/uncommontrap/DeoptReallocFailure.java
+++ b/test/hotspot/jtreg/compiler/uncommontrap/DeoptReallocFailure.java
@@ -63,7 +63,7 @@ public class DeoptReallocFailure {
         NoEscape[] noEscape = new NoEscape[45];
         noEscape[0] = new NoEscape();
         for (int i=0;i<1024*256;i++) {
-           root.array[i]= new Object[45];
+           root.array[i]= new Object[4500];
         }
         return noEscape[0].f1;
     }


### PR DESCRIPTION
Simple increasing allocation size to reach OOM sooner. See more detail failure analysis in the bug ticket.

Test: timeout before the fix but pass afterwards.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335308](https://bugs.openjdk.org/browse/JDK-8335308): compiler/uncommontrap/DeoptReallocFailure.java times out with SerialGC on Windows (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19944/head:pull/19944` \
`$ git checkout pull/19944`

Update a local copy of the PR: \
`$ git checkout pull/19944` \
`$ git pull https://git.openjdk.org/jdk.git pull/19944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19944`

View PR using the GUI difftool: \
`$ git pr show -t 19944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19944.diff">https://git.openjdk.org/jdk/pull/19944.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19944#issuecomment-2197178386)