### PR TITLE
8335743: jhsdb jstack cannot print some information on the waiting thread

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public abstract class JavaVFrame extends VFrame {
     // then print out the receiver. Locals are not always available,
     // e.g., compiled native frames have no scope so there are no locals.
     if (frameCount == 0) {
-      if (getMethod().getName().asString().equals("wait") &&
+      if (getMethod().getName().asString().equals("wait0") &&
           getMethod().getMethodHolder().getName().asString().equals("java/lang/Object")) {
         String waitState = "waiting on"; // assume we are waiting
         // If earlier in the output we reported java.lang.Thread.State ==

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,16 +36,28 @@ public class LingeredAppWithLock extends LingeredApp {
         }
     }
 
+    public static void waitMethod(Object lock) {
+        synchronized (lock) {
+            try {
+                lock.wait(300000);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
     public static void main(String args[]) {
         Thread classLock1 = new Thread(() -> lockMethod(LingeredAppWithLock.class));
         Thread classLock2 = new Thread(() -> lockMethod(LingeredAppWithLock.class));
         Thread objectLock = new Thread(() -> lockMethod(classLock1));
         Thread primitiveLock = new Thread(() -> lockMethod(int.class));
+        Thread objectWait = new Thread(() -> waitMethod(new Object()));
 
         classLock1.start();
         classLock2.start();
         objectLock.start();
         primitiveLock.start();
+        objectWait.start();
 
         // Wait until all threads have reached their blocked or timed wait state
         while ((classLock1.getState() != Thread.State.BLOCKED &&
@@ -53,7 +65,8 @@ public class LingeredAppWithLock extends LingeredApp {
                (classLock2.getState() != Thread.State.BLOCKED &&
                 classLock2.getState() != Thread.State.TIMED_WAITING) ||
                (objectLock.getState() != Thread.State.TIMED_WAITING) ||
-               (primitiveLock.getState() != Thread.State.TIMED_WAITING)) {
+               (primitiveLock.getState() != Thread.State.TIMED_WAITING) ||
+               (objectWait.getState() != Thread.State.TIMED_WAITING)) {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ex) {

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLock.java
@@ -25,6 +25,7 @@ import jdk.test.lib.apps.LingeredApp;
 
 
 public class LingeredAppWithLock extends LingeredApp {
+    private static Object lockObj = new Object();
 
     public static void lockMethod(Object lock) {
         synchronized (lock) {
@@ -36,10 +37,10 @@ public class LingeredAppWithLock extends LingeredApp {
         }
     }
 
-    public static void waitMethod(Object lock) {
-        synchronized (lock) {
+    public static void waitMethod() {
+        synchronized (lockObj) {
             try {
-                lock.wait(300000);
+                lockObj.wait(300000);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
@@ -51,7 +52,7 @@ public class LingeredAppWithLock extends LingeredApp {
         Thread classLock2 = new Thread(() -> lockMethod(LingeredAppWithLock.class));
         Thread objectLock = new Thread(() -> lockMethod(classLock1));
         Thread primitiveLock = new Thread(() -> lockMethod(int.class));
-        Thread objectWait = new Thread(() -> waitMethod(new Object()));
+        Thread objectWait = new Thread(() -> waitMethod());
 
         classLock1.start();
         classLock2.start();

--- a/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import jtreg.SkippedException;
 
 /**
  * @test
+ * @bug 8185796 8335743
  * @requires vm.hasSA
  * @library /test/lib
  * @run main/othervm TestClhsdbJstackLock
@@ -57,7 +58,8 @@ public class TestClhsdbJstackLock {
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$",
-                "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$"));
+                "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$",
+                "^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$"));
             unExpStrMap.put("jstack", List.of(
                 "missing reason for "));
             test.run(app.getPid(), cmds, expStrMap, unExpStrMap);

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import jdk.test.lib.Utils;
 
 /**
  * @test
+ * @bug 8185796 8335743
  * @requires vm.hasSA
  * @library /test/lib
  * @run driver TestJhsdbJstackLock
@@ -64,6 +65,7 @@ public class TestJhsdbJstackLock {
             out.shouldMatch("^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$");
+            out.shouldMatch("^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$");
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
 


### PR DESCRIPTION
This bug was introduced by JDK-8284161. "Object.wait (long timeoutMillis)" was changed to call "Object.wait0 (long timeoutMillis)" in JDK-8284161.

When "jhdsb jstack" is executed, the stack and lock information are printed in "sun.jvm.hotspot.runtime.JavaVFrame.printLockInfo(PrintStream tty, int frameCount)". This method checks whether the method is java.lang.Object.wait (...) and then reports the waitstate only if the check passes.
https://github.com/openjdk/jdk/blob/7bc8f9c150cbf457edf6144adba734ecd5ca5a0f/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java#L103

```
      if (getMethod().getName().asString().equals("wait") &&
          getMethod().getMethodHolder().getName().asString().equals("java/lang/Object")) {
```

However, after JDK-8284161, the waiting thread waits on "java.lang.Object.wait0 (long timeoutMillis)", so it no longer reports the waitstate.

I changed "printLockInfo(PrintStream tty, int frameCount)" to check for "java.lang.Object.wait0 (...)".
I confirmed that the lock information is correctly printed with this fix.
I tested hotspot/jtreg/serviceability/sa/ and jdk/sun/tools/jhsdb/heapconfig/, and there were no regressions by this fix.

Would anyone review this change, please?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8335743: jhsdb jstack cannot print some information on the waiting thread`

### Issue
 * [JDK-8335743](https://bugs.openjdk.org/browse/JDK-8335743): jhsdb jstack cannot print some information on the waiting thread (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20049/head:pull/20049` \
`$ git checkout pull/20049`

Update a local copy of the PR: \
`$ git checkout pull/20049` \
`$ git pull https://git.openjdk.org/jdk.git pull/20049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20049`

View PR using the GUI difftool: \
`$ git pr show -t 20049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20049.diff">https://git.openjdk.org/jdk/pull/20049.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20049#issuecomment-2210531207)