### PR TITLE
8336278: Micro-optimize Replace String.format("%n") to System.lineSeparator

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeUtil.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/code/CodeUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import jdk.vm.ci.meta.Signature;
  */
 public class CodeUtil {
 
-    public static final String NEW_LINE = String.format("%n");
+    public static final String NEW_LINE = System.lineSeparator();
 
     public static final int K = 1024;
     public static final int M = 1024 * 1024;

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotMethodData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -318,7 +318,7 @@ final class HotSpotMethodData implements MetaspaceObject {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        String nl = String.format("%n");
+        String nl = System.lineSeparator();
         String nlIndent = String.format("%n%38s", "");
         sb.append("Raw method data for ");
         sb.append(method.format("%H.%n(%p)"));

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/tool/StructuredWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ abstract class StructuredWriter {
     private int column;
     // print first event immediately so tool feels responsive
     private boolean first = true;
-    private String lineSeparator = String.format("%n");
+    private String lineSeparator = System.lineSeparator();
 
     StructuredWriter(PrintWriter p) {
         out = p;


### PR DESCRIPTION
There are three places in the JDK code where String.format("%n") is used. This is actually equivalent to System.lineSeparator and does not require the implementation of String.format.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336278](https://bugs.openjdk.org/browse/JDK-8336278): Micro-optimize Replace String.format("%n") to System.lineSeparator (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20149/head:pull/20149` \
`$ git checkout pull/20149`

Update a local copy of the PR: \
`$ git checkout pull/20149` \
`$ git pull https://git.openjdk.org/jdk.git pull/20149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20149`

View PR using the GUI difftool: \
`$ git pr show -t 20149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20149.diff">https://git.openjdk.org/jdk/pull/20149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20149#issuecomment-2224265469)