### PR TITLE
JDK-8332423 : [PPC64] Remove C1_MacroAssembler::call_c_with_frame_resize

### DIFF
--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -2057,7 +2057,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
         int sco_offset = in_bytes(Klass::super_check_offset_offset());
         __ lwz(chk_off, sco_offset, super_k);
 
-        __ call_c(copyfunc_addr, relocInfo::runtime_call_type); ;
+        __ call_c(copyfunc_addr, relocInfo::runtime_call_type);
 
 #ifndef PRODUCT
         if (PrintC1Statistics) {
@@ -2181,7 +2181,8 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
   // Arraycopy stubs takes a length in number of elements, so don't scale it.
   __ mr(len, length);
-  __ call_c(entry, relocInfo::runtime_call_type); 
+  __ call_c(entry, relocInfo::runtime_call_type);
+
   if (stub != nullptr) {
     __ bind(*stub->continuation());
   }

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1859,7 +1859,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       __ stw(R11_scratch1, simm16_offs, tmp);
     }
 #endif
-    __ call_c(copyfunc_addr, relocInfo::runtime_call_type); 
+    __ call_c(copyfunc_addr, relocInfo::runtime_call_type);
 
     __ nand(tmp, R3_RET, R3_RET);
     __ subf(length, tmp, length);
@@ -2862,7 +2862,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest,
     return;
   }
 
-  __ call_c(dest, relocInfo::runtime_call_type); 
+  __ call_c(dest, relocInfo::runtime_call_type);
   if (info != nullptr) {
     add_call_info_here(info);
   }

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1859,7 +1859,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       __ stw(R11_scratch1, simm16_offs, tmp);
     }
 #endif
-    __ call_c_with_frame_resize(copyfunc_addr, /*stub does not need resized frame*/ 0);
+    __ call_c(copyfunc_addr);
 
     __ nand(tmp, R3_RET, R3_RET);
     __ subf(length, tmp, length);
@@ -2057,7 +2057,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
         int sco_offset = in_bytes(Klass::super_check_offset_offset());
         __ lwz(chk_off, sco_offset, super_k);
 
-        __ call_c_with_frame_resize(copyfunc_addr, /*stub does not need resized frame*/ 0);
+        __ call_c(copyfunc_addr);
 
 #ifndef PRODUCT
         if (PrintC1Statistics) {
@@ -2181,7 +2181,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
   // Arraycopy stubs takes a length in number of elements, so don't scale it.
   __ mr(len, length);
-  __ call_c_with_frame_resize(entry, /*stub does not need resized frame*/ 0);
+  __ call_c(entry);
 
   if (stub != nullptr) {
     __ bind(*stub->continuation());
@@ -2862,7 +2862,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest,
     return;
   }
 
-  __ call_c_with_frame_resize(dest, /*no resizing*/ 0);
+  __ call_c(dest);
   if (info != nullptr) {
     add_call_info_here(info);
   }

--- a/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_LIRAssembler_ppc.cpp
@@ -1859,7 +1859,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
       __ stw(R11_scratch1, simm16_offs, tmp);
     }
 #endif
-    __ call_c(copyfunc_addr);
+    __ call_c(copyfunc_addr, relocInfo::runtime_call_type); 
 
     __ nand(tmp, R3_RET, R3_RET);
     __ subf(length, tmp, length);
@@ -2057,7 +2057,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
         int sco_offset = in_bytes(Klass::super_check_offset_offset());
         __ lwz(chk_off, sco_offset, super_k);
 
-        __ call_c(copyfunc_addr);
+        __ call_c(copyfunc_addr, relocInfo::runtime_call_type); ;
 
 #ifndef PRODUCT
         if (PrintC1Statistics) {
@@ -2181,8 +2181,7 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 
   // Arraycopy stubs takes a length in number of elements, so don't scale it.
   __ mr(len, length);
-  __ call_c(entry);
-
+  __ call_c(entry, relocInfo::runtime_call_type); 
   if (stub != nullptr) {
     __ bind(*stub->continuation());
   }
@@ -2862,7 +2861,7 @@ void LIR_Assembler::rt_call(LIR_Opr result, address dest,
     return;
   }
 
-  __ call_c(dest);
+  __ call_c(dest, relocInfo::runtime_call_type); 
   if (info != nullptr) {
     add_call_info_here(info);
   }

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -404,10 +404,3 @@ void C1_MacroAssembler::null_check(Register r, Label* Lnull) {
     bc_far_optimized(Assembler::bcondCRbiIs1, bi0(CCR0, Assembler::equal), *Lnull);
   }
 }
