### PR TITLE
8335397: Improve reliability of TestRecursiveMonitorChurn.java

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1115,6 +1115,10 @@ bool WhiteBox::compile_method(Method* method, int comp_level, int bci, JavaThrea
   return false;
 }
 
+size_t WhiteBox::get_in_use_monitor_count() {
+  return ObjectSynchronizer::_in_use_list.count();
+}
+
 WB_ENTRY(jboolean, WB_EnqueueMethodForCompilation(JNIEnv* env, jobject o, jobject method, jint comp_level, jint bci))
   jmethodID jmid = reflected_method_to_jmid(thread, env, method);
   CHECK_JNI_EXCEPTION_(env, JNI_FALSE);
@@ -1848,6 +1852,10 @@ WB_END
 WB_ENTRY(jboolean, WB_IsMonitorInflated(JNIEnv* env, jobject wb, jobject obj))
   oop obj_oop = JNIHandles::resolve(obj);
   return (jboolean) obj_oop->mark().has_monitor();
+WB_END
+
+WB_ENTRY(jlong, WB_getInUseMonitorCount(JNIEnv* env, jobject wb))
+  return (jlong) WhiteBox::get_in_use_monitor_count();
 WB_END
 
 WB_ENTRY(jint, WB_getLockStackCapacity(JNIEnv* env))
@@ -2844,6 +2852,7 @@ static JNINativeMethod methods[] = {
                                                       (void*)&WB_AddModuleExportsToAll },
   {CC"deflateIdleMonitors", CC"()Z",                  (void*)&WB_DeflateIdleMonitors },
   {CC"isMonitorInflated0", CC"(Ljava/lang/Object;)Z", (void*)&WB_IsMonitorInflated  },
+  {CC"getInUseMonitorCount", CC"()J", (void*)&WB_getInUseMonitorCount  },
   {CC"getLockStackCapacity", CC"()I",                 (void*)&WB_getLockStackCapacity },
   {CC"supportsRecursiveLightweightLocking", CC"()Z",  (void*)&WB_supportsRecursiveLightweightLocking },
   {CC"forceSafepoint",     CC"()V",                   (void*)&WB_ForceSafepoint     },

--- a/src/hotspot/share/prims/whitebox.hpp
+++ b/src/hotspot/share/prims/whitebox.hpp
@@ -68,6 +68,7 @@ class WhiteBox : public AllStatic {
     JNINativeMethod* method_array, int method_count);
   static void register_extended(JNIEnv* env, jclass wbclass, JavaThread* thread);
   static bool compile_method(Method* method, int comp_level, int bci, JavaThread* THREAD);
