### PR TITLE
8324966: Allow selecting jtreg test case by ID from make

### DIFF
--- a/make/InitSupport.gmk
+++ b/make/InitSupport.gmk
@@ -63,14 +63,14 @@ ifeq ($(HAS_SPEC),)
 
   # The variable MAKEOVERRIDES contains variable assignments from the command
   # line, but in reverse order to what the user entered.
-  # The '\#' <=> '\ 'dance is needed to keep values with space in them connected.
-  COMMAND_LINE_VARIABLES := $(subst \#,\ , $(call reverse, $(subst \ ,\#,$(MAKEOVERRIDES))))
+  # The '§' <=> '\ 'dance is needed to keep values with space in them connected.
+  COMMAND_LINE_VARIABLES := $(subst §,\ , $(call reverse, $(subst \ ,§,$(MAKEOVERRIDES))))
 
   # A list like FOO="val1" BAR="val2" containing all user-supplied make
   # variables that we should propagate.
-  # The '\#' <=> '\ 'dance is needed to keep values with space in them connected.
-  USER_MAKE_VARS := $(subst \#,\ , $(filter-out $(addsuffix =%, $(INIT_CONTROL_VARIABLES)), \
-      $(subst \ ,\#,$(MAKEOVERRIDES))))
+  # The '§' <=> '\ 'dance is needed to keep values with space in them connected.
+  USER_MAKE_VARS := $(subst §,\ , $(filter-out $(addsuffix =%, $(INIT_CONTROL_VARIABLES)), \
+      $(subst \ ,§,$(MAKEOVERRIDES))))
 
   # Setup information about available configurations, if any.
   ifneq ($(CUSTOM_ROOT), )


### PR DESCRIPTION
[JDK-8287828](https://bugs.openjdk.org/browse/JDK-8287828) added support for selecting specific JTREG tests cases by their ID. However because of how we handle input strings in make it was not possible to use `#` anywhere, breaking this feature.

Prior to this change
 * `TEST="gc/TestSystemGC.java#Serial gc/TestSystemGC.java#G1" make test` Works.
 * `make test TEST="gc/TestSystemGC.java#Serial gc/TestSystemGC.java#G1"` Does not work.

After this change both works.

When propagating command line variables through the make system we transiently replaced spaces with `#` (which drops any actual `#` when restoring the spaces). This patch replaced the `#` character with `§` under the assumption that it will not be used in these arguments.

This works for now. An alternative would be to make this more robust by selecting a sequence of characters that is checked to not be part of the strings in question as the space placeholder. But I will leave that to our more advance Make engineers to handle.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324966](https://bugs.openjdk.org/browse/JDK-8324966): Allow selecting jtreg test case by ID from make (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19963/head:pull/19963` \
`$ git checkout pull/19963`

Update a local copy of the PR: \
`$ git checkout pull/19963` \
`$ git pull https://git.openjdk.org/jdk.git pull/19963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19963`

View PR using the GUI difftool: \
`$ git pr show -t 19963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19963.diff">https://git.openjdk.org/jdk/pull/19963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19963#issuecomment-2199378304)