### PR TITLE
8325369: @sealedGraph: Bad link to image for tag on nested classes

### DIFF
--- a/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
+++ b/make/jdk/src/classes/build/tools/taglet/SealedGraph.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,7 +107,7 @@ public final class SealedGraph implements Taglet {
             throw new RuntimeException(e);
         }
 
-        String simpleTypeName = element.getSimpleName().toString();
+        String simpleTypeName = packagelessCanonicalName(typeElement).replace('.', '/');
         String imageFile = simpleTypeName + "-sealed-graph.svg";
         int thumbnailHeight = 100; // also appears in the stylesheet
         String hoverImage = "<span>"
@@ -315,14 +315,14 @@ public final class SealedGraph implements Taglet {
                 case MEMBER -> packageName((TypeElement) element.getEnclosingElement());
             };
         }
+    }
 
-        private static String packagelessCanonicalName(TypeElement element) {
-            String result = element.getSimpleName().toString();
-            while (element.getNestingKind() == NestingKind.MEMBER) {
-                element = (TypeElement) element.getEnclosingElement();
-                result = element.getSimpleName().toString() + '.' + result;
-            }
-            return result;
+    private static String packagelessCanonicalName(TypeElement element) {
+        String result = element.getSimpleName().toString();
+        while (element.getNestingKind() == NestingKind.MEMBER) {
+            element = (TypeElement) element.getEnclosingElement();
+            result = element.getSimpleName().toString() + '.' + result;
         }
+        return result;
     }
 }


### PR DESCRIPTION
Fixes the link to the generated sealed graph svg generated by the sealed graph taglet.

Affected interfaces includes [`ClassFile.Option`](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8325369-nested-sealed-svg/api/java.base/java/lang/classfile/ClassFile.Option.html) ([before](https://download.java.net/java/early_access/jdk23/docs/api/java.base/java/lang/classfile/ClassFile.Option.html)), [`AnnotationValue.OfConstant`](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8325369-nested-sealed-svg/api/java.base/java/lang/classfile/AnnotationValue.OfConstant.html) ([before](https://download.java.net/java/early_access/jdk23/docs/api/java.base/java/lang/classfile/AnnotationValue.OfConstant.html)), a few [nested interfaces](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8325369-nested-sealed-svg/api/java.base/java/lang/classfile/Signature.html#nested-class-summary) in `Signature` ([original](https://download.java.net/java/early_access/jdk23/docs/api/java.base/java/lang/classfile/Signature.html#nested-class-summary)), and [`TypeAnnotaton.TargetInfo`](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8325369-nested-sealed-svg/api/java.base/java/lang/classfile/TypeAnnotation.TargetInfo.html) ([before](https://download.java.net/java/early_access/jdk23/docs/api/java.base/java/lang/classfile/TypeAnnotation.TargetInfo.html)).

Courtesy to @nizarbenalla for hosting the updated doc rendering.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325369](https://bugs.openjdk.org/browse/JDK-8325369): @<!---->sealedGraph: Bad link to image for tag on nested classes (**Bug** - P3)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20122/head:pull/20122` \
`$ git checkout pull/20122`

Update a local copy of the PR: \
`$ git checkout pull/20122` \
`$ git pull https://git.openjdk.org/jdk.git pull/20122/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20122`

View PR using the GUI difftool: \
`$ git pr show -t 20122`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20122.diff">https://git.openjdk.org/jdk/pull/20122.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20122#issuecomment-2221343361)