-
-address C1_MacroAssembler::call_c_with_frame_resize(address dest, int frame_resize) {
-  if (frame_resize) { resize_frame(-frame_resize, R0); }
-  address return_pc = call_c(dest, relocInfo::runtime_call_type);
-  if (frame_resize) { resize_frame(frame_resize, R0); }
-  return return_pc;
-}

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.cpp
@@ -407,11 +407,7 @@ void C1_MacroAssembler::null_check(Register r, Label* Lnull) {
 
 address C1_MacroAssembler::call_c_with_frame_resize(address dest, int frame_resize) {
   if (frame_resize) { resize_frame(-frame_resize, R0); }
-#if defined(ABI_ELFv2)
   address return_pc = call_c(dest, relocInfo::runtime_call_type);
-#else
-  address return_pc = call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, dest), relocInfo::runtime_call_type);
-#endif
   if (frame_resize) { resize_frame(frame_resize, R0); }
   return return_pc;
 }

--- a/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/c1_MacroAssembler_ppc.hpp
@@ -89,6 +89,5 @@
 
   void null_check(Register r, Label *Lnull = nullptr);
 
-  address call_c_with_frame_resize(address dest, int frame_resize);
 
 #endif // CPU_PPC_C1_MACROASSEMBLER_PPC_HPP

--- a/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_Runtime1_ppc.cpp
@@ -62,7 +62,7 @@ int StubAssembler::call_RT(Register oop_result1, Register metadata_result,
   // ARG1 must hold thread address.
   mr(R3_ARG1, R16_thread);
 
-  address return_pc = call_c_with_frame_resize(entry_point, /*No resize, we have a C compatible frame.*/0);
+  address return_pc = call_c(entry_point);
 
   reset_last_Java_frame();
 

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -135,15 +135,7 @@ void InterpreterMacroAssembler::check_and_handle_popframe(Register scratch_reg) 
     // Call the Interpreter::remove_activation_preserving_args_entry()
     // func to get the address of the same-named entrypoint in the
     // generated interpreter code.
-#if defined(ABI_ELFv2)
-    call_c(CAST_FROM_FN_PTR(address,
-                            Interpreter::remove_activation_preserving_args_entry),
-           relocInfo::none);
-#else
-    call_c(CAST_FROM_FN_PTR(FunctionDescriptor*,
-                            Interpreter::remove_activation_preserving_args_entry),
-           relocInfo::none);
-#endif
+    call_c(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_preserving_args_entry), relocInfo::none);
 
     // Jump to Interpreter::_remove_activation_preserving_args_entry.
     mtctr(R3_RET);

--- a/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/interp_masm_ppc_64.cpp
@@ -135,7 +135,7 @@ void InterpreterMacroAssembler::check_and_handle_popframe(Register scratch_reg) 
     // Call the Interpreter::remove_activation_preserving_args_entry()
     // func to get the address of the same-named entrypoint in the
     // generated interpreter code.
-    call_c(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_preserving_args_entry), relocInfo::none);
+    call_c(CAST_FROM_FN_PTR(address, Interpreter::remove_activation_preserving_args_entry));
 
     // Jump to Interpreter::_remove_activation_preserving_args_entry.
     mtctr(R3_RET);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1035,7 +1035,7 @@ address MacroAssembler::call_c_and_return_to_caller(Register r_function_entry) {
   return branch_to(r_function_entry, /*and_link=*/false);
 }
 
