### PR TITLE
8335911: Document ccls indexer in doc/ide.md

### DIFF
--- a/doc/ide.html
+++ b/doc/ide.html
@@ -63,11 +63,12 @@ workspace has been generated. To use it, choose
 <p>The main <code>vscode-project</code> target configures the default
 C++ support in Visual Studio Code. There are also other source indexers
 that can be installed, that may provide additional features. It's
-currently possible to generate configuration for two such indexers, <a
-href="https://clang.llvm.org/extra/clangd/">clangd</a> and <a
-href="https://github.com/Andersbakken/rtags">rtags</a>. These can be
-configured by appending the name of the indexer to the make target, such
-as:</p>
+currently possible to generate configuration for three such indexers, <a
+href="https://clang.llvm.org/extra/clangd/">clangd</a>, <a
+href="https://github.com/MaskRay/ccls/wiki/Visual-Studio-Code">ccls</a>
+and <a href="https://github.com/Andersbakken/rtags">rtags</a>. These can
+be configured by appending the name of the indexer to the make target,
+such as:</p>
 <pre class="shell"><code>make vscode-project-clangd</code></pre>
 <p>Additional instructions for configuring the given indexer will be
 displayed after the workspace has been generated.</p>

--- a/doc/ide.md
+++ b/doc/ide.md
@@ -32,7 +32,8 @@ choose `File -> Open Workspace...` in Visual Studio Code.
 The main `vscode-project` target configures the default C++ support in Visual
 Studio Code. There are also other source indexers that can be installed, that
 may provide additional features. It's currently possible to generate
-configuration for two such indexers, [clangd](https://clang.llvm.org/extra/clangd/)
+configuration for three such indexers, [clangd](https://clang.llvm.org/extra/clangd/),
+[ccls](https://github.com/MaskRay/ccls/wiki/Visual-Studio-Code)
 and [rtags](https://github.com/Andersbakken/rtags). These can be configured by
 appending the name of the indexer to the make target, such as:
 


### PR DESCRIPTION
`doc/ide.md` should also mention the [ccls indexer](https://github.com/MaskRay/ccls/wiki/Visual-Studio-Code).

Project files for it can be created by `make vscode-project-ccls`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335911](https://bugs.openjdk.org/browse/JDK-8335911): Document ccls indexer in doc/ide.md (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20082/head:pull/20082` \
`$ git checkout pull/20082`

Update a local copy of the PR: \
`$ git checkout pull/20082` \
`$ git pull https://git.openjdk.org/jdk.git pull/20082/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20082`

View PR using the GUI difftool: \
`$ git pr show -t 20082`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20082.diff">https://git.openjdk.org/jdk/pull/20082.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20082#issuecomment-2214885809)