### PR TITLE
8336464: C2: Force CastX2P to be a two-address instruction

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2321,6 +2321,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return true;
+}
+
 // Is this branch offset short enough that a short branch can be used?
 //
 // NOTE: If the platform does not provide any short branch variants, then

--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -7906,31 +7906,31 @@ instruct membar_volatile() %{
 instruct castX2P(iRegPNoSp dst, iRegL src) %{
   match(Set dst (CastX2P src));
 
+  // We still assign cost here because two-address instructions may bring
+  // side impact, i.e., spilling.
   ins_cost(INSN_COST);
-  format %{ "mov $dst, $src\t# long -> ptr" %}
-
+  format %{ "castX2P $src\t# long -> ptr" %}
+  size(0);
   ins_encode %{
-    if ($dst$$reg != $src$$reg) {
-      __ mov(as_Register($dst$$reg), as_Register($src$$reg));
-    }
+    /* empty encoding */
+    assert($dst$$reg == $src$$reg, "We can't remove it when dst != src");
   %}
-
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_empty);
 %}
 
 instruct castP2X(iRegLNoSp dst, iRegP src) %{
   match(Set dst (CastP2X src));
 
+  // We still assign cost here because two-address instructions may bring
+  // side impact, i.e., spilling.
   ins_cost(INSN_COST);
-  format %{ "mov $dst, $src\t# ptr -> long" %}
-
+  format %{ "castP2X $src\t# ptr -> long" %}
+  size(0);
   ins_encode %{
-    if ($dst$$reg != $src$$reg) {
-      __ mov(as_Register($dst$$reg), as_Register($src$$reg));
-    }
+    /* empty encoding */
+    assert($dst$$reg == $src$$reg, "We can't remove it when dst != src");
   %}
-
-  ins_pipe(ialu_reg);
+  ins_pipe(pipe_class_empty);
 %}
 
 // Convert oop into int for vectors alignment masking

