### PR TITLE
8334481: [JVMCI] add LINK_TO_NATIVE to MethodHandleAccessProvider.IntrinsicMethod

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -778,6 +778,7 @@
   declare_constant(vmIntrinsics::_linkToStatic)                           \
   declare_constant(vmIntrinsics::_linkToSpecial)                          \
   declare_constant(vmIntrinsics::_linkToInterface)                        \
+  declare_constant(vmIntrinsics::_linkToNative)                           \
                                                                           \
   declare_constant(vmSymbols::FIRST_SID)                                  \
   declare_constant(vmSymbols::SID_LIMIT)                                  \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodHandleAccessProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodHandleAccessProvider.java
@@ -146,6 +146,8 @@ public class HotSpotMethodHandleAccessProvider implements MethodHandleAccessProv
             return IntrinsicMethod.LINK_TO_STATIC;
         } else if (intrinsicId == config.vmIntrinsicLinkToVirtual) {
             return IntrinsicMethod.LINK_TO_VIRTUAL;
+        } else if (intrinsicId == config.vmIntrinsicLinkToNative) {
+            return IntrinsicMethod.LINK_TO_NATIVE;
         }
         return null;
     }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -342,6 +342,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int vmIntrinsicLinkToStatic = getConstant("vmIntrinsics::_linkToStatic", Integer.class);
     final int vmIntrinsicLinkToSpecial = getConstant("vmIntrinsics::_linkToSpecial", Integer.class);
     final int vmIntrinsicLinkToInterface = getConstant("vmIntrinsics::_linkToInterface", Integer.class);
+    final int vmIntrinsicLinkToNative = getConstant("vmIntrinsics::_linkToNative", Integer.class);
 
     final int codeInstallResultOk = getConstant("JVMCI::ok", Integer.class);
     final int codeInstallResultDependenciesFailed = getConstant("JVMCI::dependencies_failed", Integer.class);

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/MethodHandleAccessProvider.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/meta/MethodHandleAccessProvider.java
@@ -45,7 +45,9 @@ public interface MethodHandleAccessProvider {
         /** The method {@code MethodHandle.linkToVirtual}. */
         LINK_TO_VIRTUAL,
         /** The method {@code MethodHandle.linkToInterface}. */
-        LINK_TO_INTERFACE
+        LINK_TO_INTERFACE,
+        /** The method {@code MethodHandle.linkToNative}. */
+        LINK_TO_NATIVE
     }
 
     /**


### PR DESCRIPTION
This PR allows Graal to query if a method is a `vmIntrinsics::_linkToNative` intrinsic.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334481](https://bugs.openjdk.org/browse/JDK-8334481): [JVMCI] add LINK_TO_NATIVE to MethodHandleAccessProvider.IntrinsicMethod (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20118/head:pull/20118` \
`$ git checkout pull/20118`

Update a local copy of the PR: \
`$ git checkout pull/20118` \
`$ git pull https://git.openjdk.org/jdk.git pull/20118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20118`

View PR using the GUI difftool: \
`$ git pr show -t 20118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20118.diff">https://git.openjdk.org/jdk/pull/20118.diff</a>

</details>
