### PR TITLE
8334229: Optimize InterpreterOopMap layout

### DIFF
--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -83,21 +83,21 @@ class InterpreterOopMap: ResourceObj {
 
  private:
   Method*        _method;         // the method for which the mask is valid
-  unsigned short _bci;            // the bci    for which the mask is valid
   int            _mask_size;      // the mask size in bits (USHRT_MAX if invalid)
   int            _expression_stack_size; // the size of the expression stack in slots
+  unsigned short _bci;            // the bci    for which the mask is valid
 
  protected:
-  intptr_t       _bit_mask[N];    // the bit mask if
+ int            _num_oops;
+#ifdef ASSERT
+ bool _resource_allocate_bit_mask;
+#endif
+ intptr_t       _bit_mask[N];    // the bit mask if
                                   // mask_size <= small_mask_limit,
                                   // ptr to bit mask otherwise
                                   // "protected" so that sub classes can
                                   // access it without using trickery in
                                   // method bit_mask().
-  int            _num_oops;
-#ifdef ASSERT
-  bool _resource_allocate_bit_mask;
-#endif
 
   // access methods
   Method*        method() const                  { return _method; }

--- a/src/hotspot/share/interpreter/oopMapCache.hpp
+++ b/src/hotspot/share/interpreter/oopMapCache.hpp
@@ -88,11 +88,11 @@ class InterpreterOopMap: ResourceObj {
   unsigned short _bci;            // the bci    for which the mask is valid
 
  protected:
- int            _num_oops;
 #ifdef ASSERT
- bool _resource_allocate_bit_mask;
+  bool _resource_allocate_bit_mask;
 #endif
- intptr_t       _bit_mask[N];    // the bit mask if
+  int            _num_oops;
+  intptr_t       _bit_mask[N];    // the bit mask if
                                   // mask_size <= small_mask_limit,
                                   // ptr to bit mask otherwise
                                   // "protected" so that sub classes can


### PR DESCRIPTION
Hi all,
   This PR is re-arrange the fields in InterpreterOopMap to optimize the layout of the class; by moving ```unsigned short _bci ``` to the place after ```int _expression_stack_size```, and ```int _num_oops``` to the place before ```intptr_t _bit_mask[4];```, most of the holes are removed. 
   
    Layout before the fix:
```
(gdb) ptype /xo InterpreterOopMap
/* offset      |    size */  type = class InterpreterOopMap : private ResourceObj {
                             private:
/* 0x0000      |  0x0008 */    class Method *_method;
/* 0x0008      |  0x0002 */    unsigned short _bci;
/* XXX  2-byte hole      */
/* 0x000c      |  0x0004 */    int _mask_size;
/* 0x0010      |  0x0004 */    int _expression_stack_size;
                             protected:
/* XXX  4-byte hole      */
/* 0x0018      |  0x0020 */    intptr_t _bit_mask[4];
/* 0x0038      |  0x0004 */    int _num_oops;
/* XXX  4-byte padding   */

                               /* total size (bytes):   64 */
                             }
```

After fix:
```
(gdb) ptype /xo  InterpreterOopMap
/* offset      |    size */  type = class InterpreterOopMap : private ResourceObj {
                             private:
/* 0x0000      |  0x0008 */    class Method *_method;
/* 0x0008      |  0x0004 */    int _mask_size;
/* 0x000c      |  0x0004 */    int _expression_stack_size;
/* 0x0010      |  0x0002 */    unsigned short _bci;
                             protected:
/* XXX  2-byte hole      */
/* 0x0014      |  0x0004 */    int _num_oops;
/* 0x0018      |  0x0020 */    intptr_t _bit_mask[4];

                               /* total size (bytes):   56 */
                             }
```

(Also moved ```bool _resource_allocate_bit_mask``` to before ```intptr_t _bit_mask[4];```, so it will use 1 byte of the 2-byte hole, resulting in 1 byte hole in fastdebug build.)

Layout in fastdebug build:
```
(gdb) ptype /xo InterpreterOopMap
/* offset      |    size */  type = class InterpreterOopMap : private ResourceObj {
                             private:
/* 0x0000      |  0x0008 */    class Method *_method;
/* 0x0008      |  0x0004 */    int _mask_size;
/* 0x000c      |  0x0004 */    int _expression_stack_size;
/* 0x0010      |  0x0002 */    unsigned short _bci;
                             protected:
/* 0x0012      |  0x0001 */    bool _resource_allocate_bit_mask;
/* XXX  1-byte hole      */
/* 0x0014      |  0x0004 */    int _num_oops;
/* 0x0018      |  0x0020 */    intptr_t _bit_mask[4];

                               /* total size (bytes):   56 */
                             }
(gdb) 
```

Additional test:
- [x] ```JTREG_KEYWORDS="\!headful & \!external-dep & \!printer" make test TEST=all``` only one un-related test failure: https://bugs.openjdk.org/browse/JDK-8333783

Best,
Xiaolong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334229](https://bugs.openjdk.org/browse/JDK-8334229): Optimize InterpreterOopMap layout (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19979/head:pull/19979` \
`$ git checkout pull/19979`

Update a local copy of the PR: \
`$ git checkout pull/19979` \
`$ git pull https://git.openjdk.org/jdk.git pull/19979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19979`

View PR using the GUI difftool: \
`$ git pr show -t 19979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19979.diff">https://git.openjdk.org/jdk/pull/19979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19979#issuecomment-2201107362)