### PR TITLE
6381729: Javadoc for generic constructor doesn't document type parameter

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractExecutableMemberWriter.java
@@ -31,6 +31,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
@@ -128,6 +129,24 @@ public abstract class AbstractExecutableMemberWriter extends AbstractMemberWrite
     @Override
     protected void addInheritedSummaryLink(TypeElement te, Element member, Content target) {
         target.add(writer.getDocLink(PLAIN, te, member, name(member)));
+    }
+
+    /**
+     * Adds the generic type parameters.
+     *
+     * @param member the member to add the generic type parameters for
+     * @param target the content to which the generic type parameters will be added
+     */
+    protected void addTypeParameters(ExecutableElement member, Content target) {
+        Content typeParameters = getTypeParameters(member);
+        target.add(typeParameters);
+        // Add explicit line break between method type parameters and
+        // return type in member summary table to avoid random wrapping.
+        if (typeParameters.charCount() > 10) {
+            target.add(new HtmlTree(TagName.BR));
+        } else {
+            target.add(Entity.NO_BREAK_SPACE);
+        }
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/AbstractMemberWriter.java
@@ -466,16 +466,8 @@ public abstract class AbstractMemberWriter {
                     ? ((ExecutableElement)member).getTypeParameters()
                     : null;
             if (list != null && !list.isEmpty()) {
-                Content typeParameters = ((AbstractExecutableMemberWriter) this)
-                        .getTypeParameters((ExecutableElement)member);
-                code.add(typeParameters);
-                // Add explicit line break between method type parameters and
-                // return type in member summary table to avoid random wrapping.
-                if (typeParameters.charCount() > 10) {
-                    code.add(new HtmlTree(TagName.BR));
-                } else {
-                    code.add(Entity.NO_BREAK_SPACE);
-                }
+                ((AbstractExecutableMemberWriter) this)
+                  .addTypeParameters((ExecutableElement)member, code);
             }
             code.add(
                     writer.getLink(new HtmlLinkInfo(configuration,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ClassUseWriter.java
@@ -142,7 +142,7 @@ public class ClassUseWriter extends SubWriterHolderWriter {
 
         methodSubWriter = new MethodWriter(this);
         constrSubWriter = new ConstructorWriter(this);
-        constrSubWriter.setFoundNonPubConstructor(true);
+        constrSubWriter.setShowConstructorModifiers(true);
         fieldSubWriter = new FieldWriter(this);
         classSubWriter = new NestedClassWriter(this);
     }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ConstructorWriter.java
@@ -53,7 +53,11 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
      */
     private ExecutableElement currentConstructor;
 
-    private boolean foundNonPubConstructor = false;
+    /**
+     * If any constructors are non-public, then we want the modifiers shown in the summary.
+     * This implies we need a three-column summary.
+     */
+    private boolean showConstructorModifiers = false;
 
     /**
      * Construct a new member writer for constructors.
@@ -65,11 +69,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
 
         // the following must be done before the summary table is generated
         var constructors = getVisibleMembers(VisibleMemberTable.Kind.CONSTRUCTORS);
-        for (Element constructor : constructors) {
-            if (utils.isProtected(constructor) || utils.isPrivate(constructor)) {
-                setFoundNonPubConstructor(true);
-            }
-        }
+        analyzeConstructors(constructors);
     }
 
     /**
@@ -94,11 +94,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
     protected void buildConstructorDoc(Content target) {
         var constructors = getVisibleMembers(VisibleMemberTable.Kind.CONSTRUCTORS);
         if (!constructors.isEmpty()) {
-            for (Element constructor : constructors) {
-                if (utils.isProtected(constructor) || utils.isPrivate(constructor)) {
-                    setFoundNonPubConstructor(true);
-                }
-            }
+            analyzeConstructors(constructors);
 
             Content constructorDetailsHeader = getConstructorDetailsHeader(target);
             Content memberList = getMemberList();
@@ -124,6 +120,20 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
             target.add(constructorDetails);
             writer.tableOfContents.popNestedList();
         }
+    }
+
+    // Calculate "showConstructorModifiers"
+    private void analyzeConstructors(List<? extends Element> constructors) {
+        for (Element constructor : constructors) {
+            if (utils.isProtected(constructor) || utils.isPrivate(constructor)) {
+                setShowConstructorModifiers(true);
+            }
+        }
+    }
+
+    // Does the constructor summary need three columnns or just two?
+    protected boolean threeColumnSummary() {
+        return showConstructorModifiers;
     }
 
     @Override
@@ -231,8 +241,8 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
                         .add(memberDetails));
     }
 
-    protected void setFoundNonPubConstructor(boolean foundNonPubConstructor) {
-        this.foundNonPubConstructor = foundNonPubConstructor;
+    protected void setShowConstructorModifiers(boolean showConstructorModifiers) {
+        this.showConstructorModifiers = showConstructorModifiers;
     }
 
     @Override
@@ -244,7 +254,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
 
     @Override
     public TableHeader getSummaryTableHeader(Element member) {
-        if (foundNonPubConstructor) {
+        if (threeColumnSummary()) {
             return new TableHeader(contents.modifierLabel, contents.constructorLabel,
                     contents.descriptionLabel);
         } else {
@@ -256,7 +266,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
     protected Table<Element> createSummaryTable() {
         List<HtmlStyle> bodyRowStyles;
 
-        if (foundNonPubConstructor) {
+        if (threeColumnSummary()) {
             bodyRowStyles = Arrays.asList(HtmlStyle.colFirst, HtmlStyle.colConstructorName,
                     HtmlStyle.colLast);
         } else {
@@ -276,7 +286,7 @@ public class ConstructorWriter extends AbstractExecutableMemberWriter {
 
     @Override
     protected void addSummaryType(Element member, Content content) {
-        if (foundNonPubConstructor) {
+        if (threeColumnSummary()) {
             var code = new HtmlTree(TagName.CODE);
             if (utils.isProtected(member)) {
                 code.add("protected ");

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/Signatures.java
@@ -529,6 +529,7 @@ public class Signatures {
         private int appendTypeParameters(Content target, int lastLineSeparator) {
             // Apply different wrapping strategies for type parameters
             // depending on the combined length of type parameters and return type.
+            // Note return type will be null if this is a constructor.
             int typeParamLength = typeParameters.charCount();
 
             if (typeParamLength >= TYPE_PARAMS_MAX_INLINE_LENGTH) {
@@ -539,9 +540,10 @@ public class Signatures {
 
             int lineLength = target.charCount() - lastLineSeparator;
             int newLastLineSeparator = lastLineSeparator;
+            int returnTypeLength = returnType != null ? returnType.charCount() : 0;
 
             // sum below includes length of modifiers plus type params added above
-            if (lineLength + returnType.charCount() > RETURN_TYPE_MAX_LINE_LENGTH) {
+            if (lineLength + returnTypeLength > RETURN_TYPE_MAX_LINE_LENGTH) {
                 target.add(Text.NL);
                 newLastLineSeparator = target.charCount();
             } else {

--- a/test/langtools/jdk/javadoc/doclet/testConstructorGenericParam/TestConstructorGenericParam.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructorGenericParam/TestConstructorGenericParam.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6381729
+ * @summary Verify that generic type parameters on constructors are documented.
+ * @library ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.*
+ * @run main TestConstructorGenericParam
+ */
+
+import javadoc.tester.JavadocTester;
+
+public class TestConstructorGenericParam extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestConstructorGenericParam();
+        tester.runTests();
+    }
+
+    @Test
+    public void test() {
+        javadoc("-d", "out",
+                "-sourcepath", testSrc,
+                "-Xdoclint:none",
+                "--no-platform-links",
+                "pkg1");
+        checkExit(Exit.OK);
+
+        checkOutput("pkg1/A.html", true,
+                """
+                    <div class="col-first even-row-color"><code>&nbsp;&lt;T extends java.lang.Runnable&gt;<br></code></div>
+                    <div class="col-constructor-name even-row-color"><code>\
+                    <a href="#%3Cinit%3E()" class="member-name-link">A</a>()</code></div>
+                    <div class="col-last even-row-color">&nbsp;</div>""",
+                """
+                    <div class="member-signature"><span class="modifiers">public</span>\
+                    &nbsp;<span class="type-parameters">&lt;T extends java.lang.Runnable&gt;</span>\
+                    &nbsp;<span class="element-name">A</span>()</div>""");
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testConstructorGenericParam/pkg1/A.java
+++ b/test/langtools/jdk/javadoc/doclet/testConstructorGenericParam/pkg1/A.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package pkg1;
+
+public class A {
+    public <T extends Runnable> A() {
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testErasure/TestErasure.java
+++ b/test/langtools/jdk/javadoc/doclet/testErasure/TestErasure.java
@@ -82,15 +82,19 @@ public class TestErasure extends JavadocTester {
                 <section class="constructor-summary" id="constructor-summary">
                 <h2>Constructor Summary</h2>
                 <div class="caption"><span>Constructors</span></div>
-                <div class="summary-table two-column-summary">
-                <div class="table-header col-first">Constructor</div>
+                <div class="summary-table three-column-summary">
+                <div class="table-header col-first">Modifier</div>
+                <div class="table-header col-second">Constructor</div>
                 <div class="table-header col-last">Description</div>
+                <div class="col-first even-row-color"><code>&nbsp;</code></div>
                 <div class="col-constructor-name even-row-color"><code>\
                 <a href="#%3Cinit%3E(T)" class="member-name-link">Foo</a><wbr>(T&nbsp;arg)</code></div>
                 <div class="col-last even-row-color">&nbsp;</div>
+                <div class="col-first odd-row-color"><code>&nbsp;&lt;T extends X&gt;<br></code></div>
                 <div class="col-constructor-name odd-row-color"><code>\
                 <a href="#%3Cinit%3E(X)" class="member-name-link">Foo</a><wbr>(T&nbsp;arg)</code></div>
                 <div class="col-last odd-row-color">&nbsp;</div>
+                <div class="col-first even-row-color"><code>&nbsp;&lt;T extends Y&gt;<br></code></div>
                 <div class="col-constructor-name even-row-color"><code>\
                 <a href="#%3Cinit%3E(Y)" class="member-name-link">Foo</a><wbr>(T&nbsp;arg)</code></div>
                 <div class="col-last even-row-color">&nbsp;</div>
@@ -188,13 +192,16 @@ public class TestErasure extends JavadocTester {
                 <section class="constructor-summary" id="constructor-summary">
                 <h2>Constructor Summary</h2>
                 <div class="caption"><span>Constructors</span></div>
-                <div class="summary-table two-column-summary">
-                <div class="table-header col-first">Constructor</div>
+                <div class="summary-table three-column-summary">
+                <div class="table-header col-first">Modifier</div>
+                <div class="table-header col-second">Constructor</div>
                 <div class="table-header col-last">Description</div>
+                <div class="col-first even-row-color"><code>&nbsp;</code></div>
                 <div class="col-constructor-name even-row-color"><code>\
                 <a href="#%3Cinit%3E(T)" class="member-name-link">Foo</a>\
                 <wbr>(<a href="Foo.html" title="type parameter in Foo">T</a>&nbsp;arg)</code></div>
                 <div class="col-last even-row-color">&nbsp;</div>
+                <div class="col-first odd-row-color"><code>&nbsp;&lt;T extends X&gt;<br></code></div>
                 <div class="col-constructor-name odd-row-color"><code>\
                 <a href="#%3Cinit%3E(X)" class="member-name-link">Foo</a><wbr>(T&nbsp;arg)</code></div>
                 <div class="col-last odd-row-color">&nbsp;</div>


### PR DESCRIPTION
The standard Javadoc doclet has a long-standing bug (since 2006, old enough to vote :) whereby constructor type parameters are simply omitted from the output. This results in confusing documentation that look like this:
```java
public MyClass(T obj) - Description of this constructor...
```
with no explanation of what type `T` is.

The fix itself is straightforward (a one liner), but it requires a bit of prerequisite refactoring:

1. The method `Signatures.appendTypeParameters()` would throw an NPE if given a constructor, because the `returnType` is null. This is easy to work around with a simple null check.

2. The code for generating the HTML for the type parameters was embedded in a method `AbstractMemberWriter.addModifiersAndType()` which assumed a normal method with a return type. In order to make this bit resuable for constructors too, it has been extracted out into a new method `AbstractExecutableMemberWriter.addTypeParameters()`.

3. `ConstructorWriter` has an optimization in which constructor modifiers are omitted if all constructors are `public`, a common case. This optimization is disabled using a field named `foundNonPubConstructor`. A side effect of this optimization is that the constructor summary table has only two columns instead of three (the first being unnecessary). However, type parameters should appear in the same column as modifiers, so this logic was generalized to check for both (a) all constructors `public`, and (b) no constructors with type parameters. The field `foundNonPubConstructor` has been renamed to `showConstructorModifiers`; this clarifies `ClassUseWriter` using it for that purpose when generating the use index.

The above steps have been broken out into separate commits.