### PR TITLE
8335532: [JVMCI] Export VM_Version::L1_line_size in JVMCI

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -108,6 +108,10 @@ class CompilerToVM {
     static int sizeof_ZStoreBarrierEntry;
 #endif
 
+#ifdef X86
+    static int L1_line_size;
+#endif
+
     static address dsin;
     static address dcos;
     static address dtan;

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -114,6 +114,10 @@ int CompilerToVM::Data::_fields_annotations_base_offset;
 CardTable::CardValue* CompilerToVM::Data::cardtable_start_address;
 int CompilerToVM::Data::cardtable_shift;
 
+#ifdef X86
+int CompilerToVM::Data::L1_line_size;
+#endif
+
 size_t CompilerToVM::Data::vm_page_size;
 
 int CompilerToVM::Data::sizeof_vtableEntry = sizeof(vtableEntry);
@@ -239,6 +243,10 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
     cardtable_start_address = 0;
     cardtable_shift = 0;
   }
+
+#ifdef X86
+  L1_line_size = VM_Version::L1_line_size();
+#endif
 
   vm_page_size = os::vm_page_size();
 

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -112,6 +112,8 @@
   static_field(CompilerToVM::Data,             cardtable_start_address,                CardTable::CardValue*)                        \
   static_field(CompilerToVM::Data,             cardtable_shift,                        int)                                          \
                                                                                                                                      \
+  X86_ONLY(static_field(CompilerToVM::Data,    L1_line_size,                           int))                                         \
+                                                                                                                                     \
   static_field(CompilerToVM::Data,             vm_page_size,                           size_t)                                       \
                                                                                                                                      \
   static_field(CompilerToVM::Data,             sizeof_vtableEntry,                     int)                                          \


### PR DESCRIPTION
This PR allows JVMCI compiler to implement lock add instruction same as `Assembler::membar`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335532](https://bugs.openjdk.org/browse/JDK-8335532): [JVMCI] Export VM_Version::L1_line_size in JVMCI (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20024/head:pull/20024` \
`$ git checkout pull/20024`

Update a local copy of the PR: \
`$ git checkout pull/20024` \
`$ git pull https://git.openjdk.org/jdk.git pull/20024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20024`

View PR using the GUI difftool: \
`$ git pr show -t 20024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20024.diff">https://git.openjdk.org/jdk/pull/20024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20024#issuecomment-2208538720)