### PR TITLE
8336021: Doccheck: valign not allowed for HTML5 in java.xml

### DIFF
--- a/src/java.xml/share/classes/org/w3c/dom/Attr.java
+++ b/src/java.xml/share/classes/org/w3c/dom/Attr.java
@@ -124,65 +124,63 @@ package org.w3c.dom;
  * </thead>
  * <tbody>
  * <tr>
- * <th scope="row" valign='top' rowspan='1' colspan='1'>
+ * <th scope="row">
  * Character reference</th>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x&amp;#178;=5"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x&#178;=5"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x&amp;#178;=5"</pre>
  * </td>
  * </tr>
  * <tr>
- * <th scope="row" valign='top' rowspan='1' colspan='1'>Built-in
- * character entity</th>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <th scope="row">Built-in character entity</th>
+ * <td>
  * <pre>"y&amp;lt;6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"y&lt;6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"y&amp;lt;6"</pre>
  * </td>
  * </tr>
  * <tr>
- * <th scope="row" valign='top' rowspan='1' colspan='1'>Literal newline between</th>
- * <td valign='top' rowspan='1' colspan='1'>
- * <pre>
- * "x=5&amp;#10;y=6"</pre>
+ * <th scope="row">Literal newline between</th>
+ * <td>
+ * <pre>"x=5&amp;#10;y=6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x=5 y=6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x=5&amp;#10;y=6"</pre>
  * </td>
  * </tr>
  * <tr>
- * <th scope="row" valign='top' rowspan='1' colspan='1'>Normalized newline between</th>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <th scope="row">Normalized newline between</th>
+ * <td>
  * <pre>"x=5
  * y=6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x=5 y=6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <td>
  * <pre>"x=5 y=6"</pre>
  * </td>
  * </tr>
  * <tr>
- * <th scope="row" valign='top' rowspan='1' colspan='1'>Entity <code>e</code> with literal newline</th>
- * <td valign='top' rowspan='1' colspan='1'>
+ * <th scope="row">Entity <code>e</code> with literal newline</th>
+ * <td>
  * <pre>
  * &lt;!ENTITY e '...&amp;#10;...'&gt; [...]&gt; "x=5&amp;e;y=6"</pre>
  * </td>
- * <td valign='top' rowspan='1' colspan='1'><em>Dependent on Implementation and Load Options</em></td>
- * <td valign='top' rowspan='1' colspan='1'><em>Dependent on Implementation and Load/Save Options</em></td>
+ * <td><em>Dependent on Implementation and Load Options</em></td>
+ * <td><em>Dependent on Implementation and Load/Save Options</em></td>
  * </tr>
  * </tbody>
  * </table>


### PR DESCRIPTION
Remove valign Attribute from the javadoc for org.w3c.dom.Attr. The table looks good with the default setting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336021](https://bugs.openjdk.org/browse/JDK-8336021): Doccheck: valign not allowed for HTML5 in java.xml (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20117/head:pull/20117` \
`$ git checkout pull/20117`

Update a local copy of the PR: \
`$ git checkout pull/20117` \
`$ git pull https://git.openjdk.org/jdk.git pull/20117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20117`

View PR using the GUI difftool: \
`$ git pr show -t 20117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20117.diff">https://git.openjdk.org/jdk/pull/20117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20117#issuecomment-2221343721)