### PR TITLE
8336675: Remove UnixFileSystemProvider.checkPath in favor of UnixPath.toUnixPath

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -244,15 +244,7 @@ public abstract class UnixFileSystemProvider
                                               FileAttribute<?>... attrs)
          throws IOException
     {
-        UnixPath file = UnixPath.toUnixPath(obj);
-        int mode = UnixFileModeAttribute
-            .toUnixMode(UnixFileModeAttribute.ALL_READWRITE, attrs);
-        try {
-            return UnixChannelFactory.newFileChannel(file, options, mode);
-        } catch (UnixException x) {
-            x.rethrowAsIOException(file);
-            return null;  // keep compiler happy
-        }
+        return newFileChannel(obj, options, attrs);
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.nio.file.NotDirectoryException;
 import java.nio.file.NotLinkException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
-import java.nio.file.ProviderMismatchException;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileAttribute;
@@ -124,14 +123,6 @@ public abstract class UnixFileSystemProvider
     @Override
     public Path getPath(URI uri) {
         return UnixUriUtils.fromUri(theFileSystem, uri);
-    }
-
-    UnixPath checkPath(Path obj) {
-        if (obj == null)
-            throw new NullPointerException();
-        if (!(obj instanceof UnixPath))
-            throw new ProviderMismatchException();
-        return (UnixPath)obj;
     }
 
     @Override
@@ -216,7 +207,7 @@ public abstract class UnixFileSystemProvider
                                       FileAttribute<?>... attrs)
         throws IOException
     {
-        UnixPath file = checkPath(obj);
+        UnixPath file = UnixPath.toUnixPath(obj);
         int mode = UnixFileModeAttribute
             .toUnixMode(UnixFileModeAttribute.ALL_READWRITE, attrs);
         try {
@@ -233,7 +224,7 @@ public abstract class UnixFileSystemProvider
                                                               ExecutorService executor,
                                                               FileAttribute<?>... attrs) throws IOException
     {
-        UnixPath file = checkPath(obj);
+        UnixPath file = UnixPath.toUnixPath(obj);
         int mode = UnixFileModeAttribute
             .toUnixMode(UnixFileModeAttribute.ALL_READWRITE, attrs);
         ThreadPool pool = (executor == null) ? null : ThreadPool.wrap(executor, 0);


### PR DESCRIPTION
Implementation of both methods is the same.
https://github.com/openjdk/jdk/blob/9b6f6c5c9dd6d0fbb056e8d84c3a0888a3320edf/src/java.base/unix/classes/sun/nio/fs/UnixFileSystemProvider.java#L129-L135

https://github.com/openjdk/jdk/blob/9b6f6c5c9dd6d0fbb056e8d84c3a0888a3320edf/src/java.base/unix/classes/sun/nio/fs/UnixPath.java#L172-L179

`UnixPath.toUnixPath` is already used by UnixFileSystemProvider in multiple places. Two more usages shouldn't cause problems.

Tested on linux x64 `test/jdk/java/nio` + `test/jdk/java/io`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336675](https://bugs.openjdk.org/browse/JDK-8336675): Remove UnixFileSystemProvider.checkPath in favor of UnixPath.toUnixPath (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20155/head:pull/20155` \
`$ git checkout pull/20155`

Update a local copy of the PR: \
`$ git checkout pull/20155` \
`$ git pull https://git.openjdk.org/jdk.git pull/20155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20155`

View PR using the GUI difftool: \
`$ git pr show -t 20155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20155.diff">https://git.openjdk.org/jdk/pull/20155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20155#issuecomment-2234097673)