### PR TITLE
8335395: G1: Verification does not detect references into Free regions

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -253,9 +253,7 @@ inline bool G1CollectedHeap::is_obj_filler(const oop obj) {
 }
 
 inline bool G1CollectedHeap::is_obj_dead(const oop obj, const G1HeapRegion* hr) const {
-  if (hr->is_free()) {
-    return true;
-  }
+  assert(!hr->is_free(), "looking up obj " PTR_FORMAT " in Free region %u", p2i(obj), hr->hrm_index());
   if (hr->is_in_parsable_area(obj)) {
     // This object is in the parsable part of the heap, live unless scrubbed.
     return is_obj_filler(obj);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.inline.hpp
@@ -253,6 +253,9 @@ inline bool G1CollectedHeap::is_obj_filler(const oop obj) {
 }
 
 inline bool G1CollectedHeap::is_obj_dead(const oop obj, const G1HeapRegion* hr) const {
+  if (hr->is_free()) {
+    return true;
+  }
   if (hr->is_in_parsable_area(obj)) {
     // This object is in the parsable part of the heap, live unless scrubbed.
     return is_obj_filler(obj);

--- a/src/hotspot/share/gc/g1/g1HeapRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegion.cpp
@@ -547,7 +547,10 @@ class G1VerifyLiveAndRemSetClosure : public BasicOopIterateClosure {
     }
 
     bool failed() const {
-      return !_is_in_heap || this->_g1h->is_obj_dead_cond(this->_obj, _vo);
+      return !_is_in_heap ||
+             // is_obj_dead* assume that obj is not in a Free region.
+             this->_g1h->heap_region_containing(this->_obj)->is_free() ||
+             this->_g1h->is_obj_dead_cond(this->_obj, _vo);
     }
 
     void report_error() {


### PR DESCRIPTION
Hi all,

  please review this improvement to `G1CollectedHeap::is_obj_dead()` where references into free regions were inadvertedly considered as live. This makes verification not fail with a proper error message when encountering references to objects in free regions (it may still fail for other reasons).

The alternative would have been fixing this in verification code only, but that method does not seem that hot, and the additional code not too slow either, but feel free to tell me otherwise and have me move the check.

This has been verified by @christianhaeubl who reported the issue.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335395](https://bugs.openjdk.org/browse/JDK-8335395): G1: Verification does not detect references into Free regions (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19983/head:pull/19983` \
`$ git checkout pull/19983`

Update a local copy of the PR: \
`$ git checkout pull/19983` \
`$ git pull https://git.openjdk.org/jdk.git pull/19983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19983`

View PR using the GUI difftool: \
`$ git pr show -t 19983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19983.diff">https://git.openjdk.org/jdk/pull/19983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19983#issuecomment-2202285422)