### PR TITLE
8310915: Typo in aarch64.ad: "envcodings"

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -3360,7 +3360,7 @@ encode %{
     }
   %}
 
-  /// mov envcodings
+  // mov encodings
 
   enc_class aarch64_enc_movw_imm(iRegI dst, immI src) %{
     uint32_t con = (uint32_t)$src$$constant;


### PR DESCRIPTION
This is a trivial update to a comment that starts with an unnecessary extra slash and contains a typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310915](https://bugs.openjdk.org/browse/JDK-8310915): Typo in aarch64.ad: "envcodings" (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20081/head:pull/20081` \
`$ git checkout pull/20081`

Update a local copy of the PR: \
`$ git checkout pull/20081` \
`$ git pull https://git.openjdk.org/jdk.git pull/20081/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20081`

View PR using the GUI difftool: \
`$ git pr show -t 20081`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20081.diff">https://git.openjdk.org/jdk/pull/20081.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20081#issuecomment-2214858352)