### PR TITLE
8269881: SA stack dump fails to include stack trace for SteadyStateThread

### DIFF
--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -585,6 +585,13 @@ public class LingeredApp {
         while (steadyStateThread.getState() != Thread.State.BLOCKED) {
             Thread.onSpinWait();
         }
+
+        // Wait a short period of time so we can be sure the thread truly is blocked. See JDK-8269881.
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     static class SteadyStateLock {};


### PR DESCRIPTION
The completely unrelated fix to [JDK-8335124](https://bugs.openjdk.org/browse/JDK-8335124) led me to believe that the issue with sometimes not being able to get the stack trace of the SteadyStateThread might be due to the thread being active for a short period after being reported as in the Thread.State.BLOCKED state. Once set to that state, the thread still needs to call a native OS API to block the thread so it is truly idle. During this time the thread stack might be inconsistent and not walk-able. The fix is to add a short sleep after the thread has moved to the Thread.State.BLOCKED state to give it a chance to finish blocking.

Tested with Tier1 CI and all svc test tasks for tier2 and tier5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269881](https://bugs.openjdk.org/browse/JDK-8269881): SA stack dump fails to include stack trace for SteadyStateThread (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19951/head:pull/19951` \
`$ git checkout pull/19951`

Update a local copy of the PR: \
`$ git checkout pull/19951` \
`$ git pull https://git.openjdk.org/jdk.git pull/19951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19951`

View PR using the GUI difftool: \
`$ git pr show -t 19951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19951.diff">https://git.openjdk.org/jdk/pull/19951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19951#issuecomment-2197627520)