### PR TITLE
8335896: Source launcher should set TCCL

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/MemoryContext.java
@@ -184,10 +184,9 @@ final class MemoryContext {
      * @param parent the class loader to be used as the parent loader
      * @param mainClassName the fully-qualified name of the application class to load
      * @return class loader object able to find and load the desired class
-     * @throws ClassNotFoundException if the class cannot be located
      * @throws Fault if a modular application class is in the unnamed package
      */
-    ClassLoader newClassLoaderFor(ClassLoader parent, String mainClassName) throws ClassNotFoundException, Fault {
+    ClassLoader newClassLoaderFor(ClassLoader parent, String mainClassName) throws Fault {
         var moduleInfoBytes = inMemoryClasses.get("module-info");
         if (moduleInfoBytes == null) {
             // Trivial case: no compiled module descriptor available, no extra module layer required

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
@@ -201,6 +201,7 @@ public final class SourceLauncher {
         try {
             ClassLoader loader = context.newClassLoaderFor(parentLoader, firstClassName);
             firstClass = Class.forName(firstClassName, false, loader);
+            Thread.currentThread().setContextClassLoader(loader);
         } catch (ClassNotFoundException e) {
             throw new Fault(Errors.CantFindClass(firstClassName));
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/launcher/SourceLauncher.java
@@ -198,10 +198,10 @@ public final class SourceLauncher {
         // 1. Find a main method in the first class and if there is one - invoke it
         Class<?> firstClass;
         String firstClassName = program.qualifiedTypeNames().getFirst();
+        ClassLoader loader = context.newClassLoaderFor(parentLoader, firstClassName);
+        Thread.currentThread().setContextClassLoader(loader);
         try {
-            ClassLoader loader = context.newClassLoaderFor(parentLoader, firstClassName);
             firstClass = Class.forName(firstClassName, false, loader);
-            Thread.currentThread().setContextClassLoader(loader);
         } catch (ClassNotFoundException e) {
             throw new Fault(Errors.CantFindClass(firstClassName));
         }

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339
+ * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339 8335896
  * @summary Test source launcher
  * @library /tools/lib
  * @enablePreview
@@ -274,6 +274,27 @@ public class SourceLauncherTest extends TestRunner {
                 .run(Task.Expect.SUCCESS)
                 .getOutput(Task.OutputKind.STDOUT);
         checkEqual("stdout", log.trim(), file.toAbsolutePath().toString());
+    }
+
+    @Test
+    public void testThreadContextClassLoader(Path base) throws IOException {
+        tb.writeJavaFiles(base, //language=java
+                """
+                class ThreadContextClassLoader {
+                    public static void main(String... args) {
+                        var expected = ThreadContextClassLoader.class.getClassLoader();
+                        var actual = Thread.currentThread().getContextClassLoader();
+                        System.out.println(expected == actual);
+                    }
+                }
+                """);
+
+        Path file = base.resolve("ThreadContextClassLoader.java");
+        String log = new JavaTask(tb)
+                .className(file.toString())
+                .run(Task.Expect.SUCCESS)
+                .getOutput(Task.OutputKind.STDOUT);
+        checkEqual("stdout", log.trim(), "true");
     }
 
     void testSuccess(Path file, String expect) throws IOException {


### PR DESCRIPTION
Please review this change to set the context class loader of the current thread to the in-memory class loader when the `java` launcher is invoked in source mode. Having the source launcher set the TCCL to the in-memory classloader is benefical for scenarious depending on the TCCL being set to the application-loading loader.

For example, the single-argument taking [`ServiceLoader.load(Class)`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/ServiceLoader.html#load(java.lang.Class)) method creates "a new service loader for the given service type, using the current thread's [context class loader](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/Thread.html#getContextClassLoader())."

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335896](https://bugs.openjdk.org/browse/JDK-8335896): Source launcher should set TCCL (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20097/head:pull/20097` \
`$ git checkout pull/20097`

Update a local copy of the PR: \
`$ git checkout pull/20097` \
`$ git pull https://git.openjdk.org/jdk.git pull/20097/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20097`

View PR using the GUI difftool: \
`$ git pr show -t 20097`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20097.diff">https://git.openjdk.org/jdk/pull/20097.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20097#issuecomment-2217327974)