### PR TITLE
8335727: since-checker: Add `@since` tags to ClassFile::transformClass and CodeBuilder

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -440,6 +440,8 @@ public sealed interface ClassFile
      * @param model the class model to transform
      * @param transform the transform
      * @return the bytes of the new class
+     *
+     * @since 24
      */
     default byte[] transformClass(ClassModel model, ClassTransform transform) {
         return transformClass(model, model.thisClass(), transform);
@@ -456,6 +458,8 @@ public sealed interface ClassFile
      * @param newClassName new class name
      * @param transform the transform
      * @return the bytes of the new class
+     *
+     * @since 24
      */
     default byte[] transformClass(ClassModel model, ClassDesc newClassName, ClassTransform transform) {
         return transformClass(model, TemporaryConstantPool.INSTANCE.classEntry(newClassName), transform);
@@ -479,6 +483,8 @@ public sealed interface ClassFile
      * @param newClassName new class name
      * @param transform the transform
      * @return the bytes of the new class
+     *
+     * @since 24
      */
     byte[] transformClass(ClassModel model, ClassEntry newClassName, ClassTransform transform);
 

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -1640,6 +1640,7 @@ public sealed interface CodeBuilder
      * Generate an instruction to branch if reference is not null
      * @param target the branch target
      * @return this builder
+     * @since 24
      */
     default CodeBuilder ifnonnull(Label target) {
         return branch(Opcode.IFNONNULL, target);
@@ -1649,6 +1650,7 @@ public sealed interface CodeBuilder
      * Generate an instruction to branch if reference is null
      * @param target the branch target
      * @return this builder
+     * @since 24
      */
     default CodeBuilder ifnull(Label target) {
         return branch(Opcode.IFNULL, target);


### PR DESCRIPTION
Please review this simple doc only change.
Some methods in ClassFile API were renamed recently as part of [JDK-8335290](https://bugs.openjdk.org/browse/JDK-8335290) and [JDK-8335110](https://bugs.openjdk.org/browse/JDK-8335110) and need to have `@since 24`, as they are essentially new methods.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335727](https://bugs.openjdk.org/browse/JDK-8335727): since-checker: Add `@<!---->since` tags to ClassFile::transformClass and CodeBuilder (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20041/head:pull/20041` \
`$ git checkout pull/20041`

Update a local copy of the PR: \
`$ git checkout pull/20041` \
`$ git pull https://git.openjdk.org/jdk.git pull/20041/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20041`

View PR using the GUI difftool: \
`$ git pr show -t 20041`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20041.diff">https://git.openjdk.org/jdk/pull/20041.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20041#issuecomment-2209422272)