### PR TITLE
8335623: Clean up HtmlTag.HtmlTag and make the ARIA role attribute global

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/HtmlTag.java
@@ -507,7 +507,7 @@ public enum HtmlTag {
         PROFILE,
         REV,
         REVERSED,
-        ROLE,
+        ROLE(true),
         ROWSPAN,
         RULES,
         SCHEME,
@@ -606,26 +606,6 @@ public enum HtmlTag {
         this.attrs = new EnumMap<>(Attr.class);
         for (Map<Attr,AttrKind> m: attrMaps)
             this.attrs.putAll(m);
-        attrs.put(Attr.CLASS, AttrKind.OK);
-        attrs.put(Attr.ID, AttrKind.OK);
-        attrs.put(Attr.STYLE, AttrKind.OK);
-        attrs.put(Attr.ROLE, AttrKind.OK);
-        // for now, assume that all ARIA attributes are allowed on all tags.
-        attrs.put(Attr.ARIA_ACTIVEDESCENDANT, AttrKind.OK);
-        attrs.put(Attr.ARIA_CONTROLS, AttrKind.OK);
-        attrs.put(Attr.ARIA_DESCRIBEDBY, AttrKind.OK);
-        attrs.put(Attr.ARIA_EXPANDED, AttrKind.OK);
-        attrs.put(Attr.ARIA_LABEL, AttrKind.OK);
-        attrs.put(Attr.ARIA_LABELLEDBY, AttrKind.OK);
-        attrs.put(Attr.ARIA_LEVEL, AttrKind.OK);
-        attrs.put(Attr.ARIA_MULTISELECTABLE, AttrKind.OK);
-        attrs.put(Attr.ARIA_OWNS, AttrKind.OK);
-        attrs.put(Attr.ARIA_POSINSET, AttrKind.OK);
-        attrs.put(Attr.ARIA_READONLY, AttrKind.OK);
-        attrs.put(Attr.ARIA_REQUIRED, AttrKind.OK);
-        attrs.put(Attr.ARIA_SELECTED, AttrKind.OK);
-        attrs.put(Attr.ARIA_SETSIZE, AttrKind.OK);
-        attrs.put(Attr.ARIA_SORT, AttrKind.OK);
     }
 
     public boolean accepts(HtmlTag t) {


### PR DESCRIPTION
Can I please get a review for this small change? It removes some lines that are no longer necessary and sets the ARIA role as global.
Thanks in advance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335623](https://bugs.openjdk.org/browse/JDK-8335623): Clean up HtmlTag.HtmlTag and make the ARIA role attribute global (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20007/head:pull/20007` \
`$ git checkout pull/20007`

Update a local copy of the PR: \
`$ git checkout pull/20007` \
`$ git pull https://git.openjdk.org/jdk.git pull/20007/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20007`

View PR using the GUI difftool: \
`$ git pr show -t 20007`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20007.diff">https://git.openjdk.org/jdk/pull/20007.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20007#issuecomment-2206267975)