### PR TITLE
8313235: TestClhsdbJstackLock.java failed with  '^\s+- waiting to lock <0x[0-9a-f]+> \(a java\.lang\.Class for LingeredAppWithLock\)$' missing from stdout/stderr

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithConcurrentLock.java
@@ -63,6 +63,15 @@ public class LingeredAppWithConcurrentLock extends LingeredApp {
             } catch (InterruptedException ex) {
             }
         }
+
+        // Wait a short period of time so we can be sure the threads truly have moved
+        // to the required state and are now idle. See JDK-8313235.
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
         System.out.println("classLock1 state: " + classLock1.getState());
         System.out.println("classLock2 state: " + classLock2.getState());
         System.out.println("classLock3 state: " + classLock3.getState());

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,14 @@ public class LingeredAppWithLock extends LingeredApp {
                 Thread.sleep(100);
             } catch (InterruptedException ex) {
             }
+        }
+
+        // Wait a short period of time so we can be sure the threads truly have moved
+        // to the required state and are now idle. See JDK-8313235.
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
 
         LingeredApp.main(args);


### PR DESCRIPTION
Once the main thread has detected that the spawned thread is in the BLOCKED state, the spawned thread's LingeredAppWithLock.lockMethod() should be visible on the top of the stack, but it is not, so the "waiting to lock" message is missing from the stack trace.

I think the explanations mentioned in [JDK-8335124](https://bugs.openjdk.org/browse/JDK-8335124) and [JDK-8269881](https://bugs.openjdk.org/browse/JDK-8269881) apply here also. The state of the thread has moved to BLOCKED, but the thread still needs to finish making an OS call to actually become blocked and the thread become idle. During that time we may not be able to get an accurate stack trace. In this case probably SP has not been flushed, so we are not seeing the lockMethod() frame, which should appear at the top of the stack.

A short delay has been added after all threads have entered the desired state to make sure they have fully reached the desired state and are now idle.

Tested with Tier1 CI and all svc test tasks for tier2 and tier5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313235](https://bugs.openjdk.org/browse/JDK-8313235): TestClhsdbJstackLock.java failed with  '^\s+- waiting to lock &lt;0x[0-9a-f]+&gt; \(a java\.lang\.Class for LingeredAppWithLock\)$' missing from stdout/stderr (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19953/head:pull/19953` \
`$ git checkout pull/19953`

Update a local copy of the PR: \
`$ git checkout pull/19953` \
`$ git pull https://git.openjdk.org/jdk.git pull/19953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19953`

View PR using the GUI difftool: \
`$ git pr show -t 19953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19953.diff">https://git.openjdk.org/jdk/pull/19953.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19953#issuecomment-2199507006)