### PR TITLE
8335231: [macos] Test java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java failed on macOS because the case didn't get the expected PrintAbortException

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -753,16 +753,13 @@ public final class CPrinterJob extends RasterPrinterJob {
         // but that will block the AppKit thread against whomever is holding the synchronized lock
         boolean cancelled = (performingPrinting && userCancelled);
         if (cancelled) {
-            try {
-                LWCToolkit.invokeLater(new Runnable() { public void run() {
-                    try {
+            EventQueue.invokeLater(() -> {
+                try {
                     cancelDoc();
-                    } catch (PrinterAbortException pae) {
-                        // no-op, let the native side handle it
-                    }
-                }}, null);
-            } catch (NullPointerException ex) {
-            } catch (java.lang.reflect.InvocationTargetException ite) {}
+                } catch (PrinterAbortException pae) {
+                    // no-op, let the native side handle it
+                }
+            });
         }
         return cancelled;
     }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -259,7 +259,9 @@ public final class CPrinterJob extends RasterPrinterJob {
             }
         }};
 
-        printerAbortExcpn = excpn;
+        if (excpn != null && excpn.toString().contains("PrinterAbortException")) {
+            printerAbortExcpn = excpn;
+        }
 
         if (onEventThread) {
             try { EventQueue.invokeAndWait(r); } catch (Exception e) { e.printStackTrace(); }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -372,7 +372,7 @@ public final class CPrinterJob extends RasterPrinterJob {
                     try {
                         printLoop(true, firstPage, lastPage);
                     } catch (PrinterAbortException pex) {
-                        throw new PrinterAbortException(pex.getMessage());
+                        throw pex;
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -748,10 +748,7 @@ public final class CPrinterJob extends RasterPrinterJob {
     private boolean cancelCheck() throws PrinterAbortException {
         // This is called from the native side.
 
-        // This is used to avoid deadlock
-        // We would like to just call if isCancelled(),
-        // but that will block the AppKit thread against whomever is holding the synchronized lock
-        boolean cancelled = (performingPrinting && userCancelled);
+        boolean cancelled = isCancelled();
         if (cancelled) {
             cancelDoc();
         }

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -371,6 +371,8 @@ public final class CPrinterJob extends RasterPrinterJob {
 
                     try {
                         printLoop(true, firstPage, lastPage);
+                    } catch (PrinterAbortException pex) {
+                        throw new PrinterAbortException(pex.getMessage());
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -743,7 +745,7 @@ public final class CPrinterJob extends RasterPrinterJob {
         }
     }
 
-    private boolean cancelCheck() {
+    private boolean cancelCheck() throws PrinterAbortException {
         // This is called from the native side.
 
         // This is used to avoid deadlock
@@ -751,15 +753,7 @@ public final class CPrinterJob extends RasterPrinterJob {
         // but that will block the AppKit thread against whomever is holding the synchronized lock
         boolean cancelled = (performingPrinting && userCancelled);
         if (cancelled) {
-            try {
-                LWCToolkit.invokeLater(new Runnable() { public void run() {
-                    try {
-                    cancelDoc();
-                    } catch (PrinterAbortException pae) {
-                        // no-op, let the native side handle it
-                    }
-                }}, null);
-            } catch (java.lang.reflect.InvocationTargetException ite) {}
+            cancelDoc();
         }
         return cancelled;
     }

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,10 @@
 #import "JNIUtilities.h"
 
 static jclass sjc_CPrinterJob = NULL;
+static jclass sjc_PAbortEx = NULL;
 #define GET_CPRINTERJOB_CLASS() (sjc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob");
 #define GET_CPRINTERJOB_CLASS_RETURN(ret) GET_CLASS_RETURN(sjc_CPrinterJob, "sun/lwawt/macosx/CPrinterJob", ret);
+#define GET_PRINERABORTEXCEPTION_CLASS(ret) GET_CLASS_RETURN(sjc_PAbortEx, "java/awt/print/PrinterAbortException", ret);
 
 @implementation PrinterView
 
@@ -261,6 +263,10 @@ static jclass sjc_CPrinterJob = NULL;
 
     BOOL b = (*env)->CallBooleanMethod(env, fPrinterJob, jm_cancelCheck); // AWT_THREADING Safe (known object)
     CHECK_EXCEPTION();
+    if (b) {
+        GET_PRINERABORTEXCEPTION_CLASS(b);
+        (*env)->ThrowNew(env, sjc_PAbortEx, "Printer Job cancelled");
+    }
     return b;
 }
 

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/PrinterView.m
@@ -278,7 +278,6 @@ static jclass sjc_PAbortEx = NULL;
 
     jthrowable excpn = (*env)->ExceptionOccurred(env);
     if (excpn != NULL) {
-        (*env)->ExceptionDescribe(env);
         (*env)->ExceptionClear(env);
     }
     DECLARE_METHOD(jf_completePrintLoop, sjc_CPrinterJob, "completePrintLoop", "(Ljava/lang/Throwable;)V");

--- a/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
+++ b/test/jdk/java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java
@@ -32,7 +32,7 @@ import java.awt.print.PrinterJob;
 
 /*
  * @test
- * @bug 4245280
+ * @bug 4245280 8335231
  * @key printer
  * @summary PrinterJob not cancelled when PrinterJob.cancel() is used
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
When a printjob is cancelled midway, `PrinterAbortException `was not thrown in macos. because 
firstly,` cancelCheck` invokes` LWCToolkit.invokeLater` with null as parameter causing it to fail with NPE and
secondly PrinterAbortException was consumed silently when `printLoop` throws any exception
which is rectified to throw the PrinterAbortException when encountered..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335231](https://bugs.openjdk.org/browse/JDK-8335231): [macos] Test java/awt/print/PrinterJob/Cancel/PrinterJobCancel.java failed on macOS because the case didn't get the expected PrintAbortException (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20027/head:pull/20027` \
`$ git checkout pull/20027`

Update a local copy of the PR: \
`$ git checkout pull/20027` \
`$ git pull https://git.openjdk.org/jdk.git pull/20027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20027`

View PR using the GUI difftool: \
`$ git pr show -t 20027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20027.diff">https://git.openjdk.org/jdk/pull/20027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20027#issuecomment-2208660380)
</details>
