### PR TITLE
8335357: Delete HotSpotJDKReflection.oopSizeOffset

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJDKReflection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,9 +107,6 @@ final class HotSpotJDKReflection extends HotSpotJVMCIReflection {
     boolean equals(HotSpotObjectConstantImpl a, HotSpotObjectConstantImpl b) {
         return resolveObject(a) == resolveObject(b) && a.isCompressed() == b.isCompressed();
     }
-
-    // This field is being kept around for compatibility with libgraal
-    @SuppressWarnings("unused") private long oopSizeOffset;
 
     @Override
     ResolvedJavaMethod.Parameter[] getParameters(HotSpotResolvedJavaMethodImpl javaMethod) {


### PR DESCRIPTION
The jdk.vm.ci.hotspot.HotSpotJDKReflection#oopSizeOffset field exists purely to satisfy a libgraal substitution. The latter is unused and is being removed from Graal in https://github.com/oracle/graal/pull/9217. As such HotSpotJDKReflection#oopSizeOffset can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335357](https://bugs.openjdk.org/browse/JDK-8335357): Delete HotSpotJDKReflection.oopSizeOffset (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19966/head:pull/19966` \
`$ git checkout pull/19966`

Update a local copy of the PR: \
`$ git checkout pull/19966` \
`$ git pull https://git.openjdk.org/jdk.git pull/19966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19966`

View PR using the GUI difftool: \
`$ git pr show -t 19966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19966.diff">https://git.openjdk.org/jdk/pull/19966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19966#issuecomment-2199675535)