### PR TITLE
8303884: jlink --add-options plugin does not allow GNU style options to be provided

### DIFF
--- a/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
+++ b/src/jdk.jlink/share/classes/jdk/tools/jlink/internal/TaskHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -545,9 +545,7 @@ public final class TaskHelper {
                         } else if (i + 1 < args.length) {
                             param = args[++i];
                         }
-                        if (param == null || param.isEmpty()
-                                || (param.length() >= 2 && param.charAt(0) == '-'
-                                && param.charAt(1) == '-')) {
+                        if (param == null || param.isEmpty()) {
                             throw new BadArgs("err.missing.arg", name).
                                     showUsage(true);
                         }

--- a/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
+++ b/test/jdk/tools/jlink/plugins/AddOptionsPluginTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ public class AddOptionsPluginTest {
 
     private static final String PROP = "add.options.plugin.test";
     private static final String VALUE = "xyzzy";
-    private static final String OPTS = "-D" + PROP + "=" + VALUE;
+    private static final String OPTS = String.format("--enable-preview -D%s=%s", PROP, VALUE);
 
     public static void main(String[] args) throws Throwable {
 
@@ -65,9 +65,9 @@ public class AddOptionsPluginTest {
                                      + (System.getProperty("os.name").startsWith("Windows")
                                         ? ".exe" : ""));
         var oa = ProcessTools.executeProcess(launcher.toString(),
-                                             "-XshowSettings:properties", "--version");
+                                             "-Xlog:arguments=info", "-XshowSettings:properties", "--version");
         oa.stderrShouldMatch("^ +" + PROP + " = " + VALUE + "$");
-
+        oa.stdoutShouldContain("--enable-preview");
     }
 
 }


### PR DESCRIPTION
We cannot pass GNU style options like `--enable-preview` to `jlink --add-option`. It is hard to use for complex application.

We have workaround for this issue (see JBS), but I think it is better to fix on JDK side.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8303884: jlink --add-options plugin does not allow GNU style options to be provided`

### Issue
 * [JDK-8303884](https://bugs.openjdk.org/browse/JDK-8303884): jlink --add-options plugin does not allow GNU style options to be provided (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19987/head:pull/19987` \
`$ git checkout pull/19987`

Update a local copy of the PR: \
`$ git checkout pull/19987` \
`$ git pull https://git.openjdk.org/jdk.git pull/19987/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19987`

View PR using the GUI difftool: \
`$ git pr show -t 19987`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19987.diff">https://git.openjdk.org/jdk/pull/19987.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19987#issuecomment-2203044567)