### PR TITLE
8234071: JTable.AUTO_RESIZE_LAST_COLUMN acts like AUTO_RESIZE_ALL_COLUMNS

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1267,9 +1267,9 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             resizeAndRepaint();
             if (tableHeader != null) {
                 if (mode == JTable.AUTO_RESIZE_LAST_COLUMN) {
-                    if (columnModel.getColumnCount() > 0) {
-                        tableHeader.setResizingColumn(
-                                columnModel.getColumn(columnModel.getColumnCount() - 1));
+                    int colCnt = columnModel.getColumnCount();
+                    if (colCnt > 0) {
+                        tableHeader.setResizingColumn(columnModel.getColumn(colCnt - 1));
                     }
                 }
                 tableHeader.resizeAndRepaint();

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1266,6 +1266,10 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             autoResizeMode = mode;
             resizeAndRepaint();
             if (tableHeader != null) {
+                if (mode == JTable.AUTO_RESIZE_LAST_COLUMN) {
+                    tableHeader.setResizingColumn(
+                        columnModel.getColumn(columnModel.getColumnCount() - 1));
+                }
                 tableHeader.resizeAndRepaint();
             }
             firePropertyChange("autoResizeMode", old, autoResizeMode);

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1267,8 +1267,10 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             resizeAndRepaint();
             if (tableHeader != null) {
                 if (mode == JTable.AUTO_RESIZE_LAST_COLUMN) {
-                    tableHeader.setResizingColumn(
-                        columnModel.getColumn(columnModel.getColumnCount() - 1));
+                    if (columnModel.getColumnCount() > 0) {
+                        tableHeader.setResizingColumn(
+                                columnModel.getColumn(columnModel.getColumnCount() - 1));
+                    }
                 }
                 tableHeader.resizeAndRepaint();
             }


### PR DESCRIPTION
When a JTable is resized with` JTable.setAutoResizeMode` set to ` AUTO_RESIZE_LAST_COLUMN` then it behaves exactly as if I specified `AUTO_RESIZE_ALL_COLUMNS`. 
This is because when `JTable.doLayout` tries to resize the columns, it checks which column to resize by calling `getResizingColumn `and in absence of any column info, it resizes all, so during `setAutoResizeMode` the resizing column needs to be set, which is being done for AUTO_RESIZE_LAST_COLUMN in this fix.
No regression test is provided as it can be easily checked with SwingSet2->JTable(demo)->Autoresize mode (set to "Last Column")

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8234071](https://bugs.openjdk.org/browse/JDK-8234071): JTable.AUTO_RESIZE_LAST_COLUMN acts like AUTO_RESIZE_ALL_COLUMNS (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20107/head:pull/20107` \
`$ git checkout pull/20107`

Update a local copy of the PR: \
`$ git checkout pull/20107` \
`$ git pull https://git.openjdk.org/jdk.git pull/20107/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20107`

View PR using the GUI difftool: \
`$ git pr show -t 20107`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20107.diff">https://git.openjdk.org/jdk/pull/20107.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20107#issuecomment-2221343537)