### PR TITLE
8334904: Add some perf counters to monitor the usage of VM locks

### DIFF
--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -212,6 +212,7 @@ class outputStream;
   LOG_TAG(valuebasedclasses) \
   LOG_TAG(verification) \
   LOG_TAG(verify) \
+  LOG_TAG(vmlocks) \
   LOG_TAG(vmmutex) \
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -212,7 +212,6 @@ class outputStream;
   LOG_TAG(valuebasedclasses) \
   LOG_TAG(verification) \
   LOG_TAG(verify) \
-  LOG_TAG(vmlocks) \
   LOG_TAG(vmmutex) \
   LOG_TAG(vmoperation) \
   LOG_TAG(vmthread) \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3740,10 +3740,10 @@ jint Arguments::apply_ergo() {
     }
   }
 
-  if (log_is_enabled(Info, perf, vmlocks)) {
+  if (log_is_enabled(Info, perf, vmmutex)) {
     if (!UsePerfData) {
-      warning("Disabling -Xlog:perf+vmlocks since UsePerfData is turned off.");
-      LogConfiguration::configure_stdout(LogLevel::Off, false, LOG_TAGS(perf, vmlocks));
+      warning("Disabling -Xlog:perf+vmmutex since UsePerfData is turned off.");
+      LogConfiguration::configure_stdout(LogLevel::Off, false, LOG_TAGS(perf, vmmutex));
     }
   }
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3740,6 +3740,13 @@ jint Arguments::apply_ergo() {
     }
   }
 
