### PR TITLE
8335592: Fix -Wzero-as-null-pointer-constant warnings in RootNode ctor

### DIFF
--- a/src/hotspot/share/opto/rootnode.hpp
+++ b/src/hotspot/share/opto/rootnode.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@
 // procedure start.
 class RootNode : public LoopNode {
 public:
-  RootNode( ) : LoopNode(0,0) {
+  RootNode( ) : LoopNode(nullptr, nullptr) {
     init_class_id(Class_Root);
     del_req(2);
     del_req(1);


### PR DESCRIPTION
Please review this trivial change to the RootNode constructor. Both arguments
to the LoopNode base class constructor are changed from 0 to nullptr. This
removes some -Wzero-as-null-pointer-constant warnings when building with that
enabled.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335592](https://bugs.openjdk.org/browse/JDK-8335592): Fix -Wzero-as-null-pointer-constant warnings in RootNode ctor (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19997/head:pull/19997` \
`$ git checkout pull/19997`

Update a local copy of the PR: \
`$ git checkout pull/19997` \
`$ git pull https://git.openjdk.org/jdk.git pull/19997/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19997`

View PR using the GUI difftool: \
`$ git pr show -t 19997`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19997.diff">https://git.openjdk.org/jdk/pull/19997.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19997#issuecomment-2205110491)