### PR TITLE
8334758: Incorrect note in Javadoc for a few RandomGenerator methods

### DIFF
--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -809,12 +809,11 @@ public interface RandomGenerator {
      *
      * @throws IllegalArgumentException if {@code bound} is not positive
      *
-     * @implSpec The default implementation checks that {@code bound} is a
-     * positive {@code int}. Then invokes {@code nextInt()}, limiting the result
-     * to be greater than or equal zero and less than {@code bound}. If {@code bound}
-     * is a power of two then limiting is a simple masking operation. Otherwise,
-     * the result is re-calculated by invoking {@code nextInt()} until the
-     * result is greater than or equal zero and less than {@code bound}.
+     * @implSpec The default implementation checks that {@code bound} is positive.
+     * It then invokes {@link #nextInt()} one or more times to ensure a uniform
+     * distribution in the range 0 (inclusive)
+     * to {@code bound} (exclusive).
+     * It assumes the distribution of {@link #nextInt()} to be uniform in turn.
      */
     default int nextInt(int bound) {
         RandomSupport.checkBound(bound);
@@ -835,13 +834,12 @@ public interface RandomGenerator {
      * @throws IllegalArgumentException if {@code origin} is greater than
      *         or equal to {@code bound}
      *
-     * @implSpec The default implementation checks that {@code origin} and
-     * {@code bound} are positive {@code ints}. Then invokes {@code nextInt()},
-     * limiting the result to be greater that or equal {@code origin} and less
-     * than {@code bound}. If {@code bound} is a power of two then limiting is a
-     * simple masking operation. Otherwise, the result is re-calculated  by
-     * invoking {@code nextInt()} until the result is greater than or equal
-     * {@code origin} and less than {@code bound}.
+     * @implSpec The default implementation checks that {@code origin}
+     * is less than {@code bound}.
+     * It then invokes {@link #nextInt()} one or more times to ensure a uniform
+     * distribution in the range {@code origin} (inclusive)
+     * to {@code bound} (exclusive).
+     * It assumes the distribution of {@link #nextInt()} to be uniform in turn.
      */
     default int nextInt(int origin, int bound) {
         RandomSupport.checkRange(origin, bound);
@@ -868,13 +866,11 @@ public interface RandomGenerator {
      *
      * @throws IllegalArgumentException if {@code bound} is not positive
      *
-     * @implSpec The default implementation checks that {@code bound} is a
-     * positive  {@code long}. Then invokes {@code nextLong()}, limiting the
-     * result to be greater than or equal zero and less than {@code bound}. If
-     * {@code bound} is a power of two then limiting is a simple masking
-     * operation. Otherwise, the result is re-calculated by invoking
-     * {@code nextLong()} until the result is greater than or equal zero and
-     * less than {@code bound}.
+     * @implSpec The default implementation checks that {@code bound} is positive.
+     * It then invokes {@link #nextLong()} one or more times to ensure a uniform
+     * distribution in the range 0 (inclusive)
+     * to {@code bound} (exclusive).
+     * It assumes the distribution of {@link #nextLong()} to be uniform in turn.
      */
     default long nextLong(long bound) {
         RandomSupport.checkBound(bound);
@@ -895,13 +891,12 @@ public interface RandomGenerator {
      * @throws IllegalArgumentException if {@code origin} is greater than
      *         or equal to {@code bound}
      *
-     * @implSpec The default implementation checks that {@code origin} and
-     * {@code bound} are positive {@code longs}. Then invokes {@code nextLong()},
-     * limiting the result to be greater than or equal {@code origin} and less
-     * than {@code bound}. If {@code bound} is a power of two then limiting is a
-     * simple masking operation. Otherwise, the result is re-calculated by
-     * invoking {@code nextLong()} until the result is greater than or equal
-     * {@code origin} and less than {@code bound}.
+     * @implSpec The default implementation checks that {@code origin}
+     * is less than {@code bound}.
+     * It then invokes {@link #nextLong()} one or more times to ensure a uniform
+     * distribution in the range {@code origin} (inclusive)
+     * to {@code bound} (exclusive).
+     * It assumes the distribution of {@link #nextLong()} to be uniform in turn.
      */
     default long nextLong(long origin, long bound) {
         RandomSupport.checkRange(origin, bound);

--- a/src/java.base/share/classes/java/util/random/RandomGenerator.java
+++ b/src/java.base/share/classes/java/util/random/RandomGenerator.java
@@ -813,7 +813,7 @@ public interface RandomGenerator {
      * It then invokes {@link #nextInt()} one or more times to ensure a uniform
      * distribution in the range 0 (inclusive)
      * to {@code bound} (exclusive).
-     * It assumes the distribution of {@link #nextInt()} to be uniform in turn.
+     * It assumes the distribution of {@link #nextInt()} to be uniform.
      */
     default int nextInt(int bound) {
         RandomSupport.checkBound(bound);
@@ -839,7 +839,7 @@ public interface RandomGenerator {
      * It then invokes {@link #nextInt()} one or more times to ensure a uniform
      * distribution in the range {@code origin} (inclusive)
      * to {@code bound} (exclusive).
-     * It assumes the distribution of {@link #nextInt()} to be uniform in turn.
+     * It assumes the distribution of {@link #nextInt()} to be uniform.
      */
     default int nextInt(int origin, int bound) {
         RandomSupport.checkRange(origin, bound);
@@ -870,7 +870,7 @@ public interface RandomGenerator {
      * It then invokes {@link #nextLong()} one or more times to ensure a uniform
      * distribution in the range 0 (inclusive)
      * to {@code bound} (exclusive).
-     * It assumes the distribution of {@link #nextLong()} to be uniform in turn.
+     * It assumes the distribution of {@link #nextLong()} to be uniform.
      */
     default long nextLong(long bound) {
         RandomSupport.checkBound(bound);
@@ -896,7 +896,7 @@ public interface RandomGenerator {
      * It then invokes {@link #nextLong()} one or more times to ensure a uniform
      * distribution in the range {@code origin} (inclusive)
      * to {@code bound} (exclusive).
-     * It assumes the distribution of {@link #nextLong()} to be uniform in turn.
+     * It assumes the distribution of {@link #nextLong()} to be uniform.
      */
     default long nextLong(long origin, long bound) {
         RandomSupport.checkRange(origin, bound);


### PR DESCRIPTION
Small corrections to @implSpec notes in a few methods in RandomGenerator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8336288](https://bugs.openjdk.org/browse/JDK-8336288) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8334758](https://bugs.openjdk.org/browse/JDK-8334758): Incorrect note in Javadoc for a few RandomGenerator methods (**Bug** - P4)
 * [JDK-8336288](https://bugs.openjdk.org/browse/JDK-8336288): Incorrect note in Javadoc for a few RandomGenerator methods (**CSR**)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20152/head:pull/20152` \
`$ git checkout pull/20152`

Update a local copy of the PR: \
`$ git checkout pull/20152` \
`$ git pull https://git.openjdk.org/jdk.git pull/20152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20152`

View PR using the GUI difftool: \
`$ git pr show -t 20152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20152.diff">https://git.openjdk.org/jdk/pull/20152.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20152#issuecomment-2224890425)