### PR TITLE
8335369: Fix -Wzero-as-null-pointer-constant warnings in ImmutableOopMapBuilder

### DIFF
--- a/src/hotspot/share/compiler/oopMap.hpp
+++ b/src/hotspot/share/compiler/oopMap.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -411,7 +411,7 @@ private:
 
     Mapping() : _kind(OOPMAP_UNKNOWN), _offset(-1), _size(-1), _map(nullptr) {}
 
-    void set(kind_t kind, int offset, int size, const OopMap* map = 0, const OopMap* other = 0) {
+    void set(kind_t kind, int offset, int size, const OopMap* map, const OopMap* other = nullptr) {
       _kind = kind;
       _offset = offset;
       _size = size;


### PR DESCRIPTION
Please review this change to ImmutableOopMapBuilder::set.  It used to have 2
OopMap* arguments that defaulted to 0, triggering -Wzero-as-null-pointer-constant
if that warning is enabled.

The first of those arguments is being changed from optional to required.  All
callers provide it.  This removes 1/2 the warnings.

The second of those arguments is being changed to default to nullptr, removing
the other 1/2 of the warnings.

This removes about 25% of the -Wzero-as-null-pointer-constant warnings when
building with that option.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335369](https://bugs.openjdk.org/browse/JDK-8335369): Fix -Wzero-as-null-pointer-constant warnings in ImmutableOopMapBuilder (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19961/head:pull/19961` \
`$ git checkout pull/19961`

Update a local copy of the PR: \
`$ git checkout pull/19961` \
`$ git pull https://git.openjdk.org/jdk.git pull/19961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19961`

View PR using the GUI difftool: \
`$ git pr show -t 19961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19961.diff">https://git.openjdk.org/jdk/pull/19961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19961#issuecomment-2198773818)