### PR TITLE
8335778: runtime/ClassInitErrors/TestStackOverflowDuringInit.java fails on ppc64 platforms after JDK-8334545

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -28,6 +28,7 @@
  *          a StackOverflowError, that we record the SOE as the underlying
  *          cause, even if we can't create the ExceptionInInitializerError
  * @comment This test could easily be perturbed so don't allow flag settings.
+ * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @requires vm.flagless
  * @comment Run with the smallest stack possible to limit the execution time.
  *          This is the smallest stack that is supported by all platforms.

--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestStackOverflowDuringInit.java
@@ -28,11 +28,10 @@
  *          a StackOverflowError, that we record the SOE as the underlying
  *          cause, even if we can't create the ExceptionInInitializerError
  * @comment This test could easily be perturbed so don't allow flag settings.
- * @requires vm.simpleArch == "x64" | vm.simpleArch == "aarch64" | vm.simpleArch == "riscv64"
  * @requires vm.flagless
  * @comment Run with the smallest stack possible to limit the execution time.
  *          This is the smallest stack that is supported by all platforms.
- * @run main/othervm -Xss240K -Xint TestStackOverflowDuringInit
+ * @run main/othervm -Xss384K -Xint TestStackOverflowDuringInit
  */
 
 import java.io.ByteArrayOutputStream;


### PR DESCRIPTION
stdout shows :
 "The Java thread stack size specified is too small. Specify at least 384k"
Previously the test was done only on x64 platforms (comment said that it only works there 'in desired way') .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335778](https://bugs.openjdk.org/browse/JDK-8335778): runtime/ClassInitErrors/TestStackOverflowDuringInit.java fails on ppc64 platforms after JDK-8334545 (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andreas Steiner](https://openjdk.org/census#asteiner) (@ansteiner - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20053/head:pull/20053` \
`$ git checkout pull/20053`

Update a local copy of the PR: \
`$ git checkout pull/20053` \
`$ git pull https://git.openjdk.org/jdk.git pull/20053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20053`

View PR using the GUI difftool: \
`$ git pr show -t 20053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20053.diff">https://git.openjdk.org/jdk/pull/20053.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20053#issuecomment-2210794245)