### PR TITLE
8335290: Rename ClassFile::transform to ClassFile::transformClass

### DIFF
--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -54,13 +54,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.lang.classfile.AccessFlags;
 import java.lang.classfile.Attribute;
-import java.lang.classfile.ClassModel;
-import java.lang.classfile.ClassTransform;
 import java.lang.classfile.ClassFile;
-import java.lang.classfile.attribute.ModuleAttribute;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.loader.BuiltinClassLoader;
 import jdk.internal.loader.BootLoader;
 import jdk.internal.loader.ClassLoaders;
@@ -1588,7 +1584,7 @@ public final class Module implements AnnotatedElement {
     private Class<?> loadModuleInfoClass(InputStream in) throws IOException {
         final String MODULE_INFO = "module-info";
         var cc = ClassFile.of(ClassFile.ConstantPoolSharingOption.NEW_POOL);
-        byte[] bytes = cc.transform(cc.parse(in.readAllBytes()), (clb, cle) -> {
+        byte[] bytes = cc.transformClass(cc.parse(in.readAllBytes()), (clb, cle) -> {
             switch (cle) {
                 case AccessFlags af -> clb.withFlags(AccessFlag.INTERFACE,
                         AccessFlag.ABSTRACT, AccessFlag.SYNTHETIC);

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -32,7 +32,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import java.lang.classfile.attribute.ModuleAttribute;
-import java.lang.classfile.attribute.UnknownAttribute;
 import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.Utf8Entry;
@@ -435,15 +434,15 @@ public sealed interface ClassFile
      * This method behaves as if:
      * {@snippet lang=java :
      *     this.build(model.thisClass(), ConstantPoolBuilder.of(model),
-     *                     b -> b.transform(model, transform));
+     *                     b -> b.transformClass(model, transform));
      * }
      *
      * @param model the class model to transform
      * @param transform the transform
      * @return the bytes of the new class
      */
-    default byte[] transform(ClassModel model, ClassTransform transform) {
-        return transform(model, model.thisClass(), transform);
+    default byte[] transformClass(ClassModel model, ClassTransform transform) {
+        return transformClass(model, model.thisClass(), transform);
     }
 
     /**
@@ -458,8 +457,8 @@ public sealed interface ClassFile
      * @param transform the transform
      * @return the bytes of the new class
      */
-    default byte[] transform(ClassModel model, ClassDesc newClassName, ClassTransform transform) {
-        return transform(model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
+    default byte[] transformClass(ClassModel model, ClassDesc newClassName, ClassTransform transform) {
+        return transformClass(model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
     }
 
     /**
@@ -473,7 +472,7 @@ public sealed interface ClassFile
      * This method behaves as if:
      * {@snippet lang=java :
      *     this.build(newClassName, ConstantPoolBuilder.of(model),
-     *                     b -> b.transform(model, transform));
+     *                     clb -> clb.transform(model, transform));
      * }
      *
      * @param model the class model to transform
@@ -481,7 +480,7 @@ public sealed interface ClassFile
      * @param transform the transform
      * @return the bytes of the new class
      */
-    byte[] transform(ClassModel model, ClassEntry newClassName, ClassTransform transform);
+    byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform);
 
     /**
      * Verify a classfile.  Any verification errors found will be returned.

--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -434,7 +434,7 @@ public sealed interface ClassFile
      * This method behaves as if:
      * {@snippet lang=java :
      *     this.build(model.thisClass(), ConstantPoolBuilder.of(model),
-     *                     b -> b.transformClass(model, transform));
+     *                     clb -> clb.transform(model, transform));
      * }
      *
      * @param model the class model to transform

--- a/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFileTransform.java
@@ -33,7 +33,7 @@ import jdk.internal.javac.PreviewFeature;
 /**
  * A transformation on streams of elements. Transforms are used during
  * transformation of classfile entities; a transform is provided to a method like
- * {@link ClassFile#transform(ClassModel, ClassTransform)}, and the elements of the class,
+ * {@link ClassFile#transformClass(ClassModel, ClassTransform)}, and the elements of the class,
  * along with a builder, are presented to the transform.
  *
  * <p>The subtypes of {@linkplain

--- a/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/ClassRemapper.java
@@ -107,6 +107,6 @@ public sealed interface ClassRemapper extends ClassTransform permits ClassRemapp
      * @return re-mapped class file bytes
      */
     default byte[] remapClass(ClassFile context, ClassModel clm) {
-        return context.transform(clm, map(clm.thisClass().asSymbol()), this);
+        return context.transformClass(clm, map(clm.thisClass().asSymbol()), this);
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/components/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/snippet-files/PackageSnippets.java
@@ -130,7 +130,7 @@ class PackageSnippets {
 
     void codeLocalsShifting(ClassModel classModel) {
         // @start region="codeLocalsShifting"
-        byte[] newBytes = ClassFile.of().transform(
+        byte[] newBytes = ClassFile.of().transformClass(
                 classModel,
                 (classBuilder, classElement) -> {
                     if (classElement instanceof MethodModel method)
@@ -145,7 +145,7 @@ class PackageSnippets {
 
     void codeRelabeling(ClassModel classModel) {
         // @start region="codeRelabeling"
-        byte[] newBytes = ClassFile.of().transform(
+        byte[] newBytes = ClassFile.of().transformClass(
                 classModel,
                 ClassTransform.transformingMethodBodies(
                         CodeTransform.ofStateful(CodeRelabeler::of)));
@@ -160,7 +160,7 @@ class PackageSnippets {
         var targetFieldNames = target.fields().stream().map(f -> f.fieldName().stringValue()).collect(Collectors.toSet());
         var targetMethods = target.methods().stream().map(m -> m.methodName().stringValue() + m.methodType().stringValue()).collect(Collectors.toSet());
         var instrumentorClassRemapper = ClassRemapper.of(Map.of(instrumentor.thisClass().asSymbol(), target.thisClass().asSymbol()));
-        return ClassFile.of().transform(target,
+        return ClassFile.of().transformClass(target,
                 ClassTransform.transformingMethods(
                         instrumentedMethodsFilter,
                         (mb, me) -> {
@@ -191,7 +191,7 @@ class PackageSnippets {
 
                                                 //inlined target locals must be shifted based on the actual instrumentor locals
                                                 codeBuilder.block(inlinedBlockBuilder -> inlinedBlockBuilder
-                                                        .transform(targetCodeModel, CodeLocalsShifter.of(mm.flags(), mm.methodTypeSymbol())
+                                                    .transform(targetCodeModel, CodeLocalsShifter.of(mm.flags(), mm.methodTypeSymbol())
                                                         .andThen(CodeRelabeler.of())
                                                         .andThen((innerBuilder, shiftedTargetCode) -> {
                                                             //returns must be replaced with jump to the end of the inlined method

--- a/src/java.base/share/classes/java/lang/classfile/snippet-files/PackageSnippets.java
+++ b/src/java.base/share/classes/java/lang/classfile/snippet-files/PackageSnippets.java
@@ -195,7 +195,7 @@ class PackageSnippets {
                 builder.with(element);
         };
         var cc = ClassFile.of();
-        byte[] newBytes = cc.transform(cc.parse(bytes), ct);
+        byte[] newBytes = cc.transformClass(cc.parse(bytes), ct);
         // @end
     }
 
@@ -346,7 +346,7 @@ class PackageSnippets {
 
     void codeRelabeling(ClassModel classModel) {
         // @start region="codeRelabeling"
-        byte[] newBytes = ClassFile.of().transform(classModel,
+        byte[] newBytes = ClassFile.of().transformClass(classModel,
                 ClassTransform.transformingMethodBodies(
                         CodeTransform.ofStateful(CodeRelabeler::of)));
         // @end
@@ -360,7 +360,7 @@ class PackageSnippets {
         var targetFieldNames = target.fields().stream().map(f -> f.fieldName().stringValue()).collect(Collectors.toSet());
         var targetMethods = target.methods().stream().map(m -> m.methodName().stringValue() + m.methodType().stringValue()).collect(Collectors.toSet());
         var instrumentorClassRemapper = ClassRemapper.of(Map.of(instrumentor.thisClass().asSymbol(), target.thisClass().asSymbol()));
-        return ClassFile.of().transform(target,
+        return ClassFile.of().transformClass(target,
                 ClassTransform.transformingMethods(
                         instrumentedMethodsFilter,
                         (mb, me) -> {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -115,7 +115,7 @@ public record ClassFileImpl(StackMapsOption stackMapsOption,
     }
 
     @Override
-    public byte[] transform(ClassModel model, ClassEntry newClassName, ClassTransform transform) {
+    public byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform) {
         ConstantPoolBuilder constantPool = constantPoolSharingOption() == ConstantPoolSharingOption.SHARED_POOL
                                                                      ? ConstantPoolBuilder.of(model)
                                                                      : ConstantPoolBuilder.of();

--- a/src/java.base/share/classes/jdk/internal/module/ModuleInfoExtender.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleInfoExtender.java
@@ -153,7 +153,7 @@ public final class ModuleInfoExtender {
         var cc = ClassFile.of();
         var cm = cc.parse(in.readAllBytes());
         Version v = ModuleInfoExtender.this.version;
-        return cc.transform(cm, ClassTransform.endHandler(clb -> {
+        return cc.transformClass(cm, ClassTransform.endHandler(clb -> {
             // ModuleMainClass attribute
             if (mainClass != null) {
                 clb.with(ModuleMainClassAttribute.of(ClassDesc.of(mainClass)));

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/StripJavaDebugAttributesPlugin.java
@@ -67,7 +67,7 @@ public final class StripJavaDebugAttributesPlugin extends AbstractPlugin {
                         var clm = newClassReader(path, resource,
                                 ClassFile.DebugElementsOption.DROP_DEBUG,
                                 ClassFile.LineNumbersOption.DROP_LINE_NUMBERS);
-                        byte[] content = ClassFile.of().transform(clm, ClassTransform
+                        byte[] content = ClassFile.of().transformClass(clm, ClassTransform
                                         .dropping(cle -> cle instanceof SourceFileAttribute
                                                             || cle instanceof SourceDebugExtensionAttribute)
                                               .andThen(ClassTransform.transformingMethods(MethodTransform

--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/VersionPropsPlugin.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/plugins/VersionPropsPlugin.java
@@ -101,7 +101,7 @@ abstract class VersionPropsPlugin extends AbstractPlugin {
 
     @SuppressWarnings("deprecation")
     private byte[] redefine(String path, byte[] classFile) {
-        return ClassFile.of().transform(newClassReader(path, classFile),
+        return ClassFile.of().transformClass(newClassReader(path, classFile),
             ClassTransform.transformingMethodBodies(
                 mm -> mm.methodName().equalsString("<clinit>"),
                 new CodeTransform() {

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/LocalExecutionControl.java
@@ -89,7 +89,7 @@ public class LocalExecutionControl extends DirectExecutionControl {
 
     private static byte[] instrument(byte[] classFile) {
         var cc = ClassFile.of();
-        return cc.transform(cc.parse(classFile),
+        return cc.transformClass(cc.parse(classFile),
                         ClassTransform.transformingMethodBodies((cob, coe) -> {
                             if (coe instanceof BranchInstruction)
                                 cob.invokestatic(CD_Cancel, "stopCheck", ConstantDescs.MTD_void);

--- a/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
+++ b/test/jdk/java/io/Serializable/records/BadCanonicalCtrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,7 +207,7 @@ public class BadCanonicalCtrTest {
      */
     static byte[] removeConstructor(byte[] classBytes) {
         var cf = ClassFile.of();
-        return cf.transform(cf.parse(classBytes), ClassTransform.dropping(ce ->
+        return cf.transformClass(cf.parse(classBytes), ClassTransform.dropping(ce ->
                 ce instanceof MethodModel mm && mm.methodName().equalsString(INIT_NAME)));
     }
 
@@ -217,7 +217,7 @@ public class BadCanonicalCtrTest {
      */
     static byte[] modifyConstructor(byte[] classBytes) {
         var cf = ClassFile.of();
-        return cf.transform(cf.parse(classBytes), ClassTransform.dropping(ce ->
+        return cf.transformClass(cf.parse(classBytes), ClassTransform.dropping(ce ->
                         ce instanceof MethodModel mm && mm.methodName().equalsString(INIT_NAME))
                 .andThen(ClassTransform.endHandler(clb -> clb.withMethodBody(INIT_NAME,
                         MethodTypeDesc.of(CD_void, CD_Object), ACC_PUBLIC, cob -> {

--- a/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
+++ b/test/jdk/java/io/Serializable/records/ProhibitedMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public class ProhibitedMethods {
     static byte[] addMethod(byte[] classBytes,
                             String name, MethodTypeDesc desc) {
         var cf = ClassFile.of();
-        return cf.transform(cf.parse(classBytes), ClassTransform.endHandler(clb -> {
+        return cf.transformClass(cf.parse(classBytes), ClassTransform.endHandler(clb -> {
             clb.withMethodBody(name, desc, ACC_PRIVATE, cob -> {
                 cob.loadConstant(name + " should not be invoked");
                 cob.invokestatic(Assert.class.describeConstable().orElseThrow(), "fail",

--- a/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
+++ b/test/jdk/java/io/Serializable/records/SerialPersistentFieldsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,7 +231,7 @@ public class SerialPersistentFieldsTest {
                                             ObjectStreamField[] spf) {
         var cf = ClassFile.of();
         var model = cf.parse(classBytes);
-        return cf.transform(model, new SerialPersistentFieldsVisitor(model.thisClass().asSymbol(), spf));
+        return cf.transformClass(model, new SerialPersistentFieldsVisitor(model.thisClass().asSymbol(), spf));
     }
 
     /** A visitor that adds a serialPersistentFields field, and assigns it in clinit. */

--- a/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
+++ b/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class AnnotationsTest {
     static byte[] addDeprecated(byte[] bytes, boolean forRemoval, String since) {
         var cf = ClassFile.of();
         var oldModel = cf.parse(bytes);
-        return cf.transform(oldModel, new ClassTransform() {
+        return cf.transformClass(oldModel, new ClassTransform() {
             boolean rvaaFound = false;
 
             @Override

--- a/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
+++ b/test/jdk/java/lang/instrument/asmlib/Instrumentor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class Instrumentor {
     }
 
     public synchronized byte[] apply() {
-        var bytes = ClassFile.of().transform(model, transform);
+        var bytes = ClassFile.of().transformClass(model, transform);
 
         return dirty.get() ? bytes : null;
     }

--- a/test/jdk/java/lang/invoke/8022701/BogoLoader.java
+++ b/test/jdk/java/lang/invoke/8022701/BogoLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class BogoLoader extends ClassLoader {
                         System.err.println("Replacing class " + name);
                     }
                     var cf = ClassFile.of();
-                    classData = cf.transform(cf.parse(classData), replaced.get(name));
+                    classData = cf.transformClass(cf.parse(classData), replaced.get(name));
                 }
                 clazz = defineClass(name, classData, 0, classData.length);
             } catch (java.io.EOFException ioe) {

--- a/test/jdk/java/lang/invoke/accessProtectedSuper/BogoLoader.java
+++ b/test/jdk/java/lang/invoke/accessProtectedSuper/BogoLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ public class BogoLoader extends ClassLoader {
                         System.err.println("Replacing class " + name);
                     }
                     var cf = ClassFile.of();
-                    classData = cf.transform(cf.parse(classData), replaced.get(name));
+                    classData = cf.transformClass(cf.parse(classData), replaced.get(name));
                 }
                 clazz = defineClass(name, classData, 0, classData.length);
             } catch (java.io.EOFException ioe) {

--- a/test/jdk/jdk/classfile/AdaptCodeTest.java
+++ b/test/jdk/jdk/classfile/AdaptCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ class AdaptCodeTest {
         var cc = ClassFile.of();
         ClassModel cm = cc.parse(testClassPath);
         for (ClassTransform t : Transforms.noops) {
-            byte[] newBytes = cc.transform(cm, t);
+            byte[] newBytes = cc.transformClass(cm, t);
             String result = (String)
                     new ByteArrayClassLoader(AdaptCodeTest.class.getClassLoader(), testClassName, newBytes)
                             .getMethod(testClassName, "many")
@@ -79,7 +79,7 @@ class AdaptCodeTest {
         var cc = ClassFile.of();
         ClassModel cm = cc.parse(fs.getPath(path));
         for (ClassTransform t : Transforms.noops) {
-            byte[] newBytes = cc.transform(cm, t);
+            byte[] newBytes = cc.transformClass(cm, t);
         }
     }
 
@@ -101,7 +101,7 @@ class AdaptCodeTest {
             }
         });
 
-        byte[] newBytes = cc.transform(cm, transform);
+        byte[] newBytes = cc.transformClass(cm, transform);
 //        Files.write(Path.of("foo.class"), newBytes);
         String result = (String)
                 new ByteArrayClassLoader(AdaptCodeTest.class.getClassLoader(), testClassName, newBytes)

--- a/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
+++ b/test/jdk/jdk/classfile/AdvancedTransformationsTest.java
@@ -77,7 +77,7 @@ class AdvancedTransformationsTest {
         try (var in = StackMapGenerator.class.getResourceAsStream("StackMapGenerator.class")) {
             var cc = ClassFile.of();
             var clm = cc.parse(in.readAllBytes());
-            cc.verify(cc.transform(clm, (clb, cle) -> {
+            cc.verify(cc.transformClass(clm, (clb, cle) -> {
                 if (cle instanceof MethodModel mm) {
                     clb.transformMethod(mm, (mb, me) -> {
                         if (me instanceof CodeModel com) {
@@ -303,7 +303,7 @@ class AdvancedTransformationsTest {
         var targetFieldNames = target.fields().stream().map(f -> f.fieldName().stringValue()).collect(Collectors.toSet());
         var targetMethods = target.methods().stream().map(m -> m.methodName().stringValue() + m.methodType().stringValue()).collect(Collectors.toSet());
         var instrumentorClassRemapper = ClassRemapper.of(Map.of(instrumentor.thisClass().asSymbol(), target.thisClass().asSymbol()));
-        return ClassFile.of().transform(target,
+        return ClassFile.of().transformClass(target,
                 ClassTransform.transformingMethods(
                         instrumentedMethodsFilter,
                         (mb, me) -> {
@@ -334,7 +334,7 @@ class AdvancedTransformationsTest {
 
                                                 //inlined target locals must be shifted based on the actual instrumentor locals
                                                 codeBuilder.block(inlinedBlockBuilder -> inlinedBlockBuilder
-                                                        .transform(targetCodeModel, CodeLocalsShifter.of(mm.flags(), mm.methodTypeSymbol())
+                                                    .transform(targetCodeModel, CodeLocalsShifter.of(mm.flags(), mm.methodTypeSymbol())
                                                         .andThen(CodeRelabeler.of())
                                                         .andThen((innerBuilder, shiftedTargetCode) -> {
                                                             //returns must be replaced with jump to the end of the inlined method

--- a/test/jdk/jdk/classfile/BSMTest.java
+++ b/test/jdk/jdk/classfile/BSMTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class BSMTest {
     void testSevenOfThirteenIterator() throws Exception {
         var cc = ClassFile.of();
         ClassModel cm = cc.parse(testClassPath);
-        byte[] newBytes = cc.transform(cm, (cb, ce) -> {
+        byte[] newBytes = cc.transformClass(cm, (cb, ce) -> {
             if (ce instanceof MethodModel mm) {
                 cb.transformMethod(mm, (mb, me) -> {
                     if (me instanceof CodeModel xm) {

--- a/test/jdk/jdk/classfile/ClassBuildingTest.java
+++ b/test/jdk/jdk/classfile/ClassBuildingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class ClassBuildingTest {
         transform = transform.andThen(ClassTransform.transformingMethods(MethodTransform.dropping(me
                 -> me instanceof SignatureAttribute)));
 
-        MethodHandles.lookup().defineClass(cc.transform(cm, transform));
+        MethodHandles.lookup().defineClass(cc.transformClass(cm, transform));
     }
 }
 

--- a/test/jdk/jdk/classfile/ClassHierarchyInfoTest.java
+++ b/test/jdk/jdk/classfile/ClassHierarchyInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,7 +122,7 @@ class ClassHierarchyInfoTest {
     void transformAndVerifySingle(ClassHierarchyResolver res) throws Exception {
         Path path = FileSystems.getFileSystem(URI.create("jrt:/")).getPath("modules/java.base/java/util/HashMap.class");
         var classModel = ClassFile.of().parse(path);
-        byte[] newBytes = ClassFile.of(ClassFile.ClassHierarchyResolverOption.of(res)).transform(classModel,
+        byte[] newBytes = ClassFile.of(ClassFile.ClassHierarchyResolverOption.of(res)).transformClass(classModel,
                 (clb, cle) -> {
                     if (cle instanceof MethodModel mm) {
                         clb.transformMethod(mm, (mb, me) -> {

--- a/test/jdk/jdk/classfile/CorpusTest.java
+++ b/test/jdk/jdk/classfile/CorpusTest.java
@@ -79,7 +79,7 @@ class CorpusTest {
     static void splitTableAttributes(String sourceClassFile, String targetClassFile) throws IOException, URISyntaxException {
         var root = Paths.get(URI.create(CorpusTest.class.getResource("CorpusTest.class").toString())).getParent();
         var cc = ClassFile.of();
-        Files.write(root.resolve(targetClassFile), cc.transform(cc.parse(root.resolve(sourceClassFile)), ClassTransform.transformingMethodBodies((cob, coe) -> {
+        Files.write(root.resolve(targetClassFile), cc.transformClass(cc.parse(root.resolve(sourceClassFile)), ClassTransform.transformingMethodBodies((cob, coe) -> {
             var dcob = (DirectCodeBuilder)cob;
             var curPc = dcob.curPc();
             switch (coe) {
@@ -147,7 +147,7 @@ class CorpusTest {
             try {
                 byte[] transformed = m.shared && m.classTransform != null
                                      ? ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS)
-                                                .transform(ClassFile.of().parse(bytes), m.classTransform)
+                                                .transformClass(ClassFile.of().parse(bytes), m.classTransform)
                                      : m.transform.apply(bytes);
                 Map<Integer, Integer> newDups = findDups(transformed);
                 oldRecord = m.classRecord(bytes);
@@ -210,7 +210,7 @@ class CorpusTest {
 
         //testing maxStack and maxLocals are calculated identically by StackMapGenerator and StackCounter
         byte[] noStackMaps = ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS)
-                                      .transform(newModel,
+                                      .transformClass(newModel,
                                                          ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL));
         var noStackModel = cc.parse(noStackMaps);
         var itStack = newModel.methods().iterator();

--- a/test/jdk/jdk/classfile/DiscontinuedInstructionsTest.java
+++ b/test/jdk/jdk/classfile/DiscontinuedInstructionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ class DiscontinuedInstructionsTest {
                 .invoke(null, list);
         assertEquals(list, List.of("Hello", "World"));
 
-        bytes = cc.transform(cc.parse(bytes), ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL));
+        bytes = cc.transformClass(cc.parse(bytes), ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL));
 
         new ByteArrayClassLoader(DiscontinuedInstructionsTest.class.getClassLoader(), testClass, bytes)
                 .getMethod(testClass, testMethod)
@@ -84,17 +84,17 @@ class DiscontinuedInstructionsTest {
         var clm = cc.parse(bytes);
 
         //test failover stack map generation
-        cc.transform(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
+        cc.transformClass(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
                  .andThen(ClassTransform.endHandler(clb -> clb.withVersion(JAVA_6_VERSION, 0))));
 
         //test failure of stack map generation for Java 7
         assertThrows(IllegalArgumentException.class, () ->
-                cc.transform(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
+                cc.transformClass(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
                          .andThen(ClassTransform.endHandler(clb -> clb.withVersion(JAVA_7_VERSION, 0)))));
 
         //test failure of stack map generation when enforced to generate
         assertThrows(IllegalArgumentException.class, () ->
                 ClassFile.of(ClassFile.StackMapsOption.GENERATE_STACK_MAPS)
-                         .transform(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)));
+                         .transformClass(clm, ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)));
     }
 }

--- a/test/jdk/jdk/classfile/LvtTest.java
+++ b/test/jdk/jdk/classfile/LvtTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ class LvtTest {
         ClassModel c = cc.parse(fileBytes);
 
         // Compare transformed model and original with CodeBuilder filter
-        byte[] newClass = cc.transform(c, Transforms.threeLevelNoop);
+        byte[] newClass = cc.transformClass(c, Transforms.threeLevelNoop);
         ClassRecord orig = ClassRecord.ofClassModel(cc.parse(fileBytes), ClassRecord.CompatibilityFilter.By_ClassBuilder);
         ClassRecord transformed = ClassRecord.ofClassModel(cc.parse(newClass), ClassRecord.CompatibilityFilter.By_ClassBuilder);
         ClassRecord.assertEqualsDeep(transformed, orig);

--- a/test/jdk/jdk/classfile/MassAdaptCopyCodeTest.java
+++ b/test/jdk/jdk/classfile/MassAdaptCopyCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,7 +80,7 @@ class MassAdaptCopyCodeTest {
     }
 
     public byte[] adaptCopy(ClassModel cm) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             if (ce instanceof MethodModel mm) {
                 cb.transformMethod(mm, (mb, me) -> {
                     if (me instanceof CodeModel xm) {

--- a/test/jdk/jdk/classfile/MassAdaptCopyPrimitiveMatchCodeTest.java
+++ b/test/jdk/jdk/classfile/MassAdaptCopyPrimitiveMatchCodeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,7 +99,7 @@ class MassAdaptCopyPrimitiveMatchCodeTest {
         Map<String, byte[]> m2b = new HashMap<>();
         Map<String, CodeAttribute> m2c = new HashMap<>();
         byte[] resultBytes =
-                cc.transform(cm, (cb, e) -> {
+                cc.transformClass(cm, (cb, e) -> {
                     if (e instanceof MethodModel mm) {
                         Optional<CodeModel> code = mm.code();
                         if (code.isPresent()) {

--- a/test/jdk/jdk/classfile/OptionsTest.java
+++ b/test/jdk/jdk/classfile/OptionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ class OptionsTest {
     @MethodSource("corpus")
     void testAttributesProcessingOptionOnTransform(Path path) throws Exception {
         testNoUnstable(path, ClassFile.of().parse(
-                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES).transform(
+                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES).transformClass(
                             ClassFile.of().parse(path),
                             ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL))));
     }
@@ -108,7 +108,7 @@ class OptionsTest {
 
         //test drop unknown at transform
         assertTrue(ClassFile.of().parse(
-                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNKNOWN_ATTRIBUTES).transform(
+                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNKNOWN_ATTRIBUTES).transformClass(
                         ClassFile.of().parse(classBytes),
                         ClassTransform.ACCEPT_ALL)).attributes().isEmpty());
     }

--- a/test/jdk/jdk/classfile/ShortJumpsFixTest.java
+++ b/test/jdk/jdk/classfile/ShortJumpsFixTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,7 +136,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideFwd")
     void testFixFwdJumpsTransform(Sample sample) throws Exception {
         assertFixed(sample,
-                    CC_Fixed_Jumps.transform(
+                    CC_Fixed_Jumps.transformClass(
                             generateFwd(CC_No_Stack_No_Patch, sample, false),
                             overflow()));
     }
@@ -145,7 +145,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideBack")
     void testFixBackJumpsTransform(Sample sample) throws Exception {
         assertFixed(sample,
-                    CC_Fixed_Jumps.transform(
+                    CC_Fixed_Jumps.transformClass(
                             generateBack(CC_No_Stack_No_Patch, sample, false),
                             overflow()));
     }
@@ -154,7 +154,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideFwd")
     void testFailFwdJumpsTransform(Sample sample) throws Exception {
         assertThrows(IllegalArgumentException.class, () ->
-                     CC_Not_Fixed_Jumps.transform(
+                     CC_Not_Fixed_Jumps.transformClass(
                             generateFwd(CC_No_Stack_No_Patch, sample, false),
                             overflow()));
     }
@@ -163,7 +163,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideBack")
     void testFailBackJumpsTransform(Sample sample) throws Exception {
         assertThrows(IllegalArgumentException.class, () ->
-                     CC_Not_Fixed_Jumps.transform(
+                     CC_Not_Fixed_Jumps.transformClass(
                             generateBack(CC_No_Stack_No_Patch, sample, false),
                             overflow()));
     }
@@ -172,7 +172,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideFwd")
     void testFixFwdJumpsChainedTransform(Sample sample) throws Exception {
         assertFixed(sample,
-                    CC_Fixed_Jumps.transform(
+                    CC_Fixed_Jumps.transformClass(
                             generateFwd(CC_No_Stack_No_Patch, sample, false),
                             ClassTransform.ACCEPT_ALL.andThen(overflow()))); //involve BufferedCodeBuilder here
     }
@@ -181,7 +181,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideBack")
     void testFixBackJumpsChainedTransform(Sample sample) throws Exception {
         assertFixed(sample,
-                    CC_Fixed_Jumps.transform(
+                    CC_Fixed_Jumps.transformClass(
                             generateBack(CC_No_Stack_No_Patch, sample, false),
                             ClassTransform.ACCEPT_ALL.andThen(overflow()))); //involve BufferedCodeBuilder here
     }
@@ -190,7 +190,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideFwd")
     void testFailFwdJumpsChainedTransform(Sample sample) throws Exception {
         assertThrows(IllegalArgumentException.class, () ->
-                     CC_Not_Fixed_Jumps.transform(
+                     CC_Not_Fixed_Jumps.transformClass(
                             generateFwd(CC_No_Stack_No_Patch, sample, false),
                             ClassTransform.ACCEPT_ALL.andThen(overflow()))); //involve BufferedCodeBuilder here
     }
@@ -199,7 +199,7 @@ class ShortJumpsFixTest {
     @MethodSource("provideBack")
     void testFailBackJumpsChainedTransform(Sample sample) throws Exception {
         assertThrows(IllegalArgumentException.class, () ->
-                     CC_Not_Fixed_Jumps.transform(
+                     CC_Not_Fixed_Jumps.transformClass(
                             generateBack(CC_No_Stack_No_Patch, sample, false),
                             ClassTransform.ACCEPT_ALL.andThen(overflow()))); //involve BufferedCodeBuilder here
     }

--- a/test/jdk/jdk/classfile/StackMapsTest.java
+++ b/test/jdk/jdk/classfile/StackMapsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,7 +221,7 @@ class StackMapsTest {
         var actualVersion = cc.parse(StackMapsTest.class.getResourceAsStream("/testdata/Pattern1.class").readAllBytes());
 
         //test transformation to class version 49 with removal of StackMapTable attributes
-        var version49 = cc.parse(cc.transform(
+        var version49 = cc.parse(cc.transformClass(
                                     actualVersion,
                                     ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
                                                   .andThen(ClassTransform.endHandler(clb -> clb.withVersion(49, 0)))));
@@ -229,7 +229,7 @@ class StackMapsTest {
                                 .walk().anyMatch(n -> n.name().equals("stack map frames")));
 
         //test transformation to class version 50 with re-generation of StackMapTable attributes
-         assertEmpty(cc.verify(cc.transform(
+         assertEmpty(cc.verify(cc.transformClass(
                                     version49,
                                     ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL)
                                                   .andThen(ClassTransform.endHandler(clb -> clb.withVersion(50, 0))))));

--- a/test/jdk/jdk/classfile/TestRecordComponent.java
+++ b/test/jdk/jdk/classfile/TestRecordComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ class TestRecordComponent {
             } else
                 cb.with(ce);
         };
-        ClassModel newModel = cc.parse(cc.transform(cm, xform));
+        ClassModel newModel = cc.parse(cc.transformClass(cm, xform));
         ClassRecord.assertEquals(newModel, cm);
     }
 
@@ -74,7 +74,7 @@ class TestRecordComponent {
         var cc = ClassFile.of();
         ClassModel cm = cc.parse(Files.readAllBytes(testClassPath));
         ClassTransform xform = (cb, ce) -> cb.with(ce);
-        ClassModel newModel = cc.parse(cc.transform(cm, xform));
+        ClassModel newModel = cc.parse(cc.transformClass(cm, xform));
         ClassRecord.assertEquals(newModel, cm);
     }
 
@@ -92,7 +92,7 @@ class TestRecordComponent {
             else
                 cb.with(ce);
         };
-        ClassModel newModel = cc.parse(cc.transform(cm, xform));
+        ClassModel newModel = cc.parse(cc.transformClass(cm, xform));
         RecordAttribute ra = newModel.findAttribute(Attributes.record()).orElseThrow();
         assertEquals(ra.components().size(), 2, "Should have two components");
         assertEquals(ra.components().get(0).name().stringValue(), "fooXYZ");

--- a/test/jdk/jdk/classfile/TransformTests.java
+++ b/test/jdk/jdk/classfile/TransformTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,8 +97,8 @@ class TransformTests {
         ClassModel cm = cc.parse(bytes);
 
         assertEquals(invoke(bytes), "foo");
-        assertEquals(invoke(cc.transform(cm, transformCode(foo2foo))), "foo");
-        assertEquals(invoke(cc.transform(cm, transformCode(foo2bar))), "bar");
+        assertEquals(invoke(cc.transformClass(cm, transformCode(foo2foo))), "foo");
+        assertEquals(invoke(cc.transformClass(cm, transformCode(foo2bar))), "bar");
     }
 
     @Test
@@ -110,7 +110,7 @@ class TransformTests {
 
         assertEquals(invoke(bytes), "foo");
         ClassTransform transform = transformCode(foo2bar.andThen(bar2baz));
-        assertEquals(invoke(cc.transform(cm, transform)), "baz");
+        assertEquals(invoke(cc.transformClass(cm, transform)), "baz");
     }
 
     @Test
@@ -121,9 +121,9 @@ class TransformTests {
         ClassModel cm = cc.parse(bytes);
 
         assertEquals(invoke(bytes), "foo");
-        assertEquals(invoke(cc.transform(cm, transformCode(foo2bar.andThen(bar2baz).andThen(baz2foo)))), "foo");
-        assertEquals(invoke(cc.transform(cm, transformCode(foo2bar.andThen(bar2baz).andThen(baz2quux)))), "quux");
-        assertEquals(invoke(cc.transform(cm, transformCode(foo2foo.andThen(foo2bar).andThen(bar2baz)))), "baz");
+        assertEquals(invoke(cc.transformClass(cm, transformCode(foo2bar.andThen(bar2baz).andThen(baz2foo)))), "foo");
+        assertEquals(invoke(cc.transformClass(cm, transformCode(foo2bar.andThen(bar2baz).andThen(baz2quux)))), "quux");
+        assertEquals(invoke(cc.transformClass(cm, transformCode(foo2foo.andThen(foo2bar).andThen(bar2baz)))), "baz");
     }
 
     public static class TestClass {

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ class VerifierSelfTest {
         var cc = ClassFile.of(ClassFile.ClassHierarchyResolverOption.of(
                 className -> ClassHierarchyResolver.ClassHierarchyInfo.ofClass(null)));
         var classModel = cc.parse(path);
-        byte[] brokenClassBytes = cc.transform(classModel,
+        byte[] brokenClassBytes = cc.transformClass(classModel,
                 (clb, cle) -> {
                     if (cle instanceof MethodModel mm) {
                         clb.transformMethod(mm, (mb, me) -> {

--- a/test/jdk/jdk/classfile/examples/AnnotationsExamples.java
+++ b/test/jdk/jdk/classfile/examples/AnnotationsExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public class AnnotationsExamples {
     public byte[] addAnno(ClassModel m) {
         // @@@ Not correct
         List<Annotation> annos = List.of(Annotation.of(ClassDesc.of("java.lang.FunctionalInterface")));
-        return ClassFile.of().transform(m, ClassTransform.endHandler(cb -> cb.with(RuntimeVisibleAnnotationsAttribute.of(annos))));
+        return ClassFile.of().transformClass(m, ClassTransform.endHandler(cb -> cb.with(RuntimeVisibleAnnotationsAttribute.of(annos))));
     }
 
     /**
@@ -75,7 +75,7 @@ public class AnnotationsExamples {
             var cc = ClassFile.of();
             for (Annotation ann : a.annotations()) {
                 if (ann.className().stringValue().equals("Ljava/lang/annotation/Documented;")) {
-                    m2 = cc.parse(cc.transform(m, SWAP_ANNO_TRANSFORM));
+                    m2 = cc.parse(cc.transformClass(m, SWAP_ANNO_TRANSFORM));
                 }
             }
         }
@@ -119,7 +119,7 @@ public class AnnotationsExamples {
             var cc = ClassFile.of();
             for (Annotation ann : a.annotations()) {
                 if (ann.className().stringValue().equals("Ljava/lang/FunctionalInterface;")) {
-                    m2 = cc.parse(cc.transform(m, (cb, ce) -> {
+                    m2 = cc.parse(cc.transformClass(m, (cb, ce) -> {
                         if (ce instanceof RuntimeVisibleAnnotationsAttribute ra) {
                             var oldAnnos = ra.annotations();
                             List<Annotation> newAnnos = new ArrayList<>(oldAnnos.size() + 1);
@@ -145,7 +145,7 @@ public class AnnotationsExamples {
     }
 
     public byte[] viaEndHandlerClassBuilderEdition(ClassModel m) {
-        return ClassFile.of().transform(m, ClassTransform.ofStateful(() -> new ClassTransform() {
+        return ClassFile.of().transformClass(m, ClassTransform.ofStateful(() -> new ClassTransform() {
             boolean found = false;
 
             @Override
@@ -172,7 +172,7 @@ public class AnnotationsExamples {
     }
 
     public byte[] viaEndHandlerClassTransformEdition(ClassModel m) {
-        return ClassFile.of().transform(m, ClassTransform.ofStateful(() -> new ClassTransform() {
+        return ClassFile.of().transformClass(m, ClassTransform.ofStateful(() -> new ClassTransform() {
             boolean found = false;
 
             @Override

--- a/test/jdk/jdk/classfile/examples/ExampleGallery.java
+++ b/test/jdk/jdk/classfile/examples/ExampleGallery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,7 +62,7 @@ import java.lang.classfile.instruction.InvokeInstruction;
  */
 public class ExampleGallery {
     public byte[] changeClassVersion(ClassModel cm) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case ClassFileVersion cv -> cb.withVersion(57, 0);
                 default -> cb.with(ce);
@@ -71,7 +71,7 @@ public class ExampleGallery {
     }
 
     public byte[] incrementClassVersion(ClassModel cm) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case ClassFileVersion cv -> cb.withVersion(cv.majorVersion() + 1, 0);
                 default -> cb.with(ce);
@@ -80,7 +80,7 @@ public class ExampleGallery {
     }
 
     public byte[] changeSuperclass(ClassModel cm, ClassDesc superclass) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case Superclass sc -> cb.withSuperclass(superclass);
                 default -> cb.with(ce);
@@ -89,11 +89,11 @@ public class ExampleGallery {
     }
 
     public byte[] overrideSuperclass(ClassModel cm, ClassDesc superclass) {
-        return ClassFile.of().transform(cm, ClassTransform.endHandler(cb -> cb.withSuperclass(superclass)));
+        return ClassFile.of().transformClass(cm, ClassTransform.endHandler(cb -> cb.withSuperclass(superclass)));
     }
 
     public byte[] removeInterface(ClassModel cm, String internalName) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case Interfaces i -> cb.withInterfaces(i.interfaces().stream()
                                                         .filter(e -> !e.asInternalName().equals(internalName))
@@ -104,7 +104,7 @@ public class ExampleGallery {
     }
 
     public byte[] addInterface(ClassModel cm, ClassDesc newIntf) {
-        return ClassFile.of().transform(cm, ClassTransform.ofStateful(()  -> new ClassTransform() {
+        return ClassFile.of().transformClass(cm, ClassTransform.ofStateful(()  -> new ClassTransform() {
             boolean seen = false;
 
             @Override
@@ -133,7 +133,7 @@ public class ExampleGallery {
 
     }
     public byte[] addInterface1(ClassModel cm, ClassDesc newIntf) {
-        return ClassFile.of().transform(cm, ClassTransform.ofStateful(()  -> new ClassTransform() {
+        return ClassFile.of().transformClass(cm, ClassTransform.ofStateful(()  -> new ClassTransform() {
             Interfaces interfaces;
 
             @Override
@@ -160,11 +160,11 @@ public class ExampleGallery {
     }
 
     public byte[] removeSignature(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.dropping(e -> e instanceof SignatureAttribute));
+        return ClassFile.of().transformClass(cm, ClassTransform.dropping(e -> e instanceof SignatureAttribute));
     }
 
     public byte[] changeSignature(ClassModel cm) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case SignatureAttribute sa -> {
                     String result = sa.signature().stringValue();
@@ -176,7 +176,7 @@ public class ExampleGallery {
     }
 
     public byte[] setSignature(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.dropping(e -> e instanceof SignatureAttribute)
+        return ClassFile.of().transformClass(cm, ClassTransform.dropping(e -> e instanceof SignatureAttribute)
                                           .andThen(ClassTransform.endHandler(b -> b.with(SignatureAttribute.of(
                                               ClassSignature.of(
                                                       ClassTypeSig.of(ClassDesc.of("impl.Fox"),
@@ -187,16 +187,16 @@ public class ExampleGallery {
     // @@@ strip annos (class, all)
 
     public byte[] stripFields(ClassModel cm, Predicate<String> filter) {
-        return ClassFile.of().transform(cm, ClassTransform.dropping(e -> e instanceof FieldModel fm
+        return ClassFile.of().transformClass(cm, ClassTransform.dropping(e -> e instanceof FieldModel fm
                                                          && filter.test(fm.fieldName().stringValue())));
     }
 
     public byte[] addField(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.endHandler(cb -> cb.withField("cool", ClassDesc.ofDescriptor("(I)D"), ClassFile.ACC_PUBLIC)));
+        return ClassFile.of().transformClass(cm, ClassTransform.endHandler(cb -> cb.withField("cool", ClassDesc.ofDescriptor("(I)D"), ClassFile.ACC_PUBLIC)));
     }
 
     public byte[] changeFieldSig(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.transformingFields((fb, fe) -> {
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingFields((fb, fe) -> {
             if (fe instanceof SignatureAttribute sa)
                 fb.with(SignatureAttribute.of(Signature.parseFrom(sa.signature().stringValue().replace("this/", "that/"))));
             else
@@ -205,7 +205,7 @@ public class ExampleGallery {
     }
 
     public byte[] changeFieldFlags(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.transformingFields((fb, fe) -> {
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingFields((fb, fe) -> {
             switch (fe) {
                 case AccessFlags a -> fb.with(AccessFlags.ofField(a.flagsMask() & ~ClassFile.ACC_PUBLIC & ~ClassFile.ACC_PROTECTED));
                 default -> fb.with(fe);
@@ -214,7 +214,7 @@ public class ExampleGallery {
     }
 
     public byte[] addException(ClassModel cm, ClassDesc ex) {
-        return ClassFile.of().transform(cm, ClassTransform.transformingMethods(
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingMethods(
                 MethodTransform.ofStateful(() -> new MethodTransform() {
                     ExceptionsAttribute attr;
 
@@ -258,11 +258,11 @@ public class ExampleGallery {
             }
         });
 
-        return ClassFile.of().transform(cm, ClassTransform.transformingMethodBodies(transform));
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingMethodBodies(transform));
     }
 
     public byte[] addInstrumentationBeforeInvoke(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.transformingMethodBodies((codeB, codeE) -> {
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingMethodBodies((codeB, codeE) -> {
             switch (codeE) {
                 case InvokeInstruction i -> {
                     codeB.nop();
@@ -274,7 +274,7 @@ public class ExampleGallery {
     }
 
     public byte[] replaceIntegerConstant(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.transformingMethodBodies((codeB, codeE) -> {
+        return ClassFile.of().transformClass(cm, ClassTransform.transformingMethodBodies((codeB, codeE) -> {
             switch (codeE) {
                 case ConstantInstruction ci -> {
                         if (ci.constantValue() instanceof Integer i) codeB.loadConstant(i + 1);

--- a/test/jdk/jdk/classfile/examples/ExperimentalTransformExamples.java
+++ b/test/jdk/jdk/classfile/examples/ExperimentalTransformExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ public class ExperimentalTransformExamples {
     };
 
     public byte[] deleteAnnotations(ClassModel cm) {
-        return ClassFile.of().transform(cm, (cb, ce) -> {
+        return ClassFile.of().transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case MethodModel m -> cb.transformMethod(m, dropMethodAnnos);
                 case FieldModel f -> cb.transformField(f, dropFieldAnnos);

--- a/test/jdk/jdk/classfile/examples/TransformExamples.java
+++ b/test/jdk/jdk/classfile/examples/TransformExamples.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,18 +38,18 @@ import java.lang.classfile.Attribute;
  */
 public class TransformExamples {
     public byte[] noop(ClassModel cm) {
-        return ClassFile.of().transform(cm, ClassTransform.ACCEPT_ALL);
+        return ClassFile.of().transformClass(cm, ClassTransform.ACCEPT_ALL);
     }
 
     public byte[] deleteAllMethods(ClassModel cm) {
-        return ClassFile.of().transform(cm, (b, e) -> {
+        return ClassFile.of().transformClass(cm, (b, e) -> {
             if (!(e instanceof MethodModel))
                 b.with(e);
         });
     }
 
     public byte[] deleteFieldsWithDollarInName(ClassModel cm) {
-        return ClassFile.of().transform(cm, (b, e) ->
+        return ClassFile.of().transformClass(cm, (b, e) ->
                         {
                             if (!(e instanceof FieldModel fm && fm.fieldName().stringValue().contains("$")))
                                 b.with(e);
@@ -57,14 +57,14 @@ public class TransformExamples {
     }
 
     public byte[] deleteAttributes(ClassModel cm) {
-        return ClassFile.of().transform(cm, (b, e) -> {
+        return ClassFile.of().transformClass(cm, (b, e) -> {
             if (!(e instanceof Attribute))
                 b.with(e);
         });
     }
 
     public byte[] keepMethodsAndFields(ClassModel cm) {
-        return ClassFile.of().transform(cm, (b, e) -> {
+        return ClassFile.of().transformClass(cm, (b, e) -> {
             if (e instanceof MethodModel || e instanceof FieldModel)
                 b.with(e);
         });

--- a/test/jdk/jdk/classfile/helpers/Transforms.java
+++ b/test/jdk/jdk/classfile/helpers/Transforms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,7 +187,7 @@ public class Transforms {
                     shared
                     ? options
                     : Stream.concat(Stream.of(options), Stream.of(ClassFile.ConstantPoolSharingOption.NEW_POOL)).toArray(ClassFile.Option[]::new));
-            this.transform = bytes -> cc.transform(cc.parse(bytes), classTransform);
+            this.transform = bytes -> cc.transformClass(cc.parse(bytes), classTransform);
         }
 
         public Optional<ClassRecord> classRecord(byte[] bytes) throws IOException {
@@ -212,7 +212,7 @@ public class Transforms {
         NOP_SHARED(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, (cb, ce) -> {
+            return cc.transformClass(cm, (cb, ce) -> {
                 if (ce instanceof MethodModel mm) {
                     cb.transformMethod(mm, (mb, me) -> {
                         if (me instanceof CodeModel xm) {
@@ -253,7 +253,7 @@ public class Transforms {
         HIGH_SHARED_ADD_FIELD(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, new ClassTransform() {
+            return cc.transformClass(cm, new ClassTransform() {
                 @Override
                 public void accept(ClassBuilder builder, ClassElement element) {
                     builder.with(element);
@@ -291,7 +291,7 @@ public class Transforms {
         HIGH_SHARED_DEL_METHOD(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, (builder, element) -> {
+            return cc.transformClass(cm, (builder, element) -> {
                 if (!(element instanceof MethodModel mm))
                     builder.with(element);
             });

--- a/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
+++ b/test/jdk/jdk/jfr/event/io/TestInstrumentation.java
@@ -317,7 +317,7 @@ public class TestInstrumentation implements ClassFileTransformer {
 
         instrClassesDone.add(target);
         var cf = ClassFile.of();
-        return cf.transform(cf.parse(bytes), (clb, ce) -> {
+        return cf.transformClass(cf.parse(bytes), (clb, ce) -> {
             MethodKey key;
             if (ce instanceof MethodModel mm && instrMethodKeys.contains(key = new MethodKey(
                     target, mm.methodName().stringValue(), mm.methodTypeSymbol()))) {

--- a/test/jdk/jdk/jfr/javaagent/TestEventInstrumentation.java
+++ b/test/jdk/jdk/jfr/javaagent/TestEventInstrumentation.java
@@ -116,7 +116,7 @@ public class TestEventInstrumentation {
                 }
 
                 var cf = ClassFile.of();
-                result = cf.transform(cf.parse(bytes), (clb, ce) -> {
+                result = cf.transformClass(cf.parse(bytes), (clb, ce) -> {
                     if (ce instanceof MethodModel mm && mm.methodName().equalsString(INIT_NAME)) {
                         clb.transformMethod(mm, MethodTransform.transformingCode(new CodeTransform() {
                             @Override

--- a/test/jdk/jdk/lambda/separate/ClassToInterfaceConverter.java
+++ b/test/jdk/jdk/lambda/separate/ClassToInterfaceConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class ClassToInterfaceConverter implements ClassFilePreprocessor {
             }
         };
 
-        return ClassFile.of().transform(classModel,
+        return ClassFile.of().transformClass(classModel,
             ClassTransform.dropping(ce -> ce instanceof MethodModel mm && mm.methodName().equalsString(INIT_NAME))
                           .andThen(ClassTransform.transformingMethodBodies(ct))
                           .andThen(ClassTransform.endHandler(b -> b.withFlags(ACC_INTERFACE | ACC_ABSTRACT | ACC_PUBLIC)))

--- a/test/langtools/tools/javac/MethodParametersTest.java
+++ b/test/langtools/tools/javac/MethodParametersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ public class MethodParametersTest {
 
         // Alter the MethodParameters attribute, changing the name of
         // the parameter from i to baz.
-        byte[] bazBytes = ClassFile.of().transform(baz, ClassTransform.transformingMethods((methodBuilder, methodElement) -> {
+        byte[] bazBytes = ClassFile.of().transformClass(baz, ClassTransform.transformingMethods((methodBuilder, methodElement) -> {
             if (methodElement instanceof MethodParametersAttribute a) {
                 List<MethodParameterInfo> newParameterInfos = new ArrayList<>();
                 for (MethodParameterInfo info : a.parameters()) {
@@ -200,7 +200,7 @@ public class MethodParametersTest {
         // Flip the code and method attributes().  This is for checking
         // that order doesn't matter.
         if (flip) {
-            bazBytes = ClassFile.of().transform(baz, ClassTransform.transformingMethods((methodBuilder, methodElement) -> {
+            bazBytes = ClassFile.of().transformClass(baz, ClassTransform.transformingMethods((methodBuilder, methodElement) -> {
                 if (methodElement instanceof MethodParametersAttribute) {
                     methodBuilder.with(cattr);
                 } else if (methodElement instanceof CodeAttribute){

--- a/test/langtools/tools/javac/classreader/8171132/BadConstantValue.java
+++ b/test/langtools/tools/javac/classreader/8171132/BadConstantValue.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 Google, Inc.  All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +185,7 @@ public class BadConstantValue {
         ClassModel cf = ClassFile.of().parse(file.toPath());
         FieldModel a = cf.fields().getFirst();
         FieldModel b = cf.fields().get(1);
-        byte[] Bytes = ClassFile.of().transform(cf, ClassTransform
+        byte[] Bytes = ClassFile.of().transformClass(cf, ClassTransform
                 .dropping(ce -> ce instanceof ClassFileVersion || ce instanceof FieldModel)
                 .andThen(ClassTransform.endHandler(classBuilder -> classBuilder
                         .withField(b.fieldName(), b.fieldType(), fieldBuilder -> {

--- a/test/langtools/tools/javac/classreader/BadMethodParameter.java
+++ b/test/langtools/tools/javac/classreader/BadMethodParameter.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Alphabet LLC. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +149,7 @@ public class BadMethodParameter extends TestRunner {
                 };
 
         ClassTransform classTransform = ClassTransform.transformingMethods(methodTransform);
-        bytes = cf.transform(classModel, classTransform);
+        bytes = cf.transformClass(classModel, classTransform);
         Files.write(path, bytes);
     }
 }

--- a/test/langtools/tools/javac/defaultMethods/BadClassfile.java
+++ b/test/langtools/tools/javac/defaultMethods/BadClassfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ public class BadClassfile {
     private static void test(String classname, String expected) throws Exception {
         File classfile = new File(System.getProperty("test.classes", "."), classname + ".class");
         ClassModel cf = ClassFile.of().parse(classfile.toPath());
-        ClassFile.of().transform(cf, ClassTransform.dropping(ce -> ce instanceof ClassFileVersion)
+        ClassFile.of().transformClass(cf, ClassTransform.dropping(ce -> ce instanceof ClassFileVersion)
                 .andThen(ClassTransform.endHandler(classBuilder -> classBuilder.withVersion(Target.JDK1_7.majorVersion, Target.JDK1_7.minorVersion))));
         JavaCompiler c = ToolProvider.getSystemJavaCompiler();
         JavacTaskImpl task = (JavacTaskImpl) c.getTask(null, null, null, Arrays.asList("-classpath", System.getProperty("test.classes", ".")), null, null);

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -743,7 +743,7 @@ public class SourceLauncherTest extends TestRunner {
         private static void markModuleAsIncubator(Path moduleInfoFile) throws Exception {
             ClassModel cf = ClassFile.of().parse(moduleInfoFile);
             ModuleResolutionAttribute newAttr = ModuleResolutionAttribute.of(WARN_INCUBATING);
-            byte[] newBytes = ClassFile.of().transform(cf,
+            byte[] newBytes = ClassFile.of().transformClass(cf,
                     ClassTransform.endHandler(classBuilder -> classBuilder.with(newAttr)));
             try (OutputStream out = Files.newOutputStream(moduleInfoFile)) {
                 out.write(newBytes);

--- a/test/langtools/tools/javac/modules/IncubatingTest.java
+++ b/test/langtools/tools/javac/modules/IncubatingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ public class IncubatingTest extends ModuleTestBase {
     private void addModuleResolutionAttribute(Path classfile, int resolution_flags) throws Exception {
         ClassModel cm = ClassFile.of().parse(classfile);
         ModuleResolutionAttribute modRAttr = ModuleResolutionAttribute.of(resolution_flags);
-        byte[] newBytes = ClassFile.of().transform(cm, ClassTransform.dropping(ce -> ce instanceof ModuleResolutionAttribute).
+        byte[] newBytes = ClassFile.of().transformClass(cm, ClassTransform.dropping(ce -> ce instanceof ModuleResolutionAttribute).
                 andThen(ClassTransform.endHandler(classBuilder -> classBuilder.with(modRAttr))));
         try (OutputStream out = Files.newOutputStream(classfile)) {
             out.write(newBytes);

--- a/test/langtools/tools/javac/modules/JavaBaseTest.java
+++ b/test/langtools/tools/javac/modules/JavaBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,7 @@ public class JavaBaseTest {
                 modAttr1.provides());
         Path modInfo = base.resolve("test-modules").resolve("module-info.class");
         Files.createDirectories(modInfo.getParent());
-        byte[] newBytes = ClassFile.of().transform(cm1, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute).
+        byte[] newBytes = ClassFile.of().transformClass(cm1, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute).
                 andThen(ClassTransform.endHandler(classBuilder -> classBuilder.with(modAttr2))));
         try (OutputStream out = Files.newOutputStream(modInfo)) {
             out.write(newBytes);

--- a/test/langtools/tools/javac/modules/OpenModulesTest.java
+++ b/test/langtools/tools/javac/modules/OpenModulesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public class OpenModulesTest extends ModuleTestBase {
                                                           module.uses(),
                                                           module.provides());
 
-        byte[] newBytes = ClassFile.of().transform(cm, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute).
+        byte[] newBytes = ClassFile.of().transformClass(cm, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute).
                 andThen(ClassTransform.endHandler(classBuilder -> classBuilder.with(newModule))));
         try (OutputStream out = Files.newOutputStream(miClass)) {
             out.write(newBytes);

--- a/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
+++ b/test/langtools/tools/javac/platform/createsymbols/CreateSymbolsTestImpl.java
@@ -1070,7 +1070,7 @@ public class CreateSymbolsTestImpl {
                            try {
                                Path moduleInfo = classesDir.resolve("module-info.class");
                                byte[] newClassData =
-                                       cf.transform(cf.parse(moduleInfo),
+                                       cf.transformClass(cf.parse(moduleInfo),
                                                     (builder, element) -> {
                                                         builder.with(element);
                                                         if (element instanceof ModuleAttribute) {
@@ -1179,7 +1179,7 @@ public class CreateSymbolsTestImpl {
             }
             ClassFile cf = ClassFile.of();
             ClassModel cm = cf.parse(moduleInfo);
-            byte[] newData = cf.transform(cm, (builder, element) -> {
+            byte[] newData = cf.transformClass(cm, (builder, element) -> {
                 builder.with(element);
                 if (element instanceof ModuleAttribute) {
                     builder.with(ModulePackagesAttribute.ofNames(packages.stream()

--- a/test/langtools/tools/javac/processing/model/element/TestOrigin.java
+++ b/test/langtools/tools/javac/processing/model/element/TestOrigin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,7 @@ public class TestOrigin extends TestRunner {
                                                           newOpens,
                                                           module.uses(),
                                                           module.provides());
-        byte[] newClassFileBytes = ClassFile.of().transform(cf, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute)
+        byte[] newClassFileBytes = ClassFile.of().transformClass(cf, ClassTransform.dropping(ce -> ce instanceof ModuleAttribute)
                                                  .andThen(ClassTransform.endHandler(classBuilder -> classBuilder.with(newModule))));
         try (OutputStream out = Files.newOutputStream(moduleInfo)) {
             out.write(newClassFileBytes);

--- a/test/langtools/tools/javap/UndefinedAccessFlagTest.java
+++ b/test/langtools/tools/javap/UndefinedAccessFlagTest.java
@@ -70,7 +70,7 @@ public class UndefinedAccessFlagTest {
         )) {
             cm = cf.parse(is.readAllBytes());
         }
-        var bytes = cf.transform(cm, (cb, ce) -> {
+        var bytes = cf.transformClass(cm, (cb, ce) -> {
             switch (ce) {
                 case AccessFlags flags when location == TestLocation.CLASS -> cb
                     .withFlags(flags.flagsMask() | ACC_PRIVATE);

--- a/test/micro/org/openjdk/bench/jdk/classfile/AdHocAdapt.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AdHocAdapt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,6 @@ public class AdHocAdapt extends AbstractCorpusBenchmark {
     public void transform(Blackhole bh) {
         var cc = ClassFile.of();
         for (byte[] bytes : classes)
-            bh.consume(cc.transform(cc.parse(bytes), transform.transform));
+            bh.consume(cc.transformClass(cc.parse(bytes), transform.transform));
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/classfile/ClassfileBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ClassfileBenchmark.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,18 +99,18 @@ public class ClassfileBenchmark {
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void transformWithSharedCP(Blackhole bh) {
-        bh.consume(sharedCP.transform(benchModel, threeLevelNoop));
+        bh.consume(sharedCP.transformClass(benchModel, threeLevelNoop));
     }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void transformWithNewCP(Blackhole bh) {
-        bh.consume(newCP.transform(benchModel, threeLevelNoop));
+        bh.consume(newCP.transformClass(benchModel, threeLevelNoop));
     }
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     public void transformWithAddedNOP(Blackhole bh) {
-        bh.consume(sharedCP.transform(benchModel, addNOP));
+        bh.consume(sharedCP.transformClass(benchModel, addNOP));
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/classfile/ParseOptions.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ParseOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ public class ParseOptions extends AbstractCorpusBenchmark {
         var cc = ClassFile.of(ClassFile.DebugElementsOption.DROP_DEBUG);
         for (byte[] aClass : classes) {
             ClassModel cm = cc.parse(aClass);
-            bh.consume(cc.transform(cm, threeLevelNoop));
+            bh.consume(cc.transformClass(cm, threeLevelNoop));
         }
     }
 
@@ -52,7 +52,7 @@ public class ParseOptions extends AbstractCorpusBenchmark {
         var cc = ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS);
         for (byte[] aClass : classes) {
             ClassModel cm = cc.parse(aClass);
-            bh.consume(cc.transform(cm, threeLevelNoop));
+            bh.consume(cc.transformClass(cm, threeLevelNoop));
         }
     }
 
@@ -62,7 +62,7 @@ public class ParseOptions extends AbstractCorpusBenchmark {
         var cc = ClassFile.of(ClassFile.LineNumbersOption.DROP_LINE_NUMBERS);
         for (byte[] aClass : classes) {
             ClassModel cm = cc.parse(aClass);
-            bh.consume(cc.transform(cm, threeLevelNoop));
+            bh.consume(cc.transformClass(cm, threeLevelNoop));
         }
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class RebuildMethodBodies {
     }
 
     private static void transform(ClassFile cc, ClassModel clm) {
-        cc.transform(clm, ClassTransform.transformingMethodBodies((cob, coe) -> {
+        cc.transformClass(clm, ClassTransform.transformingMethodBodies((cob, coe) -> {
             switch (coe) {
                 case FieldInstruction i ->
                     cob.fieldAccess(i.opcode(), i.owner().asSymbol(), i.name().stringValue(), i.typeSymbol());

--- a/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Transforms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,7 @@ public class Transforms {
                     shared
                     ? options
                     : Stream.concat(Stream.of(options), Stream.of(ClassFile.ConstantPoolSharingOption.NEW_POOL)).toArray(ClassFile.Option[]::new));
-            this.transform = bytes -> cc.transform(cc.parse(bytes), classTransform);
+            this.transform = bytes -> cc.transformClass(cc.parse(bytes), classTransform);
         }
     }
 
@@ -198,7 +198,7 @@ public class Transforms {
         NOP_SHARED(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, (cb, ce) -> {
+            return cc.transformClass(cm, (cb, ce) -> {
                 if (ce instanceof MethodModel mm) {
                     cb.transformMethod(mm, (mb, me) -> {
                         if (me instanceof CodeModel xm) {
@@ -239,7 +239,7 @@ public class Transforms {
         HIGH_SHARED_ADD_FIELD(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, new ClassTransform() {
+            return cc.transformClass(cm, new ClassTransform() {
                 @Override
                 public void accept(ClassBuilder builder, ClassElement element) {
                     builder.with(element);
@@ -277,7 +277,7 @@ public class Transforms {
         HIGH_SHARED_DEL_METHOD(bytes -> {
             var cc = ClassFile.of();
             ClassModel cm = cc.parse(bytes);
-            return cc.transform(cm, (builder, element) -> {
+            return cc.transformClass(cm, (builder, element) -> {
                 if (!(element instanceof MethodModel mm))
                     builder.with(element);
             });


### PR DESCRIPTION
`ClassFile::transform` was initially `ClassModel::transform`, which transforms the receiver class model to a new class byte array. This functionality was in parallel with `ClassBuilder::transform`, which accepts a `ClassModel` and a `ClassTransform` and forwards the results to the receiver builder.

After the `ClassFile` context object introduction, `ClassModel::transform` becomes `ClassFile::transform`; now, its role is more similar to `ClassBuilder::transformMethod`, `ClassBuilder::transformField`, or `MethodBuilder::transformCode` (transforming subtypes), and it is confusing with `ClassFileBuilder::transform` (which accepts the same model type as the built type). We should rename `ClassFile::transform` to `ClassFile::transformClass` to make this method's role more clear.

This is separate from #19928 as this has much more user impact.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8335359](https://bugs.openjdk.org/browse/JDK-8335359) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8335290](https://bugs.openjdk.org/browse/JDK-8335290): Rename ClassFile::transform to ClassFile::transformClass (**Enhancement** - P4)
 * [JDK-8335359](https://bugs.openjdk.org/browse/JDK-8335359): Rename ClassFile::transform to ClassFile::transformClass (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19952/head:pull/19952` \
`$ git checkout pull/19952`

Update a local copy of the PR: \
`$ git checkout pull/19952` \
`$ git pull https://git.openjdk.org/jdk.git pull/19952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19952`

View PR using the GUI difftool: \
`$ git pr show -t 19952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19952.diff">https://git.openjdk.org/jdk/pull/19952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19952#issuecomment-2197716425)