### PR TITLE
8335654: Remove stale hyperlink in divnode.cpp

### DIFF
--- a/src/hotspot/share/opto/divnode.cpp
+++ b/src/hotspot/share/opto/divnode.cpp
@@ -266,7 +266,6 @@ static Node* long_by_long_mulhi(PhaseGVN* phase, Node* dividend, jlong magic_con
   }
 
   // Taken from Hacker's Delight, Fig. 8-2. Multiply high signed.
-  // (http://www.hackersdelight.org/HDcode/mulhs.c)
   //
   // int mulhs(int u, int v) {
   //    unsigned u0, v0, w0;


### PR DESCRIPTION
This is a trivial patch to remove a stale hyperlink in divnode.cpp. I noticed while reading the code that this link no longer points to the relevant Hacker's Delight code, and since the referenced code ([archived version](https://web.archive.org/web/20070507103558/http://www.hackersdelight.org/HDcode/mulhs.c)) is also embedded in the comment, let's remove it.

Thanks!