### PR TITLE
8304484: CDS dynamic dumping incorrectly leads to "Error occurred during initialization of VM"

### DIFF
--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -470,7 +470,7 @@ bool ClassPathImageEntry::is_modules_image() const {
 void ClassLoader::exit_with_path_failure(const char* error, const char* message) {
   assert(CDSConfig::is_dumping_archive(), "sanity");
   tty->print_cr("Hint: enable -Xlog:class+path=info to diagnose the failure");
-  vm_exit_during_initialization(error, message);
+  vm_exit_during_cds_dumping(error, message);
 }
 #endif
 


### PR DESCRIPTION
When a non-empty directory is found in the shared path table, the follow error is emitted:
 `Error occurred during initialization of VM
 Cannot have non-empty directory in paths`

While this makes sense for static dumping, which occurs during initialization, it is not true for a dynamic dump. To remove confusion, path failures exit with `vm_exit_during_cds_dumping`. Verified with