### PR TITLE
8335614: RISC-V: make multiple v regs in one v reg group explicit in macroAssembler

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1147,6 +1147,10 @@ enum VTA {
   ta, // agnostic
 };
 
+static Assembler::LMUL vgrp_to_lmul(VectorRegisterGroup vgrp) {
+  return m2; // just for temporary demo
+}
+
 static Assembler::SEW elembytes_to_sew(int ebytes) {
   assert(ebytes > 0 && ebytes <= 8, "unsupported element size");
   return (Assembler::SEW) exact_log2(ebytes);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2355,16 +2355,36 @@ void C2_MacroAssembler::element_compare(Register a1, Register a2, Register resul
 }
 
 void C2_MacroAssembler::string_equals_v(Register a1, Register a2, Register result, Register cnt,
-                                        VectorRegisterGroup vg1, VectorRegisterGroup vg2) {
+                                        VectorRegisterGroup vg1, VectorRegisterGroup vg2,
+                                         VectorRegister v6, VectorRegister vx, VectorRegister vy, VectorRegister vz, VectorRegister v00, VectorRegister v01, VectorRegister v02,
+                                        Register rx, Register ry, Register rz, Register r00, Register r01, Register r02) {
   Label DONE;
   Register tmp1 = t0;
   Register tmp2 = t1;
-
   BLOCK_COMMENT("string_equals_v {");
 
   mv(result, false);
 
   element_compare(a1, a2, result, cnt, tmp1, tmp2, vg1, vg2, vg1, true, DONE);
+
+  vsetvli(ry, rx, Assembler::e32, Assembler::m1);
+  if (true) {
+
+    vlex_v(v6, a1, Assembler::e32);
+    vlex_v(vx, a2, Assembler::e32);
+
+    Register src = a1;
+    Register dsts[] = {rx, ry, rz, r00, r01, r02};
+    VectorRegister vdsts[] = {v6, vx, vy, vz, v00, v01, v02};
+    for (int i = 0; i < sizeof(dsts)/sizeof(Register); i++) {
+      mv(dsts[i], src);
+    }
+    for (int j = 0; j < sizeof(vdsts)/sizeof(VectorRegister); j++) {
+      vlex_v(vdsts[j], src, Assembler::e32);
+    }
+
+  }
+  ld(r02, Address(zr, 0));
 
   bind(DONE);
   BLOCK_COMMENT("} string_equals_v");

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -2330,7 +2330,7 @@ void C2_MacroAssembler::element_compare(Register a1, Register a2, Register resul
   Label loop;
   Assembler::SEW sew = islatin ? Assembler::e8 : Assembler::e16;
   assert(vgrp_to_lmul(vg1) == vgrp_to_lmul(vg2), "sanity");
-  assert(vgrp_to_lmul(vg1) == vgrp_to_lmul(vvgss), "sanity");
+  assert(vgrp_to_lmul(vg1) == vgrp_to_lmul(vgs), "sanity");
   Assembler::LMUL lmul = vgrp_to_lmul(vg1);
   VectorRegister vr1 = vg1.start_vreg();
   VectorRegister vr2 = vg2.start_vreg();

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -35,9 +35,8 @@
   void element_compare(Register r1, Register r2,
                        Register result, Register cnt,
                        Register tmp1, Register tmp2,
-                       VectorRegister vr1, VectorRegister vr2,
-                       VectorRegister vrs,
-                       bool is_latin, Label& DONE, Assembler::LMUL lmul);
+                       VectorRegisterGroup vg1, VectorRegisterGroup vg2, VectorRegisterGroup vgs,
+                       bool is_latin, Label& DONE);
 
   void compress_bits_v(Register dst, Register src, Register mask, bool is_long);
   void expand_bits_v(Register dst, Register src, Register mask, bool is_long);
@@ -191,17 +190,20 @@
   void float_to_float16_v(VectorRegister dst, VectorRegister src, VectorRegister vtmp, Register tmp, uint vector_length);
 
   void string_equals_v(Register r1, Register r2,
-                       Register result, Register cnt1);
+                       Register result, Register cnt1,
+                       VectorRegisterGroup vg1, VectorRegisterGroup vg2);
 
   void arrays_equals_v(Register r1, Register r2,
                        Register result, Register cnt1,
-                       int elem_size);
+                       int elem_size,
+                       VectorRegisterGroup vg1, VectorRegisterGroup vg2);
 
   void string_compare_v(Register str1, Register str2,
                         Register cnt1, Register cnt2,
                         Register result,
                         Register tmp1, Register tmp2,
-                        int encForm);
+                        int encForm,
+                        VectorRegisterGroup vg1, VectorRegisterGroup vg2);
 
   void clear_array_v(Register base, Register cnt);
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -191,7 +191,9 @@
 
   void string_equals_v(Register r1, Register r2,
                        Register result, Register cnt1,
-                       VectorRegisterGroup vg1, VectorRegisterGroup vg2);
+                       VectorRegisterGroup vg1, VectorRegisterGroup vg2,
+                       VectorRegister v6, VectorRegister vx, VectorRegister vy, VectorRegister vz, VectorRegister v00, VectorRegister v01, VectorRegister v02,
+                       Register rx, Register ry, Register rz, Register r00, Register r01, Register r02);
 
   void arrays_equals_v(Register r1, Register r2,
                        Register result, Register cnt1,

--- a/src/hotspot/cpu/riscv/register_riscv.cpp
+++ b/src/hotspot/cpu/riscv/register_riscv.cpp
@@ -29,6 +29,7 @@
 Register::RegisterImpl             all_RegisterImpls      [Register::number_of_registers       + 1];
 FloatRegister::FloatRegisterImpl   all_FloatRegisterImpls [FloatRegister::number_of_registers  + 1];
 VectorRegister::VectorRegisterImpl all_VectorRegisterImpls[VectorRegister::number_of_registers + 1];
+VectorRegisterGroup::VectorRegisterGroupImpl all_VectorRegisterGroupImpls[VectorRegisterGroup::number_of_registers + 1];
 
 const char* Register::RegisterImpl::name() const {
   static const char *const names[number_of_registers] = {
@@ -58,4 +59,12 @@ const char* VectorRegister::VectorRegisterImpl::name() const {
     "v24", "v25", "v26", "v27", "v28", "v29", "v30", "v31"
   };
   return is_valid() ? names[encoding()] : "noreg";
+}
+
+const char* VectorRegisterGroup::VectorRegisterGroupImpl::name() const {
+  static const char *const names[number_of_registers] = {
+    "v2m2", "v4m2", "v4m4"
+  };
+
+  return is_valid() ? names[encoding()] : "vnoreg_grp";
 }

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -372,6 +372,37 @@ constexpr VectorRegister v29    = as_VectorRegister(29);
 constexpr VectorRegister v30    = as_VectorRegister(30);
 constexpr VectorRegister v31    = as_VectorRegister(31);
 
+class VectorRegisterGroup {
+  int _encoding;
+
+  constexpr explicit VectorRegisterGroup(int encoding) : _encoding(encoding) {}
+
+ public:
+  inline friend constexpr VectorRegisterGroup as_VectorRegisterGroup(int encoding);
+
+  constexpr VectorRegisterGroup() : _encoding(-1) {} // vnoreg_grp
+
+  int operator==(const VectorRegisterGroup r) const { return _encoding == r._encoding; }
+  int operator!=(const VectorRegisterGroup r) const { return _encoding != r._encoding; }
+
+  VectorRegister vreg_at(int i) {
+    return vnoreg; // just for temporary demo
+  }
+  VectorRegister start_vreg() {
+    return vreg_at(0);
+  }
+  int group_len() {
+    return 2; // just for temporary demo
+  }
+  // Assembler::LMUL lmul() { return Assembler::m2;}
+};
+
+constexpr VectorRegisterGroup vnoreg_grp = VectorRegisterGroup();
+
+inline constexpr VectorRegisterGroup as_VectorRegisterGroup(int encoding) {
+  return vnoreg_grp; // just for temporary demo
+}
+
 // Need to know the total number of registers of all sorts for SharedInfo.
 // Define a class that exports it.
 class ConcreteRegisterImpl : public AbstractRegisterImpl {

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -378,30 +378,86 @@ class VectorRegisterGroup {
   constexpr explicit VectorRegisterGroup(int encoding) : _encoding(encoding) {}
 
  public:
-  inline friend constexpr VectorRegisterGroup as_VectorRegisterGroup(int encoding);
+  inline constexpr friend VectorRegisterGroup as_VectorRegisterGroup(int encoding);
 
-  constexpr VectorRegisterGroup() : _encoding(-1) {} // vnoreg_grp
+ constexpr VectorRegisterGroup() : _encoding(-1) {
+    assert(false, "must");
+    // tty->print_cr("=========== VectorRegisterGroup()");
+  } // vnoreg_grp
+
+  enum {
+    number_of_registers    = 32,
+    max_slots_per_register = 4
+  };
+
+  class VectorRegisterGroupImpl: public AbstractRegisterImpl {
+    friend class VectorRegisterGroup;
+
+    static constexpr const VectorRegisterGroupImpl* first();
+
+   public:
+    // accessors
+    constexpr int raw_encoding() const { return checked_cast<int>(this - first()); }
+    constexpr int     encoding() const { assert(is_valid(), "invalid register, %d", raw_encoding()); return raw_encoding(); }
+    constexpr bool    is_valid() const { return 0 <= raw_encoding() && raw_encoding() < number_of_registers; }
+
+    // derived registers, offsets, and addresses
+    inline VectorRegisterGroup successor() const;
+
+    VMReg as_VMReg() const;
+
+    const char* name() const;
+  };
 
   int operator==(const VectorRegisterGroup r) const { return _encoding == r._encoding; }
   int operator!=(const VectorRegisterGroup r) const { return _encoding != r._encoding; }
 
-  VectorRegister vreg_at(int i) {
-    return vnoreg; // just for temporary demo
-  }
+  constexpr const VectorRegisterGroupImpl* operator->() const { return VectorRegisterGroupImpl::first() + _encoding; }
+
   VectorRegister start_vreg() {
-    return vreg_at(0);
+    tty->print_cr("=========== start_vreg: %d, %d", _encoding >> 5, _encoding & 0x1f);
+    return as_VectorRegister(_encoding & 0x1f);
   }
+  /*
   int group_len() {
     return 2; // just for temporary demo
-  }
+  }*/
   // Assembler::LMUL lmul() { return Assembler::m2;}
 };
 
-constexpr VectorRegisterGroup vnoreg_grp = VectorRegisterGroup();
+extern VectorRegisterGroup::VectorRegisterGroupImpl all_VectorRegisterGroupImpls[VectorRegisterGroup::number_of_registers + 1] INTERNAL_VISIBILITY;
+
+inline constexpr const VectorRegisterGroup::VectorRegisterGroupImpl* VectorRegisterGroup::VectorRegisterGroupImpl::first() {
+  return all_VectorRegisterGroupImpls + 1;
+}
+
 
 inline constexpr VectorRegisterGroup as_VectorRegisterGroup(int encoding) {
-  return vnoreg_grp; // just for temporary demo
+  // tty->print_cr("=========== as_VectorRegisterGroup: %d", encoding);
+  // encoding -= 32;
+  if (false) {
+    int mi = encoding >> 5;
+    int vi = encoding & 0x1f;
+    if (0 <= vi && vi < VectorRegisterGroup::number_of_registers) {
+      return VectorRegisterGroup(encoding);
+    }
+  } else {
+    if (0 <= encoding && encoding < VectorRegisterGroup::number_of_registers) {
+      return VectorRegisterGroup(encoding);
+    }
+  }
+  return VectorRegisterGroup(-1); // just for temporary demo
 }
+
+constexpr VectorRegisterGroup vnoreg_grp = as_VectorRegisterGroup(-1);
+ // constexpr VectorRegisterGroup v2m2    = as_VectorRegisterGroup((1 << 5) + 2); // (mi << 5) + vi
+ // constexpr VectorRegisterGroup v4m2    = as_VectorRegisterGroup((1 << 5) + 4);
+ // constexpr VectorRegisterGroup v4m4    = as_VectorRegisterGroup((2 << 5) + 4);
+ constexpr VectorRegisterGroup v2m2    = as_VectorRegisterGroup(0);
+ constexpr VectorRegisterGroup v4m2    = as_VectorRegisterGroup(1);
+ constexpr VectorRegisterGroup v4m4    = as_VectorRegisterGroup(1);
+
+
 
 // Need to know the total number of registers of all sorts for SharedInfo.
 // Define a class that exports it.
@@ -411,12 +467,13 @@ class ConcreteRegisterImpl : public AbstractRegisterImpl {
     max_gpr = Register::number_of_registers * Register::max_slots_per_register,
     max_fpr = max_gpr + FloatRegister::number_of_registers * FloatRegister::max_slots_per_register,
     max_vpr = max_fpr + VectorRegister::number_of_registers * VectorRegister::max_slots_per_register,
+    max_vgpr = max_vpr + VectorRegisterGroup::number_of_registers * VectorRegisterGroup::max_slots_per_register,
 
     // A big enough number for C2: all the registers plus flags
     // This number must be large enough to cover REG_COUNT (defined by c2) registers.
     // There is no requirement that any ordering here matches any ordering c2 gives
     // it's optoregs.
-    number_of_registers = max_vpr // gpr/fpr/vpr
+    number_of_registers = max_vgpr // gpr/fpr/vpr
   };
 };
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -897,6 +897,10 @@ reg_class v2_reg(
     V2, V2_H, V2_J, V2_K
 );
 
+reg_class v2_m2_reg(
+    V2, V2_H, V2_J, V2_K, V3, V3_H, V3_J, V3_K
+);
+
 // class for vector register v3
 reg_class v3_reg(
     V3, V3_H, V3_J, V3_K
@@ -905,6 +909,15 @@ reg_class v3_reg(
 // class for vector register v4
 reg_class v4_reg(
     V4, V4_H, V4_J, V4_K
+);
+
+reg_class v4_m2_reg(
+    V4, V4_H, V4_J, V4_K, V5, V5_H, V5_J, V5_K
+);
+
+reg_class v4_m4_reg(
+    V4, V4_H, V4_J, V4_K, V5, V5_H, V5_J, V5_K,
+    V6, V6_H, V6_J, V6_K, V7, V7_H, V7_J, V7_K
 );
 
 // class for vector register v5
@@ -925,6 +938,11 @@ reg_class v7_reg(
 // class for vector register v8
 reg_class v8_reg(
     V8, V8_H, V8_J, V8_K
+);
+
+reg_class v8_m4_reg(
+    V8, V8_H, V8_J, V8_K, V9, V9_H, V9_J, V9_K,
+    V10, V10_H, V10_J, V10_K, V11, V11_H, V11_J, V11_K
 );
 
 // class for vector register v9
@@ -3446,6 +3464,16 @@ operand vReg_V2()
   interface(REG_INTER);
 %}
 
+operand vReg_V2_m2()
+%{
+  constraint(ALLOC_IN_RC(v2_m2_reg));
+  match(VecA);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
 operand vReg_V3()
 %{
   constraint(ALLOC_IN_RC(v3_reg));
@@ -3459,6 +3487,26 @@ operand vReg_V3()
 operand vReg_V4()
 %{
   constraint(ALLOC_IN_RC(v4_reg));
+  match(VecA);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V4_m2()
+%{
+  constraint(ALLOC_IN_RC(v4_m2_reg));
+  match(VecA);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V4_m4()
+%{
+  constraint(ALLOC_IN_RC(v4_m4_reg));
   match(VecA);
   match(vReg);
   op_cost(0);
@@ -3499,6 +3547,16 @@ operand vReg_V7()
 operand vReg_V8()
 %{
   constraint(ALLOC_IN_RC(v8_reg));
+  match(VecA);
+  match(vReg);
+  op_cost(0);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand vReg_V8_m4()
+%{
+  constraint(ALLOC_IN_RC(v8_m4_reg));
   match(VecA);
   match(vReg);
   op_cost(0);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -397,6 +397,12 @@ reg_def V31_H ( SOC, SOC, Op_VecA, 31, v31->as_VMReg()->next()  );
 reg_def V31_J ( SOC, SOC, Op_VecA, 31, v31->as_VMReg()->next(2) );
 reg_def V31_K ( SOC, SOC, Op_VecA, 31, v31->as_VMReg()->next(3) );
 
+
+// reg_def V2_M2    ( SOC, SOC, Op_VecA, 0,  v2m2->as_VMReg()           );
+// reg_def V4_M2    ( SOC, SOC, Op_VecA, 1,  v4m2->as_VMReg()           );
+// reg_def V4_M4    ( SOC, SOC, Op_VecA, 2,  v4m4->as_VMReg()           );
+
+
 // ----------------------------
 // Special Registers
 // ----------------------------
@@ -527,10 +533,17 @@ alloc_class chunk2(
     V28, V28_H, V28_J, V28_K,
     V29, V29_H, V29_J, V29_K,
     V30, V30_H, V30_J, V30_K,
-    V31, V31_H, V31_J, V31_K,
+    V31, V31_H, V31_J, V31_K
+    // ,V2_M2, V4_M2, V4_M4
 );
 
 alloc_class chunk3(RFLAGS);
+
+/*
+alloc_class chunk4(
+    V2_M2, V4_M2, V4_M4
+);
+*/
 
 //----------Architecture Description Register Classes--------------------------
 // Several register classes are automatically defined based upon information in
@@ -865,6 +878,7 @@ reg_class vectora_reg(
     V27, V27_H, V27_J, V27_K,
     V28, V28_H, V28_J, V28_K,
     V29, V29_H, V29_J, V29_K
+    // , V2_M2, V4_M2, V4_M4
 );
 
 // Class for 64 bit register f0
@@ -897,7 +911,7 @@ reg_class v2_reg(
     V2, V2_H, V2_J, V2_K
 );
 
-reg_class v2_m2_reg(
+reg_class v2m2_reg(
     V2, V2_H, V2_J, V2_K, V3, V3_H, V3_J, V3_K
 );
 
@@ -911,11 +925,11 @@ reg_class v4_reg(
     V4, V4_H, V4_J, V4_K
 );
 
-reg_class v4_m2_reg(
+reg_class v4m2_reg(
     V4, V4_H, V4_J, V4_K, V5, V5_H, V5_J, V5_K
 );
 
-reg_class v4_m4_reg(
+reg_class v4m4_reg(
     V4, V4_H, V4_J, V4_K, V5, V5_H, V5_J, V5_K,
     V6, V6_H, V6_J, V6_K, V7, V7_H, V7_J, V7_K
 );
@@ -940,7 +954,7 @@ reg_class v8_reg(
     V8, V8_H, V8_J, V8_K
 );
 
-reg_class v8_m4_reg(
+reg_class v8m4_reg(
     V8, V8_H, V8_J, V8_K, V9, V9_H, V9_J, V9_K,
     V10, V10_H, V10_J, V10_K, V11, V11_H, V11_J, V11_K
 );
@@ -3466,7 +3480,7 @@ operand vReg_V2()
 
 operand vReg_V2_m2()
 %{
-  constraint(ALLOC_IN_RC(v2_m2_reg));
+  constraint(ALLOC_IN_RC(v2m2_reg));
   match(VecA);
   match(vReg);
   op_cost(0);
@@ -3496,7 +3510,7 @@ operand vReg_V4()
 
 operand vReg_V4_m2()
 %{
-  constraint(ALLOC_IN_RC(v4_m2_reg));
+  constraint(ALLOC_IN_RC(v4m2_reg));
   match(VecA);
   match(vReg);
   op_cost(0);
@@ -3506,7 +3520,7 @@ operand vReg_V4_m2()
 
 operand vReg_V4_m4()
 %{
-  constraint(ALLOC_IN_RC(v4_m4_reg));
+  constraint(ALLOC_IN_RC(v4m4_reg));
   match(VecA);
   match(vReg);
   op_cost(0);
@@ -3556,7 +3570,7 @@ operand vReg_V8()
 
 operand vReg_V8_m4()
 %{
-  constraint(ALLOC_IN_RC(v8_m4_reg));
+  constraint(ALLOC_IN_RC(v8m4_reg));
   match(VecA);
   match(vReg);
   op_cost(0);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3558,63 +3558,64 @@ instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
-                         iRegI_R10 result, vReg_V2 v2,
-                         vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, rFlagsReg cr)
+instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt, iRegI_R10 result,
+                         vReg_V2_m2 v2m2, vReg_V4_m2 v4m2, rFlagsReg cr)
 %{
   predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrEquals (Binary str1 str2) cnt));
-  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v2m2, TEMP v4m2, KILL cr);
 
   format %{ "String Equals $str1, $str2, $cnt -> $result\t#@string_equalsL" %}
   ins_encode %{
     // Count is in 8-bit bytes; non-Compact chars are 16 bits.
     __ string_equals_v($str1$$Register, $str2$$Register,
-                       $result$$Register, $cnt$$Register);
+                       $result$$Register, $cnt$$Register,
+                      $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
-                        vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, iRegP_R28 tmp, rFlagsReg cr)
+                        vReg_V2_m2 v2m2, vReg_V4_m2 v4m2, iRegP_R28 tmp, rFlagsReg cr)
 %{
   predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2m2, TEMP v4m2, KILL cr);
 
   format %{ "Array Equals $ary1, ary2 -> $result\t#@array_equalsB // KILL $tmp" %}
   ins_encode %{
     __ arrays_equals_v($ary1$$Register, $ary2$$Register,
-                       $result$$Register, $tmp$$Register, 1);
+                       $result$$Register, $tmp$$Register, 1,
+                       $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
     %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
-                        vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5, iRegP_R28 tmp, rFlagsReg cr)
+                        vReg_V2_m2 v2m2, vReg_V4_m2 v4m2, iRegP_R28 tmp, rFlagsReg cr)
 %{
   predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
-  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2, TEMP v3, TEMP v4, TEMP v5, KILL cr);
+  effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v2m2, TEMP v4m2, KILL cr);
 
   format %{ "Array Equals $ary1, ary2 -> $result\t#@array_equalsC // KILL $tmp" %}
   ins_encode %{
     __ arrays_equals_v($ary1$$Register, $ary2$$Register,
-                       $result$$Register, $tmp$$Register, 2);
+                       $result$$Register, $tmp$$Register, 2,
+                       $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct vstring_compareU_128b(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                          vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                          iRegI_R10 result, vReg_V4_m4 v4m4, vReg_V8_m4 v8m4,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
             MaxVectorSize == 16);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+        TEMP v4m4, TEMP v8m4);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -3622,20 +3623,21 @@ instruct vstring_compareU_128b(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, i
     __ string_compare_v($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register, $result$$Register,
                         $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::UU);
+                        StrIntrinsicNode::UU,
+                        $v4m4$$VectorRegisterGroup, $v8m4$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V2_m2 v2m2, vReg_V4_m2 v4m2,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU &&
             MaxVectorSize > 16);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+        TEMP v2m2, TEMP v4m2);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareU" %}
   ins_encode %{
@@ -3643,65 +3645,67 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
     __ string_compare_v($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register, $result$$Register,
                         $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::UU);
+                        StrIntrinsicNode::UU,
+                        $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                          iRegI_R10 result, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
+                          iRegI_R10 result, vReg_V2_m2 v2m2, vReg_V4_m2 v4m2,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-        TEMP v2, TEMP v3, TEMP v4, TEMP v5);
+        TEMP v2m2, TEMP v4m2);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareL" %}
   ins_encode %{
     __ string_compare_v($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register, $result$$Register,
                         $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::LL);
+                        StrIntrinsicNode::LL,
+                        $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 
 instruct vstring_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                           iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                           iRegI_R10 result, vReg_V4_m4 v4m4, vReg_V8_m4 v8m4,
                            iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-         TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+         TEMP v4m4, TEMP v8m4);
 
   format %{"String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareUL" %}
   ins_encode %{
     __ string_compare_v($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register, $result$$Register,
                         $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::UL);
+                        StrIntrinsicNode::UL,
+                        $v4m4$$VectorRegisterGroup, $v8m4$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}
 instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
-                           iRegI_R10 result, vReg_V4 v4, vReg_V5 v5, vReg_V6 v6, vReg_V7 v7,
-                           vReg_V8 v8, vReg_V9 v9, vReg_V10 v10, vReg_V11 v11,
+                           iRegI_R10 result, vReg_V4_m4 v4m4, vReg_V8_m4 v8m4,
                            iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
   predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result (StrComp (Binary str1 cnt1) (Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
-         TEMP v4, TEMP v5, TEMP v6, TEMP v7, TEMP v8, TEMP v9, TEMP v10, TEMP v11);
+         TEMP v4m4, TEMP v8m4);
 
   format %{ "String Compare $str1, $cnt1, $str2, $cnt2 -> $result\t#@string_compareLU" %}
   ins_encode %{
     __ string_compare_v($str1$$Register, $str2$$Register,
                         $cnt1$$Register, $cnt2$$Register, $result$$Register,
                         $tmp1$$Register, $tmp2$$Register,
-                        StrIntrinsicNode::LU);
+                        StrIntrinsicNode::LU,
+                        $v4m4$$VectorRegisterGroup, $v8m4$$VectorRegisterGroup);
   %}
   ins_pipe(pipe_class_memory);
 %}

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -3558,19 +3558,25 @@ instruct vsqrt_fp_masked(vReg dst_src, vRegMask_V0 v0) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt, iRegI_R10 result,
-                         vReg_V2_m2 v2m2, vReg_V4_m2 v4m2, rFlagsReg cr)
+instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt, iRegI_R10 result, iRegP_R28 tx28, iRegP_R30 tx30,
+                         vReg_V2_m2 v2m2, vReg_V4_m2 v4m2,
+                          vReg_V6 v1, vReg vx, vReg vy, vReg vz, vReg v00, vReg v01, vReg v02,
+                         iRegLNoSp rx, iRegLNoSp ry, iRegLNoSp rz, iRegLNoSp r0, iRegLNoSp r1, iRegLNoSp r2, rFlagsReg cr)
 %{
   predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrEquals (Binary str1 str2) cnt));
-  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v2m2, TEMP v4m2, KILL cr);
+  effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, TEMP v2m2, TEMP v4m2, TEMP tx28, TEMP tx30,
+         TEMP v1, TEMP vx, TEMP vy, TEMP vz, TEMP v00, TEMP v01, TEMP v02,
+         TEMP rx, TEMP ry, TEMP rz, TEMP r0, TEMP r1, TEMP r2, KILL cr);
 
   format %{ "String Equals $str1, $str2, $cnt -> $result\t#@string_equalsL" %}
   ins_encode %{
     // Count is in 8-bit bytes; non-Compact chars are 16 bits.
     __ string_equals_v($str1$$Register, $str2$$Register,
                        $result$$Register, $cnt$$Register,
-                      $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup);
+                       $v2m2$$VectorRegisterGroup, $v4m2$$VectorRegisterGroup,
+                       $v1$$VectorRegister, $vx$$VectorRegister, $vy$$VectorRegister, $vz$$VectorRegister, $v00$$VectorRegister, $v01$$VectorRegister, $v02$$VectorRegister,
+                       $rx$$Register, $ry$$Register, $rz$$Register, $r0$$Register, $r1$$Register, $r2$$Register);
   %}
   ins_pipe(pipe_class_memory);
 %}

--- a/src/hotspot/cpu/riscv/vmreg_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/vmreg_riscv.inline.hpp
@@ -40,4 +40,9 @@ inline VMReg VectorRegister::VectorRegisterImpl::as_VMReg() const {
                              ConcreteRegisterImpl::max_fpr);
 }
 