+  static size_t get_in_use_monitor_count();
 #ifdef LINUX
   static bool validate_cgroup(const char* proc_cgroups, const char* proc_self_cgroup, const char* proc_self_mountinfo, u1* cg_flags);
 #endif

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -69,6 +69,7 @@ public:
 class ObjectSynchronizer : AllStatic {
   friend class VMStructs;
   friend class ObjectMonitorDeflationLogging;
+  friend class WhiteBox;
 
  public:
   typedef enum {

--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -55,7 +55,7 @@ public class TestRecursiveMonitorChurn {
     public static volatile Monitor monitor;
     public static void main(String[] args) {
         if (WB.getIntVMFlag("LockingMode") == LM_MONITOR) {
-            throw new SkippedException("LM_MONITOR always infaltes. Invalid test.");
+            throw new SkippedException("LM_MONITOR always inflates. Invalid test.");
         }
         final long pre_monitor_count = WB.getInUseMonitorCount();
         System.out.println(" Precount = " + pre_monitor_count);

--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -21,19 +21,21 @@
  * questions.
  */
 
-import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.process.ProcessTools;
-
-import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /*
  * @test
  * @summary Tests that recursive locking doesn't cause excessive native memory usage
  * @library /test/lib
- * @run driver TestRecursiveMonitorChurn
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *                   -Xmx100M -XX:AsyncDeflationInterval=0 -XX:GuaranteedAsyncDeflationInterval=0
+ *                   -Xlog:monitorinflation=trace
+ *                   TestRecursiveMonitorChurn
  */
+
+import jdk.test.whitebox.WhiteBox;
+import jtreg.SkippedException;
+
 public class TestRecursiveMonitorChurn {
     static class Monitor {
         public static volatile int i, j;
@@ -46,50 +48,32 @@ public class TestRecursiveMonitorChurn {
         }
     }
 
+    static final WhiteBox WB = WhiteBox.getWhiteBox();
+    static final int LM_MONITOR = 0;
+    static final int COUNT = 100000;
+
     public static volatile Monitor monitor;
-    public static void main(String[] args) throws IOException {
-        if (args.length == 1 && args[0].equals("test")) {
-            // The actual test, in a forked JVM.
-            for (int i = 0; i < 100000; i++) {
-                monitor = new Monitor();
-                monitor.doSomething();
+    public static void main(String[] args) {
+        if (WB.getIntVMFlag("LockingMode") == LM_MONITOR) {
+            throw new SkippedException("LM_MONITOR always infaltes. Invalid test.");
+        }
+        final long pre_monitor_count = WB.getInUseMonitorCount();
+        System.out.println(" Precount = " + pre_monitor_count);
+        for (int i = 0; i < COUNT; i++) {
+            monitor = new Monitor();
+            monitor.doSomething();
+        }
+        System.out.println("i + j = " + (Monitor.i + Monitor.j));
+        final long post_monitor_count = WB.getInUseMonitorCount();
+        System.out.println("Postcount = " + post_monitor_count);
+
+        if (pre_monitor_count != post_monitor_count) {
+            final long monitor_count_change = post_monitor_count - pre_monitor_count;
+            System.out.println("Unexpected change in mointor count: " + monitor_count_change);
+            if (monitor_count_change < 0) {
+                throw new RuntimeException("Unexpected Deflation");
             }
-            System.out.println("i + j = " + (Monitor.i + Monitor.j));
-        } else {
-            ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
-                    "-XX:+UnlockDiagnosticVMOptions",
-                    "-Xmx100M", "-XX:AsyncDeflationInterval=0", "-XX:GuaranteedAsyncDeflationInterval=0",
-                    "-XX:NativeMemoryTracking=summary", "-XX:+PrintNMTStatistics",
-                    "TestRecursiveMonitorChurn",
-                    "test");
-            OutputAnalyzer output = new OutputAnalyzer(pb.start());
-            output.reportDiagnosticSummary();
-
-            output.shouldHaveExitValue(0);
-
-            // We want to see, in the final NMT printout, a committed object monitor size that is reasonably low.
-            // Like this:
-            // -           Object Monitors (reserved=208, committed=208)
-            //                             (malloc=208 #1) (at peak)
-            //
-            // Without recursive locking support, this would look more like this:
-            // -           Object Monitors (reserved=20800624, committed=20800624)
-            //                             (malloc=20800624 #100003) (at peak)
-
-            Pattern pat = Pattern.compile("- *Object Monitors.*reserved=(\\d+), committed=(\\d+).*");
-            for (String line : output.asLines()) {
-                Matcher m = pat.matcher(line);
-                if (m.matches()) {
-                    long reserved = Long.parseLong(m.group(1));
-                    long committed = Long.parseLong(m.group(2));
-                    System.out.println(">>>>> " + line + ": " + reserved + " - " + committed);
-                    if (committed > 1000) {
-                        throw new RuntimeException("Allocated too many monitors");
-                    }
-                    return;
-                }
-            }
-            throw new RuntimeException("Did not find expected NMT output");
+            throw new RuntimeException("Unexpected Inflation");
         }
     }
 }

--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -69,7 +69,7 @@ public class TestRecursiveMonitorChurn {
 
         if (pre_monitor_count != post_monitor_count) {
             final long monitor_count_change = post_monitor_count - pre_monitor_count;
-            System.out.println("Unexpected change in mointor count: " + monitor_count_change);
+            System.out.println("Unexpected change in monitor count: " + monitor_count_change);
             if (monitor_count_change < 0) {
                 throw new RuntimeException("Unexpected Deflation");
             }

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -119,6 +119,8 @@ public class WhiteBox {
     return isMonitorInflated0(obj);
   }
 
+  public native long getInUseMonitorCount();
+
   public native int getLockStackCapacity();
 
   public native boolean supportsRecursiveLightweightLocking();


### PR DESCRIPTION
TestRecursiveMonitorChurn.java currently uses NMT to try and correlate the native memory increase with unwanted inflation.

Change to instead query the JVM for exact number of inflations via the Whitebox API. This allow us to both be more exact and less dependent on interactions with NMT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335397](https://bugs.openjdk.org/browse/JDK-8335397): Improve reliability of TestRecursiveMonitorChurn.java (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) 🔄 Re-review required (review applies to [81fd7c07](https://git.openjdk.org/jdk/pull/19965/files/81fd7c075f1d35e9bf0449ea0cb98231303b74c7))
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) 🔄 Re-review required (review applies to [44279523](https://git.openjdk.org/jdk/pull/19965/files/442795230dae18c26a808ab452872c35771eb5a5))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19965/head:pull/19965` \
`$ git checkout pull/19965`

Update a local copy of the PR: \
`$ git checkout pull/19965` \
`$ git pull https://git.openjdk.org/jdk.git pull/19965/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19965`

View PR using the GUI difftool: \
`$ git pr show -t 19965`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19965.diff">https://git.openjdk.org/jdk/pull/19965.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19965#issuecomment-2199667741)