### PR TITLE
8334232: Optimize C1 classes layout

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.hpp
+++ b/src/hotspot/share/c1/c1_Instruction.hpp
@@ -281,11 +281,11 @@ class Instruction: public CompilationResourceObj {
 #endif
   int          _use_count;                       // the number of instructions referring to this value (w/o prev/next); only roots can have use count = 0 or > 1
   int          _pin_state;                       // set of PinReason describing the reason for pinning
+  unsigned int _flags;                           // Flag bits
   ValueType*   _type;                            // the instruction value type
   Instruction* _next;                            // the next instruction if any (null for BlockEnd instructions)
   Instruction* _subst;                           // the substitution instruction if any
   LIR_Opr      _operand;                         // LIR specific information
-  unsigned int _flags;                           // Flag bits
 
   ValueStack*  _state_before;                    // Copy of state with input operands still on stack (or null)
   ValueStack*  _exception_state;                 // Copy of state for exception handling
@@ -403,11 +403,11 @@ class Instruction: public CompilationResourceObj {
 #endif
     _use_count(0)
   , _pin_state(0)
+  , _flags(0)
   , _type(type)
   , _next(nullptr)
   , _subst(nullptr)
   , _operand(LIR_OprFact::illegalOpr)
-  , _flags(0)
   , _state_before(state_before)
   , _exception_handlers(nullptr)
   , _block(nullptr)
@@ -1518,9 +1518,9 @@ LEAF(MonitorExit, AccessMonitor)
 LEAF(Intrinsic, StateSplit)
  private:
   vmIntrinsics::ID _id;
+  ArgsNonNullState _nonnull_state;
   Values*          _args;
   Value            _recv;
-  ArgsNonNullState _nonnull_state;
 
  public:
   // preserves_state can be set to true for Intrinsics

--- a/src/hotspot/share/c1/c1_LIR.cpp
+++ b/src/hotspot/share/c1/c1_LIR.cpp
@@ -296,13 +296,13 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr result, LIR_Opr object, 
   , _tmp1(tmp1)
   , _tmp2(tmp2)
   , _tmp3(tmp3)
-  , _fast_check(fast_check)
   , _info_for_patch(info_for_patch)
   , _info_for_exception(info_for_exception)
   , _stub(stub)
   , _profiled_method(nullptr)
   , _profiled_bci(-1)
   , _should_profile(false)
+  , _fast_check(fast_check)
 {
   if (code == lir_checkcast) {
     assert(info_for_exception != nullptr, "checkcast throws exceptions");
@@ -323,13 +323,13 @@ LIR_OpTypeCheck::LIR_OpTypeCheck(LIR_Code code, LIR_Opr object, LIR_Opr array, L
   , _tmp1(tmp1)
   , _tmp2(tmp2)
   , _tmp3(tmp3)
-  , _fast_check(false)
   , _info_for_patch(nullptr)
   , _info_for_exception(info_for_exception)
   , _stub(nullptr)
   , _profiled_method(nullptr)
   , _profiled_bci(-1)
   , _should_profile(false)
+  , _fast_check(false)
 {
   if (code == lir_store_check) {
     _stub = new ArrayStoreExceptionStub(object, info_for_exception);

--- a/src/hotspot/share/c1/c1_LIR.hpp
+++ b/src/hotspot/share/c1/c1_LIR.hpp
@@ -528,44 +528,44 @@ class LIR_Address: public LIR_OprPtr {
  private:
   LIR_Opr   _base;
   LIR_Opr   _index;
-  Scale     _scale;
   intx      _disp;
+  Scale     _scale;
   BasicType _type;
 
  public:
   LIR_Address(LIR_Opr base, LIR_Opr index, BasicType type):
        _base(base)
      , _index(index)
-     , _scale(times_1)
      , _disp(0)
+     , _scale(times_1)
      , _type(type) { verify(); }
 
   LIR_Address(LIR_Opr base, intx disp, BasicType type):
        _base(base)
      , _index(LIR_Opr::illegalOpr())
-     , _scale(times_1)
      , _disp(disp)
+     , _scale(times_1)
      , _type(type) { verify(); }
 
   LIR_Address(LIR_Opr base, BasicType type):
        _base(base)
      , _index(LIR_Opr::illegalOpr())
-     , _scale(times_1)
      , _disp(0)
+     , _scale(times_1)
      , _type(type) { verify(); }
 
   LIR_Address(LIR_Opr base, LIR_Opr index, intx disp, BasicType type):
        _base(base)
      , _index(index)
-     , _scale(times_1)
      , _disp(disp)
+     , _scale(times_1)
      , _type(type) { verify(); }
 
   LIR_Address(LIR_Opr base, LIR_Opr index, Scale scale, intx disp, BasicType type):
        _base(base)
      , _index(index)
-     , _scale(scale)
      , _disp(disp)
+     , _scale(scale)
      , _type(type) { verify(); }
 
   LIR_Opr base()  const                          { return _base;  }
@@ -1544,13 +1544,13 @@ class LIR_OpTypeCheck: public LIR_Op {
   LIR_Opr       _tmp1;
   LIR_Opr       _tmp2;
   LIR_Opr       _tmp3;
-  bool          _fast_check;
   CodeEmitInfo* _info_for_patch;
   CodeEmitInfo* _info_for_exception;
   CodeStub*     _stub;
   ciMethod*     _profiled_method;
   int           _profiled_bci;
   bool          _should_profile;
+  bool          _fast_check;
 
 public:
   LIR_OpTypeCheck(LIR_Code code, LIR_Opr result, LIR_Opr object, ciKlass* klass,
@@ -1593,13 +1593,13 @@ class LIR_Op2: public LIR_Op {
  protected:
   LIR_Opr   _opr1;
   LIR_Opr   _opr2;
-  BasicType _type;
   LIR_Opr   _tmp1;
   LIR_Opr   _tmp2;
   LIR_Opr   _tmp3;
   LIR_Opr   _tmp4;
   LIR_Opr   _tmp5;
   LIR_Condition _condition;
+  BasicType _type;
 
   void verify() const;
 
@@ -1609,13 +1609,13 @@ class LIR_Op2: public LIR_Op {
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
-    , _type(type)
     , _tmp1(LIR_OprFact::illegalOpr)
     , _tmp2(LIR_OprFact::illegalOpr)
     , _tmp3(LIR_OprFact::illegalOpr)
     , _tmp4(LIR_OprFact::illegalOpr)
     , _tmp5(LIR_OprFact::illegalOpr)
-    , _condition(condition) {
+    , _condition(condition)
+    , _type(type) {
     assert(code == lir_cmp || code == lir_branch || code == lir_cond_float_branch || code == lir_assert, "code check");
   }
 
@@ -1624,13 +1624,13 @@ class LIR_Op2: public LIR_Op {
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
-    , _type(type)
     , _tmp1(LIR_OprFact::illegalOpr)
     , _tmp2(LIR_OprFact::illegalOpr)
     , _tmp3(LIR_OprFact::illegalOpr)
     , _tmp4(LIR_OprFact::illegalOpr)
     , _tmp5(LIR_OprFact::illegalOpr)
-    , _condition(condition) {
+    , _condition(condition)
+    , _type(type) {
     assert(code == lir_cmove, "code check");
     assert(type != T_ILLEGAL, "cmove should have type");
   }
@@ -1641,13 +1641,13 @@ class LIR_Op2: public LIR_Op {
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
-    , _type(type)
     , _tmp1(LIR_OprFact::illegalOpr)
     , _tmp2(LIR_OprFact::illegalOpr)
     , _tmp3(LIR_OprFact::illegalOpr)
     , _tmp4(LIR_OprFact::illegalOpr)
     , _tmp5(LIR_OprFact::illegalOpr)
-    , _condition(lir_cond_unknown) {
+    , _condition(lir_cond_unknown)
+    , _type(type) {
     assert(code != lir_cmp && code != lir_branch && code != lir_cond_float_branch && is_in_range(code, begin_op2, end_op2), "code check");
   }
 
@@ -1657,13 +1657,13 @@ class LIR_Op2: public LIR_Op {
     , _fpu_stack_size(0)
     , _opr1(opr1)
     , _opr2(opr2)
-    , _type(T_ILLEGAL)
     , _tmp1(tmp1)
     , _tmp2(tmp2)
     , _tmp3(tmp3)
     , _tmp4(tmp4)
     , _tmp5(tmp5)
-    , _condition(lir_cond_unknown) {
+    , _condition(lir_cond_unknown)
+    , _type(T_ILLEGAL)    {
     assert(code != lir_cmp && code != lir_branch && code != lir_cond_float_branch && is_in_range(code, begin_op2, end_op2), "code check");
   }
 
@@ -1748,8 +1748,8 @@ class LIR_OpAllocArray : public LIR_Op {
   LIR_Opr   _tmp2;
   LIR_Opr   _tmp3;
   LIR_Opr   _tmp4;
-  BasicType _type;
   CodeStub* _stub;
+  BasicType _type;
   bool      _zero_array;
 
  public:
@@ -1761,8 +1761,8 @@ class LIR_OpAllocArray : public LIR_Op {
     , _tmp2(t2)
     , _tmp3(t3)
     , _tmp4(t4)
-    , _type(type)
     , _stub(stub)
+    , _type(type)
     , _zero_array(zero_array) {}
 
   LIR_Opr   klass()   const                      { return _klass;       }
@@ -1811,13 +1811,13 @@ class LIR_Op4: public LIR_Op {
   LIR_Opr   _opr2;
   LIR_Opr   _opr3;
   LIR_Opr   _opr4;
-  BasicType _type;
   LIR_Opr   _tmp1;
   LIR_Opr   _tmp2;
   LIR_Opr   _tmp3;
   LIR_Opr   _tmp4;
   LIR_Opr   _tmp5;
   LIR_Condition _condition;
+  BasicType _type;
 
  public:
   LIR_Op4(LIR_Code code, LIR_Condition condition, LIR_Opr opr1, LIR_Opr opr2, LIR_Opr opr3, LIR_Opr opr4,
@@ -1827,13 +1827,13 @@ class LIR_Op4: public LIR_Op {
     , _opr2(opr2)
     , _opr3(opr3)
     , _opr4(opr4)
-    , _type(type)
     , _tmp1(LIR_OprFact::illegalOpr)
     , _tmp2(LIR_OprFact::illegalOpr)
     , _tmp3(LIR_OprFact::illegalOpr)
     , _tmp4(LIR_OprFact::illegalOpr)
     , _tmp5(LIR_OprFact::illegalOpr)
-    , _condition(condition) {
+    , _condition(condition)
+    , _type(type) {
     assert(code == lir_cmove, "code check");
     assert(type != T_ILLEGAL, "cmove should have type");
   }


### PR DESCRIPTION
**Notes**

Rearrange C1 class fields to optimize footprint.


**Verification**

1. Ran tier2_compiler, hotspot_compiler, tier 1 & tier 2 tests.
2. Ran pahole on 64 bit machine post re-ordering and verified that there are no holes / reduction in total bytes.

| Class | Size | Cachelines | Holes | Sum holes | Last Cacheline | Padding |
| ----- | ----- | ---------- | ----- | ---------- | --------------- | -------- |
| Instruction | 96 -> 88 | 2 -> 2  |  2 -> 0  |  8 -> 0  | 32 -> 24  | 1 -> 1  |
| Intrinsic | 136 -> 120 | 3 -> 2  |  1 -> 1  | 4 -> 96   |  8 ->  56 |  4-> 0 |
| LIR_Address | 48 -> 40 | 1 -> 1  |  1-> 0  | 4 -> 0  |  48 -> 40 | 7 -> 3   |
| LIR_Op2 | 128 -> 120  | 2 -> 2  | 2 -> 0  |  11 -> 0  | N/A -> 56  | 4 -> 7  |
| LIR_Op4 | 136 -> 128  | 3 -> 2  | 1-> 0  |  7 -> 0 |  8-> 0  |  4 ->  3 |
| LIR_OpAllocArray  | 120 -> 112  | 2 -> 2  | 1-> 0   |  7 -> 0  | 56 -> 48 |  7 -> 6 |
|LIR_OpTypeCheck  | 144 -> 136  | 3 -> 3  | 1-> 0  |  7 -> 0  |  16 ->  8 |  3 -> 2  |


```
/* class CompilationResourceObj <ancestor>; */   /*     0     0 */

	/* XXX last struct has 1 byte of padding */

	int ()(void) * *           _vptr.Instruction;    /*     0     8 */
	int                        _id;                  /*     8     4 */
	int                        _use_count;           /*    12     4 */
	int                        _pin_state;           /*    16     4 */
	unsigned int               _flags;               /*    20     4 */
	class ValueType *          _type;                /*    24     8 */
	class Instruction *        _next;                /*    32     8 */
	class Instruction *        _subst;               /*    40     8 */
	class LIR_Opr             _operand;              /*    48     8 */
	class ValueStack *         _state_before;        /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	class ValueStack *         _exception_state;     /*    64     8 */
	class XHandlers *          _exception_handlers;  /*    72     8 */
protected:

	class BlockBegin *         _block;               /*    80     8 */
public:


	/* Bitfield combined with previous fields */

	static const int                  no_bci;        /*     0     0 */
protected:

public:


	/* size: 88, cachelines: 2, members: 14, static members: 1 */
	/* paddings: 1, sum paddings: 1 */
	/* last cacheline: 24 bytes */
};

```

```
class LIR_Address : public LIR_OprPtr {
public:

	/* class LIR_OprPtr          <ancestor>; */      /*     0     8 */
	class LIR_Opr             _base;                 /*     8     8 */
	class LIR_Opr             _index;                /*    16     8 */
	intx                       _disp;                /*    24     8 */
	enum Scale                 _scale;               /*    32     4 */
	enum BasicType             _type;                /*    36     1 */

	/* size: 40, cachelines: 1, members: 6 */
	/* padding: 3 */
	/* last cacheline: 40 bytes */

	/* BRAIN FART ALERT! 40 bytes != 29 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 64 bits */
};
```

```
class LIR_Op2 : public LIR_Op {
public:

	/* class LIR_Op              <ancestor>; */      /*     0    48 */
protected:

	class LIR_Opr             _opr1;                 /*    48     8 */
	class LIR_Opr             _opr2;                 /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	class LIR_Opr             _tmp1;                 /*    64     8 */
	class LIR_Opr             _tmp2;                 /*    72     8 */
	class LIR_Opr             _tmp3;                 /*    80     8 */
	class LIR_Opr             _tmp4;                 /*    88     8 */
	class LIR_Opr             _tmp5;                 /*    96     8 */
	enum LIR_Condition         _condition;           /*   104     4 */
	int                        _fpu_stack_size;      /*   108     4 */
	enum BasicType             _type;                /*   112     1 */
public:

protected:

public:


	/* size: 120, cachelines: 2, members: 11 */
	/* padding: 7 */
	/* last cacheline: 56 bytes */

	/* BRAIN FART ALERT! 120 bytes != 65 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 384 bits */
};
```

```
class LIR_Op4 : public LIR_Op {
public:

	/* class LIR_Op              <ancestor>; */      /*     0    48 */
protected:

	class LIR_Opr             _opr1;                 /*    48     8 */
	class LIR_Opr             _opr2;                 /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	class LIR_Opr             _opr3;                 /*    64     8 */
	class LIR_Opr             _opr4;                 /*    72     8 */
	class LIR_Opr             _tmp1;                 /*    80     8 */
	class LIR_Opr             _tmp2;                 /*    88     8 */
	class LIR_Opr             _tmp3;                 /*    96     8 */
	class LIR_Opr             _tmp4;                 /*   104     8 */
	class LIR_Opr             _tmp5;                 /*   112     8 */
	enum LIR_Condition         _condition;           /*   120     4 */
	enum BasicType             _type;                /*   124     1 */
public:


	/* size: 128, cachelines: 2, members: 12 */
	/* padding: 3 */

	/* BRAIN FART ALERT! 128 bytes != 77 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 384 bits */
};
```

```
class LIR_OpAllocArray : public LIR_Op {
public:

	/* class LIR_Op              <ancestor>; */      /*     0    48 */
	class LIR_Opr             _klass;                /*    48     8 */
	class LIR_Opr             _len;                  /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	class LIR_Opr             _tmp1;                 /*    64     8 */
	class LIR_Opr             _tmp2;                 /*    72     8 */
	class LIR_Opr             _tmp3;                 /*    80     8 */
	class LIR_Opr             _tmp4;                 /*    88     8 */
	class CodeStub *           _stub;                /*    96     8 */
	enum BasicType             _type;                /*   104     1 */
	bool                       _zero_array;          /*   105     1 */

	/* size: 112, cachelines: 2, members: 10 */
	/* padding: 6 */
	/* last cacheline: 48 bytes */

	/* BRAIN FART ALERT! 112 bytes != 58 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 384 bits */
};
```

```
class LIR_OpTypeCheck : public LIR_Op {
public:

	/* class LIR_Op              <ancestor>; */      /*     0    48 */
	class LIR_Opr             _object;               /*    48     8 */
	class LIR_Opr             _array;                /*    56     8 */
	/* --- cacheline 1 boundary (64 bytes) --- */
	class ciKlass *            _klass;               /*    64     8 */
	class LIR_Opr             _tmp1;                 /*    72     8 */
	class LIR_Opr             _tmp2;                 /*    80     8 */
	class LIR_Opr             _tmp3;                 /*    88     8 */
	class CodeEmitInfo *       _info_for_patch;      /*    96     8 */
	class CodeEmitInfo *       _info_for_exception;  /*   104     8 */
	class CodeStub *           _stub;                /*   112     8 */
	class ciMethod *           _profiled_method;     /*   120     8 */
	/* --- cacheline 2 boundary (128 bytes) --- */
	int                        _profiled_bci;        /*   128     4 */
	bool                       _should_profile;      /*   132     1 */
	bool                       _fast_check;          /*   133     1 */

	/* size: 136, cachelines: 3, members: 14 */
	/* padding: 2 */
	/* last cacheline: 8 bytes */

	/* BRAIN FART ALERT! 136 bytes != 86 (member bytes) + 0 (member bits) + 0 (byte holes) + 0 (bit holes), diff = 384 bits */
};
```

```
class Intrinsic : public StateSplit {
public:

	/* class StateSplit          <ancestor>; */      /*     0     0 */

	/* XXX 96 bytes hole, try to pack */

	/* --- cacheline 1 boundary (64 bytes) was 32 bytes ago --- */
	ID                         _id;                  /*    96     4 */
	class ArgsNonNullState    _nonnull_state;        /*   100     4 */
	Values *                   _args;                /*   104     8 */
	Value                      _recv;                /*   112     8 */

	/* size: 120, cachelines: 2, members: 5 */
	/* sum members: 24, holes: 1, sum holes: 96 */
	/* last cacheline: 56 bytes */
};

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334232](https://bugs.openjdk.org/browse/JDK-8334232): Optimize C1 classes layout (**Sub-task** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20017/head:pull/20017` \
`$ git checkout pull/20017`

Update a local copy of the PR: \
`$ git checkout pull/20017` \
`$ git pull https://git.openjdk.org/jdk.git pull/20017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20017`

View PR using the GUI difftool: \
`$ git pr show -t 20017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20017.diff">https://git.openjdk.org/jdk/pull/20017.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20017#issuecomment-2211033825)