### PR TITLE
Optimize parseInt & parseLong

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.lang;
 
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
@@ -230,6 +231,7 @@ class CharacterDataLatin1 extends CharacterData {
     //
     // Analysis has shown that generating the whole array allows the JIT to generate
     // better code compared to a slimmed down array, such as one cutting off after 'z'
+    @Stable
     private static final byte[] DIGITS = new byte[] {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -245,10 +247,30 @@ class CharacterDataLatin1 extends CharacterData {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
 
+    @Stable
+    private static final byte[] DECIMAL_DIGITS = new byte[] {
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+
     int digit(int ch, int radix) {
         int value = DIGITS[ch];
         return (value >= 0 && value < radix && radix >= Character.MIN_RADIX
                 && radix <= Character.MAX_RADIX) ? value : -1;
+    }
+
+    static int digit(byte ch) {
+        return DECIMAL_DIGITS[ch & 0xFF];
     }
 
     int getNumericValue(int ch) {

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -580,42 +580,37 @@ public final class Long extends Number
             throw new NumberFormatException("Cannot parse null string");
         }
 
-        if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+        if (radix != 10 || !s.isLatin1()) {
+            return parseLong(s, 0, s.length(), radix);
         }
 
-        if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
-        }
-
-        int len = s.length();
+        byte[] value = s.value();
+        int len = value.length;
         if (len == 0) {
-            throw NumberFormatException.forInputString("", radix);
+            throw NumberFormatException.forInputString(s, 10);
         }
         int digit = ~0xFF;
         int i = 0;
-        char firstChar = s.charAt(i++);
+        byte firstChar = value[i++];
         if (firstChar != '-' && firstChar != '+') {
-            digit = digit(firstChar, radix);
+            digit = CharacterDataLatin1.digit(firstChar);
         }
         if (digit >= 0 || digit == ~0xFF && len > 1) {
             long limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
-            long multmin = limit / radix;
+            long multmin = -922337203685477580L; // actual limit / 10
             long result = -(digit & 0xFF);
             boolean inRange = true;
             /* Accumulating negatively avoids surprises near MAX_VALUE */
-            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
+            while (i < len && (digit = CharacterDataLatin1.digit(value[i++])) >= 0
                     && (inRange = result > multmin
-                        || result == multmin && digit <= (int) (radix * multmin - limit))) {
-                result = radix * result - digit;
+                        || result == multmin && digit <= (int) (10 * multmin - limit))) {
+                result = 10 * result - digit;
             }
             if (inRange && i == len && digit >= 0) {
                 return firstChar != '-' ? -result : result;
             }
         }
-        throw NumberFormatException.forInputString(s, radix);
+        throw NumberFormatException.forInputString(s, 10);
     }
 
     /**

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,13 @@ public class Longs {
     public void toStringSmall(Blackhole bh) {
         for (long value : longArraySmall) {
             bh.consume(Long.toString(value));
+        }
+    }
+
+    @Benchmark
+    public void parseLong(Blackhole bh) {
+        for (String s : strings) {
+            bh.consume(Long.parseLong(s));
         }
     }
 


### PR DESCRIPTION
Currently, about 25% of the time spent by the Integer.parseInt and Long.parseLong methods is spent on the Character.digit method.

The Character.digit method is common to all radixes. We can use a digit method optimized for Latin1 encoding radix 10 to improve the performance of Integer.parseInt and Long.parseLong methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20165/head:pull/20165` \
`$ git checkout pull/20165`

Update a local copy of the PR: \
`$ git checkout pull/20165` \
`$ git pull https://git.openjdk.org/jdk.git pull/20165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20165`

View PR using the GUI difftool: \
`$ git pr show -t 20165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20165.diff">https://git.openjdk.org/jdk/pull/20165.diff</a>

</details>
