### PR TITLE
8335775: Remove extraneous 's' in comment of rawmonitor.cpp test file

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/unit/functions/rawmonitor/rawmonitor.cpp
@@ -1,5 +1,4 @@
 /*
-s
  * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
Trivial comment only change in a test. Please review!

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335775](https://bugs.openjdk.org/browse/JDK-8335775): Remove extraneous 's' in comment of rawmonitor.cpp test file (**Bug** - P4)


### Reviewers
 * [George Adams](https://openjdk.org/census#gdams) (@gdams - Author)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20051/head:pull/20051` \
`$ git checkout pull/20051`

Update a local copy of the PR: \
`$ git checkout pull/20051` \
`$ git pull https://git.openjdk.org/jdk.git pull/20051/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20051`

View PR using the GUI difftool: \
`$ git pr show -t 20051`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20051.diff">https://git.openjdk.org/jdk/pull/20051.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20051#issuecomment-2210696657)