### PR TITLE
8335530: Java file extension missing in AuthenticatorTest

### DIFF
--- a/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
+++ b/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
@@ -40,7 +40,7 @@ public class AuthenticatorTest {
     @Test
     public void testFailure() {
         var failureResult = new Authenticator.Failure(666);
-        assertEquals(666, failureResult.getResponseCode(), );
+        assertEquals(666, failureResult.getResponseCode());
     }
 
     @Test

--- a/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
+++ b/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,15 @@
  * @test
  * @bug 8251496
  * @summary Tests for methods in Authenticator
- * @run testng/othervm AuthenticatorTest
+ * @run junit AuthenticatorTest
  */
 
 import com.sun.net.httpserver.Authenticator;
-import com.sun.net.httpserver.BasicAuthenticator;
 import com.sun.net.httpserver.HttpPrincipal;
-import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class AuthenticatorTest {
@@ -50,11 +50,11 @@ public class AuthenticatorTest {
     }
 
     @Test
-    public void TestSuccess() {
+    public void testSuccess() {
         var principal = new HttpPrincipal("test", "123");
         var successResult = new Authenticator.Success(principal);
         assertEquals(successResult.getPrincipal(), principal);
-        assertEquals("test", principal.getName());
+        assertEquals("test", principal.getUsername());
         assertEquals("123", principal.getRealm());
     }
 }

--- a/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
+++ b/test/jdk/com/sun/net/httpserver/AuthenticatorTest.java
@@ -40,20 +40,20 @@ public class AuthenticatorTest {
     @Test
     public void testFailure() {
         var failureResult = new Authenticator.Failure(666);
-        assertEquals(failureResult.getResponseCode(), 666);
+        assertEquals(666, failureResult.getResponseCode(), );
     }
 
     @Test
     public void testRetry() {
         var retryResult = new Authenticator.Retry(333);
-        assertEquals(retryResult.getResponseCode(), 333);
+        assertEquals(333, retryResult.getResponseCode());
     }
 
     @Test
     public void testSuccess() {
         var principal = new HttpPrincipal("test", "123");
         var successResult = new Authenticator.Success(principal);
-        assertEquals(successResult.getPrincipal(), principal);
+        assertEquals(principal, successResult.getPrincipal());
         assertEquals("test", principal.getUsername());
         assertEquals("123", principal.getRealm());
     }


### PR DESCRIPTION
This trivial test was pushed without a .java file extension and none of us spotted this.

This change renames the test to add the proper file extension, converts it to use jupiter APIs instead of TestNG, and fixes a small mistake (s/principal.getName()/principal.getUsername()/).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335530](https://bugs.openjdk.org/browse/JDK-8335530): Java file extension missing in AuthenticatorTest (**Bug** - P4)


### Reviewers
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer) ⚠️ Review applies to [6b944e6e](https://git.openjdk.org/jdk/pull/19984/files/6b944e6eb2d986dc16b8defd9e5facb27072f1b4)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19984/head:pull/19984` \
`$ git checkout pull/19984`

Update a local copy of the PR: \
`$ git checkout pull/19984` \
`$ git pull https://git.openjdk.org/jdk.git pull/19984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19984`

View PR using the GUI difftool: \
`$ git pr show -t 19984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19984.diff">https://git.openjdk.org/jdk/pull/19984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19984#issuecomment-2202408646)