### PR TITLE
8335955: JDK-8335742 wrongly used a "JDK-" prefix in the problemlist bug number

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Virtual.txt
+++ b/test/hotspot/jtreg/ProblemList-Virtual.txt
@@ -89,7 +89,7 @@ vmTestbase/nsk/jdi/VMOutOfMemoryException/VMOutOfMemoryException001/VMOutOfMemor
 ###
 # Fails on Windows because of additional memory allocation.
 
-gc/g1/TestMixedGCLiveThreshold.java#25percent JDK-8334759 windows-x64
+gc/g1/TestMixedGCLiveThreshold.java#25percent 8334759 windows-x64
 
 ##########
 ## Tests incompatible with  with virtual test thread factory.


### PR DESCRIPTION
JDK-8335742 added a slightly malformed problemlist entry, adding a "JDK-" prefix to the bug number. While the entry is still valid and the test is excluded, some tools might not work correctly with such an entry.

Imo this is a trivial change... :)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335955](https://bugs.openjdk.org/browse/JDK-8335955): JDK-8335742 wrongly used a "JDK-" prefix in the problemlist bug number (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20092/head:pull/20092` \
`$ git checkout pull/20092`

Update a local copy of the PR: \
`$ git checkout pull/20092` \
`$ git pull https://git.openjdk.org/jdk.git pull/20092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20092`

View PR using the GUI difftool: \
`$ git pr show -t 20092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20092.diff">https://git.openjdk.org/jdk/pull/20092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20092#issuecomment-2216852690)