### PR TITLE
8335130: The test "javax/swing/plaf/synth/ComponentsOrientationSupport/5033822/bug5033822.java" fails because the background color of the tabs is displayed incorrectly.

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -965,25 +965,27 @@ class GTKPainter extends SynthPainter {
                                            Graphics g,
                                            int x, int y, int w, int h,
                                            int tabIndex) {
-        Region id = context.getRegion();
-        int state = context.getComponentState();
-        int gtkState = ((state & SynthConstants.SELECTED) != 0 ?
-            SynthConstants.ENABLED : SynthConstants.PRESSED);
         JTabbedPane pane = (JTabbedPane)context.getComponent();
-        int placement = pane.getTabPlacement();
+        if (UIManager.getBoolean("TabbedPane.tabsOpaque") || pane.isOpaque()) {
+            Region id = context.getRegion();
+            int state = context.getComponentState();
+            int gtkState = ((state & SynthConstants.SELECTED) != 0 ?
+                    SynthConstants.ENABLED : SynthConstants.PRESSED);
+            int placement = pane.getTabPlacement();
 
-        // Fill the tab rect area
-        g.fillRect(x, y, w, h);
+            // Fill the tab rect area
+            g.fillRect(x, y, w, h);
 
-        synchronized (UNIXToolkit.GTK_LOCK) {
-            if (! ENGINE.paintCachedImage(g, x, y, w, h,
-                    id, gtkState, placement, tabIndex)) {
-                PositionType side = POSITIONS[placement - 1];
-                ENGINE.startPainting(g, x, y, w, h,
-                        id, gtkState, placement, tabIndex);
-                ENGINE.paintExtension(g, context, id, gtkState,
-                        ShadowType.OUT, "tab", x, y, w, h, side, tabIndex);
-                ENGINE.finishPainting();
+            synchronized (UNIXToolkit.GTK_LOCK) {
+                if (!ENGINE.paintCachedImage(g, x, y, w, h,
+                        id, gtkState, placement, tabIndex)) {
+                    PositionType side = POSITIONS[placement - 1];
+                    ENGINE.startPainting(g, x, y, w, h,
+                            id, gtkState, placement, tabIndex);
+                    ENGINE.paintExtension(g, context, id, gtkState,
+                            ShadowType.OUT, "tab", x, y, w, h, side, tabIndex);
+                    ENGINE.finishPainting();
+                }
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
@@ -2098,24 +2098,27 @@ class SynthPainterImpl extends SynthPainter {
     public void paintTabbedPaneTabBackground(SynthContext context, Graphics g,
                                          int x, int y, int w, int h,
                                          int tabIndex, int orientation) {
-        if (orientation == JTabbedPane.LEFT) {
-            AffineTransform transform = new AffineTransform();
-            transform.scale(-1, 1);
-            transform.rotate(Math.toRadians(90));
-            paintBackground(context, g, y, x, h, w, transform);
-        } else if (orientation == JTabbedPane.RIGHT) {
-            AffineTransform transform = new AffineTransform();
-            transform.rotate(Math.toRadians(90));
-            transform.translate(0, -(x + w));
-            paintBackground(context, g, y, 0, h, w, transform);
-        } else if (orientation == JTabbedPane.BOTTOM) {
-            AffineTransform transform = new AffineTransform();
-            transform.translate(x,y);
-            transform.scale(1, -1);
-            transform.translate(0,-h);
-            paintBackground(context, g, 0, 0, w, h, transform);
-        } else {
-            paintBackground(context, g, x, y, w, h, null);
+        JTabbedPane pane = (JTabbedPane)context.getComponent();
+        if (UIManager.getBoolean("TabbedPane.tabsOpaque") || pane.isOpaque()) {
+            if (orientation == JTabbedPane.LEFT) {
+                AffineTransform transform = new AffineTransform();
+                transform.scale(-1, 1);
+                transform.rotate(Math.toRadians(90));
+                paintBackground(context, g, y, x, h, w, transform);
+            } else if (orientation == JTabbedPane.RIGHT) {
+                AffineTransform transform = new AffineTransform();
+                transform.rotate(Math.toRadians(90));
+                transform.translate(0, -(x + w));
+                paintBackground(context, g, y, 0, h, w, transform);
+            } else if (orientation == JTabbedPane.BOTTOM) {
+                AffineTransform transform = new AffineTransform();
+                transform.translate(x, y);
+                transform.scale(1, -1);
+                transform.translate(0, -h);
+                paintBackground(context, g, 0, 0, w, h, transform);
+            } else {
+                paintBackground(context, g, x, y, w, h, null);
+            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
@@ -127,7 +127,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
     // Background color for unselected tabs
     private Color unselectedBackground;
     private boolean contentOpaque = true;
-    private boolean tabsOpaque = true;
 
     /**
      *
@@ -156,7 +155,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
     protected void installDefaults() {
         selectColor = UIManager.getColor("TabbedPane.selected");
         contentOpaque = UIManager.getBoolean("TabbedPane.contentOpaque");
-        tabsOpaque = UIManager.getBoolean("TabbedPane.tabsOpaque");
         unselectedBackground = UIManager.getColor("TabbedPane.unselectedBackground");
         updateStyle(tabPane);
     }
@@ -655,10 +653,8 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
             g.setColor(getUnselectedBackgroundAt(tabIndex));
         }
 
-        if (tabsOpaque || tabPane.isOpaque()) {
-            tabContext.getPainter().paintTabbedPaneTabBackground(tabContext, g,
-                    x, y, width, height, tabIndex, placement);
-        }
+        tabContext.getPainter().paintTabbedPaneTabBackground(tabContext, g,
+                x, y, width, height, tabIndex, placement);
         tabContext.getPainter().paintTabbedPaneTabBorder(tabContext, g,
                 x, y, width, height, tabIndex, placement);
 


### PR DESCRIPTION
Issue is due to the condition added for the opaque property of SynthTabbedPane in [JDK-8226990](https://bugs.openjdk.org/browse/JDK-8226990). The previous fix for GTK and Nimbus was handled commonly in `SynthTabbedPaneUI` class to render the tabs based on opaque property. Since the Synth package is responsible to create a custom L&F using user defined XML file. In this test the L&F is fetched through the XML file and when `SynthTabbedPaneUI` APIs are invoked for the tab rendering, it is not correctly rendered. Setting the opaque property to true also doesn't help as the selected tab is rendered incorrectly. The proposed fix is to move the fix to GTK and Nimbus specific class and that will not cause any impact on custom xml based L&F.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8335130: The test "javax/swing/plaf/synth/ComponentsOrientationSupport/5033822/bug5033822.java" fails because the background color of the tabs is displayed incorrectly.`

### Issue
 * [JDK-8335130](https://bugs.openjdk.org/browse/JDK-8335130): The test "javax/swing/plaf/synth/ComponentsOrientationSupport/5033822/bug5033822.java" fails because the background color of the tabs is displayed incorrectly. (**Bug** - P3)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20091/head:pull/20091` \
`$ git checkout pull/20091`

Update a local copy of the PR: \
`$ git checkout pull/20091` \
`$ git pull https://git.openjdk.org/jdk.git pull/20091/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20091`

View PR using the GUI difftool: \
`$ git pr show -t 20091`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20091.diff">https://git.openjdk.org/jdk/pull/20091.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20091#issuecomment-2227684790)