### PR TITLE
8335860: compiler/vectorization/TestFloat16VectorConvChain.java fails with non-standard AVX/SSE settings

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -834,6 +834,7 @@ public:
     return true;
   }
 
+  // For AVX CPUs only. f16c support is disabled if UseAVX == 0.
   static bool supports_float16() {
     return supports_f16c() || supports_avx512vl();
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -834,7 +834,8 @@ public:
     return true;
   }
 
-  // For AVX CPUs only. f16c support is disabled if UseAVX == 0.
+  // For AVX CPUs only since it needs VEX encoding which is missing on SSE targets,
+  // thus f16c support is disabled if UseAVX == 0.
   static bool supports_float16() {
     return supports_f16c() || supports_avx512vl();
   }

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -834,8 +834,6 @@ public:
     return true;
   }
 
-  // For AVX CPUs only since it needs VEX encoding which is missing on SSE targets,
-  // thus f16c support is disabled if UseAVX == 0.
   static bool supports_float16() {
     return supports_f16c() || supports_avx512vl();
   }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -69,8 +69,6 @@ compiler/startup/StartupOutput.java 8326615 generic-x64
 
 compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
-compiler/vectorization/TestFloat16VectorConvChain.java 8335860 generic-all
-
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -24,7 +24,6 @@
 /**
 * @test
 * @summary Test Float16 vector conversion chain.
-* @requires vm.compiler2.enabled
 * @library /test/lib /
 * @run driver compiler.vectorization.TestFloat16VectorConvChain
 */

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -39,7 +39,7 @@ import java.util.Arrays;
 public class TestFloat16VectorConvChain {
 
     @Test
-    @IR(counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
+    @IR(applyIfCPUFeatureOr = {"f16c", "true", "avx512vl", "true"}, counts = {IRNode.VECTOR_CAST_HF2F, IRNode.VECTOR_SIZE_ANY, ">= 1", IRNode.VECTOR_CAST_F2HF, IRNode.VECTOR_SIZE_ANY, " >= 1"})
     public static void test(short [] res, short [] src1, short [] src2) {
         for (int i = 0; i < res.length; i++) {
             res[i] = (short)Float.float16ToFloat(Float.floatToFloat16(Float.float16ToFloat(src1[i]) + Float.float16ToFloat(src2[i])));


### PR DESCRIPTION
Enabling test with explicit feature checks for x86 target.
Removing from test/hotspot/jtreg/ProblemList.txt

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335860](https://bugs.openjdk.org/browse/JDK-8335860): compiler/vectorization/TestFloat16VectorConvChain.java fails with non-standard AVX/SSE settings (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20160/head:pull/20160` \
`$ git checkout pull/20160`

Update a local copy of the PR: \
`$ git checkout pull/20160` \
`$ git pull https://git.openjdk.org/jdk.git pull/20160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20160`

View PR using the GUI difftool: \
`$ git pr show -t 20160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20160.diff">https://git.openjdk.org/jdk/pull/20160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20160#issuecomment-2226156586)