### PR TITLE
8318106: Generated HTML for snippet does not always contain an id

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -619,7 +619,7 @@ public class HtmlIds {
             id += ((ModuleElement) e).getQualifiedName();
         } else {
             // while utterly unexpected, we shouldn't fail
-            id += "unknown-element-";
+            id += "unknown-element";
         }
         int counter = 1;
         while (!snippetIds.add(id + counter)) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlIds.java
@@ -36,6 +36,7 @@ import java.util.stream.Stream;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.ModuleElement;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -594,5 +595,36 @@ public class HtmlIds {
             idValue = idValue + counter;
         }
         return HtmlId.of(idValue);
+    }
+
+    /**
+     * Returns an id for a snippet.
+     *
+     * @param e the element in whose documentation the snippet appears
+     * @param snippetIds the set of snippet ids already generated
+     * @return a unique id for the snippet
+     */
+    public HtmlId forSnippet(Element e, Set<String> snippetIds) {
+        String id = "snippet-";
+        ElementKind kind = e.getKind();
+        if (kind == ElementKind.PACKAGE) {
+            id += forPackage((PackageElement) e).name();
+        } else if (kind.isDeclaredType()) {
+            id += forClass((TypeElement) e).name();
+        } else if (kind.isExecutable()) {
+            id += forMember((ExecutableElement) e).getFirst().name();
+        } else if (kind.isField()) {
+            id += forMember((VariableElement) e).name();
+        } else if (kind == ElementKind.MODULE) {
+            id += ((ModuleElement) e).getQualifiedName();
+        } else {
+            // while utterly unexpected, we shouldn't fail
+            id += "unknown-element-";
+        }
+        int counter = 1;
+        while (!snippetIds.add(id + counter)) {
+            counter++;
+        }
+        return HtmlId.of(id + counter);
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/SnippetTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,6 +148,8 @@ public class SnippetTaglet extends BaseTaglet {
         var pre = new HtmlTree(TagName.PRE).setStyle(HtmlStyle.snippet);
         if (id != null && !id.isBlank()) {
             pre.put(HtmlAttr.ID, id);
+        } else {
+            pre.put(HtmlAttr.ID, config.htmlIds.forSnippet(element, ids).name());
         }
         var code = new HtmlTree(TagName.CODE)
                 .addUnchecked(Text.EMPTY); // Make sure the element is always rendered
@@ -231,6 +233,8 @@ public class SnippetTaglet extends BaseTaglet {
                         .put(HtmlAttr.ONCLICK, "copySnippet(this)"));
         return snippetContainer.add(pre.add(code));
     }
+
+    private final Set<String> ids = new HashSet<>();
 
     private static final class BadSnippetException extends Exception {
 

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownTaglets.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownTaglets.java
@@ -121,7 +121,7 @@ public class TestMarkdownTaglets extends JavadocTester {
                     <div class="snippet-container"><button class="copy snippet-copy" aria-label="Copy snippet" \
                     onclick="copySnippet(this)"><span data-copied="Copied!">Copy</span>\
                     <img src="../resource-files/copy.svg" alt="Copy snippet"></button>
-                    <pre class="snippet"><code>   this is snippet_standalone
+                    <pre class="snippet" id="snippet-snippet_standalone()1"><code>   this is snippet_standalone
                     </code></pre>
                     </div>
 
@@ -131,7 +131,7 @@ public class TestMarkdownTaglets extends JavadocTester {
                     <div class="block"><p>First sentence.</p>
                     <p>Before.</p>
                     <div class="snippet-container"><button class="copy snippet-copy" aria-label="Copy snippet" onclick="copySnippet(this)"><span data-copied="Copied!">Copy</span><img src="../resource-files/copy.svg" alt="Copy snippet"></button>
-                    <pre class="snippet"><code>   this is a snippet_wrapped
+                    <pre class="snippet" id="snippet-snippet_wrapped()1"><code>   this is a snippet_wrapped
                     </code></pre>
                     </div>
 

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestLangProperties.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestLangProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -179,7 +179,7 @@ public class TestLangProperties extends SnippetTester {
                     <div class="block">
                     %s
                     </div>""".formatted(index, getSnippetHtmlRepresentation("A.html",
-                    t.expectedOutput(), Optional.of("properties")));
+                    t.expectedOutput(), Optional.of("properties"), Optional.of("snippet-case" + index + "()2")));
             checkOutput("A.html", true, html);
         });
     }

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetMarkup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.regex.MatchResult;
@@ -365,7 +366,7 @@ First line // @highlight :
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
                         %s
-                        </div>""".formatted(index, getSnippetHtmlRepresentation("A.html", t.expectedOutput()));
+                        </div>""".formatted(index, getSnippetHtmlRepresentation("A.html", t.expectedOutput(), Optional.empty(), Optional.of("snippet-case" + index + "()2")));
             checkOutput("A.html", true, html);
         });
     }

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,8 +220,9 @@ public class TestSnippetTag extends SnippetTester {
         checkLinks();
         for (int j = 0; j < snippets.size(); j++) {
             var attr = snippets.get(j);
+            Optional<String> id = (attr.id() != null ? Optional.of(attr.id()) : Optional.of("snippet-case" + j + "()1"));
             var snippetHtml = getSnippetHtmlRepresentation("pkg/A.html", "    Hello, Snippet!\n",
-                    Optional.ofNullable(attr.lang()), Optional.ofNullable(attr.id()));
+                    Optional.ofNullable(attr.lang()), id);
             checkOutput("pkg/A.html", true,
                         """
                         <span class="element-name">case%s</span>()</div>
@@ -879,7 +880,8 @@ public class TestSnippetTag extends SnippetTester {
                         """
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
-                        %s""".formatted(id, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput())));
+                        %s""".formatted(id, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput(), Optional.empty(),
+                                Optional.of("snippet-case" + id + "()2"))));
         });
     }
 
@@ -971,7 +973,8 @@ public class TestSnippetTag extends SnippetTester {
                         """
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
-                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", expectedOutput)));
+                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", expectedOutput, Optional.empty(),
+                                Optional.of("snippet-case" + index + "()2"))));
         });
     }
 
