### PR TITLE
8335946: DTrace code snippets should be generated when DTrace flags are enabled

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -1418,8 +1418,7 @@ void InterpreterMacroAssembler::notify_method_entry() {
     bind(L);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     get_method(c_rarg1);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
                  rthread, c_rarg1);
@@ -1458,8 +1457,7 @@ void InterpreterMacroAssembler::notify_method_exit(
     pop(state);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     push(state);
     get_method(c_rarg1);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),

--- a/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateTable_aarch64.cpp
@@ -3648,8 +3648,7 @@ void TemplateTable::_new() {
     __ store_klass_gap(r0, zr);  // zero klass gap for compressed oops
     __ store_klass(r0, r4);      // store klass last
 
-    {
-      SkipIfEqual skip(_masm, &DTraceAllocProbes, false);
+    if (DTraceAllocProbes) {
       // Trigger dtrace event for fastpath
       __ push(atos); // save the return value
       __ call_VM_leaf(

--- a/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
+++ b/src/hotspot/cpu/ppc/templateTable_ppc_64.cpp
@@ -3859,10 +3859,11 @@ void TemplateTable::_new() {
     __ store_klass(RallocatedObject, RinstanceKlass, Rscratch); // klass (last for cms)
 
     // Check and trigger dtrace event.
-    SkipIfEqualZero::skip_to_label_if_equal_zero(_masm, Rscratch, &DTraceAllocProbes, Ldone);
-    __ push(atos);
-    __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)));
-    __ pop(atos);
+    if (DTraceAllocProbes) {
+      __ push(atos);
+      __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)));
+      __ pop(atos);
+    }
 
     __ b(Ldone);
   }

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -1467,8 +1467,7 @@ void InterpreterMacroAssembler::notify_method_entry() {
     bind(L);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     get_method(c_rarg1);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
                  xthread, c_rarg1);
@@ -1506,8 +1505,7 @@ void InterpreterMacroAssembler::notify_method_exit(
     pop(state);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false);
