### PR TITLE
8335475: ClassBuilder incorrectly calculates max_locals in some cases

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1047,7 +1047,7 @@ public final class StackMapGenerator {
         void setLocalsFromArg(String name, MethodTypeDesc methodDesc, boolean isStatic, Type thisKlass) {
             int localsSize = 0;
             // Pre-emptively create a locals array that encompass all parameter slots
-            checkLocal(methodDesc.parameterCount() + (isStatic ? 0 : -1));
+            checkLocal(methodDesc.parameterCount() + (isStatic ? -1 : 0));
             if (!isStatic) {
                 localsSize++;
                 if (OBJECT_INITIALIZER_NAME.equals(name) && !CD_Object.equals(thisKlass.sym)) {


### PR DESCRIPTION
Please review this clean backport of #19981 onto JDK 23, fixing `StackMapGenerator` generating static methods with no declared local variable a max local of 1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335475](https://bugs.openjdk.org/browse/JDK-8335475): ClassBuilder incorrectly calculates max_locals in some cases (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19993/head:pull/19993` \
`$ git checkout pull/19993`

Update a local copy of the PR: \
`$ git checkout pull/19993` \
`$ git pull https://git.openjdk.org/jdk.git pull/19993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19993`

View PR using the GUI difftool: \
`$ git pr show -t 19993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19993.diff">https://git.openjdk.org/jdk/pull/19993.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19993#issuecomment-2204955280)