### PR TITLE
8335390: C2 MergeStores: wrong result with Unsafe

### DIFF
--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -2984,6 +2984,9 @@ StoreNode* MergePrimitiveArrayStores::run() {
       type2aelembytes(bt) != _store->memory_size()) {
     return nullptr;
   }
+  if (_store->is_unsafe_access()) {
+    return nullptr;
+  }
 
   // The _store must be the "last" store in a chain. If we find a use we could merge with
   // then that use or a store further down is the "last" store.
@@ -3017,11 +3020,13 @@ bool MergePrimitiveArrayStores::is_compatible_store(const StoreNode* other_store
   int opc = _store->Opcode();
   assert(opc == Op_StoreB || opc == Op_StoreC || opc == Op_StoreI, "precondition");
   assert(_store->adr_type()->isa_aryptr() != nullptr, "must be array store");
+  assert(!_store->is_unsafe_access(), "no unsafe accesses");
 
   if (other_store == nullptr ||
       _store->Opcode() != other_store->Opcode() ||
       other_store->adr_type() == nullptr ||
-      other_store->adr_type()->isa_aryptr() == nullptr) {
+      other_store->adr_type()->isa_aryptr() == nullptr ||
+      other_store->is_unsafe_access()) {
     return false;
   }
 

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -611,8 +611,9 @@ public class TestMergeStores {
     }
 
     @Test
-    @IR(counts = {IRNode.STORE_L_OF_CLASS, "byte\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "1"},
-        applyIf = {"UseUnalignedAccesses", "true"})
+    // Disabled by JDK-8335390, to be enabled again by JDK-8335392.
+    // @IR(counts = {IRNode.STORE_L_OF_CLASS, "byte\\\\[int:>=0] \\\\(java/lang/Cloneable,java/io/Serializable\\\\)", "1"},
+    //     applyIf = {"UseUnalignedAccesses", "true"})
     static Object[] test1f(byte[] a) {
         UNSAFE.putByte(a, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 0, (byte)0xbe);
         UNSAFE.putByte(a, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 1, (byte)0xba);

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
@@ -26,6 +26,7 @@
  * @bug 8335390
  * @summary Test merge stores for some Unsafe store address patterns.
  * @modules java.base/jdk.internal.misc
+ * @requires vm.bits == 64
  * @requires os.maxMemory > 8G
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresUnsafeArrayPointer::test*
  *                   -Xbatch

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
@@ -26,10 +26,13 @@
  * @bug 8335390
  * @summary Test merge stores for some Unsafe store address patterns.
  * @modules java.base/jdk.internal.misc
+ * @requires os.maxMemory > 8G
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresUnsafeArrayPointer::test*
  *                   -Xbatch
+ *                   -Xmx8g
  *                   compiler.c2.TestMergeStoresUnsafeArrayPointer
- * @run main compiler.c2.TestMergeStoresUnsafeArrayPointer
+ * @run main/othervm -Xmx8g
+ *                   compiler.c2.TestMergeStoresUnsafeArrayPointer
  */
 
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335390
+ * @summary Test merge stores, when the index can overflow.
+ * @modules java.base/jdk.internal.misc
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresUnsafeArrayPointer::test*
+ *                   -Xbatch
+ *                   compiler.c2.TestMergeStoresUnsafeArrayPointer
+ * @run main compiler.c2.TestMergeStoresUnsafeArrayPointer
+ */
+
+package compiler.c2;
+import jdk.internal.misc.Unsafe;
+
+public class TestMergeStoresUnsafeArrayPointer {
+    static final Unsafe UNSAFE = Unsafe.getUnsafe();
+
+    // We allocate a big int array of length:
+    static final int SIZE = (1 << 30) + 100;
+
+    // This gives us a memory region of 4x as many bytes:
+    static final long BYTE_SIZE = 4L * SIZE; // = 1L << 32 + 400L
+
+    // We set an "anchor" in the middle of this memory region, in bytes:
+    static final long ANCHOR = BYTE_SIZE / 2;
+
+    static int four = 4;
+
+    public static void main(String[] args) {
+        System.out.println("Allocate big array of SIZE = " + SIZE);
+        int[] big = new int[SIZE];
+
+        // Each test is executed a few times, so that we can see the difference between
+        // interpreter and compiler.
+        int errors = 0;
+
+        long val = 0;
+        System.out.println("test1");
+        for (int i = 0; i < 100_000; i++) {
+            testClear(big);
+            test1(big, ANCHOR);
+            long sum = testSum(big);
+            if (i == 0) {
+                val = sum;
+            } else {
+                if (sum != val) {
+                    System.out.println("ERROR: test1 had wrong value: " + val + " != " + sum);
+                    errors++;
+                    break;
+                }
+            }
+        }
+
+        val = 0;
+        System.out.println("test2");
+        for (int i = 0; i < 100_000; i++) {
+            testClear(big);
+            test2(big, ANCHOR);
+            long sum = testSum(big);
+            if (i == 0) {
+                val = sum;
+            } else {
+                if (sum != val) {
+                    System.out.println("ERROR: test2 had wrong value: " + val + " != " + sum);
+                    errors++;
+                    break;
+                }
+            }
+        }
+
+        if (errors > 0) {
+            throw new RuntimeException("ERRORS: " + errors);
+        }
+        System.out.println("PASSED");
+    }
+
+    // Only clear and sum over relevant parts of array to make the test fast.
+    static void testClear(int[] a) {
+        for (int j = 0               ; j <              100; j++) { a[j] = j; }
+        for (int j = a.length/2 - 100; j < a.length/2 + 100; j++) { a[j] = j; }
+        for (int j = a.length   - 100; j < a.length   +   0; j++) { a[j] = j; }
+    }
+
+    static long testSum(int[] a) {
+        long sum = 0;
+        for (int j = 0               ; j <              100; j++) { sum += a[j]; }
+        for (int j = a.length/2 - 100; j < a.length/2 + 100; j++) { sum += a[j]; }
+        for (int j = a.length   - 100; j < a.length   +   0; j++) { sum += a[j]; }
+        return sum;
+    }
+
+    // Reference: expected to merge.
+    static void test1(int[] a, long anchor) {
+        long base = UNSAFE.ARRAY_INT_BASE_OFFSET + anchor;
+        UNSAFE.putInt(a, base + 0, 0x42424242);
+        UNSAFE.putInt(a, base + 4, 0x66666666);
+    }
+
+    // Test: if MergeStores is applied this can lead to wrong results
+    static void test2(int[] a, long anchor) {
+        long base = UNSAFE.ARRAY_INT_BASE_OFFSET + ANCHOR;
+        UNSAFE.putInt(a, base + 0                 + (long)(four + Integer.MAX_VALUE), 0x42424242);
+        UNSAFE.putInt(a, base + Integer.MAX_VALUE + (long)(four + 4                ), 0x66666666);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStoresUnsafeArrayPointer.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8335390
- * @summary Test merge stores, when the index can overflow.
+ * @summary Test merge stores for some Unsafe store address patterns.
  * @modules java.base/jdk.internal.misc
  * @run main/othervm -XX:CompileCommand=compileonly,compiler.c2.TestMergeStoresUnsafeArrayPointer::test*
  *                   -Xbatch


### PR DESCRIPTION
In JDK23, I introduced `MergeStores` [JDK-8318446](https://bugs.openjdk.org/browse/JDK-8318446) https://github.com/openjdk/jdk/pull/16245.

I now realized that the pointer-parsing has some issues with `Unsafe` stores. Thus, I disable the optimization for those for now.

**Future Work**
In [JDK-8335392](https://bugs.openjdk.org/browse/JDK-8335392), I plan to redesign the pointer-parsing, and enable more features, including `Unsafe` stores.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335390](https://bugs.openjdk.org/browse/JDK-8335390): C2 MergeStores: wrong result with Unsafe (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [ec5cc941](https://git.openjdk.org/jdk/pull/19964/files/ec5cc94128e3627878a0d0232835fae5cdefbe9d)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19964/head:pull/19964` \
`$ git checkout pull/19964`

Update a local copy of the PR: \
`$ git checkout pull/19964` \
`$ git pull https://git.openjdk.org/jdk.git pull/19964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19964`

View PR using the GUI difftool: \
`$ git pr show -t 19964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19964.diff">https://git.openjdk.org/jdk/pull/19964.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19964#issuecomment-2200063308)