### PR TITLE
8335684: Test ThreadCpuTime.java should pause like ThreadCpuTimeArray.java

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/ThreadCpuTime.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/ThreadCpuTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,6 +177,8 @@ public class ThreadCpuTime {
                 }
             }
         }
+        // Account for threads using CPU for a few millis after their WAITING state is visible:
+        goSleep(500);
     }
 
     static class MyThread extends Thread {
@@ -228,15 +230,6 @@ public class ThreadCpuTime {
                     " CurrentThreadCpuTime = " + time1 +
                     " > ThreadCpuTime = " + time2);
             }
-/*************
- * FIXME: Seems that on Solaris-sparc,
- * It occasionally returns a different current thread user time > thread user time
-            if (utime1 > utime2) {
-                throw new RuntimeException("TEST FAILED: " + getName() +
-                    " CurrentThreadUserTime = " + utime1 +
-                    " > ThreadUserTime = " + utime2);
-            }
-*/
         }
     }
 


### PR DESCRIPTION
There are two similarly names tests.
Recently:
JDK-8335124: com/sun/management/ThreadMXBean/ThreadCpuTimeArray.java failed with CPU time out of expected range
...made a simple change to try and avoid noisy test failures.  The same fix should be applied here to ThreadCpuTime.java.

Also removing an old comment about a Solaris issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335684](https://bugs.openjdk.org/browse/JDK-8335684): Test ThreadCpuTime.java should pause like ThreadCpuTimeArray.java (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20025/head:pull/20025` \
`$ git checkout pull/20025`

Update a local copy of the PR: \
`$ git checkout pull/20025` \
`$ git pull https://git.openjdk.org/jdk.git pull/20025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20025`

View PR using the GUI difftool: \
`$ git pr show -t 20025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20025.diff">https://git.openjdk.org/jdk/pull/20025.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20025#issuecomment-2208713400)