### PR TITLE
8335861: Problem list compiler/vectorization/TestFloat16VectorConvChain.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,6 +69,8 @@ compiler/startup/StartupOutput.java 8326615 generic-x64
 
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
+compiler/vectorization/TestFloat16VectorConvChain.java 8335860 generic-all
+
 #############################################################################
 
 # :hotspot_gc


### PR DESCRIPTION
Problem list compiler/vectorization/TestFloat16VectorConvChain.java until [JDK-8335860](https://bugs.openjdk.org/browse/JDK-8335860) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335861](https://bugs.openjdk.org/browse/JDK-8335861): Problem list compiler/vectorization/TestFloat16VectorConvChain.java (**Sub-task** - P2)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20071/head:pull/20071` \
`$ git checkout pull/20071`

Update a local copy of the PR: \
`$ git checkout pull/20071` \
`$ git pull https://git.openjdk.org/jdk.git pull/20071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20071`

View PR using the GUI difftool: \
`$ git pr show -t 20071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20071.diff">https://git.openjdk.org/jdk/pull/20071.diff</a>

</details>
