### PR TITLE
8333884: MemorySegment::reinterpret removes read-only property

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -631,6 +631,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, newSize, 1);
      * }
      * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
+     * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
      *
@@ -649,6 +652,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * Returns a slice of this memory segment, at the given offset, with the provided
      * alignment constraint. The returned segment's address is the address of this
      * segment plus the given offset; its size is specified by the given argument.
+     * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
      * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
@@ -677,6 +683,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, layout.byteSize(), layout.byteAlignment());
      * }
      * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
+     * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
      *
@@ -703,6 +712,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * asSlice(offset, byteSize() - offset);
      * }
      * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
+     * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
      *
@@ -718,6 +730,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
     /**
      * Returns a new memory segment that has the same address and scope as this segment,
      * but with the provided size.
+     * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
      * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
@@ -756,6 +771,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * That is, the cleanup action receives a segment that is associated with the global
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@link #byteSize()}.
+     * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
      * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.
@@ -804,6 +822,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * That is, the cleanup action receives a segment that is associated with the global
      * scope, and is accessible from any thread. The size of the segment accepted by the
      * cleanup action is {@code newSize}.
+     * <p>
+     * If this segment is {@linkplain MemorySegment#isReadOnly() read-only},
+     * the returned segment is also {@linkplain MemorySegment#isReadOnly() read-only}.
      * <p>
      * The returned memory segment shares a region of backing memory with this segment.
      * Hence, no memory will be allocated or freed by this method.

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -159,7 +159,7 @@ public abstract sealed class AbstractMemorySegmentImpl
                 () -> cleanup.accept(SegmentFactories.makeNativeSegmentUnchecked(address(), newSize)) :
                 null;
         return SegmentFactories.makeNativeSegmentUnchecked(address(), newSize,
-                (MemorySessionImpl)scope, action);
+                (MemorySessionImpl)scope, readOnly, action);
     }
 
     private AbstractMemorySegmentImpl asSliceNoCheck(long offset, long newSize) {

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,14 +57,18 @@ public class SegmentFactories {
     // associated with MemorySegment::ofAddress.
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl, Runnable action) {
+    public static MemorySegment makeNativeSegmentUnchecked(long min,
+                                                           long byteSize,
+                                                           MemorySessionImpl sessionImpl,
+                                                           boolean readOnly,
+                                                           Runnable action) {
         ensureInitialized();
         if (action == null) {
             sessionImpl.checkValidState();
         } else {
             sessionImpl.addCloseAction(action);
         }
-        return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
+        return new NativeMemorySegmentImpl(min, byteSize, readOnly, sessionImpl);
     }
 
     @ForceInline

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,6 @@ import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
 import static java.lang.foreign.ValueLayout.JAVA_INT;
-import static java.lang.foreign.ValueLayout.JAVA_LONG;
 import static org.testng.Assert.*;
 
 public class TestSegments {
@@ -383,9 +382,14 @@ public class TestSegments {
             assertEquals(MemorySegment.ofAddress(42).reinterpret(100, Arena.ofAuto(), null).byteSize(), 100);
             // check scope and cleanup
             assertEquals(MemorySegment.ofAddress(42).reinterpret(100, arena, s -> counter.incrementAndGet()).scope(), arena.scope());
-            assertEquals(MemorySegment.ofAddress(42).reinterpret(arena, s -> counter.incrementAndGet()).scope(), arena.scope());
+            assertEquals(MemorySegment.ofAddress(42).reinterpret(arena, _ -> counter.incrementAndGet()).scope(), arena.scope());
+            // check read-only state
+            assertFalse(MemorySegment.ofAddress(42).reinterpret(100).isReadOnly());
+            assertTrue(MemorySegment.ofAddress(42).asReadOnly().reinterpret(100).isReadOnly());
+            assertTrue(MemorySegment.ofAddress(42).asReadOnly().reinterpret(100, Arena.ofAuto(), null).isReadOnly());
+            assertTrue(MemorySegment.ofAddress(42).asReadOnly().reinterpret(arena, _ -> counter.incrementAndGet()).isReadOnly());
         }
-        assertEquals(counter.get(), 2);
+        assertEquals(counter.get(), 3);
     }
 
     @Test


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [6f7f0f1d](https://github.com/openjdk/jdk/commit/6f7f0f1de05fdc0f6a88ccd90b806e8a5c5074ef) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Per Minborg on 6 Jul 2024 and was reviewed by Jorn Vernee and Maurizio Cimadamore.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8333892](https://bugs.openjdk.org/browse/JDK-8333892) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8333884](https://bugs.openjdk.org/browse/JDK-8333884): MemorySegment::reinterpret removes read-only property (**Bug** - P3)
 * [JDK-8333892](https://bugs.openjdk.org/browse/JDK-8333892): MemorySegment::reinterpret removes read-only property (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - Committer)
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20119/head:pull/20119` \
`$ git checkout pull/20119`

Update a local copy of the PR: \
`$ git checkout pull/20119` \
`$ git pull https://git.openjdk.org/jdk.git pull/20119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20119`

View PR using the GUI difftool: \
`$ git pr show -t 20119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20119.diff">https://git.openjdk.org/jdk/pull/20119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20119#issuecomment-2221344135)