### PR TITLE
8335904: Fix invalid comment in ShenandoahLock

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -44,7 +44,7 @@ void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
 template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
-  // Spin this much on multi-processor, do not spin on single-processor.
+  // Spin this much, but only on multi-processor systems.
   int ctr = os::is_MP() ? 0xFF : 0;
   // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||

--- a/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahLock.cpp
@@ -44,7 +44,7 @@ void ShenandoahLock::contended_lock(bool allow_block_for_safepoint) {
 template<bool ALLOW_BLOCK>
 void ShenandoahLock::contended_lock_internal(JavaThread* java_thread) {
   assert(!ALLOW_BLOCK || java_thread != nullptr, "Must have a Java thread when allowing block.");
-  // Spin this much on multi-processor, do not spin on multi-processor.
+  // Spin this much on multi-processor, do not spin on single-processor.
   int ctr = os::is_MP() ? 0xFF : 0;
   // Apply TTAS to avoid more expensive CAS calls if the lock is still held by other thread.
   while (Atomic::load(&_state) == locked ||


### PR DESCRIPTION
Hi all,
   This PR is to fix an invalid comment in ShenandoahLock I introduced in https://github.com/openjdk/jdk/pull/19570/files#r1668249587, thank you turbanoff@ for catching this, it is easy to miss since the PR had been closed.
    This PR should be trivial. 

Best,
Xiaolong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335904](https://bugs.openjdk.org/browse/JDK-8335904): Fix invalid comment in ShenandoahLock (**Bug** - P5)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20079/head:pull/20079` \
`$ git checkout pull/20079`

Update a local copy of the PR: \
`$ git checkout pull/20079` \
`$ git pull https://git.openjdk.org/jdk.git pull/20079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20079`

View PR using the GUI difftool: \
`$ git pr show -t 20079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20079.diff">https://git.openjdk.org/jdk/pull/20079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20079#issuecomment-2214678818)