### PR TITLE
8335710: serviceability/dcmd/vm/SystemDumpMapTest.java and SystemMapTest.java fail on Linux Alpine after 8322475

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -49,8 +49,6 @@ public class SystemMapTestBase {
         regexBase_committed + "/bin/java",
         // libjvm
         regexBase_committed + "/lib/.*/libjvm.so",
-        // vdso library, should be part of all user space apps on all architectures OpenJDK supports.
-        regexBase_committed + "\\[vdso\\]",
         // we should see the hs-perf data file, and it should appear as shared as well as committed
         regexBase_shared_and_committed + "hsperfdata_.*"
     };

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -49,6 +49,8 @@ public class SystemMapTestBase {
         regexBase_committed + "/bin/java",
         // libjvm
         regexBase_committed + "/lib/.*/libjvm.so",
+        // heap segment, should be part of all user space apps on all architectures OpenJDK supports.
+        regexBase_committed + "\\[heap\\]",
         // we should see the hs-perf data file, and it should appear as shared as well as committed
         regexBase_shared_and_committed + "hsperfdata_.*"
     };


### PR DESCRIPTION
Unfortunately those 2 tests fail now on Linux Alpine (x86_64) :
serviceability/dcmd/vm/SystemDumpMapTest.java

Missing patterns in dump:
0x\\p{XDigit}+-0x\\p{XDigit}+ +\\d+ +[rwsxp-]+ +\\d+ +\\d+ +(4K|8K|16K|64K|2M|16M|64M) +com.*\\[vdso\\]
test SystemDumpMapTest.jmx(): failure
java.lang.RuntimeException: java.lang.RuntimeException: Missing patterns
at SystemDumpMapTest.run_test(SystemDumpMapTest.java:100)
at SystemDumpMapTest.run(SystemDumpMapTest.java:106)
at SystemDumpMapTest.jmx(SystemDumpMapTest.java:112)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:580)
at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)
 ....

Reason is that the vdso lib is not there on all Linux flavors; e.g. we do not seem to have it on our Alpine Linux test system.
So better avoid the check because it is based on false assumptions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335710](https://bugs.openjdk.org/browse/JDK-8335710): serviceability/dcmd/vm/SystemDumpMapTest.java and SystemMapTest.java fail on Linux Alpine after 8322475 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) 🔄 Re-review required (review applies to [3c9d1b9e](https://git.openjdk.org/jdk/pull/20072/files/3c9d1b9e64b037766ada319006a92454fcfbf041))
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20072/head:pull/20072` \
`$ git checkout pull/20072`

Update a local copy of the PR: \
`$ git checkout pull/20072` \
`$ git pull https://git.openjdk.org/jdk.git pull/20072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20072`

View PR using the GUI difftool: \
`$ git pr show -t 20072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20072.diff">https://git.openjdk.org/jdk/pull/20072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20072#issuecomment-2213711155)