### PR TITLE
8335385: javac crash on unattributed piece of AST

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -2423,7 +2423,14 @@ public class Resolve {
      *                   (a subset of VAL, TYP, PCK).
      */
     Symbol findIdent(DiagnosticPosition pos, Env<AttrContext> env, Name name, KindSelector kind) {
-        return checkNonExistentType(checkRestrictedType(pos, findIdentInternal(pos, env, name, kind), name));
+        try {
+            return checkNonExistentType(checkRestrictedType(pos, findIdentInternal(pos, env, name, kind), name));
+        } catch (ClassFinder.BadClassFile err) {
+            return new BadClassFileError(err);
+        } catch (CompletionFailure cf) {
+            chk.completionError(pos, cf);
+            return typeNotFound;
+        }
     }
 
     Symbol findIdentInternal(DiagnosticPosition pos, Env<AttrContext> env, Name name, KindSelector kind) {
@@ -2495,7 +2502,14 @@ public class Resolve {
     Symbol findIdentInType(DiagnosticPosition pos,
                            Env<AttrContext> env, Type site,
                            Name name, KindSelector kind) {
-        return checkNonExistentType(checkRestrictedType(pos, findIdentInTypeInternal(env, site, name, kind), name));
+        try {
+            return checkNonExistentType(checkRestrictedType(pos, findIdentInTypeInternal(env, site, name, kind), name));
+        } catch (ClassFinder.BadClassFile err) {
+            return new BadClassFileError(err);
+        } catch (CompletionFailure cf) {
+            chk.completionError(pos, cf);
+            return typeNotFound;
+        }
     }
 
     private Symbol checkNonExistentType(Symbol symbol) {

--- a/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
+++ b/test/langtools/tools/javac/tree/ASTAttributesFilledForReferencesOnMissingTypes.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8335385
+ * @summary Verify that BadClassFile related to imports are handled properly.
+ * @library /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @run main ASTAttributesFilledForReferencesOnMissingTypes
+ */
+
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.util.TaskEvent;
+import com.sun.source.util.TaskListener;
+import com.sun.source.util.TreePathScanner;
+import com.sun.source.util.Trees;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import javax.lang.model.element.Element;
+
+import toolbox.JavacTask;
+import toolbox.Task;
+import toolbox.ToolBox;
+
+public class ASTAttributesFilledForReferencesOnMissingTypes {
+    public static void main(String... args) throws Exception {
+        new ASTAttributesFilledForReferencesOnMissingTypes().run();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    void run() throws Exception {
+        new JavacTask(tb)
+          .outdir(".")
+          .sources("package p; public class A { }",
+                   "package p; public class B { public static class I { } public static class M { } }",
+                   "package p; public class C { }")
+          .run()
+          .writeAll();
+
+        try (OutputStream out = Files.newOutputStream(Paths.get(".", "p", "A.class"))) {
+            out.write("broken".getBytes("UTF-8"));
+        }
+
+        try (OutputStream out = Files.newOutputStream(Paths.get(".", "p", "B$I.class"))) {
+            out.write("broken".getBytes("UTF-8"));
+        }
+
+        Files.delete(Paths.get(".", "p", "C.class"));
+        Files.delete(Paths.get(".", "p", "B$M.class"));
+
+        //tests for findIdent (must be in some global scope):
+        doTest("""
+               package p;
+               public class Test {
+                   A a;
+               }
+               """,
+               "Test.java:3:5: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
+               "1 error");
+        doTest("""
+               import p.*;
+               public class Test {
+                   A a;
+               }
+               """,
+               "Test.java:3:5: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
+               "1 error");
+        doTest("""
+               package p;
+               public class Test {
+                   C c;
+               }
+               """,
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.class, p.Test, null)",
+               "1 error");
+        doTest("""
+               import p.*;
+               public class Test {
+                   C c;
+               }
+               """,
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.class, Test, null)",
+               "1 error");
+
+        //tests for findIdentInPackage:
+        doTest("""
+               import p.A;
+               public class Test {
+                   A a;
+               }
+               """,
+               "Test.java:1:9: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, A, , , (compiler.misc.location: kindname.class, Test, null)",
+               "2 errors");
+        doTest("""
+               public class Test {
+                   p.A a;
+               }
+               """,
+               "Test.java:2:6: compiler.err.cant.access: p.A, (compiler.misc.bad.class.file.header: A.class, (compiler.misc.illegal.start.of.class.file))",
+               "1 error");
+        doTest("""
+               import p.C;
+               public class Test {
+                   C c;
+               }
+               """,
+               "Test.java:1:9: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.package, p, null)",
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.class, Test, null)",
+               "2 errors");
+        doTest("""
+               public class Test {
+                   p.C c;
+               }
+               """,
+               "Test.java:2:6: compiler.err.cant.resolve.location: kindname.class, C, , , (compiler.misc.location: kindname.package, p, null)",
+               "1 error");
+
+        //tests for findIdentInType:
+        doTest("""
+               import p.B.I;
+               public class Test {
+                   I i;
+               }
+               """,
+               "Test.java:1:11: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, I, , , (compiler.misc.location: kindname.class, Test, null)",
+               "2 errors");
+        doTest("""
+               import p.B.M;
+               public class Test {
+                   M m;
+               }
+               """,
+               "Test.java:1:11: compiler.err.cant.access: p.B.M, (compiler.misc.class.file.not.found: p.B$M)",
+               "Test.java:3:5: compiler.err.cant.resolve.location: kindname.class, M, , , (compiler.misc.location: kindname.class, Test, null)",
+               "2 errors");
+        doTest("""
+               public class Test {
+                   p.B.I i;
+               }
+               """,
+               "Test.java:2:8: compiler.err.cant.access: p.B.I, (compiler.misc.bad.class.file.header: B$I.class, (compiler.misc.illegal.start.of.class.file))",
+               "1 error");
+        doTest("""
+               public class Test {
+                   p.B.M m;
+               }
+               """,
+               "Test.java:2:8: compiler.err.cant.access: p.B.M, (compiler.misc.class.file.not.found: p.B$M)",
+               "1 error");
+    }
+
+    void doTest(String code, String... expectedOutput) {
+        List<String> log = new JavacTask(tb)
+                .classpath(".")
+                .sources(code)
+                .options("-XDrawDiagnostics")
+                .callback(task -> {
+                    task.addTaskListener(new TaskListener() {
+                        @Override
+                        public void finished(TaskEvent e) {
+                            if (e.getKind() != TaskEvent.Kind.ANALYZE) {
+                                return ;
+                            }
+                            Trees trees = Trees.instance(task);
+                            new TreePathScanner<Void, Void>() {
+                                @Override
+                                public Void visitIdentifier(IdentifierTree node, Void p) {
+                                    validateAttributes();
+                                    return super.visitIdentifier(node, p);
+                                }
+                                @Override
+                                public Void visitMemberSelect(MemberSelectTree node, Void p) {
+                                    if (!node.getIdentifier().contentEquals("*")) {
+                                        validateAttributes();
+                                    }
+                                    return super.visitMemberSelect(node, p);
+                                }
+                                void validateAttributes() {
+                                    Element el = trees.getElement(getCurrentPath());
+                                    if (el == null) {
+                                        throw new AssertionError("A null sym attribute for: " + getCurrentPath().getLeaf() + "!");
+                                    }
+                                }
+                            }.scan(e.getCompilationUnit(), null);
+                        }
+                    });
+                })
+                .run(expectedOutput != null ? Task.Expect.FAIL : Task.Expect.SUCCESS,
+                     expectedOutput != null ? 1 : 0)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        if (expectedOutput != null && !log.equals(Arrays.asList(expectedOutput))) {
+            throw new AssertionError("Unexpected output: " + log);
+        }
+    }
+}


### PR DESCRIPTION
Consider the following sources:
```
//B.java
package p;

public class B {
    public interface I {}
}
```
```
Test.java
import p.B.I;
```

Then compile `B`, remove the `I` nested interface, and try to compile `Test` with the remaining classfiles of `B` on the classpath:
```
$ javac -d out B.java
$ rm out/p/B\$I.class
$ javac -classpath out -XDdev Test.java
Test.java:1: error: cannot access I
import p.B.I;
          ^
  class file for p.B$I not found
1 error
An exception has occurred in the compiler (24-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot read field "owner" because "s.sym" is null
        at jdk.compiler/com.sun.tools.javac.comp.Check.isCanonical(Check.java:4264)
        at jdk.compiler/com.sun.tools.javac.comp.Check.checkCanonical(Check.java:4256)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.doImport(TypeEnter.java:466)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.handleImports(TypeEnter.java:416)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.resolveImports(TypeEnter.java:389)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter.lambda$ensureImportsChecked$0(TypeEnter.java:165)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter.finishImports(TypeEnter.java:217)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter.ensureImportsChecked(TypeEnter.java:165)
        at jdk.compiler/com.sun.tools.javac.comp.Enter.complete(Enter.java:650)
        at jdk.compiler/com.sun.tools.javac.comp.Enter.main(Enter.java:600)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.enterTrees(JavaCompiler.java:1077)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:948)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:66)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:52)
printing javac parameters to: /tmp/javac.20240701_092709.args
```

The reason is that when the import is attributed, `Resolve.findIdentInType` is called to find `I` in `p.B`. It will, however, fail with a `CompletionFailure`, as `I` does not exist. And the `CompletionFailure` won't be called sooner than in `Attr.attribTree`, and as a consequence, the `sym` field of the `p.B.I` select will remain `null`, as the code that sets it will be skipped due to the `CompletionFailure`. This then leads to the follow-up NPE.

The proposal herein is to change `Resolve.findIdentInType` and `Resolve.findIdent` to handle `CompletionFailures` immediately, report an error, and return a "missing" `Symbol`. Note that `Resolve.findIdentInPackage` will not throw `CompletionFailure`s, as it uses `Resolve.loadClass`, which handles `CompletionFailure`s. So, this should be making the behavior consistent across `findIdent`, `findIdentInPackage` and `findIdentInType`.
