### PR TITLE
8336284: Test TestClhsdbJstackLock.java/TestJhsdbJstackLock.java fails with -Xcomp after JDK-8335743

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestClhsdbJstackLock.java
@@ -59,7 +59,7 @@ public class TestClhsdbJstackLock {
                 "^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$",
                 "^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$",
-                "^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$"));
+                "^\\s+- waiting on (<0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)|<no object reference available>)$"));
             unExpStrMap.put("jstack", List.of(
                 "missing reason for "));
             test.run(app.getPid(), cmds, expStrMap, unExpStrMap);

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLock.java
@@ -65,7 +65,7 @@ public class TestJhsdbJstackLock {
             out.shouldMatch("^\\s+- waiting to lock <0x[0-9a-f]+> \\(a java\\.lang\\.Class for LingeredAppWithLock\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Thread\\)$");
             out.shouldMatch("^\\s+- locked <0x[0-9a-f]+> \\(a java\\.lang\\.Class for int\\)$");
-            out.shouldMatch("^\\s+- waiting on <0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)$");
+            out.shouldMatch("^\\s+- waiting on (<0x[0-9a-f]+> \\(a java\\.lang\\.Object\\)|<no object reference available>)$");
 
             out.stderrShouldBeEmptyIgnoreDeprecatedWarnings();
 


### PR DESCRIPTION
Hi all,
Test TestClhsdbJstackLock.java/TestJhsdbJstackLock.java fails with -Xcomp after [JDK-8335743](https://bugs.openjdk.org/browse/JDK-8335743). I think the new failures was testcase bug.

https://github.com/openjdk/jdk/blob/627a32d6722c92f814c1ddd1c2fdf9a3b28cd655/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/JavaVFrame.java#L112
Locals are not always available, e.g., compiled native frames have no scope so there are no locals. So the output `- waiting on <no object reference available>` also acceptable.

The change has been verified by -Xmixed/-Xcomp(c2)/-Xcomp -XX:TieredStopAtLevel=1(c1), only change the testcase, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336284](https://bugs.openjdk.org/browse/JDK-8336284): Test TestClhsdbJstackLock.java/TestJhsdbJstackLock.java fails with -Xcomp after JDK-8335743 (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20151/head:pull/20151` \
`$ git checkout pull/20151`

Update a local copy of the PR: \
`$ git checkout pull/20151` \
`$ git pull https://git.openjdk.org/jdk.git pull/20151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20151`

View PR using the GUI difftool: \
`$ git pr show -t 20151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20151.diff">https://git.openjdk.org/jdk/pull/20151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20151#issuecomment-2224356203)