### PR TITLE
8335820: java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java fails due to IllegalArgumentException: hash must be nonzero

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -68,24 +68,19 @@ public abstract sealed class AbstractPoolEntry {
      */
 
     private static final int TAG_SMEAR = 0x13C4B2D1;
-    private static final int INT_PHI = 0x9E3779B9;
+    private static final int NON_ZERO = 0x40000000;
 
     public static int hash1(int tag, int x1) {
-        return phiMix(tag * TAG_SMEAR + x1);
+        return (tag * TAG_SMEAR + x1) | NON_ZERO;
     }
 
     public static int hash2(int tag, int x1, int x2) {
-        return phiMix(tag * TAG_SMEAR + x1 + 31*x2);
+        return (tag * TAG_SMEAR + x1 + 31 * x2) | NON_ZERO;
     }
 
     // Ensure that hash is never zero
     public static int hashString(int stringHash) {
-        return phiMix(stringHash | (1 << 30));
-    }
-
-    public static int phiMix(int x) {
-        int h = x * INT_PHI;
-        return h ^ (h >> 16);
+        return stringHash | NON_ZERO;
     }
 
     public static Utf8Entry rawUtf8EntryFromStandardAttributeName(String name) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -68,7 +68,7 @@ public abstract sealed class AbstractPoolEntry {
      */
 
     private static final int TAG_SMEAR = 0x13C4B2D1;
-    private static final int NON_ZERO = 0x40000000;
+    static final int NON_ZERO = 0x40000000;
 
     public static int hash1(int tag, int x1) {
         return (tag * TAG_SMEAR + x1) | NON_ZERO;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     static int computeHashCode(MethodHandleEntryImpl handle,
                                List<? extends LoadableConstantEntry> arguments) {
-        return 31 * handle.hashCode() + arguments.hashCode();
+        return (31 * handle.hashCode() + arguments.hashCode()) | AbstractPoolEntry.NON_ZERO;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BootstrapMethodEntryImpl.java
@@ -76,9 +76,7 @@ public final class BootstrapMethodEntryImpl implements BootstrapMethodEntry {
 
     static int computeHashCode(MethodHandleEntryImpl handle,
                                List<? extends LoadableConstantEntry> arguments) {
-        int hash = handle.hashCode();
-        hash = 31 * hash + arguments.hashCode();
-        return AbstractPoolEntry.phiMix(hash);
+        return 31 * handle.hashCode() + arguments.hashCode();
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -987,77 +987,77 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
     public static AttributeMapper<?> standardAttribute(Utf8Entry name) {
         // critical bootstrap path, so no lambdas nor method handles here
         return switch (name.hashCode()) {
-            case 0x78147009 ->
+            case 0x46699ff2 ->
                 name.equalsString(NAME_ANNOTATION_DEFAULT) ? annotationDefault() : null;
-            case 0x665e3a3a ->
+            case 0x5208e184 ->
                 name.equalsString(NAME_BOOTSTRAP_METHODS) ? bootstrapMethods() : null;
-            case 0xcb7e162 ->
+            case 0xcb60907a ->
                 name.equalsString(NAME_CHARACTER_RANGE_TABLE) ? characterRangeTable() : null;
-            case 0x21e41e7e ->
+            case 0x4020220d ->
                 name.equalsString(NAME_CODE) ? code() : null;
-            case 0x5a306b41 ->
+            case 0xc20dd1fe ->
                 name.equalsString(NAME_COMPILATION_ID) ? compilationId() : null;
-            case 0x3e191c7c ->
+            case 0xcab1940d ->
                 name.equalsString(NAME_CONSTANT_VALUE) ? constantValue() : null;
-            case 0x5e88ed0c ->
+            case 0x558641d3 ->
                 name.equalsString(NAME_DEPRECATED) ? deprecated() : null;
-            case 0x7284695e ->
+            case 0x51d443cd ->
                 name.equalsString(NAME_ENCLOSING_METHOD) ? enclosingMethod() : null;
-            case 0x21df25db ->
+            case 0x687c1624 ->
                 name.equalsString(NAME_EXCEPTIONS) ? exceptions() : null;
-            case 0x11392da9 ->
+            case 0x7adb2910 ->
                 name.equalsString(NAME_INNER_CLASSES) ? innerClasses() : null;
-            case 0x167536fc ->
+            case 0x653f0551 ->
                 name.equalsString(NAME_LINE_NUMBER_TABLE) ? lineNumberTable() : null;
-            case 0x46939abc ->
+            case 0x64c75927 ->
                 name.equalsString(NAME_LOCAL_VARIABLE_TABLE) ? localVariableTable() : null;
-            case 0x63ee67f4 ->
+            case 0x6697f98d ->
                 name.equalsString(NAME_LOCAL_VARIABLE_TYPE_TABLE) ? localVariableTypeTable() : null;
-            case 0x2b597e15 ->
+            case 0xdbb0cdcb ->
                 name.equalsString(NAME_METHOD_PARAMETERS) ? methodParameters() : null;
-            case 0x19f20ade ->
+            case 0xc9b0928c ->
                 name.equalsString(NAME_MODULE) ? module() : null;
-            case 0x47f6395e ->
+            case 0x41cd27e8 ->
                 name.equalsString(NAME_MODULE_HASHES) ? moduleHashes() : null;
-            case 0x54db809 ->
+            case 0x7deb0a13 ->
                 name.equalsString(NAME_MODULE_MAIN_CLASS) ? moduleMainClass() : null;
-            case 0x1abd1c2c ->
+            case 0x6706ff99 ->
                 name.equalsString(NAME_MODULE_PACKAGES) ? modulePackages() : null;
-            case 0x6ba46dd ->
+            case 0x60272858 ->
                 name.equalsString(NAME_MODULE_RESOLUTION) ? moduleResolution() : null;
-            case 0x46f7d91d ->
+            case 0x5646d73d ->
                 name.equalsString(NAME_MODULE_TARGET) ? moduleTarget() : null;
-            case 0x5137f53 ->
+            case 0x50336c40 ->
                 name.equalsString(NAME_NEST_HOST) ? nestHost() : null;
-            case 0x4a8fa3b6 ->
+            case 0x4735ab81 ->
                 name.equalsString(NAME_NEST_MEMBERS) ? nestMembers() : null;
-            case 0x55c73cb6 ->
+            case 0x7100d9fe ->
                 name.equalsString(NAME_PERMITTED_SUBCLASSES) ? permittedSubclasses() : null;
-            case 0x3fe76d4e ->
+            case 0xd1ab5871 ->
                 name.equalsString(NAME_RECORD) ? record() : null;
-            case 0x180d6925 ->
+            case 0x7588550f ->
                 name.equalsString(NAME_RUNTIME_INVISIBLE_ANNOTATIONS) ? runtimeInvisibleAnnotations() : null;
-            case 0x7be22752 ->
+            case 0xcc74da30 ->
                 name.equalsString(NAME_RUNTIME_INVISIBLE_PARAMETER_ANNOTATIONS) ? runtimeInvisibleParameterAnnotations() : null;
-            case 0x5299824 ->
+            case 0xf67697f5 ->
                 name.equalsString(NAME_RUNTIME_INVISIBLE_TYPE_ANNOTATIONS) ? runtimeInvisibleTypeAnnotations() : null;
-            case 0x3534786e ->
+            case 0xe0837d2a ->
                 name.equalsString(NAME_RUNTIME_VISIBLE_ANNOTATIONS) ? runtimeVisibleAnnotations() : null;
-            case 0xb4b4ac6 ->
+            case 0xc945a075 ->
                 name.equalsString(NAME_RUNTIME_VISIBLE_PARAMETER_ANNOTATIONS) ? runtimeVisibleParameterAnnotations() : null;
-            case 0x6926482 ->
+            case 0x611a3a90 ->
                 name.equalsString(NAME_RUNTIME_VISIBLE_TYPE_ANNOTATIONS) ? runtimeVisibleTypeAnnotations() : null;
-            case 0x16a42b7c ->
+            case 0xf76fb898 ->
                 name.equalsString(NAME_SIGNATURE) ? signature() : null;
-            case 0x400ab245 ->
+            case 0x6b41b047 ->
                 name.equalsString(NAME_SOURCE_DEBUG_EXTENSION) ? sourceDebugExtension() : null;
-            case 0x2af490d4 ->
+            case 0x748c2857 ->
                 name.equalsString(NAME_SOURCE_FILE) ? sourceFile() : null;
-            case 0x303e0c58 ->
+            case 0x6bf13a96 ->
                 name.equalsString(NAME_SOURCE_ID) ? sourceId() : null;
-            case 0x19c7d0cd ->
+            case 0xfa85ee5a ->
                 name.equalsString(NAME_STACK_MAP_TABLE) ? stackMapTable() : null;
-            case 0x3dc79b7a ->
+            case 0xf2670725 ->
                 name.equalsString(NAME_SYNTHETIC) ? synthetic() : null;
             default -> null;
         };

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360 8330684 8331320 8331655 8331940 8332486
+ * @bug 8320360 8330684 8331320 8331655 8331940 8332486 8335820
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */
@@ -39,6 +39,7 @@ import java.lang.classfile.attribute.LineNumberInfo;
 import java.lang.classfile.attribute.LineNumberTableAttribute;
 import java.lang.classfile.attribute.LocalVariableInfo;
 import java.lang.classfile.attribute.LocalVariableTableAttribute;
+import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.ConstantPoolException;
 import java.lang.classfile.constantpool.IntegerEntry;
 import java.lang.classfile.instruction.LocalVariable;
@@ -189,5 +190,11 @@ class LimitsTest {
                                 new UnboundAttribute.UnboundLocalVariableInfo(0, 200,
                                         cob.constantPool().utf8Entry("a"), cob.constantPool().utf8Entry("A"), 0))))
                 ))).methods().get(0).code().get().elementList());
+    }
+
+    @Test
+    void testZeroHashCPEntry() {
+        var cpb = ConstantPoolBuilder.of();
+        cpb.intEntry(-cpb.intEntry(0).hashCode());
     }
 }


### PR DESCRIPTION
Class-File API constant pool implementation requires non-zero entry hash code.
Unfortunately current implementation computes zero hash code for specific CP entries.

This patch removes invalid and obsolete `AbstractPoolEntry::phiMix` calculation and assures all pool entries have non-zero hash. A regression test of the actual zero-hash `IntegerEntry` has been added. 

All pre-computed hash codes in `BoundAttribute::standardAttribute` are updated.

The patch has no performance effect measurable by any of the actual Class-File API benchmarks.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335820](https://bugs.openjdk.org/browse/JDK-8335820): java/lang/invoke/LFCaching/LFSingleThreadCachingTest.java fails due to IllegalArgumentException: hash must be nonzero (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20074/head:pull/20074` \
`$ git checkout pull/20074`

Update a local copy of the PR: \
`$ git checkout pull/20074` \
`$ git pull https://git.openjdk.org/jdk.git pull/20074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20074`

View PR using the GUI difftool: \
`$ git pr show -t 20074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20074.diff">https://git.openjdk.org/jdk/pull/20074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20074#issuecomment-2214045252)