--- a/src/hotspot/cpu/arm/arm.ad
+++ b/src/hotspot/cpu/arm/arm.ad
@@ -1017,6 +1017,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 // Vector width in bytes
 int Matcher::vector_width_in_bytes(BasicType bt) {
   return MaxVectorSize;

--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -2164,6 +2164,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 // Vector width in bytes.
 int Matcher::vector_width_in_bytes(BasicType bt) {
   if (SuperwordUseVSX) {

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1958,6 +1958,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 // Is this branch offset short enough that a short branch can be used?
 //
 // NOTE: If the platform does not provide any short branch variants, then

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -1489,6 +1489,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 //----------SUPERWORD HELPERS----------------------------------------
 
 // Vector width in bytes.

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -1398,6 +1398,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(0, 0);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 // Is this branch offset short enough that a short branch can be used?
 //
 // NOTE: If the platform does not provide any short branch variants, then

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -1597,6 +1597,10 @@ OptoRegPair Matcher::vector_return_value(uint ideal_reg) {
   return OptoRegPair(hi, lo);
 }
 
+bool Matcher::use_same_src_and_dest_reg_for_CastX2P(void) {
+  return false;
+}
+
 // Is this branch offset short enough that a short branch can be used?
 //
 // NOTE: If the platform does not provide any short branch variants, then

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1688,14 +1688,18 @@ void ArchDesc::declareClasses(FILE *fp) {
     // Identify which input register matches the input register.
     uint  matching_input = instr->two_address(_globalNames);
 
-#if defined(AARCH64)
-    // Allocate the same register for src and dst, then we can remove
-    // the instructions in the final assembly.
+    // Allocate the same src and dest register for CastX2P and CastP2X
+    // on some target platforms, then we can remove the instructions in
+    // the final assembly.
     if (strcmp("CastX2P", instr->ideal_Opcode(_globalNames)) == 0 ||
         strcmp("CastP2X", instr->ideal_Opcode(_globalNames)) == 0) {
-      matching_input = 1;
+      assert(matching_input == 0, "");
+      fprintf(fp,"  virtual uint           two_adr() const  {\n");
+      fprintf(fp,"    if (Matcher::use_same_src_and_dest_reg_for_CastX2P())\n");
+      fprintf(fp,"      return oper_input_base();\n");
+      fprintf(fp,"    return 0;\n");
+      fprintf(fp,"  }\n");
     }
-#endif
 
     // Generate the method if it returns != 0 otherwise use MachNode::two_adr()
     if( matching_input != 0 ) {

--- a/src/hotspot/share/adlc/output_h.cpp
+++ b/src/hotspot/share/adlc/output_h.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1687,6 +1687,15 @@ void ArchDesc::declareClasses(FILE *fp) {
 
     // Identify which input register matches the input register.
     uint  matching_input = instr->two_address(_globalNames);
+
+#if defined(AARCH64)
+    // Allocate the same register for src and dst, then we can remove
+    // the instructions in the final assembly.
+    if (strcmp("CastX2P", instr->ideal_Opcode(_globalNames)) == 0 ||
+        strcmp("CastP2X", instr->ideal_Opcode(_globalNames)) == 0) {
+      matching_input = 1;
+    }
+#endif
 
     // Generate the method if it returns != 0 otherwise use MachNode::two_adr()
     if( matching_input != 0 ) {

--- a/src/hotspot/share/opto/matcher.hpp
+++ b/src/hotspot/share/opto/matcher.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -455,6 +455,10 @@ public:
   // Java-Native vector calling convention
   static bool supports_vector_calling_convention();
   static OptoRegPair vector_return_value(uint ideal_reg);
+
+  // Is it preferred to use the same src and dest register for CastX2P and
+  // CastP2X? If true, we can remove the instructions in the final assembly.
+  static bool use_same_src_and_dest_reg_for_CastX2P();
 
   // Is this branch offset small enough to be addressed by a short branch?
   bool is_short_branch_offset(int rule, int br_size, int offset);


### PR DESCRIPTION
This patch forces `CastX2P` to be a two-address instruction, so that C2 could allocate the same register for `dst` and `src`. Then we can remove the instruction completely in the assembly.

The motivation comes from some cast operations like `castPP`. The difference for ADLC between `castPP` and `CastX2P` lies in that `CastX2P` always has different types for `dst` and `src`. We can force ADLC to generate an extra `two_adr()` for `CastX2P` like it does automatically for `castPP`, which could tell register allocator that the instruction needs the same register for `dst` and `src`.

However, sometimes, RA and GCM in C2 can't work as we expected.

For example, we have Assembly on the existing code:
```
  ldp    x10, x11, [x17,#136]
  add    x10, x10, x15
  add    x11, x11, x10
  ldr    x12, [x17,#152]
  str    x16, [x10]
  add    x10, x12, x15
  str    x16, [x11]
  str    x16, [x10]
```

After applying the patch independently, the assembly is:
```
  ldr    x10, [x16,#136]  <--- 1
  add    x10, x10, x15
  ldr    x11, [x16,#144]  <--- 2
  mov    x13, x10         <--- 3
  str    x17, [x13]
  ldr    x12, [x16,#152]
  add    x10, x11, x10
  str    x17, [x10]
  add    x10, x12, x15
  str    x17, [x10]
```

C2 generates a totally extra `mov`, see 3, and we even lost the chance to merge load pair, see 1 and 2. That's terrible.

Although this scenario would disappear after combining with https://github.com/openjdk/jdk/pull/20157, I'm still not sure if this patch is worthwhile.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336464](https://bugs.openjdk.org/browse/JDK-8336464): C2: Force CastX2P to be a two-address instruction (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20159/head:pull/20159` \
`$ git checkout pull/20159`

Update a local copy of the PR: \
`$ git checkout pull/20159` \
`$ git pull https://git.openjdk.org/jdk.git pull/20159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20159`

View PR using the GUI difftool: \
`$ git pr show -t 20159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20159.diff">https://git.openjdk.org/jdk/pull/20159.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20159#issuecomment-2233402165)
</details>
