### PR TITLE
8072701: resume001 failed due to ERROR: timeout for waiting for a BreakpintEvent

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
@@ -370,10 +370,9 @@ public class resume001 {
                         break label1;
                 log2("       thread2 is at breakpoint");
 
-
                 log2("       resuming the thread2");
                 thread2.resume();
-                
+
                 log2("       undo the vm.suspend() with vm.resume()");
                 vm.resume();
             }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
@@ -336,7 +336,6 @@ public class resume001 {
                     break label1;
                 log2("       thread2 is at breakpoint");
 
-
                 log2("......checking up that thread2.resume() resumes thread2 suspended with VirtualMachine.suspend()");
 
                 log2("       enabling breakpRequest3");
@@ -353,6 +352,13 @@ public class resume001 {
                     expresult = returnCode1;
                     break label1;
                 }
+
+                // We need to resume the main thread because thread2 might be blocked on it,
+                // but we want to keep thread2 suspended.
+                log2("       allow main thead (and others) to run while keeping thread2 suspended");
+                thread2.suspend();
+                vm.resume();
+
                 log2("       second resuming the thread2 with thread2.resume()");
                 thread2.resume();
                 log2("       getting BreakpointEvent");
@@ -366,7 +372,6 @@ public class resume001 {
                 thread2.resume();
 
             }
-            vm.resume();
             vm.resume();  // for case error when both VirtualMachine and the thread2 were suspended
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -487,7 +492,7 @@ public class resume001 {
                 try {
                     eventSet = eventQueue.remove(waitTime*60000);
                     if (eventSet == null) {
-                        log3("ERROR:  timeout for waiting for a BreakpintEvent");
+                        log3("ERROR:  timeout for waiting for a BreakpointEvent");
                         returnCode = returnCode3;
                         break labelBP;
                     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001.java
@@ -117,6 +117,7 @@ public class resume001 {
     static int waitTime;
 
     static VirtualMachine      vm            = null;
+    static Debugee             debuggee      = null;
     static EventRequestManager eventRManager = null;
     static EventQueue          eventQueue    = null;
     static EventSet            eventSet      = null;
@@ -136,8 +137,6 @@ public class resume001 {
     //------------------------------------------------------ methods
 
     private int runThis (String argv[], PrintStream out) {
-
-        Debugee debuggee;
 
         argsHandler     = new ArgumentHandler(argv);
         logHandler      = new Log(out, argsHandler);
@@ -340,8 +339,19 @@ public class resume001 {
 
                 log2("       enabling breakpRequest3");
                 breakpRequest3.enable();
+
+                // don't do vm.suspend() until mainThread is waiting
+                line = pipe.readln();
+                if (line.equals("waiting")) {
+                    log2("     : returned string is 'waiting'");
+                } else {
+                    log3("ERROR: returned string is not 'waiting': " + line);
+                    expresult = returnCode4;
+                    break label1;
+                }
                 log2("       suspending the thread2 with vm.suspend()");
                 vm.suspend();
+
                 log2("       first resuming the thread2 with eventSet.resume()");
                 eventSet.resume();
                 log2("       checking up thread's state");
@@ -352,13 +362,6 @@ public class resume001 {
                     expresult = returnCode1;
                     break label1;
                 }
-
-                // We need to resume the main thread because thread2 might be blocked on it,
-                // but we want to keep thread2 suspended.
-                log2("       allow main thead (and others) to run while keeping thread2 suspended");
-                thread2.suspend();
-                vm.resume();
-
                 log2("       second resuming the thread2 with thread2.resume()");
                 thread2.resume();
                 log2("       getting BreakpointEvent");
@@ -368,11 +371,17 @@ public class resume001 {
                 log2("       thread2 is at breakpoint");
 
 
-                log2("      resuming the thread2");
+                log2("       resuming the thread2");
                 thread2.resume();
-
+                
+                log2("       undo the vm.suspend() with vm.resume()");
+                vm.resume();
             }
-            vm.resume();  // for case error when both VirtualMachine and the thread2 were suspended
+            // These are only needed if we break out of the loop due to an error
+            if (expresult != returnCode0) {
+                vm.resume();
+                vm.resume();  // for case error when both VirtualMachine and the thread2 were suspended
+            }
 
             //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             log2("     the end of testing");
@@ -493,6 +502,7 @@ public class resume001 {
                     eventSet = eventQueue.remove(waitTime*60000);
                     if (eventSet == null) {
                         log3("ERROR:  timeout for waiting for a BreakpointEvent");
+                        debuggee.printThreadsInfo(vm);
                         returnCode = returnCode3;
                         break labelBP;
                     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/ThreadReference/resume/resume001a.java
@@ -81,7 +81,13 @@ public class resume001a {
 
             String instruction;
 
-            log1("waiting for an instruction from the debugger ...");
+            log1("waiting for an instruction from the debugger: iteration " + i);
+            if (i == 1) {
+                // Let the debugger know we finished the first iteration and are now
+                // waiting for next command. This is needed so we don't suspend the
+                // main thread while it is doing a log(), which can hold a needed lock.
+                pipe.println("waiting");
+            }
             instruction = pipe.readln();
             if (instruction.equals("quit")) {
                 log1("'quit' recieved");

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -595,9 +595,9 @@ public class Debugee extends DebugeeProcess {
     /*
      * Print information about all threads in debuggee VM
      */
-    public void printThreadsInfo(VirtualMachine vm)  {
+    public void printThreadsInfo(VirtualMachine vm) {
         try {
-            log.display("------------ Try to print debuggee threads before killing process ------------");
+            log.display("------------ Print debuggee threads ------------");
             if (vm == null) {
                 log.display("Can't print threads info because 'vm' is null");
                 return;
@@ -631,7 +631,7 @@ public class Debugee extends DebugeeProcess {
                     }
                 }
             }
-            log.display("----------------------------------------------------------------------");
+            log.display("------------------------------------------------");
         } catch (Throwable t) {
             log.complain("");
             t.printStackTrace(log.getOutStream());

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/Debugee.java
@@ -595,7 +595,7 @@ public class Debugee extends DebugeeProcess {
     /*
      * Print information about all threads in debuggee VM
      */
-    protected void printThreadsInfo(VirtualMachine vm)  {
+    public void printThreadsInfo(VirtualMachine vm)  {
         try {
             log.display("------------ Try to print debuggee threads before killing process ------------");
             if (vm == null) {


### PR DESCRIPTION
The test hits a breakpoint on thread2 with SUSPEND_EVENT_THREAD policy, so only thread2 is suspended. It then does a vm.suspend(), which suspends all threads and bumps the suspendCount of thread2 up to 2. It then does an eventSet.resume(), which decrements the thread2 suspendCount to 1, so now all threads are suspended with a suspendCount of 1. thread2 is then resumed and we expect to hit the next thread2 breakpoint. The problem is that thread2 can't hit the breakpoint until the main thread has proceeded far enough, and if the vm.suspend() that suspended the main thread happens too quickly, it won't have proceeded far enough, so thread2 never hits the breakpoint.

Essentially we need a vm.resume() to allow the main thread to run, but we need to do it in a way that does nullify part of what the test is testing for. So in order to allow the vm.resume() but not subvert the intent of the test, we first do a thread2.suspend() so the vm.resume() won't resume thread2.

Testing in progress: tier1 and tier5 svc testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8072701](https://bugs.openjdk.org/browse/JDK-8072701): resume001 failed due to ERROR: timeout for waiting for a BreakpintEvent (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) 🔄 Re-review required (review applies to [b70bcd19](https://git.openjdk.org/jdk/pull/20088/files/b70bcd1943105509f627df588010c5d5db461ac5))
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) 🔄 Re-review required (review applies to [3c9b88d6](https://git.openjdk.org/jdk/pull/20088/files/3c9b88d63a4491f6216d547deab64e367a1ab85c))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20088/head:pull/20088` \
`$ git checkout pull/20088`

Update a local copy of the PR: \
`$ git checkout pull/20088` \
`$ git pull https://git.openjdk.org/jdk.git pull/20088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20088`

View PR using the GUI difftool: \
`$ git pr show -t 20088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20088.diff">https://git.openjdk.org/jdk/pull/20088.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20088#issuecomment-2216507558)