### PR TITLE
8335795: Clarify comments related to ZipEntry.externalFileAttributes

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -59,7 +59,16 @@ public class ZipEntry implements ZipConstants, Cloneable {
     int flag = 0;       // general purpose flag
     byte[] extra;       // optional extra field data for entry
     String comment;     // optional comment string for entry
-    int externalFileAttributes = -1; // File type, setuid, setgid, sticky, POSIX permissions
+
+    /**
+     *  External file attributes when processing Unix-compatible files.
+     *  Contains file type (4 bits), setuid, setgid, sticky, POSIX permissions (9 bits).
+     *
+     *  While this field is not accessible to users, it allows conserving
+     *  the external file attributes when processing ZIP file entries.
+     */
+    int externalFileAttributes = -1;
+
     /**
      * Compression method for uncompressed entries.
      */

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -696,8 +696,8 @@ public class ZipFile implements ZipConstants, Closeable {
         e.csize = CENSIZ(cen, pos);
         e.method = CENHOW(cen, pos);
         if (CENVEM_FA(cen, pos) == FILE_ATTRIBUTES_UNIX) {
-            // read all bits in this field, including sym link attributes
-            e.externalFileAttributes = CENATX_PERMS(cen, pos) & 0xFFFF;
+            // Read the 16 Unix-related bits of the 'external file attributes' field
+            e.externalFileAttributes = CENATX_UNIX(cen, pos);
         }
 
         if (elen != 0) {

--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -279,7 +279,7 @@ class ZipUtils {
     static final int  CENDSK(byte[] b, int pos) { return SH(b, pos + 34);}
     static final int  CENATT(byte[] b, int pos) { return SH(b, pos + 36);}
     static final long CENATX(byte[] b, int pos) { return LG(b, pos + 38);}
-    static final int  CENATX_PERMS(byte[] b, int pos) { return SH(b, pos + 40);} // posix permission data
+    static final int  CENATX_UNIX(byte[] b, int pos) { return SH(b, pos + 40);} // Unix file attributes
     static final long CENOFF(byte[] b, int pos) { return LG(b, pos + 42);}
 
     // The END header is followed by a variable length comment of size < 64k.


### PR DESCRIPTION
Please review this PR which aims to clarify some code comments related to processing of 'external file attributes' for Unix-compatible ZIP file entries. This is a follow-up to #16952.

The PR includes the following code comment-only changes:

* The `ZipEntry.externalFileAttributes` field comment is updated to reflect that this field only holds data for Unix-compatible entries. The comment is also expanded to explain the Unix-relevant bits contained in the field and to note that the field is inaccessible to users, but allows conserving the external file attributes when processing ZIP entries.
* In `ZipFile.getZipEntry`, a comment is updated to reflect that all 16 Unix-relevant bits are read
* In `ZipFile.getZipEntry`, there is no longer any need to mask the bits read with 0xFFFF, the masking is removed.

Additionally, a package-private method is renamed in `ZipUtils`:

* `ZipUtils.CENATX_PERMS` no longer reads just the permissions bits, but the full 16 Unix bits, this method is renamed to `ZipUtils.CENATX_UNIX`. The code comment in this method is updated accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335795](https://bugs.openjdk.org/browse/JDK-8335795): Clarify comments related to ZipEntry.externalFileAttributes (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20059/head:pull/20059` \
`$ git checkout pull/20059`

Update a local copy of the PR: \
`$ git checkout pull/20059` \
`$ git pull https://git.openjdk.org/jdk.git pull/20059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20059`

View PR using the GUI difftool: \
`$ git pr show -t 20059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20059.diff">https://git.openjdk.org/jdk/pull/20059.diff</a>

</details>
