### PR TITLE
8335134: Test com/sun/jdi/BreakpointOnClassPrepare.java timeout

### DIFF
--- a/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
+++ b/test/jdk/com/sun/jdi/BreakpointOnClassPrepare.java
@@ -104,7 +104,15 @@ public class BreakpointOnClassPrepare extends TestScaffold {
 
     public void breakpointReached(BreakpointEvent event) {
         bkptCount++;
-        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + event.thread());
+        String threadInfo;
+        try {
+            threadInfo = event.thread().toString();
+        } catch (ObjectCollectedException e) {
+            // It's possible the Thread already terminated and was collected
+            // if the SUSPEND_NONE policy was used.
+            threadInfo = "(thread collected)";
+        }
+        System.out.println("Got BreakpointEvent: " + bkptCount + " for thread " + threadInfo);
     }
 
     public void vmDisconnected(VMDisconnectEvent event) {


### PR DESCRIPTION
Clean backport. Need to backport this since it was introduced with the new test in [JDK-8333542](https://bugs.openjdk.org/browse/JDK-8333542), which has also been backpoted to 23.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335134](https://bugs.openjdk.org/browse/JDK-8335134): Test com/sun/jdi/BreakpointOnClassPrepare.java timeout (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19976/head:pull/19976` \
`$ git checkout pull/19976`

Update a local copy of the PR: \
`$ git checkout pull/19976` \
`$ git pull https://git.openjdk.org/jdk.git pull/19976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19976`

View PR using the GUI difftool: \
`$ git pr show -t 19976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19976.diff">https://git.openjdk.org/jdk/pull/19976.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19976#issuecomment-2200658544)