### PR TITLE
8335593: Fix -Wzero-as-null-pointer-constant warning in Type_Array ctor 

### DIFF
--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,7 +125,7 @@ class Type_Array : public AnyObj {
   const Type **_types;
   void grow( uint i );          // Grow array node to fit
 public:
-  Type_Array(Arena *a) : _a(a), _max(0), _types(0) {}
+  Type_Array(Arena *a) : _a(a), _max(0), _types(nullptr) {}
   const Type *operator[] ( uint i ) const // Lookup, or null for not mapped
   { return (i<_max) ? _types[i] : (Type*)nullptr; }
   const Type *fast_lookup(uint i) const{assert(i<_max,"oob");return _types[i];}


### PR DESCRIPTION
Please review this trivial change to the Type_Array constructor. The initial
value for the _types member is changed from 0 to nullptr. This removes some
-Wzero-as-null-pointer-constant warnings when building with that enabled.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335593](https://bugs.openjdk.org/browse/JDK-8335593): Fix -Wzero-as-null-pointer-constant warning in Type_Array ctor (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/19998/head:pull/19998` \
`$ git checkout pull/19998`

Update a local copy of the PR: \
`$ git checkout pull/19998` \
`$ git pull https://git.openjdk.org/jdk.git pull/19998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19998`

View PR using the GUI difftool: \
`$ git pr show -t 19998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/19998.diff">https://git.openjdk.org/jdk/pull/19998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/19998#issuecomment-2205129726)