### PR TITLE
8328723: IP Address error when client enables HTTPS endpoint check on server socket

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,8 +428,17 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
         }
 
         if (!identifiable) {
-            checkIdentity(peerHost,
-                    trustedChain[0], algorithm, chainsToPublicCA);
+            try {
+                checkIdentity(peerHost,
+                        trustedChain[0], algorithm, chainsToPublicCA);
+            } catch(CertificateException ce) {
+                if(checkClientTrusted && "HTTPS".equalsIgnoreCase(algorithm)) {
+                    throw new CertificateException("Endpoint Identification algorithm " +
+                            "HTTPS is not supported on the server side");
+                } else {
+                    throw ce;
+                }
+            }
         }
     }
 

--- a/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
+++ b/src/java.base/share/classes/sun/security/ssl/X509TrustManagerImpl.java
@@ -432,8 +432,8 @@ final class X509TrustManagerImpl extends X509ExtendedTrustManager
                 checkIdentity(peerHost,
                         trustedChain[0], algorithm, chainsToPublicCA);
             } catch(CertificateException ce) {
-                if(checkClientTrusted && "HTTPS".equalsIgnoreCase(algorithm)) {
-                    throw new CertificateException("Endpoint Identification algorithm " +
+                if (checkClientTrusted && "HTTPS".equalsIgnoreCase(algorithm)) {
+                    throw new CertificateException("Endpoint Identification Algorithm " +
                             "HTTPS is not supported on the server side");
                 } else {
                     throw ce;


### PR DESCRIPTION
The client identity checks when "HTTPS" endpoint identification algorithm is set on SSL server throws "java.security.cert.CertificateException: No subject alternative names present" when client certificate's SubjectAltName extension does not match its IP address

Since the server has no external knowledge of what the client's identity ought to be,  HTTPS identity checks must be disabled on the server side.
The exception message has been fixed to indicate the same.

I have performed the test both on SSL Server Engine and SSL Server Socket and attached are logs and snapshot for reference, also I have ran the changes against external test suite and test runs are green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328723](https://bugs.openjdk.org/browse/JDK-8328723): IP Address error when client enables HTTPS endpoint check on server socket (**Bug** - P3)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20048/head:pull/20048` \
`$ git checkout pull/20048`

Update a local copy of the PR: \
`$ git checkout pull/20048` \
`$ git pull https://git.openjdk.org/jdk.git pull/20048/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20048`

View PR using the GUI difftool: \
`$ git pr show -t 20048`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20048.diff">https://git.openjdk.org/jdk/pull/20048.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20048#issuecomment-2210489586)