### PR TITLE
8336257: Additional tests in jmxremote/startstop to match on PID not app name

### DIFF
--- a/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -348,7 +348,6 @@ public class JMXStartStopTest {
                     }
                     pid = p.pid();
                     jcmd = new ManagementAgentJcmd(p, verbose);
-
                 } catch (TimeoutException e) {
                     if (p != null) {
                         p.destroy();

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStartStopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class JMXStartStopTest {
 
     private static final boolean verbose = false;
 
-    private static ManagementAgentJcmd jcmd = new ManagementAgentJcmd(TEST_APP_NAME, verbose);
+    private static ManagementAgentJcmd jcmd;
 
     private static void dbg_print(String msg) {
         if (verbose) {
@@ -347,6 +347,8 @@ public class JMXStartStopTest {
                                                 "the requested port not being available");
                     }
                     pid = p.pid();
+                    jcmd = new ManagementAgentJcmd(p, verbose);
+
                 } catch (TimeoutException e) {
                     if (p != null) {
                         p.destroy();

--- a/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
+++ b/test/jdk/sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,7 +67,6 @@ public class JMXStatusPerfCountersTest {
 
     @BeforeTest
     public void setup() {
-        jcmd = new ManagementAgentJcmd(TEST_APP_NAME, false);
     }
 
     @BeforeMethod
@@ -76,6 +75,7 @@ public class JMXStatusPerfCountersTest {
             TEST_APP_NAME, testAppPb,
             (Predicate<String>)l->l.trim().equals("main enter")
         );
+        jcmd = new ManagementAgentJcmd(testApp, false);
     }
 
     @AfterMethod


### PR DESCRIPTION
Follow-on from JDK-8207908.

Two tests are broken by that change:
sun/management/jmxremote/startstop/JMXStartStopTest.java	
sun/management/jmxremote/startstop/JMXStatusPerfCountersTest.java

These are additional tests which use jcmd and an application name pattern to find a process.
They should use the PID to avoid finding a process from some other concurrent test invocation.
So it's good to have the same kind of change applied here too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336257](https://bugs.openjdk.org/browse/JDK-8336257): Additional tests in jmxremote/startstop to match on PID not app name (**Bug** - P2)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20138/head:pull/20138` \
`$ git checkout pull/20138`

Update a local copy of the PR: \
`$ git checkout pull/20138` \
`$ git pull https://git.openjdk.org/jdk.git pull/20138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20138`

View PR using the GUI difftool: \
`$ git pr show -t 20138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20138.diff">https://git.openjdk.org/jdk/pull/20138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20138#issuecomment-2223173622)