### PR TITLE
8336082: Fix -Wzero-as-null-pointer-constant warnings in SimpleCompactHashtable

### DIFF
--- a/src/hotspot/share/classfile/compactHashtable.hpp
+++ b/src/hotspot/share/classfile/compactHashtable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -204,18 +204,20 @@ protected:
   u4* _entries;
 
 public:
-  SimpleCompactHashtable() {
-    _entry_count = 0;
-    _bucket_count = 0;
-    _buckets = 0;
-    _entries = 0;
-  }
+  SimpleCompactHashtable() :
+    _base_address(nullptr),
+    _bucket_count(0),
+    _entry_count(0),
+    _buckets(nullptr),
+    _entries(nullptr)
+  {}
 
   void reset() {
+    _base_address = nullptr;
     _bucket_count = 0;
     _entry_count = 0;
-    _buckets = 0;
-    _entries = 0;
+    _buckets = nullptr;
+    _entries = nullptr;
   }
 
   void init(address base_address, u4 entry_count, u4 bucket_count, u4* buckets, u4* entries);


### PR DESCRIPTION
Please review this change to SimpleCompactHashtable to remove some
-Wzero-as-null-pointer-constant warnings when enabled.

It has some pointer-typed members that were being initialized with 0, and are
now initialized with nullptr.

The constructor was also changed to initialize in the mem-initializer-list
rather than as assignments in the body.

In both the constructor and the reset function, the _base_address member was
added to the initialization/assignment sequence.  It was previously missing,
so was uninitialized by the constructor and left unchanged by reset.  This
appears to have been a "harmless" bug; at least, I couldn't find any way to
use the "unset" value.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336082](https://bugs.openjdk.org/browse/JDK-8336082): Fix -Wzero-as-null-pointer-constant warnings in SimpleCompactHashtable (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20113/head:pull/20113` \
`$ git checkout pull/20113`

Update a local copy of the PR: \
`$ git checkout pull/20113` \
`$ git pull https://git.openjdk.org/jdk.git pull/20113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20113`

View PR using the GUI difftool: \
`$ git pr show -t 20113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20113.diff">https://git.openjdk.org/jdk/pull/20113.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20113#issuecomment-2221344942)