### PR TITLE
8304929: MethodTypeDesc throws an unchecked exception than ReflectiveOperationException when a component class cannot be resolved

### DIFF
--- a/test/jdk/java/lang/constant/MethodTypeDescTest.java
+++ b/test/jdk/java/lang/constant/MethodTypeDescTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
@@ -303,5 +304,10 @@ public class MethodTypeDescTest extends SymbolicDescTest {
         assertThrows(UnsupportedOperationException.class, () ->
                 mtd.parameterList().set(1, CD_void));
         assertEquals(mtd, MethodTypeDesc.of(CD_void, CD_Object, CD_int));
+    }
+
+    public void testMissingClass() {
+        var mtd = MTD_void.insertParameterTypes(0, ClassDesc.of("does.not.exist.DoesNotExist"));
+        assertThrows(ReflectiveOperationException.class, () -> mtd.resolveConstantDesc(MethodHandles.publicLookup()));
     }
 }


### PR DESCRIPTION
Simple fix for `MethodTypeDescImpl`'s violation of `resolveConstantDesc` specification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8335554](https://bugs.openjdk.org/browse/JDK-8335554) to be approved

### Issues
 * [JDK-8304929](https://bugs.openjdk.org/browse/JDK-8304929): MethodTypeDesc throws an unchecked exception than ReflectiveOperationException when a component class cannot be resolved (**Bug** - P4)
 * [JDK-8335554](https://bugs.openjdk.org/browse/JDK-8335554): MethodTypeDesc throws an unchecked exception than ReflectiveOperationException when a component class cannot be resolved (**CSR**)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19991/head:pull/19991` \
`$ git checkout pull/19991`

Update a local copy of the PR: \
`$ git checkout pull/19991` \
`$ git pull https://git.openjdk.org/jdk.git pull/19991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19991`

View PR using the GUI difftool: \
`$ git pr show -t 19991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19991.diff">https://git.openjdk.org/jdk/pull/19991.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19991#issuecomment-2203770785)