+inline VMReg VectorRegisterGroup::VectorRegisterGroupImpl::as_VMReg() const {
+  return VMRegImpl::as_VMReg((encoding() * VectorRegisterGroup::max_slots_per_register) +
+                             ConcreteRegisterImpl::max_vpr);
+}
+
 #endif // CPU_RISCV_VM_VMREG_RISCV_INLINE_HPP

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -173,7 +173,7 @@ int RegisterForm::RegMask_Size() {
   // is something like 90+ parameters.
   // Add a few (3 words == 96 bits) for incoming & outgoing arguments to calls.
   // Round up to the next doubleword size.
-  return (words_for_regs + 3 + 1) & ~1;
+  return (words_for_regs + 30 + 1) & ~1;
 }
 
 void RegisterForm::dump() {                  // Debug printer

--- a/src/hotspot/share/adlc/output_c.cpp
+++ b/src/hotspot/share/adlc/output_c.cpp
@@ -2358,6 +2358,10 @@ private:
     if (strcmp(rep_var,"$VectorRegister") == 0)   return "as_VectorRegister";
     if (strcmp(rep_var,"$VectorSRegister") == 0)  return "as_VectorSRegister";
 #endif
+#if defined(RISCV64)
+    if (strcmp(rep_var,"$VectorRegister") == 0)   return "as_VectorRegister";
+    if (strcmp(rep_var,"$VectorRegisterGroup") == 0)   return "as_VectorRegisterGroup";
+#endif
 #if defined(AARCH64)
     if (strcmp(rep_var,"$PRegister") == 0)  return "as_PRegister";
 #endif

--- a/src/hotspot/share/opto/c2compiler.cpp
+++ b/src/hotspot/share/opto/c2compiler.cpp
@@ -82,9 +82,11 @@ bool C2Compiler::init_c2_runtime() {
 
   for( OptoReg::Name i=OptoReg::Name(0); i<OptoReg::Name(REG_COUNT); i = OptoReg::add(i,1) ) {
     VMReg r = OptoReg::as_VMReg(i);
+    tty->print_cr ("============: %s, %d, %d", r->name(), i, REG_COUNT);
     if (r->is_valid()) {
       OptoReg::vm2opto[r->value()] = i;
     }
+    tty->print_cr (">>>>>");
   }
 
   DEBUG_ONLY( Node::init_NodeProperty(); )

--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -134,6 +134,20 @@ public:
     return ::as_VectorSRegister(reg(ra_, node, idx));
   }
 #endif
+#if defined(RISCV64)
+  VectorRegister as_VectorRegister(PhaseRegAlloc *ra_, const Node *node) const {
+    return ::as_VectorRegister(reg(ra_, node));
+  }
+  VectorRegister as_VectorRegister(PhaseRegAlloc *ra_, const Node *node, int idx) const {
+    return ::as_VectorRegister(reg(ra_, node, idx));
+  }
+  VectorRegisterGroup as_VectorRegisterGroup(PhaseRegAlloc *ra_, const Node *node) const {
+    return ::as_VectorRegisterGroup(reg(ra_, node));
+  }
+  VectorRegisterGroup as_VectorRegisterGroup(PhaseRegAlloc *ra_, const Node *node, int idx) const {
+    return ::as_VectorRegisterGroup(reg(ra_, node, idx));
+  }
+#endif
 #if defined(AARCH64)
   PRegister as_PRegister(PhaseRegAlloc* ra_, const Node* node) const {
     return ::as_PRegister(reg(ra_, node));

--- a/src/hotspot/share/opto/regmask.cpp
+++ b/src/hotspot/share/opto/regmask.cpp
@@ -323,6 +323,8 @@ bool RegMask::is_aligned_sets(const unsigned int size) const {
       uintptr_t bit = uintptr_t(1) << find_lowest_bit(bits);
       // Low bit is not odd means its mis-aligned.
       if ((bit & low_bits_mask) == 0) {
+        print();
+        assert(false, "_lwm: %d, _hwm: %d, i: %d, bits: %ld, bit: %ld", _lwm, _hwm, i, bits, bit);
         return false;
       }
       // Do extra work since (bit << size) may overflow.
@@ -330,6 +332,8 @@ bool RegMask::is_aligned_sets(const unsigned int size) const {
       uintptr_t set = hi_bit + ((hi_bit-1) & ~(bit-1));
       // Check for aligned adjacent bits in this set
       if ((bits & set) != set) {
+        print();
+        assert(false, "_RM_UP[2]: %ld, _RM_UP[3]: %ld, _lwm: %d, _hwm: %d, i: %d, bits: %ld, bit: %ld, hi_bit: %ld, set: %ld", _RM_UP[2], _RM_UP[3], _lwm, _hwm, i, bits, bit, hi_bit, set);
         return false;
       }
       bits -= set;  // Remove this set

--- a/src/hotspot/share/opto/regmask.hpp
+++ b/src/hotspot/share/opto/regmask.hpp
@@ -296,7 +296,7 @@ class RegMask {
   void Insert(OptoReg::Name reg) {
     assert(reg != OptoReg::Bad, "sanity");
     assert(reg != OptoReg::Special, "sanity");
-    assert(reg < CHUNK_SIZE, "sanity");
+    assert(reg < CHUNK_SIZE, "sanity, %d, %d, %d, %d", reg, CHUNK_SIZE, _RM_SIZE, BitsPerWord);
     assert(valid_watermarks(), "pre-condition");
     unsigned r = (unsigned)reg;
     unsigned index = r >> _LogWordBits;


### PR DESCRIPTION
draft prototype.

This is the prototype version, just want to get some feedback about the interface & design, i.e. what it looks like, rather than a normal review (Of course, if you have any concerns about its implementation, also welcome to point it out in advance.).
If we are happy with this interface, I will investigate further and implement it.
BTW, currently this prototype only compiles successfully, can not run yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335614](https://bugs.openjdk.org/browse/JDK-8335614): RISC-V: make multiple v regs in one v reg group explicit in macroAssembler (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20040/head:pull/20040` \
`$ git checkout pull/20040`

Update a local copy of the PR: \
`$ git checkout pull/20040` \
`$ git pull https://git.openjdk.org/jdk.git pull/20040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20040`

View PR using the GUI difftool: \
`$ git pr show -t 20040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20040.diff">https://git.openjdk.org/jdk/pull/20040.diff</a>

</details>
