### PR TITLE
8322812: Manpage for jcmd is missing JFR.view command

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -681,6 +681,55 @@ If no path is provided, the data from the recording is discarded.
 value)
 .RE
 .TP
+\f[V]JFR.view\f[R] [\f[I]options\f[R]]
+Display event data in predefined views.
+.RS
+.PP
+Impact: Medium
+.PP
+\f[B]Note:\f[R]
+.PP
+The \f[I]options\f[R] must be specified using either \f[I]key\f[R] or
+\f[I]key\f[R]\f[V]=\f[R]\f[I]value\f[R] syntax.
+If no parameters are entered, then a list of available views are
+displayed.
+.PP
+\f[I]options\f[R]:
+.IP \[bu] 2
+\f[V]cell-height\f[R]: (Optional) Maximum number of rows in a table
+cell.
+(INT, default value depends on the view)
+.IP \[bu] 2
+\f[V]maxage\f[R]: (Optional) Length of time for the view to span.
+(INT followed by \[aq]s\[aq] for seconds \[aq]m\[aq] for minutes or
+\[aq]h\[aq] for hours, default value is 10m)
+.IP \[bu] 2
+\f[V]maxsize\f[R]: (Optional) Maximum size for the view to span in bytes
+if one of the following suffixes is not used: \[aq]m\[aq] or \[aq]M\[aq]
+for megabytes OR \[aq]g\[aq] or \[aq]G\[aq] for gigabytes.
+(STRING, default value is 32MB)
+.IP \[bu] 2
+\f[V]truncate\f[R]: (Optional) Maximum number of rows in a table cell.
+(INT, default value depends on the view)
+.IP \[bu] 2
+\f[V]verbose\f[R]: (Optional) Displays the query that makes up the view.
+(BOOLEAN, default value is false)
+.IP \[bu] 2
+\f[V]width\f[R]: (Optional) The width of the view in characters.
+(INT, default value depends on the view)
+.PP
+\f[I]arguments\f[R]:
+.IP \[bu] 2
+\f[V]view\f[R]: Name of the view or event type to display.
+Use \f[V]help JFR.view\f[R] to see a list of available views.
+(STRING, no default value)
+.PP
+The view parameter can be an event type name.
+Use \f[V]JFR.view types\f[R] to see a list.
+To display all views, use \f[V]JFR.view all-views\f[R].
+To display all events, use \f[V]JFR.view all-events\f[R].
+.RE
+.TP
 \f[V]JVMTI.agent_load\f[R] [\f[I]arguments\f[R]]
 Loads JVMTI native agent.
 .RS


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322812](https://bugs.openjdk.org/browse/JDK-8322812): Manpage for jcmd is missing JFR.view command (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20028/head:pull/20028` \
`$ git checkout pull/20028`

Update a local copy of the PR: \
`$ git checkout pull/20028` \
`$ git pull https://git.openjdk.org/jdk.git pull/20028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20028`

View PR using the GUI difftool: \
`$ git pr show -t 20028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20028.diff">https://git.openjdk.org/jdk/pull/20028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20028#issuecomment-2208758915)