### PR TITLE
8335637: Add explicit non-null return value expectations to Object.toString()

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -95,14 +95,6 @@ public class Object {
      * As far as is reasonably practical, the {@code hashCode} method defined
      * by class {@code Object} returns distinct integers for distinct objects.
      *
-     * <p>This method should <em>not</em> throw any exceptions. The
-     * implementation should not use excessive memory or time for its
-     * computations and should return a result for cyclic/circular data
-     * structures.
-     * The {@code hashCode} method may be called frequently, possibly
-     * in the context of {@linkplain java.util##CollectionsFramework
-     * collections}.
-     *
      * @apiNote
      * The {@link java.util.Objects#hash(Object...) hash} and {@link
      * java.util.Objects#hashCode(Object) hashCode} methods of {@link
@@ -273,11 +265,6 @@ public class Object {
      * object equal to the string that would be returned if neither
      * the {@code toString} nor {@code hashCode} methods were
      * overridden by the object's class.
-     *
-     * <p>This method should <em>not</em> throw any exceptions. The
-     * implementation should not use excessive memory or time for its
-     * computations and should return a result for cyclic/circular data
-     * structures.
      */
     public String toString() {
         return getClass().getName() + "@" + Integer.toHexString(hashCode());

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -97,7 +97,7 @@ public class Object {
      *
      * <p>This method should <em>not</em> throw any exceptions. The
      * implementation should not use excessive memory or time for its
-     * computations and should return a result for cyclic data
+     * computations and should return a result for cyclic/circular data
      * structures.
      *
      * @apiNote
@@ -273,7 +273,7 @@ public class Object {
      *
      * <p>This method should <em>not</em> throw any exceptions. The
      * implementation should not use excessive memory or time for its
-     * computations and should return a result for cyclic data
+     * computations and should return a result for cyclic/circular data
      * structures.
      */
     public String toString() {

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -99,6 +99,9 @@ public class Object {
      * implementation should not use excessive memory or time for its
      * computations and should return a result for cyclic/circular data
      * structures.
+     * The {@code hashCode} method may be called frequently, possibly
+     * in the context of {@linkplain java.util##CollectionsFramework
+     * collections}.
      *
      * @apiNote
      * The {@link java.util.Objects#hash(Object...) hash} and {@link

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -95,6 +95,11 @@ public class Object {
      * As far as is reasonably practical, the {@code hashCode} method defined
      * by class {@code Object} returns distinct integers for distinct objects.
      *
+     * <p>This method should <em>not</em> throw any exceptions. The
+     * implementation should not use excessive memory or time for its
+     * computations and should return a result for cyclic data
+     * structures.
+     *
      * @apiNote
      * The {@link java.util.Objects#hash(Object...) hash} and {@link
      * java.util.Objects#hashCode(Object) hashCode} methods of {@link
@@ -237,6 +242,10 @@ public class Object {
 
     /**
      * {@return a string representation of the object}
+     *
+     * Satisfying this method's contract implies a non-{@code null}
+     * result must be returned.
+     *
      * @apiNote
      * In general, the
      * {@code toString} method returns a string that
@@ -261,6 +270,11 @@ public class Object {
      * object equal to the string that would be returned if neither
      * the {@code toString} nor {@code hashCode} methods were
      * overridden by the object's class.
+     *
+     * <p>This method should <em>not</em> throw any exceptions. The
+     * implementation should not use excessive memory or time for its
+     * computations and should return a result for cyclic data
+     * structures.
      */
     public String toString() {
         return getClass().getName() + "@" + Integer.toHexString(hashCode());


### PR DESCRIPTION
Make well-behaved implementation expectations of Object.{toString, hashCode} explicit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8335822](https://bugs.openjdk.org/browse/JDK-8335822) to be approved

### Issues
 * [JDK-8335637](https://bugs.openjdk.org/browse/JDK-8335637): Add explicit non-null return value expectations to Object.toString() (**Enhancement** - P4)
 * [JDK-8335822](https://bugs.openjdk.org/browse/JDK-8335822): Add explicit non-null return value expectations to Object.toString() (**CSR**)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) 🔄 Re-review required (review applies to [3db25519](https://git.openjdk.org/jdk/pull/20063/files/3db25519e7ba573a9331e114d9b8c61494c68188))
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20063/head:pull/20063` \
`$ git checkout pull/20063`

Update a local copy of the PR: \
`$ git checkout pull/20063` \
`$ git pull https://git.openjdk.org/jdk.git pull/20063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20063`

View PR using the GUI difftool: \
`$ git pr show -t 20063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20063.diff">https://git.openjdk.org/jdk/pull/20063.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20063#issuecomment-2212561103)