### PR TITLE
8336239: Fix javadoc markup in java.lang.Process

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -64,7 +64,7 @@ import java.util.stream.Stream;
  * {@link #getInputStream()}, and
  * {@link #getErrorStream()}.
  * The I/O streams of characters and lines can be written and read using the methods
- * {@link #outputWriter()}, {@link #outputWriter(Charset)}},
+ * {@link #outputWriter()}, {@link #outputWriter(Charset)},
  * {@link #inputReader()}, {@link #inputReader(Charset)},
  * {@link #errorReader()}, and {@link #errorReader(Charset)}.
  * The parent process uses these streams to feed input to and get output


### PR DESCRIPTION
Was reading Process' documentation the other day and spotted a markup typo. Please review this utmost trivial fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336239](https://bugs.openjdk.org/browse/JDK-8336239): Fix javadoc markup in java.lang.Process (**Bug** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20133/head:pull/20133` \
`$ git checkout pull/20133`

Update a local copy of the PR: \
`$ git checkout pull/20133` \
`$ git pull https://git.openjdk.org/jdk.git pull/20133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20133`

View PR using the GUI difftool: \
`$ git pr show -t 20133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20133.diff">https://git.openjdk.org/jdk/pull/20133.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20133#issuecomment-2222485142)