### PR TITLE
8334457: Test javax/swing/JTabbedPane/bug4666224.java fail on macOS with because pressing the ‘C’ key does not switch the layout to WRAP_TAB_LAYOUT

### DIFF
--- a/test/jdk/javax/swing/JTabbedPane/bug4666224.java
+++ b/test/jdk/javax/swing/JTabbedPane/bug4666224.java
@@ -49,7 +49,7 @@ public class bug4666224 {
     private static JFrame frame;
 
     private static final String INSTRUCTIONS = """
-                ON ALL PLATFORMS
+                ON ALL PLATFORMS except macos where pt.6 is not applicable
                     1. Click on any of the tabs, focus indicator is visible.
                     2. Lose focus on the window by clicking on some other window.
                     3. Focus indicator should disappear


### PR DESCRIPTION
This test tests the wrapping policy of JTabbedPane in one of the subinstructions which is not applicable for macos which does not support wrapping or scrolling in tabbed layout.
It can be seen in "Dictionary" native app amongst others where resizing the windows to smaller size does not wrap the tabbedpane.
Updated test instruction to highlight the macos-not-applicable point..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334457](https://bugs.openjdk.org/browse/JDK-8334457): Test javax/swing/JTabbedPane/bug4666224.java fail on macOS with because pressing the ‘C’ key does not switch the layout to WRAP_TAB_LAYOUT (**Bug** - P3)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20068/head:pull/20068` \
`$ git checkout pull/20068`

Update a local copy of the PR: \
`$ git checkout pull/20068` \
`$ git pull https://git.openjdk.org/jdk.git pull/20068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20068`

View PR using the GUI difftool: \
`$ git pr show -t 20068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20068.diff">https://git.openjdk.org/jdk/pull/20068.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20068#issuecomment-2213585699)