### PR TITLE
8335632: jdk/jfr/api/consumer/streaming/TestJVMExit.java failed with "Process [...] is no longer alive"

### DIFF
--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
@@ -34,7 +34,7 @@ import jdk.jfr.consumer.EventStream;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr jdk.attach java.base/jdk.internal.misc
- * @build jdk.jfr.api.consumer.streaming.Application
+ * @build jdk.jfr.api.consumer.streaming.TestProcess
  *
  * @run main/othervm -Dsun.tools.attach.attachTimeout=100000 jdk.jfr.api.consumer.streaming.TestJVMExit
  */

--- a/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
+++ b/test/jdk/jdk/jfr/api/consumer/streaming/TestJVMExit.java
@@ -34,12 +34,29 @@ import jdk.jfr.consumer.EventStream;
  * @requires vm.hasJFR
  * @library /test/lib /test/jdk
  * @modules jdk.jfr jdk.attach java.base/jdk.internal.misc
+ * @build jdk.jfr.api.consumer.streaming.Application
  *
  * @run main/othervm -Dsun.tools.attach.attachTimeout=100000 jdk.jfr.api.consumer.streaming.TestJVMExit
  */
 public class TestJVMExit {
 
     public static void main(String... args) throws Exception {
+        while (true) {
+            try {
+                testExit();
+                return;
+            } catch (RuntimeException e) {
+                String message = String.valueOf(e.getMessage());
+                // If the test application crashes during startup, retry.
+                if (!message.contains("is no longer alive")) {
+                    throw e;
+                }
+                System.out.println("Application not alive when trying to get repository. Retrying.");
+            }
+        }
+    }
+
+    private static void testExit() throws Exception {
         try (TestProcess process = new TestProcess("exit-application")) {
             AtomicInteger eventCounter = new AtomicInteger();
             try (EventStream es = EventStream.openRepository(process.getRepository())) {


### PR DESCRIPTION
Could I have a review of a test fix?

Testing: 100 * jdk/jdk/jfr/consumer/streaming/TestJVMExit.java

Thanks.
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335632](https://bugs.openjdk.org/browse/JDK-8335632): jdk/jfr/api/consumer/streaming/TestJVMExit.java failed with "Process [...] is no longer alive" (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20043/head:pull/20043` \
`$ git checkout pull/20043`

Update a local copy of the PR: \
`$ git checkout pull/20043` \
`$ git pull https://git.openjdk.org/jdk.git pull/20043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20043`

View PR using the GUI difftool: \
`$ git pr show -t 20043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20043.diff">https://git.openjdk.org/jdk/pull/20043.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20043#issuecomment-2209601419)