@@ -1549,7 +1552,8 @@ public class TestSnippetTag extends SnippetTester {
                         """
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
-                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput())));
+                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput(), Optional.empty(),
+                                Optional.of("snippet-case" + index + "()2"))));
         });
     }
 
@@ -1662,12 +1666,14 @@ public class TestSnippetTag extends SnippetTester {
                     """
                     <span class="element-name">case0</span>()</div>
                     <div class="block">
-                    """ + getSnippetHtmlRepresentation("pkg/A.html", ""));
+                    """ + getSnippetHtmlRepresentation("pkg/A.html", "", Optional.empty(),
+                            Optional.of("snippet-case0()2")));
         checkOutput("pkg/A.html", true,
                     """
                     <span class="element-name">case1</span>()</div>
                     <div class="block">
-                    """ + getSnippetHtmlRepresentation("pkg/A.html", ""));
+                    """ + getSnippetHtmlRepresentation("pkg/A.html", "", Optional.empty(),
+                            Optional.of("snippet-case1()2")));
     }
 
     @Test // TODO: use combinatorial methods
@@ -1765,7 +1771,8 @@ public class TestSnippetTag extends SnippetTester {
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
                         %s
-                        """.formatted(j, getSnippetHtmlRepresentation("pkg/A.html", "2")));
+                        """.formatted(j, getSnippetHtmlRepresentation("pkg/A.html", "2", Optional.empty(),
+                                Optional.of("snippet-case" + j + "()2"))));
         }
     }
 
@@ -1844,7 +1851,8 @@ public class TestSnippetTag extends SnippetTester {
                         """
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
-                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput())));
+                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput(), Optional.empty(),
+                                Optional.of("snippet-case" + index + "()2"))));
         });
     }
 
@@ -2302,7 +2310,8 @@ public class TestSnippetTag extends SnippetTester {
                         """
                         <span class="element-name">case%s</span>()</div>
                         <div class="block">
-                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput())));
+                        %s""".formatted(index, getSnippetHtmlRepresentation("pkg/A.html", t.expectedOutput(), Optional.empty(),
+                                Optional.of("snippet-case" + index + "()2"))));
         });
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
+++ b/test/langtools/jdk/javadoc/doclet/testSnippetTag/TestSnippetUnnamedPackage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,6 +91,6 @@ public class TestSnippetUnnamedPackage extends SnippetTester {
                         %s
 
                          After.""".formatted(getSnippetHtmlRepresentation("C.html",
-                        "public class S { }", Optional.of("java"))));
+                        "public class S { }", Optional.of("java"), Optional.of("snippet-C1"))));
     }
 }


### PR DESCRIPTION
Please review this jdk24 bug, which we intend to backport to jdk23 before RDP2, which is a week away. This is a simple fix, but it disturbs multiple tests.

Here's a tip for reviewing. Sometimes a snippet id in a test ends up with `()1`, other times with `()2`. This is because the same snippet may appear more than once on the same page, and we are always looking for its last appearance. For example, if a snippet resides in the first sentence of a method documentation, that snippet will appear in both the "Method Summary" and "Method Details" sections. Otherwise, it will only appear in "Method Details". Appearances are numbered starting from 1 and increment by 1 from top ("Method Summary") to bottom ("Method Details").

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318106](https://bugs.openjdk.org/browse/JDK-8318106): Generated HTML for snippet does not always contain an id (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20136/head:pull/20136` \
`$ git checkout pull/20136`

Update a local copy of the PR: \
`$ git checkout pull/20136` \
`$ git pull https://git.openjdk.org/jdk.git pull/20136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20136`

View PR using the GUI difftool: \
`$ git pr show -t 20136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20136.diff">https://git.openjdk.org/jdk/pull/20136.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20136#issuecomment-2223048018)