### PR TITLE
8336080: Fix -Wzero-as-null-pointer-constant warnings in ClassLoaderStats ctor

### DIFF
--- a/src/hotspot/share/classfile/classLoaderStats.hpp
+++ b/src/hotspot/share/classfile/classLoaderStats.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,9 @@ public:
   uintx             _hidden_classes_count;
 
   ClassLoaderStats() :
-    _cld(0),
-    _class_loader(0),
-    _parent(0),
+    _cld(nullptr),
+    _class_loader(),
+    _parent(),
     _chunk_sz(0),
     _block_sz(0),
     _classes_count(0),


### PR DESCRIPTION
Please review this change to member initializers in the ClassLoaderStats
constructor.

The initial value for members of pointer type are changed from 0 to nullptr.

The initializers for members of oop type are changed from a value of 0 to
using value initialization. In debug builds this calls the provided default
ctor for the (debug-only) oop class, which initialized the underlying value to
nullptr. In release builds (where oop is a type alias for oopDesc*) this is a
zero initialization of the pointer-typed member, but without triggering
-Wzero-as-null-pointer-constant warnings.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336080](https://bugs.openjdk.org/browse/JDK-8336080): Fix -Wzero-as-null-pointer-constant warnings in ClassLoaderStats ctor (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20109/head:pull/20109` \
`$ git checkout pull/20109`

Update a local copy of the PR: \
`$ git checkout pull/20109` \
`$ git pull https://git.openjdk.org/jdk.git pull/20109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20109`

View PR using the GUI difftool: \
`$ git pr show -t 20109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20109.diff">https://git.openjdk.org/jdk/pull/20109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20109#issuecomment-2221343113)