### PR TITLE
8335668: NumberFormat integer only parsing should throw exception for edge case

### DIFF
--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -143,7 +143,8 @@ public class LenientParseTest {
     @Test // Non-localized, run once
     @EnabledIfSystemProperty(named = "user.language", matches = "en")
     public void compactIntegerParseOnlyFractionOnlyTest() {
-        var fmt = NumberFormat.getIntegerInstance();
+        var fmt = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        fmt.setParseIntegerOnly(true);
         failParse(fmt, ".K", 0);
         failParse(fmt, ".0K", 0);
         failParse(fmt, ".55K", 0);

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -334,7 +334,11 @@ public class LenientParseTest {
                 Arguments.of("10000", 10000d),
                 Arguments.of("100,000", 100000d),
                 Arguments.of("1,000,000", 1000000d),
-                Arguments.of("10,000,000", 10000000d))
+                Arguments.of("10,000,000", 10000000d),
+                // Smaller value cases (w/ decimal)
+                Arguments.of(".1", .1d),
+                Arguments.of("1.1", 1.1d),
+                Arguments.of("11.1", 11.1d))
                 .map(args -> Arguments.of(
                         localizeText(String.valueOf(args.get()[0])), args.get()[1]));
     }

--- a/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/LenientParseTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8327640 8331485 8333456
+ * @bug 8327640 8331485 8333456 8335668
  * @summary Test suite for NumberFormat parsing when lenient.
  * @run junit/othervm -Duser.language=en -Duser.country=US LenientParseTest
  * @run junit/othervm -Duser.language=ja -Duser.country=JP LenientParseTest
@@ -126,6 +126,27 @@ public class LenientParseTest {
         dFmt.setParseIntegerOnly(true);
         assertEquals(expectedValue, successParse(dFmt, toParse, expectedIndex));
         dFmt.setParseIntegerOnly(false);
+    }
+
+    // 8335668: Parsing with integer only against String with no integer portion
+    // should fail, not return 0. Expected error index should be 0
+    @Test
+    public void integerParseOnlyFractionOnlyTest() {
+        var fmt = NumberFormat.getIntegerInstance();
+        failParse(fmt, localizeText("."), 0);
+        failParse(fmt, localizeText(".0"), 0);
+        failParse(fmt, localizeText(".55"), 0);
+    }
+
+    // 8335668: Parsing with integer only against String with no integer portion
+    // should fail, not return 0. Expected error index should be 0
+    @Test // Non-localized, run once
+    @EnabledIfSystemProperty(named = "user.language", matches = "en")
+    public void compactIntegerParseOnlyFractionOnlyTest() {
+        var fmt = NumberFormat.getIntegerInstance();
+        failParse(fmt, ".K", 0);
+        failParse(fmt, ".0K", 0);
+        failParse(fmt, ".55K", 0);
     }
 
     @Test // Non-localized, only run once

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -218,7 +218,8 @@ public class StrictParseTest {
     @Test // Non-localized, run once
     @EnabledIfSystemProperty(named = "user.language", matches = "en")
     public void compactIntegerParseOnlyFractionOnlyTest() {
-        var fmt = NumberFormat.getIntegerInstance();
+        var fmt = NumberFormat.getCompactNumberInstance(Locale.US, NumberFormat.Style.SHORT);
+        fmt.setParseIntegerOnly(true);
         failParse(fmt, ".K", 0);
         failParse(fmt, ".0K", 0);
         failParse(fmt, ".55K", 0);

--- a/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
+++ b/test/jdk/java/text/Format/NumberFormat/StrictParseTest.java
@@ -447,9 +447,9 @@ public class StrictParseTest {
                 Arguments.of("1,234a", 5),
                 Arguments.of("1,.a", 2),
                 Arguments.of("1.a", 2),
-                Arguments.of("1,234,a", 5),
                 Arguments.of("1.22a", 4),
                 Arguments.of("1.1a1", 3),
+                Arguments.of("1,234,a", 5),
                 // Double decimal
                 Arguments.of("1,234..5", 5))
                 .map(args -> Arguments.of(
@@ -460,8 +460,6 @@ public class StrictParseTest {
     // Given as Arguments<String, expectedParsedNumber>
     private static Stream<Arguments> validParseStrings() {
         return Stream.of(
-                Arguments.of(".22", .22d),
-                Arguments.of(".1", .1d),
                 Arguments.of("1,234.55", 1234.55d),
                 Arguments.of("1,234.5", 1234.5d),
                 Arguments.of("1,234.00", 1234d),
@@ -476,7 +474,11 @@ public class StrictParseTest {
                 Arguments.of("10000", 10000d),
                 Arguments.of("100,000", 100000d),
                 Arguments.of("1,000,000", 1000000d),
-                Arguments.of("10,000,000", 10000000d))
+                Arguments.of("10,000,000", 10000000d),
+                // Smaller value cases (w/ decimal)
+                Arguments.of(".1", .1d),
+                Arguments.of("1.1", 1.1d),
+                Arguments.of("11.1", 11.1d))
                 .map(args -> Arguments.of(
                         localizeText(String.valueOf(args.get()[0])), args.get()[1]));
     }


### PR DESCRIPTION
Please review this PR which corrects a case in NumberFormat integer only parsing.

[JDK-8333755](https://bugs.openjdk.org/browse/JDK-8333755) fixed integer only parsing when the value has a suffix, although it caused incorrect behavior for the following case: when the parsed string does not contain an integer portion, and the format has integer only parsing, parsing should fail, instead of 0 being returned. For example, 

```
var fmt = NumberFormat.getIntegerInstance();
fmt.parse(".5", new ParsePosition(0)); // should return null, not 0
```

The changes to the _badParseStrings_ data provider in _StrictParseTest.java_ are needed since those cases _should_ fail in different indexes depending on if integer parsing is enabled. Thus, they were updated to ensure they fail for both integer and non-integer parsing with the same errorIndex.

In the fix itself, I also updated the initial value of `intIndex` to -1 from 0, to provide better clarity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335668](https://bugs.openjdk.org/browse/JDK-8335668): NumberFormat integer only parsing should throw exception for edge case (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20101/head:pull/20101` \
`$ git checkout pull/20101`

Update a local copy of the PR: \
`$ git checkout pull/20101` \
`$ git pull https://git.openjdk.org/jdk.git pull/20101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20101`

View PR using the GUI difftool: \
`$ git pr show -t 20101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20101.diff">https://git.openjdk.org/jdk/pull/20101.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20101#issuecomment-2218416003)