### PR TITLE
8335742: Problemlist gc/g1/TestMixedGCLiveThreshold.java#25percent with virtual threads

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -86,6 +86,11 @@ vmTestbase/nsk/jdi/ExceptionEvent/catchLocation/location002/TestDescription.java
 
 vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemoryException001.java 8285417 generic-all
 
+###
+# Fails on Windows because of additional memory allocation.
+
+gc/g1/TestMixedGCLiveThreshold.java#25percent JDK-8334759 windows-x64
+
 ##########
 ## Tests incompatible with  with virtual test thread factory.
 ## There is no goal to run all test with virtual test thread factory.


### PR DESCRIPTION
Hi all,

  please review this trivial change to add the gc/g1/TestMixedGCLiveThreshold.java#25percent for when
running with virtual threads to reduce noise in CI

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335742](https://bugs.openjdk.org/browse/JDK-8335742): Problemlist gc/g1/TestMixedGCLiveThreshold.java#25percent with virtual threads (**Sub-task** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20046/head:pull/20046` \
`$ git checkout pull/20046`

Update a local copy of the PR: \
`$ git checkout pull/20046` \
`$ git pull https://git.openjdk.org/jdk.git pull/20046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20046`

View PR using the GUI difftool: \
`$ git pr show -t 20046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20046.diff">https://git.openjdk.org/jdk/pull/20046.diff</a>

</details>
