### PR TITLE
8331725: ubsan: pc may not always be the entry point for a VtableStub

### DIFF
--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -255,6 +255,19 @@ inline uint VtableStubs::hash(bool is_vtable_stub, int vtable_index){
 }
 
 
+inline uint VtableStubs::unsafe_hash(address entry_point) {
+  // The entrypoint may or may not be a VtableStub. Generate a hash as if it was.
+  address vtable_stub_addr = entry_point - VtableStub::entry_offset();
+  assert(CodeCache::contains(vtable_stub_addr), "assumed to always be the case");
+  address vtable_type_addr = vtable_stub_addr + offset_of(VtableStub, _type);
+  address vtable_index_addr = vtable_stub_addr + offset_of(VtableStub, _index);
+  bool is_vtable_stub = *vtable_type_addr == static_cast<uint8_t>(VtableStub::Type::vtable_stub);
+  int vtable_index;
+  memcpy(&vtable_index, vtable_index_addr, sizeof(vtable_index));
+  return hash(is_vtable_stub, vtable_index);
+}
+
+
 VtableStub* VtableStubs::lookup(bool is_vtable_stub, int vtable_index) {
   assert_lock_strong(VtableStubs_lock);
   unsigned hash = VtableStubs::hash(is_vtable_stub, vtable_index);
@@ -275,12 +288,15 @@ void VtableStubs::enter(bool is_vtable_stub, int vtable_index, VtableStub* s) {
 }
 
 VtableStub* VtableStubs::entry_point(address pc) {
+  // The pc may or may not be the entry point for a VtableStub. Use unsafe_hash
+  // to generate the hash that would have been used if it was. The lookup in the
+  // _table will only succeed if there is a VtableStub with an entry point at
+  // the pc.
   MutexLocker ml(VtableStubs_lock, Mutex::_no_safepoint_check_flag);
-  VtableStub* stub = (VtableStub*)(pc - VtableStub::entry_offset());
-  uint hash = VtableStubs::hash(stub->is_vtable_stub(), stub->index());
+  uint hash = VtableStubs::unsafe_hash(pc);
   VtableStub* s;
-  for (s = Atomic::load(&_table[hash]); s != nullptr && s != stub; s = s->next()) {}
-  return (s == stub) ? s : nullptr;
+  for (s = Atomic::load(&_table[hash]); s != nullptr && s->entry_point() != pc; s = s->next()) {}
+  return (s != nullptr && s->entry_point() == pc) ? s : nullptr;
 }
 
 bool VtableStubs::contains(address pc) {


### PR DESCRIPTION
`VtableStub* VtableStubs::entry_point(address pc)` has multiple issues causing undefined behaviour. Most of it stems from the fact that the pc sent in may sometimes not be the entry point of a `VtableStub`. We check this by doing a lookup in a hash table, but to generate the hash we need to extract data from the `VtableStub`. The original implementation simply cast the address to a `*VtableStub` and called the member function getters. This caused both unaligned accesses and bad bool values, all symptoms of the fact that we reinterpret_cast the memory as a `VtableStub`.

This change will instead look at the raw bytes when generating the hash which neither suffers from unaligned access nor bad reinterpret_casts. 

My initial patch did not create an `enum class` to represent the boolean value but instead looked at the object representation of the `bool` field. However this suffers from the fact that the object representation of `false` is implementation defined. I assumed it to be all 0 bits. It was also required unfortunate extra logic to handle the cases when `sizeof(bool) != 1`. Alt patch: https://github.com/openjdk/jdk/commit/b20140f49983b1903f9038e4e47def792c4493ac

There may be some better name than `unsafe_hash`. Suggestions?

Verified that this patch resolves the UB.
Running testing.

Side note:
There is still an unaligned access issue on aarch64 because of the way we construct `VtableStub`. We align the chunk where we create the `VtableStub` so that the `<VtableStub address> + sizeof(VtableStub)` is aligned to the platforms code entry alignment. On all platforms but `aarch64`  `<VtableStub address> + sizeof(VtableStub) % pd_code_alignment == 0` implies `<VtableStub address>  % alignof(VtableStub) == 0`. 
https://github.com/xmas92/jdk/blob/beea5305b071820e2b128a55c5ca384caf470fdd/src/hotspot/share/code/vtableStubs.hpp#L168-L171

Also note that there are already assumptions in the JVM about the object representation of bool. On `x86` `MacroAssembler::testbool` assumes that `false` is all 0 bits, and in addition to that `MacroAssembler::movbool` assumes that `1` is `true`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331725](https://bugs.openjdk.org/browse/JDK-8331725): ubsan: pc may not always be the entry point for a VtableStub (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19968/head:pull/19968` \
`$ git checkout pull/19968`

Update a local copy of the PR: \
`$ git checkout pull/19968` \
`$ git pull https://git.openjdk.org/jdk.git pull/19968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19968`

View PR using the GUI difftool: \
`$ git pr show -t 19968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19968.diff">https://git.openjdk.org/jdk/pull/19968.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19968#issuecomment-2199779452)