### PR TITLE
8335637: Add explicit non-null return value expectations to Object.toString()

### DIFF
--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -237,6 +237,10 @@ public class Object {
 
     /**
      * {@return a string representation of the object}
+     *
+     * Satisfying this method's contract implies a non-{@code null}
+     * result must be returned.
+     *
      * @apiNote
      * In general, the
      * {@code toString} method returns a string that


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8335822](https://bugs.openjdk.org/browse/JDK-8335822) to be approved

### Issues
 * [JDK-8335637](https://bugs.openjdk.org/browse/JDK-8335637): Add explicit non-null return value expectations to Object.toString() (**Enhancement** - P4)
 * [JDK-8335822](https://bugs.openjdk.org/browse/JDK-8335822): Add explicit non-null return value expectations to Object.toString() (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20124/head:pull/20124` \
`$ git checkout pull/20124`

Update a local copy of the PR: \
`$ git checkout pull/20124` \
`$ git pull https://git.openjdk.org/jdk.git pull/20124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20124`

View PR using the GUI difftool: \
`$ git pr show -t 20124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20124.diff">https://git.openjdk.org/jdk/pull/20124.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20124#issuecomment-2221569216)