### PR TITLE
8334757: AssertionError: Missing type variable in where clause

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/RichDiagnosticFormatter.java
@@ -184,6 +184,9 @@ public class RichDiagnosticFormatter extends
         if (arg instanceof Type type) {
             preprocessType(type);
         }
+        else if (arg instanceof JCDiagnostic.AnnotatedType type) {
+            preprocessType(type.type());
+        }
         else if (arg instanceof Symbol symbol) {
             preprocessSymbol(symbol);
         }

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateClassWithTypeVariable.java
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateClassWithTypeVariable.java
@@ -1,0 +1,19 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334757
+ * @compile/fail/ref=CantAnnotateClassWithTypeVariable.out -XDrawDiagnostics CantAnnotateClassWithTypeVariable.java
+ */
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+public class CantAnnotateClassWithTypeVariable {
+  @Target(ElementType.TYPE_USE)
+  @interface TA {}
+
+  static class A {
+    static class B<T> {}
+  }
+
+  <T> @TA A.B<T> f() {}
+}

--- a/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateClassWithTypeVariable.out
+++ b/test/langtools/tools/javac/annotations/typeAnnotations/failures/CantAnnotateClassWithTypeVariable.out
@@ -1,0 +1,2 @@
+CantAnnotateClassWithTypeVariable.java:18:14: compiler.err.type.annotation.inadmissible: (compiler.misc.type.annotation.1: @CantAnnotateClassWithTypeVariable.TA), CantAnnotateClassWithTypeVariable.A, @CantAnnotateClassWithTypeVariable.TA CantAnnotateClassWithTypeVariable.A.B<T>
+1 error


### PR DESCRIPTION
Please review this clean backport of #19840 to JDK 23, which avoids a crash when types with type variables appear as arguments for diagnostics that use `JCDiagnostic.AnnotatedType`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334757](https://bugs.openjdk.org/browse/JDK-8334757): AssertionError: Missing type variable in where clause (**Bug** - P2)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20085/head:pull/20085` \
`$ git checkout pull/20085`

Update a local copy of the PR: \
`$ git checkout pull/20085` \
`$ git pull https://git.openjdk.org/jdk.git pull/20085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20085`

View PR using the GUI difftool: \
`$ git pr show -t 20085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20085.diff">https://git.openjdk.org/jdk/pull/20085.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20085#issuecomment-2215203221)