### PR TITLE
8335688: Fix -Wzero-as-null-pointer-constant warnings from fflush calls in jvmti tests

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/AddModuleUsesAndProvides/libAddModuleUsesAndProvidesTest.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/AddModuleUsesAndProvides/libAddModuleUsesAndProvidesTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,7 +200,7 @@ Java_MyPackage_AddModuleUsesAndProvidesTest_checkUses(JNIEnv *env,
         throw_exc(env, "Check #UC3: service can not be used unexpectedly");
         return FAILED;
     }
-    fflush(0);
+    fflush(NULL);
     return PASSED;
 }
 
@@ -275,7 +275,7 @@ Java_MyPackage_AddModuleUsesAndProvidesTest_checkProvides(JNIEnv *env,
         throw_exc(env, "Check #PC2: error in add provides to baseModule with correct service and serviceImpl");
         return FAILED;
     }
-    fflush(0);
+    fflush(NULL);
     return PASSED;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GenerateEvents/libGenerateEvents1.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GenerateEvents/libGenerateEvents1.cpp
@@ -71,7 +71,7 @@ CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method,
   check_jvmti_status(env, err, "CompiledMethodLoad: Error in JVMTI GetMethodName");
 
   printf("%s: CompiledMethodLoad: %s%s\n", AGENT_NAME, name, sign);
-  fflush(0);
+  fflush(nullptr);
 }
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/GenerateEvents/libGenerateEvents2.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GenerateEvents/libGenerateEvents2.cpp
@@ -71,7 +71,7 @@ CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method,
   check_jvmti_status(env, err, "CompiledMethodLoad: Error in JVMTI GetMethodName");
 
   printf("%s: CompiledMethodLoad: %s%s\n", AGENT_NAME, name, sign);
-  fflush(0);
+  fflush(nullptr);
 }
 
 JNIEXPORT jint JNICALL
@@ -132,7 +132,7 @@ Java_MyPackage_GenerateEventsTest_agent2FailStatus(JNIEnv *env, jclass cls) {
     printf("check2: Unexpected non-zero event count in agent2: %d\n", agent2_event_count);
   }
   printf("\n");
-  fflush(0);
+  fflush(nullptr);
 
   return fail_status;
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/GetClassFields/FilteredFields/libFilteredFieldsTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetClassFields/FilteredFields/libFilteredFieldsTest.cpp
@@ -35,7 +35,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
     jint res = jvm->GetEnv((void **)&jvmti, JVMTI_VERSION_1_1);
     if (res != JNI_OK || jvmti == nullptr) {
         printf("Wrong result of a valid call to GetEnv!\n");
-        fflush(0);
+        fflush(nullptr);
         return JNI_ERR;
     }
     return JNI_OK;
@@ -72,7 +72,7 @@ Java_FilteredFieldsTest_getJVMTIFieldCount(JNIEnv *env, jclass cls, jclass clazz
         printf("  [%d]: %s\n", i, name);
         jvmti->Deallocate((unsigned char *)name);
     }
-    fflush(0);
+    fflush(nullptr);
     return fcount;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/MissedStackMapFrames/libMissedStackMapFrames.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/MissedStackMapFrames/libMissedStackMapFrames.cpp
