### PR TITLE
JDK-8333826: Update --release 23 symbol information for JDK 23 build 29

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.desktop-N.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.desktop-N.sym.txt
@@ -119,6 +119,10 @@ class name javax/swing/JScrollBar
 method name setMinimumSize descriptor (Ljava/awt/Dimension;)V flags 1
 method name setMaximumSize descriptor (Ljava/awt/Dimension;)V flags 1
 
+class name javax/swing/plaf/basic/BasicSliderUI
+-method name <init> descriptor ()V
+method name <init> descriptor ()V flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="23")
+
 class name javax/swing/plaf/synth/SynthTreeUI
 method name getCollapsedIcon descriptor ()Ljavax/swing/Icon; flags 1
 


### PR DESCRIPTION
Update symbol files to include changes from JDK-8335133.

(No API updates in JDK 23 b30.)