### PR TITLE
8335493: check_gc_overhead_limit should reset SoftRefPolicy::_should_clear_all_soft_refs

### DIFF
--- a/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
+++ b/src/hotspot/share/gc/shared/gcOverheadChecker.cpp
@@ -40,7 +40,11 @@ void GCOverheadChecker::check_gc_overhead_limit(GCOverheadTester* time_overhead,
                                                 bool is_full_gc,
                                                 GCCause::Cause gc_cause,
                                                 SoftRefPolicy* soft_ref_policy) {
-
+  if (is_full_gc) {
+    // Explicit Full GC would do the clearing of soft-refs as well
+    // So reset in the beginning
+    soft_ref_policy->set_should_clear_all_soft_refs(false);
+  }
   // Ignore explicit GC's.  Exiting here does not set the flag and
   // does not reset the count.
   if (GCCause::is_user_requested_gc(gc_cause) ||

--- a/src/hotspot/share/gc/shared/softRefPolicy.hpp
+++ b/src/hotspot/share/gc/shared/softRefPolicy.hpp
@@ -69,6 +69,7 @@ class ClearedAllSoftRefs : public StackObj {
   ~ClearedAllSoftRefs() {
     if (_clear_all_soft_refs) {
       _soft_ref_policy->cleared_all_soft_refs();
+      _soft_ref_policy->set_should_clear_all_soft_refs(false);
     }
   }
 

--- a/src/hotspot/share/gc/shared/softRefPolicy.hpp
+++ b/src/hotspot/share/gc/shared/softRefPolicy.hpp
@@ -69,7 +69,6 @@ class ClearedAllSoftRefs : public StackObj {
   ~ClearedAllSoftRefs() {
     if (_clear_all_soft_refs) {
       _soft_ref_policy->cleared_all_soft_refs();
-      _soft_ref_policy->set_should_clear_all_soft_refs(false);
     }
   }
 


### PR DESCRIPTION
It's for fixing the issue should_clear_all_soft_refs is not reset after Parallel Full GC.

Tested test/hotspot/jtreg/gc with -XX:+UseParallelGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335493](https://bugs.openjdk.org/browse/JDK-8335493): check_gc_overhead_limit should reset SoftRefPolicy::_should_clear_all_soft_refs (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19982/head:pull/19982` \
`$ git checkout pull/19982`

Update a local copy of the PR: \
`$ git checkout pull/19982` \
`$ git pull https://git.openjdk.org/jdk.git pull/19982/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19982`

View PR using the GUI difftool: \
`$ git pr show -t 19982`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19982.diff">https://git.openjdk.org/jdk/pull/19982.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19982#issuecomment-2202111395)