@@ -31,7 +31,7 @@ static void _log(const char* format, ...) {
   va_start(args, format);
   vprintf(format, args);
   va_end(args);
-  fflush(0);
+  fflush(nullptr);
 }
 
 static jvmtiEnv* jvmti = nullptr;

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineRetransform/libRedefineRetransform.cpp
@@ -36,7 +36,7 @@ static void _log(const char* format, ...) {
     va_start(args, format);
     vprintf(format, args);
     va_end(args);
-    fflush(0);
+    fflush(nullptr);
 }
 
 static bool isTestClass(const char* name) {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
@@ -194,7 +194,7 @@ void JNICALL MethodEntry(jvmtiEnv *jvmti, JNIEnv *jni,
   {
     if (printdump == JNI_TRUE) {
       print_current_time();
-      fflush(0);
+      fflush(nullptr);
       LOG(">>> %sMethod entry\n>>>", (isNative == JNI_TRUE) ? "Native " : "");
       printInfo(jni, jvmti, thr, method, frameCount);
     }
@@ -231,7 +231,7 @@ void JNICALL FramePop(jvmtiEnv *jvmti, JNIEnv *jni,
   {
     if (printdump == JNI_TRUE) {
       print_current_time();
-      fflush(0);
+      fflush(nullptr);
       LOG(" >>> Frame Pop\n>>>");
       printInfo(jni, jvmti, thr, method, frameCount);
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/get_stack_trace.hpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetStackTrace/get_stack_trace.hpp
@@ -70,7 +70,7 @@ int compare_stack_trace(jvmtiEnv *jvmti, JNIEnv *jni, jthread thread,
 
     int exp_idx = expected_frames_length - 1 - i;
     printf("expected idx %d\n", exp_idx);
-    fflush(0);
+    fflush(nullptr);
     if (i < expected_frames_length) {
 
       // for generated classes don't compare lambda indicies

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/libSuspendResume1.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SuspendResume1/libSuspendResume1.cpp
@@ -138,7 +138,7 @@ check_suspended_state(JNIEnv* jni, jthread thread, int thr_idx, char* tname, con
 
       LOG("## Agent: %s:  virtual thread of carrier thread has state: %s (%d)\n",
           func_name, TranslateState(state), (int)state);
-      fflush(0);
+      fflush(nullptr);
     }
     set_agent_fail_status();
     fatal(jni, "check_resumed_state: expected SUSPENDED flag in thread state");
@@ -169,7 +169,7 @@ check_resumed_state(JNIEnv* jni, jthread thread, int thr_idx, char* tname, const
 
       LOG("## Agent: %s:  virtual thread of carrier thread has state: %s (%d)\n",
           func_name, TranslateState(state), (int)state);
-      fflush(0);
+      fflush(nullptr);
     }
     set_agent_fail_status();
     fatal(jni, "check_resumed_state: NOT expected SUSPENDED flag in thread state");
@@ -210,7 +210,7 @@ test_thread_resume(JNIEnv* jni, jthread thread, int thr_idx, char* tname) {
 
     LOG("## Agent: test_thread_resume:  virtual thread of carrier thread has state: %s (%d)\n",
         TranslateState(state), (int)state);
-    fflush(0);
+    fflush(nullptr);
   }
   check_jvmti_status(jni, err, "test_thread_resume: error in JVMTI ResumeThread");
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetClassFields/getclfld007/getclfld007.cpp
@@ -86,7 +86,7 @@ Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jclass 
 
     if (jvmti == nullptr) {
         printf("JVMTI client was not properly loaded!\n");
-        fflush(0);
+        fflush(nullptr);
         result = STATUS_FAILED;
         return;
     }
@@ -98,7 +98,7 @@ Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jclass 
     if (err != JVMTI_ERROR_NONE) {
         printf("GetClassFields unexpected error: %s (%d)\n",
                TranslateError(err), err);
-        fflush(0);
+        fflush(nullptr);
         result = STATUS_FAILED;
         return;
     }
@@ -132,7 +132,7 @@ Java_nsk_jvmti_GetClassFields_getclfld007_check(JNIEnv *env, jclass cls, jclass 
         jvmti->Deallocate((unsigned char *)name);
         jvmti->Deallocate((unsigned char *)sig);
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 JNIEXPORT int JNICALL

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref001/followref001.cpp
@@ -137,14 +137,14 @@ static bool initObjectDescList(jvmtiEnv*    jvmti,
     *objectsCount = 1 + 2 * chainLength;
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
                                           (unsigned char**) objectDescList))) {
         nsk_jvmti_setFailStatus();
         return false;
     }
     printf("  ... allocated array: 0x%p\n", (void*)objectDescList);
-    fflush(0);
+    fflush(nullptr);
 
     {
         int k;
@@ -179,7 +179,7 @@ static bool getAndTagClasses(jvmtiEnv*    jvmti,
     }
     printf("\nFound debugee class: 0x%p\n  %s\n",
            (void*) *debugeeClass, DEBUGEE_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObjectClass =
             jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != nullptr)) {
@@ -194,7 +194,7 @@ static bool getAndTagClasses(jvmtiEnv*    jvmti,
     printf("\nFound root object class: 0x%p, tag=%ld\n  %s\n",
            (void*) *rootObjectClass,(long) ROOT_CLASS_TAG,
            ROOT_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
 
 
     if (!NSK_JNI_VERIFY(jni, (*chainObjectClass =
@@ -209,7 +209,7 @@ static bool getAndTagClasses(jvmtiEnv*    jvmti,
     printf("\nFound chain object class: 0x%p, tag=%ld\n  %s\n",
            (void*) *chainObjectClass, (long) CHAIN_CLASS_TAG,
            CHAIN_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
 
      return true;
 } /* getAndTagClasses */
@@ -234,7 +234,7 @@ static bool getFieldsAndObjects(jvmtiEnv*  jvmti,
     }
     printf("\nFound fieldID: 0x%p - \'%s\' static field in debugee class\n",
            (void*) rootObjectField, OBJECT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*reachableChainField =
             jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
@@ -243,7 +243,7 @@ static bool getFieldsAndObjects(jvmtiEnv*  jvmti,
     }
     printf("\nFound fieldID: 0x%p - \'%s\' field in root object class\n",
            (void*) reachableChainField, REACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*unreachableChainField =
             jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
@@ -253,7 +253,7 @@ static bool getFieldsAndObjects(jvmtiEnv*  jvmti,
 
     printf("\nFound fieldID: 0x%p - \'%s\' field in root object class\n",
            (void*) unreachableChainField, UNREACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*nextField =
             jni->GetFieldID(chainObjectClass, NEXT_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
@@ -262,7 +262,7 @@ static bool getFieldsAndObjects(jvmtiEnv*  jvmti,
     }
     printf("\nFound fieldID: 0x%p - \'%s\' field in chain object class\n",
            (void*) nextField, NEXT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObjectPtr =
             jni->GetStaticObjectField(debugeeClass, rootObjectField)) != nullptr)) {
@@ -270,14 +270,14 @@ static bool getFieldsAndObjects(jvmtiEnv*  jvmti,
         return false;
     }
     printf("\nFound root object: 0x%p\n", (void*) *rootObjectPtr);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObjectPtr = jni->NewGlobalRef(*rootObjectPtr)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return false;
     }
     printf("Created root object global ref: 0x%p\n", (void*)*rootObjectPtr);
-    fflush(0);
+    fflush(nullptr);
 
      return true;
 } /* getFieldsAndObjects */
@@ -318,7 +318,7 @@ static bool getAndTagChainObjects(
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)nextObj);
-    fflush(0);
+    fflush(nullptr);
 
     /* To continue traversing objects in the chain */
     if (!getAndTagChainObjects(jvmti,
@@ -394,7 +394,7 @@ static int getAndTagTestedObjects(
            (long) ROOT_OBJECT_TAG, (void*) *rootObjectPtr);
 
     printf("    reachable objects chain: %d objects\n", chainLength);
-    fflush(0);
+    fflush(nullptr);
 
     if (!getAndTagChainObjects(jvmti,
                                jni,
@@ -453,7 +453,7 @@ static bool checkTestedObjects(jvmtiEnv*  jvmti,
     }
 
     printf("\nReachable objects:\n");
-    fflush(0);
+    fflush(nullptr);
     for (i = 0; i < chainLength; i++) {
         idx = i + 1;
         printf("Reachable object:\n"
@@ -488,7 +488,7 @@ static bool checkTestedObjects(jvmtiEnv*  jvmti,
             NSK_COMPLAIN0("Unreachable object was iterated\n");
             nsk_jvmti_setFailStatus();
         }
-        fflush(0);
+        fflush(nullptr);
     }
 
     return true;
@@ -514,7 +514,7 @@ static void releaseTestedObjects(jvmtiEnv*   jvmti,
         }
     }
 
-    fflush(0);
+    fflush(nullptr);
 } /* releaseTestedObjects */
 
 
@@ -542,7 +542,7 @@ jint JNICALL heapReferenceCallback(
                           /* ss45998: class_tag=>referrence_class_tag */
     printf("   size: %" LL "d, tag_ptr: 0x%p, referrer_tag_ptr: 0x%p, length: %-d\n",
                size,         tag_ptr,       referrer_tag_ptr,       length);
-    fflush(0);
+    fflush(nullptr);
 
     if (((uintptr_t) tag_ptr & FULL_32_BIT_MASK) == FULL_32_BIT_MASK) {
         NSK_COMPLAIN1("wrong tag_ptr passed to "
@@ -567,7 +567,7 @@ jint JNICALL heapReferenceCallback(
     printf("   class_tag=%" LL "d, tag=%" LL "d, size=%" LL "d,"
            " ref_tag=%" LL "d, referrer_index=%d\n\n",
                class_tag, tag, size, ref_tag, referrer_index);
-    fflush(0);
+    fflush(nullptr);
 
     if (length != -1) {
         NSK_COMPLAIN1("wrong length passed to heapReferenceCallback: "
@@ -647,7 +647,7 @@ jint JNICALL heapReferenceCallback(
         case JVMTI_HEAP_REFERENCE_OTHER: {
             NSK_COMPLAIN1("This reference kind was not expected: %s\n",
                            ref_kind_str[reference_kind]);
-            fflush(0);
+            fflush(nullptr);
             nsk_jvmti_setFailStatus();
             return 0;
         }
@@ -674,7 +674,7 @@ jint JNICALL primitiveFieldCallback(
                (long) class_tag,
                (long) DEREF(tag_ptr),
                (int) value_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 } /* primitiveFieldCallback */
 
@@ -694,7 +694,7 @@ jint JNICALL arrayPrimitiveValueCallback(
            (long) DEREF(tag_ptr),
            (int) element_count,
            (int) element_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 } /* arrayPrimitiveValueCallback */
 
@@ -711,7 +711,7 @@ jint JNICALL stringPrimitiveValueCallback(
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_length);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 } /* stringPrimitiveValueCallback */
 
@@ -725,14 +725,14 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     jobject rootObject = nullptr;
 
     printf("Wait for tested objects created\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout))) {
         return;
     }
 
 
     printf(">>> Obtain and tag tested objects from debugee class\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(getAndTagTestedObjects(jvmti,
                                            jni,
@@ -745,7 +745,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Let debugee to clean links to unreachable objects\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(nsk_jvmti_resumeSync())) {
         return;
@@ -755,7 +755,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Start iteration from root tested object: 0x%p\n\n", rootObject);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences((jint)   0,    /* heap_filter    */
                                                   (jclass) nullptr, /* class          */
@@ -767,19 +767,19 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Check if reachable objects were iterated:\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!checkTestedObjects(jvmti, jni, chainLength, objectDescList)) {
         nsk_jvmti_setFailStatus();
     }
 
     printf(">>> Clean used data\n");
-    fflush(0);
+    fflush(nullptr);
 
     releaseTestedObjects(jvmti, jni, chainLength, objectDescList, rootObject);
 
     printf(">>> Let debugee to finish\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_resumeSync())) {
         return;
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref002/followref002.cpp
@@ -131,7 +131,7 @@ static int getAndTagChainObjects(
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)obj);
-    fflush(0);
+    fflush(nullptr);
     if (!getAndTagChainObjects(jvmti, jni, obj,
                                nextField,
                                nextFieldName,
@@ -170,14 +170,14 @@ static int getAndTagTestedObjects(
     *objectsCount = 1 + 2 * chainLength;
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
                                           (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... allocated array: 0x%p\n", (void*)objectDescList);
-    fflush(0);
+    fflush(nullptr);
 
     {
         int k;
@@ -191,7 +191,7 @@ static int getAndTagTestedObjects(
     (*objectDescList)[0].exp_class_tag = rootClassTag;
 
     printf("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -199,7 +199,7 @@ static int getAndTagTestedObjects(
     printf("  ... found class: 0x%p\n", (void*)debugeeClass);
 
     printf("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -212,7 +212,7 @@ static int getAndTagTestedObjects(
     printf("        tag=%-5ld rootClass=0x%p\n", (long)rootClassTag, (void*)rootObjectClass);
 
     printf("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
             jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -226,7 +226,7 @@ static int getAndTagTestedObjects(
     printf("        tag=%-5ld chainClass=0x%p\n", (long)chainClassTag, (void*)chainObjectClass);
 
     printf("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (objectField =
             jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -235,7 +235,7 @@ static int getAndTagTestedObjects(
     printf("  ... got fieldID: 0x%p\n", (void*)objectField);
 
     printf("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
             jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -244,7 +244,7 @@ static int getAndTagTestedObjects(
     printf("  ... got fieldID: 0x%p\n", (void*)reachableChainField);
 
     printf("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
             jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -253,7 +253,7 @@ static int getAndTagTestedObjects(
     printf("  ... got fieldID: 0x%p\n", (void*)unreachableChainField);
 
     printf("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (tailField =
             jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -262,14 +262,14 @@ static int getAndTagTestedObjects(
     printf("  ... got fieldID: 0x%p\n", (void*)tailField);
 
     printf("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (*rootObject =
             jni->GetStaticObjectField(debugeeClass, objectField)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... got object: 0x%p\n", (void*)*rootObject);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObject = jni->NewGlobalRef(*rootObject)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -280,7 +280,7 @@ static int getAndTagTestedObjects(
     printf("Obtain and tag chain objects:\n");
 
     printf("    root tested object:\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObject, rootObjectTag))) {
         nsk_jvmti_setFailStatus();
     }
@@ -295,7 +295,7 @@ static int getAndTagTestedObjects(
     (*objectDescList)[chainLength].exp_found = 1;
 
     printf("    reachable objects chain: %d objects\n", chainLength);
-    fflush(0);
+    fflush(nullptr);
     if (!getAndTagChainObjects(jvmti, jni, *rootObject,
                                reachableChainField,
                                REACHABLE_CHAIN_FIELD_NAME,
@@ -348,7 +348,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni,
     }
 
     printf("\nReachable objects:\n");
-    fflush(0);
+    fflush(nullptr);
     for (i = 0; i < chainLength; i++) {
         idx = i + 1;
         printf("Reachable object:\n"
@@ -383,7 +383,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni,
             NSK_COMPLAIN0("Unreachable object was iterated\n");
             nsk_jvmti_setFailStatus();
         }
-        fflush(0);
+        fflush(nullptr);
     }
 
     return NSK_TRUE;
@@ -404,7 +404,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
         }
     }
 
-    fflush(0);
+    fflush(nullptr);
     return NSK_TRUE;
 } /* releaseTestedObjects */
 
@@ -456,7 +456,7 @@ jint JNICALL heapReferenceCallback(
            (long) size,
            (long) ref_tag,
            (int) referrer_index);
-    fflush(0);
+    fflush(nullptr);
 
     if (tag_ptr == nullptr) {
         NSK_COMPLAIN1("null tag_ptr is passed to heapReferenceCallback:"
@@ -531,7 +531,7 @@ jint JNICALL heapReferenceCallback(
         case JVMTI_HEAP_REFERENCE_OTHER: {
             NSK_COMPLAIN1("This reference kind was not expected: %s\n",
                            ref_kind_str[reference_kind]);
-            fflush(0);
+            fflush(nullptr);
             nsk_jvmti_setFailStatus();
             return 0;
         }
@@ -556,7 +556,7 @@ jint JNICALL primitiveFieldCallback(
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -574,7 +574,7 @@ jint JNICALL arrayPrimitiveValueCallback(
            (long) DEREF(tag_ptr),
            (int) element_count,
            (int) element_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -590,7 +590,7 @@ jint JNICALL stringPrimitiveValueCallback(
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_length);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -602,13 +602,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     jobject rootObject = nullptr;
 
     printf("Wait for tested objects created\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout))) {
         return;
     }
 
     printf(">>> Obtain and tag tested objects from debugee class\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(getAndTagTestedObjects(jvmti, jni,
                                                chainLength, &objectsCount,
@@ -618,7 +618,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Let debugee to clean links to unreachable objects\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(nsk_jvmti_resumeSync())) {
             return;
@@ -629,7 +629,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("\n\n>>> Start 1-st iteration for root tested object: 0x%p\n", rootObject);
-    fflush(0);
+    fflush(nullptr);
     {
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED | JVMTI_HEAP_FILTER_CLASS_UNTAGGED;
         if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences(heap_filter,
@@ -643,7 +643,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Check if reachable objects were iterated\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!checkTestedObjects(jvmti, jni, chainLength, objectDescList)) {
             nsk_jvmti_setFailStatus();
@@ -660,7 +660,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("\n\n>>> Start 2-nd iteration for root tested object: 0x%p\n", rootObject);
-    fflush(0);
+    fflush(nullptr);
     {
         /* This time everythig is filtered out */
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED | JVMTI_HEAP_FILTER_CLASS_UNTAGGED |
@@ -676,7 +676,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Check if reachable objects were not reported this time\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!checkTestedObjects(jvmti, jni, chainLength, objectDescList)) {
             nsk_jvmti_setFailStatus();
@@ -684,7 +684,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Clean used data\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(releaseTestedObjects(jvmti, jni, chainLength, objectDescList, rootObject))) {
             return;
@@ -692,7 +692,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("Let debugee to finish\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
         return;
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref003/followref003.cpp
@@ -146,7 +146,7 @@ static int getChainObjects(jvmtiEnv* jvmti, JNIEnv* jni, jobject firstObject,
         nsk_jvmti_setFailStatus();
     }
     printf("        tag=%-5ld object=0x%p\n", (long)objTag, (void*)obj);
-    fflush(0);
+    fflush(nullptr);
     if (!getChainObjects(jvmti, jni, obj, nextField, nextFieldName,
                                 nextField, nextFieldName,
                                 count, objectDescList, tag, reachable)) {
@@ -173,14 +173,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     *objectsCount = 1 + 2 * chainLength;
 
     printf("Allocate memory for objects list: %d objects\n", *objectsCount);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JVMTI_VERIFY(jvmti->Allocate((*objectsCount * sizeof(ObjectDesc)),
                                           (unsigned char**)objectDescList))) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... allocated array: 0x%p\n", (void*)objectDescList);
-    fflush(0);
+    fflush(nullptr);
 
     {
         int k;
@@ -194,7 +194,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     (*objectDescList)[0].exp_class_tag = rootClassTag;
 
     printf("Find debugee class: %s\n", DEBUGEE_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (debugeeClass = jni->FindClass(DEBUGEE_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -202,7 +202,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("  ... found class: 0x%p\n", (void*)debugeeClass);
 
     printf("Find root object class: %s\n", ROOT_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (rootObjectClass = jni->FindClass(ROOT_OBJECT_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
@@ -216,7 +216,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
            (long)rootClassTag, (void*)rootObjectClass);
 
     printf("Find chain object class: %s\n", CHAIN_OBJECT_CLASS_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (chainObjectClass =
             jni->FindClass(CHAIN_OBJECT_CLASS_NAME)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -232,7 +232,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
            (long)chainClassTag, (void*)chainObjectClass);
 
     printf("Find static field in debugee class: %s\n", OBJECT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (objectField =
             jni->GetStaticFieldID(debugeeClass, OBJECT_FIELD_NAME, ROOT_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -241,7 +241,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("  ... got fieldID: 0x%p\n", (void*)objectField);
 
     printf("Find instance field in root object class: %s\n", REACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (reachableChainField =
             jni->GetFieldID(rootObjectClass, REACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -250,7 +250,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("  ... got fieldID: 0x%p\n", (void*)reachableChainField);
 
     printf("Find instance field in root object class: %s\n", UNREACHABLE_CHAIN_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (unreachableChainField =
             jni->GetFieldID(rootObjectClass, UNREACHABLE_CHAIN_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -259,7 +259,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("  ... got fieldID: 0x%p\n", (void*)unreachableChainField);
 
     printf("Find instance field in chain object class: %s\n", TAIL_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (tailField =
             jni->GetFieldID(chainObjectClass, TAIL_FIELD_NAME, CHAIN_OBJECT_CLASS_SIG)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -268,14 +268,14 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("  ... got fieldID: 0x%p\n", (void*)tailField);
 
     printf("Get root object from static field: %s\n", OBJECT_FIELD_NAME);
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JNI_VERIFY(jni, (*rootObject =
             jni->GetStaticObjectField(debugeeClass, objectField)) != nullptr)) {
         nsk_jvmti_setFailStatus();
         return NSK_FALSE;
     }
     printf("  ... got object: 0x%p\n", (void*)*rootObject);
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_JNI_VERIFY(jni, (*rootObject = jni->NewGlobalRef(*rootObject)) != nullptr)) {
         nsk_jvmti_setFailStatus();
@@ -286,7 +286,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     printf("Obtain and tag chain objects:\n");
 
     printf("    root tested object\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_JVMTI_VERIFY(jvmti->SetTag(*rootObject, rootObjectTag))) {
         nsk_jvmti_setFailStatus();
     }
@@ -298,7 +298,7 @@ static int getTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
     (*objectDescList)[0].tag = rootObjectTag;
 
     printf("    reachable objects chain: %d objects\n", chainLength);
-    fflush(0);
+    fflush(nullptr);
     if (!getChainObjects(jvmti, jni, *rootObject,
                                 reachableChainField, REACHABLE_CHAIN_FIELD_NAME,
                                 tailField, TAIL_FIELD_NAME,
@@ -347,7 +347,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni,
     }
 
     printf("\nReachable objects:\n");
-    fflush(0);
+    fflush(nullptr);
     for (i = 0; i < chainLength; i++) {
         idx = i + 1;
         printf("Reachable object:\n"
@@ -382,7 +382,7 @@ static int checkTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni,
             NSK_COMPLAIN0("Unreachable object was iterated\n");
             nsk_jvmti_setFailStatus();
         }
-        fflush(0);
+        fflush(nullptr);
     }
 
     return NSK_TRUE;
@@ -403,7 +403,7 @@ static int releaseTestedObjects(jvmtiEnv* jvmti, JNIEnv* jni, int chainLength,
         }
     }
 
-    fflush(0);
+    fflush(nullptr);
     return NSK_TRUE;
 }
 
@@ -646,7 +646,7 @@ jint JNICALL heapReferenceCallback(
                    (long) size);
         }
 
-        fflush(0);
+        fflush(nullptr);
         return 0;
     }
 
@@ -665,7 +665,7 @@ jint JNICALL heapReferenceCallback(
            method,
            (long) location,
            (int) index);
-    fflush(0);
+    fflush(nullptr);
 
     if (tag_ptr == nullptr) {
         NSK_COMPLAIN1("null tag_ptr is passed to heapReferenceCallback:"
@@ -748,7 +748,7 @@ jint JNICALL heapReferenceCallback(
             if (tag != rootObjectTag || class_tag != rootClassTag) {
                  NSK_COMPLAIN1("This reference kind was not expected: %s\n",
                                ref_kind_str[ref_kind]);
-                 fflush(0);
+                 fflush(nullptr);
                  nsk_jvmti_setFailStatus();
             }
             break;
@@ -818,7 +818,7 @@ jint JNICALL heapReferenceCallback(
         default: {
             NSK_COMPLAIN1("This reference kind was not expected: %s\n\n",
                            ref_kind_str[ref_kind]);
-            fflush(0);
+            fflush(nullptr);
             nsk_jvmti_setFailStatus();
             break;
         }
@@ -840,7 +840,7 @@ jint JNICALL primitiveFieldCallback
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -853,7 +853,7 @@ jint JNICALL arrayPrimitiveValueCallback
            (long) DEREF(tag_ptr),
            (int) element_count,
            (int) element_type);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -865,7 +865,7 @@ jint JNICALL stringPrimitiveValueCallback
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_length);
-    fflush(0);
+    fflush(nullptr);
     return 0;
 }
 
@@ -902,13 +902,13 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     jobject rootObject = nullptr;
 
     printf("Wait for tested objects created\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(timeout))) {
         return;
     }
 
     printf(">>> Obtain and tag tested objects from debugee class\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(getTestedObjects(jvmti, jni, chainLength, &objectsCount,
                                          &objectDescList, &rootObject))) {
@@ -917,7 +917,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Let debugee to clean links to unreachable objects\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(nsk_jvmti_resumeSync())) {
             return;
@@ -933,7 +933,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("\n\n>>> Start 1-st iteration starting from the heap root\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_JVMTI_VERIFY(jvmti->FollowReferences((jint)   0,     /* heap_filter    */
                                                       (jclass)  nullptr, /* class          */
@@ -946,7 +946,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Check if reachable objects were iterated\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!checkTestedObjects(jvmti, jni, chainLength, objectDescList)) {
             nsk_jvmti_setFailStatus();
@@ -968,7 +968,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("\n\n>>> Start 2-nd iteration starting from the heap root\n");
-    fflush(0);
+    fflush(nullptr);
     first_followref = 0;
     {
         jint heap_filter = JVMTI_HEAP_FILTER_UNTAGGED
@@ -985,7 +985,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
     printf(">>> Check that both reachable and unreachable "
            "objects were not iterated\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!checkTestedObjects(jvmti, jni, chainLength, objectDescList)) {
             nsk_jvmti_setFailStatus();
@@ -994,7 +994,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
 
 
     printf(">>> Clean used data\n");
-    fflush(0);
+    fflush(nullptr);
     {
         if (!NSK_VERIFY(releaseTestedObjects(jvmti, jni, chainLength,
                         objectDescList, rootObject))) {
@@ -1003,7 +1003,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf("Let debugee to finish\n");
-    fflush(0);
+    fflush(nullptr);
     if (!NSK_VERIFY(nsk_jvmti_resumeSync()))
         return;
 }
@@ -1047,7 +1047,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
                 info = INFO_HEAPOBJ;
             else {
                 printf("Unknown option value: info=%s\n", infoOpt);
-                fflush(0);
+                fflush(nullptr);
                 return JNI_ERR;
             }
         }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/followref004.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref004/followref004.cpp
@@ -86,7 +86,7 @@ jint JNICALL primitiveFieldCallback(
                (long) DEREF(tag_ptr),
                (int) value_type);
 
-    fflush(0);
+    fflush(nullptr);
 
     markTagVisited(DEREF(tag_ptr));
 
@@ -111,7 +111,7 @@ jint JNICALL arrayPrimitiveValueCallback(
            (long) DEREF(tag_ptr),
            (int) element_count,
            (int) element_type);
-    fflush(0);
+    fflush(nullptr);
 
     markTagVisited(DEREF(tag_ptr));
 
@@ -132,7 +132,7 @@ jint JNICALL stringPrimitiveValueCallback(
            (long) class_tag,
            (long) DEREF(tag_ptr),
            (int) value_length);
-    fflush(0);
+    fflush(nullptr);
 
     markTagVisited(DEREF(tag_ptr));
 
@@ -168,14 +168,14 @@ static void JNICALL agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg)
     jvmtiError retCode;
 
     printf(">>> Sync with Java code\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(g_timeout))) {
         return;
     }
 
     printf(">>> Create JNI global references\n");
-    fflush(0);
+    fflush(nullptr);
 
     createGlobalRefs(jni);
 
@@ -192,7 +192,7 @@ static void JNICALL agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg)
     checkThatAllTagsVisited();
 
     printf(">>> Let debugee to finish\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(nsk_jvmti_resumeSync())) {
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/followref005.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref005/followref005.cpp
@@ -88,7 +88,7 @@ agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg) {
     }
 
     printf(">>> Let debugee to finish\n");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(g_timeout))) {
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/followref006.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/FollowReferences/followref006/followref006.cpp
@@ -181,7 +181,7 @@ static void JNICALL agentProc(jvmtiEnv* jvmti, JNIEnv* jni, void* arg)
     checkNoObjIterated(jni, jvmti, JAVA_UTIL_CALENDAR_CLASS_NAME);
 
     NSK_DISPLAY0("Let debugee to finish");
-    fflush(0);
+    fflush(nullptr);
 
     if (!NSK_VERIFY(nsk_jvmti_waitForSync(g_timeout))) {
         return;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretbase/earlyretbase.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretbase/earlyretbase.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define STATUS_FAILED 2
 #define PASSED 0
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return errCode
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return errCode
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -59,7 +59,7 @@ MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thr,
 
     if (method == midActiveMethod) {
         printf("#### MethodExit event occurred ####\n");
-        fflush(0);
+        fflush(nullptr);
         meth_exit_gen_events++;
     }
 }
@@ -70,7 +70,7 @@ FramePop(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
 
     if (method == midActiveMethod) {
         printf("#### FramePop event occurred ####\n");
-        fflush(0);
+        fflush(nullptr);
         pop_frame_gen_events++;
     }
 }
@@ -120,7 +120,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretbase_resThread(JNIEnv *env,
         return JNI_ERR;
     }
     printf("<<<<<<<< ResumeThread() is successfully done\n");
-    fflush(0);
+    fflush(nullptr);
     return PASSED;
 }
 
@@ -176,7 +176,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretbase_doForceEarlyReturn(JNIEnv *env
         RETURN_FAILED;
     }
     printf("Check #1 PASSED: ForceEarlyReturn() is successfully done\n");
-    fflush(0);
+    fflush(nullptr);
 
     return(errCode);
 }
@@ -268,7 +268,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretbase_check(JNIEnv *env, jclass cls)
                "events generated correctly\n");
         errCode = PASSED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp/earlyretfp.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretfp/earlyretfp.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 #define METHCNT 2
 static jvmtiEnv *jvmti = nullptr;
@@ -175,7 +175,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         printf(" expected: %d\n", framesCount + 1);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -220,7 +220,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -256,7 +256,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
@@ -289,7 +289,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
         printf("Method was_popped_by_exception unexpectedly\n");
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -361,7 +361,7 @@ jint Agent_Initialize(JavaVM *jvm, char *options, void *reserved) {
         printf("Warning: Breakpoint or SingleStep event are not implemented\n");
     }
 
-    fflush(0);
+    fflush(nullptr);
     return JNI_OK;
 }
 
@@ -431,7 +431,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretfp_printFloat(
       JNIEnv *env, jclass cls, jfloat val) {
 
     printf("\n>>> Returned value is %8.4f, hex: %#a\n", val, val);
-    fflush(0);
+    fflush(nullptr);
     return;
 }
 
@@ -440,7 +440,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretfp_printDouble(
       JNIEnv *env, jclass cls, jdouble val) {
 
     printf("\n>>> Returned value is %8.4f, hex: %#a\n", val, val);
-    fflush(0);
+    fflush(nullptr);
     return;
 }
 
@@ -451,7 +451,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretfp_check(JNIEnv *env, jclass cls) {
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint/earlyretint.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretint/earlyretint.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -184,7 +184,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         printf(" expected: %d\n", framesCount + 1);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -229,7 +229,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -270,7 +270,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
@@ -295,7 +295,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
         printf("Method was_popped_by_exception unexpectedly\n");
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -452,7 +452,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretint_printInt(
       JNIEnv *env, jclass cls, jint val) {
 
     printf("\n>>> Returned value: dec %d, hex: %#x\n", val, val);
-    fflush(0);
+    fflush(nullptr);
     return;
 }
 
@@ -463,7 +463,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretint_check(JNIEnv *env, jclass cls) 
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong/earlyretlong.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretlong/earlyretlong.cpp
@@ -34,7 +34,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -168,7 +168,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         printf(" expected: %d\n", framesCount + 1);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -213,7 +213,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -251,7 +251,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
@@ -276,7 +276,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
             errCode = STATUS_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -412,7 +412,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretlong_printLong(
 
     printf("\n>>> Returned value: dec: %" LL "d, hex: %#x %#x\n",
             val, iptr[0], iptr[1]);
-    fflush(0);
+    fflush(nullptr);
     return;
 }
 
@@ -423,7 +423,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretlong_check(JNIEnv *env, jclass cls)
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj/earlyretobj.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretobj/earlyretobj.cpp
@@ -34,7 +34,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -168,7 +168,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         printf(" expected: %d\n", framesCount + 1);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -213,7 +213,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -251,7 +251,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
@@ -274,7 +274,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
             errCode = STATUS_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -410,7 +410,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretobj_check(JNIEnv *env, jclass cls) 
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 
@@ -419,7 +419,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretobj_printObject(
          JNIEnv *env, jclass cls, jobject obj) {
 
     printf("\nReturned jobject: %#" PRIxPTR "\n", (uintptr_t)obj);
-    fflush(0);
+    fflush(nullptr);
     return;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr/earlyretstr.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretstr/earlyretstr.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -167,7 +167,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         printf(" expected: %d\n", framesCount + 1);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -212,7 +212,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -249,7 +249,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
@@ -273,7 +273,7 @@ void JNICALL MethodExit(jvmtiEnv *jvmti_env, JNIEnv *env, jthread thread,
           errCode = STATUS_FAILED;
       }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -409,7 +409,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretstr_check(JNIEnv *env, jclass cls) 
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid/earlyretvoid.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/ForceEarlyReturn/earlyretvoid/earlyretvoid.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #define PASSED 0
 #define STATUS_FAILED 2
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jvmtiEnv *jvmti = nullptr;
 static jvmtiCapabilities caps;
@@ -155,7 +155,7 @@ void check(jvmtiEnv *jvmti_env, jthread thr, jmethodID mid,
         }
         jvmti_env->Deallocate((unsigned char*)table);
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -192,7 +192,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -223,7 +223,7 @@ void JNICALL SingleStep(jvmtiEnv *jvmti_env, JNIEnv *env,
             RETURN_FAILED;
         }
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD
@@ -339,7 +339,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretvoid_getReady(
     } else {
         framesExpected = depth;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 JNIEXPORT jint JNICALL
@@ -349,7 +349,7 @@ Java_nsk_jvmti_unit_ForceEarlyReturn_earlyretvoid_check(JNIEnv *env, jclass cls)
             framesCount, framesExpected);
         errCode = STATUS_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
     return errCode;
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001/getallstktr001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetAllStackTraces/getallstktr001/getallstktr001.cpp
@@ -179,7 +179,7 @@ void compare_all_frames(int ti, int frames_count,
         printf("thr #%d: compare frame #%d: fields are the same: "
                " method: 0x%p, location: %#" LL "x\n",
                ti, fi, fr1->method, fr1->location);
-        fflush(0);
+        fflush(nullptr);
     }
 }
 
@@ -225,7 +225,7 @@ void compare_one_stack_trace(int ti,
            " jthread: 0x%p, state: %d, frame_count: %d\n",
            ti, stk1->thread, stk1->state, stk1->frame_count);
 
-    fflush(0);
+    fflush(nullptr);
     compare_all_frames(ti,
                        stk1->frame_count,
                        stk1->frame_buffer,
@@ -291,7 +291,7 @@ Java_nsk_jvmti_unit_GetAllStackTraces_getallstktr001_GetThreadsInfo(
             iGlobalStatus = STATUS_FAILED;
         }
         printf("GetThreadInfo %d: thread: %s\n", ti, thread_info[ti].name);
-        fflush(0);
+        fflush(nullptr);
     }
 }
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001/getcpool001.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/GetConstantPool/getcpool001/getcpool001.cpp
@@ -36,7 +36,7 @@ extern "C" {
 static jvmtiCapabilities caps;
 static jvmtiEventCallbacks callbacks;
 
-#define RETURN_FAILED errCode = STATUS_FAILED; fflush(0); return
+#define RETURN_FAILED errCode = STATUS_FAILED; fflush(nullptr); return
 
 static jint      errCode       = PASSED;
 static jvmtiEnv *jvmti         = nullptr;
@@ -63,7 +63,7 @@ Java_nsk_jvmti_unit_GetConstantPool_getcpool001_getCP(
     /* Print Constant Pool attrs*/
     printf("getCP: id = %d, cnt = %03d, bytes_cnt = %04d\n",
             id, cp_cnt, cp_bytes_cnt);
-    fflush(0);
+    fflush(nullptr);
 }
 
 void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
@@ -83,7 +83,7 @@ void JNICALL Breakpoint(jvmtiEnv *jvmti_env, JNIEnv *env,
                TranslateError(err), err);
         RETURN_FAILED;
     }
-    fflush(0);
+    fflush(nullptr);
 }
 
 #ifdef STATIC_BUILD


### PR DESCRIPTION
Please review this change to some jvmti tests, which were calling fflush with
an argument of 0. Most of these are in C++ code, where we change them to use
nullptr as the argument.  A couple are in C, where we change them to use NULL.
This removes a bunch of -Wzero-as-null-pointer-constant when building with
that enabled.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335688](https://bugs.openjdk.org/browse/JDK-8335688): Fix -Wzero-as-null-pointer-constant warnings from fflush calls in jvmti tests (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20032/head:pull/20032` \
`$ git checkout pull/20032`

Update a local copy of the PR: \
`$ git checkout pull/20032` \
`$ git pull https://git.openjdk.org/jdk.git pull/20032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20032`

View PR using the GUI difftool: \
`$ git pr show -t 20032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20032.diff">https://git.openjdk.org/jdk/pull/20032.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20032#issuecomment-2208841067)