### PR TITLE
8334890: Missing unconditional cross modifying fence in nmethod entry barriers

### DIFF
--- a/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
+++ b/src/hotspot/share/gc/shared/barrierSetNMethod.cpp
@@ -172,13 +172,9 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
   nmethod* nm = cb->as_nmethod();
   BarrierSetNMethod* bs_nm = BarrierSet::barrier_set()->barrier_set_nmethod();
 
-  if (!bs_nm->is_armed(nm)) {
-    return 0;
-  }
-
-  assert(!nm->is_osr_method(), "Should not reach here");
   // Called upon first entry after being armed
   bool may_enter = bs_nm->nmethod_entry_barrier(nm);
+  assert(!nm->is_osr_method() || may_enter, "OSR nmethods should always be entrant after migration");
 
   // In case a concurrent thread disarmed the nmethod, we need to ensure the new instructions
   // are made visible, by using a cross modify fence. Note that this is synchronous cross modifying
@@ -188,11 +184,11 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
   // it can be made conditional on the nmethod_patching_type.
   OrderAccess::cross_modify_fence();
 
-  // Diagnostic option to force deoptimization 1 in 3 times. It is otherwise
+  // Diagnostic option to force deoptimization 1 in 10 times. It is otherwise
   // a very rare event.
-  if (DeoptimizeNMethodBarriersALot) {
+  if (DeoptimizeNMethodBarriersALot && !nm->is_osr_method()) {
     static volatile uint32_t counter=0;
-    if (Atomic::add(&counter, 1u) % 3 == 0) {
+    if (Atomic::add(&counter, 1u) % 10 == 0) {
       may_enter = false;
     }
   }
@@ -205,15 +201,6 @@ int BarrierSetNMethod::nmethod_stub_entry_barrier(address* return_address_ptr) {
 }
 
 bool BarrierSetNMethod::nmethod_osr_entry_barrier(nmethod* nm) {
-  // This check depends on the invariant that all nmethods that are deoptimized / made not entrant
-  // are NOT disarmed.
-  // This invariant is important because a method can be deoptimized after the method have been
-  // resolved / looked up by OSR by another thread. By not deoptimizing them we guarantee that
-  // a deoptimized method will always hit the barrier and come to the same conclusion - deoptimize
-  if (!is_armed(nm)) {
-    return true;
-  }
-
   assert(nm->is_osr_method(), "Should not reach here");
   log_trace(nmethod, barrier)("Running osr nmethod entry barrier: " PTR_FORMAT, p2i(nm));
   bool result = nmethod_entry_barrier(nm);


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334890](https://bugs.openjdk.org/browse/JDK-8334890): Missing unconditional cross modifying fence in nmethod entry barriers (**Bug** - P3)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20036/head:pull/20036` \
`$ git checkout pull/20036`

Update a local copy of the PR: \
`$ git checkout pull/20036` \
`$ git pull https://git.openjdk.org/jdk.git pull/20036/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20036`

View PR using the GUI difftool: \
`$ git pr show -t 20036`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20036.diff">https://git.openjdk.org/jdk/pull/20036.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20036#issuecomment-2209066171)