### PR TITLE
8335553: [Graal] Compiler thread calls into jdk.internal.vm.VMSupport.decodeAndThrowThrowable and crashes in OOM situation

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -757,6 +757,35 @@ C2V_VMENTRY_NULL(jobject, lookupConstantInPool, (JNIEnv* env, jobject, ARGUMENT_
       return JVMCIENV->get_jobject(result);
     }
   }
+#ifdef ASSERT
+  // Support for testing an OOME raised in a context where the current thread cannot call Java
+  // 1. Put -Dtest.jvmci.oome_in_lookupConstantInPool=<trace> on the command line to
+  //    discover possible values for step 2.
+  //    Example output:
+  //
+  //      CompilerToVM.lookupConstantInPool: "Overflow: String length out of range"{0x00000007ffeb2960}
+  //      CompilerToVM.lookupConstantInPool: "null"{0x00000007ffebdfe8}
+  //      CompilerToVM.lookupConstantInPool: "Maximum lock count exceeded"{0x00000007ffec4f90}
+  //      CompilerToVM.lookupConstantInPool: "Negative length"{0x00000007ffec4468}
+  //
+  // 2. Choose a value shown in step 1.
+  //    Example: -Dtest.jvmci.oome_in_lookupConstantInPool=Negative
+  const char* val = Arguments::PropertyList_get_value(Arguments::system_properties(), "test.jvmci.oome_in_lookupConstantInPool");
+  if (val != nullptr) {
+    const char* str = obj->print_value_string();
+    if (strstr(val, "<trace>") != nullptr) {
+      tty->print_cr("CompilerToVM.lookupConstantInPool: %s", str);
+    } else if (strstr(str, val) != nullptr) {
+      Handle garbage;
+      while (true) {
+        // Trigger an OutOfMemoryError
+        objArrayOop next = oopFactory::new_objectArray(0x7FFFFFFF, CHECK_NULL);
+        next->obj_at_put(0, garbage());
+        garbage = Handle(THREAD, next);
+      }
+    }
+  }
+#endif
   return JVMCIENV->get_jobject(JVMCIENV->get_object_constant(obj));
 C2V_END
 

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -111,11 +111,9 @@ bool Exceptions::special_exception(JavaThread* thread, const char* file, int lin
   }
 #endif // ASSERT
 
