### PR TITLE
8335615: Clean up left-overs from 8317721

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1494,10 +1494,9 @@ void MacroAssembler::update_word_crc32(Register crc, Register v, Register tmp1, 
   xorr(crc, crc, tmp2);
 
   lwu(tmp2, Address(tmp3));
-  if (upper) {
-    tmp1 = v;
+  // It is more optimal to use 'srli' instead of 'srliw' for case when it is not necessary to clean upper bits
+  if (upper)
     srli(tmp1, v, 24);
-  }
   else
     srliw(tmp1, v, 24);
 


### PR DESCRIPTION
The `compiler/intrinsics/zip/TestCRC32.java` is ok. Note about performance: https://github.com/openjdk/jdk/pull/17046#discussion_r1548163980

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335615](https://bugs.openjdk.org/browse/JDK-8335615): Clean up left-overs from 8317721 (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20004/head:pull/20004` \
`$ git checkout pull/20004`

Update a local copy of the PR: \
`$ git checkout pull/20004` \
`$ git pull https://git.openjdk.org/jdk.git pull/20004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20004`

View PR using the GUI difftool: \
`$ git pr show -t 20004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20004.diff">https://git.openjdk.org/jdk/pull/20004.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20004#issuecomment-2205970962)