### PR TITLE
8336258: Document the behavior of 'exclude' and 'compileonly' with respect to inlining

### DIFF
--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -637,6 +637,10 @@ static void usage() {
   tty->print_cr("and 'compileonly'. There is no priority of commands. Applying (a subset of) these");
   tty->print_cr("commands to the same method results in undefined behavior.");
   tty->cr();
+  tty->print_cr("The 'exclude' command excludes methods from top-level compilations as well as");
+  tty->print_cr("from inlining whereas the 'compileonly' command only excludes methods from");
+  tty->print_cr("top-level compilations (i.e. they still can be inlined into other compilation units).");
+  tty->cr();
 };
 
 static int skip_whitespace(char* &line) {

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -639,7 +639,7 @@ static void usage() {
   tty->cr();
   tty->print_cr("The 'exclude' command excludes methods from top-level compilations as well as");
   tty->print_cr("from inlining whereas the 'compileonly' command only excludes methods from");
-  tty->print_cr("top-level compilations (i.e. they still can be inlined into other compilation units).");
+  tty->print_cr("top-level compilations (i.e. they can still be inlined into other compilation units).");
   tty->cr();
 };
 

--- a/src/hotspot/share/compiler/compilerOracle.cpp
+++ b/src/hotspot/share/compiler/compilerOracle.cpp
@@ -638,7 +638,7 @@ static void usage() {
   tty->print_cr("commands to the same method results in undefined behavior.");
   tty->cr();
   tty->print_cr("The 'exclude' command excludes methods from top-level compilations as well as");
-  tty->print_cr("from inlining whereas the 'compileonly' command only excludes methods from");
+  tty->print_cr("from inlining, whereas the 'compileonly' command only excludes methods from");
   tty->print_cr("top-level compilations (i.e. they can still be inlined into other compilation units).");
   tty->cr();
 };


### PR DESCRIPTION
The long-standing behavior of the `exclude` CompileCommand is to also apply to inlined versions of a method. On the other hand, the `compileonly` CompileCommand only affects top-level compilations of a method and not its inlining behavior.

The rational behind this decision is that `exclude` is intended to be used in production to workaround compiler crashes or bad compilations for certain methods and in these scenarios it usually doesn't matter if a "bad" method is getting compiled on the top level or if it gets inlined into another compilation unit.

The "inconsistent inlining behavior with CompileOnly" thread on hotspot-compiler-dev discusses this behavior (see [1]). The answer [2] specifically describes this long-standing behavior.

I think it would be good to document this behavior in the output of `-XX:CompileCommand=help`

[1] https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2016-June/thread.html#23575
[2] https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2016-June/023583.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336258](https://bugs.openjdk.org/browse/JDK-8336258): Document the behavior of 'exclude' and 'compileonly' with respect to inlining (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20142/head:pull/20142` \
`$ git checkout pull/20142`

Update a local copy of the PR: \
`$ git checkout pull/20142` \
`$ git pull https://git.openjdk.org/jdk.git pull/20142/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20142`

View PR using the GUI difftool: \
`$ git pr show -t 20142`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20142.diff">https://git.openjdk.org/jdk/pull/20142.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20142#issuecomment-2223413468)