### PR TITLE
8335131: Test "javax/swing/JColorChooser/Test6977726.java" failed on ubuntu x64 because "Preview" title is missing for GTK L&F

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -548,7 +548,7 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
             "CheckBoxMenuItem.alignAcceleratorText", Boolean.FALSE,
 
 
-            "ColorChooser.showPreviewPanelText", Boolean.TRUE,
+            "ColorChooser.showPreviewPanelText", Boolean.FALSE,
             "ColorChooser.panels", new UIDefaults.ActiveValue() {
                 public Object createValue(UIDefaults table) {
                     return new AbstractColorChooserPanel[] {

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -548,7 +548,7 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
             "CheckBoxMenuItem.alignAcceleratorText", Boolean.FALSE,
 
 
-            "ColorChooser.showPreviewPanelText", Boolean.FALSE,
+            "ColorChooser.showPreviewPanelText", Boolean.TRUE,
             "ColorChooser.panels", new UIDefaults.ActiveValue() {
                 public Object createValue(UIDefaults table) {
                     return new AbstractColorChooserPanel[] {

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -58,7 +58,7 @@ public class Test6977726 {
 
     private static JColorChooser createColorChooser() {
 
-        // In case if this test is run with GTK L&F, the Preview Panel title
+        // In case if this test is run with GTK L&F, the preview panel title
         // is missing due to the "ColorChooser.showPreviewPanelText" property
         // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
         // modified to reflet that "Preview" title is not applicable for GTK L&F.

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -57,6 +57,12 @@ public class Test6977726 {
     }
 
     private static JColorChooser createColorChooser() {
+
+        // In case if this test is run with GTK L&F, the Preview Panel title
+        // is missing due to the "ColorChooser.showPreviewPanelText" property
+        // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
+        // modified to reflet that "Preview" title is not applicable for GTK L&F.
+
         JColorChooser chooser = new JColorChooser(Color.BLUE);
         chooser.setPreviewPanel(new JLabel("Text Preview Panel"));
         return chooser;

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -45,6 +45,11 @@ public class Test6977726 {
 
                 Note: "Preview" title is not applicable for GTK Look and Feel.""";
 
+        // In case if this test is run with GTK L&F, the preview panel title
+        // is missing due to the "ColorChooser.showPreviewPanelText" property
+        // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
+        // modified to reflet that "Preview" title is not applicable for GTK L&F.
+
         PassFailJFrame.builder()
                 .title("Test6977726")
                 .instructions(instructions)
@@ -57,12 +62,6 @@ public class Test6977726 {
     }
 
     private static JColorChooser createColorChooser() {
-
-        // In case if this test is run with GTK L&F, the preview panel title
-        // is missing due to the "ColorChooser.showPreviewPanelText" property
-        // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
-        // modified to reflet that "Preview" title is not applicable for GTK L&F.
-
         JColorChooser chooser = new JColorChooser(Color.BLUE);
         chooser.setPreviewPanel(new JLabel("Text Preview Panel"));
         return chooser;

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -41,7 +41,9 @@ public class Test6977726 {
         String instructions = """
                 Check that there is a panel with "Text Preview Panel" text
                 and with title "Preview" in the JColorChooser.
-                Test passes if the panel is as described, test fails otherwise.""";
+                Test passes if the panel is as described, test fails otherwise.
+
+                Note: "Preview" title is not applicable for GTK Look and Feel.""";
 
         PassFailJFrame.builder()
                 .title("Test6977726")

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -45,10 +45,10 @@ public class Test6977726 {
 
                 Note: "Preview" title is not applicable for GTK Look and Feel.""";
 
-        // In case if this test is run with GTK L&F, the preview panel title
+        // In case this test is run with GTK L&F, the preview panel title
         // is missing due to the "ColorChooser.showPreviewPanelText" property
         // which is set to "Boolean.FALSE" for GTK L&F. Test instructions are
-        // modified to reflet that "Preview" title is not applicable for GTK L&F.
+        // modified to reflect that "Preview" title is not applicable for GTK L&F.
 
         PassFailJFrame.builder()
                 .title("Test6977726")

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -27,7 +27,7 @@ import javax.swing.JLabel;
 
 /*
  * @test
- * @bug 6977726 8335131
+ * @bug 6977726
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Checks if JColorChooser.setPreviewPanel(JLabel) doesn't remove the preview panel but

--- a/test/jdk/javax/swing/JColorChooser/Test6977726.java
+++ b/test/jdk/javax/swing/JColorChooser/Test6977726.java
@@ -27,7 +27,7 @@ import javax.swing.JLabel;
 
 /*
  * @test
- * @bug 6977726
+ * @bug 6977726 8335131
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Checks if JColorChooser.setPreviewPanel(JLabel) doesn't remove the preview panel but


### PR DESCRIPTION
This test was modified under [JDK-8328403](https://bugs.openjdk.org/browse/JDK-8328403) bug to remove the applet usage. Test modification includes the instruction change as well which says that `Check that there is a panel with "Text Preview Panel" text and with title "Preview" in the JColorChooser`. Applet test didn't say explicitly about the panel title.

When the test is run with `GTKLookAndFeel` option, `Preview` title is missing due to the `showPreviewPanelText` property defined for `GTKLookAndFeel` is set to **FALSE**. `showPreviewPanelText` property is not defined for other L&Fs and that leads to fallback to the default value of **TRUE** for the property while lookup.

Proposed fix is to change the default value of `showPreviewPanelText` property to **TRUE** for GTK L&F.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335131](https://bugs.openjdk.org/browse/JDK-8335131): Test "javax/swing/JColorChooser/Test6977726.java" failed on ubuntu x64 because "Preview" title is missing for GTK L&amp;F (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20104/head:pull/20104` \
`$ git checkout pull/20104`

Update a local copy of the PR: \
`$ git checkout pull/20104` \
`$ git pull https://git.openjdk.org/jdk.git pull/20104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20104`

View PR using the GUI difftool: \
`$ git pr show -t 20104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20104.diff">https://git.openjdk.org/jdk/pull/20104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20104#issuecomment-2227685077)