+  if (DTraceMethodProbes) {
     push(state);
     get_method(c_rarg1);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2001,10 +2001,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     {
       __ block_comment("dtrace entry {");
       __ bind(dtrace_method_entry);
-  
+
       // We have all of the arguments setup at this point. We must not touch any register
       // argument registers at this point (what if we save/restore them there are no oop?
-  
+
       save_args(masm, total_c_args, c_arg, out_regs);
       __ mov_metadata(c_rarg1, method());
       __ call_VM_leaf(
@@ -2014,7 +2014,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ j(dtrace_method_entry_done);
       __ block_comment("} dtrace entry");
     }
-  
+
     {
       __ block_comment("dtrace exit {");
       __ bind(dtrace_method_exit);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1638,14 +1638,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   __ set_last_Java_frame(sp, noreg, native_return, t0);
 
   Label dtrace_method_entry, dtrace_method_entry_done;
-  {
-    ExternalAddress target((address)&DTraceMethodProbes);
-    __ relocate(target.rspec(), [&] {
-      int32_t offset;
-      __ la(t0, target.target(), offset);
-      __ lbu(t0, Address(t0, offset));
-    });
-    __ bnez(t0, dtrace_method_entry);
+  if (DTraceMethodProbes) {
+    __ j(dtrace_method_entry);
     __ bind(dtrace_method_entry_done);
   }
 
@@ -1861,14 +1855,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   Label dtrace_method_exit, dtrace_method_exit_done;
-  {
-    ExternalAddress target((address)&DTraceMethodProbes);
-    __ relocate(target.rspec(), [&] {
-      int32_t offset;
-      __ la(t0, target.target(), offset);
-      __ lbu(t0, Address(t0, offset));
-    });
-    __ bnez(t0, dtrace_method_exit);
+  if (DTraceMethodProbes) {
+    __ j(dtrace_method_exit);
     __ bind(dtrace_method_exit_done);
   }
 
@@ -2009,34 +1997,36 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   }
 
   // SLOW PATH dtrace support
-  {
-    __ block_comment("dtrace entry {");
-    __ bind(dtrace_method_entry);
-
-    // We have all of the arguments setup at this point. We must not touch any register
-    // argument registers at this point (what if we save/restore them there are no oop?
-
-    save_args(masm, total_c_args, c_arg, out_regs);
-    __ mov_metadata(c_rarg1, method());
-    __ call_VM_leaf(
-      CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
-      xthread, c_rarg1);
-    restore_args(masm, total_c_args, c_arg, out_regs);
-    __ j(dtrace_method_entry_done);
-    __ block_comment("} dtrace entry");
-  }
-
-  {
-    __ block_comment("dtrace exit {");
-    __ bind(dtrace_method_exit);
-    save_native_result(masm, ret_type, stack_slots);
-    __ mov_metadata(c_rarg1, method());
-    __ call_VM_leaf(
-         CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),
-         xthread, c_rarg1);
-    restore_native_result(masm, ret_type, stack_slots);
-    __ j(dtrace_method_exit_done);
-    __ block_comment("} dtrace exit");
+  if (DTraceMethodProbes) {
+    {
+      __ block_comment("dtrace entry {");
+      __ bind(dtrace_method_entry);
+  
+      // We have all of the arguments setup at this point. We must not touch any register
+      // argument registers at this point (what if we save/restore them there are no oop?
+  
+      save_args(masm, total_c_args, c_arg, out_regs);
+      __ mov_metadata(c_rarg1, method());
+      __ call_VM_leaf(
+        CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
+        xthread, c_rarg1);
+      restore_args(masm, total_c_args, c_arg, out_regs);
+      __ j(dtrace_method_entry_done);
+      __ block_comment("} dtrace entry");
+    }
+  
+    {
+      __ block_comment("dtrace exit {");
+      __ bind(dtrace_method_exit);
+      save_native_result(masm, ret_type, stack_slots);
+      __ mov_metadata(c_rarg1, method());
+      __ call_VM_leaf(
+           CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_exit),
+           xthread, c_rarg1);
+      restore_native_result(masm, ret_type, stack_slots);
+      __ j(dtrace_method_exit_done);
+      __ block_comment("} dtrace exit");
+    }
   }
 
   __ flush();

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -3592,8 +3592,7 @@ void TemplateTable::_new() {
     __ store_klass_gap(x10, zr);   // zero klass gap for compressed oops
     __ store_klass(x10, x14);      // store klass last
 
-    {
-      SkipIfEqual skip(_masm, &DTraceAllocProbes, false);
+    if (DTraceAllocProbes) {
       // Trigger dtrace event for fastpath
       __ push(atos); // save the return value
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), x10);

--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -3976,8 +3976,7 @@ void TemplateTable::_new() {
     __ store_klass_gap(Rzero, RallocatedObject);  // Zero klass gap for compressed oops.
     __ store_klass(iklass, RallocatedObject);     // Store klass last.
 
-    {
-      SkipIfEqual skip(_masm, &DTraceAllocProbes, false, Z_ARG5 /*scratch*/);
+    if (DTraceAllocProbes) {
       // Trigger dtrace event for fastpath.
       __ push(atos); // Save the return value.
       __ call_VM_leaf(CAST_FROM_FN_PTR(address, static_cast<int (*)(oopDesc*)>(SharedRuntime::dtrace_object_alloc)), RallocatedObject);

--- a/src/hotspot/cpu/x86/interp_masm_x86.cpp
+++ b/src/hotspot/cpu/x86/interp_masm_x86.cpp
@@ -1955,8 +1955,7 @@ void InterpreterMacroAssembler::notify_method_entry() {
     bind(L);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false, rscratch1);
+  if (DTraceMethodProbes) {
     NOT_LP64(get_thread(rthread);)
     get_method(rarg);
     call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
@@ -2000,8 +1999,7 @@ void InterpreterMacroAssembler::notify_method_exit(
     pop(state);
   }
 
-  {
-    SkipIfEqual skip(this, &DTraceMethodProbes, false, rscratch1);
+  if (DTraceMethodProbes) {
     push(state);
     NOT_LP64(get_thread(rthread);)
     get_method(rarg);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1612,8 +1612,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // We have all of the arguments setup at this point. We must not touch any register
   // argument registers at this point (what if we save/restore them there are no oop?
 
-  {
-    SkipIfEqual skip_if(masm, &DTraceMethodProbes, 0, noreg);
+  if (DTraceMethodProbes) {
     __ mov_metadata(rax, method());
     __ call_VM_leaf(
          CAST_FROM_FN_PTR(address, SharedRuntime::dtrace_method_entry),
@@ -1857,8 +1856,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     __ bind(fast_done);
   }
 
-  {
-    SkipIfEqual skip_if(masm, &DTraceMethodProbes, 0, noreg);
+  if (DTraceMethodProbes) {
     // Tell dtrace about this method exit
     save_native_result(masm, ret_type, stack_slots);
     __ mov_metadata(rax, method());

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2200,8 +2200,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
   // We have all of the arguments setup at this point. We must not touch any register
   // argument registers at this point (what if we save/restore them there are no oop?
 
-  {
-    SkipIfEqual skip(masm, &DTraceMethodProbes, false, rscratch1);
+  if (DTraceMethodProbes) {
     // protect the args we've loaded
     save_args(masm, total_c_args, c_arg, out_regs);
     __ mov_metadata(c_rarg1, method());
@@ -2439,8 +2438,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
     __ bind(fast_done);
   }
-  {
-    SkipIfEqual skip(masm, &DTraceMethodProbes, false, rscratch1);
+  if (DTraceMethodProbes) {
     save_native_result(masm, ret_type, stack_slots);
     __ mov_metadata(c_rarg1, method());
     __ call_VM_leaf(

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -4123,8 +4123,7 @@ void TemplateTable::_new() {
 #endif
     __ store_klass(rax, rcx, rscratch1);  // klass
 
-    {
-      SkipIfEqual skip_if(_masm, &DTraceAllocProbes, 0, rscratch1);
+    if (DTraceAllocProbes) {
       // Trigger dtrace event for fastpath
       __ push(atos);
       __ call_VM_leaf(


### PR DESCRIPTION
Some DTrace code snippets are generated no matter dtrace is enabled or not. It looks dtrace flags could be dynamic changed in previous jdk releases. Since they are not changeable, the code snippets can be generated based on flags. The code snippets are:
1. method entry of native wrapper
2. method entry/exit of interpreter
3. allocation of interpreter

For example, run this command and check output with x86_64 build:
./java -XX:+UnlockDiagnosticVMOptions -XX:+PrintNativeNMethods -version

```asm
  0x00007f541436418f: cmpb $0x0,0x163c8b17(%rip) # 0x00007f542a72ccad
                                                            ; {external_word}
  0x00007f5414364196: je 0x00007f54143641d0
  0x00007f541436419c: push %rsi
  0x00007f541436419d: push %rdx
  0x00007f541436419e: push %rcx
  0x00007f541436419f: movabs $0x7f5386436860,%rsi ; {metadata({method} {0x00007f5386436860} 'getReferenceVolatile' '(Ljava/lang/Object;J)Ljava/lang/Object;' in 'jdk/internal/misc/Unsafe')}
  0x00007f54143641a9: mov %r15,%rdi
  0x00007f54143641ac: test $0xf,%spl
  0x00007f54143641b0: je 0x00007f54143641c8
  0x00007f54143641b6: sub $0x8,%rsp
  0x00007f54143641ba: callq 0x00007f5429ffe180 ; {runtime_call SharedRuntime::dtrace_method_entry(JavaThread*, Method*)}
  0x00007f54143641bf: add $0x8,%rsp
  0x00007f54143641c3: jmpq 0x00007f54143641cd
  0x00007f54143641c8: callq 0x00007f5429ffe180 ; {runtime_call SharedRuntime::dtrace_method_entry(JavaThread*, Method*)}
  0x00007f54143641cd: pop %rcx
  0x00007f54143641ce: pop %rdx
  0x00007f54143641cf: pop %rsi
```

Apply this patch, dtrace_method invocation will be emitted only when DTraceMethodProbes is enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335946](https://bugs.openjdk.org/browse/JDK-8335946): DTrace code snippets should be generated when DTrace flags are enabled (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20090/head:pull/20090` \
`$ git checkout pull/20090`

Update a local copy of the PR: \
`$ git checkout pull/20090` \
`$ git pull https://git.openjdk.org/jdk.git pull/20090/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20090`

View PR using the GUI difftool: \
`$ git pr show -t 20090`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20090.diff">https://git.openjdk.org/jdk/pull/20090.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20090#issuecomment-2216583461)