### PR TITLE
8207908: JMXStatusTest.java fails assertion intermittently

### DIFF
--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public:
   const char* cmd_addr() const    { return _cmd; }
   size_t cmd_len() const          { return _cmd_len; }
   bool is_empty() const           { return _cmd_len == 0; }
-  bool is_executable() const      { return is_empty() || _cmd[0] != '#'; }
+  bool is_executable() const      { return !is_empty() && _cmd[0] != '#'; }
   bool is_stop() const            { return !is_empty() && strncmp("stop", _cmd, _cmd_len) == 0; }
 };
 

--- a/src/hotspot/share/services/diagnosticFramework.hpp
+++ b/src/hotspot/share/services/diagnosticFramework.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,7 @@ public:
   const char* cmd_addr() const    { return _cmd; }
   size_t cmd_len() const          { return _cmd_len; }
   bool is_empty() const           { return _cmd_len == 0; }
-  bool is_executable() const      { return !is_empty() && _cmd[0] != '#'; }
+  bool is_executable() const      { return is_empty() || _cmd[0] != '#'; }
   bool is_stop() const            { return !is_empty() && strncmp("stop", _cmd, _cmd_len) == 0; }
 };
 

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,8 +88,6 @@ abstract public class JMXStatusTest {
         args.addAll(getCustomVmArgs());
         args.add(TEST_APP_NAME);
         testAppPb = ProcessTools.createTestJavaProcessBuilder(args);
-
-        jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }
 
     @BeforeMethod
@@ -98,6 +96,7 @@ abstract public class JMXStatusTest {
             TEST_APP_NAME, testAppPb,
             (Predicate<String>)l->l.trim().equals("main enter")
         );
+        jcmd = new ManagementAgentJcmd(testApp, false);
     }
 
     @AfterMethod

--- a/test/jdk/sun/management/jmxremote/startstop/ManagementAgentJcmd.java
+++ b/test/jdk/sun/management/jmxremote/startstop/ManagementAgentJcmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,11 +47,11 @@ final class ManagementAgentJcmd {
     private static final String CMD_STATUS = "ManagementAgent.status";
     private static final String CMD_PRINTPERF = "PerfCounter.print";
 
-    private final String id;
+    private final long pid;
     private final boolean verbose;
 
-    public ManagementAgentJcmd(String targetApp, boolean verbose) {
-        this.id = targetApp;
+    public ManagementAgentJcmd(Process targetApp, boolean verbose) {
+        this.pid = targetApp.pid();
         this.verbose = verbose;
     }
 
@@ -174,7 +174,7 @@ final class ManagementAgentJcmd {
      * @throws InterruptedException
      */
     private String jcmd(Consumer<String> c, String ... command) throws IOException, InterruptedException {
-        return jcmd(id, c, command);
+        return jcmd(Long.toString(pid), c, command);
     }
 
     /**


### PR DESCRIPTION
Test failure, reproducible running batches of tests at the same time on the same machine.
The use of "jcmd TestApp ..." gathers more output than the test wants and than its regexes can handle.

Using the PID to match only the wanted process, my batches of 25 tests at the same time run in parallel without failure.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207908](https://bugs.openjdk.org/browse/JDK-8207908): JMXStatusTest.java fails assertion intermittently (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20037/head:pull/20037` \
`$ git checkout pull/20037`

Update a local copy of the PR: \
`$ git checkout pull/20037` \
`$ git pull https://git.openjdk.org/jdk.git pull/20037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20037`

View PR using the GUI difftool: \
`$ git pr show -t 20037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20037.diff">https://git.openjdk.org/jdk/pull/20037.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20037#issuecomment-2209163608)