### PR TITLE
8333088: ubsan: shenandoahAdaptiveHeuristics.cpp:245:44: runtime error: division by zero

### DIFF
--- a/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
+++ b/src/hotspot/share/gc/shenandoah/heuristics/shenandoahAdaptiveHeuristics.cpp
@@ -242,7 +242,7 @@ bool ShenandoahAdaptiveHeuristics::should_start_gc() {
 
   double avg_cycle_time = _gc_time_history->davg() + (_margin_of_error_sd * _gc_time_history->dsd());
   double avg_alloc_rate = _allocation_rate.upper_bound(_margin_of_error_sd);
-  if (avg_cycle_time > allocation_headroom / avg_alloc_rate) {
+  if (avg_cycle_time * avg_alloc_rate > allocation_headroom) {
     log_info(gc)("Trigger: Average GC time (%.2f ms) is above the time for average allocation rate (%.0f %sB/s) to deplete free headroom (" SIZE_FORMAT "%s) (margin of error = %.2f)",
                  avg_cycle_time * 1000,
                  byte_size_in_proper_unit(avg_alloc_rate), proper_unit_for_byte_size(avg_alloc_rate),


### PR DESCRIPTION
Changed comparison to multiplication to prevent division by zero errors reported by ubsan.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333088](https://bugs.openjdk.org/browse/JDK-8333088): ubsan: shenandoahAdaptiveHeuristics.cpp:245:44: runtime error: division by zero (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20161/head:pull/20161` \
`$ git checkout pull/20161`

Update a local copy of the PR: \
`$ git checkout pull/20161` \
`$ git pull https://git.openjdk.org/jdk.git pull/20161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20161`

View PR using the GUI difftool: \
`$ git pr show -t 20161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20161.diff">https://git.openjdk.org/jdk/pull/20161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20161#issuecomment-2240186499)