### PR TITLE
8335536: Fix assertion failure in IdealGraphPrinter when append is true

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -913,8 +913,12 @@ void IdealGraphPrinter::update_compiled_method(ciMethod* current_method) {
   if (current_method != _current_method) {
     // If a different method, end the old and begin with the new one.
     if (_append) {
+      // Do not call `end_method` if we are appending, just update `_current_method`,
+      // because `begin_method` is not called in the constructor in append mode.
       _current_method = current_method;
     } else {
+      // End the old method and begin a new one.
+      // Don't worry about `_current_method`, `end_method` will clear it.
       end_method();
       begin_method();
     }

--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -143,21 +143,24 @@ void IdealGraphPrinter::init(const char* file_name, bool use_multiple_files, boo
   _depth = 0;
   _current_method = nullptr;
   _network_stream = nullptr;
+  _append = append;
 
   if (file_name != nullptr) {
-    init_file_stream(file_name, use_multiple_files, append);
+    init_file_stream(file_name, use_multiple_files);
   } else {
     init_network_stream();
   }
   _xml = new (mtCompiler) xmlStream(_output);
-  if (!append) {
+  if (!_append) {
     head(TOP_ELEMENT);
   }
 }
 
 // Destructor, close file or network stream
 IdealGraphPrinter::~IdealGraphPrinter() {
-  tail(TOP_ELEMENT);
+  if (!_append) {
+    tail(TOP_ELEMENT);
+  }
 
   // tty->print_cr("Walk time: %d", (int)_walk_time.milliseconds());
   // tty->print_cr("Output time: %d", (int)_output_time.milliseconds());
@@ -860,10 +863,10 @@ void IdealGraphPrinter::print(const char *name, Node *node) {
   _xml->flush();
 }
 
-void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multiple_files, bool append) {
+void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multiple_files) {
   ThreadCritical tc;
   if (use_multiple_files && _file_count != 0) {
-    assert(!append, "append should only be used for debugging with a single file");
+    assert(!_append, "append should only be used for debugging with a single file");
     ResourceMark rm;
     stringStream st;
     const char* dot = strrchr(file_name, '.');
@@ -875,10 +878,10 @@ void IdealGraphPrinter::init_file_stream(const char* file_name, bool use_multipl
     }
     _output = new (mtCompiler) fileStream(st.as_string(), "w");
   } else {
-    _output = new (mtCompiler) fileStream(file_name, append ? "a" : "w");
+    _output = new (mtCompiler) fileStream(file_name, _append ? "a" : "w");
   }
   if (use_multiple_files) {
-    assert(!append, "append should only be used for debugging with a single file");
+    assert(!_append, "append should only be used for debugging with a single file");
     _file_count++;
   }
 }
@@ -909,9 +912,12 @@ void IdealGraphPrinter::update_compiled_method(ciMethod* current_method) {
   assert(C != nullptr, "must already be set");
   if (current_method != _current_method) {
     // If a different method, end the old and begin with the new one.
-    end_method();
-    _current_method = nullptr;
-    begin_method();
+    if (_append) {
+      _current_method = current_method;
+    } else {
+      end_method();
+      begin_method();
+    }
   }
 }
 

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -96,6 +96,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   bool _traverse_outs;
   Compile *C;
   double _max_freq;
+  bool _append;
 
   void print_method(ciMethod* method, int bci, InlineTree* tree);
   void print_inline_tree(InlineTree* tree);
@@ -118,7 +119,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   void head(const char *name);
   void text(const char *s);
   void init(const char* file_name, bool use_multiple_files, bool append);
-  void init_file_stream(const char* file_name, bool use_multiple_files, bool append);
+  void init_file_stream(const char* file_name, bool use_multiple_files);
   void init_network_stream();
   IdealGraphPrinter();
   ~IdealGraphPrinter();


### PR DESCRIPTION
When `IdealGraphPrinter` is created with `append` set to true, it does not write the head element to the file in its constructor. But in the destructor, it always writes the tail element to the file no matter `append` is true or not, which causes an assertion failure in `xmlStream::pop_tag`.

This issue can be reproduced by calling `igv_append` directly, or by calling `Compile::igv_print_method_to_file` with `append` set to true.

This patch fixes the issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8335536](https://bugs.openjdk.org/browse/JDK-8335536): Fix assertion failure in IdealGraphPrinter when append is true (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Holenstein](https://openjdk.org/census#tholenstein) (@tobiasholenstein - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19986/head:pull/19986` \
`$ git checkout pull/19986`

Update a local copy of the PR: \
`$ git checkout pull/19986` \
`$ git pull https://git.openjdk.org/jdk.git pull/19986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19986`

View PR using the GUI difftool: \
`$ git pr show -t 19986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19986.diff">https://git.openjdk.org/jdk/pull/19986.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19986#issuecomment-2202568746)