### PR TITLE
8335610: DiagnosticFramework: CmdLine::is_executable() correction

### DIFF
--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public:
   const char* cmd_addr() const    { return _cmd; }
   size_t cmd_len() const          { return _cmd_len; }
   bool is_empty() const           { return _cmd_len == 0; }
-  bool is_executable() const      { return is_empty() || _cmd[0] != '#'; }
+  bool is_executable() const      { return !is_empty() && _cmd[0] != '#'; }
   bool is_stop() const            { return !is_empty() && strncmp("stop", _cmd, _cmd_len) == 0; }
 };
 


### PR DESCRIPTION
CmdLine::is_executable() looks wrong, surely an empty line is not executable.

With this change, in DCmd::parse_and_execute() we will avoid needlessly entering the code block to try and execute the command.

DCmd tests all good:
make images test TEST="test/hotspot/jtreg/serviceability/dcmd test/jdk/sun/tools/jcmd"

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335610](https://bugs.openjdk.org/browse/JDK-8335610): DiagnosticFramework: CmdLine::is_executable() correction (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20006/head:pull/20006` \
`$ git checkout pull/20006`

Update a local copy of the PR: \
`$ git checkout pull/20006` \
`$ git pull https://git.openjdk.org/jdk.git pull/20006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20006`

View PR using the GUI difftool: \
`$ git pr show -t 20006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20006.diff">https://git.openjdk.org/jdk/pull/20006.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20006#issuecomment-2206528105)