### PR TITLE
8335711: G1: Remove unused bot_updates argument in G1AllocRegion constructor

### DIFF
--- a/src/hotspot/share/gc/g1/g1AllocRegion.cpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.cpp
@@ -236,9 +236,7 @@ void G1AllocRegion::trace(const char* str, size_t min_word_size, size_t desired_
 }
 #endif // PRODUCT
 
-G1AllocRegion::G1AllocRegion(const char* name,
-                             bool bot_updates,
-                             uint node_index)
+G1AllocRegion::G1AllocRegion(const char* name, uint node_index)
   : _alloc_region(nullptr),
     _count(0),
     _name(name),

--- a/src/hotspot/share/gc/g1/g1AllocRegion.hpp
+++ b/src/hotspot/share/gc/g1/g1AllocRegion.hpp
@@ -118,7 +118,7 @@ protected:
   virtual G1HeapRegion* allocate_new_region(size_t word_size) = 0;
   virtual void retire_region(G1HeapRegion* alloc_region) = 0;
 
-  G1AllocRegion(const char* name, bool bot_updates, uint node_index);
+  G1AllocRegion(const char* name, uint node_index);
 
 public:
   static void setup(G1CollectedHeap* g1h, G1HeapRegion* dummy_region);
@@ -188,7 +188,7 @@ protected:
   size_t retire(bool fill_up) override;
 public:
   MutatorAllocRegion(uint node_index)
-    : G1AllocRegion("Mutator Alloc Region", false /* bot_updates */, node_index),
+    : G1AllocRegion("Mutator Alloc Region", node_index),
       _wasted_bytes(0),
       _retained_alloc_region(nullptr) { }
 
@@ -228,9 +228,9 @@ protected:
 
   size_t retire(bool fill_up) override;
 
-  G1GCAllocRegion(const char* name, bool bot_updates, G1EvacStats* stats,
+  G1GCAllocRegion(const char* name, G1EvacStats* stats,
                   G1HeapRegionAttr::region_type_t purpose, uint node_index = G1NUMA::AnyNodeIndex)
-    : G1AllocRegion(name, bot_updates, node_index), _used_bytes_before(0), _stats(stats), _purpose(purpose) {
+    : G1AllocRegion(name, node_index), _used_bytes_before(0), _stats(stats), _purpose(purpose) {
     assert(stats != nullptr, "Must pass non-null PLAB statistics");
   }
 public:
@@ -243,13 +243,13 @@ public:
 class SurvivorGCAllocRegion : public G1GCAllocRegion {
 public:
   SurvivorGCAllocRegion(G1EvacStats* stats, uint node_index)
-  : G1GCAllocRegion("Survivor GC Alloc Region", false /* bot_updates */, stats, G1HeapRegionAttr::Young, node_index) { }
+  : G1GCAllocRegion("Survivor GC Alloc Region", stats, G1HeapRegionAttr::Young, node_index) { }
 };
 
 class OldGCAllocRegion : public G1GCAllocRegion {
 public:
   OldGCAllocRegion(G1EvacStats* stats)
-  : G1GCAllocRegion("Old GC Alloc Region", true /* bot_updates */, stats, G1HeapRegionAttr::Old) { }
+  : G1GCAllocRegion("Old GC Alloc Region", stats, G1HeapRegionAttr::Old) { }
 };
 
 #endif // SHARE_GC_G1_G1ALLOCREGION_HPP


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335711](https://bugs.openjdk.org/browse/JDK-8335711): G1: Remove unused bot_updates argument in G1AllocRegion constructor (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20038/head:pull/20038` \
`$ git checkout pull/20038`

Update a local copy of the PR: \
`$ git checkout pull/20038` \
`$ git pull https://git.openjdk.org/jdk.git pull/20038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20038`

View PR using the GUI difftool: \
`$ git pr show -t 20038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20038.diff">https://git.openjdk.org/jdk/pull/20038.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20038#issuecomment-2209161968)