### PR TITLE
8335756: NMT: VMATree should provide iterators for reserved regions

### DIFF
--- a/src/hotspot/share/nmt/nmtNativeCallStackStorage.hpp
+++ b/src/hotspot/share/nmt/nmtNativeCallStackStorage.hpp
@@ -53,6 +53,9 @@ public:
     bool is_invalid() {
       return _stack_index == invalid;
     }
+
+    int32_t raw() const { return _stack_index; }
+
   };
 
 private:

--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -75,6 +75,7 @@ public:
 
     const K& key() const { return _key; }
     V& val() { return _value; }
+    const V& val() const { return _value; }
 
     TreapNode* left() const { return _left; }
     TreapNode* right() const { return _right; }

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -186,6 +186,21 @@ public:
   void visit_in_order(F f) const {
     _tree.visit_in_order(f);
   }
+
+  struct WalkedRegion {
+    position from;
+    position to;
+    RegionData data;
+  };
+
+  struct WalkedRegionClosure {
+    // Gets region info in (out).
+    // Should return true to continue walking, false to abort.
+    virtual bool do_region(const WalkedRegion* r) = 0;
+  };
+
+  void walk_all_reserved_regions(WalkedRegionClosure* closure) const;
+
 };
 
 #endif


### PR DESCRIPTION
Implemented a reserved region walker.

Implementation is straightforward. 

The only annoying part was to deal with the inability to copy RegionData by value, which is caused by NativeCallStackStorage::StackIndex not being copyable. I tried to solve that but went into a painful rabbit hole of missing operators and constructors. I gave up when running against a static assert for trivially copyable. I just gave up and used memcpy instead, since I ran out of time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335756](https://bugs.openjdk.org/browse/JDK-8335756): NMT: VMATree should provide iterators for reserved regions (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20047/head:pull/20047` \
`$ git checkout pull/20047`

Update a local copy of the PR: \
`$ git checkout pull/20047` \
`$ git pull https://git.openjdk.org/jdk.git pull/20047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20047`

View PR using the GUI difftool: \
`$ git pr show -t 20047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20047.diff">https://git.openjdk.org/jdk/pull/20047.diff</a>

</details>
