### PR TITLE
8335766: Switch case with pattern matching and guard clause compiles inconsistently

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -3436,7 +3436,15 @@ public class JavacParser implements Parser {
                                 : PatternResult.PATTERN;
                     }
                     parenDepth++; break;
-                case RPAREN: parenDepth--; break;
+                case RPAREN:
+                    parenDepth--;
+                    if (parenDepth == 0 &&
+                        typeDepth == 0 &&
+                        peekToken(lookahead, TokenKind.IDENTIFIER) &&
+                        S.token(lookahead + 1).name() == names.when) {
+                        return PatternResult.PATTERN;
+                    }
+                    break;
                 case ARROW: return parenDepth > 0 ? PatternResult.EXPRESSION
                                                    : pendingResult;
                 case FINAL:

--- a/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
+++ b/test/langtools/tools/javac/patterns/DisambiguatePatterns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,6 +109,10 @@ public class DisambiguatePatterns {
                                  ExpressionType.EXPRESSION);
         test.disambiguationTest("a & b",
                                  ExpressionType.EXPRESSION);
+        test.disambiguationTest("R r when (x > 0)",
+                                 ExpressionType.PATTERN);
+        test.disambiguationTest("R(int x) when (x > 0)",
+                                 ExpressionType.PATTERN);
     }
 
     private final ParserFactory factory;


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [537d20af](https://github.com/openjdk/jdk/commit/537d20afbff255489a7b1bdb0410b9d1aba715b7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 10 Jul 2024 and was reviewed by Aggelos Biboudis.

Thanks!

Original description:
When javac parser see a `case` label, it needs to disambiguate between expressions (constant labels) and patterns. But, for code like:
```
case R(int x) when (x > 0)
```

the parser will try to parse the label as an expression, which is obviously not correct. The problem is that it does not disambiguate before `when`, and there indeed is an expression after `when`.

The proposal is to disambiguate as a pattern once there is `when` after a closing parenthesis at the top-level. This should prevent the code to even look at the `when` expression

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335766](https://bugs.openjdk.org/browse/JDK-8335766): Switch case with pattern matching and guard clause compiles inconsistently (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20111/head:pull/20111` \
`$ git checkout pull/20111`

Update a local copy of the PR: \
`$ git checkout pull/20111` \
`$ git pull https://git.openjdk.org/jdk.git pull/20111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20111`

View PR using the GUI difftool: \
`$ git pr show -t 20111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20111.diff">https://git.openjdk.org/jdk/pull/20111.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20111#issuecomment-2221385329)