### PR TITLE
8335730: JFR: Clean up jdk.jfr

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedClass.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public final class RecordedClass extends RecordedObject {
      * @see java.lang.reflect.Modifier
      */
     public int getModifiers() {
-        return getTyped("modifiers", Integer.class, -1);
+        return getTyped("modifiers", Integer.class, INTEGER_MINUS_ONE);
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedFrame.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public final class RecordedFrame extends RecordedObject {
      * @return byte code index, or {@code -1} if doesn't exist
      */
     public int getBytecodeIndex() {
-        return getTyped("bytecodeIndex", Integer.class, Integer.valueOf(-1));
+        return getTyped("bytecodeIndex", Integer.class, INTEGER_MINUS_ONE);
     }
 
     /**
@@ -75,7 +75,7 @@ public final class RecordedFrame extends RecordedObject {
      * @return the line number, or {@code -1} if doesn't exist
      */
     public int getLineNumber() {
-        return getTyped("lineNumber", Integer.class, Integer.valueOf(-1));
+        return getTyped("lineNumber", Integer.class, INTEGER_MINUS_ONE);
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedMethod.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -94,7 +94,7 @@ public final class RecordedMethod extends RecordedObject {
      * @see RecordedFrame#isJavaFrame
      */
     public int getModifiers() {
-        return getTyped("modifiers", Integer.class, Integer.valueOf(0));
+        return getTyped("modifiers", Integer.class, INTEGER_ZERO);
     }
 
     /**

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,6 +154,9 @@ public sealed class RecordedObject
 
     private static final record UnsignedValue(Object value) {
     }
+    static final Integer INTEGER_MINUS_ONE = Integer.valueOf(-1);
+    static final Integer INTEGER_ZERO = Integer.valueOf(0);
+    static final Long LONG_MINUS_ONE = Long.valueOf(-1L);
 
     final Object[] objects;
     final ObjectContext objectContext;

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public final class RecordedThread extends RecordedObject {
         if (isVirtual()) {
             return -1L;
         }
-        Long l = getTyped("osThreadId", Long.class, -1L);
+        Long l = getTyped("osThreadId", Long.class, LONG_MINUS_ONE);
         return l.longValue();
     }
 
@@ -92,7 +92,7 @@ public final class RecordedThread extends RecordedObject {
      * @see java.lang.Thread#threadId()
      */
     public long getJavaThreadId() {
-        Long l = getTyped("javaThreadId", Long.class, -1L);
+        Long l = getTyped("javaThreadId", Long.class, LONG_MINUS_ONE);
         long id = l.longValue();
         return id == 0 ? -1L : id;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/AbstractBufferStatisticsEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/AbstractBufferStatisticsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@ import jdk.internal.misc.VM;
 import jdk.jfr.*;
 
 @Category({ "Java Application", "Statistics" })
-public abstract class AbstractBufferStatisticsEvent extends AbstractPeriodicEvent {
+abstract class AbstractBufferStatisticsEvent extends AbstractPeriodicEvent {
 
     protected AbstractBufferStatisticsEvent(BufferPool bufferPool) {
         count = bufferPool.getCount();

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveRecordingEvent.java
@@ -29,7 +29,6 @@ import jdk.jfr.Category;
 import jdk.jfr.Label;
 import jdk.jfr.DataAmount;
 import jdk.jfr.Name;
-import jdk.jfr.StackTrace;
 import jdk.jfr.Timespan;
 import jdk.jfr.Timestamp;
 import jdk.jfr.internal.RemoveFields;

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ActiveSettingEvent.java
@@ -28,7 +28,6 @@ package jdk.jfr.events;
 import jdk.jfr.Category;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
-import jdk.jfr.StackTrace;
 import jdk.jfr.internal.RemoveFields;
 import jdk.jfr.internal.Type;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/events/ExceptionStatisticsEvent.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/events/ExceptionStatisticsEvent.java
@@ -29,7 +29,6 @@ import jdk.jfr.Category;
 import jdk.jfr.Description;
 import jdk.jfr.Label;
 import jdk.jfr.Name;
-import jdk.jfr.StackTrace;
 import jdk.jfr.internal.MirrorEvent;
 import jdk.jfr.internal.RemoveFields;
 import jdk.jfr.internal.Type;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventControl.java
@@ -46,7 +46,6 @@ import jdk.jfr.StackTrace;
 import jdk.jfr.Threshold;
 import jdk.jfr.events.ActiveSettingEvent;
 import jdk.jfr.events.StackFilter;
-import jdk.jfr.internal.JVM;
 import jdk.jfr.internal.settings.CutoffSetting;
 import jdk.jfr.internal.settings.EnabledSetting;
 import jdk.jfr.internal.settings.LevelSetting;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -44,8 +44,6 @@ import jdk.jfr.Event;
 import jdk.jfr.EventType;
 import jdk.jfr.Name;
 import jdk.jfr.Period;
-import jdk.jfr.StackTrace;
-import jdk.jfr.Threshold;
 import jdk.jfr.ValueDescriptor;
 import jdk.jfr.internal.consumer.RepositoryFiles;
 import jdk.jfr.internal.event.EventConfiguration;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/OldObjectSample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import jdk.jfr.Enabled;
 import jdk.jfr.RecordingState;
 import jdk.jfr.internal.settings.CutoffSetting;
 import jdk.jfr.internal.test.WhiteBox;
-import jdk.jfr.internal.util.Utils;
 
 // The Old Object event could have been implemented as a periodic event, but
 // due to chunk rotations and how settings are calculated when multiple recordings

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/RepositoryChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.channels.ReadableByteChannel;
 import java.time.Instant;
-import java.time.Period;
-import java.time.Duration;
 import java.util.Comparator;
-import java.util.Optional;
 
 import jdk.jfr.internal.SecuritySupport.SafePath;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ShutdownHook.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ShutdownHook.java
@@ -25,14 +25,12 @@
 
 package jdk.jfr.internal;
 
-import java.io.IOException;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 
 import jdk.jfr.RecordingState;
-import jdk.jfr.internal.util.Utils;
 
 /**
  * Class responsible for dumping recordings on exit

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/QueryRecording.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/QueryRecording.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package jdk.jfr.internal.dcmd;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -37,12 +36,8 @@ import jdk.jfr.internal.PlatformRecorder;
 import jdk.jfr.internal.PrivateAccess;
 import jdk.jfr.internal.RepositoryChunk;
 import jdk.jfr.internal.query.Configuration;
-import jdk.jfr.internal.query.QueryPrinter;
-import jdk.jfr.internal.query.ViewPrinter;
 import jdk.jfr.internal.query.Configuration.Truncate;
 import jdk.jfr.internal.util.UserDataException;
-import jdk.jfr.internal.util.UserSyntaxException;
-import jdk.jfr.internal.util.Output;
 
 /**
  * Helper class that holds recording chunks alive during a query. It also helps

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ public final class JFC {
     public static String formatException(String prefix, Exception e, String input) {
         String message = prefix + " " + JFC.exceptionToVerb(e) + " file '" + input + "'";
         String details = e.getMessage();
-        if (e instanceof JFCModelException m) {
+        if (e instanceof JFCModelException) {
             return message +  ". " + details;
         }
         if (e instanceof ParseException && !details.isEmpty()) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ final class XmlSetting extends XmlElement {
     @Override
     final void setContent(String value) {
         super.setContent(value);
-        if (getParent() instanceof XmlEvent event) {
+        if (getParent() instanceof XmlEvent) {
             SettingsLog.log(this, value);
         }
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Row.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/Row.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,6 @@ final class Row {
 
     @Override
     public String toString() {
-        return Arrays.asList(values).toString();
+        return Arrays.toString(values);
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,7 @@
  */
 package jdk.jfr.internal.query;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.function.Predicate;
 
 import jdk.jfr.internal.query.Query.OrderElement;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/LevelSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/LevelSetting.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.jfr.internal.Type;
 @MetadataDefinition
 @Label("Level")
 @Name(Type.SETTINGS_PREFIX + "Level")
-public class LevelSetting extends JDKSettingControl {
+public final class LevelSetting extends JDKSettingControl {
     private final PlatformEventType eventType;
     private final List<String> levels;
     private String value;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Disassemble.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/Disassemble.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -223,9 +223,9 @@ final class Disassemble extends Command {
                 Path p = directory.resolve(formattedFilename);
                 File splittedFile = p.toFile();
                 println("Writing " + splittedFile + " ... " + bytes.length);
-                FileOutputStream fos = new FileOutputStream(splittedFile);
-                fos.write(bytes);
-                fos.close();
+                try (var fos = new FileOutputStream(splittedFile)) {
+                    fos.write(bytes);
+                }
             }
         } catch (IOException ioe) {
             throw new UserDataException("i/o error writing file " + file);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/PrettyWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.StringJoiner;
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/View.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/View.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.util.Deque;
 import java.util.List;
 
 import jdk.jfr.consumer.EventStream;
-import jdk.jfr.internal.util.Columnizer;
 import jdk.jfr.internal.query.ViewPrinter;
 import jdk.jfr.internal.query.Configuration;
 import jdk.jfr.internal.query.Configuration.Truncate;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-public class ValueParser {
+public final class ValueParser {
     private static final String INFINITY = "infinity";
 
     public static long parseTimespanWithInfinity(String s) {


### PR DESCRIPTION
Could I have review of a PR that:
- remove unused imports
- remove unused variables in instanceof
- use constants instead Integer.valueOf(-1) or Long.valueOf(0L)
- add final modifier where missing
- prefer package protected classes over public
- use try-with-resources
- use Arrays.toString(...) instead of Arrays.asList(...).toString();

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335730](https://bugs.openjdk.org/browse/JDK-8335730): JFR: Clean up jdk.jfr (**Enhancement** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20042/head:pull/20042` \
`$ git checkout pull/20042`

Update a local copy of the PR: \
`$ git checkout pull/20042` \
`$ git pull https://git.openjdk.org/jdk.git pull/20042/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20042`

View PR using the GUI difftool: \
`$ git pr show -t 20042`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20042.diff">https://git.openjdk.org/jdk/pull/20042.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20042#issuecomment-2209600046)