### PR TITLE
8335667: Fix simple -Wzero-as-null-pointer-constant warnings in compiler code

### DIFF
--- a/src/hotspot/share/ci/ciStreams.hpp
+++ b/src/hotspot/share/ci/ciStreams.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ private:
   Bytecodes::Code _raw_bc;         // Current bytecode, raw form
 
   void reset( address base, unsigned int size ) {
-    _bc_start =_was_wide = 0;
+    _bc_start = _was_wide = nullptr;
     _start = _pc = base; _end = base + size;
   }
 

--- a/src/hotspot/share/code/exceptionHandlerTable.hpp
+++ b/src/hotspot/share/code/exceptionHandlerTable.hpp
@@ -148,7 +148,7 @@ class ImplicitExceptionTable {
   ReallocMark          _nesting;  // assertion check for reallocations
 
 public:
-  ImplicitExceptionTable( ) :  _size(0), _len(0), _data(0) { }
+  ImplicitExceptionTable( ) :  _size(0), _len(0), _data(nullptr) { }
   // (run-time) construction from nmethod
   ImplicitExceptionTable(const nmethod *nm);
 


### PR DESCRIPTION
Please review this trivial change that replaces some uses of literal 0 as a
null pointer constant in compiler code to instead use nullptr.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335667](https://bugs.openjdk.org/browse/JDK-8335667): Fix simple -Wzero-as-null-pointer-constant warnings in compiler code (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20023/head:pull/20023` \
`$ git checkout pull/20023`

Update a local copy of the PR: \
`$ git checkout pull/20023` \
`$ git pull https://git.openjdk.org/jdk.git pull/20023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20023`

View PR using the GUI difftool: \
`$ git pr show -t 20023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20023.diff">https://git.openjdk.org/jdk/pull/20023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20023#issuecomment-2208511932)