### PR TITLE
8335824: Test gc/arguments/TestMinInitialErgonomics.java is timing out

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
+++ b/test/hotspot/jtreg/gc/arguments/TestMinInitialErgonomics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package gc.arguments;
  * @test TestMinInitialErgonomics
  * @bug 8006088
  * @requires vm.gc.Parallel
+ * @requires vm.compMode != "Xcomp"
  * @summary Test Parallel GC ergonomics decisions related to minimum and initial heap size.
  * @library /test/lib
  * @library /


### PR DESCRIPTION
Hi all,

  please review this fix to this test to avoid running it with -Xcomp. The test spawns tons of threads to cover lots of different cases; when running with -Xcomp this takes too much time and triggers timeouts in CI.

There is no reason to run this test with -Xcomp as these initial heap size ergonomics will not be affected by that.

Testing: gha, local testing showing that the test times out with -Xcomp (and does not without) and does not run with that option afterwards

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335824](https://bugs.openjdk.org/browse/JDK-8335824): Test gc/arguments/TestMinInitialErgonomics.java is timing out (**Bug** - P3)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20069/head:pull/20069` \
`$ git checkout pull/20069`

Update a local copy of the PR: \
`$ git checkout pull/20069` \
`$ git pull https://git.openjdk.org/jdk.git pull/20069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20069`

View PR using the GUI difftool: \
`$ git pr show -t 20069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20069.diff">https://git.openjdk.org/jdk/pull/20069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20069#issuecomment-2213590439)