### PR TITLE
8336259: Wrong link to stylesheet.css in JavaDoc API documentation

### DIFF
--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
- Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -26,7 +26,6 @@
 <html lang="en">
 <head>
   <title>Value-based Classes</title>
-  <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
 </head>
 <body>
 <h1 id="ValueBased">{@index "Value-based Classes"}</h1>

--- a/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
+++ b/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
- Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
+++ b/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
@@ -26,7 +26,6 @@
 <html lang="en">
 <head>
   <title>Java Thread Primitive Deprecation</title>
-  <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
 </head>
 <body>
 <h1>Java Thread Primitive Deprecation</h1>


### PR DESCRIPTION
Can I please get a review for this small change, the relative link to the stylesheet isn't needed as it wasn't used anyway in the generated HTML. The correct link to the stylesheet is already in the generated HTML.

This is the difference between the generated docs before and after this change, by running `diff -r` on the docs before and after the change.

```
GeneratedDocs % diff -r 8336259-stylesheet old-docs           
diff -r 8336259-stylesheet/api/java.base/java/lang/doc-files/ValueBased.html old-docs/api/java.base/java/lang/doc-files/ValueBased.html
13a14
> <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
diff -r 8336259-stylesheet/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html old-docs/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html
13a14
> <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
```

Here is the link for the generated docs after the change, no visual change is seen but the erronous link is gone.
Value based classes [before](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/lang/doc-files/ValueBased.html) - [after](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8336259-stylesheet/api/java.base/java/lang/doc-files/ValueBased.html)

Java Thread Primitive Deprecation [before](https://docs.oracle.com/en%2Fjava%2Fjavase%2F22%2Fdocs%2Fapi%2F%2F/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html) - [after](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8336259-stylesheet/api/java.base/java/lang/doc-files/threadPrimitiveDeprecation.html)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336259](https://bugs.openjdk.org/browse/JDK-8336259): Wrong link to stylesheet.css in JavaDoc API documentation (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20145/head:pull/20145` \
`$ git checkout pull/20145`

Update a local copy of the PR: \
`$ git checkout pull/20145` \
`$ git pull https://git.openjdk.org/jdk.git pull/20145/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20145`

View PR using the GUI difftool: \
`$ git pr show -t 20145`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20145.diff">https://git.openjdk.org/jdk/pull/20145.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20145#issuecomment-2223934208)