### PR TITLE
8332697: ubsan: shenandoahSimpleBitMap.inline.hpp:68:23: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long int'

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp
@@ -72,7 +72,7 @@ size_t ShenandoahSimpleBitMap::count_trailing_ones(idx_t last_idx) const {
   uintx element_bits = _bitmap[array_idx];
   uintx bit_number = last_idx & right_n_bits(LogBitsPerWord);
   // All ones from bit 0 to the_bit
-  uintx mask = right_n_bits(bit_number + 1);
+  uintx mask = u_right_n_bits(bit_number + 1);
   size_t counted_ones = 0;
   while ((element_bits & mask) == mask) {
     // All bits numbered <= bit_number are set
@@ -164,7 +164,7 @@ idx_t ShenandoahSimpleBitMap::find_first_consecutive_set_bits(idx_t beg, idx_t e
   uintx bit_number = beg & right_n_bits(LogBitsPerWord);
   uintx element_bits = _bitmap[array_idx];
   if (bit_number > 0) {
-    uintx mask_out = right_n_bits(bit_number);
+    uintx mask_out = u_right_n_bits(bit_number);
     element_bits &= ~mask_out;
   }
 
@@ -224,7 +224,7 @@ idx_t ShenandoahSimpleBitMap::find_first_consecutive_set_bits(idx_t beg, idx_t e
       element_bits = _bitmap[array_idx];
       bit_number = beg & right_n_bits(LogBitsPerWord);
       if (bit_number > 0) {
-        size_t mask_out = right_n_bits(bit_number);
+        size_t mask_out = u_right_n_bits(bit_number);
         element_bits &= ~mask_out;
       }
     }

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -47,6 +47,12 @@
 
 typedef ssize_t idx_t;
 
+
+const uintptr_t OneBitUnsigned = 1;
+#define u_nth_bit(n)      (((n) >= BitsPerWord) ? 0 : (OneBitUnsigned << (n)))
+// unsigned version of right_n_bits to prevent undefined behavior from shifting and overflow
+#define u_right_n_bits(n) ((uintptr_t)u_nth_bit(n) - 1)
+
 // ShenandoahSimpleBitMap resembles CHeapBitMap but adds missing support for find_first_consecutive_set_bits() and
 // find_last_consecutive_set_bits.  An alternative refactoring of code would subclass CHeapBitMap, but this might
 // break abstraction rules, because efficient implementation requires assumptions about superclass internals that

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -47,7 +47,6 @@
 
 typedef ssize_t idx_t;
 
-
 const uintptr_t OneBitUnsigned = 1;
 #define u_nth_bit(n)      (((n) >= BitsPerWord) ? 0 : (OneBitUnsigned << (n)))
 // unsigned version of right_n_bits to prevent undefined behavior from shifting and overflow

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
@@ -35,7 +35,7 @@ inline idx_t ShenandoahSimpleBitMap::find_first_set_bit(idx_t beg, idx_t end) co
     uintx bit_number = beg & right_n_bits(LogBitsPerWord);
     uintx element_bits = _bitmap[array_idx];
     if (bit_number > 0) {
-      uintx mask_out = right_n_bits(bit_number);
+      uintx mask_out = u_right_n_bits(bit_number);
       element_bits &= ~mask_out;
     }
     if (element_bits) {
@@ -65,7 +65,7 @@ inline idx_t ShenandoahSimpleBitMap::find_last_set_bit(idx_t beg, idx_t end) con
     uintx bit_number = end & right_n_bits(LogBitsPerWord);
     uintx element_bits = _bitmap[array_idx];
     if (bit_number < BitsPerWord - 1){
-      uintx mask_in = right_n_bits(bit_number + 1);
+      uintx mask_in = u_right_n_bits(bit_number + 1);
       element_bits &= mask_in;
     }
     if (element_bits) {

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1067,6 +1067,7 @@ const intptr_t OneBit     =  1; // only right_most bit set in a word
 // (note: #define used only so that they can be used in enum constant definitions)
 #define nth_bit(n)        (((n) >= BitsPerWord) ? 0 : (OneBit << (n)))
 #define right_n_bits(n)   (nth_bit(n) - 1)
+
 // bit-operations using a mask m
 inline void   set_bits    (intptr_t& x, intptr_t m) { x |= m; }
 inline void clear_bits    (intptr_t& x, intptr_t m) { x &= ~m; }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1066,7 +1066,7 @@ const intptr_t OneBit     =  1; // only right_most bit set in a word
 // get a word with the n.th or the right-most or left-most n bits set
 // (note: #define used only so that they can be used in enum constant definitions)
 #define nth_bit(n)        (((n) >= BitsPerWord) ? 0 : (OneBit << (n)))
-#define right_n_bits(n)   (nth_bit(n) - 1)
+#define right_n_bits(n)   ((uintptr_t) nth_bit(n) - 1)
 
 // bit-operations using a mask m
 inline void   set_bits    (intptr_t& x, intptr_t m) { x |= m; }

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -1066,8 +1066,7 @@ const intptr_t OneBit     =  1; // only right_most bit set in a word
 // get a word with the n.th or the right-most or left-most n bits set
 // (note: #define used only so that they can be used in enum constant definitions)
 #define nth_bit(n)        (((n) >= BitsPerWord) ? 0 : (OneBit << (n)))
-#define right_n_bits(n)   ((uintptr_t) nth_bit(n) - 1)
-
+#define right_n_bits(n)   (nth_bit(n) - 1)
 // bit-operations using a mask m
 inline void   set_bits    (intptr_t& x, intptr_t m) { x |= m; }
 inline void clear_bits    (intptr_t& x, intptr_t m) { x &= ~m; }


### PR DESCRIPTION
Cast the result of `nth_bit(n)` to `uintptr_t` to prevent signed integer overflow error reported by `ubsan`. Unsigned overflow is not undefined behavior and is not checked by `ubsan`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332697](https://bugs.openjdk.org/browse/JDK-8332697): ubsan: shenandoahSimpleBitMap.inline.hpp:68:23: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'long int' (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20164/head:pull/20164` \
`$ git checkout pull/20164`

Update a local copy of the PR: \
`$ git checkout pull/20164` \
`$ git pull https://git.openjdk.org/jdk.git pull/20164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20164`

View PR using the GUI difftool: \
`$ git pr show -t 20164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20164.diff">https://git.openjdk.org/jdk/pull/20164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20164#issuecomment-2240184491)