### PR TITLE
8335480: Only deoptimize threads if needed when closing shared arena

### DIFF
--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -193,10 +193,9 @@ public:
         // another memory access. If the scope has been closed at that point,
         // the target thread will see it and throw an exception.
 
-        // We would like to conditionally deoptimize here if last_frame::oops_do
-        // reports the session oop being somehwere in the frame, but this currently
-        // isn't possible because of JDK-8290892 (i.e. the session may not actually be
-        // live at the safepoint we're stopped at)
+        // We would like to deoptimize here only if last_frame::oops_do
+        // reports the session oop being live at this safepoint, but this
+        // currently isn't possible due to JDK-8290892
         Deoptimization::deoptimize(jt, last_frame);
       }
     }

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -182,7 +182,8 @@ public:
         // we're also not sure whether a memory access will actually occur after
         // this safepoint. So, we can not just install an async exception here
         //
-        // Instead, we deoptimize the frame to get back to code like this:
+        // Instead, we mark the frame for deoptimization (which happens immediately
+        // when execution continues) to get back to code like this:
         //
         // for (...) {
         //     call to ScopedMemoryAccess

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -120,8 +120,6 @@ public:
 
   virtual void do_thread(Thread* thread) {
     JavaThread* jt = JavaThread::cast(thread);
-    // FIXME: why would this not be true? Exception should be installed
-    // before initial handshake returns. This should be an assert (but it can fail)
     bool ignored;
     if (is_accessing_session(jt, _session.resolve(), ignored)) {
       // Throw exception to unwind out from the scoped access

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -182,8 +182,8 @@ public:
         // we're also not sure whether a memory access will actually occur after
         // this safepoint. So, we can not just install an async exception here
         //
-        // Instead, we mark the frame for deoptimization (which happens immediately
-        // when execution continues) to get back to code like this:
+        // Instead, we mark the frame for deoptimization (which happens just before
+        // execution in this frame continues) to get back to code like this:
         //
         // for (...) {
         //     call to ScopedMemoryAccess

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -195,6 +195,10 @@ public:
         // another memory access. If the scope has been closed at that point,
         // the target thread will see it and throw an exception.
 
+        // We would like to conditionally deoptimize here if last_frame::oops_do
+        // reports the session oop being somehwere in the frame, but this currently
+        // isn't possible because of JDK-8290892 (i.e. the session may not actually be
+        // live at the safepoint we're stopped at)
         Deoptimization::deoptimize(jt, last_frame);
       }
     }

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -26,6 +26,7 @@
 #include "classfile/vmSymbols.hpp"
 #include "jni.h"
 #include "jvm.h"
