### PR TITLE
8335344: test/jdk/sun/security/tools/keytool/NssTest.java fails to compile

### DIFF
--- a/test/jdk/sun/security/tools/keytool/NssTest.java
+++ b/test/jdk/sun/security/tools/keytool/NssTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/sun/security/tools/keytool/NssTest.java
+++ b/test/jdk/sun/security/tools/keytool/NssTest.java
@@ -29,7 +29,7 @@ import java.nio.file.Paths;
 /*
  * @test
  * @summary It tests (almost) all keytool behaviors with NSS.
- * @library /test/lib /test/jdk/sun/security/pkcs11
+ * @library /test/lib /test/jdk/sun/security/pkcs11 /java/security/testlibrary
  * @modules java.base/sun.security.tools.keytool
  *          java.base/sun.security.util
  *          java.base/sun.security.x509


### PR DESCRIPTION
There is a compilation issue in the test **test/jdk/sun/security/tools/keytool/NssTest.java** because the [HumanInputStream](https://github.com/openjdk/jdk/blob/master/test/jdk/java/security/testlibrary/HumanInputStream.java) class was moved from keytool/KeyToolTest.java to a library class in this [PR](https://github.com/openjdk/jdk/pull/19790) for reusability. NssTest depends on KeyToolTest.java, therefore it will also need to import HumanInputStream from the test library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335344](https://bugs.openjdk.org/browse/JDK-8335344): test/jdk/sun/security/tools/keytool/NssTest.java fails to compile (**Bug** - P3)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19946/head:pull/19946` \
`$ git checkout pull/19946`

Update a local copy of the PR: \
`$ git checkout pull/19946` \
`$ git pull https://git.openjdk.org/jdk.git pull/19946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19946`

View PR using the GUI difftool: \
`$ git pr show -t 19946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19946.diff">https://git.openjdk.org/jdk/pull/19946.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19946#issuecomment-2197268474)