### PR TITLE
8335589: Fix -Wzero-as-null-pointer-constant warnings in IdealLoopTree ctor

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -607,7 +607,7 @@ public:
   bool  _allow_optimizations;   // Allow loop optimizations
 
   IdealLoopTree( PhaseIdealLoop* phase, Node *head, Node *tail )
-    : _parent(0), _next(0), _child(0),
+    : _parent(nullptr), _next(nullptr), _child(nullptr),
       _head(head), _tail(tail),
       _phase(phase),
       _local_loop_unroll_limit(0), _local_loop_unroll_factor(0),


### PR DESCRIPTION
Please review this trivial change to the IdealLoopTree constructor. The
initial values for some pointer-typed data members are changed from 0 to
nullptr. This removes ~275 -Wzero-as-null-pointer-constant when that warning
is enabled.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335589](https://bugs.openjdk.org/browse/JDK-8335589): Fix -Wzero-as-null-pointer-constant warnings in IdealLoopTree ctor (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19995/head:pull/19995` \
`$ git checkout pull/19995`

Update a local copy of the PR: \
`$ git checkout pull/19995` \
`$ git pull https://git.openjdk.org/jdk.git pull/19995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19995`

View PR using the GUI difftool: \
`$ git pr show -t 19995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19995.diff">https://git.openjdk.org/jdk/pull/19995.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19995#issuecomment-2205090148)