+#include "logging/logStream.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "prims/stackwalk.hpp"
@@ -37,15 +38,34 @@
 
 template<typename Func>
 static bool for_scoped_method(JavaThread* jt, const Func& func) {
+  ResourceMark rm;
+#ifdef ASSERT
+  LogMessage(foreign) msg;
+  NonInterleavingLogStream ls{LogLevelType::Trace, msg};
+  if (ls.is_enabled()) {
+    ls.print_cr("Walking thread: %s", jt->name());
+  }
+#endif
+
   const int max_critical_stack_depth = 10;
   int depth = 0;
   for (vframeStream stream(jt); !stream.at_end(); stream.next()) {
     Method* m = stream.method();
-    if (m->is_scoped()) {
+    bool is_scoped = m->is_scoped();
+
+#ifdef ASSERT
+    if (ls.is_enabled()) {
+      stream.asJavaVFrame()->print_value(&ls);
+      ls.print_cr("    is_scoped=%s", is_scoped ? "true" : "false");
+    }
+#endif
+
+    if (is_scoped) {
       assert(depth < max_critical_stack_depth, "can't have more than %d critical frames", max_critical_stack_depth);
       return func(stream);
     }
     depth++;
+
 #ifndef ASSERT
     // On debug builds, just keep searching the stack
     // in case we missed an @Scoped method further up
@@ -57,41 +77,9 @@ static bool for_scoped_method(JavaThread* jt, const Func& func) {
   return false;
 }
 
-// static bool is_in_scoped_method(JavaThread* jt) {
-//   return for_scoped_method(jt, [](vframeStream& stream){ return true; });
-// }
-
-static void deoptimize_top_frame(JavaThread* jt) {
-  frame last_frame = jt->last_frame();
-  RegisterMap register_map(jt,
-                            RegisterMap::UpdateMap::include,
-                            RegisterMap::ProcessFrames::include,
-                            RegisterMap::WalkContinuation::skip);
-
-  if (last_frame.is_safepoint_blob_frame()) {
-    last_frame = last_frame.sender(&register_map);
-  }
-
-  if (last_frame.is_compiled_frame() && last_frame.can_be_deoptimized()) {
-    Deoptimization::deoptimize(jt, last_frame);
-  }
-}
-
-static bool is_accessing_session(JavaThread* jt, oop session, bool should_deopt) {
-  // Quick check to see  if we are inside an @Scoped method, to avoid deoptimizing
-  // FIXME: this only seems to work correctly after deoptimizing
-  // if (!is_in_scoped_method(jt)) {
-  //   return;
-  // }
-
-  if (should_deopt) {
-    // FIXME: Reference.reachabilityFence doesn work, see JDK-8290892
-    // We deoptimize here so that we can accurately inspect locals.
-    deoptimize_top_frame(jt);
-  }
-
-  return for_scoped_method(jt, [&session = session](vframeStream& stream){
-    ResourceMark rm;
+static bool is_accessing_session(JavaThread* jt, oop session, bool& in_scoped) {
+  return for_scoped_method(jt, [&](vframeStream& stream){
+    in_scoped = true;
     StackValueCollection* locals = stream.asJavaVFrame()->locals();
     for (int i = 0; i < locals->size(); i++) {
       StackValue* var = locals->at(i);
@@ -103,6 +91,19 @@ static bool is_accessing_session(JavaThread* jt, oop session, bool should_deopt)
     }
     return false;
   });
+}
+
+static frame get_last_frame(JavaThread* jt) {
+  frame last_frame = jt->last_frame();
+  RegisterMap register_map(jt,
+                            RegisterMap::UpdateMap::include,
+                            RegisterMap::ProcessFrames::include,
+                            RegisterMap::WalkContinuation::skip);
+
+  if (last_frame.is_safepoint_blob_frame()) {
+    last_frame = last_frame.sender(&register_map);
+  }
+  return last_frame;
 }
 
 class ScopedAsyncExceptionHandshake : public AsyncExceptionHandshake {
@@ -121,7 +122,8 @@ public:
     JavaThread* jt = JavaThread::cast(thread);
     // FIXME: why would this not be true? Exception should be installed
     // before initial handshake returns. This should be an assert (but it can fail)
-    if (is_accessing_session(jt, _session.resolve(), false)) {
+    bool ignored;
+    if (is_accessing_session(jt, _session.resolve(), ignored)) {
       // Throw exception to unwind out from the scoped access
       AsyncExceptionHandshake::do_thread(thread);
     }
@@ -152,7 +154,8 @@ public:
       return;
     }
 
-    if (is_accessing_session(jt, JNIHandles::resolve(_session), true)) {
+    bool in_scoped = false;
+    if (is_accessing_session(jt, JNIHandles::resolve(_session), in_scoped)) {
       // We have found that the target thread is inside of a scoped access.
       // An asynchronous handshake is sent to the target thread, telling it
       // to throw an exception, which will unwind the target thread out from
@@ -160,6 +163,40 @@ public:
       OopHandle session(Universe::vm_global(), JNIHandles::resolve(_session));
       OopHandle error(Universe::vm_global(), JNIHandles::resolve(_error));
       jt->install_async_exception(new ScopedAsyncExceptionHandshake(session, error));
+    } else if (!in_scoped) {
+      frame last_frame = get_last_frame(jt);
+      if (last_frame.is_compiled_frame() && last_frame.can_be_deoptimized()) {
+        // We are not at a safepoint that is 'in' an @Scoped method, but due to the compiler
+        // moving code around/hoisting checks, we may be in a situation like this:
+        //
+        // liveness check (from @Scoped method)
+        // for (...) {
+        //    for (...) { // strip-mining inner loop
+        //        memory access (from @Scoped method)
+        //    }
+        //    safepoint <-- STOPPED HERE
+        // }
+        //
+        // The safepoint at which we're stopped may be in between the liveness check
+        // and actual memory access, but is itself 'outside' of @Scoped code
+        //
+        // However, we're not sure whether we are in this exact situation, and
+        // we're also not sure whether a memory access will actually occur after
+        // this safepoint. So, we can not just install an async exception here
+        //
+        // Instead, we deoptimize the frame to get back to code like this:
+        //
+        // for (...) {
+        //     call to ScopedMemoryAccess
+        //     safepoint <-- STOPPED HERE
+        // }
+        //
+        // This means that we will re-do the liveness check before attempting
+        // another memory access. If the scope has been closed at that point,
+        // the target thread will see it and throw an exception.
+
+        Deoptimization::deoptimize(jt, last_frame);
+      }
     }
   }
 };

--- a/src/hotspot/share/prims/scopedMemoryAccess.cpp
+++ b/src/hotspot/share/prims/scopedMemoryAccess.cpp
@@ -104,6 +104,12 @@ public:
       return;
     }
 
+    if (jt->has_async_exception_condition()) {
+      // Target thread just about to throw an async exception using async handshakes,
+      // we will then unwind out from the scoped memory access.
+      return;
+    }
+
     frame last_frame = jt->last_frame();
     RegisterMap register_map(jt,
                              RegisterMap::UpdateMap::include,
@@ -120,12 +126,6 @@ public:
       // _session is reachable from the frame, but reachabilityFence doesn't currently
       // work the way it should. Therefore we deopt unconditionally for now.
       Deoptimization::deoptimize(jt, last_frame);
-    }
-
-    if (jt->has_async_exception_condition()) {
-      // Target thread just about to throw an async exception using async handshakes,
-      // we will then unwind out from the scoped memory access.
-      return;
     }
 
     if (is_in_scoped_access(jt, JNIHandles::resolve(_session))) {

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -618,94 +618,94 @@ javaVFrame* vframeStreamCommon::asJavaVFrame() {
 }
 
 #ifndef PRODUCT
-void vframe::print() {
-  if (WizardMode) _fr.print_value_on(tty,nullptr);
+void vframe::print(outputStream* output) {
+  if (WizardMode) _fr.print_value_on(output, nullptr);
 }
 
-void vframe::print_value() const {
-  ((vframe*)this)->print();
+void vframe::print_value(outputStream* output) const {
+  ((vframe*)this)->print(output);
 }
 
 
-void entryVFrame::print_value() const {
-  ((entryVFrame*)this)->print();
+void entryVFrame::print_value(outputStream* output) const {
+  ((entryVFrame*)this)->print(output);
 }
 
-void entryVFrame::print() {
-  vframe::print();
-  tty->print_cr("C Chunk in between Java");
-  tty->print_cr("C     link " INTPTR_FORMAT, p2i(_fr.link()));
+void entryVFrame::print(outputStream* output) {
+  vframe::print(output);
+  output->print_cr("C Chunk in between Java");
+  output->print_cr("C     link " INTPTR_FORMAT, p2i(_fr.link()));
 }
 
 
 // ------------- javaVFrame --------------
 
-static void print_stack_values(const char* title, StackValueCollection* values) {
+static void print_stack_values(outputStream* output, const char* title, StackValueCollection* values) {
   if (values->is_empty()) return;
-  tty->print_cr("\t%s:", title);
+  output->print_cr("\t%s:", title);
   values->print();
 }
 
 
-void javaVFrame::print() {
+void javaVFrame::print(outputStream* output) {
   Thread* current_thread = Thread::current();
   ResourceMark rm(current_thread);
   HandleMark hm(current_thread);
 
-  vframe::print();
-  tty->print("\t");
+  vframe::print(output);
+  output->print("\t");
   method()->print_value();
-  tty->cr();
-  tty->print_cr("\tbci:    %d", bci());
+  output->cr();
+  output->print_cr("\tbci:    %d", bci());
 
-  print_stack_values("locals",      locals());
-  print_stack_values("expressions", expressions());
+  print_stack_values(output, "locals",      locals());
+  print_stack_values(output, "expressions", expressions());
 
   GrowableArray<MonitorInfo*>* list = monitors();
   if (list->is_empty()) return;
-  tty->print_cr("\tmonitor list:");
+  output->print_cr("\tmonitor list:");
   for (int index = (list->length()-1); index >= 0; index--) {
     MonitorInfo* monitor = list->at(index);
-    tty->print("\t  obj\t");
+    output->print("\t  obj\t");
     if (monitor->owner_is_scalar_replaced()) {
       Klass* k = java_lang_Class::as_Klass(monitor->owner_klass());
-      tty->print("( is scalar replaced %s)", k->external_name());
+      output->print("( is scalar replaced %s)", k->external_name());
     } else if (monitor->owner() == nullptr) {
-      tty->print("( null )");
+      output->print("( null )");
     } else {
       monitor->owner()->print_value();
-      tty->print("(owner=" INTPTR_FORMAT ")", p2i(monitor->owner()));
+      output->print("(owner=" INTPTR_FORMAT ")", p2i(monitor->owner()));
     }
     if (monitor->eliminated()) {
       if(is_compiled_frame()) {
-        tty->print(" ( lock is eliminated in compiled frame )");
+        output->print(" ( lock is eliminated in compiled frame )");
       } else {
-        tty->print(" ( lock is eliminated, frame not compiled )");
+        output->print(" ( lock is eliminated, frame not compiled )");
       }
     }
-    tty->cr();
-    tty->print("\t  ");
-    monitor->lock()->print_on(tty, monitor->owner());
-    tty->cr();
+    output->cr();
+    output->print("\t  ");
+    monitor->lock()->print_on(output, monitor->owner());
+    output->cr();
   }
 }
 
 
-void javaVFrame::print_value() const {
+void javaVFrame::print_value(outputStream* output) const {
   Method*    m = method();
   InstanceKlass*     k = m->method_holder();
-  tty->print_cr("frame( sp=" INTPTR_FORMAT ", unextended_sp=" INTPTR_FORMAT ", fp=" INTPTR_FORMAT ", pc=" INTPTR_FORMAT ")",
+  output->print_cr("frame( sp=" INTPTR_FORMAT ", unextended_sp=" INTPTR_FORMAT ", fp=" INTPTR_FORMAT ", pc=" INTPTR_FORMAT ")",
                 p2i(_fr.sp()),  p2i(_fr.unextended_sp()), p2i(_fr.fp()), p2i(_fr.pc()));
-  tty->print("%s.%s", k->internal_name(), m->name()->as_C_string());
+  output->print("%s.%s", k->internal_name(), m->name()->as_C_string());
 
   if (!m->is_native()) {
     Symbol*  source_name = k->source_file_name();
     int        line_number = m->line_number_from_bci(bci());
     if (source_name != nullptr && (line_number != -1)) {
-      tty->print("(%s:%d)", source_name->as_C_string(), line_number);
+      output->print("(%s:%d)", source_name->as_C_string(), line_number);
     }
   } else {
-    tty->print("(Native Method)");
+    output->print("(Native Method)");
   }
   // Check frame size and print warning if it looks suspiciously large
   if (fr().sp() != nullptr) {
@@ -719,25 +719,25 @@ void javaVFrame::print_value() const {
   }
 }
 
-void javaVFrame::print_activation(int index) const {
+void javaVFrame::print_activation(int index, outputStream* output) const {
   // frame number and method
-  tty->print("%2d - ", index);
+  output->print("%2d - ", index);
   ((vframe*)this)->print_value();
-  tty->cr();
+  output->cr();
 
   if (WizardMode) {
     ((vframe*)this)->print();
-    tty->cr();
+    output->cr();
   }
 }
 
 // ------------- externalVFrame --------------
 
-void externalVFrame::print() {
-  _fr.print_value_on(tty,nullptr);
+void externalVFrame::print(outputStream* output) {
+  _fr.print_value_on(output, nullptr);
 }
 
-void externalVFrame::print_value() const {
-  ((vframe*)this)->print();
+void externalVFrame::print_value(outputStream* output) const {
+  ((vframe*)this)->print(output);
 }
 #endif // PRODUCT

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -99,8 +99,8 @@ class vframe: public ResourceObj {
 
 #ifndef PRODUCT
   // printing operations
-  virtual void print_value() const;
-  virtual void print();
+  virtual void print_value(outputStream* output = tty) const;
+  virtual void print(outputStream* output = tty);
 #endif
 };
 
@@ -145,9 +145,9 @@ class javaVFrame: public vframe {
 #ifndef PRODUCT
  public:
   // printing operations
-  void print();
-  void print_value() const;
-  void print_activation(int index) const;
+  void print(outputStream* output = tty);
+  void print_value(outputStream* output = tty) const;
+  void print_activation(int index, outputStream* output = tty) const;
 #endif
   friend class vframe;
 };
@@ -195,8 +195,8 @@ class externalVFrame: public vframe {
 #ifndef PRODUCT
  public:
   // printing operations
-  void print_value() const;
-  void print();
+  void print_value(outputStream* output = tty) const;
+  void print(outputStream* output = tty);
 #endif
   friend class vframe;
 };
@@ -211,8 +211,8 @@ class entryVFrame: public externalVFrame {
 #ifndef PRODUCT
  public:
   // printing
-  void print_value() const;
-  void print();
+  void print_value(outputStream* output = tty) const;
+  void print(outputStream* output = tty);
 #endif
   friend class vframe;
 };

--- a/test/jdk/java/foreign/TestConcurrentClose.java
+++ b/test/jdk/java/foreign/TestConcurrentClose.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @requires vm.flavor != "zero"
+ * @requires vm.compiler2.enabled
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @key randomness
  * @library /test/lib

--- a/test/jdk/java/foreign/TestConcurrentClose.java
+++ b/test/jdk/java/foreign/TestConcurrentClose.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires vm.flavor != "zero"
+ * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
+ * @key randomness
+ * @library /test/lib
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ *
+ * @run testng/othervm
+ *   -Xbootclasspath/a:.
+ *   -XX:+UnlockDiagnosticVMOptions
+ *   -XX:+WhiteBoxAPI
+ *   -XX:CompileCommand=dontinline,TestConcurrentClose$SegmentAccessor::doAccess
+ *   TestConcurrentClose
+ */
+
+import jdk.test.whitebox.WhiteBox;
+import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestConcurrentClose {
+    static final WhiteBox WB = WhiteBox.getWhiteBox();
+    static final Method DO_ACCESS_METHOD;
+    static final int C2_COMPILED_LEVEL = 4;
+
+    static {
+        try {
+            DO_ACCESS_METHOD = SegmentAccessor.class.getDeclaredMethod("doAccess");
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    static final int ITERATIONS = 5;
+    static final int SEGMENT_SIZE = 10_000;
+    static final int MAX_EXECUTOR_WAIT_SECONDS = 20;
+    static final int NUM_ACCESSORS = 50;
+
+    static final AtomicLong start = new AtomicLong();
+    static final AtomicBoolean started = new AtomicBoolean();
+
+    @Test
+    public void testHandshake() throws InterruptedException {
+        for (int it = 0; it < ITERATIONS; it++) {
+            System.out.println("ITERATION " + it + " - starting");
+            ExecutorService accessExecutor = Executors.newCachedThreadPool();
+            start.set(System.currentTimeMillis());
+            started.set(false);
+            CountDownLatch startClosureLatch = new CountDownLatch(1);
+
+            for (int i = 0; i < NUM_ACCESSORS ; i++) {
+                Arena arena = Arena.ofShared();
+                MemorySegment segment = arena.allocate(SEGMENT_SIZE, 1);
+                accessExecutor.execute(new SegmentAccessor(i, segment));
+                accessExecutor.execute(new Closer(i, startClosureLatch, arena));
+            }
+
+            awaitCompilation();
+
+            long closeDelay = System.currentTimeMillis() - start.get();
+            System.out.println("Starting closers after delay of " + closeDelay + " millis");
+            startClosureLatch.countDown();
+            accessExecutor.shutdown();
+            assertTrue(accessExecutor.awaitTermination(MAX_EXECUTOR_WAIT_SECONDS, TimeUnit.SECONDS));
+            long finishDelay = System.currentTimeMillis() - start.get();
+            System.out.println("ITERATION " + it + " - finished, after " + finishDelay + "milis");
+        }
+    }
+
+    static class SegmentAccessor implements Runnable {
+        final MemorySegment segment;
+        final int id;
+        boolean hasFailed = false;
+
+        SegmentAccessor(int id, MemorySegment segment) {
+            this.id = id;
+            this.segment = segment;
+        }
+
+        @Override
+        public final void run() {
+            start("Accessor #" + id);
+            while (segment.scope().isAlive()) {
+                try {
+                    doAccess();
+                } catch (IllegalStateException ex) {
+                    // scope was closed, loop should exit
+                    assertFalse(hasFailed);
+                    hasFailed = true;
+                }
+            }
+            long delay = System.currentTimeMillis() - start.get();
+            System.out.println("Accessor #" + id + " terminated - elapsed (ms): " + delay);
+        }
+
+        // keep this out of line, so it has a chance to be fully C2 compiled
+        private int doAccess() {
+            int sum = 0;
+            for (int i = 0; i < segment.byteSize(); i++) {
+                sum += segment.get(JAVA_BYTE, i);
+            }
+            return sum;
+        }
+    }
+
+    static class Closer implements Runnable {
+        final int id;
+        final Arena arena;
+        final CountDownLatch startLatch;
+
+        Closer(int id, CountDownLatch startLatch, Arena arena) {
+            this.id = id;
+            this.arena = arena;
+            this.startLatch = startLatch;
+        }
+
+        @Override
+        public void run() {
+            start("Closer #" + id);
+            try {
+                // try to close all at the same time, to simulate concurrent
+                // closures of unrelated arenas
+                startLatch.await();
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Unexpected interruption", e);
+            }
+            arena.close(); // This should NOT throw
+            long delay = System.currentTimeMillis() - start.get();
+            System.out.println("Closer #" + id + "terminated - elapsed (ms): " + delay);
+        }
+    }
+
+    static void start(String name) {
+        if (started.compareAndSet(false, true)) {
+            long delay = System.currentTimeMillis() - start.get();
+            System.out.println("Started first thread: " + name + " ; elapsed (ms): " + delay);
+        }
+    }
+
+    private static void awaitCompilation() throws InterruptedException {
+        int retries = 0;
+        while (WB.getMethodCompilationLevel(DO_ACCESS_METHOD, false) != C2_COMPILED_LEVEL) {
+            if (retries > 20) {
+                throw new IllegalStateException("SegmentAccessor::doAccess method not being compiled");
+            }
+            Thread.sleep(1000);
+            retries++;
+        }
+    }
+}

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -26,11 +26,15 @@
  * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @key randomness
- * @run testng/othervm TestHandshake
- * @run testng/othervm -Xint TestHandshake
- * @run testng/othervm -XX:TieredStopAtLevel=1 TestHandshake
- * @run testng/othervm -XX:-TieredCompilation TestHandshake
+ * @run testng/othervm
+ *   -XX:-TieredCompilation
+ *   TestHandshake
  */
+
+// -Xlog:foreign=trace
+// * @run testng/othervm TestHandshake
+// * @run testng/othervm -Xint TestHandshake
+// * @run testng/othervm -XX:TieredStopAtLevel=1 TestHandshake
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -100,7 +104,7 @@ public class TestHandshake {
 
         @Override
         public final void run() {
-            start("\"Accessor #\" + id");
+            start("Accessor #" + id);
             while (segment.scope().isAlive()) {
                 try {
                     doAccess();
@@ -290,12 +294,12 @@ public class TestHandshake {
     static Object[][] accessors() {
         return new Object[][] {
                 { "SegmentAccessor", (AccessorFactory)SegmentAccessor::new },
-                { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
-                { "SegmentSwappyCopyAccessor", (AccessorFactory)SegmentSwappyCopyAccessor::new },
-                { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
-                { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
-                { "BufferAccessor", (AccessorFactory)BufferAccessor::new },
-                { "BufferHandleAccessor", (AccessorFactory)BufferHandleAccessor::new }
+                // { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
+                // { "SegmentSwappyCopyAccessor", (AccessorFactory)SegmentSwappyCopyAccessor::new },
+                // { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
+                // { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
+                // { "BufferAccessor", (AccessorFactory)BufferAccessor::new },
+                // { "BufferHandleAccessor", (AccessorFactory)BufferHandleAccessor::new }
         };
     }
 }

--- a/test/jdk/java/foreign/TestHandshake.java
+++ b/test/jdk/java/foreign/TestHandshake.java
@@ -26,15 +26,11 @@
  * @requires vm.flavor != "zero"
  * @modules java.base/jdk.internal.vm.annotation java.base/jdk.internal.misc
  * @key randomness
- * @run testng/othervm
- *   -XX:-TieredCompilation
- *   TestHandshake
+ * @run testng/othervm TestHandshake
+ * @run testng/othervm -Xint TestHandshake
+ * @run testng/othervm -XX:TieredStopAtLevel=1 TestHandshake
+ * @run testng/othervm -XX:-TieredCompilation TestHandshake
  */
-
-// -Xlog:foreign=trace
-// * @run testng/othervm TestHandshake
-// * @run testng/othervm -Xint TestHandshake
-// * @run testng/othervm -XX:TieredStopAtLevel=1 TestHandshake
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
@@ -294,12 +290,12 @@ public class TestHandshake {
     static Object[][] accessors() {
         return new Object[][] {
                 { "SegmentAccessor", (AccessorFactory)SegmentAccessor::new },
-                // { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
-                // { "SegmentSwappyCopyAccessor", (AccessorFactory)SegmentSwappyCopyAccessor::new },
-                // { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
-                // { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
-                // { "BufferAccessor", (AccessorFactory)BufferAccessor::new },
-                // { "BufferHandleAccessor", (AccessorFactory)BufferHandleAccessor::new }
+                { "SegmentCopyAccessor", (AccessorFactory)SegmentCopyAccessor::new },
+                { "SegmentSwappyCopyAccessor", (AccessorFactory)SegmentSwappyCopyAccessor::new },
+                { "SegmentMismatchAccessor", (AccessorFactory)SegmentMismatchAccessor::new },
+                { "SegmentFillAccessor", (AccessorFactory)SegmentFillAccessor::new },
+                { "BufferAccessor", (AccessorFactory)BufferAccessor::new },
+                { "BufferHandleAccessor", (AccessorFactory)BufferHandleAccessor::new }
         };
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ConcurrentClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ConcurrentClose.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandle;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+
+import static java.lang.foreign.ValueLayout.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(3)
+@Threads(Threads.MAX)
+public class ConcurrentClose {
+
+    static final int SIZE = 10_000;
+
+    @Benchmark
+    public void sharedAccess() {
+        try (Arena arena = Arena.ofShared()) {
+            MemorySegment segment = arena.allocate(SIZE);
+            access(segment);
+        }
+    }
+
+    @Benchmark
+    public void confinedAccess() {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment segment = arena.allocate(SIZE);
+            access(segment);
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public int access(MemorySegment segment) {
+        int sum = 0;
+        for (int i = 0; i < segment.byteSize(); i++) {
+            sum += segment.get(JAVA_BYTE, i);
+        }
+        return sum;
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ConcurrentClose.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ConcurrentClose.java
@@ -32,11 +32,11 @@ import org.openjdk.jmh.annotations.*;
 import static java.lang.foreign.ValueLayout.*;
 
 @BenchmarkMode(Mode.AverageTime)
-@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@State(org.openjdk.jmh.annotations.Scope.Thread)
+@Warmup(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 10, time = 10, timeUnit = TimeUnit.SECONDS)
+@State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(3)
+@Fork(1)
 @Threads(Threads.MAX)
 public class ConcurrentClose {
 


### PR DESCRIPTION
This PR limits the number of cases in which we deoptimize frames when closing a shared Arena. The initial intent of this was to improve the performance of shared arena closure in cases where a lot of threads are accessing and closing shared arenas at the same time (see attached benchmark), but unfortunately even disabling deoptimization altogether does not have a great effect on that benchmark.

Nevertheless, I think the extra logging/testing/benchmark code, and comments I've written, together with reducing the number of cases where we deoptimize, which makes it clearer exactly why we need to deoptimize in the first place, will be useful going forward. So, I've a create this PR out of them.

In this PR:
- I've separate the stack walking code (`for_scope_method`) from the code that checks for a reference to the arena being closed (`is_accessing_session`), and added logging code to the former. That also required changing vframe code to accept an `ouputStream*` rather than always printing to `tty`.
- Added a new test (`TestConcurrentClose`), that tries to close many shared arenas at the same time, in order to stress that use case.
- Added a new benchmark (`ConcurrentClose`), that stresses the cases where many threads are accessing and closing shared arenas.

I've done several benchmark runs with different amounts of threads. The confined case stays much more consistent, while the shared cases balloons up in time spent quickly when there are more than 4 threads:

```
Benchmark                     Threads   Mode  Cnt     Score     Error  Units
ConcurrentClose.sharedAccess       32   avgt   10  9017.397 ± 202.870  us/op
ConcurrentClose.sharedAccess       24   avgt   10  5178.214 ± 164.922  us/op
ConcurrentClose.sharedAccess       16   avgt   10  2224.420 ± 165.754  us/op
ConcurrentClose.sharedAccess        8   avgt   10   593.828 ±   8.321  us/op
ConcurrentClose.sharedAccess        7   avgt   10   470.700 ±  22.511  us/op
ConcurrentClose.sharedAccess        6   avgt   10   386.697 ±  59.170  us/op
ConcurrentClose.sharedAccess        5   avgt   10   291.157 ±   7.023  us/op
ConcurrentClose.sharedAccess        4   avgt   10   209.178 ±   5.802  us/op
ConcurrentClose.sharedAccess        1   avgt   10    52.042 ±   0.630  us/op
ConcurrentClose.confinedAccess     32   avgt   10    25.517 ±   1.069  us/op
ConcurrentClose.confinedAccess      1   avgt   10    12.398 ±   0.098  us/op
```

(I manually added the `Threads` collumn btw)

Testing: tier 1-4