### PR TITLE
8335588: Fix -Wzero-as-null-pointer-constant warnings in calls to Node ctor

### DIFF
--- a/src/hotspot/share/opto/addnode.hpp
+++ b/src/hotspot/share/opto/addnode.hpp
@@ -43,7 +43,7 @@ typedef const Pair<Node*, jint> ConstAddOperands;
 class AddNode : public Node {
   virtual uint hash() const;
 public:
-  AddNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {
+  AddNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {
     init_class_id(Class_Add);
   }
 
@@ -165,7 +165,7 @@ public:
          Base,                  // Base oop, for GC purposes
          Address,               // Actually address, derived from base
          Offset } ;             // Offset added to address
-  AddPNode( Node *base, Node *ptr, Node *off ) : Node(0,base,ptr,off) {
+  AddPNode( Node *base, Node *ptr, Node *off ) : Node(nullptr,base,ptr,off) {
     init_class_id(Class_AddP);
   }
   virtual int Opcode() const;

--- a/src/hotspot/share/opto/convertnode.hpp
+++ b/src/hotspot/share/opto/convertnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -260,7 +260,7 @@ class RoundDoubleModeNode: public Node {
     rmode_floor = 1,
     rmode_ceil  = 2
   };
-  RoundDoubleModeNode(Node *in1, Node * rmode): Node(0, in1, rmode) {}
+  RoundDoubleModeNode(Node *in1, Node * rmode): Node(nullptr, in1, rmode) {}
   static RoundDoubleModeNode* make(PhaseGVN& gvn, Node* arg, RoundDoubleModeNode::RoundingMode rmode);
   virtual int   Opcode() const;
   virtual const Type *bottom_type() const { return Type::DOUBLE; }

--- a/src/hotspot/share/opto/countbitsnode.hpp
+++ b/src/hotspot/share/opto/countbitsnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ class PhaseTransform;
 //---------- CountBitsNode -----------------------------------------------------
 class CountBitsNode : public Node {
   public:
-  CountBitsNode(Node* in1) : Node(0, in1) {}
+  CountBitsNode(Node* in1) : Node(nullptr, in1) {}
   const Type* bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
 };

--- a/src/hotspot/share/opto/intrinsicnode.hpp
+++ b/src/hotspot/share/opto/intrinsicnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -239,7 +239,7 @@ public:
 //------------------------------CopySign-----------------------------------------
 class CopySignDNode : public Node {
  protected:
-  CopySignDNode(Node* in1, Node* in2, Node* in3) : Node(0, in1, in2, in3) {}
+  CopySignDNode(Node* in1, Node* in2, Node* in3) : Node(nullptr, in1, in2, in3) {}
  public:
   static CopySignDNode* make(PhaseGVN& gvn, Node* in1, Node* in2);
   virtual int Opcode() const;
@@ -249,7 +249,7 @@ class CopySignDNode : public Node {
 
 class CopySignFNode : public Node {
  public:
-  CopySignFNode(Node* in1, Node* in2) : Node(0, in1, in2) {}
+  CopySignFNode(Node* in1, Node* in2) : Node(nullptr, in1, in2) {}
   virtual int Opcode() const;
   const Type* bottom_type() const { return TypeLong::FLOAT; }
   virtual uint ideal_reg() const { return Op_RegF; }
@@ -258,7 +258,7 @@ class CopySignFNode : public Node {
 //------------------------------Signum-------------------------------------------
 class SignumDNode : public Node {
  protected:
-  SignumDNode(Node* in1, Node* in2, Node* in3) : Node(0, in1, in2, in3) {}
+  SignumDNode(Node* in1, Node* in2, Node* in3) : Node(nullptr, in1, in2, in3) {}
  public:
   static SignumDNode* make(PhaseGVN& gvn, Node* in);
   virtual int Opcode() const;
@@ -268,7 +268,7 @@ class SignumDNode : public Node {
 
 class SignumFNode : public Node {
  protected:
-  SignumFNode(Node* in1, Node* in2, Node* in3) : Node(0, in1, in2, in3) {}
+  SignumFNode(Node* in1, Node* in2, Node* in3) : Node(nullptr, in1, in2, in3) {}
  public:
   static SignumFNode* make(PhaseGVN& gvn, Node* in);
   virtual int Opcode() const;
@@ -306,7 +306,7 @@ class ExpandBitsNode : public TypeNode {
 //---------- IsInfiniteFNode -----------------------------------------------------
 class IsInfiniteFNode : public Node {
   public:
-  IsInfiniteFNode(Node* in1) : Node(0, in1) {}
+  IsInfiniteFNode(Node* in1) : Node(nullptr, in1) {}
   virtual int   Opcode() const;
   const Type* bottom_type() const { return TypeInt::BOOL; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -315,7 +315,7 @@ class IsInfiniteFNode : public Node {
 //---------- IsInfiniteDNode -----------------------------------------------------
 class IsInfiniteDNode : public Node {
   public:
-  IsInfiniteDNode(Node* in1) : Node(0, in1) {}
+  IsInfiniteDNode(Node* in1) : Node(nullptr, in1) {}
   virtual int   Opcode() const;
   const Type* bottom_type() const { return TypeInt::BOOL; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -324,7 +324,7 @@ class IsInfiniteDNode : public Node {
 //---------- IsFiniteFNode -----------------------------------------------------
 class IsFiniteFNode : public Node {
   public:
-  IsFiniteFNode(Node* in1) : Node(0, in1) {}
+  IsFiniteFNode(Node* in1) : Node(nullptr, in1) {}
   virtual int   Opcode() const;
   const Type* bottom_type() const { return TypeInt::BOOL; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -333,7 +333,7 @@ class IsFiniteFNode : public Node {
 //---------- IsFiniteDNode -----------------------------------------------------
 class IsFiniteDNode : public Node {
   public:
-  IsFiniteDNode(Node* in1) : Node(0, in1) {}
+  IsFiniteDNode(Node* in1) : Node(nullptr, in1) {}
   virtual int   Opcode() const;
   const Type* bottom_type() const { return TypeInt::BOOL; }
   virtual uint ideal_reg() const { return Op_RegI; }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -514,7 +514,7 @@ inline jlong BaseCountedLoopNode::stride_con() const {
 class LoopLimitNode : public Node {
   enum { Init=1, Limit=2, Stride=3 };
  public:
-  LoopLimitNode( Compile* C, Node *init, Node *limit, Node *stride ) : Node(0,init,limit,stride) {
+  LoopLimitNode( Compile* C, Node *init, Node *limit, Node *stride ) : Node(nullptr,init,limit,stride) {
     // Put it on the Macro nodes list to optimize during macro nodes expansion.
     init_flags(Flag_is_macro);
     C->add_macro_node(this);

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -1681,7 +1681,7 @@ public:
 // Allocation prefetch which may fault, TLAB size have to be adjusted.
 class PrefetchAllocationNode : public Node {
 public:
-  PrefetchAllocationNode(Node *mem, Node *adr) : Node(0,mem,adr) {}
+  PrefetchAllocationNode(Node *mem, Node *adr) : Node(nullptr,mem,adr) {}
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return NotAMachineReg; }
   virtual uint match_edge(uint idx) const { return idx==2; }

--- a/src/hotspot/share/opto/movenode.hpp
+++ b/src/hotspot/share/opto/movenode.hpp
@@ -158,7 +158,7 @@ class MoveD2LNode : public MoveNode {
 //     (CMove (Binary bol cmp) (Binary src1 src2))
 class BinaryNode : public Node {
   public:
-  BinaryNode( Node *n1, Node *n2 ) : Node(0,n1,n2) { }
+  BinaryNode( Node *n1, Node *n2 ) : Node(nullptr,n1,n2) { }
   virtual int Opcode() const;
   virtual uint ideal_reg() const { return 0; }
 };

--- a/src/hotspot/share/opto/mulnode.hpp
+++ b/src/hotspot/share/opto/mulnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -167,7 +167,7 @@ const Type* MulHiValue(const Type *t1, const Type *t2, const Type *bot);
 // Upper 64 bits of a 64 bit by 64 bit multiply
 class MulHiLNode : public Node {
 public:
-  MulHiLNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  MulHiLNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual const Type* Value(PhaseGVN* phase) const;
   const Type *bottom_type() const { return TypeLong::LONG; }
@@ -178,7 +178,7 @@ public:
 // Upper 64 bits of a 64 bit by 64 bit unsigned multiply
 class UMulHiLNode : public Node {
 public:
-  UMulHiLNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  UMulHiLNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual const Type* Value(PhaseGVN* phase) const;
   const Type *bottom_type() const { return TypeLong::LONG; }
@@ -291,7 +291,7 @@ class RotateRightNode : public TypeNode {
 // Signed shift right
 class RShiftINode : public Node {
 public:
-  RShiftINode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  RShiftINode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
@@ -304,7 +304,7 @@ public:
 // Signed shift right
 class RShiftLNode : public Node {
 public:
-  RShiftLNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  RShiftLNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual const Type* Value(PhaseGVN* phase) const;
@@ -316,7 +316,7 @@ public:
 // Logical shift right
 class URShiftBNode : public Node {
 public:
-  URShiftBNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {
+  URShiftBNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {
     ShouldNotReachHere(); // only vector variant is used
   }
   virtual int Opcode() const;
@@ -326,7 +326,7 @@ public:
 // Logical shift right
 class URShiftSNode : public Node {
 public:
-  URShiftSNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {
+  URShiftSNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {
     ShouldNotReachHere(); // only vector variant is used
   }
   virtual int Opcode() const;
@@ -336,7 +336,7 @@ public:
 // Logical shift right
 class URShiftINode : public Node {
 public:
-  URShiftINode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  URShiftINode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
@@ -349,7 +349,7 @@ public:
 // Logical shift right
 class URShiftLNode : public Node {
 public:
-  URShiftLNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {}
+  URShiftLNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {}
   virtual int Opcode() const;
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
@@ -396,7 +396,7 @@ public:
 class MulAddS2INode : public Node {
   virtual uint hash() const;
 public:
-  MulAddS2INode(Node* in1, Node *in2, Node *in3, Node* in4) : Node(0, in1, in2, in3, in4) {}
+  MulAddS2INode(Node* in1, Node *in2, Node *in3, Node* in4) : Node(nullptr, in1, in2, in3, in4) {}
   virtual int Opcode() const;
   const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }

--- a/src/hotspot/share/opto/opaquenode.hpp
+++ b/src/hotspot/share/opto/opaquenode.hpp
@@ -140,7 +140,7 @@ class ProfileBooleanNode : public Node {
   virtual uint hash() const ;                  // { return NO_HASH; }
   virtual bool cmp( const Node &n ) const;
   public:
-  ProfileBooleanNode(Node *n, uint false_cnt, uint true_cnt) : Node(0, n),
+  ProfileBooleanNode(Node *n, uint false_cnt, uint true_cnt) : Node(nullptr, n),
           _false_cnt(false_cnt), _true_cnt(true_cnt), _consumed(false), _delay_removal(true) {}
 
   uint false_count() const { return _false_cnt; }

--- a/src/hotspot/share/opto/subnode.hpp
+++ b/src/hotspot/share/opto/subnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@
 // are compressed into -1, and all positive answers compressed to 1.
 class SubNode : public Node {
 public:
-  SubNode( Node *in1, Node *in2 ) : Node(0,in1,in2) {
+  SubNode( Node *in1, Node *in2 ) : Node(nullptr,in1,in2) {
     init_class_id(Class_Sub);
   }
 
@@ -363,7 +363,7 @@ public:
 // for finding this pattern in the graph.
 class AbsNode : public Node {
 public:
-  AbsNode( Node *value ) : Node(0,value) {}
+  AbsNode( Node *value ) : Node(nullptr,value) {}
   virtual Node* Identity(PhaseGVN* phase);
   virtual Node* Ideal(PhaseGVN* phase, bool can_reshape);
   virtual const Type* Value(PhaseGVN* phase) const;
@@ -420,7 +420,7 @@ public:
 // If p < q, return -1 else return 0.  Nice for flow-free idioms.
 class CmpLTMaskNode : public Node {
 public:
-  CmpLTMaskNode( Node *p, Node *q ) : Node(0, p, q) {}
+  CmpLTMaskNode( Node *p, Node *q ) : Node(nullptr, p, q) {}
   virtual int Opcode() const;
   const Type *bottom_type() const { return TypeInt::INT; }
   virtual uint ideal_reg() const { return Op_RegI; }
@@ -430,7 +430,7 @@ public:
 //------------------------------NegNode----------------------------------------
 class NegNode : public Node {
 public:
-  NegNode(Node* in1) : Node(0, in1) {
+  NegNode(Node* in1) : Node(nullptr, in1) {
     init_class_id(Class_Neg);
   }
 };


### PR DESCRIPTION
Please review this change to callers of the Node constructor that were passing
0 as the first argument, which is of type Node*, thereby triggering
-Wzero-as-null-pointer-constant warnings when enabled. Instead of 0, pass
nullptr.  This removes over 2K warnings when building with that option.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335588](https://bugs.openjdk.org/browse/JDK-8335588): Fix -Wzero-as-null-pointer-constant warnings in calls to Node ctor (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19994/head:pull/19994` \
`$ git checkout pull/19994`

Update a local copy of the PR: \
`$ git checkout pull/19994` \
`$ git pull https://git.openjdk.org/jdk.git pull/19994/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19994`

View PR using the GUI difftool: \
`$ git pr show -t 19994`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19994.diff">https://git.openjdk.org/jdk/pull/19994.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19994#issuecomment-2204956046)