### PR TITLE
8335298: Fix -Wzero-as-null-pointer-constant warning in G1CardSetContainers

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
+++ b/src/hotspot/share/gc/g1/g1CardSetContainers.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,12 +86,21 @@ class G1CardSetInlinePtr : public StackObj {
 
   uint find(uint const card_idx, uint const bits_per_card, uint start_at, uint num_cards);
 
-public:
-  G1CardSetInlinePtr() : _value_addr(nullptr), _value((ContainerPtr)G1CardSet::ContainerInlinePtr) { }
-
-  G1CardSetInlinePtr(ContainerPtr value) : _value_addr(nullptr), _value(value) {
-    assert(G1CardSet::container_type(_value) == G1CardSet::ContainerInlinePtr, "Value " PTR_FORMAT " is not a valid G1CardSetInlinePtr.", p2i(_value));
+  static ContainerPtr empty_card_set() {
+    // Don't directly cast ContainerInlinePtr (a constant 0) to ContainerPtr
+    // (a pointer type), to avoid -Wzero-as-null-pointer-constant.  Instead cast
+    // a non-const copy, and let the compiler's constant propagation optimize
+    // into equivalent code.
+    static_assert(G1CardSet::ContainerInlinePtr == 0, "unnecessary warning dodge");
+    auto value = G1CardSet::ContainerInlinePtr;
+    return reinterpret_cast<ContainerPtr>(value);
   }
+
+public:
+  G1CardSetInlinePtr() : G1CardSetInlinePtr(empty_card_set()) {}
+
+  explicit G1CardSetInlinePtr(ContainerPtr value) :
+    G1CardSetInlinePtr(nullptr, value) {}
 
   G1CardSetInlinePtr(ContainerPtr volatile* value_addr, ContainerPtr value) : _value_addr(value_addr), _value(value) {
     assert(G1CardSet::container_type(_value) == G1CardSet::ContainerInlinePtr, "Value " PTR_FORMAT " is not a valid G1CardSetInlinePtr.", p2i(_value));


### PR DESCRIPTION
Please review this change to the G1CardSetInlinePtr default constructor to
avoid -Wzero-as-null-pointer-constant.  The problem is that it is casting a
constant 0 to a pointer.  Because casting 0 to a pointer is what this code
needs to do, the options are to (1) suppress the warning, or (2) write the
code in such a way as to dodge the warning.  We take the latter approach, as
it involves less source code clutter.  We expect an optimizing compiler to
produce the same code either way.

Also simplified the constructors by using delegation.

Testing: mach5 tier1.
Locally (linux-x64) verified the warning no longer occurs with this change.