+  if (log_is_enabled(Info, perf, vmlocks)) {
+    if (!UsePerfData) {
+      warning("Disabling -Xlog:perf+vmlocks since UsePerfData is turned off.");
+      LogConfiguration::configure_stdout(LogLevel::Off, false, LOG_TAGS(perf, vmlocks));
+    }
+  }
+
   if (FLAG_IS_CMDLINE(DiagnoseSyncOnValueBasedClasses)) {
     if (DiagnoseSyncOnValueBasedClasses == ObjectSynchronizer::LOG_WARNING && !log_is_enabled(Info, valuebasedclasses)) {
       LogConfiguration::configure_stdout(LogLevel::Info, true, LOG_TAGS(valuebasedclasses));

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -69,6 +69,7 @@
 #include "runtime/interfaceSupport.inline.hpp"
 #include "runtime/java.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/mutexLocker.hpp"
 #include "runtime/sharedRuntime.hpp"
 #include "runtime/statSampler.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -360,6 +361,8 @@ void print_statistics() {
   ThreadsSMRSupport::log_statistics();
 
   ClassLoader::print_counters(tty);
+
+  MutexLockerImpl::print_counters_on(tty);
 }
 
 // Note: before_exit() can be executed only once, if more than one threads

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -272,10 +272,11 @@ Mutex::~Mutex() {
   os::free(const_cast<char*>(_name));
 }
 
-Mutex::Mutex(Rank rank, const char * name, bool allow_vm_block) : _owner(nullptr) {
+Mutex::Mutex(Rank rank, const char * name, bool allow_vm_block) : _owner(nullptr), _id(-1) {
   assert(os::mutex_init_done(), "Too early!");
   assert(name != nullptr, "Mutex requires a name");
   _name = os::strdup(name, mtInternal);
+  _id = MutexLocker::name2id(name);
 #ifdef ASSERT
   _allow_vm_block  = allow_vm_block;
   _rank            = rank;

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -98,6 +98,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
  protected:                              // Monitor-Mutex metadata
   PlatformMonitor _lock;                 // Native monitor implementation
   const char* _name;                     // Name of mutex/monitor
+  int _id;                               // ID for named mutexes
 
   // Debugging fields for naming, deadlock detection, etc. (some only used in debug mode)
 #ifndef PRODUCT
@@ -193,6 +194,9 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   bool owned_by_self() const;
 
   const char *name() const                  { return _name; }
+
+  int      id() const { return _id; }
+  void set_id(int id) { _id = id; }
 
   void print_on_error(outputStream* st) const;
   #ifndef PRODUCT

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -98,7 +98,8 @@ class Mutex : public CHeapObj<mtSynchronizer> {
  protected:                              // Monitor-Mutex metadata
   PlatformMonitor _lock;                 // Native monitor implementation
   const char* _name;                     // Name of mutex/monitor
-  int _id;                               // ID for named mutexes
+  int _id;                               // ID for named mutexes. It is for indexing into the _perf_lock_count,
+                                         // _perf_lock_wait_time, and _perf_lock_hold_time arrays in MutexLockerImpl.
 
   // Debugging fields for naming, deadlock detection, etc. (some only used in debug mode)
 #ifndef PRODUCT
@@ -195,8 +196,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 
   const char *name() const                  { return _name; }
 
-  int      id() const { return _id; }
-  void set_id(int id) { _id = id; }
+  int id() const { return _id; }
 
   void print_on_error(outputStream* st) const;
   #ifndef PRODUCT

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -435,7 +435,7 @@ int MutexLockerImpl::name2id(const char* name) {
 void MutexLockerImpl::print_counter_on(outputStream* st, const char* name, bool is_unique, int idx) {
   jlong count = _perf_lock_count[idx]->get_value();
   if (count > 0) {
-    st->print_cr("  %3d: %s%40s = %5ldms (%5ldms) / %9ld events", idx, (is_unique ? " " : "M"), name,
+    st->print_cr("  %3d: %s%40s = " JLONG_FORMAT_W(5) "ms (" JLONG_FORMAT_W(5) "ms) / " JLONG_FORMAT_W(9) " events", idx, (is_unique ? " " : "M"), name,
                  Management::ticks_to_ms(_perf_lock_hold_time[idx]->get_value()),
                  Management::ticks_to_ms(_perf_lock_wait_time[idx]->get_value()),
                  count);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -28,10 +28,12 @@
 #include "logging/logStream.hpp"
 #include "memory/resourceArea.hpp"
 #include "memory/universe.hpp"
+#include "runtime/java.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/mutexLocker.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/vmThread.hpp"
+#include "services/management.hpp"
 #include "utilities/vmError.hpp"
 
 // Mutexes used in the VM (see comment in mutexLocker.hpp):
@@ -185,7 +187,9 @@ void assert_lock_strong(const Mutex* lock) {
 
 static void add_mutex(Mutex* var) {
   assert(_num_mutex < MAX_NUM_MUTEX, "increase MAX_NUM_MUTEX");
-  _mutex_array[_num_mutex++] = var;
+  int id = _num_mutex++;
+  _mutex_array[id] = var;
+  var->set_id(id);
 }
 
 #define MUTEX_STORAGE_NAME(name) name##_storage
@@ -370,6 +374,100 @@ void mutex_init() {
 #undef MUTEX_DEF
 #undef MUTEX_STORAGE
 #undef MUTEX_STORAGE_NAME
+
+static const int MAX_NAMES = 200;
+static const char* _names[MAX_NAMES] = { nullptr };
+static bool _is_unique[MAX_NAMES] = { false };
+static int _num_names = 0;
+
+PerfCounter** MutexLockerImpl::_perf_lock_count     = nullptr;
+PerfCounter** MutexLockerImpl::_perf_lock_wait_time = nullptr;
+PerfCounter** MutexLockerImpl::_perf_lock_hold_time = nullptr;
+
+void MutexLockerImpl::init_counters() {
+  if (log_is_enabled(Info, perf, vmlocks)) {
+    ResourceMark rm;
+    EXCEPTION_MARK;
+    _perf_lock_count     = NEW_C_HEAP_ARRAY(PerfCounter*, MAX_NAMES + 1, mtInternal);
+    _perf_lock_wait_time = NEW_C_HEAP_ARRAY(PerfCounter*, MAX_NAMES + 1, mtInternal);
+    _perf_lock_hold_time = NEW_C_HEAP_ARRAY(PerfCounter*, MAX_NAMES + 1, mtInternal);
+
+    NEWPERFEVENTCOUNTER(_perf_lock_count[0],     SUN_RT, PerfDataManager::counter_name("Other", "Count"));
+    NEWPERFEVENTCOUNTER(_perf_lock_wait_time[0], SUN_RT, PerfDataManager::counter_name("Other", "BeforeTime"));
+    NEWPERFEVENTCOUNTER(_perf_lock_hold_time[0], SUN_RT, PerfDataManager::counter_name("Other", "AfterTime"));
+    for (int i = 0; i < MAX_NAMES; i++) {
+      ResourceMark rm;
+      const char* counter_name = _names[i];
+      if (counter_name == nullptr) {
+        stringStream ss;
+        ss.print("UnnamedMutex#%d", i);
+        counter_name = ss.as_string();
+      }
+      NEWPERFEVENTCOUNTER(_perf_lock_count[i+1],       SUN_RT, PerfDataManager::counter_name(counter_name, "Count"));
+      NEWPERFEVENTCOUNTER(_perf_lock_wait_time[i + 1], SUN_RT, PerfDataManager::counter_name(counter_name, "BeforeTime"));
+      NEWPERFEVENTCOUNTER(_perf_lock_hold_time[i + 1], SUN_RT, PerfDataManager::counter_name(counter_name, "AfterTime"));
+    }
+    if (HAS_PENDING_EXCEPTION) {
+      vm_exit_during_initialization("MutexLockerImpl::init_counters() failed unexpectedly");
+    }
+  }
+}
+
+int MutexLockerImpl::name2id(const char* name) {
+  if (log_is_enabled(Info, perf, vmlocks)) {
+    for (int i = 0; i < _num_names; i++) {
+      if (strcmp(_names[i], name) == 0) {
+        _is_unique[i] = false;
+        return i;
+      }
+    }
+    if (_num_names < MAX_NAMES) {
+      int new_id = _num_names++;
+      _names[new_id] = os::strdup(name, mtInternal);
+      _is_unique[new_id] = true;
+      return new_id;
+    }
+    log_debug(init)("Unnamed: %s", name); // no slots left
+  }
+  return -1;
+}
+
+void MutexLockerImpl::print_counter_on(outputStream* st, const char* name, bool is_unique, int idx) {
+  jlong count = _perf_lock_count[idx]->get_value();
+  if (count > 0) {
+    st->print_cr("  %3d: %s%40s = %5ldms (%5ldms) / %9ld events", idx, (is_unique ? " " : "M"), name,
+                 Management::ticks_to_ms(_perf_lock_hold_time[idx]->get_value()),
+                 Management::ticks_to_ms(_perf_lock_wait_time[idx]->get_value()),
+                 count);
+  }
+}
+
+static jlong accumulate_lock_counters(PerfCounter** lock_counters) {
+  jlong acc = 0;
+  for (int i = 0; i < _num_mutex + 1; i++) { // 0 slot is reserved for unnamed locks
+    acc += lock_counters[i]->get_value();
+  }
+  return acc;
+}
+
+void MutexLockerImpl::print_counters_on(outputStream* st) {
+  if (log_is_enabled(Info, perf, vmlocks)) {
+    jlong total_count     = accumulate_lock_counters(_perf_lock_count);
+    jlong total_wait_time = accumulate_lock_counters(_perf_lock_wait_time);
+    jlong total_hold_time = accumulate_lock_counters(_perf_lock_hold_time);
+
+    st->print_cr("MutexLocker: Total: %d named locks (%d unique names); hold = "
+                 "" JLONG_FORMAT "ms (wait = " JLONG_FORMAT "ms) / " JLONG_FORMAT " events for thread \"main\"",
+                 _num_mutex, _num_names,
+                 Management::ticks_to_ms(total_hold_time),
+                 Management::ticks_to_ms(total_wait_time),
+                 total_count);
+    for (int i = 0; i < _num_names; i++) {
+      print_counter_on(st, _names[i], _is_unique[i], i+1);
+    }
+    print_counter_on(st, "Unnamed / Other", false /*is_unique*/, 0);
+  }
+}
 
 void MutexLockerImpl::post_initialize() {
   // Print mutex ranks if requested.

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -25,9 +25,12 @@
 #ifndef SHARE_RUNTIME_MUTEXLOCKER_HPP
 #define SHARE_RUNTIME_MUTEXLOCKER_HPP
 
+#include "logging/log.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/mutex.hpp"
+#include "runtime/perfData.hpp"
+#include "runtime/thread.hpp"
 
 // Mutexes used in the VM.
 
@@ -188,21 +191,39 @@ void assert_lock_strong(const Mutex* lock);
 class MutexLockerImpl: public StackObj {
  protected:
   Mutex* _mutex;
+  bool _prof;
+  elapsedTimer _before;
+  elapsedTimer _after;
+
+private:
+  static PerfCounter** _perf_lock_count;
+  static PerfCounter** _perf_lock_wait_time;
+  static PerfCounter** _perf_lock_hold_time;
+
+public:
 
   MutexLockerImpl(Mutex* mutex, Mutex::SafepointCheckFlag flag = Mutex::_safepoint_check_flag) :
-    _mutex(mutex) {
+    _mutex(mutex), _prof(log_is_enabled(Info, perf, vmlocks) && Thread::current_or_null() != nullptr && Thread::current()->profile_vm_locks()) {
+
     bool no_safepoint_check = flag == Mutex::_no_safepoint_check_flag;
     if (_mutex != nullptr) {
+      if (_prof) { _before.start(); } // before
+
       if (no_safepoint_check) {
         _mutex->lock_without_safepoint_check();
       } else {
         _mutex->lock();
       }
+
+      if (_prof) { _before.stop(); _after.start(); } // after
     }
   }
 
   MutexLockerImpl(Thread* thread, Mutex* mutex, Mutex::SafepointCheckFlag flag = Mutex::_safepoint_check_flag) :
-    _mutex(mutex) {
+    _mutex(mutex), _prof(thread->profile_vm_locks()) {
+
+    if (_prof) { _before.start(); } // before
+
     bool no_safepoint_check = flag == Mutex::_no_safepoint_check_flag;
     if (_mutex != nullptr) {
       if (no_safepoint_check) {
@@ -211,17 +232,34 @@ class MutexLockerImpl: public StackObj {
         _mutex->lock(thread);
       }
     }
+
+    if (_prof) { _before.stop(); _after.start(); } // after
   }
 
   ~MutexLockerImpl() {
     if (_mutex != nullptr) {
       assert_lock_strong(_mutex);
       _mutex->unlock();
+
+      if (_prof) {
+        assert(UsePerfData, "required");
+        _after.stop();
+        _perf_lock_count    [_mutex->id() + 1]->inc();
+        _perf_lock_wait_time[_mutex->id() + 1]->inc(_before.ticks());
+        _perf_lock_hold_time[_mutex->id() + 1]->inc(_after.ticks());
+      }
     }
   }
 
+ private:
+  static void print_counter_on(outputStream* st, const char* name, bool is_unique, int idx);
+
  public:
+  static int name2id(const char* name);
+
   static void post_initialize();
+  static void init_counters();
+  static void print_counters_on(outputStream* st);
 };
 
 // Simplest mutex locker.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -143,6 +143,8 @@ Thread::Thread(MEMFLAGS flags) {
   }
 
   MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
+
+  _profile_vm_locks = false;
 }
 
 void Thread::initialize_tlab() {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -639,6 +639,11 @@ protected:
 
  private:
   VMErrorCallback* _vm_error_callbacks;
+
+  bool  _profile_vm_locks;
+ public:
+   bool     profile_vm_locks() const { return _profile_vm_locks; }
+   void set_profile_vm_locks()       { _profile_vm_locks = true; }
 };
 
 class ThreadInAsgct {

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -530,7 +530,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   main_thread->set_active_handles(JNIHandleBlock::allocate_block());
   MACOS_AARCH64_ONLY(main_thread->init_wx());
 
-  MutexLockerImpl::init_counters(); // depends on mutex_init(), perfMemory_init(), and Thread::initialize_thread_current().
+  MutexLocker::init_counters(); // depends on mutex_init(), perfMemory_init(), and Thread::initialize_thread_current().
 
   if (!main_thread->set_as_starting_thread()) {
     vm_shutdown_during_initialization(
@@ -829,8 +829,8 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     ClassLoader::print_counters(&log);
   }
 
-  if (log_is_enabled(Info, perf, vmlocks)) {
-    LogStreamHandle(Info, perf, vmlocks) log;
+  if (log_is_enabled(Info, perf, vmmutex)) {
+    LogStreamHandle(Info, perf, vmmutex) log;
     log.print_cr("At VM initialization completion");
     MutexLockerImpl::print_counters_on(&log);
     main_thread->set_profile_vm_locks();


### PR DESCRIPTION
Adding a few perf counters to monitor the usage of VM locks. The counters include hold time, wait time, and number of events. They can be enabled via `-Xlog:pref+vmlocks`.

Please refer to the [comment](https://bugs.openjdk.org/browse/JDK-8334904?focusedId=14684322&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14684322) in the bug report for an example output.

Passed tiers 1 - 4 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334904](https://bugs.openjdk.org/browse/JDK-8334904): Add some perf counters to monitor the usage of VM locks (**Enhancement** - P4)


### Contributors
 * Vladimir Ivanov `<vlivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19954/head:pull/19954` \
`$ git checkout pull/19954`

Update a local copy of the PR: \
`$ git checkout pull/19954` \
`$ git pull https://git.openjdk.org/jdk.git pull/19954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19954`

View PR using the GUI difftool: \
`$ git pr show -t 19954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19954.diff">https://git.openjdk.org/jdk/pull/19954.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19954#issuecomment-2200651088)