### PR TITLE
8336301: test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java leaves around a FIFO file upon test completion

### DIFF
--- a/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
+++ b/test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java
@@ -155,6 +155,7 @@ public class AsyncCloseAndInterrupt {
             return;
         }
         fifoFile = new File("x.fifo");
+        fifoFile.deleteOnExit();
         if (fifoFile.exists()) {
             if (!fifoFile.delete())
                 throw new IOException("Cannot delete existing fifo " + fifoFile);


### PR DESCRIPTION
Can I please get a review of this test-only change which proposes to address the issue noted in https://bugs.openjdk.org/browse/JDK-8336301?

The update in this PR, marks the FIFO file to be deleted upon JVM exit so that it isn't left around causing any subsequent process reading that file to block forever.

After this change, I've locally verified that this file isn't left around irrespective of whether or not the test passes.

The test continues to pass with this change. tier2 testing with this change is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336301](https://bugs.openjdk.org/browse/JDK-8336301): test/jdk/java/nio/channels/AsyncCloseAndInterrupt.java leaves around a FIFO file upon test completion (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20156/head:pull/20156` \
`$ git checkout pull/20156`

Update a local copy of the PR: \
`$ git checkout pull/20156` \
`$ git pull https://git.openjdk.org/jdk.git pull/20156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20156`

View PR using the GUI difftool: \
`$ git pr show -t 20156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20156.diff">https://git.openjdk.org/jdk/pull/20156.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20156#issuecomment-2225433042)