### PR TITLE
8335643: serviceability/dcmd/vm tests fail for ZGC after JDK-8322475

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -114,7 +114,4 @@ serviceability/sa/sadebugd/PmapOnDebugdTest.java              8307393   generic-
 serviceability/sa/sadebugd/RunCommandOnServerTest.java        8307393   generic-all
 serviceability/sa/sadebugd/SADebugDTest.java                  8307393   generic-all
 
-serviceability/dcmd/vm/SystemMapTest.java                     8335643   generic-all
-serviceability/dcmd/vm/SystemDumpMapTest.java                 8335643   generic-all
-
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -45,7 +45,4 @@ serviceability/sa/TestSysProps.java                           8302055   generic-
 
 serviceability/sa/TestHeapDumpForInvokeDynamic.java           8315646   generic-all
 
-serviceability/dcmd/vm/SystemMapTest.java                     8335643   generic-all
-serviceability/dcmd/vm/SystemDumpMapTest.java                 8335643   generic-all
-
 vmTestbase/gc/gctests/MemoryEaterMT/MemoryEaterMT.java        8289582   windows-x64

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -42,6 +42,8 @@ public class SystemMapTestBase {
     private static final String regexBase_committed = regexBase + "com.*";
     private static final String regexBase_shared_and_committed = regexBase + "shrd,com.*";
 
+    // java heap is either committed, non-shared, or - in case of ZGC - committed and shared.
+    private static final String regexBase_java_heap = regexBase + "(shrd,)?com.*";
     protected static final String shouldMatchUnconditionally[] = {
         // java launcher
         regexBase_committed + "/bin/java",
@@ -54,7 +56,7 @@ public class SystemMapTestBase {
     };
 
     protected static final String shouldMatchIfNMTIsEnabled[] = {
-        regexBase_committed + "JAVAHEAP.*",
+        regexBase_java_heap + "JAVAHEAP.*",
         // metaspace
         regexBase_committed + "META.*",
         // parts of metaspace should be uncommitted


### PR DESCRIPTION
The new System.map facility fails its tests when the JVM is using ZGC. The facility is working fine, but the test checks for the java heap to appear as committed non-shared memory segment, but on ZGC we reserve the memory as shared memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335643](https://bugs.openjdk.org/browse/JDK-8335643): serviceability/dcmd/vm tests fail for ZGC after JDK-8322475 (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20034/head:pull/20034` \
`$ git checkout pull/20034`

Update a local copy of the PR: \
`$ git checkout pull/20034` \
`$ git pull https://git.openjdk.org/jdk.git pull/20034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20034`

View PR using the GUI difftool: \
`$ git pr show -t 20034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20034.diff">https://git.openjdk.org/jdk/pull/20034.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20034#issuecomment-2210161216)