### PR TITLE
8336259: Wrong link to stylesheet.css in JavaDoc API documentation

### DIFF
--- a/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
+++ b/src/java.base/share/classes/java/lang/doc-files/ValueBased.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
- Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 <html lang="en">
 <head>
   <title>Value-based Classes</title>
-  <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
 </head>
 <body>
 <h1 id="ValueBased">{@index "Value-based Classes"}</h1>

--- a/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
+++ b/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!--
- Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 <html lang="en">
 <head>
   <title>Java Thread Primitive Deprecation</title>
-  <link rel="stylesheet" type="text/css" href="../../../../stylesheet.css" title="Style">
 </head>
 <body>
 <h1>Java Thread Primitive Deprecation</h1>


### PR DESCRIPTION
Please review the backport of #20145 onto jdk23, fixing 2 unnecessary and erroneous links in the doc files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336259](https://bugs.openjdk.org/browse/JDK-8336259): Wrong link to stylesheet.css in JavaDoc API documentation (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20166/head:pull/20166` \
`$ git checkout pull/20166`

Update a local copy of the PR: \
`$ git checkout pull/20166` \
`$ git pull https://git.openjdk.org/jdk.git pull/20166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20166`

View PR using the GUI difftool: \
`$ git pr show -t 20166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20166.diff">https://git.openjdk.org/jdk/pull/20166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20166#issuecomment-2226535102)