### PR TITLE
8324089: Fix typo in the manual page for "jcmd" (man jcmd)

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -528,7 +528,7 @@ is not used: \[aq]m\[aq] or \[aq]M\[aq] for megabytes OR \[aq]g\[aq] or
 If no name is given, data from all recordings is dumped.
 (STRING, no default value)
 .IP \[bu] 2
-\f[V]path-to-gc-root\f[R]: (Optional) Flag for saving the path to
+\f[V]path-to-gc-roots\f[R]: (Optional) Flag for saving the path to
 garbage collection (GC) roots at the time the recording data is dumped.
 The path information is useful for finding memory leaks but collecting
 it can cause the application to pause for a short period of time.
@@ -606,7 +606,7 @@ Make note of the generated name that is shown in the response to the
 command so that you can use it with other commands.
 (STRING, system-generated default name)
 .IP \[bu] 2
-\f[V]path-to-gc-root\f[R]: (Optional) Flag for saving the path to
+\f[V]path-to-gc-roots\f[R]: (Optional) Flag for saving the path to
 garbage collection (GC) roots at the end of a recording.
 The path information is useful for finding memory leaks but collecting
 it is time consuming.


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324089](https://bugs.openjdk.org/browse/JDK-8324089): Fix typo in the manual page for "jcmd" (man jcmd) (**Sub-task** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20030/head:pull/20030` \
`$ git checkout pull/20030`

Update a local copy of the PR: \
`$ git checkout pull/20030` \
`$ git pull https://git.openjdk.org/jdk.git pull/20030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20030`

View PR using the GUI difftool: \
`$ git pr show -t 20030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20030.diff">https://git.openjdk.org/jdk/pull/20030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20030#issuecomment-2208759245)