### PR TITLE
8333890: Fatal error in auto-vectorizer with float16 kernel.

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3170,6 +3170,12 @@ const Type* VLoopTypes::container_type(Node* n) const {
   }
   const Type* t = _vloop.phase()->igvn().type(n);
   if (t->basic_type() == T_INT) {
+    // Float to half float conversion may be succeded by a conversion from
+    // half float to float, in such a case backpropagation of narrow type (SHORT)
+    // may not be possible.
+    if (n->Opcode() == Op_ConvF2HF) {
+      return TypeInt::SHORT;
+    }
     // A narrow type of arithmetic operations will be determined by
     // propagating the type of memory operations.
     return TypeInt::INT;

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -3170,8 +3170,8 @@ const Type* VLoopTypes::container_type(Node* n) const {
   }
   const Type* t = _vloop.phase()->igvn().type(n);
   if (t->basic_type() == T_INT) {
-    // Float to half float conversion may be succeded by a conversion from
-    // half float to float, in such a case backpropagation of narrow type (SHORT)
+    // Float to half float conversion may be succeeded by a conversion from
+    // half float to float, in such a case back propagation of narrow type (SHORT)
     // may not be possible.
     if (n->Opcode() == Op_ConvF2HF) {
       return TypeInt::SHORT;

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+* @test
+* @summary Test Float16 vector conversion chain.
+* @requires vm.compiler2.enabled
+* @library /test/lib /
+* @run driver compiler.vectorization.TestFloat16VectorConvChain
+*/
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+import java.util.Arrays;
+
+
+public class TestFloat16VectorConvChain {
+
+    @Test
+    @IR(counts = {IRNode.VECTOR_CAST_HF2F, ">= 1", IRNode.VECTOR_CAST_F2HF, " >= 1"})
+    public static void test(short [] res, short [] src1, short [] src2) {
+        for (int i = 0; i < res.length; i++) {
+            res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));
+        }
+    }
+
+    @Run(test = {"test"})
+    @Warmup(1000)
+    public static void micro() {
+        short [] res = new short[1024];
+        short [] src1 = new short[1024];
+        short [] src2 = new short[1024];
+        Arrays.fill(src1, (short)Float.floatToFloat16(1.0f));
+        Arrays.fill(src2, (short)Float.floatToFloat16(2.0f));
+        for (int i = 0; i < 1000; i++) {
+            test(res, src1, src2);
+        }
+    }
+
+    public static void main(String [] args) {
+        TestFramework.run(TestFloat16VectorConvChain.class);
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
 public class TestFloat16VectorConvChain {
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_HF2F, ">= 1", IRNode.VECTOR_CAST_F2HF, " >= 1"})
+    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
     public static void test(short [] res, short [] src1, short [] src2) {
         for (int i = 0; i < res.length; i++) {
             res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));


### PR DESCRIPTION
Hi,

This bug fix patch fixes an assertion failure seen while auto-vectorizing conversion chain involving float16 type.
Constraining the container type for ConvF2HF IR to short type upfront , as relying on backpropagating narrow
type from memory operation  may not be sufficient if IR is succeeded by ConvHF2F as depicted by the include test case.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8333890: Fatal error in auto-vectorizer with float16 kernel.`

### Issue
 * [JDK-8333890](https://bugs.openjdk.org/browse/JDK-8333890): Fatal error in auto-vectorizer with float16 kernel. (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20062/head:pull/20062` \
`$ git checkout pull/20062`

Update a local copy of the PR: \
`$ git checkout pull/20062` \
`$ git pull https://git.openjdk.org/jdk.git pull/20062/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20062`

View PR using the GUI difftool: \
`$ git pr show -t 20062`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20062.diff">https://git.openjdk.org/jdk/pull/20062.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20062#issuecomment-2211847607)