### PR TITLE
8315231: runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java timed out

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  * @build jdk.test.whitebox.WhiteBox OldProvider
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run driver RedefineClassHelper
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. RedefineCallerClassTest
+ * @run main/othervm/timeout=360 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. RedefineCallerClassTest
  */
 
 import jdk.test.lib.helpers.ClassFileInstaller;


### PR DESCRIPTION
When this test is run with the `-Xcomp -UseAVX=3` VM options, the `test.timeout.factor` is set to 4 (default value) which is insufficient in some platforms especially on Windows. Increasing the timeout value for this test. If later more tests are timing out, we can consider increasing the `test.timeout.factor` for all the tests running with the above VM options.

Testing: ran the test 20 times with the `-Xcomp -UseAVX=3` VM options on windows-x64 and linux-x64 platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315231](https://bugs.openjdk.org/browse/JDK-8315231): runtime/cds/appcds/dynamicArchive/RedefineCallerClassTest.java timed out (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20121/head:pull/20121` \
`$ git checkout pull/20121`

Update a local copy of the PR: \
`$ git checkout pull/20121` \
`$ git pull https://git.openjdk.org/jdk.git pull/20121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20121`

View PR using the GUI difftool: \
`$ git pr show -t 20121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20121.diff">https://git.openjdk.org/jdk/pull/20121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20121#issuecomment-2221343958)