### PR TITLE
8335591: Fix -Wzero-as-null-pointer-constant warnings in ConcurrentHashTable 

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -318,7 +318,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   } else {
     return false;
   }
-  _invisible_epoch = 0;
+  _invisible_epoch = nullptr;
   _resize_lock_owner = locker;
   return true;
 }
@@ -345,14 +345,14 @@ inline void ConcurrentHashTable<CONFIG, F>::
     }
   } while(true);
   _resize_lock_owner = locker;
-  _invisible_epoch = 0;
+  _invisible_epoch = nullptr;
 }
 
 template <typename CONFIG, MEMFLAGS F>
 inline void ConcurrentHashTable<CONFIG, F>::
   unlock_resize_lock(Thread* locker)
 {
-  _invisible_epoch = 0;
+  _invisible_epoch = nullptr;
   assert(locker == _resize_lock_owner, "Not unlocked by locker.");
   _resize_lock_owner = nullptr;
   _resize_lock->unlock();
@@ -1016,7 +1016,7 @@ ConcurrentHashTable(size_t log2size, size_t log2size_limit, size_t grow_hint, bo
     : _context(context), _new_table(nullptr), _log2_size_limit(log2size_limit),
       _log2_start_size(log2size), _grow_hint(grow_hint),
       _size_limit_reached(false), _resize_lock_owner(nullptr),
-      _invisible_epoch(0)
+      _invisible_epoch(nullptr)
 {
   if (enable_statistics) {
     _stats_rate = new TableRateStatistics();


### PR DESCRIPTION
Please review this trivial change to ConcurrentHashTable.  Initialization of
and assignments to the _invisible_epoch member are changed from a value of 0
to nullptr.  This removes some -Wzero-as-null-pointer-constant warnings when
building with that enabled.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335591](https://bugs.openjdk.org/browse/JDK-8335591): Fix -Wzero-as-null-pointer-constant warnings in ConcurrentHashTable (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19996/head:pull/19996` \
`$ git checkout pull/19996`

Update a local copy of the PR: \
`$ git checkout pull/19996` \
`$ git pull https://git.openjdk.org/jdk.git pull/19996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19996`

View PR using the GUI difftool: \
`$ git pr show -t 19996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19996.diff">https://git.openjdk.org/jdk/pull/19996.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19996#issuecomment-2205103582)