### PR TITLE
8335478: Add notes for Error handling in Method.invoke and Constructor.newInstance

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/Constructor.java
+++ b/src/java.base/share/classes/java/lang/reflect/Constructor.java
@@ -450,6 +450,15 @@ public final class Constructor<T> extends Executable {
      * <p>If the constructor completes normally, returns the newly
      * created and initialized instance.
      *
+     * @apiNote
+     * {@link Throwable}s thrown by the constructor, including {@link
+     * Error}s, are wrapped in {@link InvocationTargetException}s.
+     * The wrapped throwable should be handled; ignoring the wrapped
+     * throwable, such as passing the {@link InvocationTargetException}
+     * as the cause to construct a new throwable, may fail in cases
+     * like {@link OutOfMemoryError} or {@link StackOverflowError}.
+     * The JVM may throw new errors that hide the original ones.
+     *
      * @param initargs array of objects to be passed as arguments to
      * the constructor call; values of primitive types are wrapped in
      * a wrapper object of the appropriate type (e.g. a {@code float}
@@ -471,7 +480,7 @@ public final class Constructor<T> extends Executable {
      * @throws    InstantiationException    if the class that declares the
      *              underlying constructor represents an abstract class.
      * @throws    InvocationTargetException if the underlying constructor
-     *              throws an exception.
+     *              throws any {@link Throwable}.
      * @throws    ExceptionInInitializerError if the initialization provoked
      *              by this method fails.
      */

--- a/src/java.base/share/classes/java/lang/reflect/Method.java
+++ b/src/java.base/share/classes/java/lang/reflect/Method.java
@@ -526,6 +526,16 @@ public final class Method extends Executable {
      * underlying method return type is void, the invocation returns
      * null.
      *
+     * @apiNote
+     * {@link Throwable}s thrown by the underlying method, including
+     * {@link Error}s like {@link AbstractMethodError}, are wrapped
+     * in {@link InvocationTargetException}s.
+     * The wrapped throwable should be handled; ignoring the wrapped
+     * throwable, such as passing the {@link InvocationTargetException}
+     * as the cause to construct a new throwable, may fail in cases
+     * like {@link OutOfMemoryError} or {@link StackOverflowError}.
+     * The JVM may throw new errors that hide the original ones.
+     *
      * @param obj  the object the underlying method is invoked from
      * @param args the arguments used for the method call
      * @return the result of dispatching the method represented by
@@ -546,7 +556,7 @@ public final class Method extends Executable {
      *              cannot be converted to the corresponding formal
      *              parameter type by a method invocation conversion.
      * @throws    InvocationTargetException if the underlying method
-     *              throws an exception.
+     *              throws any {@link Throwable}.
      * @throws    NullPointerException      if the specified object is null
      *              and the method is an instance method.
      * @throws    ExceptionInInitializerError if the initialization


### PR DESCRIPTION
`Method.invoke` and `Constructor.newInstance` wraps `Error` in `InvocationTargetException`, which is bug-prone for users. Worse, this is only ambiguously mentioned in the API specification.

This patch proposes to explicitly mention that `InvocationTargetException` wraps any throwable, and adds an API notes section describing the risk of not handling `InvocationTargetException` (and thereby ignoring the wrapped errors), to advise against future user errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8335482](https://bugs.openjdk.org/browse/JDK-8335482) to be approved

### Issues
 * [JDK-8335478](https://bugs.openjdk.org/browse/JDK-8335478): Add notes for Error handling in Method.invoke and Constructor.newInstance (**Enhancement** - P4)
 * [JDK-8335482](https://bugs.openjdk.org/browse/JDK-8335482): Add notes for Error handling in Method.invoke and Constructor.newInstance (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19980/head:pull/19980` \
`$ git checkout pull/19980`

Update a local copy of the PR: \
`$ git checkout pull/19980` \
`$ git pull https://git.openjdk.org/jdk.git pull/19980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19980`

View PR using the GUI difftool: \
`$ git pr show -t 19980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19980.diff">https://git.openjdk.org/jdk/pull/19980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19980#issuecomment-2201141624)
</details>
