### PR TITLE
8335966: Remove incorrect problem listing of java/lang/instrument/NativeMethodPrefixAgent.java in ProblemList-Virtual.txt

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -36,8 +36,6 @@ javax/management/remote/mandatory/loading/MissingClassTest.java 8145413 windows-
 
 javax/management/remote/mandatory/loading/RMIDownloadTest.java 8308366 windows-x64
 
-java/lang/instrument/NativeMethodPrefixAgent.java 8307169 generic-all
-
 java/lang/ScopedValue/StressStackOverflow.java#default 8309646 generic-all
 java/lang/ScopedValue/StressStackOverflow.java#no-TieredCompilation 8309646 generic-all
 java/lang/ScopedValue/StressStackOverflow.java#TieredStopAtLevel1 8309646 generic-all


### PR DESCRIPTION
I would like to backport this test-only change into `jdk23`. This cleans up the incorrect problem listing that was caused by a change that we introduced in JDK 23 as part of https://bugs.openjdk.org/browse/JDK-8333130.

This is a clean backport of the commit that was integrated into master branch through https://github.com/openjdk/jdk/pull/20094.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335966](https://bugs.openjdk.org/browse/JDK-8335966): Remove incorrect problem listing of java/lang/instrument/NativeMethodPrefixAgent.java in ProblemList-Virtual.txt (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20132/head:pull/20132` \
`$ git checkout pull/20132`

Update a local copy of the PR: \
`$ git checkout pull/20132` \
`$ git pull https://git.openjdk.org/jdk.git pull/20132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20132`

View PR using the GUI difftool: \
`$ git pr show -t 20132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20132.diff">https://git.openjdk.org/jdk/pull/20132.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20132#issuecomment-2221966666)