### PR TITLE
8336256: memcpy short value to int local is incorrect in VtableStubs::unsafe_hash

### DIFF
--- a/src/hotspot/share/code/vtableStubs.cpp
+++ b/src/hotspot/share/code/vtableStubs.cpp
@@ -262,7 +262,8 @@ inline uint VtableStubs::unsafe_hash(address entry_point) {
   address vtable_type_addr = vtable_stub_addr + offset_of(VtableStub, _type);
   address vtable_index_addr = vtable_stub_addr + offset_of(VtableStub, _index);
   bool is_vtable_stub = *vtable_type_addr == static_cast<uint8_t>(VtableStub::Type::vtable_stub);
-  int vtable_index;
+  short vtable_index;
+  static_assert(sizeof(VtableStub::_index) == sizeof(vtable_index), "precondition");
   memcpy(&vtable_index, vtable_index_addr, sizeof(vtable_index));
   return hash(is_vtable_stub, vtable_index);
 }


### PR DESCRIPTION
Make sure the local variable used as target of the `memcpy` in `VtableStubs::unsafe_hash` has the same size as `VtableStub::_index` which is the source of the `memcpy`.

With this fix we don't see the crashes given in the JBS-issue.

Further tests are pending.
