### PR TITLE
8335349: jcmd VM.classloaders "fold" option should be optional

### DIFF
--- a/src/hotspot/share/classfile/classLoaderHierarchyDCmd.cpp
+++ b/src/hotspot/share/classfile/classLoaderHierarchyDCmd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,7 +39,7 @@ ClassLoaderHierarchyDCmd::ClassLoaderHierarchyDCmd(outputStream* output, bool he
   : DCmdWithParser(output, heap),
    _show_classes("show-classes", "Print loaded classes.", "BOOLEAN", false, "false"),
   _verbose("verbose", "Print detailed information.", "BOOLEAN", false, "false"),
-  _fold("fold", "Show loaders of the same name and class as one.", "BOOLEAN", true, "true") {
+  _fold("fold", "Show loaders of the same name and class as one.", "BOOLEAN", false, "true") {
   _dcmdparser.add_dcmd_option(&_show_classes);
   _dcmdparser.add_dcmd_option(&_verbose);
   _dcmdparser.add_dcmd_option(&_fold);


### PR DESCRIPTION
Trivial tweak to ```ClassLoaderHierarchyDCmd::ClassLoaderHierarchyDCmd(outputStream* output, bool heap)``` to make _fold an optional argument.  

It still _is_ optional, but without this change it's not listed as optional in help.

The man page is already correct, and shows all the options as optional.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8335349: jcmd VM.classloaders "fold" option should be optional`

### Issue
 * [JDK-8335349](https://bugs.openjdk.org/browse/JDK-8335349): jcmd VM.classloaders "fold" option should be optional (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19948/head:pull/19948` \
`$ git checkout pull/19948`

Update a local copy of the PR: \
`$ git checkout pull/19948` \
`$ git pull https://git.openjdk.org/jdk.git pull/19948/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19948`

View PR using the GUI difftool: \
`$ git pr show -t 19948`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19948.diff">https://git.openjdk.org/jdk/pull/19948.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19948#issuecomment-2197331533)