### PR TITLE
8335618: Serial: Remove unused definitions in SerialHeap

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -43,7 +43,6 @@ class CSpaceCounters;
 class OldGenScanClosure;
 class YoungGenScanClosure;
 class DefNewTracer;
-class ScanWeakRefClosure;
 class SerialHeap;
 class STWGCTimer;
 

--- a/src/hotspot/share/gc/serial/serialHeap.hpp
+++ b/src/hotspot/share/gc/serial/serialHeap.hpp
@@ -72,13 +72,7 @@ class SerialHeap : public CollectedHeap {
   friend class HeapInspection;
   friend class GCCauseSetter;
   friend class VMStructs;
-public:
   friend class VM_PopulateDumpSharedSpace;
-
-  enum GenerationType {
-    YoungGen,
-    OldGen
-  };
 
 private:
   DefNewGeneration* _young_gen;
@@ -124,7 +118,6 @@ public:
   // Does operations required after initialization has been done.
   void post_initialize() override;
 
-  bool is_young_gen(const Generation* gen) const { return gen == _young_gen; }
   bool is_in_reserved(const void* addr) const { return _reserved.contains(addr); }
 
   // Performance Counter support


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335618](https://bugs.openjdk.org/browse/JDK-8335618): Serial: Remove unused definitions in SerialHeap (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20005/head:pull/20005` \
`$ git checkout pull/20005`

Update a local copy of the PR: \
`$ git checkout pull/20005` \
`$ git pull https://git.openjdk.org/jdk.git pull/20005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20005`

View PR using the GUI difftool: \
`$ git pr show -t 20005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20005.diff">https://git.openjdk.org/jdk/pull/20005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20005#issuecomment-2206047835)