-address MacroAssembler::call_c(address function_entry,relocInfo::relocType) {
+address MacroAssembler::call_c(address function_entry, relocInfo::relocType rt) {
   load_const(R12, function_entry, R0);
   return branch_to(R12,  /*and_link=*/true);
 }

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1035,7 +1035,7 @@ address MacroAssembler::call_c_and_return_to_caller(Register r_function_entry) {
   return branch_to(r_function_entry, /*and_link=*/false);
 }
 
-address MacroAssembler::call_c(address function_entry, relocInfo::relocType rt) {
+address MacroAssembler::call_c(address function_entry,relocInfo::relocType) {
   load_const(R12, function_entry, R0);
   return branch_to(R12,  /*and_link=*/true);
 }
@@ -1293,11 +1293,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
 
   // ARG1 must hold thread address.
   mr(R3_ARG1, R16_thread);
-#if defined(ABI_ELFv2)
   address return_pc = call_c(entry_point, relocInfo::none);
-#else
-  address return_pc = call_c((FunctionDescriptor*)entry_point, relocInfo::none);
-#endif
 
   reset_last_Java_frame();
 
@@ -1318,11 +1314,7 @@ void MacroAssembler::call_VM_base(Register oop_result,
 
 void MacroAssembler::call_VM_leaf_base(address entry_point) {
   BLOCK_COMMENT("call_VM_leaf {");
-#if defined(ABI_ELFv2)
-  call_c(entry_point, relocInfo::none);
-#else
-  call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, entry_point), relocInfo::none);
-#endif
+  call_c(entry_point);
   BLOCK_COMMENT("} call_VM_leaf");
 }
 

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -364,7 +364,7 @@ class MacroAssembler: public Assembler {
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
   address call_c(Register function_descriptor);
-    // For tail calls: only branch, don't link, so callee returns to caller of this function.
+  // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_descriptor);
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -367,7 +367,7 @@ class MacroAssembler: public Assembler {
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {
     return call_c((const FunctionDescriptor*)function_entry, rt);
-  }	
+  }
     // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_descriptor);
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -364,13 +364,12 @@ class MacroAssembler: public Assembler {
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
   address call_c(Register function_descriptor);
+    // For tail calls: only branch, don't link, so callee returns to caller of this function.
+  address call_c_and_return_to_caller(Register function_descriptor);
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {
     return call_c((const FunctionDescriptor*)function_entry, rt);
   }
-    // For tail calls: only branch, don't link, so callee returns to caller of this function.
-  address call_c_and_return_to_caller(Register function_descriptor);
-  address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c_using_toc(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt,
                            Register toc);
 #endif

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -359,11 +359,14 @@ class MacroAssembler: public Assembler {
   address call_c(Register function_entry);
   // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_entry);
-  address call_c(address function_entry, relocInfo::relocType rt);
+  address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none);
 #else
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
   address call_c(Register function_descriptor);
+  address call_c(address function_entry, relocInfo::relocType rt = relocInfo::relocType::none) {
+    return call_c((FunctionDescriptor*)function_entry, rt);
+  }
   // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_descriptor);
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
@@ -416,7 +419,6 @@ class MacroAssembler: public Assembler {
   void call_VM_leaf(address entry_point, Register arg_1);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2, Register arg_3);
-
   // Call a stub function via a function descriptor, but don't save
   // TOC before call, don't setup TOC and ENV for call, and don't
   // restore TOC after call. Updates and returns _last_calls_return_pc.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -419,7 +419,7 @@ class MacroAssembler: public Assembler {
   void call_VM_leaf(address entry_point, Register arg_1);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2, Register arg_3);
-  
+
   // Call a stub function via a function descriptor, but don't save
   // TOC before call, don't setup TOC and ENV for call, and don't
   // restore TOC after call. Updates and returns _last_calls_return_pc.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -364,7 +364,7 @@ class MacroAssembler: public Assembler {
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
   address call_c(Register function_descriptor);
-  address call_c(address function_entry, relocInfo::relocType rt = relocInfo::relocType::none) {
+  address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {
     return call_c((FunctionDescriptor*)function_entry, rt);
   }
   // For tail calls: only branch, don't link, so callee returns to caller of this function.
@@ -419,6 +419,7 @@ class MacroAssembler: public Assembler {
   void call_VM_leaf(address entry_point, Register arg_1);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2);
   void call_VM_leaf(address entry_point, Register arg_1, Register arg_2, Register arg_3);
+  
   // Call a stub function via a function descriptor, but don't save
   // TOC before call, don't setup TOC and ENV for call, and don't
   // restore TOC after call. Updates and returns _last_calls_return_pc.

--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.hpp
@@ -364,10 +364,11 @@ class MacroAssembler: public Assembler {
   // Call a C function via a function descriptor and use full C
   // calling conventions. Updates and returns _last_calls_return_pc.
   address call_c(Register function_descriptor);
+  address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c(address function_entry, relocInfo::relocType rt = relocInfo::none) {
-    return call_c((FunctionDescriptor*)function_entry, rt);
-  }
-  // For tail calls: only branch, don't link, so callee returns to caller of this function.
+    return call_c((const FunctionDescriptor*)function_entry, rt);
+  }	
+    // For tail calls: only branch, don't link, so callee returns to caller of this function.
   address call_c_and_return_to_caller(Register function_descriptor);
   address call_c(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt);
   address call_c_using_toc(const FunctionDescriptor* function_descriptor, relocInfo::relocType rt,

--- a/src/hotspot/cpu/ppc/runtime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/runtime_ppc.cpp
@@ -99,12 +99,7 @@ void OptoRuntime::generate_exception_blob() {
   __ set_last_Java_frame(/*sp=*/R1_SP, noreg);
 
   __ mr(R3_ARG1, R16_thread);
-#if defined(ABI_ELFv2)
-  __ call_c((address) OptoRuntime::handle_exception_C, relocInfo::none);
-#else
-  __ call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, OptoRuntime::handle_exception_C),
-            relocInfo::none);
-#endif
+  __ call_c((address) OptoRuntime::handle_exception_C);
   address calls_return_pc = __ last_calls_return_pc();
 # ifdef ASSERT
   __ cmpdi(CCR0, R3_RET, 0);

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3450,11 +3450,7 @@ RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address r
   __ set_last_Java_frame(/*sp*/R1_SP, /*pc*/R11_scratch1);
 
   __ mr(R3_ARG1, R16_thread);
-#if defined(ABI_ELFv2)
-  __ call_c(runtime_entry, relocInfo::none);
-#else
-  __ call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, runtime_entry), relocInfo::none);
-#endif
+  __ call_c(runtime_entry);
 
   // Set an oopmap for the call site.
   oop_maps->add_gc_map((int)(gc_map_pc - start), map);

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2444,12 +2444,7 @@ nmethod *SharedRuntime::generate_native_wrapper(MacroAssembler *masm,
 
   // The JNI call
   // --------------------------------------------------------------------------
-#if defined(ABI_ELFv2)
   __ call_c(native_func, relocInfo::runtime_call_type);
-#else
-  FunctionDescriptor* fd_native_method = (FunctionDescriptor*) native_func;
-  __ call_c(fd_native_method, relocInfo::runtime_call_type);
-#endif
 
 
   // Now, we are back from the native code.

--- a/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
+++ b/src/hotspot/cpu/ppc/templateInterpreterGenerator_ppc.cpp
@@ -1464,13 +1464,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // native result across the call. No oop is present.
 
   __ mr(R3_ARG1, R16_thread);
-#if defined(ABI_ELFv2)
-  __ call_c(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans),
-            relocInfo::none);
-#else
-  __ call_c(CAST_FROM_FN_PTR(FunctionDescriptor*, JavaThread::check_special_condition_for_native_trans),
-            relocInfo::none);
-#endif
+  __ call_c(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
 
   __ bind(sync_check_done);
 


### PR DESCRIPTION
JBS Issue : [JDK-8332423](https://bugs.openjdk.org/browse/JDK-8332423)
C1_MacroAssembler::call_c_with_frame_resize is only used with frame_resize == 0. 
Also, call_c is adapted as per endianess of system. 
We can adapt the exisiting code to handle the endianness check at one place and not have to repeatedly check at multiple places to make calls to call_c.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332423](https://bugs.openjdk.org/browse/JDK-8332423): [PPC64] Remove C1_MacroAssembler::call_c_with_frame_resize (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Varada M](https://openjdk.org/census#varadam) (@varada1110 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19947/head:pull/19947` \
`$ git checkout pull/19947`

Update a local copy of the PR: \
`$ git checkout pull/19947` \
`$ git pull https://git.openjdk.org/jdk.git pull/19947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19947`

View PR using the GUI difftool: \
`$ git pr show -t 19947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19947.diff">https://git.openjdk.org/jdk/pull/19947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19947#issuecomment-2308923707)