### PR TITLE
8336081: Fix -Wzero-as-null-pointer-constant warnings in JVMTypedFlagLimit ctors

### DIFF
--- a/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagLimit.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,7 +155,7 @@ public:
   // dummy - no range or constraint. This object will not be emitted into the .o file
   // because we declare it as "const" but has no reference to it.
   constexpr JVMTypedFlagLimit(int type_enum) :
-  JVMFlagLimit(0, 0, JVMFlagConstraintPhase::AtParse, 0), _min(0), _max(0) {}
+  JVMFlagLimit(0, 0, JVMFlagConstraintPhase::AtParse, 0), _min(), _max() {}
 
   // range only
   constexpr JVMTypedFlagLimit(int type_enum, T min, T max) :
@@ -163,7 +163,7 @@ public:
 
   // constraint only
   constexpr JVMTypedFlagLimit(int type_enum, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase) :
-    JVMFlagLimit(type_enum, func, phase, HAS_CONSTRAINT), _min(0), _max(0) {}
+    JVMFlagLimit(type_enum, func, phase, HAS_CONSTRAINT), _min(), _max() {}
 
   // range and constraint
   constexpr JVMTypedFlagLimit(int type_enum, T min, T max, ConstraintMarker dummy2, short func, JVMFlagConstraintPhase phase)  :


### PR DESCRIPTION
Please review this change to member initializers in the JVMTypedFlagLimit<T>
class template.  It has two members of type T, which were being initialized
with a literal value of 0, triggering -Wzero-as-null-pointer-constant when T
is a pointer type and that warning is enabled.

We instead value initialize these members. For scalar types this performs
zero-initialization, without triggering -Wzero-as-null-pointer-constant if
it's a pointer type.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336081](https://bugs.openjdk.org/browse/JDK-8336081): Fix -Wzero-as-null-pointer-constant warnings in JVMTypedFlagLimit ctors (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20112/head:pull/20112` \
`$ git checkout pull/20112`

Update a local copy of the PR: \
`$ git checkout pull/20112` \
`$ git pull https://git.openjdk.org/jdk.git pull/20112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20112`

View PR using the GUI difftool: \
`$ git pr show -t 20112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20112.diff">https://git.openjdk.org/jdk/pull/20112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20112#issuecomment-2221342954)