### PR TITLE
8335479: JFR: Missing documentation for -XX:StartFlightRecording

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1710,10 +1710,12 @@ This prevents the JVM from exiting and keeps the process active so that
 you can attach a debugger to it to investigate the cause of the error.
 By default, this option is disabled.
 .TP
-\f[V]-XX:StartFlightRecording=\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R]
+\f[V]-XX:StartFlightRecording:\f[R]\f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R]
 Starts a JFR recording for the Java application.
 This option is equivalent to the \f[V]JFR.start\f[R] diagnostic command
 that starts a recording during runtime.
+\f[V]-XX:StartFlightRecording:help\f[R] prints available options and
+example command lines.
 You can set the following \f[I]parameter\f[R]\f[V]=\f[R]\f[I]value\f[R]
 entries when starting a JFR recording:
 .RS
@@ -1760,6 +1762,8 @@ written when the recording is stopped, for example:
 .PP
 If %p and/or %t is specified in the filename, it expands to the
 JVM\[aq]s PID and the current timestamp, respectively.
+The filename may also be a directory in which case, the filename is
+generated from the PID and the current date in the specified directory.
 .RE
 .TP
 \f[V]name=\f[R]\f[I]identifier\f[R]
@@ -1840,6 +1844,9 @@ The whitespace delimiter can be omitted for timespan values, i.e.
 20ms.
 For more information about the settings syntax, see Javadoc of the
 jdk.jfr package.
+.PP
+To only see warnings and errors from JFR during startup set
+-Xlog:jfr+startup=warning.
 .RE
 .TP
 \f[V]-XX:ThreadStackSize=\f[R]\f[I]size\f[R]


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335479](https://bugs.openjdk.org/browse/JDK-8335479): JFR: Missing documentation for -XX:StartFlightRecording (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20029/head:pull/20029` \
`$ git checkout pull/20029`

Update a local copy of the PR: \
`$ git checkout pull/20029` \
`$ git pull https://git.openjdk.org/jdk.git pull/20029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20029`

View PR using the GUI difftool: \
`$ git pr show -t 20029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20029.diff">https://git.openjdk.org/jdk/pull/20029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20029#issuecomment-2208759375)