-  if (!thread->can_call_java()) {
+  if (h_exception.is_null() && !thread->can_call_java()) {
     ResourceMark rm(thread);
-    const char* exc_value = h_exception.not_null() ? h_exception->print_value_string() :
-                      h_name != nullptr ? h_name->as_C_string() :
-                      "null";
+    const char* exc_value = h_name != nullptr ? h_name->as_C_string() : "null";
     log_info(exceptions)("Thread cannot call Java so instead of throwing exception <%s%s%s> (" PTR_FORMAT ") \n"
                         "at [%s, line %d]\nfor thread " PTR_FORMAT ",\n"
                         "throwing pre-allocated exception: %s",
@@ -205,7 +203,7 @@ void Exceptions::_throw_msg_cause(JavaThread* thread, const char* file, int line
 void Exceptions::_throw_cause(JavaThread* thread, const char* file, int line, Symbol* name, Handle h_cause,
                               Handle h_loader, Handle h_protection_domain) {
   // Check for special boot-strapping/compiler-thread handling
-  if (special_exception(thread, file, line, h_cause)) return;
+  if (special_exception(thread, file, line, Handle(), name)) return;
   // Create and throw exception
   Handle h_exception = new_exception(thread, name, h_cause, h_loader, h_protection_domain);
   _throw(thread, file, line, h_exception, nullptr);

--- a/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
+++ b/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
@@ -42,6 +42,10 @@ import java.util.zip.GZIPOutputStream;
 
 /**
  * Support for translating exceptions between the HotSpot heap and libjvmci heap.
+ *
+ * Successfully translated exceptions are wrapped in a TranslatedException instance.
+ * This allows callers to distiguish between a translated exception and an error
+ * that arose during translation.
  */
 @SuppressWarnings("serial")
 final class TranslatedException extends Exception {
@@ -61,13 +65,16 @@ final class TranslatedException extends Exception {
         maybeFailClinit();
         try {
             FALLBACK_ENCODED_THROWABLE_BYTES =
-                encodeThrowable(new TranslatedException("error during encoding",
-                                                        "<unknown>"), false);
+                encodeThrowable(translationFailure("error during encoding"), false);
             FALLBACK_ENCODED_OUTOFMEMORYERROR_BYTES =
-                encodeThrowable(new OutOfMemoryError(), false);
+                encodeThrowable(translationFailure("OutOfMemoryError during encoding"), false);
         } catch (IOException e) {
             throw new InternalError(e);
         }
+    }
+
+    private static InternalError translationFailure(String messageFormat, Object... messageArgs) {
+        return new InternalError(messageFormat.formatted(messageArgs));
     }
 
     /**
@@ -86,14 +93,8 @@ final class TranslatedException extends Exception {
         }
     }
 
-    /**
-     * Class name of exception that could not be instantiated.
-     */
-    private String originalExceptionClassName;
-
-    private TranslatedException(String message, String originalExceptionClassName) {
-        super(message);
-        this.originalExceptionClassName = originalExceptionClassName;
+    TranslatedException(Throwable translated) {
+        super(translated);
     }
 
     /**
@@ -104,18 +105,6 @@ final class TranslatedException extends Exception {
     @Override
     public Throwable fillInStackTrace() {
         return this;
-    }
-
-    @Override
-    public String toString() {
-        String s;
-        if (originalExceptionClassName.equals(TranslatedException.class.getName())) {
-            s = getClass().getName();
-        } else {
-            s = getClass().getName() + "[" + originalExceptionClassName + "]";
-        }
-        String message = getMessage();
-        return (message != null) ? (s + ": " + message) : s;
     }
 
     /**
@@ -163,7 +152,7 @@ final class TranslatedException extends Exception {
             return initCause((Throwable) cons.newInstance(message), cause, debug);
         } catch (Throwable translationFailure) {
             debugPrintStackTrace(translationFailure, debug);
-            return initCause(new TranslatedException(message, className), cause, debug);
+            return initCause(translationFailure("%s [%s]", message, className), cause, debug);
         }
     }
 
@@ -308,11 +297,10 @@ final class TranslatedException extends Exception {
                 throwable.setStackTrace(stackTrace);
                 cause = throwable;
             }
-            return throwable;
+            return new TranslatedException(throwable);
         } catch (Throwable translationFailure) {
             debugPrintStackTrace(translationFailure, debug);
-            return new TranslatedException("Error decoding exception: " + encodedThrowable,
-                                           translationFailure.getClass().getName());
+            return translationFailure("error decoding exception: %s", encodedThrowable);
         }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
+++ b/src/java.base/share/classes/jdk/internal/vm/TranslatedException.java
@@ -48,7 +48,7 @@ import java.util.zip.GZIPOutputStream;
  * that arose during translation.
  */
 @SuppressWarnings("serial")
-final class TranslatedException extends Exception {
+public final class TranslatedException extends Exception {
 
     /**
      * The value returned by {@link #encodeThrowable(Throwable)} when encoding


### PR DESCRIPTION
This PR addresses intermittent failures in jtreg GC stress tests. The failures occur under these conditions:
1. Using a libgraal build with assertions enabled as the top tier JIT compiler. Such a libgraal build will cause a VM exit if an assertion or GraalError occurs in a compiler thread (as this catches more errors in testing).
2. A libgraal compiler thread makes a call into the VM (via `CompilerToVM`) to a routine that performs a HotSpot heap allocation that fails.
3. The resulting OOME is wrapped in a GraalError, causing the VM to exit as described in 1.

An OOME thrown in these specific conditions should not exit the VM as it not related to an OOME in the app or test. Instead, the failure should be treated as a bailout and the libgraal compiler should continue.

To accomplish this, libgraal needs to be able to distinguish a GraalError caused by an OOME. This PR modifies the exception translation code to make this possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335553](https://bugs.openjdk.org/browse/JDK-8335553): [Graal] Compiler thread calls into jdk.internal.vm.VMSupport.decodeAndThrowThrowable and crashes in OOM situation (**Bug** - P4)


### Reviewers
 * [Yudi Zheng](https://openjdk.org/census#yzheng) (@mur47x111 - Committer)
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20083/head:pull/20083` \
`$ git checkout pull/20083`

Update a local copy of the PR: \
`$ git checkout pull/20083` \
`$ git pull https://git.openjdk.org/jdk.git pull/20083/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20083`

View PR using the GUI difftool: \
`$ git pr show -t 20083`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20083.diff">https://git.openjdk.org/jdk/pull/20083.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20083#issuecomment-2216860159)