### PR TITLE
8336012: Fix usages of jtreg-reserved properties

### DIFF
--- a/test/jdk/java/lang/invoke/PrivateInvokeTest.java
+++ b/test/jdk/java/lang/invoke/PrivateInvokeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,8 +67,6 @@ public class PrivateInvokeTest {
         String vstr = System.getProperty(THIS_CLASS.getSimpleName()+".verbose");
         if (vstr == null)
             vstr = System.getProperty(THIS_CLASS.getName()+".verbose");
-        if (vstr == null)
-            vstr = System.getProperty("test.verbose");
         if (vstr != null)  verbose = Integer.parseInt(vstr);
     }
     private static int referenceKind(Method m) {


### PR DESCRIPTION
Please review this trivial test-only change to resolve a name clash with a jtreg-reserved property by removing the third option to control a test verbosity level via the `test.verbose` system property.

The fix assumes that the system property was only used in a manual scenario, like `make test TEST=...` and a `-Dtest.verbose=99` equivalent. For such scenarios, the other two names (for example `-DPrivateInvokeTest.verbose=99`) are still supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336012](https://bugs.openjdk.org/browse/JDK-8336012): Fix usages of jtreg-reserved properties (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20099/head:pull/20099` \
`$ git checkout pull/20099`

Update a local copy of the PR: \
`$ git checkout pull/20099` \
`$ git pull https://git.openjdk.org/jdk.git pull/20099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20099`

View PR using the GUI difftool: \
`$ git pr show -t 20099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20099.diff">https://git.openjdk.org/jdk/pull/20099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20099#issuecomment-2218071261)