### PR TITLE
8336036: Synthetic documentation for a record's equals is incorrect for floating-point types

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets.properties
@@ -319,10 +319,12 @@ doclet.record_equals_doc.fullbody.head=\
 doclet.record_equals_doc.fullbody.tail.both=\
  Reference components are compared with \
  {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}; \
- primitive components are compared with '=='.
+ primitive components are compared with the <code>compare</code> method from \
+ their corresponding wrapper classes.
 
 doclet.record_equals_doc.fullbody.tail.primitive=\
- All components in this record class are compared with '=='.
+ All components in this record class are compared with the <code>compare</code> \
+ method from their corresponding wrapper classes.
 
 doclet.record_equals_doc.fullbody.tail.reference=\
  All components in this record class are compared with \

--- a/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
+++ b/test/langtools/jdk/javadoc/doclet/testRecordTypes/TestRecordTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -237,7 +237,8 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     Indicates whether some other object is "equal to" this one. The objects are equa\
                     l if the other object is of the same class and if all the record components are \
-                    equal. All components in this record class are compared with '=='.""",
+                    equal. All components in this record class are compared with the <code>compare</\
+                    code> method from their corresponding wrapper classes.""",
                 """
                     <span class="element-name">r1</span>""",
                 """
@@ -300,7 +301,8 @@ public class TestRecordTypes extends JavadocTester {
                 """
                     Indicates whether some other object is "equal to" this one. The objects are equa\
                     l if the other object is of the same class and if all the record components are \
-                    equal. All components in this record class are compared with '=='.""",
+                    equal. All components in this record class are compared with the <code>compare</\
+                    code> method from their corresponding wrapper classes.""",
                 """
                     <span class="element-name">r1</span>""",
                 """
@@ -311,7 +313,8 @@ public class TestRecordTypes extends JavadocTester {
     @Test
     public void testGeneratedEqualsPrimitive(Path base) throws IOException {
         testGeneratedEquals(base, "int a, int b",
-             "All components in this record class are compared with '=='.");
+             "All components in this record class are compared with the <code>compare</code> method " +
+                     "from their corresponding wrapper classes.");
     }
 
     @Test
@@ -324,7 +327,8 @@ public class TestRecordTypes extends JavadocTester {
     public void testGeneratedEqualsMixed(Path base) throws IOException {
         testGeneratedEquals(base, "int a, Object b",
              "Reference components are compared with <code>Objects::equals(Object,Object)</code>; "
-             + "primitive components are compared with '=='.");
+             + "primitive components are compared with the <code>compare</code> method from their "
+             + "corresponding wrapper classes.");
     }
 
     private void testGeneratedEquals(Path base, String comps, String expect) throws IOException {


### PR DESCRIPTION
Please review this backport of #20129 to JDK 23, fixing the documentation Javadoc generates for the default object method implementations in user records about the comparison behavior for `float` and `double` values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336036](https://bugs.openjdk.org/browse/JDK-8336036): Synthetic documentation for a record's equals is incorrect for floating-point types (**Bug** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20147/head:pull/20147` \
`$ git checkout pull/20147`

Update a local copy of the PR: \
`$ git checkout pull/20147` \
`$ git pull https://git.openjdk.org/jdk.git pull/20147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20147`

View PR using the GUI difftool: \
`$ git pr show -t 20147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20147.diff">https://git.openjdk.org/jdk/pull/20147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20147#issuecomment-2223953048)