### PR TITLE
8216471: GTK LnF: Frame is clipped and does not show JTable,Tooltip and JTree demo in SwingSet2 demo

### DIFF
--- a/src/demo/share/jfc/SwingSet2/SwingSet2.java
+++ b/src/demo/share/jfc/SwingSet2/SwingSet2.java
@@ -849,7 +849,7 @@ public class SwingSet2 extends JPanel {
             SwingUtilities.updateComponentTreeUI(this);
         } else {
             if (currentLookAndFeel.name.contains("GTK")) {
-                this.setPreferredSize(new Dimension(PREFERRED_WIDTH + 260, PREFERRED_HEIGHT + 230));
+                this.setPreferredSize(new Dimension(PREFERRED_WIDTH + 260, PREFERRED_HEIGHT + 80));
             } else {
                 this.setPreferredSize(new Dimension(PREFERRED_WIDTH, PREFERRED_HEIGHT));
             }

--- a/src/demo/share/jfc/SwingSet2/SwingSet2.java
+++ b/src/demo/share/jfc/SwingSet2/SwingSet2.java
@@ -849,11 +849,13 @@ public class SwingSet2 extends JPanel {
             SwingUtilities.updateComponentTreeUI(this);
         } else {
             if (currentLookAndFeel.name.contains("GTK")) {
-                frame.setSize(980, 870);
+                this.setPreferredSize(new Dimension(PREFERRED_WIDTH + 260, PREFERRED_HEIGHT + 230));
             } else {
-                frame.setSize(PREFERRED_WIDTH, PREFERRED_HEIGHT);
+                this.setPreferredSize(new Dimension(PREFERRED_WIDTH, PREFERRED_HEIGHT));
             }
+
             SwingUtilities.updateComponentTreeUI(frame);
+            frame.pack();
         }
 
         SwingUtilities.updateComponentTreeUI(popupMenu);

--- a/src/demo/share/jfc/SwingSet2/SwingSet2.java
+++ b/src/demo/share/jfc/SwingSet2/SwingSet2.java
@@ -83,8 +83,8 @@ public class SwingSet2 extends JPanel {
     private ArrayList<DemoModule> demosList = new ArrayList<DemoModule>();
 
     // The preferred size of the demo
-    private static final int PREFERRED_WIDTH = 720;
-    private static final int PREFERRED_HEIGHT = 640;
+    private static final int PREFERRED_WIDTH = 1020;
+    private static final int PREFERRED_HEIGHT = 910;
 
     // Box spacers
     private Dimension HGAP = new Dimension(1,5);

--- a/src/demo/share/jfc/SwingSet2/SwingSet2.java
+++ b/src/demo/share/jfc/SwingSet2/SwingSet2.java
@@ -83,8 +83,8 @@ public class SwingSet2 extends JPanel {
     private ArrayList<DemoModule> demosList = new ArrayList<DemoModule>();
 
     // The preferred size of the demo
-    private static final int PREFERRED_WIDTH = 1020;
-    private static final int PREFERRED_HEIGHT = 910;
+    private static final int PREFERRED_WIDTH = 720;
+    private static final int PREFERRED_HEIGHT = 640;
 
     // Box spacers
     private Dimension HGAP = new Dimension(1,5);
@@ -848,6 +848,11 @@ public class SwingSet2 extends JPanel {
         if (frame == null) {
             SwingUtilities.updateComponentTreeUI(this);
         } else {
+            if (currentLookAndFeel.name.contains("GTK")) {
+                frame.setSize(980, 870);
+            } else {
+                frame.setSize(PREFERRED_WIDTH, PREFERRED_HEIGHT);
+            }
             SwingUtilities.updateComponentTreeUI(frame);
         }
 

--- a/src/demo/share/jfc/SwingSet2/SwingSet2.java
+++ b/src/demo/share/jfc/SwingSet2/SwingSet2.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2007, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions


### PR DESCRIPTION
The issue is due to the preferred width of the toggle button in GTK L&F for GTK3 only.
Comparing the preferred width of toggle button with GTK2 or other LAF, it is much higher in GTK3. The difference is due to the insets value in GTK3.

In SwingSet2 demo there are as many as 16 demos are added in toolbar and the preferred width of frame is set to 720px.
In GTK L&F (For GTK3), overall preferred width of toolbar is ~980 px which is more than frame width and that results in the clipping of last few demos.
In other L&F and GTK2, the preferred width of toolbar is less than frame width. Hence, there is no clipping.

The proposed solution is to increase the width and height of SwingSet2 demo frame.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8216471](https://bugs.openjdk.org/browse/JDK-8216471): GTK LnF: Frame is clipped and does not show JTable,Tooltip and JTree demo in SwingSet2 demo (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20052/head:pull/20052` \
`$ git checkout pull/20052`

Update a local copy of the PR: \
`$ git checkout pull/20052` \
`$ git pull https://git.openjdk.org/jdk.git pull/20052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20052`

View PR using the GUI difftool: \
`$ git pr show -t 20052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20052.diff">https://git.openjdk.org/jdk/pull/20052.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20052#issuecomment-2210704398)