### PR TITLE
8335655: ProblemList serviceability/dcmd/vm tests failing after JDK-8322475

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -114,4 +114,7 @@ serviceability/sa/sadebugd/PmapOnDebugdTest.java              8307393   generic-
 serviceability/sa/sadebugd/RunCommandOnServerTest.java        8307393   generic-all
 serviceability/sa/sadebugd/SADebugDTest.java                  8307393   generic-all
 
+serviceability/dcmd/vm/SystemMapTest.java                     8335643   generic-all
+serviceability/dcmd/vm/SystemDumpMapTest.java                 8335643   generic-all
+
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,4 +45,7 @@ serviceability/sa/TestSysProps.java                           8302055   generic-
 
 serviceability/sa/TestHeapDumpForInvokeDynamic.java           8315646   generic-all
 
+serviceability/dcmd/vm/SystemMapTest.java                     8335643   generic-all
+serviceability/dcmd/vm/SystemDumpMapTest.java                 8335643   generic-all
+
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64


### PR DESCRIPTION
Simple problem listing of two tests for ZGC. We only run these tests on Linux AFAICS but it is better to PL for all platforms.

Testing: tier 3 (where we first see failures) (in progress)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335655](https://bugs.openjdk.org/browse/JDK-8335655): ProblemList serviceability/dcmd/vm tests failing after JDK-8322475 (**Sub-task** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20021/head:pull/20021` \
`$ git checkout pull/20021`

Update a local copy of the PR: \
`$ git checkout pull/20021` \
`$ git pull https://git.openjdk.org/jdk.git pull/20021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20021`

View PR using the GUI difftool: \
`$ git pr show -t 20021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20021.diff">https://git.openjdk.org/jdk/pull/20021.diff</a>

</details>
