### PR TITLE
8335291

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -131,13 +131,13 @@ serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generi
 serviceability/jvmti/vthread/CarrierThreadEventNotification/CarrierThreadEventNotification.java 8333681 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 generic-all
 
-serviceability/sa/ClhsdbCDSCore.java 8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#xcomp-core 8267433 macosx-x64
-serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8267433 macosx-x64
-serviceability/sa/ClhsdbPmap.java#core 8267433 macosx-x64
-serviceability/sa/ClhsdbPstack.java#core 8267433 macosx-x64
-serviceability/sa/TestJmapCore.java 8267433 macosx-x64
-serviceability/sa/TestJmapCoreMetaspace.java 8267433 macosx-x64
+serviceability/sa/ClhsdbCDSCore.java              8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/ClhsdbFindPC.java#xcomp-core    8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/ClhsdbFindPC.java#no-xcomp-core 8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/ClhsdbPmap.java#core            8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/ClhsdbPstack.java#core          8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/TestJmapCore.java               8267433,8335291 macosx-x64,macosx-aarch64
+serviceability/sa/TestJmapCoreMetaspace.java      8267433,8335291 macosx-x64,macosx-aarch64
 
 serviceability/attach/ConcAttachTest.java 8290043 linux-all
 


### PR DESCRIPTION
On macosx-aarch64, sometimes the generated core file does not contain all valid memory. This causes SA tests to fail with various address related java exceptions. There's nothing SA can do to work around the problem, and these failures over time have been just too noisy, so I'm problem listing all the SA core files tests on macosx-aarch64. Note they are already problem listed on macosx-x64 dues to [JDK-8267433](https://bugs.openjdk.org/browse/JDK-8267433) (the tests time out while generating the core dump because it takes way too long), so unfortunately this means no more core file testing on macosx, at least for now.