### PR TITLE
8336163: Remove declarations of some debug-only methods in release build

### DIFF
--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -371,7 +371,9 @@ private:
                                              KlassSubGraphInfo* subgraph_info,
                                              oop orig_obj);
 
+#ifndef PRODUCT
   static ResourceBitMap calculate_oopmap(MemRegion region); // marks all the oop pointers
+#endif
   static void add_to_dumped_interned_strings(oop string);
 
   // Scratch objects for archiving Klass::java_mirror()
@@ -426,7 +428,9 @@ private:
   static void init_roots(oop roots_oop) NOT_CDS_JAVA_HEAP_RETURN;
   static void serialize_tables(SerializeClosure* soc) NOT_CDS_JAVA_HEAP_RETURN;
 
+#ifndef PRODUCT
   static bool is_a_test_class_in_unnamed_module(Klass* ik) NOT_CDS_JAVA_HEAP_RETURN_(false);
+#endif
 };
 
 #if INCLUDE_CDS_JAVA_HEAP

--- a/src/hotspot/share/compiler/compilationPolicy.hpp
+++ b/src/hotspot/share/compiler/compilationPolicy.hpp
@@ -179,8 +179,10 @@ class CompilationPolicy : AllStatic {
 
   // Set carry flags in the counters (in Method* and MDO).
   inline static void handle_counter_overflow(const methodHandle& method);
+#ifdef ASSERT
   // Verify that a level is consistent with the compilation mode
   static bool verify_level(CompLevel level);
+#endif
   // Clamp the request level according to various constraints.
   inline static CompLevel limit_level(CompLevel level);
   // Common transition function. Given a predicate determines if a method should transition to another level.

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -834,7 +834,9 @@ private:
   juint _class_id;
   juint _flags;
 
+#ifdef ASSERT
   static juint max_flags();
+#endif
 
 protected:
   // These methods should be called from constructors only.

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -387,7 +387,9 @@ class frame {
   static int interpreter_frame_monitor_size();
   static int interpreter_frame_monitor_size_in_bytes();
 
+#ifdef ASSERT
   void interpreter_frame_verify_monitor(BasicObjectLock* value) const;
+#endif
 
   // Return/result value from this interpreter frame
   // If the method return type is T_OBJECT or T_ARRAY populates oop_result
@@ -438,8 +440,10 @@ class frame {
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;
   static void print_C_frame(outputStream* st, char* buf, int buflen, address pc);
 
+#ifndef PRODUCT
   // Add annotated descriptions of memory locations belonging to this frame to values
   void describe(FrameValues& values, int frame_no, const RegisterMap* reg_map=nullptr);
+#endif
 
   // Conversion from a VMReg to physical stack location
   template <typename RegisterMapT>
@@ -492,9 +496,11 @@ class frame {
 
   // Verification
   void verify(const RegisterMap* map) const;
+#ifdef ASSERT
   static bool verify_return_pc(address x);
   // Usage:
   // assert(frame::verify_return_pc(return_address), "must be a return pc");
+#endif
 
 #include CPU_HEADER(frame)
 

--- a/src/hotspot/share/runtime/registerMap.hpp
+++ b/src/hotspot/share/runtime/registerMap.hpp
@@ -153,8 +153,10 @@ class RegisterMap : public StackObj {
   const RegisterMap* as_RegisterMap() const { return this; }
   RegisterMap* as_RegisterMap() { return this; }
 
+#ifndef PRODUCT
   void print_on(outputStream* st) const;
   void print() const;
+#endif
 
   void set_async(bool value)        { NOT_PRODUCT(_async = value;) }
   void set_skip_missing(bool value) { NOT_PRODUCT(_skip_missing = value;) }


### PR DESCRIPTION
Some of the methods are defined only in debug mode, but their declarations still exist in release mode.

This is considered a bug because these methods may be called mistakenly in release mode and cause the build to fail.