### PR TITLE
8335906: [s390x] Test Failure: GTestWrapper.java

### DIFF
--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -959,7 +959,7 @@ static void print_ascii_form(stringStream& ascii_form, uint64_t value, int units
     uint8_t c[sizeof(v)];
   } u = { value };
   for (int i = 0; i < unitsize; i++) {
-    const int idx = LITTLE_ENDIAN_ONLY(i) BIG_ENDIAN_ONLY(sizeof(u.v) - 1 - i);
+    const int idx = LITTLE_ENDIAN_ONLY(i) BIG_ENDIAN_ONLY(sizeof(u.v) - unitsize + i);
     const uint8_t c = u.c[idx];
     ascii_form.put(isprint(c) && isascii(c) ? c : '.');
   }


### PR DESCRIPTION
```
PAT_1 is fine because only 1 element is there, i.e. last element: 

[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  j value =   6a, v =   6a 
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  d value =   64, v =   64 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  k value =   6b, v =   6b 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  / value =   2f, v =   2f 
[debug] u.c[idx] =   69,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  i value =   69, v =   69 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  n value =   6e, v =   6e 
[debug] u.c[idx] =   74,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  t value =   74, v =   74 
[debug] u.c[idx] =   65,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  e value =   65, v =   65 
[debug] u.c[idx] =   72,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  r value =   72, v =   72 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  n value =   6e, v =   6e 
[debug] u.c[idx] =   61,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  a value =   61, v =   61 
[debug] u.c[idx] =   6c,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  l value =   6c, v =   6c 
```

issue starts when array `u.c` size increases; 
```
PAT_2:
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  d value = 6a64, v = 6a64 
[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  j value = 6a64, v = 6a64 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  / value = 6b2f, v = 6b2f 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  k value = 6b2f, v = 6b2f 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  n value = 696e, v = 696e 
[debug] u.c[idx] =   69,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  i value = 696e, v = 696e 
[debug] u.c[idx] =   65,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  e value = 7465, v = 7465 
[debug] u.c[idx] =   74,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  t value = 7465, v = 7465 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  n value = 726e, v = 726e 
[debug] u.c[idx] =   72,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  r value = 726e, v = 726e 
[debug] u.c[idx] =   6c,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  l value = 616c, v = 616c 
[debug] u.c[idx] =   61,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  a value = 616c, v = 616c 
[debug] u.c[idx] =   6c,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  l value = 2f6c, v = 2f6c 
```

```
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  d value = 6a64, v = 6a64 
[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  j value = 6a64, v = 6a64 
```
It should have been interpreted as `6a` and then `64` but chronology is reversed here. Issue is that we are reading the array in reverse order. Which is what, this patch is fixing. Instead of reading the array from back, We will find the location of location of element, respective to the iteration. i.e. in this case we will find the index of `6a` for `0th` iteration and pick index of `64` for `1st` iteration. 

With Fix:
```
PAT_1:

[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  j value =   6a, v =   6a 
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  d value =   64, v =   64 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  k value =   6b, v =   6b 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  / value =   2f, v =   2f 
[debug] u.c[idx] =   69,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  i value =   69, v =   69 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  n value =   6e, v =   6e 
[debug] u.c[idx] =   74,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  t value =   74, v =   74 
[debug] u.c[idx] =   65,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  e value =   65, v =   65 
[debug] u.c[idx] =   72,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  r value =   72, v =   72 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  n value =   6e, v =   6e 
[debug] u.c[idx] =   61,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  a value =   61, v =   61 
[debug] u.c[idx] =   6c,  sizeof(u.v) = 8, unitsize = 1 , i+1 = 1,  l value =   6c, v =   6c 
```

```
PAT_2:
[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  j value = 6a64, v = 6a64 
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  d value = 6a64, v = 6a64 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 1,  k value = 6b2f, v = 6b2f 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 2 , i+1 = 2,  / value = 6b2f, v = 6b2f 
```

```
PAT_3:
[debug] u.c[idx] =   23,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 1,  # value = 23006a64, v = 23006a64 
[debug] u.c[idx] =    0,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 2,   value = 23006a64, v = 23006a64 
[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 3,  j value = 23006a64, v = 23006a64 
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 4,  d value = 23006a64, v = 23006a64 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 1,  k value = 6b2f696e, v = 6b2f696e 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 2,  / value = 6b2f696e, v = 6b2f696e 
[debug] u.c[idx] =   69,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 3,  i value = 6b2f696e, v = 6b2f696e 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 4 , i+1 = 4,  n value = 6b2f696e, v = 6b2f696e 
```

```
PAT_4:

[debug] u.c[idx] =   ff,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 1,  ? value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   ff,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 2,  ? value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   e0,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 3,  ? value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   dc,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 4,  ? value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   23,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 5,  # value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =    0,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 6,   value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   6a,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 7,  j value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   64,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 8,  d value = ffffe0dc23006a64, v = ffffe0dc23006a64 
[debug] u.c[idx] =   6b,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 1,  k value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   2f,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 2,  / value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   69,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 3,  i value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 4,  n value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   74,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 5,  t value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   65,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 6,  e value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   72,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 7,  r value = 6b2f696e7465726e, v = 6b2f696e7465726e 
[debug] u.c[idx] =   6e,  sizeof(u.v) = 8, unitsize = 8 , i+1 = 8,  n value = 6b2f696e7465726e, v = 6b2f696e7465726e 
```


Maybe I understood whole thing incorrectly, So I'm open for suggestions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335906](https://bugs.openjdk.org/browse/JDK-8335906): [s390x] Test Failure: GTestWrapper.java (**Bug** - P3)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20089/head:pull/20089` \
`$ git checkout pull/20089`

Update a local copy of the PR: \
`$ git checkout pull/20089` \
`$ git pull https://git.openjdk.org/jdk.git pull/20089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20089`

View PR using the GUI difftool: \
`$ git pr show -t 20089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20089.diff">https://git.openjdk.org/jdk/pull/20089.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20089#issuecomment-2216549429)