### PR TITLE
8333306: gc/arguments/TestParallelGCErgo.java fails when largepage are enabled

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelGCErgo.java
@@ -27,6 +27,7 @@ package gc.arguments;
  * @test TestParallelGCErgo
  * @bug 8272364
  * @requires vm.gc.Parallel
+ * @requires vm.opt.UseLargePages == null | !vm.opt.UseLargePages
  * @summary Verify ParallelGC minimum young and old ergonomics are setup correctly
  * @modules java.base/jdk.internal.misc
  * @library /test/lib


### PR DESCRIPTION
Test gc/arguments/TestParallelGCErgo.java start new VM process with  specific heap setting and check GC ergonomics. The aligment might be different for large pages enabled. 
So it makes sense to just disable the test if LargePages are enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333306](https://bugs.openjdk.org/browse/JDK-8333306): gc/arguments/TestParallelGCErgo.java fails when largepage are enabled (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19957/head:pull/19957` \
`$ git checkout pull/19957`

Update a local copy of the PR: \
`$ git checkout pull/19957` \
`$ git pull https://git.openjdk.org/jdk.git pull/19957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19957`

View PR using the GUI difftool: \
`$ git pr show -t 19957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19957.diff">https://git.openjdk.org/jdk/pull/19957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19957#issuecomment-2198287148)