### PR TITLE
8314498: [macos] Transferring File objects to Finder fails

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CClipboard.java
@@ -89,7 +89,11 @@ final class CClipboard extends SunClipboard {
 
             try {
                 byte[] bytes = DataTransferer.getInstance().translateTransferable(contents, flavor, format);
-                setData(bytes, format);
+                if (DataFlavor.javaFileListFlavor.equals(flavor)) {
+                    writeFileObjects(bytes);
+                } else {
+                    setData(bytes, format);
+                }
             } catch (IOException e) {
                 // Fix 4696186: don't print exception if data with
                 // javaJVMLocalObjectMimeType failed to serialize.
@@ -127,6 +131,7 @@ final class CClipboard extends SunClipboard {
 
     private native void declareTypes(long[] formats, SunClipboard newOwner);
     private native void setData(byte[] data, long format);
+    private native void writeFileObjects(byte[] data);
 
     void checkPasteboardAndNotify() {
         if (checkPasteboardWithoutNotification()) {

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -176,6 +176,40 @@ JNI_COCOA_EXIT(env);
 
 /*
  * Class:     sun_lwawt_macosx_CClipboard
+ * Method:    writeFileObjects
+ * Signature: ([BJ)V
+*/
+JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CClipboard_writeFileObjects
+(JNIEnv *env, jobject inObject, jbyteArray inBytes, jlong inFormat)
+{
+    CHECK_NULL(inBytes);
+
+JNI_COCOA_ENTER(env);
+    jint nBytes = (*env)->GetArrayLength(env, inBytes);
+    jbyte *rawBytes = (*env)->GetPrimitiveArrayCritical(env, inBytes, NULL);
+    CHECK_NULL(rawBytes);
+    NSString *format = formatForIndex(inFormat);
+    NSMutableArray *formatArray = [NSMutableArray arrayWithCapacity:2];
+    int i = 0;
+    for (int j = 0; j < nBytes; j++) {
+        if (rawBytes[j] == 0) {
+            NSString *path = [NSString stringWithUTF8String:(const char*)(rawBytes + i)];
+            NSURL *fileURL = [NSURL fileURLWithPath:path];
+            [formatArray addObject:fileURL.absoluteURL];
+            i = j + 1;
+        }
+    }
+    (*env)->ReleasePrimitiveArrayCritical(env, inBytes, rawBytes, JNI_ABORT);
+
+    [ThreadUtilities performOnMainThreadWaiting:YES block:^() {
+        [[NSPasteboard generalPasteboard] writeObjects:formatArray];
+    }];
+JNI_COCOA_EXIT(env);
+}
+
+
+/*
+ * Class:     sun_lwawt_macosx_CClipboard
  * Method:    getClipboardFormats
  * Signature: (J)[J
      */

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CClipboard.m
@@ -177,10 +177,10 @@ JNI_COCOA_EXIT(env);
 /*
  * Class:     sun_lwawt_macosx_CClipboard
  * Method:    writeFileObjects
- * Signature: ([BJ)V
+ * Signature: ([B)V
 */
 JNIEXPORT void JNICALL Java_sun_lwawt_macosx_CClipboard_writeFileObjects
-(JNIEnv *env, jobject inObject, jbyteArray inBytes, jlong inFormat)
+(JNIEnv *env, jobject inObject, jbyteArray inBytes)
 {
     CHECK_NULL(inBytes);
 
@@ -188,7 +188,6 @@ JNI_COCOA_ENTER(env);
     jint nBytes = (*env)->GetArrayLength(env, inBytes);
     jbyte *rawBytes = (*env)->GetPrimitiveArrayCritical(env, inBytes, NULL);
     CHECK_NULL(rawBytes);
-    NSString *format = formatForIndex(inFormat);
     NSMutableArray *formatArray = [NSMutableArray arrayWithCapacity:2];
     int i = 0;
     for (int j = 0; j < nBytes; j++) {


### PR DESCRIPTION
Here is an updated version of the fix we have used in Jetbrains Runtime for quite a while. It has been tested by running  jdk_desktop tests and manually using a test case attached to this issue.
There is no reg test as I've not found a reliable way to verify file list content inside the system clipboard.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314498](https://bugs.openjdk.org/browse/JDK-8314498): [macos] Transferring File objects to Finder fails (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Contributors
 * Andrey Starovoyt `<Andrey.Starovoyt@jetbrains.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20144/head:pull/20144` \
`$ git checkout pull/20144`

Update a local copy of the PR: \
`$ git checkout pull/20144` \
`$ git pull https://git.openjdk.org/jdk.git pull/20144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20144`

View PR using the GUI difftool: \
`$ git pr show -t 20144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20144.diff">https://git.openjdk.org/jdk/pull/20144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20144#issuecomment-2223802984)